### PR TITLE
Update to RxJava 1.2.0 and RxJava 2.0.0-RC3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,8 @@ ext {
   // Libraries
   jacksonDatabindVersion = '2.5.1'
   jsonPathVersion = '2.0.0'
-  rxJavaVersion = '1.1.10'
-  rxJava2Version = "2.0.0-RC2"
+  rxJavaVersion = '1.2.0'
+  rxJava2Version = "2.0.0-RC3"
 
   // Testing
   spockVersion = '1.0-groovy-2.4'


### PR DESCRIPTION
Update to RxJava 1.2.0 and RxJava 2.0.0-RC3.

The adapter didn't need to change but there were important internal and API changes in RC3 compared to RC2 so a wrong transient dependeny through reactor may lead to `ClassDefNotFound` or `LinkageError`.