### PR TITLE
Add ScriptedSubscriber

### DIFF
--- a/src/main/java/reactor/test/DefaultScriptedSubscriberBuilder.java
+++ b/src/main/java/reactor/test/DefaultScriptedSubscriberBuilder.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.reactivestreams.Subscription;
+
+import reactor.core.publisher.Signal;
+
+/**
+ * Default implementation of {@link reactor.test.ScriptedSubscriber.ValueBuilder} and
+ * {@link reactor.test.ScriptedSubscriber.TerminationBuilder}.
+ *
+ * @author Arjen Poutsma
+ * @since 1.0
+ */
+class DefaultScriptedSubscriberBuilder<T> implements ScriptedSubscriber.ValueBuilder<T> {
+
+	private final List<Event<T>> script = new ArrayList<>();
+
+	private final long initialRequest;
+
+	private final long expectedValueCount;
+
+
+	DefaultScriptedSubscriberBuilder(long initialRequest) {
+		this(initialRequest, -1);
+	}
+
+	DefaultScriptedSubscriberBuilder(long initialRequest, long expectedValueCount) {
+		this.initialRequest = initialRequest;
+		this.expectedValueCount = expectedValueCount;
+
+		SignalEvent<T> event = new SignalEvent<>(signal -> {
+			if (!signal.isOnSubscribe()) {
+				return Optional.of(String.format("expected: onSubscribe(); actual: %s", signal));
+			}
+			else {
+				return Optional.empty();
+			}
+		});
+		this.script.add(event);
+	}
+
+	static void checkForNegative(long n) {
+		if (n < 0) {
+			throw new IllegalArgumentException("'n' should be >= 0 but was " + n);
+		}
+	}
+
+	@Override
+	public ScriptedSubscriber.ValueBuilder<T> expectValue(T t) {
+		SignalEvent<T> event = new SignalEvent<>(signal -> {
+			if (!signal.isOnNext()) {
+				return Optional.of(String.format("expected: onNext(%s); actual: %s", t, signal));
+			}
+			else if (!Objects.equals(t, signal.get())) {
+				return Optional.of(String.format("expected value: %s; actual value: %s", t,
+						signal.get()));
+
+			}
+			else {
+				return Optional.empty();
+			}
+		});
+		this.script.add(event);
+		return this;
+	}
+
+	@Override
+	public ScriptedSubscriber.ValueBuilder<T> expectValues(T... ts) {
+		Arrays.stream(ts).forEach(this::expectValue);
+		return this;
+	}
+
+	@Override
+	public ScriptedSubscriber.ValueBuilder<T> expectValueWith(Predicate<T> predicate) {
+		SignalEvent<T> event = new SignalEvent<>(signal -> {
+			if (!signal.isOnNext()) {
+				return Optional.of(String.format("expected: onNext(); actual: %s", signal));
+			}
+			else if (!predicate.test(signal.get())) {
+				return Optional.of(String.format("predicate failed on value: %s", signal.get()));
+			}
+			else {
+				return Optional.empty();
+			}
+		});
+		this.script.add(event);
+		return this;
+	}
+
+	@Override
+	public ScriptedSubscriber<T> expectError() {
+		SignalEvent<T> event = new SignalEvent<>(signal -> {
+			if (!signal.isOnError()) {
+				return Optional.of(String.format("expected: onError(); actual: %s", signal));
+			}
+			else {
+				return Optional.empty();
+			}
+		});
+		this.script.add(event);
+		return build();
+
+	}
+
+	@Override
+	public ScriptedSubscriber<T> expectError(Class<? extends Throwable> clazz) {
+		SignalEvent<T> event = new SignalEvent<>(signal -> {
+			if (!signal.isOnError()) {
+				return Optional.of(String.format("expected: onError(%s); actual: %s",
+						clazz.getSimpleName(), signal));
+			}
+			else if (!clazz.isInstance(signal.getThrowable())) {
+				return Optional.of(String.format("expected error of type: %s; actual type: %s",
+						clazz.getSimpleName(), signal.getThrowable()));
+			}
+			else {
+				return Optional.empty();
+			}
+		});
+		this.script.add(event);
+		return build();
+	}
+
+	@Override
+	public ScriptedSubscriber<T> expectErrorWith(Predicate<Throwable> predicate) {
+		SignalEvent<T> event = new SignalEvent<>(signal -> {
+			if (!signal.isOnError()) {
+				return Optional.of(String.format("expected: onError(); actual: %s", signal));
+			}
+			else if (!predicate.test(signal.getThrowable())) {
+				return Optional.of(String.format("predicate failed on exception: %s",
+						signal.getThrowable()));
+			}
+			else {
+				return Optional.empty();
+			}
+		});
+		this.script.add(event);
+		return build();
+	}
+
+	@Override
+	public ScriptedSubscriber<T> expectComplete() {
+		SignalEvent<T> event = new SignalEvent<>(signal -> {
+			if (!signal.isOnComplete()) {
+				return Optional.of(String.format("expected: onComplete(); actual: %s", signal));
+			}
+			else {
+				return Optional.empty();
+			}
+		});
+		this.script.add(event);
+		return build();
+	}
+
+	@Override
+	public ScriptedSubscriber.ValueBuilder<T> doRequest(long n) {
+		checkForNegative(n);
+		this.script.add(new SubscriptionEvent<T>(subscription -> subscription.request(n), false));
+		return this;
+	}
+
+	@Override
+	public ScriptedSubscriber<T> doCancel() {
+		this.script.add(new SubscriptionEvent<T>(Subscription::cancel, true));
+		return build();
+	}
+
+	private ScriptedSubscriber<T> build() {
+		Queue<Event<T>> copy = new LinkedList<>(this.script);
+		return new DefaultScriptedSubscriber<T>(copy, this.initialRequest, this.expectedValueCount);
+	}
+
+	private static class DefaultScriptedSubscriber<T> implements ScriptedSubscriber<T> {
+
+		private final AtomicReference<Subscription> subscription = new AtomicReference<>();
+
+		private final CountDownLatch completeLatch = new CountDownLatch(1);
+
+		private final Queue<Event<T>> script;
+
+		private final long initialRequest;
+
+		private final List<String> failures = new LinkedList<>();
+
+		private final AtomicLong valueCount = new AtomicLong();
+
+		private final long expectedValueCount;
+
+
+		public DefaultScriptedSubscriber(Queue<Event<T>> script, long initialRequest, long expectedValueCount) {
+			this.script = script;
+			this.initialRequest = initialRequest;
+			this.expectedValueCount = expectedValueCount;
+		}
+
+		@Override
+		public void onSubscribe(Subscription subscription) {
+			Objects.requireNonNull(subscription, "Subscription cannot be null");
+
+			if (this.subscription.compareAndSet(null, subscription)) {
+				checkExpectation(Signal.subscribe(subscription));
+				subscription.request(this.initialRequest);
+			}
+			else {
+				subscription.cancel();
+			}
+		}
+
+		@Override
+		public void onNext(T t) {
+			if (this.expectedValueCount < 0) {
+				checkExpectation(Signal.next(t));
+			} else {
+				this.valueCount.incrementAndGet();
+			}
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			checkExpectation(Signal.error(t));
+			this.completeLatch.countDown();
+		}
+
+		@Override
+		public void onComplete() {
+			checkExpectation(Signal.complete());
+			this.completeLatch.countDown();
+		}
+
+		private void checkExpectation(Signal<T> actualSignal) {
+			Event<T> event = this.script.poll();
+			if (event == null) {
+				this.failures.add(String.format("did not expect: %s", actualSignal));
+			}
+			else {
+				SignalEvent<T> signalEvent = (SignalEvent<T>) event;
+				Optional<String> error = signalEvent.test(actualSignal);
+				error.ifPresent(this.failures::add);
+			}
+
+			while (true) {
+				event = this.script.peek();
+				if (event == null || event instanceof SignalEvent) {
+					break;
+				}
+				else {
+					SubscriptionEvent<T> subscriptionEvent = (SubscriptionEvent<T>) this.script.poll();
+					subscriptionEvent.consume(this.subscription.get());
+					if (subscriptionEvent.isTerminal()) {
+						this.completeLatch.countDown();
+						break;
+					}
+				}
+			}
+
+		}
+
+		@Override
+		public void verify() throws InterruptedException {
+			if (this.subscription.get() == null) {
+				throw new IllegalStateException("ScriptedSubscriber has not been subscribed");
+			}
+			this.completeLatch.await();
+			verifyInternal();
+		}
+
+		@Override
+		public void verify(Duration duration) throws AssertionError, InterruptedException, TimeoutException {
+			if (this.subscription.get() == null) {
+				throw new IllegalStateException("ScriptedSubscriber has not been subscribed");
+			}
+			if (!this.completeLatch.await(duration.toMillis(), TimeUnit.MILLISECONDS)) {
+				throw new TimeoutException("ScriptedSubscriber timed out on " + this.subscription.get());
+			}
+			verifyInternal();
+		}
+
+		private void verifyInternal() {
+			boolean validValueCount = hasValidValueCount();
+			if (this.failures.isEmpty() && validValueCount) {
+				return;
+			}
+			StringBuilder messageBuilder = new StringBuilder("Expectation failure(s):\n");
+			this.failures.stream()
+					.flatMap(error -> Stream.of(" - ", error, "\n"))
+					.forEach(messageBuilder::append);
+			if (!validValueCount) {
+				messageBuilder.append(String.format(" - expected %d values; got %d values",
+						this.expectedValueCount, this.valueCount.get()));
+			}
+			messageBuilder.delete(messageBuilder.length() - 1, messageBuilder.length());
+			throw new AssertionError(messageBuilder.toString());
+		}
+
+		private boolean hasValidValueCount() {
+			if (this.expectedValueCount < 0) {
+				return true;
+			}
+			else {
+				return this.expectedValueCount == this.valueCount.get();
+			}
+		}
+
+	}
+
+	@SuppressWarnings("unused")
+	private abstract static class Event<T> {
+	}
+
+	private static final class SubscriptionEvent<T> extends Event<T> {
+
+		private final Consumer<Subscription> consumer;
+
+		private final boolean terminal;
+
+		public SubscriptionEvent(Consumer<Subscription> consumer, boolean terminal) {
+			this.consumer = consumer;
+			this.terminal = terminal;
+		}
+
+		public void consume(Subscription subscription) {
+			this.consumer.accept(subscription);
+		}
+
+		public boolean isTerminal() {
+			return this.terminal;
+		}
+	}
+
+
+	private static final class SignalEvent<T> extends Event<T> {
+
+		private final Function<Signal<T>, Optional<String>> function;
+
+
+		public SignalEvent(Function<Signal<T>, Optional<String>> function) {
+			this.function = function;
+		}
+
+		public Optional<String> test(Signal<T> signal) {
+			return this.function.apply(signal);
+		}
+
+	}
+
+}

--- a/src/main/java/reactor/test/DefaultScriptedSubscriberBuilder.java
+++ b/src/main/java/reactor/test/DefaultScriptedSubscriberBuilder.java
@@ -106,12 +106,19 @@ class DefaultScriptedSubscriberBuilder<T> implements ScriptedSubscriber.ValueBui
 
 	@Override
 	public ScriptedSubscriber.ValueBuilder<T> expectValueWith(Predicate<T> predicate) {
+		return expectValueWith(predicate, t -> String.format("predicate failed on value: %s", t));
+	}
+
+	@Override
+	public ScriptedSubscriber.ValueBuilder<T> expectValueWith(Predicate<T> predicate,
+			Function<T, String> assertionMessage) {
+
 		SignalEvent<T> event = new SignalEvent<>(signal -> {
 			if (!signal.isOnNext()) {
 				return Optional.of(String.format("expected: onNext(); actual: %s", signal));
 			}
 			else if (!predicate.test(signal.get())) {
-				return Optional.of(String.format("predicate failed on value: %s", signal.get()));
+				return Optional.of(assertionMessage.apply(signal.get()));
 			}
 			else {
 				return Optional.empty();
@@ -119,6 +126,7 @@ class DefaultScriptedSubscriberBuilder<T> implements ScriptedSubscriber.ValueBui
 		});
 		this.script.add(event);
 		return this;
+
 	}
 
 	@Override
@@ -157,13 +165,20 @@ class DefaultScriptedSubscriberBuilder<T> implements ScriptedSubscriber.ValueBui
 
 	@Override
 	public ScriptedSubscriber<T> expectErrorWith(Predicate<Throwable> predicate) {
+		return expectErrorWith(predicate,
+				t -> String.format("predicate failed on exception: %s", t));
+	}
+
+	@Override
+	public ScriptedSubscriber<T> expectErrorWith(Predicate<Throwable> predicate,
+			Function<Throwable, String> assertionMessage) {
+
 		SignalEvent<T> event = new SignalEvent<>(signal -> {
 			if (!signal.isOnError()) {
 				return Optional.of(String.format("expected: onError(); actual: %s", signal));
 			}
 			else if (!predicate.test(signal.getThrowable())) {
-				return Optional.of(String.format("predicate failed on exception: %s",
-						signal.getThrowable()));
+				return Optional.of(assertionMessage.apply(signal.getThrowable()));
 			}
 			else {
 				return Optional.empty();

--- a/src/main/java/reactor/test/ScriptedSubscriber.java
+++ b/src/main/java/reactor/test/ScriptedSubscriber.java
@@ -18,6 +18,7 @@ package reactor.test;
 
 import java.time.Duration;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.reactivestreams.Subscriber;
@@ -154,6 +155,18 @@ public interface ScriptedSubscriber<T> extends Subscriber<T> {
 		ScriptedSubscriber<T> expectErrorWith(Predicate<Throwable> predicate);
 
 		/**
+		 * Expect an error and evaluate with the given predicate. The given
+		 * {@code assertionMessage} function is used to create the {@code AssertionError} message,
+		 * if the expectation failed.
+		 * @param predicate the predicate to test on the next received error
+		 * @param assertionMessage supplies the exception message
+		 * @return the built subscriber
+		 * @see Subscriber#onError(Throwable)
+		 */
+		ScriptedSubscriber<T> expectErrorWith(Predicate<Throwable> predicate,
+				Function<Throwable, String> assertionMessage);
+
+		/**
 		 * Expect the completion signal.
 		 * @return the built subscriber
 		 * @see Subscriber#onComplete()
@@ -169,6 +182,11 @@ public interface ScriptedSubscriber<T> extends Subscriber<T> {
 		ScriptedSubscriber<T> doCancel();
 	}
 
+	/**
+	 * Define a builder for expecting individual values.
+	 *
+	 * @param <T> the type of values that the subscriber contains
+	 */
 	interface ValueBuilder<T> extends TerminationBuilder<T> {
 
 		/**
@@ -204,6 +222,17 @@ public interface ScriptedSubscriber<T> extends Subscriber<T> {
 		 * @see Subscriber#onNext(Object)
 		 */
 		ValueBuilder<T> expectValueWith(Predicate<T> predicate);
-	}
 
+		/**
+		 * Expect an element and evaluate with the given predicate. The given
+		 * {@code assertionMessage} function is used to create the {@code AssertionError} message,
+		 * if the expectation failed.
+		 * @param predicate the predicate to test on the next received value
+		 * @param assertionMessage supplies the exception message
+		 * @return this builder
+		 * @see Subscriber#onNext(Object)
+		 */
+		ValueBuilder<T> expectValueWith(Predicate<T> predicate,
+				Function<T, String> assertionMessage);
+	}
 }

--- a/src/main/java/reactor/test/ScriptedSubscriber.java
+++ b/src/main/java/reactor/test/ScriptedSubscriber.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Predicate;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * Subscriber implementation that verifies pre-defined expectations as part of its subscription.
+ * Typical usage consists of the following steps:
+ * <ul>
+ * <li>Create a {@code ScriptedSubscriber} builder using {@link #create()} or
+ * {@link #create(long)},</li>
+ * <li>Set individual up value expectations using
+ * {@link ValueBuilder#expectValue(Object) expectValue(Object)},
+ * {@link ValueBuilder#expectValues(Object[]) expectValues(Object[])},
+ * {@link ValueBuilder#expectValueWith(Predicate) expectValueWith(Predicate)}.</li>
+ * and/or
+ * <li>Set up subscription actions using either
+ * {@link ValueBuilder#doRequest(long) doRequest(long)} or
+ * {@link ValueBuilder#doCancel() doCancel()}.
+ * </li>
+ * <li>Build the {@code ScriptedSubscriber} using
+ * {@link TerminationBuilder#expectComplete() expectComplete()},
+ * {@link TerminationBuilder#expectError() expectError()},
+ * {@link TerminationBuilder#expectError(Class) expectError(Class)},
+ * {@link TerminationBuilder#expectErrorWith(Predicate) expectErrorWith(Predicate)}, or
+ * {@link TerminationBuilder#doCancel() doCancel()}.
+ * </li>
+ * <li>Subscribe the built {@code ScriptedSubscriber} to a {@code Publisher}.</li>
+ * <li>Verify the expectations using either {@link #verify()} or {@link #verify(Duration)}.</li>
+ * <li>If any expectations failed, an {@code AssertionError} will be thrown indicating the
+ * failures.</li>
+ * </ul>
+ * As an alternative to setting up individual expectation as described above, you can expect a
+ * certain value count using {@link #expectValueCount(long)}.
+ *
+ * <p>For example:
+ * <pre>
+ * ScriptedSubscriber&lt;String&gt; subscriber = ScriptedSubscriber.&lt;String&gt;create()
+ *   .expectValue("foo")
+ *   .expectValue("bar")
+ *   .expectComplete();
+ *
+ * Publisher&lt;String&gt; publisher = Flux.just("foo", "bar");
+ * publisher.subscribe(subscriber);
+ *
+ * subscriber.verify();
+ * </pre>
+ *
+ * @author Arjen Poutsma
+ * @since 1.0
+ */
+public interface ScriptedSubscriber<T> extends Subscriber<T> {
+
+	/**
+	 * Verify the signals received by this subscriber. This method will <strong>block</strong>
+	 * indefinitely until the stream has been terminated (either through {@link #onComplete()},
+	 * {@link #onError(Throwable)} or {@link Subscription#cancel()}).
+	 * @throws AssertionError in case of expectation failures
+	 * @throws InterruptedException if the current thread is interrupted while waiting
+	 */
+	void verify() throws AssertionError, InterruptedException;
+
+	/**
+	 * Verify the signals received by this subscriber. This method will <strong>block</strong>
+	 * for the given duration or until the stream has been terminated (either through
+	 * {@link #onComplete()}, {@link #onError(Throwable)} or {@link Subscription#cancel()}).
+	 * @throws AssertionError in case of expectation failures
+	 * @throws InterruptedException if the current thread is interrupted while waiting
+	 * @throws TimeoutException if the verification times out
+	 */
+	void verify(Duration duration) throws AssertionError, InterruptedException, TimeoutException;
+
+
+	/**
+	 * Create a new {@code ScriptedSubscriber} that requests an unbounded amount of values.
+	 * @param <T> the type of the subscriber
+	 * @return a builder for setting up value expectations
+	 */
+	static <T> ValueBuilder<T> create() {
+		return create(Long.MAX_VALUE);
+	}
+
+	/**
+	 * Create a new {@code ScriptedSubscriber} that requests a specified amount of values.
+	 * @param n the amount of items to request
+	 * @param <T> the type of the subscriber
+	 * @return a builder for setting up value expectations
+	 */
+	static <T> ValueBuilder<T> create(long n) {
+		DefaultScriptedSubscriberBuilder.checkForNegative(n);
+		return new DefaultScriptedSubscriberBuilder<T>(n);
+	}
+
+	/**
+	 * Create a new {@code ScriptedSubscriber} that expects the given amount of elements to be
+	 * received.
+	 *  @param n the expected amount of values
+	 * @return a builder for setting up termination expectations
+	 * @see Subscriber#onNext(Object)
+	 */
+	static <T> TerminationBuilder<T> expectValueCount(long n) {
+		DefaultScriptedSubscriberBuilder.checkForNegative(n);
+		return new DefaultScriptedSubscriberBuilder<T>(Long.MAX_VALUE, n);
+	}
+
+	/**
+	 * Define a builder for terminal states.
+	 *
+	 * @param <T> the type of values that the subscriber contains
+	 */
+	interface TerminationBuilder<T> {
+
+		/**
+		 * Expect an unspecified error.
+		 * @return the built subscriber
+		 * @see Subscriber#onError(Throwable)
+		 */
+		ScriptedSubscriber<T> expectError();
+
+		/**
+		 * Expect an error of the specified type.
+		 * @param clazz the expected error type
+		 * @return the built subscriber
+		 * @see Subscriber#onError(Throwable)
+		 */
+		ScriptedSubscriber<T> expectError(Class<? extends Throwable> clazz);
+
+		/**
+		 * Expect an error and evaluate with the given predicate.
+		 * @param predicate the predicate to test on the next received error
+		 * @return the built subscriber
+		 * @see Subscriber#onError(Throwable)
+		 */
+		ScriptedSubscriber<T> expectErrorWith(Predicate<Throwable> predicate);
+
+		/**
+		 * Expect the completion signal.
+		 * @return the built subscriber
+		 * @see Subscriber#onComplete()
+		 */
+		ScriptedSubscriber<T> expectComplete();
+
+		/**
+		 * Cancel the underlying subscription.
+		 * {@link ScriptedSubscriber#create(long)}.
+		 * @return the built subscriber
+		 * @see Subscription#cancel()
+		 */
+		ScriptedSubscriber<T> doCancel();
+	}
+
+	interface ValueBuilder<T> extends TerminationBuilder<T> {
+
+		/**
+		 * Request the given amount of elements from the upstream {@code Publisher}. This is in
+		 * addition to the initial number of elements requested by
+		 * {@link ScriptedSubscriber#create(long)}.
+		 * @param n the number of elements to request
+		 * @return this builder
+		 * @see Subscription#request(long)
+		 */
+		ValueBuilder<T> doRequest(long n);
+
+		/**
+		 * Expect the next element received to be equal to the given value.
+		 * @param t the value to expect
+		 * @return this builder
+		 * @see Subscriber#onNext(Object)
+		 */
+		ValueBuilder<T> expectValue(T t);
+
+		/**
+		 * Expect the next elements received to be equal to the given values.
+		 * @param ts the values to expect
+		 * @return this builder
+		 * @see Subscriber#onNext(Object)
+		 */
+		ValueBuilder<T> expectValues(T... ts);
+
+		/**
+		 * Expect an element and evaluate with the given predicate.
+		 * @param predicate the predicate to test on the next received value
+		 * @return this builder
+		 * @see Subscriber#onNext(Object)
+		 */
+		ValueBuilder<T> expectValueWith(Predicate<T> predicate);
+	}
+
+}

--- a/src/test/java/reactor/test/ScriptedSubscriberIntegrationTests.java
+++ b/src/test/java/reactor/test/ScriptedSubscriberIntegrationTests.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Test;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * @author Arjen Poutsma
+ */
+public class ScriptedSubscriberIntegrationTests {
+
+	@Test
+	public void expectValue() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValue("foo")
+				.expectValue("bar")
+				.expectComplete();
+
+		Flux<String> flux = Flux.just("foo", "bar");
+		flux.subscribe(subscriber);
+
+		subscriber.verify();
+	}
+
+	@Test(expected = AssertionError.class)
+	public void expectInvalidValue() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValue("foo")
+				.expectValue("baz")
+				.expectComplete();
+
+		Flux<String> flux = Flux.just("foo", "bar");
+		flux.subscribe(subscriber);
+
+		subscriber.verify();
+	}
+
+	@Test
+	public void expectValueAsync() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValue("foo")
+				.expectValue("bar")
+				.expectComplete();
+
+		Flux<String> flux = Flux.just("foo", "bar").publishOn(Schedulers.parallel());
+		flux.subscribe(subscriber);
+
+		subscriber.verify();
+	}
+
+	@Test
+	public void expectValues() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValues("foo", "bar")
+				.expectComplete();
+
+		Flux<String> flux = Flux.just("foo", "bar");
+		flux.subscribe(subscriber);
+
+		subscriber.verify();
+	}
+
+	@Test(expected = AssertionError.class)
+	public void expectInvalidValues() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValues("foo", "baz")
+				.expectComplete();
+
+		Flux<String> flux = Flux.just("foo", "bar");
+		flux.subscribe(subscriber);
+
+		subscriber.verify();
+	}
+
+	@Test
+	public void expectValueWith() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValueWith("foo"::equals)
+				.expectValueWith("bar"::equals)
+				.expectComplete();
+
+		Flux<String> flux = Flux.just("foo", "bar");
+		flux.subscribe(subscriber);
+
+		subscriber.verify();
+	}
+
+	@Test(expected = AssertionError.class)
+	public void expectInvalidValueWith() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValueWith("foo"::equals)
+				.expectValueWith("baz"::equals)
+				.expectComplete();
+
+		Flux<String> flux = Flux.just("foo", "bar");
+		flux.subscribe(subscriber);
+
+		subscriber.verify();
+	}
+
+	@Test(expected = AssertionError.class)
+	public void missingValue() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValue("foo")
+				.expectComplete();
+
+		Flux<String> flux = Flux.just("foo", "bar");
+		flux.subscribe(subscriber);
+
+		subscriber.verify();
+	}
+
+	@Test(expected = AssertionError.class)
+	public void missingValueAsync() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValue("foo")
+				.expectComplete();
+
+		Flux<String> flux = Flux.just("foo", "bar").publishOn(Schedulers.parallel());
+		flux.subscribe(subscriber);
+
+		subscriber.verify();
+	}
+
+	@Test
+	public void expectValueCount() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>expectValueCount(2)
+				.expectComplete();
+
+		Flux<String> flux = Flux.just("foo", "bar");
+		flux.subscribe(subscriber);
+
+		subscriber.verify();
+	}
+
+
+	@Test
+	public void error() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValue("foo")
+				.expectError();
+
+		Flux<String> flux = Flux.just("foo").concatWith(Mono.error(new IllegalArgumentException()));
+		flux.subscribe(subscriber);
+
+		subscriber.verify();
+	}
+
+	@Test
+	public void errorClass() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValue("foo")
+				.expectError(IllegalArgumentException.class);
+
+		Flux<String> flux = Flux.just("foo").concatWith(Mono.error(new IllegalArgumentException()));
+		flux.subscribe(subscriber);
+
+		subscriber.verify();
+	}
+
+	@Test
+	public void errorWith() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValue("foo")
+				.expectErrorWith(t -> t instanceof IllegalArgumentException);
+
+		Flux<String> flux = Flux.just("foo").concatWith(Mono.error(new IllegalArgumentException()));
+		flux.subscribe(subscriber);
+
+		subscriber.verify();
+	}
+
+	@Test(expected = AssertionError.class)
+	public void errorWithInvalid() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValue("foo")
+				.expectErrorWith(t -> t instanceof IllegalStateException);
+
+		Flux<String> flux = Flux.just("foo").concatWith(Mono.error(new IllegalArgumentException()));
+		flux.subscribe(subscriber);
+
+		subscriber.verify();
+	}
+
+	@Test
+	public void request() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create(1)
+				.doRequest(1)
+				.expectValue("foo")
+				.doRequest(1)
+				.expectValue("bar")
+				.expectComplete();
+
+		Flux<String> flux = Flux.just("foo", "bar");
+		flux.subscribe(subscriber);
+
+		subscriber.verify();
+	}
+
+	@Test
+	public void cancel() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValue("foo")
+				.doCancel();
+
+		Flux<String> flux = Flux.just("foo", "bar", "baz");
+		flux.subscribe(subscriber);
+
+		subscriber.verify();
+	}
+
+	@Test(expected = AssertionError.class)
+	public void cancelInvalid() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValue("foo")
+				.doCancel();
+
+		Flux<String> flux = Flux.just("bar", "baz");
+		flux.subscribe(subscriber);
+
+		subscriber.verify();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void notSubscribed() throws InterruptedException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValue("foo")
+				.expectComplete();
+
+		subscriber.verify();
+	}
+
+	@Test
+	public void verifyDuration() throws InterruptedException, TimeoutException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValue("foo")
+				.expectValue("foo")
+				.expectComplete();
+
+		Flux<String> flux = Flux.interval(Duration.ofMillis(200)).map(l -> "foo").take(2);
+		flux.subscribe(subscriber);
+
+		subscriber.verify(Duration.ofMillis(500));
+	}
+
+	@Test(expected = TimeoutException.class)
+	public void verifyDurationTimeout() throws InterruptedException, TimeoutException {
+		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
+				.expectValue("foo")
+				.expectValue("foo")
+				.expectComplete();
+
+		Flux<String> flux = Flux.interval(Duration.ofMillis(200)).map(l -> "foo" ).take(2);
+		flux.subscribe(subscriber);
+
+		subscriber.verify(Duration.ofMillis(300));
+	}
+
+}


### PR DESCRIPTION
This commit introduces a new Subscriber implementation meant for testing
purposes: the ScriptedSubscriber. This subscriber is set up with signal
expectations before subscribing. Expectations will be verified with a
verification step, resulting in an AssertionError if they are not met.