### PR TITLE
DeferCompose operator proposition

### DIFF
--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -504,6 +504,19 @@ public abstract class Flux<T> implements Publisher<T>, Introspectable, Backpress
 	public static <T> Flux<T> defer(Supplier<? extends Publisher<T>> supplier) {
 		return new FluxDefer<>(supplier);
 	}
+	
+	/**
+	 * Defers the composition of operators to subscription time.
+     * <p>
+     * This allows per-subscriber state to be present while also
+     * composing operators with the upstream.
+	 * @param <R> the result value type
+	 * @param composer the composer function taking this instance and returns a publisher with the desired type
+	 * @return a deferred {@link Flux}
+	 */
+	public <R> Flux<R> deferCompose(Function<? super Flux<? extends T>, ? extends Publisher<? extends R>> composer) {
+	    return new FluxDeferCompose<>(this, composer);
+	}
 
 	/**
 	 * Create a {@link Flux} that completes without emitting any item.

--- a/src/main/java/reactor/core/publisher/FluxDeferCompose.java
+++ b/src/main/java/reactor/core/publisher/FluxDeferCompose.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.core.publisher;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.reactivestreams.*;
+
+import reactor.core.util.*;
+
+/**
+ * Defers the composition of operators to subscription time.
+ * <p>
+ * This allows per-subscriber state to be present while also
+ * composing operators with the upstream.
+ * 
+ * @param <T> the input stream type
+ * @param <R> the output stream type
+ */
+public final class FluxDeferCompose<T, R> extends FluxSource<T, R> {
+
+    final Function<? super Flux<? extends T>, ? extends Publisher<? extends R>> composer;
+
+    public FluxDeferCompose(Flux<? extends T> source,
+            Function<? super Flux<? extends T>, ? extends Publisher<? extends R>> composer) {
+        super(source);
+        this.composer = Objects.requireNonNull(composer, "composer");
+    }
+    
+    @Override
+    public void subscribe(Subscriber<? super R> s) {
+        
+        Publisher<? extends R> output;
+        
+        try {
+            output = composer.apply((Flux<? extends T>)source);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptySubscription.error(s, ex);
+            return;
+        }
+        
+        if (output == null) {
+            EmptySubscription.error(s, new NullPointerException("The composer returned a null Publisher"));
+            return;
+        }
+        
+        output.subscribe(s);
+    }
+}

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -221,6 +221,19 @@ public abstract class Mono<T> implements Publisher<T>, Backpressurable, Introspe
 		return new MonoDefer<>(supplier);
 	}
 
+	   /**
+     * Defers the composition of operators to subscription time.
+     * <p>
+     * This allows per-subscriber state to be present while also
+     * composing operators with the upstream.
+     * @param <R> the result value type
+     * @param composer the composer function taking this instance and returns a mono with the desired type
+     * @return a deferred {@link Mono}
+     */
+    public <R> Mono<R> deferCompose(Function<? super Mono<? extends T>, ? extends Mono<? extends R>> composer) {
+        return new MonoDeferCompose<>(this, composer);
+    }
+
 	/**
 	 * Create a Mono which delays an onNext signal of {@code duration} milliseconds and complete.
 	 * If the demand cannot be produced in time, an onError will be signalled instead.

--- a/src/main/java/reactor/core/publisher/MonoDeferCompose.java
+++ b/src/main/java/reactor/core/publisher/MonoDeferCompose.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.core.publisher;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.reactivestreams.*;
+
+import reactor.core.util.*;
+
+/**
+ * Defers the composition of operators to subscription time.
+ * <p>
+ * This allows per-subscriber state to be present while also
+ * composing operators with the upstream.
+ * 
+ * @param <T> the input stream type
+ * @param <R> the output stream type
+ */
+public final class MonoDeferCompose<T, R> extends MonoSource<T, R> {
+
+    final Function<? super Mono<? extends T>, ? extends Mono<? extends R>> composer;
+
+    public MonoDeferCompose(Mono<? extends T> source,
+            Function<? super Mono<? extends T>, ? extends Mono<? extends R>> composer) {
+        super(source);
+        this.composer = Objects.requireNonNull(composer, "composer");
+    }
+    
+    @Override
+    public void subscribe(Subscriber<? super R> s) {
+        
+        Publisher<? extends R> output;
+        
+        try {
+            output = composer.apply((Mono<? extends T>)source);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptySubscription.error(s, ex);
+            return;
+        }
+        
+        if (output == null) {
+            EmptySubscription.error(s, new NullPointerException("The composer returned a null Mono"));
+            return;
+        }        
+        output.subscribe(s);
+    }
+}

--- a/src/test/java/reactor/core/publisher/FluxDeferComposeTest.java
+++ b/src/test/java/reactor/core/publisher/FluxDeferComposeTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.core.publisher;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import reactor.core.test.TestSubscriber;
+
+public class FluxDeferComposeTest {
+    @Test
+    public void perSubscriberState() {
+        
+        Flux<Integer> source = Flux.just(10).deferCompose(f -> {
+            AtomicInteger value = new AtomicInteger();
+            return f.map(v -> v + value.incrementAndGet());
+        });
+        
+        
+        for (int i = 0; i < 10; i++) {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            
+            source.subscribe(ts);
+            
+            ts.assertValues(11)
+            .assertComplete()
+            .assertNoError();
+        }
+    }
+    
+    @Test
+    public void composerThrows() {
+        Flux<Integer> source = Flux.just(10).deferCompose(f -> {
+            throw new RuntimeException("Forced failure");
+        });
+        
+        for (int i = 0; i < 10; i++) {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            
+            source.subscribe(ts);
+            
+            ts.assertNoValues()
+            .assertNotComplete()
+            .assertError(RuntimeException.class);
+        }
+        
+    }
+    
+    @Test
+    public void composerReturnsNull() {
+        Flux<Integer> source = Flux.just(10).deferCompose(f -> {
+            return null;
+        });
+        
+        for (int i = 0; i < 10; i++) {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            
+            source.subscribe(ts);
+            
+            ts.assertNoValues()
+            .assertNotComplete()
+            .assertError(NullPointerException.class);
+        }
+        
+    }
+}

--- a/src/test/java/reactor/core/publisher/MonoDeferComposeTest.java
+++ b/src/test/java/reactor/core/publisher/MonoDeferComposeTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.core.publisher;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import reactor.core.test.TestSubscriber;
+
+public class MonoDeferComposeTest {
+    @Test
+    public void perSubscriberState() {
+        
+        Mono<Integer> source = Mono.just(10).deferCompose(f -> {
+            AtomicInteger value = new AtomicInteger();
+            return f.map(v -> v + value.incrementAndGet());
+        });
+        
+        
+        for (int i = 0; i < 10; i++) {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            
+            source.subscribe(ts);
+            
+            ts.assertValues(11)
+            .assertComplete()
+            .assertNoError();
+        }
+    }
+    
+    @Test
+    public void composerThrows() {
+        Mono<Integer> source = Mono.just(10).deferCompose(f -> {
+            throw new RuntimeException("Forced failure");
+        });
+        
+        for (int i = 0; i < 10; i++) {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            
+            source.subscribe(ts);
+            
+            ts.assertNoValues()
+            .assertNotComplete()
+            .assertError(RuntimeException.class);
+        }
+        
+    }
+    
+    @Test
+    public void composerReturnsNull() {
+        Mono<Integer> source = Mono.just(10).deferCompose(f -> {
+            return null;
+        });
+        
+        for (int i = 0; i < 10; i++) {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            
+            source.subscribe(ts);
+            
+            ts.assertNoValues()
+            .assertNotComplete()
+            .assertError(NullPointerException.class);
+        }
+        
+    }
+}


### PR DESCRIPTION
This PR adds two simple, in-sequence operators that let's one defer the composition itself which then allows per-subscriber state, similar to defer().