### PR TITLE
Deprecate raw Future in favor of CompletableFuture

### DIFF
--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -416,8 +416,8 @@ public abstract class Mono<T> implements Publisher<T>, Backpressurable, Introspe
 	 * <p>
 	 * @param completableFuture {@link CompletableFuture} that will produce the value
 	 * @param <T> type of the expected value
-	 *
 	 * @return A {@link Mono}.
+	 * @deprecated Use {@link #fromFuture(CompletableFuture)} instead.
 	 */
 	public static <T> Mono<T> fromCompletableFuture(CompletableFuture<? extends T> completableFuture) {
 		return new MonoCompletableFuture<>(completableFuture);
@@ -425,19 +425,17 @@ public abstract class Mono<T> implements Publisher<T>, Backpressurable, Introspe
 
 
 	/**
-	 * Build a {@link Mono} that will only emit the result of the future and then complete.
-	 * The future will be polled for an unbounded amount of time on {@code subscribe()}.
+	 * Create a {@link Mono} producing the value for the {@link Mono} using the given {@link CompletableFuture}.
 	 *
 	 * <p>
-	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/fromfuture.png" alt="">
-	 *
-	 * @param future the future to poll value from
-	 * @param <T> the value type of the Future and the retuned Mono instance
-	 * @return a new {@link Mono}
-	 * @deprecated Try to avoid using this method because it invokes {@link Future#get()} blocking method. Try to use {@link #fromCompletableFuture(CompletableFuture)} or {@link MonoProcessor#create()} + callback when possible.
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/fromcompletablefuture.png" alt="">
+	 * <p>
+	 * @param future {@link CompletableFuture} that will produce the value
+	 * @param <T> type of the expected value
+	 * @return A {@link Mono}.
 	 */
-	public static <T> Mono<T> fromFuture(Future<? extends T> future) {
-		return new MonoFuture<>(future);
+	public static <T> Mono<T> fromFuture(CompletableFuture<? extends T> future) {
+		return new MonoCompletableFuture<>(future);
 	}
 
 	/**
@@ -451,6 +449,7 @@ public abstract class Mono<T> implements Publisher<T>, Backpressurable, Introspe
 	 * @param future the future to poll value from
 	 * @param timeout the timeout in milliseconds
 	 * @return a new {@link Mono}
+	 * @deprecated Use {@link #fromFuture(CompletableFuture)} or {@link MonoProcessor#create()} + callback instead.
 	 */
 	public static <T> Mono<T> fromFuture(Future<? extends T> future, long timeout) {
 		return new MonoFuture<>(future, timeout);
@@ -467,6 +466,7 @@ public abstract class Mono<T> implements Publisher<T>, Backpressurable, Introspe
 	 * @param duration the duration to wait for the result of the future before failing with onError
 	 * @param <T> the value type of the Future and the retuned Mono instance
 	 * @return a new {@link Mono}
+	 * @deprecated Use {@link #fromFuture(CompletableFuture)} or {@link MonoProcessor#create()} + callback instead.
 	 */
 	public static <T> Mono<T> fromFuture(Future<? extends T> future, Duration duration) {
 		return fromFuture(future, duration.toMillis());
@@ -2776,8 +2776,23 @@ public abstract class Mono<T> implements Publisher<T>, Backpressurable, Introspe
 	 * <p>
 	 *
 	 * @return a {@link CompletableFuture}
+	 * @deprecated Use {@link #toFuture()} instead.
 	 */
 	public final CompletableFuture<T> toCompletableFuture() {
+		return toFuture();
+	}
+
+	/**
+	 * Transform this {@link Mono} into a {@link CompletableFuture} completing on onNext or onComplete and failing on
+	 * onError.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/tocompletablefuture.png" alt="">
+	 * <p>
+	 *
+	 * @return a {@link CompletableFuture}
+	 */
+	public final CompletableFuture<T> toFuture() {
 		return subscribeWith(new MonoToCompletableFuture<>());
 	}
 

--- a/src/test/groovy/reactor/core/FluxSpec.groovy
+++ b/src/test/groovy/reactor/core/FluxSpec.groovy
@@ -35,6 +35,7 @@ import java.time.Duration
 import java.util.concurrent.*
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.BiFunction
+import java.util.function.Supplier
 
 import static reactor.core.publisher.Flux.error
 
@@ -1754,14 +1755,14 @@ class FluxSpec extends Specification {
 			nexts[3] + nexts[4] + nexts[5] < 50
 	}
 
-	def 'Creating Mono from future'() {
+	def 'Creating Mono from CompletableFuture'() {
 		given:
 			'a source flux pre-completed'
 			def executorService = Executors.newSingleThreadExecutor()
 
-			def future = executorService.submit({
+			def future = CompletableFuture.supplyAsync({
 				'hello future'
-			} as Callable<String>)
+			} as Supplier<String>, executorService)
 
 			def s = Mono.fromFuture(future).as{ Flux.from(it) }
 
@@ -1782,29 +1783,6 @@ class FluxSpec extends Specification {
 			!errors
 			nexts[0] == 'hello future'
 			counted
-
-		when: 'timeout'
-			latch = new CountDownLatch(1)
-
-			future = executorService.submit({
-				sleep(2000)
-				'hello future too long'
-			} as Callable<String>)
-
-			s = Mono.fromFuture(future, Duration.ofMillis(100)).publishOn(asyncGroup).as{ Flux.from(it) }
-			nexts = []
-			errors = []
-
-			s.subscribe(
-					{ nexts << 'never ever' },
-					{ errors << it; latch.countDown() }
-			)
-
-		then:
-			'error dispatching works'
-			latch.await(2, TimeUnit.SECONDS)
-			errors[0] in TimeoutException
-			!nexts
 
 		cleanup:
 			executorService.shutdown()

--- a/src/test/groovy/reactor/core/PublisherConversionSpec.groovy
+++ b/src/test/groovy/reactor/core/PublisherConversionSpec.groovy
@@ -92,7 +92,7 @@ class PublisherConversionSpec extends Specification {
 
 	given: "Iterable publisher of 1 to read queue"
 	def obs = CompletableFuture.completedFuture([1])
-	def pub = Mono.fromCompletableFuture(obs)
+	def pub = Mono.fromFuture(obs)
 	def queue = new TestSubscriber()
 
 	when: "read the queue"
@@ -105,7 +105,7 @@ class PublisherConversionSpec extends Specification {
 
 	when: "Iterable publisher of 1 to completable future"
 	def newPub = Mono.just(1)
-	obs = newPub.toCompletableFuture()
+	obs = newPub.toFuture()
 	def v = obs.get()
 
 	then: "queues values correct"


### PR DESCRIPTION
TODO:
 - update fromcompletablefuture.png and tocompletablefuture.png
    with the new method name
 - Remove MonoFuture when deprecated methods will be gone.

Close issue #92