### PR TITLE
Expose Tuple constructors

### DIFF
--- a/src/main/java/reactor/fn/tuple/Tuple1.java
+++ b/src/main/java/reactor/fn/tuple/Tuple1.java
@@ -34,7 +34,7 @@ public class Tuple1<T1> extends Tuple {
 
 	public final T1 t1;
 
-	Tuple1(int size, T1 t1) {
+	public Tuple1(int size, T1 t1) {
 		super(size);
 		this.t1 = t1;
 	}

--- a/src/main/java/reactor/fn/tuple/Tuple2.java
+++ b/src/main/java/reactor/fn/tuple/Tuple2.java
@@ -35,7 +35,7 @@ public class Tuple2<T1, T2> extends Tuple1<T1> {
 
 	public final T2 t2;
 
-	Tuple2(int size, T1 t1, T2 t2) {
+	public Tuple2(int size, T1 t1, T2 t2) {
 		super(size, t1);
 		this.t2 = t2;
 	}

--- a/src/main/java/reactor/fn/tuple/Tuple3.java
+++ b/src/main/java/reactor/fn/tuple/Tuple3.java
@@ -36,7 +36,7 @@ public class Tuple3<T1, T2, T3> extends Tuple2<T1, T2> {
 
 	public final T3 t3;
 
-	Tuple3(int size, T1 t1, T2 t2, T3 t3) {
+	public Tuple3(int size, T1 t1, T2 t2, T3 t3) {
 		super(size, t1, t2);
 		this.t3 = t3;
 	}

--- a/src/main/java/reactor/fn/tuple/Tuple4.java
+++ b/src/main/java/reactor/fn/tuple/Tuple4.java
@@ -37,7 +37,7 @@ public class Tuple4<T1, T2, T3, T4> extends Tuple3<T1, T2, T3> {
 
 	public final T4 t4;
 
-	Tuple4(int size, T1 t1, T2 t2, T3 t3, T4 t4) {
+	public Tuple4(int size, T1 t1, T2 t2, T3 t3, T4 t4) {
 		super(size, t1, t2, t3);
 		this.t4 = t4;
 	}

--- a/src/main/java/reactor/fn/tuple/Tuple5.java
+++ b/src/main/java/reactor/fn/tuple/Tuple5.java
@@ -38,7 +38,7 @@ public class Tuple5<T1, T2, T3, T4, T5> extends Tuple4<T1, T2, T3, T4> {
 
 	public final T5 t5;
 
-	Tuple5(int size, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) {
+	public Tuple5(int size, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) {
 		super(size, t1, t2, t3, t4);
 		this.t5 = t5;
 	}

--- a/src/main/java/reactor/fn/tuple/Tuple6.java
+++ b/src/main/java/reactor/fn/tuple/Tuple6.java
@@ -39,7 +39,7 @@ public class Tuple6<T1, T2, T3, T4, T5, T6> extends Tuple5<T1, T2, T3, T4, T5> {
 
 	public final T6 t6;
 
-	Tuple6(int size, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) {
+	public Tuple6(int size, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) {
 		super(size, t1, t2, t3, t4, t5);
 		this.t6 = t6;
 	}

--- a/src/main/java/reactor/fn/tuple/Tuple7.java
+++ b/src/main/java/reactor/fn/tuple/Tuple7.java
@@ -40,7 +40,7 @@ public class Tuple7<T1, T2, T3, T4, T5, T6, T7> extends Tuple6<T1, T2, T3, T4, T
 
 	public final T7 t7;
 
-	Tuple7(int size, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) {
+	public Tuple7(int size, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) {
 		super(size, t1, t2, t3, t4, t5, t6);
 		this.t7 = t7;
 	}

--- a/src/main/java/reactor/fn/tuple/Tuple8.java
+++ b/src/main/java/reactor/fn/tuple/Tuple8.java
@@ -41,7 +41,7 @@ public class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> extends Tuple7<T1, T2, T3, T
 
 	public final T8 t8;
 
-	Tuple8(int size, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) {
+	public Tuple8(int size, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) {
 		super(size, t1, t2, t3, t4, t5, t6, t7);
 		this.t8 = t8;
 	}

--- a/src/main/java/reactor/fn/tuple/TupleN.java
+++ b/src/main/java/reactor/fn/tuple/TupleN.java
@@ -34,7 +34,7 @@ public class TupleN extends Tuple8 {
 	private final Object[] entries;
 
 	@SuppressWarnings("unchecked")
-	TupleN(Object... values) {
+	public TupleN(Object... values) {
 		super(values.length, toT(0, values), toT(1, values), toT(2, values), toT(3, values), toT(4, values), toT(5,
 				values), toT(6, values), toT(7, values));
 		if(values.length > 8) {


### PR DESCRIPTION
Stream combinators, mappers and other constructs used to manipulate
streams can be extracted to standalone functions. It is desirable to
test these functions in isolation, i.e. without initializing a Reactor
environment.

Unfortunately the Tuple constructors are package private, making it hard
to create instances for testing purposes. This change makes them public
for the sole purposes of testability in projects that use the reactor
project.