### PR TITLE
Add exception mappers based on the exception type

### DIFF
--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -51,6 +51,7 @@ import reactor.core.util.*;
  *
  * @author Sebastien Deleuze
  * @author Stephane Maldini
+ * @author Joao Pedro Evangelista
  *
  * @see Mono
  * @since 2.5
@@ -967,6 +968,30 @@ public abstract class Flux<T> implements Publisher<T>, Introspectable, Backpress
 			Publisher<? extends T> source,
 			Function<Throwable, ? extends Publisher<? extends T>> fallback) {
 		return new FluxResume<>(source, fallback);
+	}
+
+	/**
+	 * Create a {@link Flux} that will fallback to a publish if the error exception matches the given type
+	 * failing to an error with the same that of original
+	 *
+	 * @param errorType exception type to match
+	 * @param source source sequence
+	 * @param fallback supplier called when the exceptions and errorType matches
+	 * @param <T> {@link Subscriber} type target
+	 * @return a {@link Flux} handling error if exceptions match otherwise an rejected Flux
+	 */
+	public static <T> Flux<T> onErrorResumeWith(
+			Class<? extends Throwable> errorType,
+			Publisher<? extends T> source,
+			Supplier<Publisher<? extends T>> fallback) {
+
+		return new FluxResume<>(source, throwable -> {
+			if (errorType.isAssignableFrom(throwable.getClass())) {
+				return fallback.get();
+			} else {
+				return Flux.error(throwable);
+			}
+		});
 	}
 
 	/**
@@ -3328,6 +3353,22 @@ public abstract class Flux<T> implements Publisher<T>, Introspectable, Backpress
 	 */
 	public final Flux<T> onErrorResumeWith(Function<Throwable, ? extends Publisher<? extends T>> fallback) {
 		return new FluxResume<>(this, fallback);
+	}
+
+	/**
+	 * Subscribe to a fallback Publisher if the error exception matches the given type
+	 * failing to an error with the same that of original and assign the supplier error
+	 * value as error, if does not match the given type it return the same error on a new Flux
+	 *
+	 * @param errorType exception type to match
+	 * @param fallback supplier called when the exceptions and errorType matches
+	 * @return a {@link Flux} handling error if exceptions match otherwise an rejected Flux
+	 */
+	public final Flux<T> onErrorResumeWith(
+			Class<? extends Throwable> errorType,
+			Supplier<Publisher<? extends T>> fallback) {
+
+		return onErrorResumeWith(errorType, this, fallback);
 	}
 
 	/**

--- a/src/test/groovy/reactor/core/FluxSpec.groovy
+++ b/src/test/groovy/reactor/core/FluxSpec.groovy
@@ -2667,7 +2667,32 @@ class FluxSpec extends Specification {
 
 		then:
 			!promise.get()
-	}/*
+	}
+
+	def 'A Flux can resume with new value only when the exception occurred match the expected'() {
+		given: 'a rejected Flux'
+
+		def failure = new Exception()
+		def promise = Flux.error(failure)
+
+		when: 'onErrorResumeWith is added to handle multiple exceptions'
+
+		def result = promise
+				.onErrorResumeWith(IllegalStateException, {Flux.just(4,5,6)})
+				.onErrorResumeWith(Exception, {Flux.just(1,2,3)})
+				.toList()
+				.get()
+
+		promise.debug()
+
+		then: 'A flux is handled using the matching exception type then resumed with supplied list of integers'
+
+		result == [1,2,3]
+		result != [4,5,6]
+	}
+
+
+	/*
 
 	def "A Codec output can be streamed"() {
 		given: "A delimiter stripping decoder and a buffer of delimited data"

--- a/src/test/groovy/reactor/core/MonoSpec.groovy
+++ b/src/test/groovy/reactor/core/MonoSpec.groovy
@@ -195,6 +195,136 @@ class MonoSpec extends Specification {
 	acceptedValue == failure
   }
 
+	def "A doOnError is called with exceptionType so only if the exception is satisfied the accept is called"() {
+		given: "a MonoProcessor with error"
+		def failure = new IllegalArgumentException()
+		def promise = Mono.error(failure)
+
+		when: "an doOnError for another exception is added"
+		def counter = 0
+		promise.doOnError(IllegalStateException, { counter = 1 })
+				.get()
+		println promise.debug()
+
+		then: "the consumer is not invoked"
+		thrown(IllegalArgumentException)
+		counter == 0
+
+	}
+
+	def "Multiple doOnError can call different types of exception"() {
+		given: "a MonoProcessor with error"
+		def failure = new IllegalArgumentException()
+		def promise = Mono.error(failure)
+
+		when: "two doOnError is added "
+
+		def counter = 0
+
+		promise.doOnError(IllegalArgumentException, {counter = 2})
+				.doOnError(IllegalStateException, {counter = 3})
+				.get()
+
+
+		println promise.debug()
+
+		then: "Only one doOnError consumer is executed"
+		thrown(IllegalArgumentException)
+		counter == 2
+	}
+
+	def "An otherwise can handle properly a type of exception if it matches the thrown"() {
+		given: "a MonoProcessor with error"
+
+		def failure = new IllegalArgumentException()
+		def promise = Mono.error(failure)
+
+		when: "otherwise is added to handle the same exception type of error"
+
+		def result = promise.otherwise(IllegalArgumentException, Mono.<String>just("I'm a fallback"))
+				.get()
+		println promise.debug()
+
+		then: "A fallback becomes the result and exception is suppressed"
+
+		result == "I'm a fallback"
+	}
+
+	def "When a error occurs it can be mapped to another exception type"() {
+		given: "A rejected Mono with NoSuchElementException"
+
+		def failure = new NoSuchElementException()
+		def promise = Mono.error(failure)
+
+		when: "otherwise is added to translate the exception"
+
+		promise.mapError(NoSuchElementException, { Mono.error(new IllegalArgumentException(it)) })
+				.get()
+
+
+		promise.debug()
+
+		then: "The error on mono is transformed to a new type and thrown"
+		thrown(IllegalArgumentException)
+	}
+
+	def "A rejected Mono can map it's error into a new Mono with value"() {
+		given: "A rejected Mono with IllegalArgumentException"
+
+		def failure = new IllegalArgumentException()
+		def promise = Mono.error(failure)
+
+		and: "A Mono as fallback"
+
+		def fallback = Mono.just(1)
+
+		when: "An error is mapped into another result by matching its error type"
+
+		def promiseResult = promise.mapError(IllegalArgumentException, { fallback }).get()
+		promise.debug()
+
+		then: "No error is thrown and fallback is available"
+		noExceptionThrown()
+		promiseResult == 1
+
+	}
+
+	def "When a mapError is provided and no error is thrown on the stream mapError must do nothing"() {
+		given: "A Mono with a value"
+
+		def promise = Mono.just(1)
+
+		when: "mapError is added to the chain and a result is got"
+
+		def result = promise.mapError(Exception, {Mono.just(2)}).get()
+
+		then: "result must be equals than the original and no exception thrown"
+		noExceptionThrown()
+		result == 1
+	}
+
+
+
+	def "A rejected Mono can use mapError to transform the original exception into a new one wrapping into a Mono"() {
+		given: "A rejected Mono"
+
+		def failure = new Exception()
+		def promise = Mono.error(failure)
+
+		when: "mapError is added to return a IllegalStateException"
+
+		promise.mapError(Exception, { Mono.error(new IllegalStateException(it))} )
+				.get()
+
+		promise.debug()
+
+		then: "A IllegalStateException must be thrown instead of the original"
+
+		thrown(IllegalStateException)
+
+	}
+
+
   def "When getting a rejected promise's value the exception that the promise was rejected with is thrown"() {
 	given: "a rejected MonoProcessor"
 	def failure = new Exception()

--- a/src/test/java/reactor/core/publisher/scenarios/MonoTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/MonoTests.java
@@ -24,11 +24,13 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
 import reactor.core.tuple.Tuple2;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Stephane Maldini
+ * @author Joao Pedro Evangelista
  */
 public class MonoTests {
 
@@ -88,5 +90,20 @@ public class MonoTests {
 		final CountDownLatch successCountDownLatch = new CountDownLatch(1);
 		promise.consume(v -> successCountDownLatch.countDown());
 		assertThat("Failed", successCountDownLatch.await(10, TimeUnit.SECONDS));
+	}
+
+	@Test
+	public void mapAnErrorThenChainWithOtherwise() throws Exception {
+		IllegalArgumentException failure = new IllegalArgumentException();
+		Mono<Object> promise = Mono.error(failure);
+		Object result = promise.mapError(IllegalArgumentException.class,
+				throwable -> Mono.error(new IllegalStateException(throwable)))
+				.otherwise(IllegalStateException.class, Mono.just(1))
+				.get();
+		assertThat("Result must be instance of integer when catch two times by otherwise",
+				result,
+				instanceOf(Integer.class));
+		Integer intResult = (Integer) result;
+		assertThat("Result is one",intResult, is(1));
 	}
 }


### PR DESCRIPTION
On Mono it includes a new `otherwise`  method that executes the callback
 only when the exception type matches the error and supply a Mono fallback,
 a new `mapError `was added to allow map the error into a new Mono or a new rejected Mono preserving the original exception.

On Flux a `onErrorResumeWith` with exception type matchers was added both for contructing a new Flux and an operator, similar to `Mono#otherwise(Class, Mono)`

Fixes #58 

> I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.