### PR TITLE
Implements onError* methods with exception type as parameter

### DIFF
--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -16,36 +16,23 @@
 
 package reactor.core.publisher;
 
-import org.reactivestreams.Processor;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
-import reactor.core.flow.Cancellation;
-import reactor.core.flow.Fuseable;
-import reactor.core.queue.QueueSupplier;
-import reactor.core.scheduler.Scheduler;
-import reactor.core.scheduler.TimedScheduler;
-import reactor.core.scheduler.Timer;
-import reactor.core.state.Backpressurable;
-import reactor.core.state.Introspectable;
-import reactor.core.subscriber.LambdaSubscriber;
-import reactor.core.subscriber.SignalEmitter;
-import reactor.core.subscriber.SubscriberWithContext;
-import reactor.core.subscriber.Subscribers;
-import reactor.core.tuple.*;
-import reactor.core.util.Exceptions;
-import reactor.core.util.Logger;
-import reactor.core.util.PlatformDependent;
-import reactor.core.util.ReactiveStateUtils;
-
 import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.function.*;
 import java.util.logging.Level;
 import java.util.stream.Stream;
+
+import org.reactivestreams.*;
+
+import reactor.core.flow.*;
+import reactor.core.queue.QueueSupplier;
+import reactor.core.scheduler.*;
+import reactor.core.scheduler.Timer;
+import reactor.core.state.*;
+import reactor.core.subscriber.*;
+import reactor.core.tuple.*;
+import reactor.core.util.*;
 
 /**
  * A Reactive Streams {@link Publisher} with rx operators that emits 0 to N elements, and then completes
@@ -993,7 +980,7 @@ public abstract class Flux<T> implements Publisher<T>, Introspectable, Backpress
 	 * @param <T> {@link Subscriber} type target
 	 * @return a {@link Flux} handling error if exceptions match otherwise an rejected Flux
 	 */
-	public final <T> Flux<T> onErrorResumeWith(
+	public final Flux<T> onErrorResumeWith(
 			Class<? extends Throwable> errorType,
 			Publisher<? extends T> source,
 			Supplier<Publisher<? extends T>> fallback) {

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -980,7 +980,7 @@ public abstract class Flux<T> implements Publisher<T>, Introspectable, Backpress
 	 * @param <T> {@link Subscriber} type target
 	 * @return a {@link Flux} handling error if exceptions match otherwise an rejected Flux
 	 */
-	public final Flux<T> onErrorResumeWith(
+	public static <T> Flux<T> onErrorResumeWith(
 			Class<? extends Throwable> errorType,
 			Publisher<? extends T> source,
 			Supplier<Publisher<? extends T>> fallback) {

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -16,6 +16,24 @@
 
 package reactor.core.publisher;
 
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.LongConsumer;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.stream.LongStream;
+
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -29,19 +47,15 @@ import reactor.core.state.Backpressurable;
 import reactor.core.state.Completable;
 import reactor.core.state.Introspectable;
 import reactor.core.subscriber.LambdaSubscriber;
-import reactor.core.tuple.*;
+import reactor.core.tuple.Tuple;
+import reactor.core.tuple.Tuple2;
+import reactor.core.tuple.Tuple3;
+import reactor.core.tuple.Tuple4;
+import reactor.core.tuple.Tuple5;
+import reactor.core.tuple.Tuple6;
 import reactor.core.util.Logger;
 import reactor.core.util.PlatformDependent;
 import reactor.core.util.ReactiveStateUtils;
-
-import java.time.Duration;
-import java.util.Optional;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.*;
-import java.util.logging.Level;
-import java.util.stream.LongStream;
 
 /**
  * A Reactive Streams {@link Publisher} with basic rx operators that completes successfully by emitting an element, or
@@ -1723,7 +1737,7 @@ public abstract class Mono<T> implements Publisher<T>, Backpressurable, Introspe
      * @return a reject Mono with supplied exception
 	 *
 	 * @see this#otherwise(Function)
-	 * @see this#otherwise(Class, Supplier) 
+	 * @see this#
      */
 	public final Mono<T> otherwiseReplace(Class<? extends Throwable> exceptionType,
                                           final Supplier<? extends Throwable> exceptionSupplier) {

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -52,7 +52,7 @@ import java.util.stream.LongStream;
  * <p>
  *
  * <p>The rx operators will offer aliases for input {@link Mono} type to preserve the "at most one"
- * property of the resulting {@link Mono}. For instance {@link Mono#flatMap flatMap} returns a {@link Flux} with 
+ * property of the resulting {@link Mono}. For instance {@link Mono#flatMap flatMap} returns a {@link Flux} with
  * possibly
  * more than 1 emission. Its alternative enforcing {@link Mono} input is {@link Mono#then then}.
  *
@@ -60,9 +60,9 @@ import java.util.stream.LongStream;
  *
  * <p>It is intended to be used in implementations and return types, input parameters should keep using raw {@link
  * Publisher} as much as possible.
- * 
+ *
  * @param <T> the type of the single value of this class
- * 
+ *
  * @author Sebastien Deleuze
  * @author Stephane Maldini
  * @author Joao Pedro Evangelista
@@ -118,7 +118,7 @@ public abstract class Mono<T> implements Publisher<T>, Backpressurable, Introspe
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/defer1.png" alt="">
 	 * <p>
 	 * @param supplier a {@link Mono} factory
-	 * 
+	 *
 	 * @param <T> the element type of the returned Mono instance
 	 *
 	 * @return a new {@link Mono} factory
@@ -821,7 +821,7 @@ public abstract class Mono<T> implements Publisher<T>, Backpressurable, Introspe
 	 * @param transformer the {@link Function} applying this {@link Mono}
 	 * @param <P> the returned {@link Publisher} output
 	 * @param <V> the element type of the returned Publisher
-	 * 
+	 *
 	 * @return the transformed {@link Mono}
 	 */
 	public final <V, P extends Publisher<V>> P as(Function<? super Mono<T>, P> transformer) {
@@ -836,7 +836,7 @@ public abstract class Mono<T> implements Publisher<T>, Backpressurable, Introspe
 	 * <p>
 	 * @param other the {@link Mono} to combine with
 	 * @param <T2> the element type of the other Mono instance
-	 * 
+	 *
 	 * @return a new combined Mono
 	 * @see #when
 	 */
@@ -1101,7 +1101,7 @@ public abstract class Mono<T> implements Publisher<T>, Backpressurable, Introspe
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/dematerialize1.png" alt="">
 	 * @param <X> the dematerialized type
-	 * 
+	 *
 	 * @return a dematerialized {@link Mono}
 	 */
 	@SuppressWarnings("unchecked")
@@ -1484,16 +1484,16 @@ public abstract class Mono<T> implements Publisher<T>, Backpressurable, Introspe
 
 	/**
 	 * Hides the identity of this {@link Mono} instance.
-	 * 
+	 *
 	 * <p>The main purpose of this operator is to prevent certain identity-based
 	 * optimizations from happening, mostly for diagnostic purposes.
-	 * 
+	 *
 	 * @return a new {@link Mono} instance
 	 */
 	public final Mono<T> hide() {
 	    return new MonoHide<>(this);
 	}
-	
+
 	/**
 	 * Ignores onNext signal (dropping it) and only reacts on termination.
 	 *
@@ -1710,6 +1710,28 @@ public abstract class Mono<T> implements Publisher<T>, Backpressurable, Introspe
 				return fallback.get();
 			} else {
 				return Mono.error(e);
+			}
+		});
+	}
+
+	/**
+	 * Subscribe to a rejected Mono which wraps the error occurred in the new
+	 * type provided by supplier
+	 *
+	 * @param exceptionType expected type of exception
+	 * @param exceptionSupplier new exception supplier
+     * @return a reject Mono with supplied exception
+	 *
+	 * @see this#otherwise(Function)
+	 * @see this#otherwise(Class, Supplier) 
+     */
+	public final Mono<T> otherwiseReplace(Class<? extends Throwable> exceptionType,
+                                          final Supplier<? extends Throwable> exceptionSupplier) {
+		return otherwise(throwable -> {
+			if (exceptionType.isAssignableFrom(throwable.getClass())) {
+				return Mono.error(exceptionSupplier.get());
+			} else {
+		        return 	Mono.error(throwable);
 			}
 		});
 	}

--- a/src/test/groovy/reactor/core/FluxSpec.groovy
+++ b/src/test/groovy/reactor/core/FluxSpec.groovy
@@ -17,18 +17,11 @@ package reactor.core
 
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscription
-import reactor.core.publisher.EmitterProcessor
-import reactor.core.publisher.FluxProcessor
-import reactor.core.publisher.Mono
-import reactor.core.publisher.Flux
-import reactor.core.publisher.MonoProcessor
-import reactor.core.publisher.SchedulerGroup
-import reactor.core.publisher.Signal
+import reactor.core.publisher.*
+import reactor.core.scheduler.Timer
 import reactor.core.subscriber.SubscriberWithContext
 import reactor.core.test.TestSubscriber
-import reactor.core.scheduler.Timer
 import reactor.core.util.ReactiveStateUtils
-import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -2668,7 +2661,32 @@ class FluxSpec extends Specification {
 
 		then:
 			!promise.get()
-	}/*
+	}
+
+
+	def 'A Flux can resume with new value only when the exception occurred match the expected'() {
+		given: 'a rejected Flux'
+
+		def failure = new Exception()
+		def promise = Flux.error(failure)
+
+		when: 'onErrorResumeWith is added to handle multiple exceptions'
+
+		def result = promise
+				.onErrorResumeWith(IllegalStateException, {Flux.just(4,5,6)})
+				.onErrorResumeWith(Exception, {Flux.just(1,2,3)})
+			.toList()
+		    .get()
+
+		promise.debug()
+
+		then: 'A flux is handled using the matching exception type then resumed with supplied list of integers'
+
+		result == [1,2,3]
+		result != [4,5,6]
+	}
+
+	/*
 
 	def "A Codec output can be streamed"() {
 		given: "A delimiter stripping decoder and a buffer of delimited data"

--- a/src/test/groovy/reactor/core/MonoSpec.groovy
+++ b/src/test/groovy/reactor/core/MonoSpec.groovy
@@ -261,8 +261,8 @@ class MonoSpec extends Specification {
 
 	  when: "otherwise is added to translate the exception"
 
-	  promise.otherwise(NoSuchElementException, {
-		  Mono.error(new IllegalArgumentException("No element on the planet"))
+	  promise.otherwiseReplace(NoSuchElementException, {
+		  new IllegalArgumentException("No element on the planet")
 	  }).subscribeWith(MonoProcessor.create())
 
 	  promise.debug()

--- a/src/test/groovy/reactor/core/MonoSpec.groovy
+++ b/src/test/groovy/reactor/core/MonoSpec.groovy
@@ -26,11 +26,11 @@ import spock.lang.Specification
 
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * @author Stephane Maldini
+ * @author Joao Pedro Evangelista
  */
 class MonoSpec extends Specification {
 
@@ -197,6 +197,78 @@ class MonoSpec extends Specification {
 	then: "the consumer is invoked with the rejecting value"
 	thrown(Exception)
 	acceptedValue == failure
+  }
+
+  def "A doOnError is called with exceptionType so only if the exception is satisfied the accept is called"() {
+	  given: "a MonoProcessor with error"
+	  def failure = new IllegalArgumentException()
+	  def promise = Mono.error(failure)
+
+	  when: "an doOnError for another exception is added"
+	  def counter = 0
+	  promise.doOnError(IllegalStateException, { counter = 1 })
+			  .subscribeWith(MonoProcessor.create())
+	  println promise.debug()
+
+	  then: "the consumer is not invoked"
+	  thrown(IllegalArgumentException)
+	  counter == 0
+
+  }
+
+  def "Multiple doOnError can call different types of exception"() {
+	  given: "a MonoProcessor with error"
+	  def failure = new IllegalArgumentException()
+	  def promise = Mono.error(failure)
+
+	  when: "two doOnError is added "
+
+	  def counter = 0
+
+	  promise.doOnError(IllegalArgumentException, {counter = 2})
+			  .doOnError(IllegalStateException, {counter = 3})
+			  .subscribeWith(MonoProcessor.create())
+
+	  println promise.debug()
+
+	  then: "Only one doOnError consumer is executed"
+	  thrown(IllegalArgumentException)
+	  counter == 2
+  }
+
+  def "An otherwise can handle properly a type of exception if it matches the thrown"() {
+	  given: "a MonoProcessor with error"
+
+	  def failure = new IllegalArgumentException()
+	  def promise = Mono.error(failure)
+
+	  when: "otherwise is added to handle the same exception type of error"
+
+	  def result = promise.otherwise(IllegalArgumentException, { Mono.just("I'm a fallback")})
+	         .get()
+	  println promise.debug()
+
+	  then: "A fallback becomes the result and exception is suppressed"
+
+	  result == "I'm a fallback"
+  }
+
+  def "When a error occurs it can be translated to another exception type"() {
+	  given: "A Mono with NoSuchElementException"
+
+	  def failure = new NoSuchElementException()
+	  def promise = Mono.error(failure)
+
+	  when: "otherwise is added to translate the exception"
+
+	  promise.otherwise(NoSuchElementException, {
+		  Mono.error(new IllegalArgumentException("No element on the planet"))
+	  }).subscribeWith(MonoProcessor.create())
+
+	  promise.debug()
+
+	  then: "The error on mono is translated to a new type and thrown"
+	  thrown(IllegalArgumentException)
   }
 
   def "When getting a rejected promise's value the exception that the promise was rejected with is thrown"() {


### PR DESCRIPTION
Now a Mono#doOnError method is added accepting the type of exception it should handle, more than one can be chained togheter
so we can create diffent types of handlers by the type of exception, the new method use the current method that only accepts
a consumer.

Another otherwise method was created to use a supplier when the exception types match,
falling back to throwing the current error into a Mono#error

Flux can now resume with when a given exception type matches the error type, the error type can not be changed like Mono#otherwiseReplace
because of UpstreamException wraps fatals exceptions based on Reactive Streams list of exceptions allowed to bubble (as seen on documentation)

Fixes #58 