### PR TITLE
Proposal: FluxEmitter

### DIFF
--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -521,6 +521,43 @@ public abstract class Flux<T> implements Publisher<T>, Introspectable, Backpress
 	}
 	
 	/**
+	 * Creates a Flux with multi-emission capabilities (synchronous or asynchronous) through
+	 * the FluxEmitter API.
+	 * <p>
+	 * This Flux factory is useful if one wants to adapt some other a multi-valued async API
+	 * and not worry about cancellation and backpressure. For example:
+	 * 
+     * <pre><code>
+     * Flux.&lt;String&gt;createEmitter(emitter -&gt; {
+     *     // setup backpressure mode, default is BUFFER
+     *     
+     *     emitter.setBackpressureHandling(FluxEmitter.BackpressureHandling.LATEST);
+     *     
+     *     ActionListener al = e -&gt; {
+     *         emitter.next(textField.getText());
+     *     };
+     *     // without cancellation support:
+     *     
+     *     button.addActionListener(al);
+     *     
+     *     // with cancellation support:
+     *     
+     *     button.addActionListener(al);
+     *     emitter.setCancellation(() -> {
+     *         button.removeListener(al);
+     *     });
+     * }); 
+     * <code></pre>
+     *  
+	 * @param <T> the value type
+	 * @param emitter the consumer that will receive a FluxEmitter for each individual Subscriber.
+	 * @return a {@link Flux}
+	 */
+	public static <T> Flux<T> createEmitter(Consumer<? super FluxEmitter<T>> emitter) {
+	    return new FluxCreateEmitter<>(emitter);
+	}
+	
+	/**
 	 * Supply a {@link Publisher} everytime subscribe is called on the returned flux. The passed {@link Supplier}
 	 * will be invoked and it's up to the developer to choose to return a new instance of a {@link Publisher} or reuse
 	 * one effecitvely behaving like {@link #from(Publisher)}.

--- a/src/main/java/reactor/core/publisher/FluxCreateEmitter.java
+++ b/src/main/java/reactor/core/publisher/FluxCreateEmitter.java
@@ -1,0 +1,460 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.*;
+import java.util.concurrent.atomic.*;
+import java.util.function.Consumer;
+
+import org.reactivestreams.Subscriber;
+
+import reactor.core.flow.*;
+import reactor.core.flow.Fuseable.QueueSubscription;
+import reactor.core.queue.QueueSupplier;
+import reactor.core.util.*;
+
+/**
+ * Provides a multi-valued emitter API for a callback that is called for
+ * each individual Subscriber.
+ *
+ * @param <T> the value type
+ */
+final class FluxCreateEmitter<T> extends Flux<T> {
+    
+    final Consumer<? super FluxEmitter<T>> emitter;
+    
+    public FluxCreateEmitter(Consumer<? super FluxEmitter<T>> emitter) {
+        this.emitter = Objects.requireNonNull(emitter, "emitter");
+    }
+    
+    @Override
+    public void subscribe(Subscriber<? super T> s) {
+        DefaultFluxEmitter<T> dfe = new DefaultFluxEmitter<>(s);
+        s.onSubscribe(dfe);
+        
+        try {
+            emitter.accept(dfe);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            dfe.fail(ex);
+        }
+    }
+    
+    static final class DefaultFluxEmitter<T> 
+    implements FluxEmitter<T>, QueueSubscription<T> {
+
+        final Subscriber<? super T> actual; 
+        
+        BackpressureHandling handling;
+        
+        boolean caughtUp;
+        
+        Queue<T> queue;
+
+        volatile T latest;
+        
+        @SuppressWarnings("rawtypes")
+        static final AtomicReferenceFieldUpdater<DefaultFluxEmitter, Object> LATEST =
+        AtomicReferenceFieldUpdater.newUpdater(DefaultFluxEmitter.class, Object.class, "latest");
+        
+        volatile boolean done;
+        Throwable error;
+        
+        volatile Cancellation cancel;
+        @SuppressWarnings("rawtypes")
+        static final AtomicReferenceFieldUpdater<DefaultFluxEmitter, Cancellation> CANCEL =
+                AtomicReferenceFieldUpdater.newUpdater(DefaultFluxEmitter.class, Cancellation.class, "cancel");
+        
+        volatile long requested;
+        @SuppressWarnings("rawtypes")
+        static final AtomicLongFieldUpdater<DefaultFluxEmitter> REQUESTED =
+                AtomicLongFieldUpdater.newUpdater(DefaultFluxEmitter.class, "requested");
+        
+        volatile int wip;
+        @SuppressWarnings("rawtypes")
+        static final AtomicIntegerFieldUpdater<DefaultFluxEmitter> WIP =
+                AtomicIntegerFieldUpdater.newUpdater(DefaultFluxEmitter.class, "wip");
+        
+        static final Cancellation CANCELLED = () -> { };
+        
+        public DefaultFluxEmitter(Subscriber<? super T> actual) {
+            this.actual = actual;
+            this.handling = BackpressureHandling.BUFFER;
+        }
+        
+        @Override
+        public void setBackpressureHandling(FluxEmitter.BackpressureHandling mode) {
+            this.handling = mode;
+            if (mode == BackpressureHandling.BUFFER) {
+                this.queue = QueueSupplier.<T>unbounded().get();
+            }
+        }
+        
+        @Override
+        public void next(T value) {
+            if (value == null) {
+                fail(new NullPointerException("value is null"));
+                return;
+            }
+            if (isCancelled() || done) {
+                Exceptions.onNextDropped(value);
+                return;
+            }
+            switch (this.handling) {
+            case IGNORE: {
+                actual.onNext(value);
+                break;
+            }
+            case ERROR: {
+                if (requested != 0L) {
+                    actual.onNext(value);
+                    if (requested != Long.MAX_VALUE) {
+                        REQUESTED.decrementAndGet(this);
+                    }
+                } else {
+                    fail(new IllegalStateException("Could not emit value due to lack of request"));
+                }
+                break;
+            }
+            case BUFFER: {
+                if (caughtUp) {
+                    actual.onNext(value);
+                } else {
+                    queue.offer(value);
+                    if (drain()) {
+                        caughtUp = true;
+                    }
+                }
+                break;
+            }
+            case LATEST: {
+                LATEST.lazySet(this, value);
+                drainLatest();
+            }
+            case DROP: {
+                if (requested != 0L) {
+                    actual.onNext(value);
+                    if (requested != Long.MAX_VALUE) {
+                        REQUESTED.decrementAndGet(this);
+                    }
+                }
+                break;
+            }
+            }
+        }
+        
+        @Override
+        public void fail(Throwable error) {
+            if (error == null) {
+                error = new NullPointerException("error is null");
+            }
+            if (isCancelled() || done) {
+                Exceptions.onErrorDropped(error);
+                return;
+            }
+            done = true;
+            switch (this.handling) {
+            case IGNORE:
+            case ERROR:
+            case DROP:
+                cancel();
+                actual.onError(error);
+                break;
+            case BUFFER:
+                if (caughtUp) {
+                    actual.onError(error);
+                } else {
+                    this.error = error;
+                    done = true;
+                    drain();
+                }
+                break;
+            case LATEST:
+                this.error = error;
+                done = true;
+                drainLatest();
+                break;
+            }
+        }
+
+        boolean isCancelled() {
+            return cancel == CANCELLED;
+        }
+        
+        @Override
+        public void complete() {
+            if (isCancelled() || done) {
+                return;
+            }
+            done = true;
+            
+            switch (this.handling) {
+            case IGNORE:
+            case ERROR:
+            case DROP:
+                cancel();
+                actual.onComplete();
+                break;
+            case BUFFER:
+                if (caughtUp) {
+                    cancel();
+                    actual.onComplete();
+                } else {
+                    drain();
+                }
+                drain();
+                break;
+            case LATEST:
+                drainLatest();
+                break;
+            }
+        }
+        
+        @Override
+        public void stop() {
+            cancel();
+        }
+        
+        boolean drain() {
+            if (WIP.getAndIncrement(this) != 0) {
+                return false;
+            }
+            
+            int missed = 1;
+            final Queue<T> q = queue;
+            final Subscriber<? super T> a = actual;
+            
+            for (;;) {
+                
+                long r = requested;
+                long e = 0L;
+                
+                while (e != r) {
+                    if (isCancelled()) {
+                        q.clear();
+                        return false;
+                    }
+                    
+                    boolean d = done;
+                    T v = q.poll();
+                    boolean empty = v == null;
+                    
+                    if (d && empty) {
+                        cancelResource();
+                        q.clear();
+                        Throwable ex = error;
+                        if (ex != null) {
+                            a.onError(ex);
+                        } else {
+                            a.onComplete();
+                        }
+                        return false;
+                    }
+                    
+                    if (empty) {
+                        break;
+                    }
+                    
+                    a.onNext(v);
+                    
+                    e++;
+                }
+                
+                if (e == r) {
+                    if (isCancelled()) {
+                        q.clear();
+                        return false;
+                    }
+                    
+                    if (done && q.isEmpty()) {
+                        cancelResource();
+                        q.clear();
+                        Throwable ex = error;
+                        if (ex != null) {
+                            a.onError(ex);
+                        } else {
+                            a.onComplete();
+                        }
+                        return false;
+                    }
+                }
+                
+                if (e != 0L) {
+                    if (r != Long.MAX_VALUE) {
+                        REQUESTED.addAndGet(this, -e);
+                    }
+                }
+                
+                missed = WIP.addAndGet(this, -missed);
+                if (missed == 0) {
+                    return r == Long.MAX_VALUE;
+                }
+            }
+        }
+        
+        void drainLatest() {
+            if (WIP.getAndIncrement(this) != 0) {
+                return;
+            }
+            
+            int missed = 1;
+            final Subscriber<? super T> a = actual;
+            
+            for (;;) {
+                
+                long r = requested;
+                long e = 0L;
+                
+                while (e != r) {
+                    if (isCancelled()) {
+                        LATEST.lazySet(this, null);
+                        return;
+                    }
+                    
+                    boolean d = done;
+                    @SuppressWarnings("unchecked")
+                    T v = (T)LATEST.getAndSet(this, null);
+                    boolean empty = v == null;
+                    
+                    if (d && empty) {
+                        cancelResource();
+                        Throwable ex = error;
+                        if (ex != null) {
+                            a.onError(ex);
+                        } else {
+                            a.onComplete();
+                        }
+                        return;
+                    }
+                    
+                    if (empty) {
+                        break;
+                    }
+                    
+                    a.onNext(v);
+                    
+                    e++;
+                }
+                
+                if (e == r) {
+                    if (isCancelled()) {
+                        LATEST.lazySet(this, null);
+                        return;
+                    }
+                    
+                    if (done && latest == null) {
+                        cancelResource();
+                        Throwable ex = error;
+                        if (ex != null) {
+                            a.onError(ex);
+                        } else {
+                            a.onComplete();
+                        }
+                        return;
+                    }
+                }
+                
+                if (e != 0L) {
+                    if (r != Long.MAX_VALUE) {
+                        REQUESTED.addAndGet(this, -e);
+                    }
+                }
+                
+                missed = WIP.addAndGet(this, -missed);
+                if (missed == 0) {
+                    return;
+                }
+            }
+        }
+        @Override
+        public void setCancellation(Cancellation c) {
+            if (!CANCEL.compareAndSet(this, null, c)) {
+                if (cancel != CANCELLED && c != null) {
+                    c.dispose();
+                }
+            }
+        }
+        
+        @Override
+        public int requestFusion(int requestedMode) {
+// TODO enable
+//            if ((requestedMode & Fuseable.ASYNC) != 0) {
+//                return Fuseable.ASYNC;
+//            }
+            return Fuseable.NONE;
+        }
+        
+        @Override
+        public T poll() {
+            // TODO Auto-generated method stub
+            return null;
+        }
+        
+        @Override
+        public boolean isEmpty() {
+            // TODO Auto-generated method stub
+            return false;
+        }
+        
+        @Override
+        public int size() {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+        
+        @Override
+        public void clear() {
+            // TODO Auto-generated method stub
+            
+        }
+        
+        @Override
+        public void request(long n) {
+            if (BackpressureUtils.validate(n)) {
+                BackpressureUtils.getAndAddCap(REQUESTED, this, n);
+                if (handling == BackpressureHandling.BUFFER) {
+                    drain();
+                } else
+                if (handling == BackpressureHandling.LATEST) {
+                    drainLatest();
+                }
+            }
+        }
+        
+        void cancelResource() {
+            Cancellation c = cancel;
+            if (c != CANCELLED) {
+                c = CANCEL.getAndSet(this, CANCELLED);
+                if (c != null && c != CANCELLED) {
+                    c.dispose();
+                }
+            }
+        }
+        
+        @Override
+        public void cancel() {
+            cancelResource();
+            
+            if (WIP.getAndIncrement(this) == 0) {
+                Queue<T> q = queue;
+                if (q != null) {
+                    q.clear();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/reactor/core/publisher/FluxEmitter.java
+++ b/src/main/java/reactor/core/publisher/FluxEmitter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import reactor.core.flow.Cancellation;
+
+/**
+ * Wrapper API around a downstream Subscriber for emittin any number of
+ * next signals followed by zero or one onError/onComplete.
+ * <p>
+ * One should call {@link FluxEmitter#setBackpressureHandling(BackpressureHandling)}
+ * before emitting any signal.
+ * @param <T> the value type
+ */
+public interface FluxEmitter<T> {
+    
+    enum BackpressureHandling {
+        IGNORE,
+        ERROR,
+        DROP,
+        LATEST,
+        BUFFER
+    }
+    
+    void setBackpressureHandling(BackpressureHandling mode);
+    
+    void next(T value);
+    
+    void fail(Throwable error);
+    
+    void complete();
+    
+    void stop();
+    
+    void setCancellation(Cancellation c);
+}


### PR DESCRIPTION
This PR proposes a multi-valued emitter API for Flux with resource handling and backpressure control.

Example use case:

```java
Flux.<String>createEmitter(emitter -> {
    // setup backpressure mode, default is BUFFER

    emitter.setBackpressureHandling(FluxEmitter.BackpressureHandling.LATEST);

    ActionListener al = e -> {
         emitter.next(textField.getText());
     };

     // without cancellation support:
     
     button.addActionListener(al);

     // with cancellation support:
     
     button.addActionListener(al);
     emitter.setCancellation(() -> {
         button.removeListener(al);
     });
}); 
```