### PR TITLE
Refactor how TestSubscriber instances are created

### DIFF
--- a/src/test/groovy/reactor/core/FluxSpec.groovy
+++ b/src/test/groovy/reactor/core/FluxSpec.groovy
@@ -115,7 +115,7 @@ class FluxSpec extends Specification {
 		when:
 			'cumulated request of Long MAX'
 			long test = Long.MAX_VALUE / 2l
-			def controls = new TestSubscriber<>(0).bindTo(stream)
+			def controls = TestSubscriber.subscribe(stream, 0)
 			controls.request(test)
 			controls.request(test)
 			controls.request(1)
@@ -1847,7 +1847,7 @@ class FluxSpec extends Specification {
 			'a source and a collected flux'
 			def source = EmitterProcessor.<Integer> create().connect()
 			def reduced = source.buffer(5, Duration.ofMillis(600))
-			def ts = new TestSubscriber().bindTo(reduced)
+			def ts = TestSubscriber.subscribe(reduced)
 
 		when:
 			'the first values are accepted on the source'
@@ -2117,7 +2117,7 @@ class FluxSpec extends Specification {
 
 			def value = null
 			def s = source.log("drop").onBackpressureDrop().doOnNext { value = it }.log('overflow-drop-test')
-			def tail = new TestSubscriber<>(0).bindTo(s)
+			def tail = TestSubscriber.subscribe(s, 0)
 
 
 			tail.request(5)

--- a/src/test/java/reactor/core/converter/RxJava1SingleConverterTest.java
+++ b/src/test/java/reactor/core/converter/RxJava1SingleConverterTest.java
@@ -17,7 +17,7 @@ public class RxJava1SingleConverterTest {
         
         Mono<Integer> m = RxJava1SingleConverter.from(s);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         
         m.subscribe(ts);
         
@@ -33,7 +33,7 @@ public class RxJava1SingleConverterTest {
         
         Mono<Integer> m = RxJava1SingleConverter.from(s);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         
         m.subscribe(ts);
         
@@ -49,7 +49,7 @@ public class RxJava1SingleConverterTest {
         
         Mono<Integer> m = RxJava1SingleConverter.from(s);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
         
         m.subscribe(ts);
         
@@ -72,7 +72,7 @@ public class RxJava1SingleConverterTest {
         
         Mono<Integer> m = RxJava1SingleConverter.from(s);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         
         m.subscribe(ts);
         
@@ -88,7 +88,7 @@ public class RxJava1SingleConverterTest {
         
         Mono<Integer> m = RxJava1SingleConverter.from(s);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         
         m.subscribe(ts);
         

--- a/src/test/java/reactor/core/converter/RxJavaCompletableTests.java
+++ b/src/test/java/reactor/core/converter/RxJavaCompletableTests.java
@@ -32,8 +32,8 @@ public class RxJavaCompletableTests {
     public void shouldConvertACompletableIntoMonoVoid() throws Exception {
         Mono<Void> printableMono = converter.toPublisher(completable);
         assertThat(printableMono, is(notNullValue()));
-        new TestSubscriber<Void>()
-                .bindTo(printableMono)
+        TestSubscriber
+                .subscribe(printableMono)
                 .assertNoValues()
                 .assertComplete();
     }
@@ -44,8 +44,8 @@ public class RxJavaCompletableTests {
         Mono<Void> voidMono = converter.toPublisher(Completable.fromAction(() -> {
             throw new IllegalStateException("This should not happen"); //something internal happened
         }));
-        new TestSubscriber<Void>()
-                .bindTo(voidMono)
+        TestSubscriber
+                .subscribe(voidMono)
                 .assertNoValues()
                 .assertError(IllegalStateException.class)
                 .assertTerminated()

--- a/src/test/java/reactor/core/publisher/ConnectableFluxAutoConnectTest.java
+++ b/src/test/java/reactor/core/publisher/ConnectableFluxAutoConnectTest.java
@@ -63,12 +63,12 @@ public class ConnectableFluxAutoConnectTest {
 		Assert.assertNull(cancel.get());
 		Assert.assertFalse("sp has subscribers?", e.downstreamCount() != 0);
 		
-		p.subscribe(new TestSubscriber<>());
+		p.subscribe(TestSubscriber.create());
 		
 		Assert.assertNull(cancel.get());
 		Assert.assertFalse("sp has subscribers?", e.downstreamCount() != 0);
 
-		p.subscribe(new TestSubscriber<>());
+		p.subscribe(TestSubscriber.create());
 
 		Assert.assertNotNull(cancel.get());
 		Assert.assertTrue("sp has no subscribers?", e.downstreamCount() != 0);

--- a/src/test/java/reactor/core/publisher/ConnectableFluxProcessTest.java
+++ b/src/test/java/reactor/core/publisher/ConnectableFluxProcessTest.java
@@ -26,8 +26,8 @@ public class ConnectableFluxProcessTest {
 
 	@Test
 	public void normal() {
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>();
-		TestSubscriber<Integer> ts2 = new TestSubscriber<>();
+		TestSubscriber<Integer> ts1 = TestSubscriber.create();
+		TestSubscriber<Integer> ts2 = TestSubscriber.create();
 		
 		ConnectableFlux<Integer> p = Flux.range(1, 5).process(EmitterProcessor.create(), Flux::log);
 		
@@ -57,8 +57,8 @@ public class ConnectableFluxProcessTest {
 	
 	@Test
 	public void normalBackpressured() {
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>(0);
-		TestSubscriber<Integer> ts2 = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts1 = TestSubscriber.create(0);
+		TestSubscriber<Integer> ts2 = TestSubscriber.create(0);
 		
 		ConnectableFlux<Integer> p = Flux.range(1, 5).process(EmitterProcessor.create());
 		
@@ -112,7 +112,7 @@ public class ConnectableFluxProcessTest {
 
 	@Test
 	public void normalProcessorBackpressured() {
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts1 = TestSubscriber.create(0);
 
 		ConnectableFlux<Integer> p = Flux.range(1, 5).process(EmitterProcessor.create());
 
@@ -147,7 +147,7 @@ public class ConnectableFluxProcessTest {
 
 	@Test
 	public void normalAsyncFused() {
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+		TestSubscriber<Integer> ts1 = TestSubscriber.create();
 
 		UnicastProcessor<Integer> up = new UnicastProcessor<>(QueueSupplier.<Integer>get(8).get());
 		up.onNext(1);
@@ -177,7 +177,7 @@ public class ConnectableFluxProcessTest {
 	
 	@Test
 	public void normalBackpressuredAsyncFused() {
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts1 = TestSubscriber.create(0);
 
 		UnicastProcessor<Integer> up = new UnicastProcessor<>(QueueSupplier.<Integer>get(8).get());
 		up.onNext(1);
@@ -219,8 +219,8 @@ public class ConnectableFluxProcessTest {
 
 	@Test
 	public void normalHidden() {
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>();
-		TestSubscriber<Integer> ts2 = new TestSubscriber<>();
+		TestSubscriber<Integer> ts1 = TestSubscriber.create();
+		TestSubscriber<Integer> ts2 = TestSubscriber.create();
 		
 		ConnectableFlux<Integer> p = Flux.range(1, 5).hide().process(EmitterProcessor.create(), Flux::log);
 		
@@ -250,8 +250,8 @@ public class ConnectableFluxProcessTest {
 	
 	@Test
 	public void normalHiddenBackpressured() {
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>(0);
-		TestSubscriber<Integer> ts2 = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts1 = TestSubscriber.create(0);
+		TestSubscriber<Integer> ts2 = TestSubscriber.create(0);
 		
 		ConnectableFlux<Integer> p = Flux.range(1, 5).hide().process(EmitterProcessor.create());
 		
@@ -305,7 +305,7 @@ public class ConnectableFluxProcessTest {
 
 	@Test
 	public void disconnect() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		ReplayProcessor<Integer> sp = ReplayProcessor.create();
 		sp.connect();
@@ -328,8 +328,8 @@ public class ConnectableFluxProcessTest {
 
 	@Test
 	public void cancel() {
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>();
-		TestSubscriber<Integer> ts2 = new TestSubscriber<>();
+		TestSubscriber<Integer> ts1 = TestSubscriber.create();
+		TestSubscriber<Integer> ts2 = TestSubscriber.create();
 
 		FluxProcessor<Integer, Integer> sp = EmitterProcessor.create();
 
@@ -362,7 +362,7 @@ public class ConnectableFluxProcessTest {
 
 	@Test
 	public void disconnectBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 		
 		FluxProcessor<Integer, Integer> sp = EmitterProcessor.create();
 		sp.connect();
@@ -382,7 +382,7 @@ public class ConnectableFluxProcessTest {
 
 	@Test
 	public void error() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		EmitterProcessor<Integer> sp = EmitterProcessor.create();
 		sp.connect();
@@ -403,7 +403,7 @@ public class ConnectableFluxProcessTest {
 
 	@Test
 	public void fusedMapInvalid() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		ConnectableFlux<Integer> p = Flux.range(1, 5).map(v -> (Integer)null).process(EmitterProcessor.create());
 		

--- a/src/test/java/reactor/core/publisher/ConnectableFluxPublishTest.java
+++ b/src/test/java/reactor/core/publisher/ConnectableFluxPublishTest.java
@@ -37,8 +37,8 @@ public class ConnectableFluxPublishTest {
 	
 	@Test
 	public void normal() {
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>();
-		TestSubscriber<Integer> ts2 = new TestSubscriber<>();
+		TestSubscriber<Integer> ts1 = TestSubscriber.create();
+		TestSubscriber<Integer> ts2 = TestSubscriber.create();
 
 		ConnectableFlux<Integer> p = Flux.range(1, 5).publish();
 		
@@ -68,8 +68,8 @@ public class ConnectableFluxPublishTest {
 	
 	@Test
 	public void normalBackpressured() {
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>(0);
-		TestSubscriber<Integer> ts2 = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts1 = TestSubscriber.create(0);
+		TestSubscriber<Integer> ts2 = TestSubscriber.create(0);
 
 		ConnectableFlux<Integer> p = Flux.range(1, 5).publish();
 		
@@ -123,8 +123,8 @@ public class ConnectableFluxPublishTest {
 
 	@Test
 	public void normalAsyncFused() {
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>();
-		TestSubscriber<Integer> ts2 = new TestSubscriber<>();
+		TestSubscriber<Integer> ts1 = TestSubscriber.create();
+		TestSubscriber<Integer> ts2 = TestSubscriber.create();
 		
 		UnicastProcessor<Integer> up = new UnicastProcessor<>(QueueSupplier.<Integer>get(8).get());
 		up.onNext(1);
@@ -162,8 +162,8 @@ public class ConnectableFluxPublishTest {
 	
 	@Test
 	public void normalBackpressuredAsyncFused() {
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>(0);
-		TestSubscriber<Integer> ts2 = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts1 = TestSubscriber.create(0);
+		TestSubscriber<Integer> ts2 = TestSubscriber.create(0);
 
 		UnicastProcessor<Integer> up = new UnicastProcessor<>(QueueSupplier.<Integer>get(8).get());
 		up.onNext(1);
@@ -225,8 +225,8 @@ public class ConnectableFluxPublishTest {
 
 	@Test
 	public void normalHidden() {
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>();
-		TestSubscriber<Integer> ts2 = new TestSubscriber<>();
+		TestSubscriber<Integer> ts1 = TestSubscriber.create();
+		TestSubscriber<Integer> ts2 = TestSubscriber.create();
 
 		ConnectableFlux<Integer> p = Flux.range(1, 5).useCapacity(5).publish();
 		
@@ -256,8 +256,8 @@ public class ConnectableFluxPublishTest {
 	
 	@Test
 	public void normalHiddenBackpressured() {
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>(0);
-		TestSubscriber<Integer> ts2 = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts1 = TestSubscriber.create(0);
+		TestSubscriber<Integer> ts2 = TestSubscriber.create(0);
 
 		ConnectableFlux<Integer> p = Flux.range(1, 5).useCapacity(5).publish();
 		
@@ -311,7 +311,7 @@ public class ConnectableFluxPublishTest {
 
 	@Test
 	public void disconnect() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		EmitterProcessor<Integer> e = EmitterProcessor.create();
 		e.connect();
@@ -336,7 +336,7 @@ public class ConnectableFluxPublishTest {
 
 	@Test
 	public void disconnectBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		EmitterProcessor<Integer> e = EmitterProcessor.create();
 		e.connect();
@@ -358,7 +358,7 @@ public class ConnectableFluxPublishTest {
 
 	@Test
 	public void error() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		EmitterProcessor<Integer> e = EmitterProcessor.create();
 		e.connect();
@@ -381,7 +381,7 @@ public class ConnectableFluxPublishTest {
 
 	@Test
 	public void fusedMapInvalid() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		ConnectableFlux<Integer> p = Flux.range(1, 5).map(v -> (Integer)null).publish();
 		

--- a/src/test/java/reactor/core/publisher/ConnectableFluxRefCountTest.java
+++ b/src/test/java/reactor/core/publisher/ConnectableFluxRefCountTest.java
@@ -40,12 +40,12 @@ public class ConnectableFluxRefCountTest {
 		
 		Assert.assertFalse("sp has subscribers?", e.downstreamCount() != 0);
 		
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+		TestSubscriber<Integer> ts1 = TestSubscriber.create();
 		p.subscribe(ts1);
 
 		Assert.assertTrue("sp has no subscribers?", e.downstreamCount() != 0);
 
-		TestSubscriber<Integer> ts2 = new TestSubscriber<>();
+		TestSubscriber<Integer> ts2 = TestSubscriber.create();
 		p.subscribe(ts2);
 
 		Assert.assertTrue("sp has no subscribers?", e.downstreamCount() != 0);
@@ -81,12 +81,12 @@ public class ConnectableFluxRefCountTest {
 		
 		Assert.assertFalse("sp has subscribers?", e.downstreamCount() != 0);
 		
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+		TestSubscriber<Integer> ts1 = TestSubscriber.create();
 		p.subscribe(ts1);
 
 		Assert.assertFalse("sp has subscribers?", e.downstreamCount() != 0);
 
-		TestSubscriber<Integer> ts2 = new TestSubscriber<>();
+		TestSubscriber<Integer> ts2 = TestSubscriber.create();
 		p.subscribe(ts2);
 
 		Assert.assertTrue("sp has no subscribers?", e.downstreamCount() != 0);
@@ -118,14 +118,14 @@ public class ConnectableFluxRefCountTest {
 		
 		Flux<Integer> p = Flux.range(1, 5).publish().refCount();
 
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+		TestSubscriber<Integer> ts1 = TestSubscriber.create();
 		p.subscribe(ts1);
 
 		ts1.assertValues(1, 2, 3, 4, 5)
 		.assertNoError()
 		.assertComplete();
 
-		TestSubscriber<Integer> ts2 = new TestSubscriber<>();
+		TestSubscriber<Integer> ts2 = TestSubscriber.create();
 		p.subscribe(ts2);
 
 		ts2.assertValues(1, 2, 3, 4, 5)
@@ -139,12 +139,12 @@ public class ConnectableFluxRefCountTest {
 		
 		Flux<Integer> p = Flux.range(1, 5).publish().refCount(2);
 
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+		TestSubscriber<Integer> ts1 = TestSubscriber.create();
 		p.subscribe(ts1);
 
 		ts1.assertValueCount(0);
 
-		TestSubscriber<Integer> ts2 = new TestSubscriber<>();
+		TestSubscriber<Integer> ts2 = TestSubscriber.create();
 		p.subscribe(ts2);
 
 		ts1.assertValues(1, 2, 3, 4, 5);
@@ -162,12 +162,12 @@ public class ConnectableFluxRefCountTest {
 		p.subscribe().dispose();
 		p.subscribe().dispose();
 		
-		TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+		TestSubscriber<Integer> ts1 = TestSubscriber.create();
 		p.subscribe(ts1);
 
 		ts1.assertValueCount(0);
 
-		TestSubscriber<Integer> ts2 = new TestSubscriber<>();
+		TestSubscriber<Integer> ts2 = TestSubscriber.create();
 		p.subscribe(ts2);
 
 		ts1.assertValues(1, 2, 3, 4, 5);

--- a/src/test/java/reactor/core/publisher/DirectProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/DirectProcessorTest.java
@@ -44,7 +44,7 @@ public class DirectProcessorTest {
 
     @Test
     public void normal() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
 
         DirectProcessor<Integer> tp = new DirectProcessor<>();
 
@@ -82,7 +82,7 @@ public class DirectProcessorTest {
 
     @Test
     public void normalBackpressured() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
         DirectProcessor<Integer> tp = new DirectProcessor<>();
 
@@ -116,7 +116,7 @@ public class DirectProcessorTest {
     @Test
     public void notEnoughRequests() {
 
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
         DirectProcessor<Integer> tp = new DirectProcessor<>();
 
@@ -144,7 +144,7 @@ public class DirectProcessorTest {
 
     @Test
     public void error() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
 
         DirectProcessor<Integer> tp = new DirectProcessor<>();
 
@@ -186,7 +186,7 @@ public class DirectProcessorTest {
 
     @Test
     public void terminatedWithError() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
 
         DirectProcessor<Integer> tp = new DirectProcessor<>();
         tp.onError(new RuntimeException("forced failure"));
@@ -210,7 +210,7 @@ public class DirectProcessorTest {
 
     @Test
     public void terminatedNormally() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
 
         DirectProcessor<Integer> tp = new DirectProcessor<>();
         tp.onComplete();
@@ -229,7 +229,7 @@ public class DirectProcessorTest {
 
     @Test
     public void subscriberAlreadyCancelled() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         ts.cancel();
 
         DirectProcessor<Integer> tp = new DirectProcessor<>();
@@ -248,7 +248,7 @@ public class DirectProcessorTest {
 
     @Test
     public void subscriberCancels() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
 
         DirectProcessor<Integer> tp = new DirectProcessor<>();
 

--- a/src/test/java/reactor/core/publisher/FluxArrayTest.java
+++ b/src/test/java/reactor/core/publisher/FluxArrayTest.java
@@ -28,7 +28,7 @@ public class FluxArrayTest {
 
 	@Test
 	public void normal() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxArray<>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).subscribe(ts);
 
@@ -39,7 +39,7 @@ public class FluxArrayTest {
 
 	@Test
 	public void normalBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		new FluxArray<>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).subscribe(ts);
 
@@ -62,7 +62,7 @@ public class FluxArrayTest {
 
 	@Test
 	public void normalBackpressuredExact() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(10);
+		TestSubscriber<Integer> ts = TestSubscriber.create(10);
 
 		new FluxArray<>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).subscribe(ts);
 
@@ -79,7 +79,7 @@ public class FluxArrayTest {
 
 	@Test
 	public void arrayContainsNull() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxArray<>(1, 2, 3, 4, 5, null, 7, 8, 9, 10).subscribe(ts);
 

--- a/src/test/java/reactor/core/publisher/FluxCombineLatestTest.java
+++ b/src/test/java/reactor/core/publisher/FluxCombineLatestTest.java
@@ -26,7 +26,7 @@ public class FluxCombineLatestTest {
 	@Test
 	public void singleSourceIsMapped() {
 		
-		TestSubscriber<String> ts = new TestSubscriber<>();
+		TestSubscriber<String> ts = TestSubscriber.create();
 		
 		Flux.combineLatest(a -> a[0].toString(), Flux.just(1))
 		.subscribe(ts);
@@ -39,7 +39,7 @@ public class FluxCombineLatestTest {
 	@Test
 	public void iterableSingleSourceIsMapped() {
 		
-		TestSubscriber<String> ts = new TestSubscriber<>();
+		TestSubscriber<String> ts = TestSubscriber.create();
 		
 		Flux.combineLatest(Collections.singleton(Flux.just(1)), a -> a[0].toString())
 		.subscribe(ts);

--- a/src/test/java/reactor/core/publisher/FluxConcatWithTest.java
+++ b/src/test/java/reactor/core/publisher/FluxConcatWithTest.java
@@ -33,7 +33,7 @@ public class FluxConcatWithTest {
 			result = result.concatWith(source);
 		}
 		
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		result.subscribe(ts);
 		
@@ -55,7 +55,7 @@ public class FluxConcatWithTest {
 			result = result.concatWith(add);
 		}
 		
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		result.subscribe(ts);
 		
@@ -77,7 +77,7 @@ public class FluxConcatWithTest {
 			result = result.concatWith(add);
 		}
 		
-		TestSubscriber<Object> ts = new TestSubscriber<>();
+		TestSubscriber<Object> ts = TestSubscriber.create();
 		
 		result.subscribe(ts);
 		
@@ -89,7 +89,7 @@ public class FluxConcatWithTest {
 	
 	@Test
 	public void dontBreakFluxArrayConcatMap() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux.just(1, 2).concatMap(Flux::just).concatWith(Flux.just(3))
 		.subscribe(ts);

--- a/src/test/java/reactor/core/publisher/FluxDeferComposeTest.java
+++ b/src/test/java/reactor/core/publisher/FluxDeferComposeTest.java
@@ -31,7 +31,7 @@ public class FluxDeferComposeTest {
         
         
         for (int i = 0; i < 10; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            TestSubscriber<Integer> ts = TestSubscriber.create();
             
             source.subscribe(ts);
             
@@ -48,7 +48,7 @@ public class FluxDeferComposeTest {
         });
         
         for (int i = 0; i < 10; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            TestSubscriber<Integer> ts = TestSubscriber.create();
             
             source.subscribe(ts);
             
@@ -66,7 +66,7 @@ public class FluxDeferComposeTest {
         });
         
         for (int i = 0; i < 10; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            TestSubscriber<Integer> ts = TestSubscriber.create();
             
             source.subscribe(ts);
             

--- a/src/test/java/reactor/core/publisher/FluxDematerializerTest.java
+++ b/src/test/java/reactor/core/publisher/FluxDematerializerTest.java
@@ -26,7 +26,7 @@ public class FluxDematerializerTest {
     
     @Test
     public void singleCompletion() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         
         Flux<Integer> dematerialize = Flux.just(Signal.<Integer>complete()).dematerialize();
         
@@ -39,7 +39,7 @@ public class FluxDematerializerTest {
 
     @Test
     public void singleError() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         
         Flux<Integer> dematerialize = Flux.just(error)
             .dematerialize();
@@ -53,7 +53,7 @@ public class FluxDematerializerTest {
 
     @Test
     public void immediateCompletion() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
         
         Flux<Integer> dematerialize = Flux.just(Signal.<Integer>complete()).dematerialize();
         
@@ -66,7 +66,7 @@ public class FluxDematerializerTest {
 
     @Test
     public void immediateError() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
         
         Flux<Integer> dematerialize = Flux.just(error).dematerialize();
         
@@ -79,7 +79,7 @@ public class FluxDematerializerTest {
 
     @Test
     public void completeAfterSingleSignal() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
         
         Flux<Integer> dematerialize = Flux.just(Signal.next(1), Signal.<Integer>complete()).dematerialize();
         
@@ -98,7 +98,7 @@ public class FluxDematerializerTest {
 
     @Test
     public void errorAfterSingleSignal() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
         
         Flux<Integer> dematerialize = Flux.just(Signal.next(1), error).dematerialize();
         
@@ -117,7 +117,7 @@ public class FluxDematerializerTest {
 
     @Test
     public void twoSignalsAndComplete() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
         
         Flux<Integer> dematerialize = Flux.just(Signal.next(1), Signal.next(2), Signal.<Integer>complete()).dematerialize();
         
@@ -142,7 +142,7 @@ public class FluxDematerializerTest {
 
     @Test
     public void twoSignalsAndError() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
         
         Flux<Integer> dematerialize = Flux.just(Signal.next(1), Signal.next(2), error).dematerialize();
         
@@ -167,7 +167,7 @@ public class FluxDematerializerTest {
 
     @Test
     public void neverEnding() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         
         Flux<Integer> dematerialize = Flux.just(Signal.next(1), Signal.next(2), 
                 Signal.next(3), Signal.<Integer>complete())

--- a/src/test/java/reactor/core/publisher/FluxFirstEmittingTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFirstEmittingTest.java
@@ -35,7 +35,7 @@ public class FluxFirstEmittingTest {
 
 	@Test
 	public void firstWinner() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxFirstEmitting<>(Flux.range(1, 10), Flux.range(11, 10)).subscribe(ts);
 
@@ -46,7 +46,7 @@ public class FluxFirstEmittingTest {
 
 	@Test
 	public void firstWinnerBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(5);
+		TestSubscriber<Integer> ts = TestSubscriber.create(5);
 
 		new FluxFirstEmitting<>(Flux.range(1, 10), Flux.range(11, 10)).subscribe(ts);
 
@@ -57,7 +57,7 @@ public class FluxFirstEmittingTest {
 
 	@Test
 	public void secondWinner() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxFirstEmitting<>(FluxNever.instance(), Flux.range(11, 10).log()).subscribe(ts);
 
@@ -68,7 +68,7 @@ public class FluxFirstEmittingTest {
 
 	@Test
 	public void secondEmitsError() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		RuntimeException ex = new RuntimeException("forced failure");
 
@@ -81,7 +81,7 @@ public class FluxFirstEmittingTest {
 
 	@Test
 	public void singleArrayNullSource() {
-		TestSubscriber<Object> ts = new TestSubscriber<>();
+		TestSubscriber<Object> ts = TestSubscriber.create();
 
 		new FluxFirstEmitting<>((Publisher<Object>) null).subscribe(ts);
 
@@ -92,7 +92,7 @@ public class FluxFirstEmittingTest {
 
 	@Test
 	public void arrayOneIsNullSource() {
-		TestSubscriber<Object> ts = new TestSubscriber<>();
+		TestSubscriber<Object> ts = TestSubscriber.create();
 
 		new FluxFirstEmitting<>(FluxNever.instance(), null, FluxNever.instance()).subscribe
 		  (ts);
@@ -104,7 +104,7 @@ public class FluxFirstEmittingTest {
 
 	@Test
 	public void singleIterableNullSource() {
-		TestSubscriber<Object> ts = new TestSubscriber<>();
+		TestSubscriber<Object> ts = TestSubscriber.create();
 
 		new FluxFirstEmitting<>(Arrays.asList((Publisher<Object>) null)).subscribe(ts);
 
@@ -115,7 +115,7 @@ public class FluxFirstEmittingTest {
 
 	@Test
 	public void iterableOneIsNullSource() {
-		TestSubscriber<Object> ts = new TestSubscriber<>();
+		TestSubscriber<Object> ts = TestSubscriber.create();
 
 		new FluxFirstEmitting<>(Arrays.asList(FluxNever.instance(), (Publisher<Object>) null, FluxNever.instance
 		  ())).subscribe(ts);

--- a/src/test/java/reactor/core/publisher/FluxFirstEmittingWithTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFirstEmittingWithTest.java
@@ -33,7 +33,7 @@ public class FluxFirstEmittingWithTest {
 			result = result.firstEmittingWith(source);
 		}
 		
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		result.subscribe(ts);
 		
@@ -44,7 +44,7 @@ public class FluxFirstEmittingWithTest {
 
 	@Test
 	public void dontBreakAmb() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux.firstEmitting(Flux.just(1), Flux.just(2)).firstEmittingWith(Flux.just(3))
 		    .subscribe(ts);

--- a/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -42,7 +42,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void normal() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux.range(1, 1000).flatMap(v -> Flux.range(v, 2)).subscribe(ts);
 		
@@ -53,7 +53,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void normalBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 		
 		Flux.range(1, 1000).flatMap(v -> Flux.range(v, 2)).subscribe(ts);
 		
@@ -76,7 +76,7 @@ public class FluxFlatMapTest {
 	
 	@Test
 	public void mainError() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Flux.<Integer>error(new RuntimeException("forced failure"))
 		.flatMap(v -> new FluxJust<>(v)).subscribe(ts);
@@ -89,7 +89,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void innerError() {
-		TestSubscriber<Object> ts = new TestSubscriber<>(0);
+		TestSubscriber<Object> ts = TestSubscriber.create(0);
 
 		new FluxJust<>(1).flatMap(v -> Flux.error(new RuntimeException("forced failure"))).subscribe(ts);
 		
@@ -101,7 +101,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void normalQueueOpt() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux.range(1, 1000).flatMap(v -> new FluxArray<>(v, v + 1)).subscribe(ts);
 		
@@ -112,7 +112,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void normalQueueOptBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 		
 		Flux.range(1, 1000).flatMap(v -> new FluxArray<>(v, v + 1)).subscribe(ts);
 		
@@ -135,7 +135,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void nullValue() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux.range(1, 1000).flatMap(v -> new FluxArray<>((Integer)null)).subscribe(ts);
 		
@@ -146,7 +146,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void mainEmpty() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Flux.<Integer>empty().flatMap(v -> new FluxJust<>(v)).subscribe(ts);
 		
@@ -157,7 +157,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void innerEmpty() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Flux.range(1, 1000).flatMap(v -> Flux.<Integer>empty()).subscribe(ts);
 		
@@ -168,7 +168,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void flatMapOfJust() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux.range(1, 1000).flatMap(Flux::just).subscribe(ts);
 		
@@ -179,7 +179,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void flatMapOfMixed() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux.range(1, 1000).flatMap(
 				v -> v % 2 == 0 ? Flux.just(v) : Flux.fromIterable(Arrays.asList(v)))
@@ -192,7 +192,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void flatMapOfMixedBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 		
 		Flux.range(1, 1000).flatMap(v -> v % 2 == 0 ? Flux.just(v) : Flux.fromIterable(Arrays.asList(v))).subscribe(ts);
 		
@@ -215,7 +215,7 @@ public class FluxFlatMapTest {
 	
 	@Test
 	public void flatMapOfMixedBackpressured1() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 		
 		Flux.range(1, 1000).flatMap(v -> v % 2 == 0 ? Flux.just(v) : Flux.fromIterable(Arrays.asList(v))).subscribe(ts);
 		
@@ -238,7 +238,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void flatMapOfJustBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 		
 		Flux.range(1, 1000).flatMap(Flux::just).subscribe(ts);
 		
@@ -261,7 +261,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void flatMapOfJustBackpressured1() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 		
 		Flux.range(1, 1000).flatMap(Flux::just).subscribe(ts);
 		
@@ -285,7 +285,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void testMaxConcurrency1() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 1_000_000).flatMap(Flux::just, 1, 32).subscribe(ts);
 		
@@ -296,7 +296,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void singleSubscriberOnly() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		AtomicInteger emission = new AtomicInteger();
 		
@@ -334,7 +334,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void flatMapUnbounded() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		AtomicInteger emission = new AtomicInteger();
 		
@@ -370,7 +370,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void syncFusionIterable() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		List<Integer> list = new ArrayList<>();
 		for (int i = 0; i < 1000; i++) {
@@ -386,7 +386,7 @@ public class FluxFlatMapTest {
 	
 	@Test
 	public void syncFusionRange() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux.range(1, 1000).flatMap(v -> Flux.range(v, 1000)).subscribe(ts);
 		
@@ -397,7 +397,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void syncFusionArray() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Integer[] array = new Integer[1000];
 		Arrays.fill(array, 777);
@@ -411,7 +411,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void innerMapSyncFusion() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 1000).flatMap(v -> Flux.range(1, 1000).map(w -> w + 1)).subscribe(ts);
 

--- a/src/test/java/reactor/core/publisher/FluxGenerateTest.java
+++ b/src/test/java/reactor/core/publisher/FluxGenerateTest.java
@@ -44,7 +44,7 @@ public class FluxGenerateTest {
 
 	@Test
 	public void generateEmpty() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxGenerate<Integer, Void>((s, o) -> {
 			o.complete();
@@ -58,7 +58,7 @@ public class FluxGenerateTest {
 
 	@Test
 	public void generateNever() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxGenerate<Integer, Void>((s, o) -> {
 			o.stop();
@@ -72,7 +72,7 @@ public class FluxGenerateTest {
 
 	@Test
 	public void generateJust() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxGenerate<Integer, Void>((s, o) -> {
 			o.next(1);
@@ -87,7 +87,7 @@ public class FluxGenerateTest {
 
 	@Test
 	public void generateError() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxGenerate<Integer, Void>((s, o) -> {
 			o.fail(new RuntimeException("forced failure"));
@@ -104,7 +104,7 @@ public class FluxGenerateTest {
 
 	@Test
 	public void generateJustBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		new FluxGenerate<Integer, Void>((s, o) -> {
 			o.next(1);
@@ -125,7 +125,7 @@ public class FluxGenerateTest {
 
 	@Test
 	public void generateRange() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxGenerate<Integer, Integer>(() -> 1, (s, o) -> {
 			if (s < 11) {
@@ -143,7 +143,7 @@ public class FluxGenerateTest {
 
 	@Test
 	public void generateRangeBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		new FluxGenerate<Integer, Integer>(() -> 1, (s, o) -> {
 			if (s < 11) {
@@ -174,7 +174,7 @@ public class FluxGenerateTest {
 
 	@Test
 	public void stateSupplierThrows() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxGenerate<Integer, Integer>(() -> {
 			throw new RuntimeException("forced failure");
@@ -190,7 +190,7 @@ public class FluxGenerateTest {
 
 	@Test
 	public void generatorThrows() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxGenerate<Integer, Integer>((s, o) -> {
 			throw new RuntimeException("forced failure");
@@ -204,7 +204,7 @@ public class FluxGenerateTest {
 
 	@Test
 	public void generatorMultipleOnErrors() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxGenerate<Integer, Integer>((s, o) -> {
 			o.fail(new RuntimeException("forced failure"));
@@ -220,7 +220,7 @@ public class FluxGenerateTest {
 
 	@Test
 	public void generatorMultipleOnCompletes() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxGenerate<Integer, Integer>((s, o) -> {
 			o.complete();
@@ -235,7 +235,7 @@ public class FluxGenerateTest {
 
 	@Test
 	public void generatorMultipleOnNexts() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxGenerate<Integer, Integer>((s, o) -> {
 			o.next(1);
@@ -250,7 +250,7 @@ public class FluxGenerateTest {
 
 	@Test
 	public void stateConsumerCalled() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		AtomicInteger stateConsumer = new AtomicInteger();
 
@@ -268,7 +268,7 @@ public class FluxGenerateTest {
 
 	@Test
 	public void iterableSource() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		List<Integer> list = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
@@ -290,7 +290,7 @@ public class FluxGenerateTest {
 
 	@Test
 	public void iterableSourceBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		List<Integer> list = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
@@ -329,7 +329,7 @@ public class FluxGenerateTest {
 	
 	@Test
 	public void fusion() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		ts.requestedFusionMode(Fuseable.ANY);
 		
 		List<Integer> list = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -353,7 +353,7 @@ public class FluxGenerateTest {
 
 	@Test
 	public void fusionBoundary() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		ts.requestedFusionMode(Fuseable.ANY | Fuseable.THREAD_BARRIER);
 		
 		List<Integer> list = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);

--- a/src/test/java/reactor/core/publisher/FluxJustTest.java
+++ b/src/test/java/reactor/core/publisher/FluxJustTest.java
@@ -34,7 +34,7 @@ public class FluxJustTest {
 
     @Test
     public void normal() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Flux.just(1).subscribe(ts);
 
@@ -45,7 +45,7 @@ public class FluxJustTest {
 
     @Test
     public void normalBackpressured() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
         Flux.just(1).subscribe(ts);
 
@@ -62,7 +62,7 @@ public class FluxJustTest {
 
     @Test
     public void fused() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         ts.requestedFusionMode(Fuseable.ANY);
         
         Flux.just(1).subscribe(ts);

--- a/src/test/java/reactor/core/publisher/FluxMapSignalTest.java
+++ b/src/test/java/reactor/core/publisher/FluxMapSignalTest.java
@@ -22,7 +22,7 @@ import reactor.core.test.TestSubscriber;
 public class FluxMapSignalTest {
     @Test
     public void completeOnlyBackpressured() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0L);
         
         new FluxMapSignal<>(Flux.empty(), null, null, () -> 1)
         .subscribe(ts);
@@ -40,7 +40,7 @@ public class FluxMapSignalTest {
 
     @Test
     public void errorOnlyBackpressured() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0L);
         
         new FluxMapSignal<>(Flux.error(new RuntimeException()), null, e -> 1, null)
         .subscribe(ts);

--- a/src/test/java/reactor/core/publisher/FluxMaterializeTest.java
+++ b/src/test/java/reactor/core/publisher/FluxMaterializeTest.java
@@ -23,7 +23,7 @@ public class FluxMaterializeTest {
 
     @Test
     public void completeOnlyBackpressured() {
-        TestSubscriber<Signal<Integer>> ts = new TestSubscriber<>(0L);
+        TestSubscriber<Signal<Integer>> ts = TestSubscriber.create(0L);
         
         Flux.<Integer>empty().materialize()
         .subscribe(ts);
@@ -41,7 +41,7 @@ public class FluxMaterializeTest {
 
     @Test
     public void errorOnlyBackpressured() {
-        TestSubscriber<Signal<Integer>> ts = new TestSubscriber<>(0L);
+        TestSubscriber<Signal<Integer>> ts = TestSubscriber.create(0L);
 
         RuntimeException ex = new RuntimeException();
         

--- a/src/test/java/reactor/core/publisher/FluxMergeWithTest.java
+++ b/src/test/java/reactor/core/publisher/FluxMergeWithTest.java
@@ -33,7 +33,7 @@ public class FluxMergeWithTest {
 			result = result.mergeWith(source);
 		}
 		
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		result.subscribe(ts);
 		
@@ -55,7 +55,7 @@ public class FluxMergeWithTest {
 			result = result.mergeWith(add);
 		}
 		
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		result.subscribe(ts);
 		
@@ -77,7 +77,7 @@ public class FluxMergeWithTest {
 			result = result.mergeWith(add);
 		}
 		
-		TestSubscriber<Object> ts = new TestSubscriber<>();
+		TestSubscriber<Object> ts = TestSubscriber.create();
 		
 		result.subscribe(ts);
 		
@@ -89,7 +89,7 @@ public class FluxMergeWithTest {
 	
 	@Test
 	public void dontBreakFluxArrayFlatmap() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux.just(1, 2).flatMap(Flux::just).mergeWith(Flux.just(3))
 		.subscribe(ts);

--- a/src/test/java/reactor/core/publisher/FluxNeverTest.java
+++ b/src/test/java/reactor/core/publisher/FluxNeverTest.java
@@ -13,7 +13,7 @@ public class FluxNeverTest {
 
 	@Test
 	public void normal() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		FluxNever.<Integer>instance().subscribe(ts);
 

--- a/src/test/java/reactor/core/publisher/FluxPeekTest.java
+++ b/src/test/java/reactor/core/publisher/FluxPeekTest.java
@@ -36,7 +36,7 @@ public class FluxPeekTest {
 
 	@Test
 	public void normal() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		AtomicReference<Subscription> onSubscribe = new AtomicReference<>();
 		AtomicReference<Integer> onNext = new AtomicReference<>();
@@ -67,7 +67,7 @@ public class FluxPeekTest {
 
 	@Test
 	public void error() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		AtomicReference<Subscription> onSubscribe = new AtomicReference<>();
 		AtomicReference<Integer> onNext = new AtomicReference<>();
@@ -98,7 +98,7 @@ public class FluxPeekTest {
 
 	@Test
 	public void empty() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		AtomicReference<Subscription> onSubscribe = new AtomicReference<>();
 		AtomicReference<Integer> onNext = new AtomicReference<>();
@@ -129,7 +129,7 @@ public class FluxPeekTest {
 
 	@Test
 	public void never() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		AtomicReference<Subscription> onSubscribe = new AtomicReference<>();
 		AtomicReference<Integer> onNext = new AtomicReference<>();
@@ -160,7 +160,7 @@ public class FluxPeekTest {
 
 	@Test
 	public void neverCancel() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		AtomicReference<Subscription> onSubscribe = new AtomicReference<>();
 		AtomicReference<Integer> onNext = new AtomicReference<>();
@@ -195,7 +195,7 @@ public class FluxPeekTest {
 
 	@Test
 	public void callbackError(){
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Throwable err = new Exception("test");
 
@@ -210,7 +210,7 @@ public class FluxPeekTest {
 		//nominal error path (DownstreamException)
 		ts.assertErrorMessage("test");
 
-		ts = new TestSubscriber<>();
+		ts = TestSubscriber.create();
 
 		try {
 			new FluxPeek<>(new FluxJust<>(1),
@@ -230,7 +230,7 @@ public class FluxPeekTest {
 
 	@Test
 	public void syncFusionAvailable() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 2)
 		    .doOnNext(v -> {
@@ -244,7 +244,7 @@ public class FluxPeekTest {
 
 	@Test
 	public void asyncFusionAvailable() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new UnicastProcessor<Integer>(QueueSupplier.<Integer>get(2).get()).doOnNext(v -> {
 		})
@@ -257,7 +257,7 @@ public class FluxPeekTest {
 
 	@Test
 	public void conditionalFusionAvailable() {
-		TestSubscriber<Object> ts = new TestSubscriber<>();
+		TestSubscriber<Object> ts = TestSubscriber.create();
 
 		FluxSource.wrap(u -> {
 			if (!(u instanceof Fuseable.ConditionalSubscriber)) {
@@ -280,7 +280,7 @@ public class FluxPeekTest {
 
 	@Test
 	public void conditionalFusionAvailableWithFuseable() {
-		TestSubscriber<Object> ts = new TestSubscriber<>();
+		TestSubscriber<Object> ts = TestSubscriber.create();
 
 		FluxSource.wrap(u -> {
 			if (!(u instanceof Fuseable.ConditionalSubscriber)) {
@@ -305,7 +305,7 @@ public class FluxPeekTest {
 	public void syncCompleteCalled() {
 		AtomicBoolean onComplete = new AtomicBoolean();
 
-		TestSubscriber<Object> ts = new TestSubscriber<>();
+		TestSubscriber<Object> ts = TestSubscriber.create();
 
 		Flux.range(1, 2)
 		    .doOnComplete(() -> onComplete.set(true))
@@ -322,7 +322,7 @@ public class FluxPeekTest {
 	public void syncdoAfterTerminateCalled() {
 		AtomicBoolean onTerminate = new AtomicBoolean();
 
-		TestSubscriber<Object> ts = new TestSubscriber<>();
+		TestSubscriber<Object> ts = TestSubscriber.create();
 
 		Flux.range(1, 2)
 		    .doAfterTerminate(() -> onTerminate.set(true))

--- a/src/test/java/reactor/core/publisher/FluxPublishTest.java
+++ b/src/test/java/reactor/core/publisher/FluxPublishTest.java
@@ -32,7 +32,7 @@ public class FluxPublishTest {
 	@Test
 	public void subsequentSum() {
 
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		range(1, 5).publish(o -> zip((Object[] a) -> (Integer) a[0] + (Integer) a[1], o, o.skip(1)))
 		           .subscribe(ts);
@@ -45,7 +45,7 @@ public class FluxPublishTest {
 	@Test
 	public void subsequentSumHidden() {
 
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		range(1, 5).hide()
 		           .publish(o -> zip((Object[] a) -> (Integer) a[0] + (Integer) a[1], o, o
@@ -60,7 +60,7 @@ public class FluxPublishTest {
 	@Test
 	public void subsequentSumAsync() {
 
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		UnicastProcessor<Integer> up =
 				new UnicastProcessor<>(QueueSupplier.<Integer>get(16).get());
@@ -82,7 +82,7 @@ public class FluxPublishTest {
 
 	@Test
 	public void cancelComposes() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		EmitterProcessor<Integer> sp = EmitterProcessor.create();
 
@@ -98,7 +98,7 @@ public class FluxPublishTest {
 
 	@Test
 	public void cancelComposes2() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		EmitterProcessor<Integer> sp = EmitterProcessor.create();
 
@@ -110,7 +110,7 @@ public class FluxPublishTest {
 
 	@Test
 	public void pairWise() {
-		TestSubscriber<Tuple2<Integer, Integer>> ts = new TestSubscriber<>();
+		TestSubscriber<Tuple2<Integer, Integer>> ts = TestSubscriber.create();
 
 		range(1, 9).compose(o -> zip(o, o.skip(1)))
 		           .subscribe(ts);
@@ -128,7 +128,7 @@ public class FluxPublishTest {
 
 	@Test
 	public void innerCanFuse() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		ts.requestedFusionMode(Fuseable.ANY);
 
 		Flux.never()

--- a/src/test/java/reactor/core/publisher/FluxResumeTest.java
+++ b/src/test/java/reactor/core/publisher/FluxResumeTest.java
@@ -33,7 +33,7 @@ public class FluxResumeTest {
 
 	@Test
 	public void normal() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 10)
 		    .onErrorResumeWith(v -> Flux.range(11, 10))
@@ -46,7 +46,7 @@ public class FluxResumeTest {
 
 	@Test
 	public void normalBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Flux.range(1, 10)
 		    .onErrorResumeWith(v -> Flux.range(11, 10))
@@ -77,7 +77,7 @@ public class FluxResumeTest {
 
 	@Test
 	public void error() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.<Integer>error(new RuntimeException("forced failure")).onErrorResumeWith(v -> Flux.range
 		  (11, 10)).subscribe(ts);
@@ -89,7 +89,7 @@ public class FluxResumeTest {
 
 	@Test
 	public void errorFiltered() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.<Integer>error(new RuntimeException("forced failure"))
 				.onErrorResumeWith(e -> e.getMessage().equals("forced failure"), v -> Mono.just(2))
@@ -102,7 +102,7 @@ public class FluxResumeTest {
 
 	@Test
 	public void errorMap() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.<Integer>error(new Exception()).mapError(d -> new RuntimeException("forced" +
 				" " +
@@ -116,7 +116,7 @@ public class FluxResumeTest {
 
 	@Test
 	public void errorBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Flux.<Integer>error(new RuntimeException("forced failure")).onErrorResumeWith(v -> Flux.range
 		  (11, 10)).subscribe(ts);
@@ -150,7 +150,7 @@ public class FluxResumeTest {
 
 		tp.connect();
 
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		tp.onErrorResumeWith(v -> Flux.range(11, 10))
 		  .subscribe(ts);
@@ -173,7 +173,7 @@ public class FluxResumeTest {
 
 		tp.connect();
 
-		TestSubscriber<Integer> ts = new TestSubscriber<>(10);
+		TestSubscriber<Integer> ts = TestSubscriber.create(10);
 
 		tp.onErrorResumeWith(v -> Flux.range(11, 10))
 		  .subscribe(ts);
@@ -198,7 +198,7 @@ public class FluxResumeTest {
 
 	@Test
 	public void nextFactoryThrows() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Flux.<Integer>error(new RuntimeException("forced failure")).onErrorResumeWith(v -> {
 			throw new RuntimeException("forced failure 2");
@@ -212,7 +212,7 @@ public class FluxResumeTest {
 
 	@Test
 	public void nextFactoryReturnsNull() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Flux.<Integer>error(new RuntimeException("forced failure")).onErrorResumeWith(v -> null)
 		                                                           .subscribe(ts);

--- a/src/test/java/reactor/core/publisher/FluxStartWithTest.java
+++ b/src/test/java/reactor/core/publisher/FluxStartWithTest.java
@@ -33,7 +33,7 @@ public class FluxStartWithTest {
 			result = result.startWith(source);
 		}
 		
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		result.subscribe(ts);
 		
@@ -55,7 +55,7 @@ public class FluxStartWithTest {
 			result = result.startWith(add);
 		}
 		
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		result.subscribe(ts);
 		
@@ -77,7 +77,7 @@ public class FluxStartWithTest {
 			result = result.startWith(add);
 		}
 		
-		TestSubscriber<Object> ts = new TestSubscriber<>();
+		TestSubscriber<Object> ts = TestSubscriber.create();
 		
 		result.subscribe(ts);
 		
@@ -89,7 +89,7 @@ public class FluxStartWithTest {
 	
 	@Test
 	public void dontBreakFluxArrayConcatMap() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux.just(1, 2).concatMap(Flux::just).startWith(Flux.just(3))
 		.subscribe(ts);

--- a/src/test/java/reactor/core/publisher/FluxSubscribeOnTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSubscribeOnTest.java
@@ -39,7 +39,7 @@ public class FluxSubscribeOnTest {
 	
 	@Test
 	public void classic() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 1000).subscribeOn(ForkJoinPool.commonPool()).subscribe(ts);
 		
@@ -52,7 +52,7 @@ public class FluxSubscribeOnTest {
 
 	@Test
 	public void classicBackpressured() throws Exception {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Flux.range(1, 1000).log().subscribeOn(ForkJoinPool.commonPool()).subscribe(ts);
 		
@@ -81,7 +81,7 @@ public class FluxSubscribeOnTest {
 	
 	@Test
 	public void classicJust() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux.just(1).subscribeOn(ForkJoinPool.commonPool()).subscribe(ts);
 		
@@ -94,7 +94,7 @@ public class FluxSubscribeOnTest {
 
 	@Test
 	public void classicJustBackpressured() throws Exception {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 		
 		Flux.just(1).subscribeOn(ForkJoinPool.commonPool()).subscribe(ts);
 		
@@ -115,7 +115,7 @@ public class FluxSubscribeOnTest {
 
 	@Test
 	public void classicEmpty() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux.<Integer>empty().subscribeOn(ForkJoinPool.commonPool()).subscribe(ts);
 		
@@ -128,7 +128,7 @@ public class FluxSubscribeOnTest {
 
 	@Test
 	public void classicEmptyBackpressured() throws Exception {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 		
 		Flux.<Integer>empty().subscribeOn(ForkJoinPool.commonPool()).subscribe(ts);
 		
@@ -149,7 +149,7 @@ public class FluxSubscribeOnTest {
 		
 		Assert.assertEquals(0, count.get());
 		
-		p.subscribeWith(new TestSubscriber<>()).await();
+		p.subscribeWith(TestSubscriber.create()).await();
 		
 		Assert.assertEquals(1, count.get());
 	}}

--- a/src/test/java/reactor/core/publisher/FluxSwitchIfEmptyTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSwitchIfEmptyTest.java
@@ -32,7 +32,7 @@ public class FluxSwitchIfEmptyTest {
 
 	@Test
 	public void nonEmpty() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxSwitchIfEmpty<>(Flux.just(1, 2, 3, 4, 5), new FluxJust<>(10)).subscribe(ts);
 
@@ -43,7 +43,7 @@ public class FluxSwitchIfEmptyTest {
 
 	@Test
 	public void nonEmptyBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		new FluxSwitchIfEmpty<>(Flux.just(1, 2, 3, 4, 5), new FluxJust<>(10)).subscribe(ts);
 
@@ -66,7 +66,7 @@ public class FluxSwitchIfEmptyTest {
 
 	@Test
 	public void empty() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxSwitchIfEmpty<>(Flux.empty(), new FluxJust<>(10)).subscribe(ts);
 
@@ -77,7 +77,7 @@ public class FluxSwitchIfEmptyTest {
 
 	@Test
 	public void emptyBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		new FluxSwitchIfEmpty<>(Flux.empty(), new FluxJust<>(10)).subscribe(ts);
 

--- a/src/test/java/reactor/core/publisher/FluxTakeUntilPredicateTest.java
+++ b/src/test/java/reactor/core/publisher/FluxTakeUntilPredicateTest.java
@@ -32,7 +32,7 @@ public class FluxTakeUntilPredicateTest {
 
 	@Test
 	public void takeAll() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxTakeUntilPredicate<>(new FluxRange(1, 5), v -> false).subscribe(ts);
 
@@ -43,7 +43,7 @@ public class FluxTakeUntilPredicateTest {
 
 	@Test
 	public void takeAllBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		new FluxTakeUntilPredicate<>(new FluxRange(1, 5), v -> false).subscribe(ts);
 
@@ -66,7 +66,7 @@ public class FluxTakeUntilPredicateTest {
 
 	@Test
 	public void takeSome() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxTakeUntilPredicate<>(new FluxRange(1, 5), v -> v == 3).subscribe(ts);
 
@@ -77,7 +77,7 @@ public class FluxTakeUntilPredicateTest {
 
 	@Test
 	public void takeSomeBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		new FluxTakeUntilPredicate<>(new FluxRange(1, 5), v -> v == 3).subscribe(ts);
 
@@ -100,7 +100,7 @@ public class FluxTakeUntilPredicateTest {
 
 	@Test
 	public void stopImmediately() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxTakeUntilPredicate<>(new FluxRange(1, 5), v -> true).subscribe(ts);
 
@@ -111,7 +111,7 @@ public class FluxTakeUntilPredicateTest {
 
 	@Test
 	public void stopImmediatelyBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		new FluxTakeUntilPredicate<>(new FluxRange(1, 5), v -> true).subscribe(ts);
 
@@ -128,7 +128,7 @@ public class FluxTakeUntilPredicateTest {
 
 	@Test
 	public void predicateThrows() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxTakeUntilPredicate<>(new FluxRange(1, 5), v -> {
 			throw new RuntimeException("forced failure");

--- a/src/test/java/reactor/core/publisher/FluxWithLatestFromTest.java
+++ b/src/test/java/reactor/core/publisher/FluxWithLatestFromTest.java
@@ -39,7 +39,7 @@ public class FluxWithLatestFromTest {
 
 	@Test
 	public void normal() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxWithLatestFrom<>(new FluxRange(1, 10), new FluxJust<>(10), (a, b) -> a + b).subscribe
 		  (ts);
@@ -51,7 +51,7 @@ public class FluxWithLatestFromTest {
 
 	@Test
 	public void normalBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		new FluxWithLatestFrom<>(new FluxRange(1, 10), new FluxJust<>(10), (a, b) -> a + b).subscribe
 		  (ts);
@@ -81,7 +81,7 @@ public class FluxWithLatestFromTest {
 
 	@Test
 	public void otherIsNever() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxWithLatestFrom<>(new FluxRange(1, 10), Flux.<Integer>empty(), (a, b) -> a + b)
 		  .subscribe(ts);
@@ -93,7 +93,7 @@ public class FluxWithLatestFromTest {
 
 	@Test
 	public void otherIsEmpty() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		new FluxWithLatestFrom<>(new FluxRange(1, 10), Flux.<Integer>empty(), (a, b) -> a + b)
 		  .subscribe(ts);
@@ -105,7 +105,7 @@ public class FluxWithLatestFromTest {
 
 	@Test
 	public void combinerReturnsNull() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxWithLatestFrom<>(new FluxRange(1, 10), new FluxJust<>(10), (a, b) -> (Integer) null)
 		  .subscribe(ts);
@@ -117,7 +117,7 @@ public class FluxWithLatestFromTest {
 
 	@Test
 	public void combinerThrows() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		new FluxWithLatestFrom<Integer, Integer, Integer>(
 		  new FluxRange(1, 10), new FluxJust<>(10),

--- a/src/test/java/reactor/core/publisher/FluxYieldTest.java
+++ b/src/test/java/reactor/core/publisher/FluxYieldTest.java
@@ -25,7 +25,7 @@ public class FluxYieldTest {
     @Test
     public void yieldSome() {
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         
         Flux<Integer> source = Flux.<Signal<Integer>>create(e -> {
             e.next(Signal.next(1));

--- a/src/test/java/reactor/core/publisher/FluxZipIterableTest.java
+++ b/src/test/java/reactor/core/publisher/FluxZipIterableTest.java
@@ -41,7 +41,7 @@ public class FluxZipIterableTest {
 	
 	@Test
 	public void normalSameSize() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		new FluxZipIterable<>(new FluxRange(1, 5),
 				Arrays.asList(10, 20, 30, 40, 50), (a, b) -> a + b).subscribe(ts);
@@ -53,7 +53,7 @@ public class FluxZipIterableTest {
 
 	@Test
 	public void normalSameSizeBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 		
 		new FluxZipIterable<>(new FluxRange(1, 5),
 				Arrays.asList(10, 20, 30, 40, 50), (a, b) -> a + b).subscribe(ts);
@@ -83,7 +83,7 @@ public class FluxZipIterableTest {
 	
 	@Test
 	public void normalSourceShorter() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		new FluxZipIterable<>(new FluxRange(1, 4),
 				Arrays.asList(10, 20, 30, 40, 50), (a, b) -> a + b).subscribe(ts);
@@ -95,7 +95,7 @@ public class FluxZipIterableTest {
 
 	@Test
 	public void normalOtherShorter() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		new FluxZipIterable<>(new FluxRange(1, 5),
 				Arrays.asList(10, 20, 30, 40), (a, b) -> a + b).subscribe(ts);
@@ -107,7 +107,7 @@ public class FluxZipIterableTest {
 
 	@Test
 	public void sourceEmpty() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		new FluxZipIterable<>(new FluxRange(1, 0),
 				Arrays.asList(10, 20, 30, 40), (a, b) -> a + b).subscribe(ts);
@@ -119,7 +119,7 @@ public class FluxZipIterableTest {
 
 	@Test
 	public void otherEmpty() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		new FluxZipIterable<>(new FluxRange(1, 5),
 				Collections.<Integer>emptyList(), (a, b) -> a + b).subscribe(ts);
@@ -131,7 +131,7 @@ public class FluxZipIterableTest {
 
 	@Test
 	public void zipperReturnsNull() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		new FluxZipIterable<>(new FluxRange(1, 5),
 				Arrays.asList(10, 20, 30, 40, 50), (a, b) -> (Integer)null).subscribe(ts);
@@ -143,7 +143,7 @@ public class FluxZipIterableTest {
 
 	@Test
 	public void iterableReturnsNull() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		new FluxZipIterable<>(new FluxRange(1, 5),
 				() -> null, (a, b) -> a).subscribe(ts);
@@ -155,7 +155,7 @@ public class FluxZipIterableTest {
 
 	@Test
 	public void zipperThrowsNull() {
-		TestSubscriber<Object> ts = new TestSubscriber<>();
+		TestSubscriber<Object> ts = TestSubscriber.create();
 		
 		new FluxZipIterable<>(new FluxRange(1, 5),
 				Arrays.asList(10, 20, 30, 40, 50), (a, b) -> { throw new RuntimeException("forced failure"); }).subscribe(ts);
@@ -168,7 +168,7 @@ public class FluxZipIterableTest {
 
 	@Test
 	public void iterableThrowsNull() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		new FluxZipIterable<>(new FluxRange(1, 5),
 				() -> { throw new RuntimeException("forced failure"); }, (a, b) -> a).subscribe(ts);

--- a/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -39,7 +39,7 @@ public class FluxZipTest {
 	@Test
 	public void sameLength() {
 		
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux<Integer> source = Flux.fromIterable(Arrays.asList(1, 2));
 		source.zipWith(source, (a, b) -> a + b).subscribe(ts);
@@ -52,7 +52,7 @@ public class FluxZipTest {
 	@Test
 	public void sameLengthOptimized() {
 		
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux<Integer> source = Flux.just(1, 2);
 		source.zipWith(source, (a, b) -> a + b).subscribe(ts);
@@ -65,7 +65,7 @@ public class FluxZipTest {
 	@Test
 	public void sameLengthBackpressured() {
 		
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 		
 		Flux<Integer> source = Flux.fromIterable(Arrays.asList(1, 2));
 		source.zipWith(source, (a, b) -> a + b).subscribe(ts);
@@ -90,7 +90,7 @@ public class FluxZipTest {
 	@Test
 	public void sameLengthOptimizedBackpressured() {
 		
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 		
 		Flux<Integer> source = Flux.just(1, 2);
 		source.zipWith(source, (a, b) -> a + b).subscribe(ts);
@@ -115,7 +115,7 @@ public class FluxZipTest {
 	@Test
 	public void differentLength() {
 		
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux<Integer> source1 = Flux.fromIterable(Arrays.asList(1, 2));
 		Flux<Integer> source2 = Flux.just(1, 2, 3);
@@ -129,7 +129,7 @@ public class FluxZipTest {
 	@Test
 	public void differentLengthOpt() {
 		
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux<Integer> source1 = Flux.fromIterable(Arrays.asList(1, 2));
 		Flux<Integer> source2 = Flux.just(1, 2, 3);
@@ -142,7 +142,7 @@ public class FluxZipTest {
 	
 	@Test
 	public void emptyNonEmpty() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux<Integer> source1 = Flux.fromIterable(Collections.emptyList());
 		Flux<Integer> source2 = Flux.just(1, 2, 3);
@@ -155,7 +155,7 @@ public class FluxZipTest {
 	
 	@Test
 	public void nonEmptyAndEmpty() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux<Integer> source1 = Flux.just(1, 2, 3);
 		Flux<Integer> source2 = Flux.fromIterable(Collections.emptyList());
@@ -168,7 +168,7 @@ public class FluxZipTest {
 	
 	@Test
 	public void scalarNonScalar() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux<Integer> source1 = Flux.just(1);
 		Flux<Integer> source2 = Flux.just(1, 2, 3);
@@ -181,7 +181,7 @@ public class FluxZipTest {
 	
 	@Test
 	public void scalarNonScalarBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 		
 		Flux<Integer> source1 = Flux.just(1);
 		Flux<Integer> source2 = Flux.just(1, 2, 3);
@@ -200,7 +200,7 @@ public class FluxZipTest {
 	
 	@Test
 	public void scalarNonScalarOpt() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux<Integer> source1 = Flux.just(1);
 		Flux<Integer> source2 = Flux.just(1, 2, 3);
@@ -213,7 +213,7 @@ public class FluxZipTest {
 	
 	@Test
 	public void scalarScalar() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux<Integer> source1 = Flux.just(1);
 		Flux<Integer> source2 = Flux.just(1);
@@ -226,7 +226,7 @@ public class FluxZipTest {
 	
 	@Test
 	public void emptyScalar() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 		
 		Flux<Integer> source1 = Flux.empty();
 		Flux<Integer> source2 = Flux.just(1);
@@ -239,7 +239,7 @@ public class FluxZipTest {
 
 	@Test
 	public void syncFusionMapToNull() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
 		.<Integer, Integer>zipWith(Flux.fromIterable(Arrays.asList(1, 2)).map(v -> v == 2 ? null : v), (a, b) -> a + b).subscribe(ts);

--- a/src/test/java/reactor/core/publisher/MonoAggregateTest.java
+++ b/src/test/java/reactor/core/publisher/MonoAggregateTest.java
@@ -34,7 +34,7 @@ public class MonoAggregateTest {
 */
 	@Test
 	public void normal() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 10)
 		       .reduce((a, b) -> a + b)
@@ -47,7 +47,7 @@ public class MonoAggregateTest {
 
 	@Test
 	public void normalBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0L);
 
 		Flux.range(1, 10)
 		       .reduce((a, b) -> a + b)
@@ -66,7 +66,7 @@ public class MonoAggregateTest {
 
 	@Test
 	public void single() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.just(1)
 		       .reduce((a, b) -> a + b)
@@ -79,7 +79,7 @@ public class MonoAggregateTest {
 
 	@Test
 	public void empty() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.<Integer>empty().reduce((a, b) -> a + b)
 		                        .subscribe(ts);
@@ -91,7 +91,7 @@ public class MonoAggregateTest {
 
 	@Test
 	public void error() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.<Integer>error(new RuntimeException("forced failure")).reduce((a, b) -> a + b)
 		                                                              .subscribe(ts);
@@ -105,7 +105,7 @@ public class MonoAggregateTest {
 
 	@Test
 	public void aggregatorThrows() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 10)
 		       .reduce((a, b) -> {
@@ -122,7 +122,7 @@ public class MonoAggregateTest {
 
 	@Test
 	public void aggregatorReturnsNull() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 10)
 		       .reduce((a, b) -> null)

--- a/src/test/java/reactor/core/publisher/MonoAllTest.java
+++ b/src/test/java/reactor/core/publisher/MonoAllTest.java
@@ -34,7 +34,7 @@ public class MonoAllTest {
 
 	@Test
 	public void normal() {
-		TestSubscriber<Boolean> ts = new TestSubscriber<>();
+		TestSubscriber<Boolean> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).all(v -> true).subscribe(ts);
 
@@ -45,7 +45,7 @@ public class MonoAllTest {
 
 	@Test
 	public void normalBackpressured() {
-		TestSubscriber<Boolean> ts = new TestSubscriber<>(0);
+		TestSubscriber<Boolean> ts = TestSubscriber.create(0);
 
 		Flux.range(1, 10).all(v -> true).subscribe(ts);
 
@@ -62,7 +62,7 @@ public class MonoAllTest {
 
 	@Test
 	public void someMatch() {
-		TestSubscriber<Boolean> ts = new TestSubscriber<>();
+		TestSubscriber<Boolean> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).all(v -> v < 6).subscribe(ts);
 
@@ -73,7 +73,7 @@ public class MonoAllTest {
 
 	@Test
 	public void someMatchBackpressured() {
-		TestSubscriber<Boolean> ts = new TestSubscriber<>(0);
+		TestSubscriber<Boolean> ts = TestSubscriber.create(0);
 
 		Flux.range(1, 10).all(v -> v < 6).subscribe(ts);
 
@@ -90,7 +90,7 @@ public class MonoAllTest {
 
 	@Test
 	public void predicateThrows() {
-		TestSubscriber<Boolean> ts = new TestSubscriber<>();
+		TestSubscriber<Boolean> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).all(v -> {
 			throw new RuntimeException("forced failure");

--- a/src/test/java/reactor/core/publisher/MonoAnyTest.java
+++ b/src/test/java/reactor/core/publisher/MonoAnyTest.java
@@ -34,7 +34,7 @@ public class MonoAnyTest {
 
 	@Test
 	public void normal() {
-		TestSubscriber<Boolean> ts = new TestSubscriber<>();
+		TestSubscriber<Boolean> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).any(v -> true).subscribe(ts);
 
@@ -45,7 +45,7 @@ public class MonoAnyTest {
 
 	@Test
 	public void normalBackpressured() {
-		TestSubscriber<Boolean> ts = new TestSubscriber<>(0);
+		TestSubscriber<Boolean> ts = TestSubscriber.create(0);
 
 		Flux.range(1, 10).any(v -> true).subscribe(ts);
 
@@ -62,7 +62,7 @@ public class MonoAnyTest {
 
 	@Test
 	public void none() {
-		TestSubscriber<Boolean> ts = new TestSubscriber<>();
+		TestSubscriber<Boolean> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).any(v -> false).subscribe(ts);
 
@@ -73,7 +73,7 @@ public class MonoAnyTest {
 
 	@Test
 	public void noneBackpressured() {
-		TestSubscriber<Boolean> ts = new TestSubscriber<>(0);
+		TestSubscriber<Boolean> ts = TestSubscriber.create(0);
 
 		Flux.range(1, 10).any(v -> false).subscribe(ts);
 
@@ -90,7 +90,7 @@ public class MonoAnyTest {
 
 	@Test
 	public void someMatch() {
-		TestSubscriber<Boolean> ts = new TestSubscriber<>();
+		TestSubscriber<Boolean> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).any(v -> v < 6).subscribe(ts);
 
@@ -101,7 +101,7 @@ public class MonoAnyTest {
 
 	@Test
 	public void someMatchBackpressured() {
-		TestSubscriber<Boolean> ts = new TestSubscriber<>(0);
+		TestSubscriber<Boolean> ts = TestSubscriber.create(0);
 
 		Flux.range(1, 10).any(v -> v < 6).subscribe(ts);
 
@@ -118,7 +118,7 @@ public class MonoAnyTest {
 
 	@Test
 	public void predicateThrows() {
-		TestSubscriber<Boolean> ts = new TestSubscriber<>();
+		TestSubscriber<Boolean> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).any(v -> {
 			throw new RuntimeException("forced failure");

--- a/src/test/java/reactor/core/publisher/MonoCallableTest.java
+++ b/src/test/java/reactor/core/publisher/MonoCallableTest.java
@@ -29,7 +29,7 @@ public class MonoCallableTest {
 
     @Test
     public void callableReturnsNull() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Mono.<Integer>fromCallable(() -> null).subscribe(ts);
 
@@ -40,7 +40,7 @@ public class MonoCallableTest {
 
     @Test
     public void callableEmptyReturnsNull() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Mono.<Integer>fromCallableOrEmpty(() -> null).subscribe(ts);
 
@@ -50,7 +50,7 @@ public class MonoCallableTest {
 
     @Test
     public void normal() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Mono.fromCallable(() -> 1).subscribe(ts);
 
@@ -61,7 +61,7 @@ public class MonoCallableTest {
 
     @Test
     public void normalBackpressured() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
         Mono.fromCallable(() -> 1).subscribe(ts);
 
@@ -78,7 +78,7 @@ public class MonoCallableTest {
 
     @Test
     public void callableThrows() {
-        TestSubscriber<Object> ts = new TestSubscriber<>();
+        TestSubscriber<Object> ts = TestSubscriber.create();
 
         Mono.fromCallable(() -> {
             throw new IOException("forced failure");

--- a/src/test/java/reactor/core/publisher/MonoCollectTest.java
+++ b/src/test/java/reactor/core/publisher/MonoCollectTest.java
@@ -44,7 +44,7 @@ public class MonoCollectTest {
 
 	@Test
 	public void normal() {
-		TestSubscriber<ArrayList<Integer>> ts = new TestSubscriber<>();
+		TestSubscriber<ArrayList<Integer>> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).collect(ArrayList<Integer>::new, (a, b) -> a.add(b)).subscribe(ts);
 
@@ -55,7 +55,7 @@ public class MonoCollectTest {
 
 	@Test
 	public void normalBackpressured() {
-		TestSubscriber<ArrayList<Integer>> ts = new TestSubscriber<>(0);
+		TestSubscriber<ArrayList<Integer>> ts = TestSubscriber.create(0);
 
 		Flux.range(1, 10).collect(ArrayList<Integer>::new, ArrayList::add).subscribe(ts);
 
@@ -72,7 +72,7 @@ public class MonoCollectTest {
 
 	@Test
 	public void supplierThrows() {
-		TestSubscriber<Object> ts = new TestSubscriber<>();
+		TestSubscriber<Object> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).collect(() -> {
 			throw new RuntimeException("forced failure");
@@ -88,7 +88,7 @@ public class MonoCollectTest {
 
 	@Test
 	public void supplierReturnsNull() {
-		TestSubscriber<Object> ts = new TestSubscriber<>();
+		TestSubscriber<Object> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).collect(() -> null, (a, b) -> {
 		}).subscribe(ts);
@@ -100,7 +100,7 @@ public class MonoCollectTest {
 
 	@Test
 	public void actionThrows() {
-		TestSubscriber<Object> ts = new TestSubscriber<>();
+		TestSubscriber<Object> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).collect(() -> 1, (a, b) -> {
 			throw new RuntimeException("forced failure");

--- a/src/test/java/reactor/core/publisher/MonoCountTest.java
+++ b/src/test/java/reactor/core/publisher/MonoCountTest.java
@@ -27,7 +27,7 @@ public class MonoCountTest {
 	}
 
 	public void normal() {
-		TestSubscriber<Long> ts = new TestSubscriber<>();
+		TestSubscriber<Long> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).count().subscribe(ts);
 
@@ -37,7 +37,7 @@ public class MonoCountTest {
 	}
 
 	public void normalBackpressured() {
-		TestSubscriber<Long> ts = new TestSubscriber<>(0);
+		TestSubscriber<Long> ts = TestSubscriber.create(0);
 
 		Flux.range(1, 10).count().subscribe(ts);
 

--- a/src/test/java/reactor/core/publisher/MonoDeferComposeTest.java
+++ b/src/test/java/reactor/core/publisher/MonoDeferComposeTest.java
@@ -32,7 +32,7 @@ public class MonoDeferComposeTest {
         
         
         for (int i = 0; i < 10; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            TestSubscriber<Integer> ts = TestSubscriber.create();
             
             source.subscribe(ts);
             
@@ -49,7 +49,7 @@ public class MonoDeferComposeTest {
         });
         
         for (int i = 0; i < 10; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            TestSubscriber<Integer> ts = TestSubscriber.create();
             
             source.subscribe(ts);
             
@@ -67,7 +67,7 @@ public class MonoDeferComposeTest {
         });
         
         for (int i = 0; i < 10; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            TestSubscriber<Integer> ts = TestSubscriber.create();
             
             source.subscribe(ts);
             

--- a/src/test/java/reactor/core/publisher/MonoElementAtTest.java
+++ b/src/test/java/reactor/core/publisher/MonoElementAtTest.java
@@ -49,7 +49,7 @@ public class MonoElementAtTest {
 
 	@Test
 	public void normal() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).elementAt(0).subscribe(ts);
 
@@ -60,7 +60,7 @@ public class MonoElementAtTest {
 
 	@Test
 	public void normalBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Flux.range(1, 10).elementAt(0).subscribe(ts);
 
@@ -77,7 +77,7 @@ public class MonoElementAtTest {
 
 	@Test
 	public void normal2() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).elementAt(4).subscribe(ts);
 
@@ -88,7 +88,7 @@ public class MonoElementAtTest {
 
 	@Test
 	public void normal5Backpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Flux.range(1, 10).elementAt(4).subscribe(ts);
 
@@ -105,7 +105,7 @@ public class MonoElementAtTest {
 
 	@Test
 	public void normal3() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).elementAt(9).subscribe(ts);
 
@@ -116,7 +116,7 @@ public class MonoElementAtTest {
 
 	@Test
 	public void normal3Backpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Flux.range(1, 10).elementAt(9).subscribe(ts);
 
@@ -133,7 +133,7 @@ public class MonoElementAtTest {
 
 	@Test
 	public void empty() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.<Integer>empty().elementAt(0).subscribe(ts);
 
@@ -144,7 +144,7 @@ public class MonoElementAtTest {
 
 	@Test
 	public void emptyDefault() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.<Integer>empty().elementAtOrDefault(0, () -> 20).subscribe(ts);
 
@@ -155,7 +155,7 @@ public class MonoElementAtTest {
 
 	@Test
 	public void emptyDefaultBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Flux.<Integer>empty().elementAtOrDefault(0, () -> 20).subscribe(ts);
 
@@ -172,7 +172,7 @@ public class MonoElementAtTest {
 
 	@Test
 	public void nonEmptyDefault() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).elementAtOrDefault(20, () -> 20).subscribe(ts);
 
@@ -183,7 +183,7 @@ public class MonoElementAtTest {
 
 	@Test
 	public void nonEmptyDefaultBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Flux.range(1, 10).elementAtOrDefault(20, () -> 20).subscribe(ts);
 
@@ -200,7 +200,7 @@ public class MonoElementAtTest {
 
 	@Test
 	public void defaultReturnsNull() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.<Integer>empty().elementAtOrDefault(0, () -> null).subscribe(ts);
 
@@ -211,7 +211,7 @@ public class MonoElementAtTest {
 
 	@Test
 	public void defaultThrows() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.<Integer>empty().elementAtOrDefault(0, () -> {
 			throw new RuntimeException("forced failure");

--- a/src/test/java/reactor/core/publisher/MonoHasElementsTest.java
+++ b/src/test/java/reactor/core/publisher/MonoHasElementsTest.java
@@ -28,7 +28,7 @@ public class MonoHasElementsTest {
 
 	@Test
 	public void emptySource() {
-		TestSubscriber<Boolean> ts = new TestSubscriber<>();
+		TestSubscriber<Boolean> ts = TestSubscriber.create();
 
 		Mono.empty().hasElement().subscribe(ts);
 
@@ -39,7 +39,7 @@ public class MonoHasElementsTest {
 
 	@Test
 	public void emptySourceBackpressured() {
-		TestSubscriber<Boolean> ts = new TestSubscriber<>(0);
+		TestSubscriber<Boolean> ts = TestSubscriber.create(0);
 
 		Mono.empty().hasElement().subscribe(ts);
 
@@ -56,7 +56,7 @@ public class MonoHasElementsTest {
 
 	@Test
 	public void nonEmptySource() {
-		TestSubscriber<Boolean> ts = new TestSubscriber<>();
+		TestSubscriber<Boolean> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).hasElements().subscribe(ts);
 
@@ -67,7 +67,7 @@ public class MonoHasElementsTest {
 
 	@Test
 	public void nonEmptySourceBackpressured() {
-		TestSubscriber<Boolean> ts = new TestSubscriber<>(0);
+		TestSubscriber<Boolean> ts = TestSubscriber.create(0);
 
 		Flux.range(1, 10).hasElements().subscribe(ts);
 

--- a/src/test/java/reactor/core/publisher/MonoJustTest.java
+++ b/src/test/java/reactor/core/publisher/MonoJustTest.java
@@ -34,7 +34,7 @@ public class MonoJustTest {
 
     @Test
     public void normal() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Mono.just(1).subscribe(ts);
 
@@ -45,7 +45,7 @@ public class MonoJustTest {
 
     @Test
     public void normalBackpressured() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
         Mono.just(1).subscribe(ts);
 
@@ -62,7 +62,7 @@ public class MonoJustTest {
 
     @Test
     public void fused() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         ts.requestedFusionMode(Fuseable.ANY);
         
         Mono.just(1).subscribe(ts);

--- a/src/test/java/reactor/core/publisher/MonoOtherwiseTest.java
+++ b/src/test/java/reactor/core/publisher/MonoOtherwiseTest.java
@@ -34,7 +34,7 @@ public class MonoOtherwiseTest {
 
 	@Test
 	public void normal() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Mono.just(1)
 		    .otherwise(v -> Mono.just(2))
@@ -47,7 +47,7 @@ public class MonoOtherwiseTest {
 
 	@Test
 	public void normalBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Mono.just(1)
 		    .otherwise(v -> Mono.just(2))
@@ -66,7 +66,7 @@ public class MonoOtherwiseTest {
 
 	@Test
 	public void error() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Mono.<Integer>error(new RuntimeException("forced failure")).otherwise(v -> Mono.just(
 				2))
@@ -79,7 +79,7 @@ public class MonoOtherwiseTest {
 
 	@Test
 	public void errorFiltered() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Mono.<Integer>error(new RuntimeException("forced failure"))
 				.otherwise(e -> e.getMessage().equals("forced failure"), v -> Mono.just(2))
@@ -92,7 +92,7 @@ public class MonoOtherwiseTest {
 
 	@Test
 	public void errorMap() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Mono.<Integer>error(new Exception()).mapError(d -> new RuntimeException("forced" +
 				" " +
@@ -107,7 +107,7 @@ public class MonoOtherwiseTest {
 
 	@Test
 	public void errorBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Mono.<Integer>error(new RuntimeException("forced failure")).otherwise(v -> Mono.just(
 				2))
@@ -125,7 +125,7 @@ public class MonoOtherwiseTest {
 
 	@Test
 	public void nextFactoryThrows() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Mono.<Integer>error(new RuntimeException("forced failure")).otherwise(v -> {
 			throw new RuntimeException("forced failure 2");
@@ -141,7 +141,7 @@ public class MonoOtherwiseTest {
 
 	@Test
 	public void nextFactoryReturnsNull() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Mono.<Integer>error(new RuntimeException("forced failure")).otherwise(v -> null)
 		                                                           .subscribe(ts);

--- a/src/test/java/reactor/core/publisher/MonoReduceTest.java
+++ b/src/test/java/reactor/core/publisher/MonoReduceTest.java
@@ -39,7 +39,7 @@ public class MonoReduceTest {
 
 	@Test
 	public void normal() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).reduceWith(() -> 0, (a, b) -> b).subscribe(ts);
 
@@ -50,7 +50,7 @@ public class MonoReduceTest {
 
 	@Test
 	public void normalBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Flux.range(1, 10).reduceWith(() -> 0, (a, b) -> b).subscribe(ts);
 
@@ -67,7 +67,7 @@ public class MonoReduceTest {
 
 	@Test
 	public void supplierThrows() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).<Integer>reduceWith(() -> {
 			throw new RuntimeException("forced failure");
@@ -81,7 +81,7 @@ public class MonoReduceTest {
 
 	@Test
 	public void accumulatorThrows() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).<Integer>reduceWith(() -> 0, (a, b) -> {
 			throw new RuntimeException("forced failure");
@@ -95,7 +95,7 @@ public class MonoReduceTest {
 
 	@Test
 	public void supplierReturnsNull() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).<Integer>reduceWith(() -> null, (a, b) -> b).subscribe(ts);
 
@@ -106,7 +106,7 @@ public class MonoReduceTest {
 
 	@Test
 	public void accumulatorReturnsNull() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).reduceWith(() -> 0, (a, b) -> null).subscribe(ts);
 

--- a/src/test/java/reactor/core/publisher/MonoRepeatWhenEmptyTest.java
+++ b/src/test/java/reactor/core/publisher/MonoRepeatWhenEmptyTest.java
@@ -34,7 +34,7 @@ public class MonoRepeatWhenEmptyTest {
         Mono<String> source = Mono.defer(() -> c.getAndIncrement() < 3 ? Mono.empty() : Mono.just("test-data"));
 
         List<Long> iterations = new ArrayList<>();
-        TestSubscriber<String> ts = new TestSubscriber<>();
+        TestSubscriber<String> ts = TestSubscriber.create();
 
         source
             .repeatWhenEmpty(o -> o.doOnNext(iterations::add))
@@ -56,7 +56,7 @@ public class MonoRepeatWhenEmptyTest {
         Mono<String> source = Mono.defer(() -> c.getAndIncrement() < 3 ? Mono.empty() : Mono.just("test-data"));
 
         List<Long> iterations = new ArrayList<>();
-        TestSubscriber<String> ts = new TestSubscriber<>();
+        TestSubscriber<String> ts = TestSubscriber.create();
 
         source
             .repeatWhenEmpty(1000, o -> o.doOnNext(iterations::add))
@@ -78,7 +78,7 @@ public class MonoRepeatWhenEmptyTest {
         Mono<String> source = Mono.defer(() -> c.getAndIncrement() < 3 ? Mono.empty() : Mono.just("test-data"));
 
         List<Long> iterations = new ArrayList<>();
-        TestSubscriber<String> ts = new TestSubscriber<>();
+        TestSubscriber<String> ts = TestSubscriber.create();
 
         source
             .repeatWhenEmpty(2, o -> o.doOnNext(iterations::add))

--- a/src/test/java/reactor/core/publisher/MonoSingleTest.java
+++ b/src/test/java/reactor/core/publisher/MonoSingleTest.java
@@ -41,7 +41,7 @@ public class MonoSingleTest {
 
 	@Test
 	public void defaultReturnsNull() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.<Integer>empty().singleOrDefault(() -> null).subscribe(ts);
 
@@ -52,7 +52,7 @@ public class MonoSingleTest {
 
 	@Test
 	public void defaultThrows() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.<Integer>empty().singleOrDefault(() -> {
 			throw new RuntimeException("forced failure");
@@ -68,7 +68,7 @@ public class MonoSingleTest {
 	@Test
 	public void normal() {
 
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.just(1).single().subscribe(ts);
 
@@ -79,7 +79,7 @@ public class MonoSingleTest {
 
 	@Test
 	public void normalBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Flux.just(1).single().subscribe(ts);
 
@@ -97,7 +97,7 @@ public class MonoSingleTest {
 	@Test
 	public void empty() {
 
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.<Integer>empty().single().subscribe(ts);
 
@@ -108,7 +108,7 @@ public class MonoSingleTest {
 
 	@Test
 	public void emptyDefault() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.<Integer>empty().singleOrDefault(() -> 1).subscribe(ts);
 
@@ -119,7 +119,7 @@ public class MonoSingleTest {
 
 	@Test
 	public void emptyDefaultBackpressured() {
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Flux.<Integer>empty().singleOrDefault(() -> 1).subscribe(ts);
 
@@ -137,7 +137,7 @@ public class MonoSingleTest {
 	@Test
 	public void multi() {
 
-		TestSubscriber<Integer> ts = new TestSubscriber<>();
+		TestSubscriber<Integer> ts = TestSubscriber.create();
 
 		Flux.range(1, 10).single().subscribe(ts);
 
@@ -149,7 +149,7 @@ public class MonoSingleTest {
 	@Test
 	public void multiBackpressured() {
 
-		TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+		TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
 		Flux.range(1, 10).single().subscribe(ts);
 

--- a/src/test/java/reactor/core/publisher/MonoStreamCollectorTest.java
+++ b/src/test/java/reactor/core/publisher/MonoStreamCollectorTest.java
@@ -31,7 +31,7 @@ public class MonoStreamCollectorTest {
         Mono<List<Integer>> source = Flux.range(1, 5).collect(Collectors.toList());
 
         for (int i = 0; i < 5; i++) {
-            TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
+            TestSubscriber<List<Integer>> ts = TestSubscriber.create();
             source.subscribe(ts);
     
             ts.assertValues(Arrays.asList(1, 2, 3, 4, 5))
@@ -45,7 +45,7 @@ public class MonoStreamCollectorTest {
         Mono<Set<Integer>> source = Flux.just(1).repeat(5).collect(Collectors.toSet());
 
         for (int i = 0; i < 5; i++) {
-            TestSubscriber<Set<Integer>> ts = new TestSubscriber<>();
+            TestSubscriber<Set<Integer>> ts = TestSubscriber.create();
             source.subscribe(ts);
     
             ts.assertValues(Collections.singleton(1))

--- a/src/test/java/reactor/core/publisher/MonoThenApplyTest.java
+++ b/src/test/java/reactor/core/publisher/MonoThenApplyTest.java
@@ -8,7 +8,7 @@ public class MonoThenApplyTest {
 
     @Test
     public void normalHidden() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         
         Mono.just(1).hide().then(v -> Mono.just(2).hide()).subscribe(ts);
         

--- a/src/test/java/reactor/core/publisher/ReplayProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/ReplayProcessorTest.java
@@ -26,7 +26,7 @@ public class ReplayProcessorTest {
     public void unbounded() {
         ReplayProcessor<Integer> rp = new ReplayProcessor<>(16, true);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0L);
         
         rp.subscribe(ts);
         
@@ -54,7 +54,7 @@ public class ReplayProcessorTest {
     public void bounded() {
         ReplayProcessor<Integer> rp = new ReplayProcessor<>(16, false);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0L);
         
         rp.subscribe(ts);
         
@@ -82,7 +82,7 @@ public class ReplayProcessorTest {
     public void cancel() {
         ReplayProcessor<Integer> rp = new ReplayProcessor<>(16, false);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         
         rp.subscribe(ts);
         
@@ -95,7 +95,7 @@ public class ReplayProcessorTest {
     public void unboundedAfter() {
         ReplayProcessor<Integer> rp = new ReplayProcessor<>(16, true);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0L);
         
         rp.onNext(1);
         rp.onNext(2);
@@ -123,7 +123,7 @@ public class ReplayProcessorTest {
     public void boundedAfter() {
         ReplayProcessor<Integer> rp = new ReplayProcessor<>(16, false);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0L);
         
         
         rp.onNext(1);
@@ -152,7 +152,7 @@ public class ReplayProcessorTest {
     public void unboundedLong() {
         ReplayProcessor<Integer> rp = new ReplayProcessor<>(16, true);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0L);
         
         for (int i = 0; i < 256; i++) {
             rp.onNext(i);
@@ -176,7 +176,7 @@ public class ReplayProcessorTest {
     public void boundedLong() {
         ReplayProcessor<Integer> rp = new ReplayProcessor<>(16, false);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
+        TestSubscriber<Integer> ts = TestSubscriber.create(0L);
         
         for (int i = 0; i < 256; i++) {
             rp.onNext(i);
@@ -200,7 +200,7 @@ public class ReplayProcessorTest {
     public void fusedUnboundedAfterLong() {
         ReplayProcessor<Integer> rp = new ReplayProcessor<>(16, true);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         ts.requestedFusionMode(Fuseable.ASYNC);
         
         for (int i = 0; i < 256; i++) {
@@ -224,7 +224,7 @@ public class ReplayProcessorTest {
     public void fusedUnboundedLong() {
         ReplayProcessor<Integer> rp = new ReplayProcessor<>(16, true);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         ts.requestedFusionMode(Fuseable.ASYNC);
 
         rp.subscribe(ts);
@@ -249,7 +249,7 @@ public class ReplayProcessorTest {
     public void fusedBoundedAfterLong() {
         ReplayProcessor<Integer> rp = new ReplayProcessor<>(16, false);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         ts.requestedFusionMode(Fuseable.ASYNC);
         
         for (int i = 0; i < 256; i++) {
@@ -273,7 +273,7 @@ public class ReplayProcessorTest {
     public void fusedBoundedLong() {
         ReplayProcessor<Integer> rp = new ReplayProcessor<>(16, false);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         ts.requestedFusionMode(Fuseable.ASYNC);
 
         rp.subscribe(ts);

--- a/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
@@ -30,7 +30,7 @@ public class UnicastProcessorTest {
         
         up.subscribe();
         
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         
         up.subscribe(ts);
         

--- a/src/test/java/reactor/core/publisher/scenarios/CombinationTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/CombinationTests.java
@@ -396,7 +396,7 @@ public class CombinationTests {
 
 	@Before
 	public void anotherBefore() {
-		ts = new TestSubscriber<Long>();
+		ts = TestSubscriber.create();
 		emitter1 = ReplayProcessor.create();
 		emitter2 = ReplayProcessor.create();
 		emitter1.connect();

--- a/src/test/java/reactor/core/publisher/scenarios/EmitterProcessorDemandTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/EmitterProcessorDemandTests.java
@@ -78,7 +78,7 @@ public class EmitterProcessorDemandTests {
 
 		Flux.from(publisher).subscribeOn(asyncGroup).subscribe(emitter);
 
-		TestSubscriber<String> subscriber = new TestSubscriber<>();
+		TestSubscriber<String> subscriber = TestSubscriber.create();
 		emitter.subscribe(subscriber);
 
 		int i = 0;
@@ -134,7 +134,7 @@ public class EmitterProcessorDemandTests {
 
 		publisher.subscribe(emitter);
 
-		TestSubscriber<String> subscriber = new TestSubscriber<>();
+		TestSubscriber<String> subscriber = TestSubscriber.create();
 		emitter.subscribe(subscriber);
 
 		String buffer = "Hello";
@@ -153,7 +153,7 @@ public class EmitterProcessorDemandTests {
 	@Test
 	public void testRed() {
 		FluxProcessor<String, String> processor = EmitterProcessor.create();
-		TestSubscriber<String> subscriber = new TestSubscriber<>(1);
+		TestSubscriber<String> subscriber = TestSubscriber.create(1);
 		processor.subscribe(subscriber);
 
 		Flux.fromIterable(DATA)
@@ -166,7 +166,7 @@ public class EmitterProcessorDemandTests {
 	@Test
 	public void testGreen() {
 		FluxProcessor<String, String> processor = EmitterProcessor.create();
-		TestSubscriber<String> subscriber = new TestSubscriber<>(1);
+		TestSubscriber<String> subscriber = TestSubscriber.create(1);
 		processor.subscribe(subscriber);
 
 		Flux.fromIterable(DATA)
@@ -184,10 +184,10 @@ public class EmitterProcessorDemandTests {
 		    .log()
 		    .subscribe(processor);
 
-		TestSubscriber<String> first = new TestSubscriber<>(0);
+		TestSubscriber<String> first = TestSubscriber.create(0);
 		processor.log("after-1").subscribe(first);
 
-		TestSubscriber<String> second = new TestSubscriber<>(0);
+		TestSubscriber<String> second = TestSubscriber.create(0);
 		processor.log("after-2").subscribe(second);
 
 		second.request(1);
@@ -204,12 +204,12 @@ public class EmitterProcessorDemandTests {
 		    .log()
 		    .subscribe(processor);
 
-		TestSubscriber<String> first = new TestSubscriber<>(1);
+		TestSubscriber<String> first = TestSubscriber.create(1);
 		processor.subscribe(first);
 
 		first.awaitAndAssertNextValues("1");
 
-		TestSubscriber<String> second = new TestSubscriber<>(3);
+		TestSubscriber<String> second = TestSubscriber.create(3);
 		processor.subscribe(second);
 
 		second.awaitAndAssertNextValues("2", "3", "4");
@@ -251,7 +251,7 @@ public class EmitterProcessorDemandTests {
 		}
 
 		public void doRun() throws Exception {
-			TestSubscriber<String> subscriber = new TestSubscriber<>(5);
+			TestSubscriber<String> subscriber = TestSubscriber.create(5);
 			processor.subscribe(subscriber);
 			barrier.await();
 

--- a/src/test/java/reactor/core/publisher/tck/TopicProcessorTests.java
+++ b/src/test/java/reactor/core/publisher/tck/TopicProcessorTests.java
@@ -87,7 +87,7 @@ public class TopicProcessorTests extends AbstractProcessorVerification {
 		Publisher<String> publisher = Flux.fromArray(new String[] { "1", "2", "3", "4", "5" });
 		publisher.subscribe(processor);
 
-		TestSubscriber<String> subscriber = new TestSubscriber<>(0);
+		TestSubscriber<String> subscriber = TestSubscriber.create(0);
 		processor.subscribe(subscriber);
 
 		subscriber.request(1);
@@ -109,7 +109,7 @@ public class TopicProcessorTests extends AbstractProcessorVerification {
 		Publisher<String> publisher = Flux.fromArray(new String[] { "1", "2", "3", "4", "5" });
 		publisher.subscribe(processor);
 
-		TestSubscriber<String> subscriber = new TestSubscriber<>(0);
+		TestSubscriber<String> subscriber = TestSubscriber.create(0);
 		processor.subscribe(subscriber);
 
 		subscriber.request(1);
@@ -127,7 +127,7 @@ public class TopicProcessorTests extends AbstractProcessorVerification {
 		Publisher<String> publisher = new CappedPublisher(2);
 		publisher.subscribe(processor);
 
-		TestSubscriber<String> subscriber = new TestSubscriber<>(0);
+		TestSubscriber<String> subscriber = TestSubscriber.create(0);
 		processor.subscribe(subscriber);
 
 		processor.forceShutdown();
@@ -181,7 +181,7 @@ public class TopicProcessorTests extends AbstractProcessorVerification {
 		Publisher<String> publisher = new CappedPublisher(2);
 		publisher.subscribe(processor);
 
-		TestSubscriber<String> subscriber = new TestSubscriber<>(0);
+		TestSubscriber<String> subscriber = TestSubscriber.create(0);
 		processor.subscribe(subscriber);
 
 		subscriber.request(3);
@@ -199,7 +199,7 @@ public class TopicProcessorTests extends AbstractProcessorVerification {
 		Publisher<String> publisher = Flux.fromArray(new String[] { "1", "2", "3", "4", "5" });
 		publisher.subscribe(processor);
 
-		TestSubscriber<String> subscriber = new TestSubscriber<>(0);
+		TestSubscriber<String> subscriber = TestSubscriber.create(0);
 		processor.subscribe(subscriber);
 
 		subscriber.request(1);

--- a/src/test/java/reactor/core/publisher/tck/WorkQueueProcessorTests.java
+++ b/src/test/java/reactor/core/publisher/tck/WorkQueueProcessorTests.java
@@ -61,7 +61,7 @@ public class WorkQueueProcessorTests extends AbstractProcessorVerification {
 		sink.onNext(2);
 		sink.onNext(3);
 
-		new TestSubscriber<Integer>().bindTo(sink.forceShutdown())
+		TestSubscriber.subscribe(sink.forceShutdown())
 		                             .assertComplete()
 		                             .assertValues(1, 2, 3);
 	}

--- a/src/test/java/reactor/core/test/TestSubscriberTests.java
+++ b/src/test/java/reactor/core/test/TestSubscriberTests.java
@@ -18,27 +18,19 @@ public class TestSubscriberTests {
 
 	@Test
 	public void assertSubscribed() {
-		TestSubscriber<String> ts = new TestSubscriber<>();
+		TestSubscriber<String> ts = TestSubscriber.create();
 		ts.assertNotSubscribed();
 		Flux.just("foo").subscribe(ts);
 		ts.assertSubscribed();
 	}
 
 	@Test
-	public void bindTo() {
-		TestSubscriber<String> ts = new TestSubscriber<>();
-		ts.bindTo(Flux.just("foo"));
-		ts.assertSubscribed();
-		ts.assertValues("foo");
-	}
-
-	@Test
 	public void assertValues() {
-		TestSubscriber<String> ts = new TestSubscriber<>();
+		TestSubscriber<String> ts = TestSubscriber.create();
 		Flux.<String>empty().subscribe(ts);
 		ts.assertNoValues();
 
-		ts = new TestSubscriber<>(0);
+		ts = TestSubscriber.create(0);
 		Flux.just("foo", "bar").subscribe(ts);
 		ts.assertNoValues();
 		ts.request(1);
@@ -51,49 +43,49 @@ public class TestSubscriberTests {
 
 	@Test(expected = AssertionError.class)
 	public void assertValuesNotSameValue() {
-		TestSubscriber<String> ts = new TestSubscriber<>();
+		TestSubscriber<String> ts = TestSubscriber.create();
 		Flux.just("foo").subscribe(ts);
 		ts.assertValues("bar");
 	}
 
 	@Test(expected = AssertionError.class)
 	public void assertValuesNotSameCount() {
-		TestSubscriber<String> ts = new TestSubscriber<>();
+		TestSubscriber<String> ts = TestSubscriber.create();
 		Flux.just("foo", "foo").subscribe(ts);
 		ts.assertValues("foo");
 	}
 
 	@Test
 	public void assertValuesWith() {
-		TestSubscriber<String> ts = new TestSubscriber<>();
+		TestSubscriber<String> ts = TestSubscriber.create();
 		Flux.just("foo", "bar").subscribe(ts);
 		ts.assertValuesWith(value -> value.equals("foo"), value -> value.equals("bar"));
 	}
 
 	@Test(expected = AssertionError.class)
 	public void assertValuesWithFailure() {
-		TestSubscriber<String> ts = new TestSubscriber<>();
+		TestSubscriber<String> ts = TestSubscriber.create();
 		Flux.just("foo", "bar").subscribe(ts);
 		ts.assertValuesWith(value -> Assert.assertEquals("foo", value), value -> Assert.assertEquals("foo", value));
 	}
 
 	@Test
 	public void assertValueSequence() {
-		TestSubscriber<String> ts = new TestSubscriber<>();
+		TestSubscriber<String> ts = TestSubscriber.create();
 		Flux.just("foo", "bar").subscribe(ts);
 		ts.assertValueSequence(Arrays.asList("foo", "bar"));
 	}
 
 	@Test(expected = AssertionError.class)
 	public void assertValueSequenceFailure() {
-		TestSubscriber<String> ts = new TestSubscriber<>();
+		TestSubscriber<String> ts = TestSubscriber.create();
 		Flux.just("foo", "bar").subscribe(ts);
 		ts.assertValueSequence(Arrays.asList("foo", "foo"));
 	}
 
 	@Test
 	public void assertComplete() {
-		TestSubscriber<String> ts = new TestSubscriber<>(0);
+		TestSubscriber<String> ts = TestSubscriber.create(0);
 		Flux.just("foo").subscribe(ts);
 		ts.assertNotComplete();
 		ts.request(1);
@@ -102,11 +94,11 @@ public class TestSubscriberTests {
 
 	@Test
 	public void assertError() {
-		TestSubscriber<String> ts = new TestSubscriber<>();
+		TestSubscriber<String> ts = TestSubscriber.create();
 		Flux.just("foo").subscribe(ts);
 		ts.assertNoError();
 
-		ts = new TestSubscriber<>(0);
+		ts = TestSubscriber.create(0);
 		Flux.<String>error(new IllegalStateException()).subscribe(ts);
 		ts.assertError();
 		ts.assertError(IllegalStateException.class);
@@ -125,11 +117,11 @@ public class TestSubscriberTests {
 
 	@Test
 	public void assertTerminated() {
-		TestSubscriber<String> ts = new TestSubscriber<>();
+		TestSubscriber<String> ts = TestSubscriber.create();
 		Flux.<String>error(new IllegalStateException()).subscribe(ts);
 		ts.assertTerminated();
 
-		ts = new TestSubscriber<>(0);
+		ts = TestSubscriber.create(0);
 		Flux.just("foo").subscribe(ts);
 		ts.assertNotTerminated();
 		ts.request(1);
@@ -138,7 +130,7 @@ public class TestSubscriberTests {
 
 	@Test
 	public void awaitAndAssertValues() {
-		TestSubscriber<String> ts = new TestSubscriber<>(1);
+		TestSubscriber<String> ts = TestSubscriber.create(1);
 		Flux.just("1", "2").log().subscribe(ts);
 		ts.awaitAndAssertNextValues("1");
 		ts.request(1);
@@ -147,14 +139,14 @@ public class TestSubscriberTests {
 
 	@Test(expected = AssertionError.class)
 	public void awaitAndAssertNotEnoughValues() {
-		TestSubscriber<String> ts = new TestSubscriber<>(1);
+		TestSubscriber<String> ts = TestSubscriber.create(1);
 		Flux.just("1", "2").log().subscribe(ts);
 		ts.awaitAndAssertNextValues("1", "2");
 	}
 
 	@Test
 	public void awaitAndAssertAsyncValues() {
-		TestSubscriber<String> ts = new TestSubscriber<>();
+		TestSubscriber<String> ts = TestSubscriber.create();
 		Flux.interval(Duration.ofMillis(100)).map(l -> "foo " + l).subscribe(ts);
 		try {
 		    Thread.sleep(500);
@@ -166,7 +158,7 @@ public class TestSubscriberTests {
 
 	@Test
 	public void awaitAndAssertValuesWith() {
-		TestSubscriber<Long> ts = new TestSubscriber<>(1);
+		TestSubscriber<Long> ts = TestSubscriber.create(1);
 		Consumer<Long> greaterThanZero = new Consumer<Long>() {
 			@Override
 			public void accept(Long aLong) {
@@ -181,7 +173,7 @@ public class TestSubscriberTests {
 
 	@Test(expected = AssertionError.class)
 	public void awaitAndAssertValuesWithFailure() {
-		TestSubscriber<Long> ts = new TestSubscriber<>(1);
+		TestSubscriber<Long> ts = TestSubscriber.create(1);
 		Flux.just(1L, 20L).log().subscribe(ts);
 		Consumer<Long> lowerThanTen = new Consumer<Long>() {
 			@Override
@@ -196,7 +188,7 @@ public class TestSubscriberTests {
 
 	@Test
 	public void awaitAndAssertValueCount() {
-		TestSubscriber<Long> ts = new TestSubscriber<>(1);
+		TestSubscriber<Long> ts = TestSubscriber.create(1);
 		Flux.just(1L, 2L).log().subscribe(ts);
 		ts.awaitAndAssertNextValueCount(1);
 		ts.request(1);
@@ -205,7 +197,7 @@ public class TestSubscriberTests {
 
 	@Test(expected = AssertionError.class)
 	public void awaitAndAssertValueCountFailure() {
-		TestSubscriber<Long> subscriber = new TestSubscriber<>();
+		TestSubscriber<Long> subscriber = TestSubscriber.create();
 		Flux.just(1L).log().subscribe(subscriber);
 		subscriber.configureValuesTimeout(Duration.ofSeconds(1)).awaitAndAssertNextValueCount(2);
 	}


### PR DESCRIPTION
To create a new instance of TestSubscriber, you now have the choice between
these static methods:
  - TestSubscriber#subscribe(Publisher): create a new TestSubscriber,
    subscribe to it with the specified Publisher and requests an unbounded
    number of elements.
  - TestSubscriber#subscribe(Publisher, long): create a new TestSubscriber,
    subscribe to it with the specified Publisher and requests n elements
    (can be 0 if you want no initial demand).
  - TestSubscriber#create(): create a new TestSubscriber and requests
    an unbounded number of elements.
  - TestSubscriber#create(long): create a new TestSubscriber and
    requests n elements (can be 0 if you want no initial demand).

Close #95