### PR TITLE
Use throw Exceptions.fail(e) instead of Exceptions.fail(e)

### DIFF
--- a/src/main/java/reactor/core/publisher/MonoError.java
+++ b/src/main/java/reactor/core/publisher/MonoError.java
@@ -57,8 +57,7 @@ extends Mono<T> {
 
 	@Override
 	public T get() {
-		Exceptions.fail(getError());
-		return null;
+		throw Exceptions.fail(getError());
 	}
 
 	@Override

--- a/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -133,7 +133,7 @@ public final class MonoProcessor<O> extends Mono<O>
 						if (error instanceof RuntimeException) {
 							throw (RuntimeException) error;
 						}
-						Exceptions.fail(error);
+						throw Exceptions.fail(error);
 					case STATE_COMPLETE_NO_VALUE:
 						return null;
 				}

--- a/src/main/java/reactor/core/publisher/SchedulerGroup.java
+++ b/src/main/java/reactor/core/publisher/SchedulerGroup.java
@@ -900,8 +900,7 @@ public class SchedulerGroup implements Callable<Consumer<Runnable>>, Consumer<Ru
 				scheduler = schedulerFactory.call();
 			}
 			catch (Throwable ex){
-				Exceptions.throwIfFatal(ex);
-				Exceptions.failUpstream(ex);
+				throw Exceptions.failUpstream(ex);
 			}
 			this.scheduler = Objects.requireNonNull(scheduler, "Provided schedulerFactory returned no scheduler");
 

--- a/src/main/java/reactor/core/timer/Timer.java
+++ b/src/main/java/reactor/core/timer/Timer.java
@@ -315,7 +315,7 @@ public class Timer implements Timeable, Cancellable {
 
 	static void checkResolution(long time, long resolution) {
 		if (time % resolution != 0) {
-			Exceptions.failUpstream(new IllegalArgumentException(
+			throw Exceptions.failUpstream(new IllegalArgumentException(
 					"Period must be a multiple of Timer resolution (e.g. period % resolution == 0 ). " +
 							"Resolution for this Timer is: " + resolution + "ms"
 			));

--- a/src/main/java/reactor/core/util/Exceptions.java
+++ b/src/main/java/reactor/core/util/Exceptions.java
@@ -78,24 +78,30 @@ public enum Exceptions {
 	}
 
 	/**
-	 * Throw an unchecked
-	 * {@link RuntimeException} that will be propagated downstream through {@link org.reactivestreams.Subscriber#onError(Throwable)}
+	 * Return an unchecked
+	 * {@link RuntimeException} to be thrown that will be propagated downstream through {@link org.reactivestreams.Subscriber#onError(Throwable)}
 	 *
 	 * @param t the root cause
 	 */
-	public static void fail(Throwable t) {
+	public static RuntimeException fail(Throwable t) {
 		throwIfFatal(t);
-		throw wrapDownstream(t);
+		if(t instanceof DownstreamException){
+			return (DownstreamException)t;
+		}
+		return new DownstreamException(t);
 	}
 
 	/**
-	 * Throw an unchecked {@link RuntimeException} that will be propagated upstream
+	 * Throw an unchecked {@link RuntimeException} to be thrown that will be propagated upstream
 	 *
 	 * @param t the root cause
 	 */
-	public static void failUpstream(Throwable t) {
+	public static RuntimeException failUpstream(Throwable t) {
 		throwIfFatal(t);
-		throw wrapUpstream(t);
+		if(t instanceof UpstreamException){
+			return (UpstreamException) t;
+		}
+		return new UpstreamException(t);
 	}
 
 	/**
@@ -140,7 +146,7 @@ public enum Exceptions {
 	 * @param e the exception to handle
 	 */
 	public static void onErrorDropped(Throwable e) {
-		failUpstream(e);
+		throw failUpstream(e);
 	}
 
 	/**
@@ -234,30 +240,6 @@ public enum Exceptions {
 			return t.getCause();
 		}
 		return t;
-	}
-
-	/**
-	 * Return an unchecked {@link RuntimeException} that will be propagated upstream
-	 *
-	 * @param t the root cause
-	 */
-	public static RuntimeException wrapDownstream(Throwable t) {
-		if(t instanceof DownstreamException){
-			return (DownstreamException)t;
-		}
-		return new DownstreamException(t);
-	}
-
-	/**
-	 * Return an unchecked {@link RuntimeException} that will be propagated upstream
-	 *
-	 * @param t the root cause
-	 */
-	public static RuntimeException wrapUpstream(Throwable t) {
-		if(t instanceof UpstreamException){
-			return (UpstreamException) t;
-		}
-		return new UpstreamException(t);
 	}
 
 	/**

--- a/src/test/java/reactor/core/publisher/FluxPeekTest.java
+++ b/src/test/java/reactor/core/publisher/FluxPeekTest.java
@@ -198,7 +198,7 @@ public class FluxPeekTest {
 
 		new FluxPeek<>(new FluxJust<>(1),
 				null,
-				d -> Exceptions.fail(err),
+				d -> { throw Exceptions.fail(err); },
 				null,
 				null,
 				null,
@@ -214,7 +214,7 @@ public class FluxPeekTest {
 		try {
 			new FluxPeek<>(new FluxJust<>(1),
 					null,
-					d -> Exceptions.failUpstream(err),
+					d -> { throw Exceptions.failUpstream(err); },
 					null,
 					null,
 					null,

--- a/src/test/java/reactor/core/publisher/tck/SchedulerGroupIOTests.java
+++ b/src/test/java/reactor/core/publisher/tck/SchedulerGroupIOTests.java
@@ -65,7 +65,7 @@ public class SchedulerGroupIOTests extends AbstractProcessorVerification {
 				Thread.sleep(1000);
 			}
 			catch(InterruptedException ie){
-				Exceptions.fail(ie);
+				throw Exceptions.fail(ie);
 			}
 		};
 		r.accept(() -> c.accept("Hello World!"));


### PR DESCRIPTION
PR for Issue #18