### PR TITLE
Refactor asserts in DataTestSubscriber

### DIFF
--- a/src/test/java/reactor/core/publisher/ProcessorEmitterDemandTests.java
+++ b/src/test/java/reactor/core/publisher/ProcessorEmitterDemandTests.java
@@ -171,7 +171,7 @@ public class ProcessorEmitterDemandTests {
 		    .log()
 		    .subscribe(processor);
 
-		subscriber.assertNextSignals("1");
+		subscriber.assertNextSignalsEqual("1");
 	}
 
 	@Test
@@ -186,7 +186,7 @@ public class ProcessorEmitterDemandTests {
 
 		subscriber.request(1);
 
-		subscriber.assertNextSignals("1");
+		subscriber.assertNextSignalsEqual("1");
 	}
 
 	@Test
@@ -205,10 +205,10 @@ public class ProcessorEmitterDemandTests {
 		         .subscribe(second);
 
 		second.request(1);
-		second.assertNextSignals("1");
+		second.assertNextSignalsEqual("1");
 
 		first.request(3);
-		first.assertNextSignals("1", "2", "3");
+		first.assertNextSignalsEqual("1", "2", "3");
 	}
 
 	@Test
@@ -222,13 +222,13 @@ public class ProcessorEmitterDemandTests {
 		processor.subscribe(first);
 
 		first.request(1);
-		first.assertNextSignals("1");
+		first.assertNextSignalsEqual("1");
 
 		DataTestSubscriber<String> second = DataTestSubscriber.createWithTimeoutSecs(1);
 		processor.subscribe(second);
 
 		second.request(3);
-		second.assertNextSignals("2", "3", "4");
+		second.assertNextSignalsEqual("2", "3", "4");
 	}
 
 	static class MyThread extends Thread {

--- a/src/test/java/reactor/core/subscriber/test/DataTestSubscriberTest.java
+++ b/src/test/java/reactor/core/subscriber/test/DataTestSubscriberTest.java
@@ -2,16 +2,19 @@ package reactor.core.subscriber.test;
 
 import java.util.Arrays;
 
+import org.junit.Assert;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
+import reactor.fn.Consumer;
 
 /**
  * @author Anatoly Kadyshev
+ * @author Brian Clozel
  */
 public class DataTestSubscriberTest {
 
 	@Test
-	public void testAssertNextSignals() throws Exception {
+	public void testAssertNextSignalsEqual() throws Exception {
 		DataTestSubscriber<String> subscriber = DataTestSubscriber.createWithTimeoutSecs(1);
 		Flux.fromIterable(Arrays.asList("1", "2"))
 		    .log()
@@ -19,11 +22,53 @@ public class DataTestSubscriberTest {
 
 		subscriber.request(1);
 
-		subscriber.assertNextSignals("1");
+		subscriber.assertNextSignalsEqual("1");
 
 		subscriber.request(1);
 
-		subscriber.assertNextSignals("2");
+		subscriber.assertNextSignalsEqual("2");
+	}
+
+	@Test
+	public void testAssertNextSignals() throws Exception {
+		DataTestSubscriber<Long> subscriber = DataTestSubscriber.createWithTimeoutSecs(1);
+		Flux.fromIterable(Arrays.asList(1L, 2L))
+				.log()
+				.subscribe(subscriber);
+
+		Consumer<Long> greaterThanZero = new Consumer<Long>() {
+			@Override
+			public void accept(Long aLong) {
+				Assert.assertTrue(aLong > 0L);
+			}
+		};
+
+		subscriber.request(1);
+		subscriber.assertNextSignals(greaterThanZero);
+
+		subscriber.request(1);
+		subscriber.assertNextSignals(greaterThanZero);
+	}
+
+	@Test(expected = AssertionError.class)
+	public void testAssertNextSignalsFailure() throws Exception {
+		DataTestSubscriber<Long> subscriber = DataTestSubscriber.createWithTimeoutSecs(1);
+		Flux.fromIterable(Arrays.asList(1L, 20L))
+				.log()
+				.subscribe(subscriber);
+
+		Consumer<Long> lowerThanTen = new Consumer<Long>() {
+			@Override
+			public void accept(Long aLong) {
+				Assert.assertTrue(aLong < 10L);
+			}
+		};
+
+		subscriber.request(1);
+		subscriber.assertNextSignals(lowerThanTen);
+
+		subscriber.request(1);
+		subscriber.assertNextSignals(lowerThanTen);
 	}
 
 }


### PR DESCRIPTION
Prior to this commit, the DataTestSubscriber would only have a
`assertNextSignals(T... signals)` which checks for
*strict object equality* between the Next received signals
and the provided arguments.

This commit renames that method to `assertNextSignalsEqual` and adds a
new one `assertNextSignals(Consumer<T>... expectations)`, which apply
each Next signal to the expectations given as arguments. This allows new
ways to verify the received Next signals, in a more flexible way.