### PR TITLE
Remove @since from Javadoc

### DIFF
--- a/src/main/java/reactor/core/adapter/JdkFlowAdapter.java
+++ b/src/main/java/reactor/core/adapter/JdkFlowAdapter.java
@@ -28,7 +28,6 @@ import reactor.core.publisher.Flux;
  *
  * @author Stephane Maldini
  * @author Sebastien Deleuze
- * @since 2.5
  */
 public enum JdkFlowAdapter {
 	;

--- a/src/main/java/reactor/core/adapter/RxJava1Adapter.java
+++ b/src/main/java/reactor/core/adapter/RxJava1Adapter.java
@@ -39,7 +39,6 @@ import rx.internal.util.ScalarSynchronousObservable;
  * {@link Publisher}.
  *
  * @author Stephane Maldini
- * @since 2.5
  */
 @SuppressWarnings("rawtypes")
 public enum RxJava1Adapter {

--- a/src/main/java/reactor/core/publisher/ConnectableFlux.java
+++ b/src/main/java/reactor/core/publisher/ConnectableFlux.java
@@ -28,7 +28,6 @@ import reactor.core.flow.Receiver;
  * @see #publish
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  * @param <T> the input and output value type
- * @since 2.5
  */
 public abstract class ConnectableFlux<T> extends Flux<T> implements Receiver {
 

--- a/src/main/java/reactor/core/publisher/ConnectableFluxAutoConnect.java
+++ b/src/main/java/reactor/core/publisher/ConnectableFluxAutoConnect.java
@@ -32,7 +32,6 @@ import reactor.core.flow.*;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class ConnectableFluxAutoConnect<T> extends Flux<T>
 		implements Receiver {

--- a/src/main/java/reactor/core/publisher/ConnectableFluxOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/ConnectableFluxOnAssembly.java
@@ -43,7 +43,6 @@ import reactor.core.publisher.FluxOnAssembly.OnAssemblySubscriber;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">https://github.com/reactor/reactive-streams-commons</a>
- * @since 2.5
  */
 final class ConnectableFluxOnAssembly<T> extends ConnectableFlux<T> implements
 		Fuseable, AssemblyOp {

--- a/src/main/java/reactor/core/publisher/ConnectableFluxProcess.java
+++ b/src/main/java/reactor/core/publisher/ConnectableFluxProcess.java
@@ -42,7 +42,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class ConnectableFluxProcess<T, U> extends ConnectableFlux<U> implements Producer {
 

--- a/src/main/java/reactor/core/publisher/ConnectableFluxPublish.java
+++ b/src/main/java/reactor/core/publisher/ConnectableFluxPublish.java
@@ -46,7 +46,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class ConnectableFluxPublish<T> extends ConnectableFlux<T>
 		implements Receiver, Loopback {

--- a/src/main/java/reactor/core/publisher/ConnectableFluxRefCount.java
+++ b/src/main/java/reactor/core/publisher/ConnectableFluxRefCount.java
@@ -39,7 +39,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class ConnectableFluxRefCount<T> extends Flux<T>
 		implements Receiver, Loopback {

--- a/src/main/java/reactor/core/publisher/Elapsed.java
+++ b/src/main/java/reactor/core/publisher/Elapsed.java
@@ -22,7 +22,6 @@ import reactor.core.util.function.Tuple2;
 
 /**
  * @author Stephane Maldini
- * @since 2.0, 2.5
  */
 final class Elapsed<T> implements Function<T, Tuple2<Long, T>> {
 

--- a/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -50,8 +50,7 @@ import reactor.core.util.concurrent.Slot;
  * <p>
  *
  * @author Stephane Maldini
- * @since 2.5
- * 
+ *
  * @param <T> the input and output value type
  */
 public final class EmitterProcessor<T> extends FluxProcessor<T, T>

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -88,7 +88,6 @@ import reactor.core.util.function.Tuple6;
  * @author David Karnok
  *
  * @see Mono
- * @since 2.5
  */
 public abstract class Flux<T> implements Publisher<T>, PublisherConfig {
 

--- a/src/main/java/reactor/core/publisher/FluxAccumulate.java
+++ b/src/main/java/reactor/core/publisher/FluxAccumulate.java
@@ -48,7 +48,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxAccumulate<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxArray.java
+++ b/src/main/java/reactor/core/publisher/FluxArray.java
@@ -36,7 +36,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxArray<T> 
 extends Flux<T>

--- a/src/main/java/reactor/core/publisher/FluxBatch.java
+++ b/src/main/java/reactor/core/publisher/FluxBatch.java
@@ -31,7 +31,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @author Stephane Maldini
- * @since 1.1, 2.0, 2.5
  */
 abstract class FluxBatch<T, V> extends FluxSource<T, V> {
 

--- a/src/main/java/reactor/core/publisher/FluxBuffer.java
+++ b/src/main/java/reactor/core/publisher/FluxBuffer.java
@@ -42,7 +42,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxBuffer<T, C extends Collection<? super T>> extends FluxSource<T, C> {
 

--- a/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
+++ b/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
@@ -39,7 +39,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 		extends FluxSource<T, C> {

--- a/src/main/java/reactor/core/publisher/FluxBufferStartEnd.java
+++ b/src/main/java/reactor/core/publisher/FluxBufferStartEnd.java
@@ -47,7 +47,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxBufferStartEnd<T, U, V, C extends Collection<? super T>>
 		extends FluxSource<T, C> {

--- a/src/main/java/reactor/core/publisher/FluxBufferTimeOrSize.java
+++ b/src/main/java/reactor/core/publisher/FluxBufferTimeOrSize.java
@@ -25,7 +25,6 @@ import reactor.core.scheduler.TimedScheduler;
 
 /**
  * @author Stephane Maldini
- * @since 1.1, 2.5
  */
 final class FluxBufferTimeOrSize<T> extends FluxBatch<T, List<T>> {
 

--- a/src/main/java/reactor/core/publisher/FluxCombineLatest.java
+++ b/src/main/java/reactor/core/publisher/FluxCombineLatest.java
@@ -45,7 +45,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxCombineLatest<T, R> 
 extends Flux<R>

--- a/src/main/java/reactor/core/publisher/FluxConcatArray.java
+++ b/src/main/java/reactor/core/publisher/FluxConcatArray.java
@@ -36,7 +36,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxConcatArray<T> 
 extends Flux<T>

--- a/src/main/java/reactor/core/publisher/FluxConcatIterable.java
+++ b/src/main/java/reactor/core/publisher/FluxConcatIterable.java
@@ -33,7 +33,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxConcatIterable<T> extends Flux<T>
 		implements MultiReceiver {

--- a/src/main/java/reactor/core/publisher/FluxConcatMap.java
+++ b/src/main/java/reactor/core/publisher/FluxConcatMap.java
@@ -41,7 +41,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxConcatMap<T, R> extends FluxSource<T, R> {
 	

--- a/src/main/java/reactor/core/publisher/FluxDefaultIfEmpty.java
+++ b/src/main/java/reactor/core/publisher/FluxDefaultIfEmpty.java
@@ -33,7 +33,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxDefaultIfEmpty<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxDefer.java
+++ b/src/main/java/reactor/core/publisher/FluxDefer.java
@@ -31,7 +31,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxDefer<T> extends Flux<T>
 		implements Receiver {

--- a/src/main/java/reactor/core/publisher/FluxDelaySubscription.java
+++ b/src/main/java/reactor/core/publisher/FluxDelaySubscription.java
@@ -34,7 +34,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxDelaySubscription<T, U> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxDematerialize.java
+++ b/src/main/java/reactor/core/publisher/FluxDematerialize.java
@@ -26,7 +26,6 @@ import reactor.core.util.*;
 
 /**
  * @author Stephane Maldini
- * @since 2.0, 2.5
  */
 final class FluxDematerialize<T> extends FluxSource<Signal<T>, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxDetach.java
+++ b/src/main/java/reactor/core/publisher/FluxDetach.java
@@ -16,7 +16,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxDetach<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxDistinct.java
+++ b/src/main/java/reactor/core/publisher/FluxDistinct.java
@@ -44,7 +44,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxDistinct<T, K, C extends Collection<? super K>> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxDistinctFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxDistinctFuseable.java
@@ -37,7 +37,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxDistinctFuseable<T, K, C extends Collection<? super K>> 
 extends FluxSource<T, T> implements Fuseable {

--- a/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
+++ b/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
@@ -38,7 +38,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxDistinctUntilChanged<T, K> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxDrop.java
+++ b/src/main/java/reactor/core/publisher/FluxDrop.java
@@ -36,7 +36,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxDrop<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxError.java
+++ b/src/main/java/reactor/core/publisher/FluxError.java
@@ -32,7 +32,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxError<T>
 		extends Flux<T> implements SubscriberState {

--- a/src/main/java/reactor/core/publisher/FluxFilter.java
+++ b/src/main/java/reactor/core/publisher/FluxFilter.java
@@ -40,7 +40,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxFilter<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
@@ -37,7 +37,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxFilterFuseable<T> extends FluxSource<T, T>
 		implements Fuseable {

--- a/src/main/java/reactor/core/publisher/FluxFirstEmitting.java
+++ b/src/main/java/reactor/core/publisher/FluxFirstEmitting.java
@@ -37,7 +37,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxFirstEmitting<T>
 extends Flux<T>

--- a/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -48,7 +48,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 

--- a/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
+++ b/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
@@ -40,7 +40,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxFlattenIterable<T, R> extends FluxSource<T, R> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/FluxGenerate.java
+++ b/src/main/java/reactor/core/publisher/FluxGenerate.java
@@ -41,7 +41,6 @@ import reactor.core.util.*;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">https://github.com/reactor/reactive-streams-commons</a>
- * @since 2.5
  */
 final class FluxGenerate<T, S> 
 extends Flux<T> {

--- a/src/main/java/reactor/core/publisher/FluxGroupBy.java
+++ b/src/main/java/reactor/core/publisher/FluxGroupBy.java
@@ -47,7 +47,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxGroupBy<T, K, V> extends FluxSource<T, GroupedFlux<K, V>>
 		implements Fuseable {

--- a/src/main/java/reactor/core/publisher/FluxHide.java
+++ b/src/main/java/reactor/core/publisher/FluxHide.java
@@ -28,7 +28,6 @@ import org.reactivestreams.Subscription;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxHide<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxInterval.java
+++ b/src/main/java/reactor/core/publisher/FluxInterval.java
@@ -32,7 +32,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxInterval extends Flux<Long> {
 

--- a/src/main/java/reactor/core/publisher/FluxIterable.java
+++ b/src/main/java/reactor/core/publisher/FluxIterable.java
@@ -35,7 +35,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxIterable<T> 
 extends Flux<T>

--- a/src/main/java/reactor/core/publisher/FluxLatest.java
+++ b/src/main/java/reactor/core/publisher/FluxLatest.java
@@ -36,7 +36,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxLatest<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxLog.java
+++ b/src/main/java/reactor/core/publisher/FluxLog.java
@@ -28,7 +28,6 @@ import reactor.core.util.Logger;
  * A logging interceptor that intercepts all reactive calls and trace them
  *
  * @author Stephane Maldini
- * @since 2.5
  */
 final class FluxLog<IN> extends FluxSource<IN, IN> {
 

--- a/src/main/java/reactor/core/publisher/FluxMap.java
+++ b/src/main/java/reactor/core/publisher/FluxMap.java
@@ -39,7 +39,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxMap<T, R> extends FluxSource<T, R> {
 

--- a/src/main/java/reactor/core/publisher/FluxMapFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxMapFuseable.java
@@ -40,7 +40,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxMapFuseable<T, R> extends FluxSource<T, R>
 		implements Fuseable {

--- a/src/main/java/reactor/core/publisher/FluxMapSignal.java
+++ b/src/main/java/reactor/core/publisher/FluxMapSignal.java
@@ -40,7 +40,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @author Stephane Maldini
- * @since 2.5
  */
 final class FluxMapSignal<T, R> extends FluxSource<T, R> {
 

--- a/src/main/java/reactor/core/publisher/FluxMaterialize.java
+++ b/src/main/java/reactor/core/publisher/FluxMaterialize.java
@@ -26,7 +26,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @author Stephane Maldini
- * @since 2.0, 2.5
  */
 final class FluxMaterialize<T> extends FluxSource<T, Signal<T>> {
 

--- a/src/main/java/reactor/core/publisher/FluxMerge.java
+++ b/src/main/java/reactor/core/publisher/FluxMerge.java
@@ -34,7 +34,6 @@ import reactor.core.subscriber.SubscriberState;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxMerge<T> extends Flux<T> implements MultiReceiver, SubscriberState {
 

--- a/src/main/java/reactor/core/publisher/FluxNever.java
+++ b/src/main/java/reactor/core/publisher/FluxNever.java
@@ -29,7 +29,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxNever 
 extends Flux<Object> implements SubscriberState {

--- a/src/main/java/reactor/core/publisher/FluxOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/FluxOnAssembly.java
@@ -50,7 +50,6 @@ import reactor.core.util.function.Tuple2;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">https://github.com/reactor/reactive-streams-commons</a>
- * @since 2.5
  */
 final class FluxOnAssembly<T> extends FluxSource<T, T> implements Fuseable, AssemblyOp {
 

--- a/src/main/java/reactor/core/publisher/FluxPeek.java
+++ b/src/main/java/reactor/core/publisher/FluxPeek.java
@@ -44,7 +44,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxPeek<T> extends FluxSource<T, T> implements FluxPeekHelper<T> {
 

--- a/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
@@ -41,7 +41,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxPeekFuseable<T> extends FluxSource<T, T> implements Fuseable, FluxPeekHelper<T> {
 

--- a/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -31,7 +31,6 @@ import reactor.core.util.Exceptions;
  * {@link ReplayProcessor}, {@link WorkQueueProcessor} and {@link TopicProcessor}.
  *
  * @author Stephane Maldini
- * @since 2.0.2, 2.5
  * 
  * @param <IN> the input value type
  * @param <OUT> the output value type

--- a/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -42,7 +42,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxPublish<T, R> extends FluxSource<T, R> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/FluxPublishOn.java
+++ b/src/main/java/reactor/core/publisher/FluxPublishOn.java
@@ -42,7 +42,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxPublishOn<T> extends FluxSource<T, T> implements Loopback, Fuseable {
 

--- a/src/main/java/reactor/core/publisher/FluxRange.java
+++ b/src/main/java/reactor/core/publisher/FluxRange.java
@@ -30,7 +30,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxRange extends Flux<Integer>
 		implements Fuseable {

--- a/src/main/java/reactor/core/publisher/FluxRepeat.java
+++ b/src/main/java/reactor/core/publisher/FluxRepeat.java
@@ -33,7 +33,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxRepeat<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxRepeatPredicate.java
+++ b/src/main/java/reactor/core/publisher/FluxRepeatPredicate.java
@@ -33,7 +33,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxRepeatPredicate<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
+++ b/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
@@ -41,7 +41,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxRepeatWhen<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxResume.java
+++ b/src/main/java/reactor/core/publisher/FluxResume.java
@@ -34,7 +34,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxResume<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxRetry.java
+++ b/src/main/java/reactor/core/publisher/FluxRetry.java
@@ -17,7 +17,6 @@ import reactor.core.subscriber.MultiSubscriptionSubscriber;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxRetry<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxRetryPredicate.java
+++ b/src/main/java/reactor/core/publisher/FluxRetryPredicate.java
@@ -33,7 +33,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxRetryPredicate<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxRetryWhen.java
+++ b/src/main/java/reactor/core/publisher/FluxRetryWhen.java
@@ -41,7 +41,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxRetryWhen<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxSample.java
+++ b/src/main/java/reactor/core/publisher/FluxSample.java
@@ -44,7 +44,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxSample<T, U> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxScan.java
+++ b/src/main/java/reactor/core/publisher/FluxScan.java
@@ -48,7 +48,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxScan<T, R> extends FluxSource<T, R> {
 

--- a/src/main/java/reactor/core/publisher/FluxSkip.java
+++ b/src/main/java/reactor/core/publisher/FluxSkip.java
@@ -33,7 +33,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxSkip<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxSkipLast.java
+++ b/src/main/java/reactor/core/publisher/FluxSkipLast.java
@@ -33,7 +33,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxSkipLast<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxSkipUntil.java
+++ b/src/main/java/reactor/core/publisher/FluxSkipUntil.java
@@ -35,7 +35,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">https://github.com/reactor/reactive-streams-commons</a>
- * @since 2.5
  */
 final class FluxSkipUntil<T, U> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxSkipWhile.java
+++ b/src/main/java/reactor/core/publisher/FluxSkipWhile.java
@@ -38,7 +38,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxSkipWhile<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxStream.java
+++ b/src/main/java/reactor/core/publisher/FluxStream.java
@@ -31,7 +31,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxStream<T> extends Flux<T>
 		implements Receiver {

--- a/src/main/java/reactor/core/publisher/FluxSubscribeOn.java
+++ b/src/main/java/reactor/core/publisher/FluxSubscribeOn.java
@@ -40,7 +40,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxSubscribeOn<T> extends FluxSource<T, T> implements Loopback, Fuseable {
 

--- a/src/main/java/reactor/core/publisher/FluxSubscribeOnCallable.java
+++ b/src/main/java/reactor/core/publisher/FluxSubscribeOnCallable.java
@@ -36,7 +36,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">https://github.com/reactor/reactive-streams-commons</a>
- * @since 2.5
  */
 final class FluxSubscribeOnCallable<T> extends Flux<T> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/FluxSubscribeOnValue.java
+++ b/src/main/java/reactor/core/publisher/FluxSubscribeOnValue.java
@@ -37,7 +37,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">https://github.com/reactor/reactive-streams-commons</a>
- * @since 2.5
  */
 final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/FluxSwitchIfEmpty.java
+++ b/src/main/java/reactor/core/publisher/FluxSwitchIfEmpty.java
@@ -30,7 +30,6 @@ import reactor.core.subscriber.MultiSubscriptionSubscriber;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxSwitchIfEmpty<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxSwitchMap.java
+++ b/src/main/java/reactor/core/publisher/FluxSwitchMap.java
@@ -38,7 +38,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxSwitchMap<T, R> extends FluxSource<T, R> {
 

--- a/src/main/java/reactor/core/publisher/FluxTake.java
+++ b/src/main/java/reactor/core/publisher/FluxTake.java
@@ -40,7 +40,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxTake<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxTakeFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxTakeFuseable.java
@@ -31,7 +31,6 @@ import reactor.core.publisher.FluxTake.TakeFuseableSubscriber;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxTakeFuseable<T> extends FluxSource<T, T> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/FluxTakeLast.java
+++ b/src/main/java/reactor/core/publisher/FluxTakeLast.java
@@ -37,7 +37,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxTakeLast<T> extends FluxSource<T, T> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/FluxTakeLastOne.java
+++ b/src/main/java/reactor/core/publisher/FluxTakeLastOne.java
@@ -31,7 +31,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxTakeLastOne<T> extends FluxSource<T, T> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/FluxTakeUntil.java
+++ b/src/main/java/reactor/core/publisher/FluxTakeUntil.java
@@ -19,7 +19,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxTakeUntil<T, U> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxTakeUntilPredicate.java
+++ b/src/main/java/reactor/core/publisher/FluxTakeUntilPredicate.java
@@ -23,7 +23,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxTakeUntilPredicate<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxTakeWhile.java
+++ b/src/main/java/reactor/core/publisher/FluxTakeWhile.java
@@ -37,7 +37,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxTakeWhile<T> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxThrottleFirst.java
+++ b/src/main/java/reactor/core/publisher/FluxThrottleFirst.java
@@ -38,7 +38,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxThrottleFirst<T, U> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxThrottleTimeout.java
+++ b/src/main/java/reactor/core/publisher/FluxThrottleTimeout.java
@@ -40,7 +40,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxThrottleTimeout<T, U> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxTimeout.java
+++ b/src/main/java/reactor/core/publisher/FluxTimeout.java
@@ -27,7 +27,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxTimeout<T, U, V> extends FluxSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/FluxUsing.java
+++ b/src/main/java/reactor/core/publisher/FluxUsing.java
@@ -46,7 +46,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxUsing<T, S> extends Flux<T> implements Receiver, Fuseable {
 

--- a/src/main/java/reactor/core/publisher/FluxWindow.java
+++ b/src/main/java/reactor/core/publisher/FluxWindow.java
@@ -43,7 +43,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">https://github.com/reactor/reactive-streams-commons</a>
- * @since 2.5
  */
 final class FluxWindow<T> extends FluxSource<T, Flux<T>> {
 

--- a/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
+++ b/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
@@ -39,7 +39,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxWindowBoundary<T, U> extends FluxSource<T, Flux<T>> {
 

--- a/src/main/java/reactor/core/publisher/FluxWindowOnCancel.java
+++ b/src/main/java/reactor/core/publisher/FluxWindowOnCancel.java
@@ -42,7 +42,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxWindowOnCancel<T> extends FluxSource<T, Flux<T>> {
 

--- a/src/main/java/reactor/core/publisher/FluxWindowStartEnd.java
+++ b/src/main/java/reactor/core/publisher/FluxWindowStartEnd.java
@@ -43,7 +43,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxWindowStartEnd<T, U, V> extends FluxSource<T, Flux<T>> {
 

--- a/src/main/java/reactor/core/publisher/FluxWindowTimeOrSize.java
+++ b/src/main/java/reactor/core/publisher/FluxWindowTimeOrSize.java
@@ -27,7 +27,6 @@ import reactor.core.scheduler.TimedScheduler;
  * WindowAction is forwarding events on a steam until {@code backlog} is reached, after that streams collected events
  * further, complete it and create a fresh new fluxion.
  * @author Stephane Maldini
- * @since 2.0, 2.5
  */
 final class FluxWindowTimeOrSize<T> extends FluxBatch<T, Flux<T>> {
 

--- a/src/main/java/reactor/core/publisher/FluxWithLatestFrom.java
+++ b/src/main/java/reactor/core/publisher/FluxWithLatestFrom.java
@@ -44,7 +44,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxWithLatestFrom<T, U, R> extends FluxSource<T, R> {
 	final Publisher<? extends U> other;

--- a/src/main/java/reactor/core/publisher/FluxZip.java
+++ b/src/main/java/reactor/core/publisher/FluxZip.java
@@ -50,7 +50,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxZip<T, R> extends Flux<R> implements MultiReceiver, SubscriberState {
 

--- a/src/main/java/reactor/core/publisher/FluxZipIterable.java
+++ b/src/main/java/reactor/core/publisher/FluxZipIterable.java
@@ -40,7 +40,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class FluxZipIterable<T, U, R> extends FluxSource<T, R> {
 

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -79,7 +79,6 @@ import reactor.core.util.function.Tuple6;
  * @author David Karnok
  *
  * @see Flux
- * @since 2.5
  */
 public abstract class Mono<T> implements Publisher<T>, PublisherConfig {
 

--- a/src/main/java/reactor/core/publisher/MonoAggregate.java
+++ b/src/main/java/reactor/core/publisher/MonoAggregate.java
@@ -34,7 +34,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoAggregate<T> extends MonoSource<T, T> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/MonoAll.java
+++ b/src/main/java/reactor/core/publisher/MonoAll.java
@@ -39,7 +39,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoAll<T> extends MonoSource<T, Boolean> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/MonoAny.java
+++ b/src/main/java/reactor/core/publisher/MonoAny.java
@@ -39,7 +39,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoAny<T> extends MonoSource<T, Boolean> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/MonoCallable.java
+++ b/src/main/java/reactor/core/publisher/MonoCallable.java
@@ -34,7 +34,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoCallable<T> 
 extends Mono<T>

--- a/src/main/java/reactor/core/publisher/MonoCallableOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/MonoCallableOnAssembly.java
@@ -40,7 +40,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">https://github.com/reactor/reactive-streams-commons</a>
- * @since 2.5
  */
 final class MonoCallableOnAssembly<T> extends MonoSource<T, T>
 		implements Fuseable, Callable<T>, AssemblyOp {

--- a/src/main/java/reactor/core/publisher/MonoCallableOrEmpty.java
+++ b/src/main/java/reactor/core/publisher/MonoCallableOrEmpty.java
@@ -34,7 +34,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoCallableOrEmpty<T>
 extends Mono<T>

--- a/src/main/java/reactor/core/publisher/MonoCollect.java
+++ b/src/main/java/reactor/core/publisher/MonoCollect.java
@@ -39,7 +39,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoCollect<T, R> extends MonoSource<T, R> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/MonoCount.java
+++ b/src/main/java/reactor/core/publisher/MonoCount.java
@@ -32,7 +32,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  *
- * @since 2.5
  */
 final class MonoCount<T> extends MonoSource<T, Long> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/MonoDefer.java
+++ b/src/main/java/reactor/core/publisher/MonoDefer.java
@@ -31,7 +31,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoDefer<T>
 extends Mono<T>

--- a/src/main/java/reactor/core/publisher/MonoDelay.java
+++ b/src/main/java/reactor/core/publisher/MonoDelay.java
@@ -34,7 +34,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoDelay extends Mono<Long> {
 

--- a/src/main/java/reactor/core/publisher/MonoDelaySubscription.java
+++ b/src/main/java/reactor/core/publisher/MonoDelaySubscription.java
@@ -30,7 +30,6 @@ import org.reactivestreams.Subscriber;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoDelaySubscription<T, U> extends MonoSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/MonoDematerialize.java
+++ b/src/main/java/reactor/core/publisher/MonoDematerialize.java
@@ -20,7 +20,6 @@ import org.reactivestreams.Subscriber;
 
 /**
  * @author Stephane Maldini
- * @since 2.0, 2.5
  */
 final class MonoDematerialize<T> extends MonoSource<Signal<T>, T> {
 

--- a/src/main/java/reactor/core/publisher/MonoElementAt.java
+++ b/src/main/java/reactor/core/publisher/MonoElementAt.java
@@ -36,7 +36,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoElementAt<T> extends MonoSource<T, T> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/MonoEmpty.java
+++ b/src/main/java/reactor/core/publisher/MonoEmpty.java
@@ -30,7 +30,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoEmpty 
 extends Mono<Object>

--- a/src/main/java/reactor/core/publisher/MonoError.java
+++ b/src/main/java/reactor/core/publisher/MonoError.java
@@ -31,7 +31,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoError<T> extends Mono<T> implements SubscriberState {
 

--- a/src/main/java/reactor/core/publisher/MonoFilter.java
+++ b/src/main/java/reactor/core/publisher/MonoFilter.java
@@ -32,7 +32,6 @@ import reactor.core.publisher.FluxFilterFuseable.*;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoFilter<T> extends MonoSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/MonoFilterFuseable.java
+++ b/src/main/java/reactor/core/publisher/MonoFilterFuseable.java
@@ -30,7 +30,6 @@ import reactor.core.flow.Fuseable;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoFilterFuseable<T> extends MonoSource<T, T>
 		implements Fuseable {

--- a/src/main/java/reactor/core/publisher/MonoHasElements.java
+++ b/src/main/java/reactor/core/publisher/MonoHasElements.java
@@ -25,7 +25,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoHasElements<T> extends MonoSource<T, Boolean> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/MonoHide.java
+++ b/src/main/java/reactor/core/publisher/MonoHide.java
@@ -26,7 +26,6 @@ import org.reactivestreams.*;
  * 
  * @param <T> the value type
  * 
- * @since 2.5
  */
 final class MonoHide<T> extends MonoSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/MonoIgnoreThen.java
+++ b/src/main/java/reactor/core/publisher/MonoIgnoreThen.java
@@ -30,7 +30,6 @@ import reactor.core.subscriber.SubscriptionHelper;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoIgnoreThen<T> extends MonoSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/MonoJust.java
+++ b/src/main/java/reactor/core/publisher/MonoJust.java
@@ -25,7 +25,6 @@ import reactor.core.subscriber.ScalarSubscription;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoJust<T> 
 extends Mono<T>

--- a/src/main/java/reactor/core/publisher/MonoMap.java
+++ b/src/main/java/reactor/core/publisher/MonoMap.java
@@ -32,7 +32,6 @@ import reactor.core.publisher.FluxMapFuseable.MapFuseableSubscriber;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoMap<T, R> extends MonoSource<T, R> {
 

--- a/src/main/java/reactor/core/publisher/MonoMapFuseable.java
+++ b/src/main/java/reactor/core/publisher/MonoMapFuseable.java
@@ -33,7 +33,6 @@ import reactor.core.flow.Fuseable;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoMapFuseable<T, R> extends MonoSource<T, R>
 		implements Fuseable {

--- a/src/main/java/reactor/core/publisher/MonoNext.java
+++ b/src/main/java/reactor/core/publisher/MonoNext.java
@@ -34,7 +34,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoNext<T> extends MonoSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/MonoOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/MonoOnAssembly.java
@@ -35,7 +35,6 @@ import reactor.core.flow.Fuseable;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">https://github.com/reactor/reactive-streams-commons</a>
- * @since 2.5
  */
 final class MonoOnAssembly<T> extends MonoSource<T, T> implements Fuseable, AssemblyOp {
 

--- a/src/main/java/reactor/core/publisher/MonoOtherwise.java
+++ b/src/main/java/reactor/core/publisher/MonoOtherwise.java
@@ -30,7 +30,6 @@ import org.reactivestreams.Subscriber;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoOtherwise<T> extends MonoSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/MonoOtherwiseIfEmpty.java
+++ b/src/main/java/reactor/core/publisher/MonoOtherwiseIfEmpty.java
@@ -27,7 +27,6 @@ import org.reactivestreams.Subscriber;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoOtherwiseIfEmpty<T> extends MonoSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/MonoPeek.java
+++ b/src/main/java/reactor/core/publisher/MonoPeek.java
@@ -37,7 +37,6 @@ import reactor.core.publisher.FluxPeekFuseable.PeekFuseableSubscriber;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoPeek<T> extends MonoSource<T, T> implements FluxPeekHelper<T> {
 

--- a/src/main/java/reactor/core/publisher/MonoPeekFuseable.java
+++ b/src/main/java/reactor/core/publisher/MonoPeekFuseable.java
@@ -33,7 +33,6 @@ import reactor.core.flow.Fuseable;
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  *
- * @since 2.5
  */
 final class MonoPeekFuseable<T> extends MonoSource<T, T>
 		implements Fuseable, FluxPeekHelper<T> {

--- a/src/main/java/reactor/core/publisher/MonoReduce.java
+++ b/src/main/java/reactor/core/publisher/MonoReduce.java
@@ -38,7 +38,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoReduce<T, R> extends MonoSource<T, R> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/MonoRetry.java
+++ b/src/main/java/reactor/core/publisher/MonoRetry.java
@@ -29,7 +29,6 @@ import org.reactivestreams.Subscriber;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoRetry<T> extends MonoSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/MonoRetryPredicate.java
+++ b/src/main/java/reactor/core/publisher/MonoRetryPredicate.java
@@ -31,7 +31,6 @@ import org.reactivestreams.Subscriber;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoRetryPredicate<T> extends MonoSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/MonoRetryWhen.java
+++ b/src/main/java/reactor/core/publisher/MonoRetryWhen.java
@@ -35,7 +35,6 @@ import org.reactivestreams.Subscriber;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoRetryWhen<T> extends MonoSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/MonoSingle.java
+++ b/src/main/java/reactor/core/publisher/MonoSingle.java
@@ -38,7 +38,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoSingle<T> extends MonoSource<T, T> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/MonoStreamCollector.java
+++ b/src/main/java/reactor/core/publisher/MonoStreamCollector.java
@@ -39,7 +39,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoStreamCollector<T, A, R> extends MonoSource<T, R> implements Fuseable {
 	

--- a/src/main/java/reactor/core/publisher/MonoSubscribeOnCallable.java
+++ b/src/main/java/reactor/core/publisher/MonoSubscribeOnCallable.java
@@ -36,7 +36,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">https://github.com/reactor/reactive-streams-commons</a>
- * @since 2.5
  */
 final class MonoSubscribeOnCallable<T> extends Mono<T> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/MonoSupplier.java
+++ b/src/main/java/reactor/core/publisher/MonoSupplier.java
@@ -33,7 +33,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoSupplier<T> 
 extends Mono<T>

--- a/src/main/java/reactor/core/publisher/MonoThenApply.java
+++ b/src/main/java/reactor/core/publisher/MonoThenApply.java
@@ -36,7 +36,6 @@ import reactor.core.util.*;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoThenApply<T, R> extends MonoSource<T, R> implements Fuseable {
 

--- a/src/main/java/reactor/core/publisher/MonoTimeout.java
+++ b/src/main/java/reactor/core/publisher/MonoTimeout.java
@@ -35,7 +35,6 @@ import reactor.core.subscriber.Subscribers;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoTimeout<T, U, V> extends MonoSource<T, T> {
 

--- a/src/main/java/reactor/core/publisher/MonoUsing.java
+++ b/src/main/java/reactor/core/publisher/MonoUsing.java
@@ -44,7 +44,6 @@ import reactor.core.util.Exceptions;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
- * @since 2.5
  */
 final class MonoUsing<T, S> extends Mono<T> implements Receiver, Fuseable {
 

--- a/src/main/java/reactor/core/subscriber/BaseSubscriber.java
+++ b/src/main/java/reactor/core/subscriber/BaseSubscriber.java
@@ -23,8 +23,7 @@ import reactor.core.util.Exceptions;
  * Convenience subscriber default interface that checks for input errors and provide a self-subscription operation.
  *
  * @author Stephane Maldini
- * @since 2.5
- * 
+ *
  * @param <T> the value type observed
  */
 public interface BaseSubscriber<T> extends Subscriber<T> {

--- a/src/main/java/reactor/core/subscriber/BoundedSubscriber.java
+++ b/src/main/java/reactor/core/subscriber/BoundedSubscriber.java
@@ -22,7 +22,6 @@ import org.reactivestreams.Subscription;
 
 /**
  * @author Stephane Maldini
- * @since 2.5
  */
 final class BoundedSubscriber<T> extends LambdaSubscriber<T>  {
 

--- a/src/main/java/reactor/core/subscriber/LambdaSubscriber.java
+++ b/src/main/java/reactor/core/subscriber/LambdaSubscriber.java
@@ -27,7 +27,6 @@ import reactor.core.util.Exceptions;
 /**
  * An unbounded Java Lambda adapter to {@link Subscriber}
  * @author Stephane Maldini
- * @since 2.5
  * @param <T> the value type
  */
 public class LambdaSubscriber<T> implements BaseSubscriber<T>, Receiver, Cancellation,

--- a/src/main/java/reactor/core/subscriber/SubmissionEmitter.java
+++ b/src/main/java/reactor/core/subscriber/SubmissionEmitter.java
@@ -42,7 +42,6 @@ import reactor.core.util.Exceptions;
  * The emitter is itself a {@link Subscriber} that will request an unbounded value if subscribed.
  *
  * @author Stephane Maldini
- * @since 2.5
  * @param <E> the element type
  */
 public final class SubmissionEmitter<E>

--- a/src/main/java/reactor/core/subscriber/SubscriberBarrier.java
+++ b/src/main/java/reactor/core/subscriber/SubscriberBarrier.java
@@ -27,7 +27,6 @@ import reactor.core.util.Exceptions;
  * the {@link org.reactivestreams.Processor} interface allowing multiple subscribes.
  *
  * @author Stephane Maldini
- * @since 2.0.4
  * 
  * @param <I> the input value type
  * @param <O> the output value type

--- a/src/main/java/reactor/core/subscriber/Subscribers.java
+++ b/src/main/java/reactor/core/subscriber/Subscribers.java
@@ -38,7 +38,6 @@ import org.reactivestreams.Subscription;
  * </pre>
  *
  * @author Stephane Maldini
- * @since 2.0.3, 2.5
  */
 public enum Subscribers{
 	;

--- a/src/main/java/reactor/core/subscriber/SubscriptionHelper.java
+++ b/src/main/java/reactor/core/subscriber/SubscriptionHelper.java
@@ -38,7 +38,6 @@ import reactor.core.util.ReactorProperties;
  *
  * @author Stephane Maldini
  *
- * @since 2.5
  */
 public enum SubscriptionHelper {
 	;

--- a/src/main/java/reactor/core/test/TestSubscriber.java
+++ b/src/main/java/reactor/core/test/TestSubscriber.java
@@ -82,7 +82,6 @@ import reactor.core.util.ReactorProperties;
  * @author Anatoly Kadyshev
  * @author Stephane Maldini
  * @author Brian Clozel
- * @since 2.5
  */
 public class TestSubscriber<T> extends DeferredSubscription implements Subscriber<T> {
 

--- a/src/main/java/reactor/core/util/Exceptions.java
+++ b/src/main/java/reactor/core/util/Exceptions.java
@@ -25,7 +25,6 @@ import reactor.core.util.concurrent.WaitStrategy;
  *
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  * @author Stephane Maldini
- * @since 2.0
  */
 public enum Exceptions {
 	;


### PR DESCRIPTION
Since so much classes have changed since 2.0, I propose to remove the current `@since 2.5` Javadoc comments instead of updated them to `@since 3.0`. We will start dealing with `@since` from 3.0.x.