### PR TITLE
Remove DependencyUtils#reactorVersion()

### DIFF
--- a/src/main/java/reactor/core/converter/DependencyUtils.java
+++ b/src/main/java/reactor/core/converter/DependencyUtils.java
@@ -24,8 +24,6 @@ import org.reactivestreams.Publisher;
  */
 public final class DependencyUtils {
 
-	static private final String VERSION = "2.5.0.BUILD-SNAPSHOT";
-
 	static private final boolean HAS_REACTOR_STREAM;
 	static private final boolean HAS_REACTOR_CODEC;
 	static private final boolean HAS_REACTOR_NET;
@@ -220,7 +218,4 @@ public final class DependencyUtils {
 		throw new UnsupportedOperationException("Cannot convert " + source.getClass() + " source to " + to.getClass() + " type");
 	}
 
-	public static String reactorVersion() {
-		return VERSION;
-	}
 }


### PR DESCRIPTION
As explained in #4, this method must be removed, there won't be a single Reactor version anymore. I am going to send a PR on https://github.com/reactor/reactor-io/ to avoid using it. As a bonus is will make release process simpler and more error prone.