### PR TITLE
Make Exceptions more consistent

### DIFF
--- a/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -386,7 +386,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T>
 	public void onError(Throwable t) {
 		super.onError(t);
 		if (autoCancel && done) {
-			Exceptions.onErrorDropped(t);
+			throw Exceptions.wrapUpstream(t);
 		}
 		reportError(t);
 		done = true;

--- a/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -18,7 +18,6 @@ package reactor.core.publisher;
 
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -602,7 +601,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T>
 			}
 			int n = a.length;
 			if (n + 1 > maxConcurrency) {
-				throw Exceptions.failWithOverflow();
+				throw Exceptions.overflow();
 			}
 			EmitterSubscriber<?>[] b = new EmitterSubscriber[n + 1];
 			System.arraycopy(a, 0, b, 0, n);

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -3142,7 +3142,7 @@ public abstract class Flux<T> implements Publisher<T>, Introspectable, Backpress
 
 	/**
 	 * Request an unbounded demand and push the returned
-	 * {@link Flux}, or emit onError fom {@link Exceptions#failWithOverflow} if not enough demand is requested
+	 * {@link Flux}, or emit onError fom {@link Exceptions#overflow} if not enough demand is requested
 	 * downstream.
 	 *
 	 * <p>
@@ -3152,7 +3152,7 @@ public abstract class Flux<T> implements Publisher<T>, Introspectable, Backpress
 	 *
 	 */
 	public final Flux<T> onBackpressureError() {
-		return onBackpressureDrop(t -> { throw Exceptions.failWithOverflow();});
+		return onBackpressureDrop(t -> { throw Exceptions.overflow();});
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/FluxAccumulate.java
+++ b/src/main/java/reactor/core/publisher/FluxAccumulate.java
@@ -121,8 +121,7 @@ final class FluxAccumulate<T> extends FluxSource<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 			actual.onError(t);

--- a/src/main/java/reactor/core/publisher/FluxBuffer.java
+++ b/src/main/java/reactor/core/publisher/FluxBuffer.java
@@ -166,8 +166,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxSource<T,
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 			actual.onError(t);
@@ -336,8 +335,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxSource<T,
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 
 			done = true;
@@ -548,8 +546,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxSource<T,
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 
 			done = true;

--- a/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
+++ b/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
@@ -167,7 +167,7 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 				
 				actual.onError(t);
 			} else {
-				Exceptions.onErrorDropped(t);
+				throw Exceptions.wrapUpstream(t);
 			}
 		}
 

--- a/src/main/java/reactor/core/publisher/FluxBufferStartEnd.java
+++ b/src/main/java/reactor/core/publisher/FluxBufferStartEnd.java
@@ -194,7 +194,7 @@ final class FluxBufferStartEnd<T, U, V, C extends Collection<? super T>>
 			if (report) {
 				anyError(t);
 			} else {
-				Exceptions.onErrorDropped(t);
+				throw Exceptions.wrapUpstream(t);
 			}
 		}
 		
@@ -281,7 +281,7 @@ final class FluxBufferStartEnd<T, U, V, C extends Collection<? super T>>
 				done = true;
 				drain();
 			} else {
-				Exceptions.onErrorDropped(t);
+				throw Exceptions.wrapUpstream(t);
 			}
 		}
 		

--- a/src/main/java/reactor/core/publisher/FluxCombineLatest.java
+++ b/src/main/java/reactor/core/publisher/FluxCombineLatest.java
@@ -354,7 +354,7 @@ final class FluxCombineLatest<T, R>
 				done = true;
 				drain();
 			} else {
-				Exceptions.onErrorDropped(e);
+				throw Exceptions.wrapUpstream(e);
 			}
 		}
 		

--- a/src/main/java/reactor/core/publisher/FluxConcatMap.java
+++ b/src/main/java/reactor/core/publisher/FluxConcatMap.java
@@ -235,7 +235,7 @@ final class FluxConcatMap<T, R> extends FluxSource<T, R> {
 					}
 				}
 			} else {
-				Exceptions.onErrorDropped(t);
+				throw Exceptions.wrapUpstream(t);
 			}
 		}
 		
@@ -277,7 +277,7 @@ final class FluxConcatMap<T, R> extends FluxSource<T, R> {
 					}
 				}
 			} else {
-				Exceptions.onErrorDropped(e);
+				throw Exceptions.wrapUpstream(e);
 			}
 		}
 		
@@ -554,7 +554,7 @@ final class FluxConcatMap<T, R> extends FluxSource<T, R> {
 				done = true;
 				drain();
 			} else {
-				Exceptions.onErrorDropped(t);
+				throw Exceptions.wrapUpstream(t);
 			}
 		}
 		
@@ -585,7 +585,7 @@ final class FluxConcatMap<T, R> extends FluxSource<T, R> {
 				active = false;
 				drain();
 			} else {
-				Exceptions.onErrorDropped(e);
+				throw Exceptions.wrapUpstream(e);
 			}
 		}
 		

--- a/src/main/java/reactor/core/publisher/FluxDelaySubscription.java
+++ b/src/main/java/reactor/core/publisher/FluxDelaySubscription.java
@@ -95,8 +95,7 @@ final class FluxDelaySubscription<T, U> extends FluxSource<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 			subscriber.onError(t);

--- a/src/main/java/reactor/core/publisher/FluxDistinct.java
+++ b/src/main/java/reactor/core/publisher/FluxDistinct.java
@@ -144,8 +144,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends FluxSour
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 

--- a/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
+++ b/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
@@ -111,8 +111,7 @@ final class FluxDistinctUntilChanged<T, K> extends FluxSource<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 

--- a/src/main/java/reactor/core/publisher/FluxDrop.java
+++ b/src/main/java/reactor/core/publisher/FluxDrop.java
@@ -146,8 +146,7 @@ final class FluxDrop<T> extends FluxSource<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 

--- a/src/main/java/reactor/core/publisher/FluxFilter.java
+++ b/src/main/java/reactor/core/publisher/FluxFilter.java
@@ -149,8 +149,7 @@ final class FluxFilter<T> extends FluxSource<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 			actual.onError(t);
@@ -276,8 +275,7 @@ final class FluxFilter<T> extends FluxSource<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 			actual.onError(t);

--- a/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
@@ -166,8 +166,7 @@ final class FluxFilterFuseable<T> extends FluxSource<T, T>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 			actual.onError(t);
@@ -401,8 +400,7 @@ final class FluxFilterFuseable<T> extends FluxSource<T, T>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 			actual.onError(t);

--- a/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -447,7 +447,7 @@ final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 						if (Exceptions.addThrowable(ERROR, this, ex)) {
 							done = true;
 						} else {
-							Exceptions.onErrorDropped(ex);
+							throw Exceptions.wrapUpstream(ex);
 						}
 
 						drainLoop();
@@ -462,7 +462,7 @@ final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 						if (Exceptions.addThrowable(ERROR, this, e)) {
 							done = true;
 						} else {
-							Exceptions.onErrorDropped(e);
+							throw Exceptions.wrapUpstream(e);
 						}
 						drainLoop();
 						return;
@@ -486,7 +486,7 @@ final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 					if (Exceptions.addThrowable(ERROR, this, ex)) {
 						done = true;
 					} else {
-						Exceptions.onErrorDropped(ex);
+						throw Exceptions.wrapUpstream(ex);
 					}
 
 					drain();
@@ -501,7 +501,7 @@ final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 					if (Exceptions.addThrowable(ERROR, this, e)) {
 						done = true;
 					} else {
-						Exceptions.onErrorDropped(e);
+						throw Exceptions.wrapUpstream(e);
 					}
 				}
 				drain();
@@ -520,14 +520,13 @@ final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			if (Exceptions.addThrowable(ERROR, this, t)) {
 				done = true;
 				drain();
 			} else {
-				Exceptions.onErrorDropped(t);
+				throw Exceptions.wrapUpstream(t);
 			}
 		}
 
@@ -645,7 +644,7 @@ final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 									Exceptions.throwIfFatal(ex);
 									inner.cancel();
 									if (!Exceptions.addThrowable(ERROR, this, ex)) {
-										Exceptions.onErrorDropped(ex);
+										throw Exceptions.wrapUpstream(ex);
 									}
 									v = null;
 									d = true;
@@ -684,7 +683,7 @@ final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 									Exceptions.throwIfFatal(ex);
 									inner.cancel();
 									if (!Exceptions.addThrowable(ERROR, this, ex)) {
-										Exceptions.onErrorDropped(ex);
+										throw Exceptions.wrapUpstream(ex);
 									}
 									empty = true;
 									d = true;
@@ -814,7 +813,7 @@ final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 				}
 				drain();
 			} else {
-				Exceptions.onErrorDropped(e);
+				throw Exceptions.wrapUpstream(e);
 			}
 		}
 
@@ -841,7 +840,7 @@ final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 						if (Exceptions.addThrowable(ERROR, this, ex)) {
 							inner.done = true;
 						} else {
-							Exceptions.onErrorDropped(ex);
+							throw Exceptions.wrapUpstream(ex);
 						}
 						drainLoop();
 						return;
@@ -855,7 +854,7 @@ final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 						if (Exceptions.addThrowable(ERROR, this, e)) {
 							inner.done = true;
 						} else {
-							Exceptions.onErrorDropped(e);
+							throw Exceptions.wrapUpstream(e);
 						}
 						drainLoop();
 						return;
@@ -877,7 +876,7 @@ final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 					if (Exceptions.addThrowable(ERROR, this, ex)) {
 						inner.done = true;
 					} else {
-						Exceptions.onErrorDropped(ex);
+						throw Exceptions.wrapUpstream(ex);
 					}
 					drain();
 					return;
@@ -891,7 +890,7 @@ final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 					if (Exceptions.addThrowable(ERROR, this, e)) {
 						inner.done = true;
 					} else {
-						Exceptions.onErrorDropped(e);
+						throw Exceptions.wrapUpstream(e);
 					}
 				}
 				drain();

--- a/src/main/java/reactor/core/publisher/FluxGroupBy.java
+++ b/src/main/java/reactor/core/publisher/FluxGroupBy.java
@@ -278,7 +278,7 @@ implements Fuseable, Backpressurable  {
 				done = true;
 				drain();
 			} else {
-				Exceptions.onErrorDropped(t);
+				throw Exceptions.wrapUpstream(t);
 			}
 		}
 		

--- a/src/main/java/reactor/core/publisher/FluxMap.java
+++ b/src/main/java/reactor/core/publisher/FluxMap.java
@@ -128,8 +128,7 @@ final class FluxMap<T, R> extends FluxSource<T, R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 
 			done = true;
@@ -264,8 +263,7 @@ final class FluxMap<T, R> extends FluxSource<T, R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 
 			done = true;

--- a/src/main/java/reactor/core/publisher/FluxMapFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxMapFuseable.java
@@ -140,8 +140,7 @@ final class FluxMapFuseable<T, R> extends FluxSource<T, R>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 
 			done = true;
@@ -359,8 +358,7 @@ final class FluxMapFuseable<T, R> extends FluxSource<T, R>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 
 			done = true;

--- a/src/main/java/reactor/core/publisher/FluxMapSignal.java
+++ b/src/main/java/reactor/core/publisher/FluxMapSignal.java
@@ -125,8 +125,7 @@ final class FluxMapSignal<T, R> extends FluxSource<T, R> {
         @Override
         public void onError(Throwable t) {
             if (done) {
-                Exceptions.onErrorDropped(t);
-                return;
+                throw Exceptions.wrapUpstream(t);
             }
 
             done = true;

--- a/src/main/java/reactor/core/publisher/FluxMulticast.java
+++ b/src/main/java/reactor/core/publisher/FluxMulticast.java
@@ -180,7 +180,7 @@ final class FluxMulticast<T, U> extends ConnectableFlux<U> implements Receiver, 
 				processor.onError(t);
 			}
 			else {
-				Exceptions.onErrorDropped(t);
+				throw Exceptions.wrapUpstream(t);
 			}
 		}
 

--- a/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -243,8 +243,7 @@ final class FluxPublish<T> extends ConnectableFlux<T>
 			if (!queue.offer(t)) {
 				Throwable ex = new IllegalStateException("Queue full?!");
 				if (!Exceptions.addThrowable(ERROR, this, ex)) {
-					Exceptions.onErrorDropped(ex);
-					return;
+					throw Exceptions.wrapUpstream(ex);
 				}
 				done = true;
 			}
@@ -254,14 +253,13 @@ final class FluxPublish<T> extends ConnectableFlux<T>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			if (Exceptions.addThrowable(ERROR, this, t)) {
 				done = true;
 				drain();
 			} else {
-				Exceptions.onErrorDropped(t);
+				throw Exceptions.wrapUpstream(t);
 			}
 		}
 		

--- a/src/main/java/reactor/core/publisher/FluxScan.java
+++ b/src/main/java/reactor/core/publisher/FluxScan.java
@@ -150,8 +150,7 @@ final class FluxScan<T, R> extends FluxSource<T, R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 			actual.onError(t);

--- a/src/main/java/reactor/core/publisher/FluxSkipWhile.java
+++ b/src/main/java/reactor/core/publisher/FluxSkipWhile.java
@@ -122,8 +122,7 @@ final class FluxSkipWhile<T> extends FluxSource<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 

--- a/src/main/java/reactor/core/publisher/FluxSwitchMap.java
+++ b/src/main/java/reactor/core/publisher/FluxSwitchMap.java
@@ -199,8 +199,7 @@ final class FluxSwitchMap<T, R> extends FluxSource<T, R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			
 			if (Exceptions.addThrowable(ERROR, this, t)) {
@@ -213,7 +212,7 @@ final class FluxSwitchMap<T, R> extends FluxSource<T, R> {
 				done = true;
 				drain();
 			} else {
-				Exceptions.onErrorDropped(t);
+				throw Exceptions.wrapUpstream(t);
 			}
 		}
 		
@@ -374,7 +373,7 @@ final class FluxSwitchMap<T, R> extends FluxSource<T, R> {
 				inner.deactivate();
 				drain();
 			} else {
-				Exceptions.onErrorDropped(e);
+				throw Exceptions.wrapUpstream(e);
 			}
 		}
 		

--- a/src/main/java/reactor/core/publisher/FluxTake.java
+++ b/src/main/java/reactor/core/publisher/FluxTake.java
@@ -135,8 +135,7 @@ final class FluxTake<T> extends FluxSource<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 			actual.onError(t);

--- a/src/main/java/reactor/core/publisher/FluxTakeWhile.java
+++ b/src/main/java/reactor/core/publisher/FluxTakeWhile.java
@@ -113,8 +113,7 @@ final class FluxTakeWhile<T> extends FluxSource<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 

--- a/src/main/java/reactor/core/publisher/FluxThrottleFirst.java
+++ b/src/main/java/reactor/core/publisher/FluxThrottleFirst.java
@@ -175,7 +175,7 @@ final class FluxThrottleFirst<T, U> extends FluxSource<T, T> {
 					handleTermination();
 				}
 			} else {
-				Exceptions.onErrorDropped(e);
+				throw Exceptions.wrapUpstream(e);
 			}
 		}
 		

--- a/src/main/java/reactor/core/publisher/FluxThrottleTimeout.java
+++ b/src/main/java/reactor/core/publisher/FluxThrottleTimeout.java
@@ -191,7 +191,7 @@ final class FluxThrottleTimeout<T, U> extends FluxSource<T, T> {
 				done = true;
 				drain();
 			} else {
-				Exceptions.onErrorDropped(t);
+				throw Exceptions.wrapUpstream(t);
 			}
 		}
 		
@@ -225,7 +225,7 @@ final class FluxThrottleTimeout<T, U> extends FluxSource<T, T> {
 				
 				error(e);
 			} else {
-				Exceptions.onErrorDropped(e);
+				throw Exceptions.wrapUpstream(e);
 			}
 		}
 		
@@ -352,7 +352,7 @@ final class FluxThrottleTimeout<T, U> extends FluxSource<T, T> {
 			if (ONCE.compareAndSet(this, 0, 1)) {
 				main.otherError(index, t);
 			} else {
-				Exceptions.onErrorDropped(t);
+				throw Exceptions.wrapUpstream(t);
 			}
 		}
 

--- a/src/main/java/reactor/core/publisher/FluxTimeout.java
+++ b/src/main/java/reactor/core/publisher/FluxTimeout.java
@@ -175,12 +175,10 @@ final class FluxTimeout<T, U, V> extends FluxSource<T, T> {
 		public void onError(Throwable t) {
 			long idx = index;
 			if (idx == Long.MIN_VALUE) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			if (!INDEX.compareAndSet(this, idx, Long.MIN_VALUE)) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 
 			cancelTimeout();

--- a/src/main/java/reactor/core/publisher/FluxUsing.java
+++ b/src/main/java/reactor/core/publisher/FluxUsing.java
@@ -167,7 +167,7 @@ final class FluxUsing<T, S>
 			try {
 				resourceCleanup.accept(resource);
 			} catch (Throwable e) {
-				Exceptions.onErrorDropped(e);
+				throw Exceptions.wrapUpstream(e);
 			}
 		}
 

--- a/src/main/java/reactor/core/publisher/FluxWindow.java
+++ b/src/main/java/reactor/core/publisher/FluxWindow.java
@@ -219,8 +219,7 @@ final class FluxWindow<T> extends FluxSource<T, Flux<T>> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			Processor<T, T> w = window;
 			if (w != null) {
@@ -421,8 +420,7 @@ final class FluxWindow<T> extends FluxSource<T, Flux<T>> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			Processor<T, T> w = window;
 			if (w != null) {
@@ -661,8 +659,7 @@ final class FluxWindow<T> extends FluxSource<T, Flux<T>> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 
 			for (Processor<T, T> w : windows) {

--- a/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
+++ b/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
@@ -180,7 +180,7 @@ final class FluxWindowBoundary<T, U> extends FluxSource<T, Flux<T>> {
 			if (Exceptions.addThrowable(ERROR, this, t)) {
 				drain();
 			} else {
-				Exceptions.onErrorDropped(t);
+				throw Exceptions.wrapUpstream(t);
 			}
 		}
 
@@ -236,7 +236,7 @@ final class FluxWindowBoundary<T, U> extends FluxSource<T, Flux<T>> {
 			if (Exceptions.addThrowable(ERROR, this, e)) {
 				drain();
 			} else {
-				Exceptions.onErrorDropped(e);
+				throw Exceptions.wrapUpstream(e);
 			}
 		}
 

--- a/src/main/java/reactor/core/publisher/FluxWindowStartEnd.java
+++ b/src/main/java/reactor/core/publisher/FluxWindowStartEnd.java
@@ -177,7 +177,7 @@ final class FluxWindowStartEnd<T, U, V> extends FluxSource<T, Flux<T>> {
 			if (Exceptions.addThrowable(ERROR, this, t)) {
 				drain();
 			} else {
-				Exceptions.onErrorDropped(t);
+				throw Exceptions.wrapUpstream(t);
 			}
 		}
 		
@@ -217,7 +217,7 @@ final class FluxWindowStartEnd<T, U, V> extends FluxSource<T, Flux<T>> {
 			if (Exceptions.addThrowable(ERROR, this, e)) {
 				drain();
 			} else {
-				Exceptions.onErrorDropped(e);
+				throw Exceptions.wrapUpstream(e);
 			}
 		}
 		
@@ -238,7 +238,7 @@ final class FluxWindowStartEnd<T, U, V> extends FluxSource<T, Flux<T>> {
 			if (Exceptions.addThrowable(ERROR, this, e)) {
 				drain();
 			} else {
-				Exceptions.onErrorDropped(e);
+				throw Exceptions.wrapUpstream(e);
 			}
 		}
 		

--- a/src/main/java/reactor/core/publisher/FluxZip.java
+++ b/src/main/java/reactor/core/publisher/FluxZip.java
@@ -344,7 +344,7 @@ final class FluxZip<T, R> extends Flux<R> implements Introspectable, MultiReceiv
 				cancelAll();
 				subscriber.onError(e);
 			} else {
-			   Exceptions.onErrorDropped(e);
+			   throw Exceptions.wrapUpstream(e);
 			}
 		}
 		
@@ -435,8 +435,7 @@ final class FluxZip<T, R> extends Flux<R> implements Introspectable, MultiReceiv
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 			parent.error(t, index);
@@ -620,7 +619,7 @@ final class FluxZip<T, R> extends Flux<R> implements Introspectable, MultiReceiv
 			if (Exceptions.addThrowable(ERROR, this, e)) {
 				drain();
 			} else {
-				Exceptions.onErrorDropped(e);
+				throw Exceptions.wrapUpstream(e);
 			}
 		}
 		

--- a/src/main/java/reactor/core/publisher/FluxZipIterable.java
+++ b/src/main/java/reactor/core/publisher/FluxZipIterable.java
@@ -183,8 +183,7 @@ final class FluxZipIterable<T, U, R> extends FluxSource<T, R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			actual.onError(t);
 		}

--- a/src/main/java/reactor/core/publisher/MonoAggregate.java
+++ b/src/main/java/reactor/core/publisher/MonoAggregate.java
@@ -108,8 +108,7 @@ final class MonoAggregate<T> extends MonoSource<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			result = null;
 			subscriber.onError(t);

--- a/src/main/java/reactor/core/publisher/MonoAll.java
+++ b/src/main/java/reactor/core/publisher/MonoAll.java
@@ -112,8 +112,7 @@ final class MonoAll<T> extends MonoSource<T, Boolean> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 

--- a/src/main/java/reactor/core/publisher/MonoAny.java
+++ b/src/main/java/reactor/core/publisher/MonoAny.java
@@ -113,8 +113,7 @@ final class MonoAny<T> extends MonoSource<T, Boolean> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 

--- a/src/main/java/reactor/core/publisher/MonoCallable.java
+++ b/src/main/java/reactor/core/publisher/MonoCallable.java
@@ -83,7 +83,10 @@ extends Mono<T>
 		try {
 			return callable.call();
 		} catch (Throwable e) {
-			throw Exceptions.propagate(e);
+			if (e instanceof RuntimeException) {
+				throw (RuntimeException)e;
+			}
+			throw Exceptions.wrapUpstream(e);
 		}
 	}
 }

--- a/src/main/java/reactor/core/publisher/MonoCollect.java
+++ b/src/main/java/reactor/core/publisher/MonoCollect.java
@@ -126,8 +126,7 @@ final class MonoCollect<T, R> extends MonoSource<T, R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 			subscriber.onError(t);

--- a/src/main/java/reactor/core/publisher/MonoElementAt.java
+++ b/src/main/java/reactor/core/publisher/MonoElementAt.java
@@ -129,8 +129,7 @@ final class MonoElementAt<T> extends MonoSource<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 

--- a/src/main/java/reactor/core/publisher/MonoError.java
+++ b/src/main/java/reactor/core/publisher/MonoError.java
@@ -57,7 +57,7 @@ extends Mono<T> {
 
 	@Override
 	public T get() {
-		throw Exceptions.fail(getError());
+		throw Exceptions.wrap(getError());
 	}
 
 	@Override

--- a/src/main/java/reactor/core/publisher/MonoNext.java
+++ b/src/main/java/reactor/core/publisher/MonoNext.java
@@ -89,8 +89,7 @@ final class MonoNext<T> extends MonoSource<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 			actual.onError(t);

--- a/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -133,13 +133,13 @@ public final class MonoProcessor<O> extends Mono<O>
 						if (error instanceof RuntimeException) {
 							throw (RuntimeException) error;
 						}
-						throw Exceptions.fail(error);
+						throw Exceptions.wrap(error);
 					case STATE_COMPLETE_NO_VALUE:
 						return null;
 				}
 				if (delay < System.currentTimeMillis()) {
 					cancel();
-					throw Exceptions.failWithCancel();
+					throw Exceptions.cancelException();
 				}
 				Thread.sleep(1);
 			}
@@ -147,7 +147,7 @@ public final class MonoProcessor<O> extends Mono<O>
 		catch (InterruptedException ie) {
 			Thread.currentThread().interrupt();
 
-			throw Exceptions.failWithCancel();
+			throw Exceptions.cancelException();
 		}
 	}
 

--- a/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -229,8 +229,7 @@ public final class MonoProcessor<O> extends Mono<O>
 		Subscription s = subscription;
 
 		if ((source != null && s == null) || this.error != null) {
-			Exceptions.onErrorDropped(cause);
-			return;
+			throw Exceptions.wrapUpstream(cause);
 		}
 
 		this.error = cause;
@@ -239,8 +238,7 @@ public final class MonoProcessor<O> extends Mono<O>
 		int state = this.state;
 		for (; ; ) {
 			if (state != STATE_READY && state != STATE_SUBSCRIBED && state != STATE_POST_SUBSCRIBED) {
-				Exceptions.onErrorDropped(cause);
-				return;
+				throw Exceptions.wrapUpstream(cause);
 			}
 			if (STATE.compareAndSet(this, state, STATE_ERROR)) {
 				if(processor == null){
@@ -248,8 +246,7 @@ public final class MonoProcessor<O> extends Mono<O>
 						throw (RuntimeException) error;
 					}
 					else {
-						Exceptions.onErrorDropped(error);
-						return;
+						throw Exceptions.wrapUpstream(error);
 					}
 				}
 				break;
@@ -335,8 +332,7 @@ public final class MonoProcessor<O> extends Mono<O>
 				throw (RuntimeException) error;
 			}
 			else {
-				Exceptions.onErrorDropped(error);
-				return null;
+				throw Exceptions.wrapUpstream(error);
 			}
 		}
 		else {
@@ -403,8 +399,7 @@ public final class MonoProcessor<O> extends Mono<O>
 				throw (RuntimeException) error;
 			}
 			else {
-				Exceptions.onErrorDropped(error);
-				return false;
+				throw Exceptions.wrapUpstream(error);
 			}
 		}
 		return state > STATE_READY && subscription != null && state > STATE_POST_SUBSCRIBED;

--- a/src/main/java/reactor/core/publisher/MonoReduce.java
+++ b/src/main/java/reactor/core/publisher/MonoReduce.java
@@ -137,8 +137,7 @@ final class MonoReduce<T, R> extends MonoSource<T, R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 

--- a/src/main/java/reactor/core/publisher/MonoSingle.java
+++ b/src/main/java/reactor/core/publisher/MonoSingle.java
@@ -136,8 +136,7 @@ final class MonoSingle<T> extends MonoSource<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Exceptions.onErrorDropped(t);
-				return;
+				throw Exceptions.wrapUpstream(t);
 			}
 			done = true;
 

--- a/src/main/java/reactor/core/publisher/SchedulerGroup.java
+++ b/src/main/java/reactor/core/publisher/SchedulerGroup.java
@@ -901,7 +901,7 @@ public class SchedulerGroup implements Callable<Consumer<Runnable>>, Consumer<Ru
 				scheduler = schedulerFactory.call();
 			}
 			catch (Throwable ex){
-				throw Exceptions.failUpstream(ex);
+				throw Exceptions.wrapUpstream(ex);
 			}
 			this.scheduler = Objects.requireNonNull(scheduler, "Provided schedulerFactory returned no scheduler");
 

--- a/src/main/java/reactor/core/queue/MultiProducer.java
+++ b/src/main/java/reactor/core/queue/MultiProducer.java
@@ -183,7 +183,7 @@ final class MultiProducer extends RingBufferProducer
 
             if (!hasAvailableCapacity(gatingSequences, n, current))
             {
-                throw Exceptions.failWithOverflow();
+                throw Exceptions.overflow();
             }
         }
         while (!cursor.compareAndSet(current, next));

--- a/src/main/java/reactor/core/queue/NotFunMultiProducer.java
+++ b/src/main/java/reactor/core/queue/NotFunMultiProducer.java
@@ -172,7 +172,7 @@ final class NotFunMultiProducer extends RingBufferProducer
 
             if (!hasAvailableCapacity(gatingSequences, n, current))
             {
-                throw Exceptions.failWithOverflow();
+                throw Exceptions.overflow();
             }
         }
         while (!cursor.compareAndSet(current, next));

--- a/src/main/java/reactor/core/queue/SingleProducer.java
+++ b/src/main/java/reactor/core/queue/SingleProducer.java
@@ -157,7 +157,7 @@ final class SingleProducerSequencer extends SingleProducerSequencerFields
 
         if (!hasAvailableCapacity(n))
         {
-            throw Exceptions.failWithOverflow();
+            throw Exceptions.overflow();
         }
 
         long nextSequence = this.nextValue += n;

--- a/src/main/java/reactor/core/subscriber/ConsumerSubscriber.java
+++ b/src/main/java/reactor/core/subscriber/ConsumerSubscriber.java
@@ -138,7 +138,7 @@ public class ConsumerSubscriber<T> implements BaseSubscriber<T>, Receiver, Runna
 			errorConsumer.accept(t);
 		}
 		else {
-			Exceptions.onErrorDropped(t);
+			throw Exceptions.wrapUpstream(t);
 		}
 	}
 

--- a/src/main/java/reactor/core/subscriber/SignalEmitter.java
+++ b/src/main/java/reactor/core/subscriber/SignalEmitter.java
@@ -460,11 +460,11 @@ public class SignalEmitter<E>
 					return;
 				}
 				else {
-					throw Exceptions.failWithOverflow();
+					throw Exceptions.overflow();
 				}
 			}
 			else {
-				throw Exceptions.failWithOverflow();
+				throw Exceptions.overflow();
 			}
 		}
 		if(emission.isFailed()){

--- a/src/main/java/reactor/core/subscriber/SubscriberWithSubscriptionContext.java
+++ b/src/main/java/reactor/core/subscriber/SubscriberWithSubscriptionContext.java
@@ -131,7 +131,7 @@ final class SubscriberWithSubscriptionContext<T, C> implements BaseSubscriber<T>
 			errorConsumer.accept(t, subscriptionWithContext != null ? subscriptionWithContext.context() : null);
 		}
 		else {
-			Exceptions.onErrorDropped(t);
+			throw Exceptions.wrapUpstream(t);
 		}
 	}
 

--- a/src/main/java/reactor/core/subscriber/SubscriptionWithContext.java
+++ b/src/main/java/reactor/core/subscriber/SubscriptionWithContext.java
@@ -76,7 +76,7 @@ public class SubscriptionWithContext<C> implements Subscription, Receiver, Intro
 	 * Throw a CancelException
 	 */
 	public void abort(){
-		throw Exceptions.failWithCancel();
+		throw Exceptions.cancelException();
 	}
 
 	@Override

--- a/src/main/java/reactor/core/timer/HashWheelTimer.java
+++ b/src/main/java/reactor/core/timer/HashWheelTimer.java
@@ -227,7 +227,7 @@ class HashWheelTimer extends Timer {
 			long firstDelay,
 			Subscriber<? super Long> subscriber) {
 		if (loop.isInterrupted() || !loop.isAlive()) {
-			throw Exceptions.failWithCancel();
+			throw Exceptions.cancelException();
 		}
 		if (recurringTimeout != 0) {
 			checkResolution(recurringTimeout, resolution);

--- a/src/main/java/reactor/core/timer/Timer.java
+++ b/src/main/java/reactor/core/timer/Timer.java
@@ -315,7 +315,7 @@ public class Timer implements Timeable, Cancellable {
 
 	static void checkResolution(long time, long resolution) {
 		if (time % resolution != 0) {
-			throw Exceptions.failUpstream(new IllegalArgumentException(
+			throw Exceptions.wrapUpstream(new IllegalArgumentException(
 					"Period must be a multiple of Timer resolution (e.g. period % resolution == 0 ). " +
 							"Resolution for this Timer is: " + resolution + "ms"
 			));

--- a/src/main/java/reactor/core/util/BackpressureUtils.java
+++ b/src/main/java/reactor/core/util/BackpressureUtils.java
@@ -458,6 +458,6 @@ public enum BackpressureUtils {
 	 * Throw {@link reactor.core.util.Exceptions.InsufficientCapacityException}
 	 */
 	public static void reportMoreProduced() {
-		throw Exceptions.failWithOverflow();
+		throw Exceptions.overflow();
 	}
 }

--- a/src/main/java/reactor/core/util/Exceptions.java
+++ b/src/main/java/reactor/core/util/Exceptions.java
@@ -84,7 +84,7 @@ public enum Exceptions {
 	 * @param t the root cause
 	 * @return an unchecked exception
 	 */
-	public static RuntimeException fail(Throwable t) {
+	public static RuntimeException wrap(Throwable t) {
 		throwIfFatal(t);
 		if(t instanceof DownstreamException){
 			return (DownstreamException)t;
@@ -98,7 +98,7 @@ public enum Exceptions {
 	 * @param t the root cause
 	 * @return an unchecked exception that should choose bubbling up over error callback path
 	 */
-	public static RuntimeException failUpstream(Throwable t) {
+	public static RuntimeException wrapUpstream(Throwable t) {
 		throwIfFatal(t);
 		if(t instanceof UpstreamException){
 			return (UpstreamException) t;
@@ -110,7 +110,7 @@ public enum Exceptions {
 	 * Return a {@link CancelException}
 	 * @return a {@link CancelException}
 	 */
-	public static CancelException failWithCancel() {
+	public static CancelException cancelException() {
 		throw PlatformDependent.TRACE_CANCEL ? new CancelException() : CancelException.INSTANCE;
 	}
 
@@ -118,7 +118,7 @@ public enum Exceptions {
 	 * Return an {@link InsufficientCapacityException}
 	 * @return an {@link InsufficientCapacityException}
 	 */
-	public static InsufficientCapacityException failWithOverflow() {
+	public static InsufficientCapacityException overflow() {
 		return PlatformDependent.TRACE_NOCAPACITY ? new InsufficientCapacityException() :
 				InsufficientCapacityException.INSTANCE;
 	}
@@ -150,7 +150,7 @@ public enum Exceptions {
 	 * @param e the exception to handle
 	 */
 	public static void onErrorDropped(Throwable e) {
-		throw failUpstream(e);
+		throw wrapUpstream(e);
 	}
 
 	/**
@@ -160,7 +160,7 @@ public enum Exceptions {
 	 */
 	public static <T> void onNextDropped(T t) {
 		if(t != null) {
-			throw failWithCancel();
+			throw cancelException();
 		}
 	}
 

--- a/src/main/java/reactor/core/util/Exceptions.java
+++ b/src/main/java/reactor/core/util/Exceptions.java
@@ -133,27 +133,6 @@ public enum Exceptions {
 	}
 
 	/**
-	 * Take an unsignalled exception that is masking anowher one due to callback failure.
-	 *
-	 * @param e the exception to handle
-	 */
-	public static void onErrorDropped(Throwable e, Throwable root) {
-		if(root != null) {
-			e.addSuppressed(root);
-		}
-		onErrorDropped(e);
-	}
-
-	/**
-	 * Take an unsignalled exception that is masking anowher one due to callback failure.
-	 *
-	 * @param e the exception to handle
-	 */
-	public static void onErrorDropped(Throwable e) {
-		throw wrapUpstream(e);
-	}
-
-	/**
 	 * An unexpected event is about to be dropped
 	 *
 	 * @param t the dropping data

--- a/src/main/java/reactor/core/util/Exceptions.java
+++ b/src/main/java/reactor/core/util/Exceptions.java
@@ -144,25 +144,6 @@ public enum Exceptions {
 	}
 
 	/**
-	 * Throws the exception if it is a regular runtimeException or wraps
-	 * it into a ReactiveException.
-	 * <p>
-	 * Use unwrap to get back the original cause.
-	 * <p>
-	 * The method calls throwIfFatal().
-	 *
-	 * @param e the exception to propagate
-	 * @return dummy return type to allow using throw with the function call
-	 */
-	public static RuntimeException propagate(Throwable e) {
-		throwIfFatal(e);
-		if (e instanceof RuntimeException) {
-			throw (RuntimeException)e;
-		}
-		throw new UpstreamException(e);
-	}
-
-	/**
 	 * Atomic utility to safely mark a volatile throwable reference with a terminal marker.
 	 *
 	 * @param field the atomic container

--- a/src/test/java/reactor/core/publisher/FluxPeekTest.java
+++ b/src/test/java/reactor/core/publisher/FluxPeekTest.java
@@ -198,7 +198,7 @@ public class FluxPeekTest {
 
 		new FluxPeek<>(new FluxJust<>(1),
 				null,
-				d -> { throw Exceptions.fail(err); },
+				d -> { throw Exceptions.wrap(err); },
 				null,
 				null,
 				null,
@@ -214,7 +214,7 @@ public class FluxPeekTest {
 		try {
 			new FluxPeek<>(new FluxJust<>(1),
 					null,
-					d -> { throw Exceptions.failUpstream(err); },
+					d -> { throw Exceptions.wrapUpstream(err); },
 					null,
 					null,
 					null,

--- a/src/test/java/reactor/core/publisher/tck/SchedulerGroupIOTests.java
+++ b/src/test/java/reactor/core/publisher/tck/SchedulerGroupIOTests.java
@@ -65,7 +65,7 @@ public class SchedulerGroupIOTests extends AbstractProcessorVerification {
 				Thread.sleep(1000);
 			}
 			catch(InterruptedException ie){
-				throw Exceptions.fail(ie);
+				throw Exceptions.wrap(ie);
 			}
 		};
 		r.accept(() -> c.accept("Hello World!"));


### PR DESCRIPTION
After more thoughts, keeping the name `wrap()` and `wrapUpstream()` is more consistent with the rest of the API and more easy to understand to the user given the new behavior (this was also names used previously). Please notice that I am not 100% sure we should keep `throwIfFatal()` call as it is but that can be polished later.

The second and third commits are a proposal to reduce Exceptions API which can be confusing (I think `Exceptions.onNextDropped()` should be removed as well).

Globally I think we should avoid to mix public API for end users and internal stuff coming from RSC.