### PR TITLE
Rename Exceptions.fail*() to propagate() and bubble()

### DIFF
--- a/src/main/java/reactor/core/publisher/MonoCallable.java
+++ b/src/main/java/reactor/core/publisher/MonoCallable.java
@@ -83,7 +83,7 @@ extends Mono<T>
 		try {
 			return callable.call();
 		} catch (Throwable e) {
-			throw Exceptions.propagate(e);
+			throw Exceptions.bubble(e);
 		}
 	}
 }

--- a/src/main/java/reactor/core/publisher/MonoError.java
+++ b/src/main/java/reactor/core/publisher/MonoError.java
@@ -57,7 +57,7 @@ extends Mono<T> {
 
 	@Override
 	public T get() {
-		throw Exceptions.fail(getError());
+		throw Exceptions.propagate(getError());
 	}
 
 	@Override

--- a/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -136,7 +136,7 @@ public final class MonoProcessor<O> extends Mono<O>
 						if (error instanceof RuntimeException) {
 							throw (RuntimeException) error;
 						}
-						throw Exceptions.fail(error);
+						throw Exceptions.propagate(error);
 					case STATE_COMPLETE_NO_VALUE:
 						return null;
 				}

--- a/src/main/java/reactor/core/scheduler/Timer.java
+++ b/src/main/java/reactor/core/scheduler/Timer.java
@@ -315,7 +315,7 @@ public class Timer implements Timeable, Cancellable {
 
 	static void checkResolution(long time, long resolution) {
 		if (time % resolution != 0) {
-			throw Exceptions.failUpstream(new IllegalArgumentException(
+			throw Exceptions.bubble(new IllegalArgumentException(
 					"Period must be a multiple of Timer resolution (e.g. period % resolution == 0 ). " +
 							"Resolution for this Timer is: " + resolution + "ms"
 			));

--- a/src/main/java/reactor/core/util/Exceptions.java
+++ b/src/main/java/reactor/core/util/Exceptions.java
@@ -78,13 +78,14 @@ public enum Exceptions {
 	}
 
 	/**
-	 * Return an unchecked
-	 * {@link RuntimeException} to be thrown that will be propagated downstream through {@link org.reactivestreams.Subscriber#onError(Throwable)}
+	 * Return an unchecked {@link RuntimeException} to be thrown that will be propagated
+	 * downstream through {@link org.reactivestreams.Subscriber#onError(Throwable)}.
+	 * <p>This method invokes {@link #throwIfFatal(Throwable)}.
 	 *
 	 * @param t the root cause
 	 * @return an unchecked exception
 	 */
-	public static RuntimeException fail(Throwable t) {
+	public static RuntimeException propagate(Throwable t) {
 		throwIfFatal(t);
 		if(t instanceof DownstreamException){
 			return (DownstreamException)t;
@@ -93,17 +94,18 @@ public enum Exceptions {
 	}
 
 	/**
-	 * Return an unchecked {@link RuntimeException} to be thrown that will be propagated upstream
+	 * Return an unchecked {@link RuntimeException} to be thrown that will bubble upstream.
+	 * <p>This method invokes {@link #throwIfFatal(Throwable)}.
 	 *
 	 * @param t the root cause
 	 * @return an unchecked exception that should choose bubbling up over error callback path
 	 */
-	public static RuntimeException failUpstream(Throwable t) {
+	public static RuntimeException bubble(Throwable t) {
 		throwIfFatal(t);
 		if(t instanceof UpstreamException){
 			return (UpstreamException) t;
 		}
-		return new UpstreamException(t);
+		throw new UpstreamException(t);
 	}
 
 	/**
@@ -150,7 +152,7 @@ public enum Exceptions {
 	 * @param e the exception to handle
 	 */
 	public static void onErrorDropped(Throwable e) {
-		throw failUpstream(e);
+		throw bubble(e);
 	}
 
 	/**
@@ -162,25 +164,6 @@ public enum Exceptions {
 		if(t != null) {
 			throw failWithCancel();
 		}
-	}
-
-	/**
-	 * Throws the exception if it is a regular runtimeException or wraps
-	 * it into a ReactiveException.
-	 * <p>
-	 * Use unwrap to get back the original cause.
-	 * <p>
-	 * The method calls throwIfFatal().
-	 *
-	 * @param e the exception to propagate
-	 * @return dummy return type to allow using throw with the function call
-	 */
-	public static RuntimeException propagate(Throwable e) {
-		throwIfFatal(e);
-		if (e instanceof RuntimeException) {
-			throw (RuntimeException)e;
-		}
-		throw new UpstreamException(e);
 	}
 
 	/**

--- a/src/test/java/reactor/core/publisher/FluxPeekTest.java
+++ b/src/test/java/reactor/core/publisher/FluxPeekTest.java
@@ -198,7 +198,7 @@ public class FluxPeekTest {
 
 		new FluxPeek<>(new FluxJust<>(1),
 				null,
-				d -> { throw Exceptions.fail(err); },
+				d -> { throw Exceptions.propagate(err); },
 				null,
 				null,
 				null,
@@ -214,7 +214,7 @@ public class FluxPeekTest {
 		try {
 			new FluxPeek<>(new FluxJust<>(1),
 					null,
-					d -> { throw Exceptions.failUpstream(err); },
+					d -> { throw Exceptions.bubble(err); },
 					null,
 					null,
 					null,

--- a/src/test/java/reactor/core/publisher/tck/SchedulerGroupIOTests.java
+++ b/src/test/java/reactor/core/publisher/tck/SchedulerGroupIOTests.java
@@ -66,7 +66,7 @@ public class SchedulerGroupIOTests extends AbstractProcessorVerification {
 				Thread.sleep(1000);
 			}
 			catch(InterruptedException ie){
-				throw Exceptions.fail(ie);
+				throw Exceptions.propagate(ie);
 			}
 		};
 		r.schedule(() -> c.accept("Hello World!"));


### PR DESCRIPTION
Closes issue #36