### PR TITLE
Avoid stack overflow from repeatedly applying xxxWith()

### DIFF
--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -1551,7 +1552,19 @@ public abstract class Flux<T> implements Publisher<T>, Introspectable, Backpress
 	 *
 	 * @return the fastest sequence
 	 */
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public final Flux<T> ambWith(Publisher<? extends T> other) {
+		if (this instanceof FluxAmb) {
+			FluxAmb fluxConcatArray = (FluxAmb) this;
+			Publisher[] array = fluxConcatArray.array;
+			int n = array.length;
+			
+			Publisher[] newArray = new Publisher[n + 1];
+			System.arraycopy(array, 0, newArray, 0, n);
+			newArray[n] = other;
+			
+			return new FluxAmb<>(newArray);
+		}
 		return amb(this, other);
 	}
 
@@ -1976,8 +1989,19 @@ public abstract class Flux<T> implements Publisher<T>, Introspectable, Backpress
 	 *
 	 * @return a concatenated {@link Flux}
 	 */
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public final Flux<T> concatWith(Publisher<? extends T> other) {
+		if (this instanceof FluxConcatArray) {
+			FluxConcatArray fluxConcatArray = (FluxConcatArray) this;
+			Publisher[] array = fluxConcatArray.array;
+			int n = array.length;
+			
+			Publisher[] newArray = new Publisher[n + 1];
+			System.arraycopy(array, 0, newArray, 0, n);
+			newArray[n] = other;
+			
+			return new FluxConcatArray<>(newArray);
+		}
 		return new FluxConcatArray<>(this, other);
 	}
 
@@ -2916,9 +2940,48 @@ public abstract class Flux<T> implements Publisher<T>, Introspectable, Backpress
 	 * @return a new {@link Flux}
 	 */
 	public final Flux<T> mergeWith(Publisher<? extends T> other) {
+		if (this instanceof FluxFlatMap) {
+			@SuppressWarnings("rawtypes")
+			Publisher<T>[] newArray = expandArraySource((FluxFlatMap)this, other);
+			if (newArray != null) {
+				return merge(fromArray(newArray));
+			}
+		}
 		return merge(just(this, other));
 	}
 
+	/**
+	 * Extracts the array from a from a fromArray().flatMap() pattern
+	 * and returns a new array containing the new item, or returns
+	 * null if the upstream source is not a fromArray or not all
+	 * array items are Publishers.
+	 * @param <U> the return type
+	 * @param source the stage whose upstream should be checked
+	 * @param newItem the new Publisher to add
+	 * @return the array of publishers expanded or null
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	static <U> Publisher<U>[] expandArraySource(FluxSource source, Publisher newItem) {
+		Publisher<?> upstream = source.source;
+		if (upstream instanceof FluxArray) {
+			FluxArray<?> fluxArray = (FluxArray<?>) source.source;
+			
+			Object[] array = fluxArray.array;
+			int n = array.length;
+			
+			Publisher<U>[] newArray = new Flux[n + 1];
+			for (int i = 0; i < n; i++) {
+				if (!(array[i] instanceof Publisher)) {
+					return null;
+				}
+				newArray[i] = (Publisher<U>)array[i];
+			}
+			newArray[n] = newItem;
+			return newArray;
+		}
+		return null;
+	}
+	
 	/**
 	 * Make this
 	 * {@link Flux} subscribed N concurrency times for each child {@link Subscriber}. In effect, if this {@link Flux}
@@ -3912,9 +3975,21 @@ public abstract class Flux<T> implements Publisher<T>, Introspectable, Backpress
 	 * 
 	 * @return a prefixed {@link Flux} with given {@link Publisher} sequence
 	 */
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public final Flux<T> startWith(Publisher<? extends T> publisher) {
 		if (publisher == null) {
 			return this;
+		}
+		if (this instanceof FluxConcatArray) {
+			FluxConcatArray fluxConcatArray = (FluxConcatArray) this;
+			Publisher[] array = fluxConcatArray.array;
+			int n = array.length;
+			
+			Publisher[] newArray = new Publisher[n + 1];
+			System.arraycopy(array, 0, newArray, 1, n);
+			newArray[0] = publisher;
+			
+			return new FluxConcatArray<>(newArray);
 		}
 		return concat(publisher, this);
 	}

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -2944,10 +2944,10 @@ public abstract class Flux<T> implements Publisher<T>, Introspectable, Backpress
 			@SuppressWarnings("rawtypes")
 			Publisher<T>[] newArray = expandArraySource((FluxFlatMap)this, other);
 			if (newArray != null) {
-				return merge(fromArray(newArray));
+				return merge(fromArray(newArray), newArray.length);
 			}
 		}
-		return merge(just(this, other));
+		return merge(just(this, other), 2);
 	}
 
 	/**

--- a/src/test/java/reactor/core/publisher/FluxAmbWithTest.java
+++ b/src/test/java/reactor/core/publisher/FluxAmbWithTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.core.publisher;
+
+import org.junit.Test;
+
+import reactor.core.test.TestSubscriber;
+
+public class FluxAmbWithTest {
+
+	@Test
+	public void noStackOverflow() {
+		int n = 5000;
+		
+		Flux<Integer> source = Flux.just(1);
+		
+		Flux<Integer> result = source;
+		
+		for (int i = 0; i < n; i++) {
+			result = result.ambWith(source);
+		}
+		
+		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		
+		result.subscribe(ts);
+		
+		ts.assertValues(1)
+		.assertNoError()
+		.assertComplete();
+	}
+
+	@Test
+	public void dontBreakAmb() {
+		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		
+		Flux.amb(Flux.just(1), Flux.just(2)).ambWith(Flux.just(3))
+		.subscribe(ts);
+
+		
+		ts.assertValues(1)
+		.assertNoError()
+		.assertComplete();
+	}
+}

--- a/src/test/java/reactor/core/publisher/FluxConcatWithTest.java
+++ b/src/test/java/reactor/core/publisher/FluxConcatWithTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.core.publisher;
+
+import org.junit.Test;
+
+import reactor.core.test.TestSubscriber;
+
+public class FluxConcatWithTest {
+
+	@Test
+	public void noStackOverflow() {
+		int n = 5000;
+		
+		Flux<Integer> source = Flux.just(1);
+		
+		Flux<Integer> result = source;
+		
+		for (int i = 0; i < n; i++) {
+			result = result.concatWith(source);
+		}
+		
+		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		
+		result.subscribe(ts);
+		
+		ts.assertValueCount(n + 1)
+		.assertNoError()
+		.assertComplete();
+	}
+
+	@Test
+	public void noStackOverflow2() {
+		int n = 5000;
+		
+		Flux<Integer> source = Flux.just(1, 2).concatMap(Flux::just);
+		Flux<Integer> add = Flux.just(3);
+		
+		Flux<Integer> result = source;
+		
+		for (int i = 0; i < n; i++) {
+			result = result.concatWith(add);
+		}
+		
+		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		
+		result.subscribe(ts);
+		
+		ts.assertValueCount(n + 2)
+		.assertNoError()
+		.assertComplete();
+	}
+
+	@Test
+	public void noStackOverflow3() {
+		int n = 5000;
+		
+		Flux<Flux<Integer>> source = Flux.just(Flux.just(1), Flux.just(2));
+		Flux<Flux<Integer>> add = Flux.just(Flux.just(3));
+		
+		Flux<Flux<Integer>> result = source;
+		
+		for (int i = 0; i < n; i++) {
+			result = result.concatWith(add);
+		}
+		
+		TestSubscriber<Object> ts = new TestSubscriber<>();
+		
+		result.subscribe(ts);
+		
+		ts.assertValueCount(n + 2)
+		.assertNoError()
+		.assertComplete();
+	}
+
+	
+	@Test
+	public void dontBreakFluxArrayConcatMap() {
+		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		
+		Flux.just(1, 2).concatMap(Flux::just).concatWith(Flux.just(3))
+		.subscribe(ts);
+
+		
+		ts.assertValues(1, 2, 3)
+		.assertNoError()
+		.assertComplete();
+	}
+}

--- a/src/test/java/reactor/core/publisher/FluxMergeWithTest.java
+++ b/src/test/java/reactor/core/publisher/FluxMergeWithTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.core.publisher;
+
+import org.junit.Test;
+
+import reactor.core.test.TestSubscriber;
+
+public class FluxMergeWithTest {
+
+	@Test
+	public void noStackOverflow() {
+		int n = 5000;
+		
+		Flux<Integer> source = Flux.just(1);
+		
+		Flux<Integer> result = source;
+		
+		for (int i = 0; i < n; i++) {
+			result = result.mergeWith(source);
+		}
+		
+		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		
+		result.subscribe(ts);
+		
+		ts.assertValueCount(n + 1)
+		.assertNoError()
+		.assertComplete();
+	}
+
+	@Test
+	public void noStackOverflow2() {
+		int n = 5000;
+		
+		Flux<Integer> source = Flux.just(1, 2).flatMap(Flux::just);
+		Flux<Integer> add = Flux.just(3);
+		
+		Flux<Integer> result = source;
+		
+		for (int i = 0; i < n; i++) {
+			result = result.mergeWith(add);
+		}
+		
+		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		
+		result.subscribe(ts);
+		
+		ts.assertValueCount(n + 2)
+		.assertNoError()
+		.assertComplete();
+	}
+
+	@Test
+	public void noStackOverflow3() {
+		int n = 5000;
+		
+		Flux<Flux<Integer>> source = Flux.just(Flux.just(1), Flux.just(2));
+		Flux<Flux<Integer>> add = Flux.just(Flux.just(3));
+		
+		Flux<Flux<Integer>> result = source;
+		
+		for (int i = 0; i < n; i++) {
+			result = result.mergeWith(add);
+		}
+		
+		TestSubscriber<Object> ts = new TestSubscriber<>();
+		
+		result.subscribe(ts);
+		
+		ts.assertValueCount(n + 2)
+		.assertNoError()
+		.assertComplete();
+	}
+
+	
+	@Test
+	public void dontBreakFluxArrayFlatmap() {
+		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		
+		Flux.just(1, 2).flatMap(Flux::just).mergeWith(Flux.just(3))
+		.subscribe(ts);
+
+		
+		ts.assertValues(1, 2, 3)
+		.assertNoError()
+		.assertComplete();
+	}
+}

--- a/src/test/java/reactor/core/publisher/FluxStartWithTest.java
+++ b/src/test/java/reactor/core/publisher/FluxStartWithTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.core.publisher;
+
+import org.junit.Test;
+
+import reactor.core.test.TestSubscriber;
+
+public class FluxStartWithTest {
+
+	@Test
+	public void noStackOverflow() {
+		int n = 5000;
+		
+		Flux<Integer> source = Flux.just(1);
+		
+		Flux<Integer> result = source;
+		
+		for (int i = 0; i < n; i++) {
+			result = result.startWith(source);
+		}
+		
+		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		
+		result.subscribe(ts);
+		
+		ts.assertValueCount(n + 1)
+		.assertNoError()
+		.assertComplete();
+	}
+
+	@Test
+	public void noStackOverflow2() {
+		int n = 5000;
+		
+		Flux<Integer> source = Flux.just(1, 2).concatMap(Flux::just);
+		Flux<Integer> add = Flux.just(3);
+		
+		Flux<Integer> result = source;
+		
+		for (int i = 0; i < n; i++) {
+			result = result.startWith(add);
+		}
+		
+		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		
+		result.subscribe(ts);
+		
+		ts.assertValueCount(n + 2)
+		.assertNoError()
+		.assertComplete();
+	}
+
+	@Test
+	public void noStackOverflow3() {
+		int n = 5000;
+		
+		Flux<Flux<Integer>> source = Flux.just(Flux.just(1), Flux.just(2));
+		Flux<Flux<Integer>> add = Flux.just(Flux.just(3));
+		
+		Flux<Flux<Integer>> result = source;
+		
+		for (int i = 0; i < n; i++) {
+			result = result.startWith(add);
+		}
+		
+		TestSubscriber<Object> ts = new TestSubscriber<>();
+		
+		result.subscribe(ts);
+		
+		ts.assertValueCount(n + 2)
+		.assertNoError()
+		.assertComplete();
+	}
+
+	
+	@Test
+	public void dontBreakFluxArrayConcatMap() {
+		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		
+		Flux.just(1, 2).concatMap(Flux::just).startWith(Flux.just(3))
+		.subscribe(ts);
+
+		
+		ts.assertValues(3, 1, 2)
+		.assertNoError()
+		.assertComplete();
+	}
+}


### PR DESCRIPTION
This PR uses macro-fusion: rewrite to avoid StackOverflowError when one applies `mergeWith`, `concatWith`, `startWith` and `ambWith` repeatedly.

The `mergeWith` is ugly because without a dedicated fixed-length `merge` operator, one has to verify the proper input to the fromArray.