### PR TITLE
Reimplement Mono.repeatWhenEmpty()

### DIFF
--- a/src/test/java/reactor/core/publisher/MonoRepeatWhenEmptyTest.java
+++ b/src/test/java/reactor/core/publisher/MonoRepeatWhenEmptyTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.*;
+
+import reactor.core.test.TestSubscriber;
+
+public class MonoRepeatWhenEmptyTest {
+	@Test
+	public void repeatInfinite() {
+		AtomicInteger c = new AtomicInteger();
+		
+		Mono<Integer> source = Mono.defer(
+		        () -> c.getAndIncrement() < 3 ? Mono.empty() : Mono.just(c.get()));
+
+		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		
+		source.repeatWhenEmpty(o -> o).subscribe(ts);
+		
+		Assert.assertEquals(4, c.get());
+		
+		ts.assertValues(4)
+		.assertComplete()
+		.assertNoError();
+	}
+
+
+	@Test
+	public void repeatFinite() {
+		AtomicInteger c = new AtomicInteger();
+		
+		Mono<Integer> source = Mono.defer(
+		        () -> c.getAndIncrement() < 3 ? Mono.empty() : Mono.just(c.get()));
+
+		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		
+		source.repeatWhenEmpty(1000, o -> o).subscribe(ts);
+		
+		Assert.assertEquals(4, c.get());
+		
+		ts.assertValues(4)
+		.assertComplete()
+		.assertNoError();
+	}
+
+	@Test
+	public void repeatFiniteLessTimes() {
+		AtomicInteger c = new AtomicInteger();
+		
+		Mono<Integer> source = Mono.defer(
+		        () -> c.getAndIncrement() < 3 ? Mono.empty() : Mono.just(c.get()));
+
+		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		
+		source.repeatWhenEmpty(2, o -> o).subscribe(ts);
+		
+		Assert.assertEquals(3, c.get());
+		
+		ts.assertNoValues()
+		.assertNotComplete()
+		.assertError(NoSuchElementException.class);
+	}
+}


### PR DESCRIPTION
In response to #46.

The operator works by deferring a stateful sequence that sends a non-emptyness indicator to the `repeatWhen` where a `takeWhile` is evaluated with it and closes the repeat if the source did emit something.

I couldn't find tests for it so I'm not sure what the expected behavior was before (i.e, if repeat of 2 means 2 subscriptions total or 3 thus repeat 0 doesn't even subscribe?).