### PR TITLE
Tuple Hash Code

### DIFF
--- a/src/main/java/reactor/util/function/Tuple2.java
+++ b/src/main/java/reactor/util/function/Tuple2.java
@@ -104,24 +104,19 @@ public class Tuple2<T1, T2> implements Iterable, Serializable {
 
 	@Override
 	public boolean equals(Object o) {
-		if (o == null) return false;
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
 
-		if (!(o instanceof Tuple2)) return false;
+		Tuple2<?, ?> tuple2 = (Tuple2<?, ?>) o;
 
-		@SuppressWarnings("rawtypes")
-		Tuple2 tuple2 = (Tuple2) o;
-
-		if (size() != tuple2.size()) return false;
-
-		return (t1 != null ? t1.equals(tuple2.t1) : tuple2.t1 == null) &&
-				t2 != null ? t2.equals(tuple2.t2) : tuple2.t2 == null;
+		if (t1 != null ? !t1.equals(tuple2.t1) : tuple2.t1 != null) return false;
+		return t2 != null ? t2.equals(tuple2.t2) : tuple2.t2 == null;
 
 	}
 
 	@Override
 	public int hashCode() {
-		int result = super.hashCode();
-		result = 31 * result + (t1 != null ? t1.hashCode() : 0);
+		int result = t1 != null ? t1.hashCode() : 0;
 		result = 31 * result + (t2 != null ? t2.hashCode() : 0);
 		return result;
 	}


### PR DESCRIPTION
Previously, `Tuple` hash codes were broken because at the root of the hierarchy, `Object` identity was used to start the calculation.  This bug was due to the recent removal of the root `Tuple` type, leaving `Tuple2` calling `Object.hashCode()` instead of a properly structured `Tuple.hashCode()`.  This change fixes the bug by using the `t1` as the start of the hash code calculation.