### PR TITLE
Add subscribe with Consumer<Subscription>

### DIFF
--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -5060,7 +5060,7 @@ public abstract class Flux<T> implements Publisher<T> {
 			Consumer<? super Throwable> errorConsumer, Runnable completeConsumer) {
 
 		LambdaSubscriber<T> consumerAction =
-				new LambdaSubscriber<>(consumer, errorConsumer, completeConsumer);
+				new LambdaSubscriber<>(consumer, errorConsumer, completeConsumer, null);
 
 		subscribe(consumerAction);
 		return consumerAction;
@@ -5090,11 +5090,41 @@ public abstract class Flux<T> implements Publisher<T> {
 			Consumer<? super Throwable> errorConsumer,
 			Runnable completeConsumer,
 			int prefetch) {
+		return subscribe(consumer, errorConsumer, completeConsumer, null, prefetch);
+	}
+
+
+	/**
+	 * Subscribe {@link Consumer} to this {@link Flux} that will consume all the sequence.
+	 * <p>If prefetch is {@code != Long.MAX_VALUE}, the {@link Subscriber} will use it as
+	 * a prefetch strategy: first request N, then when 25% of N is left to be received on
+	 * onNext, request N x 0.75.
+	 *
+	 * <p> For a passive version that observe and forward
+	 * incoming data see {@link #doOnNext(java.util.function.Consumer)}, {@link
+	 * #doOnError(java.util.function.Consumer)} and {@link #doOnComplete(Runnable)},
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/subscribecomplete.png"
+	 * alt="">
+	 *
+	 * @param consumer the consumer to invoke on each value
+	 * @param errorConsumer the consumer to invoke on error signal
+	 * @param completeConsumer the consumer to invoke on complete signal
+	 * @param subscriptionConsumer the consumer to invoke on subscribe signal
+	 * @param prefetch the demand to produce to this {@link Flux}
+	 *
+	 * @return a new {@link Cancellation} to dispose the {@link Subscription}
+	 */
+	public final Cancellation subscribe(Consumer<? super T> consumer,
+			Consumer<? super Throwable> errorConsumer,
+			Runnable completeConsumer,
+			Consumer<? super Subscription> subscriptionConsumer,
+			int prefetch) {
 
 		int c = Math.min(Integer.MAX_VALUE, prefetch);
 
 		LambdaSubscriber<T> consumerAction =
-				new LambdaSubscriber<>(consumer, errorConsumer, completeConsumer);
+				new LambdaSubscriber<>(consumer, errorConsumer, completeConsumer, subscriptionConsumer);
 
 		Flux<T> tail;
 		if (c == Integer.MAX_VALUE) {

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -5110,7 +5110,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param consumer the consumer to invoke on each value
 	 * @param errorConsumer the consumer to invoke on error signal
 	 * @param completeConsumer the consumer to invoke on complete signal
-	 * @param subscriptionConsumer the consumer to invoke on subscribe signal
+	 * @param subscriptionConsumer the consumer to invoke on subscribe signal, to be used
+	 * for the initial {@link Subscription#request(long) request}, or null for max request
 	 * @param prefetch the demand to produce to this {@link Flux}
 	 *
 	 * @return a new {@link Cancellation} to dispose the {@link Subscription}

--- a/src/main/java/reactor/core/publisher/LambdaFirstSubscriber.java
+++ b/src/main/java/reactor/core/publisher/LambdaFirstSubscriber.java
@@ -34,9 +34,10 @@ import reactor.core.Trackable;
 final class LambdaFirstSubscriber<T>
 		implements Subscriber<T>, Receiver, Cancellation, Trackable {
 
-	final Consumer<? super T>         consumer;
-	final Consumer<? super Throwable> errorConsumer;
-	final Runnable                    completeConsumer;
+	final Consumer<? super T>            consumer;
+	final Consumer<? super Throwable>    errorConsumer;
+	final Runnable                       completeConsumer;
+	final Consumer<? super Subscription> subscriptionConsumer;
 
 	volatile Subscription subscription;
 	static final AtomicReferenceFieldUpdater<LambdaFirstSubscriber, Subscription> S =
@@ -55,13 +56,17 @@ final class LambdaFirstSubscriber<T>
 	 * @param errorConsumer A {@link Consumer} called onError
 	 * @param completeConsumer A {@link Runnable} called onComplete with the actual
 	 * context if any
+	 * @param subscriptionConsumer A {@link Consumer} called with the
+	 * {@link Subscription}, or null to ignore
 	 */
 	public LambdaFirstSubscriber(Consumer<? super T> consumer,
 			Consumer<? super Throwable> errorConsumer,
-			Runnable completeConsumer) {
+			Runnable completeConsumer,
+			Consumer<? super Subscription> subscriptionConsumer) {
 		this.consumer = consumer;
 		this.errorConsumer = errorConsumer;
 		this.completeConsumer = completeConsumer;
+		this.subscriptionConsumer = subscriptionConsumer;
 	}
 
 	@Override
@@ -69,6 +74,11 @@ final class LambdaFirstSubscriber<T>
 		if (Operators.validate(subscription, s)) {
 			this.subscription = s;
 			try {
+				//note that unlike in RxJava 2.0.0 an error on accept doesn't trigger
+				// cancellation of s
+				if (subscriptionConsumer != null) {
+					subscriptionConsumer.accept(s);
+				}
 				s.request(Long.MAX_VALUE);
 			}
 			catch (Throwable t) {

--- a/src/main/java/reactor/core/publisher/LambdaFirstSubscriber.java
+++ b/src/main/java/reactor/core/publisher/LambdaFirstSubscriber.java
@@ -57,7 +57,7 @@ final class LambdaFirstSubscriber<T>
 	 * @param completeConsumer A {@link Runnable} called onComplete with the actual
 	 * context if any
 	 * @param subscriptionConsumer A {@link Consumer} called with the
-	 * {@link Subscription}, or null to ignore
+	 * {@link Subscription} to perform initial request, or null to request max
 	 */
 	public LambdaFirstSubscriber(Consumer<? super T> consumer,
 			Consumer<? super Throwable> errorConsumer,
@@ -79,7 +79,9 @@ final class LambdaFirstSubscriber<T>
 				if (subscriptionConsumer != null) {
 					subscriptionConsumer.accept(s);
 				}
-				s.request(Long.MAX_VALUE);
+				else {
+					s.request(Long.MAX_VALUE);
+				}
 			}
 			catch (Throwable t) {
 				Exceptions.throwIfFatal(t);

--- a/src/main/java/reactor/core/publisher/LambdaSubscriber.java
+++ b/src/main/java/reactor/core/publisher/LambdaSubscriber.java
@@ -34,9 +34,10 @@ import reactor.core.Trackable;
 final class LambdaSubscriber<T>
 		implements Subscriber<T>, Receiver, Cancellation, Trackable {
 
-	final Consumer<? super T>         consumer;
-	final Consumer<? super Throwable> errorConsumer;
-	final Runnable                    completeConsumer;
+	final Consumer<? super T>            consumer;
+	final Consumer<? super Throwable>    errorConsumer;
+	final Runnable                       completeConsumer;
+	final Consumer<? super Subscription> subscriptionConsumer;
 
 	volatile Subscription subscription;
 	static final AtomicReferenceFieldUpdater<LambdaSubscriber, Subscription> S =
@@ -55,13 +56,17 @@ final class LambdaSubscriber<T>
 	 * @param errorConsumer A {@link Consumer} called onError
 	 * @param completeConsumer A {@link Runnable} called onComplete with the actual
 	 * context if any
+	 * @param subscriptionConsumer A {@link Consumer} called with the
+	 * {@link Subscription}, or null to ignore
 	 */
 	public LambdaSubscriber(Consumer<? super T> consumer,
 			Consumer<? super Throwable> errorConsumer,
-			Runnable completeConsumer) {
+			Runnable completeConsumer,
+			Consumer<? super Subscription> subscriptionConsumer) {
 		this.consumer = consumer;
 		this.errorConsumer = errorConsumer;
 		this.completeConsumer = completeConsumer;
+		this.subscriptionConsumer = subscriptionConsumer;
 	}
 
 	@Override
@@ -69,6 +74,11 @@ final class LambdaSubscriber<T>
 		if (Operators.validate(subscription, s)) {
 			this.subscription = s;
 			try {
+				//note that unlike in RxJava 2.0.0 an error on accept doesn't trigger
+				// cancellation of s
+				if (subscriptionConsumer != null) {
+					subscriptionConsumer.accept(s);
+				}
 				s.request(Long.MAX_VALUE);
 			}
 			catch (Throwable t) {

--- a/src/main/java/reactor/core/publisher/LambdaSubscriber.java
+++ b/src/main/java/reactor/core/publisher/LambdaSubscriber.java
@@ -56,8 +56,8 @@ final class LambdaSubscriber<T>
 	 * @param errorConsumer A {@link Consumer} called onError
 	 * @param completeConsumer A {@link Runnable} called onComplete with the actual
 	 * context if any
-	 * @param subscriptionConsumer A {@link Consumer} called with the
-	 * {@link Subscription}, or null to ignore
+	 * @param subscriptionConsumer A {@link Consumer} called with the {@link Subscription}
+	 * to perform initial request, or null to request max
 	 */
 	public LambdaSubscriber(Consumer<? super T> consumer,
 			Consumer<? super Throwable> errorConsumer,
@@ -79,7 +79,9 @@ final class LambdaSubscriber<T>
 				if (subscriptionConsumer != null) {
 					subscriptionConsumer.accept(s);
 				}
-				s.request(Long.MAX_VALUE);
+				else {
+					s.request(Long.MAX_VALUE);
+				}
 			}
 			catch (Throwable t) {
 				Exceptions.throwIfFatal(t);
@@ -96,7 +98,7 @@ final class LambdaSubscriber<T>
 	@Override
 	public final void onComplete() {
 		Subscription s = S.getAndSet(this, Operators.cancelledSubscription());
-		if ( s == Operators.cancelledSubscription()) {
+		if (s == Operators.cancelledSubscription()) {
 			return;
 		}
 		if (completeConsumer != null) {

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -2391,8 +2391,32 @@ public abstract class Mono<T> implements Publisher<T> {
 	public final Cancellation subscribe(Consumer<? super T> consumer,
 			Consumer<? super Throwable> errorConsumer,
 			Runnable completeConsumer) {
+		return subscribe(consumer, errorConsumer, completeConsumer, null);
+	}
+
+	/**
+	 * Subscribe {@link Consumer} to this {@link Mono} that will consume all the
+	 * sequence.
+	 * <p>
+	 * For a passive version that observe and forward incoming data see {@link #doOnSuccess(Consumer)} and
+	 * {@link #doOnError(java.util.function.Consumer)}.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/subscribecomplete1.png" alt="">
+	 *
+	 * @param consumer the consumer to invoke on each value
+	 * @param errorConsumer the consumer to invoke on error signal
+	 * @param completeConsumer the consumer to invoke on complete signal
+	 * @param subscriptionConsumer the consumer to invoke on subscribe signal
+	 *
+	 * @return a new {@link Cancellation} to dispose the {@link Subscription}
+	 */
+	public final Cancellation subscribe(Consumer<? super T> consumer,
+			Consumer<? super Throwable> errorConsumer,
+			Runnable completeConsumer,
+			Consumer<? super Subscription> subscriptionConsumer) {
 		return subscribeWith(new LambdaFirstSubscriber<>(consumer, errorConsumer,
-				completeConsumer));
+				completeConsumer, subscriptionConsumer));
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -2407,7 +2407,8 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param consumer the consumer to invoke on each value
 	 * @param errorConsumer the consumer to invoke on error signal
 	 * @param completeConsumer the consumer to invoke on complete signal
-	 * @param subscriptionConsumer the consumer to invoke on subscribe signal
+	 * @param subscriptionConsumer the consumer to invoke on subscribe signal, to be used
+	 * for the initial {@link Subscription#request(long) request}, or null for max request
 	 *
 	 * @return a new {@link Cancellation} to dispose the {@link Subscription}
 	 */

--- a/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -874,14 +874,29 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	 * must be equal to the parallelism level of this ParallelFlux
 	 */
 	public void subscribe(Consumer<? super T> onNext, Consumer<? super Throwable>
-			onError, Runnable onComplete){
+			onError, Runnable onComplete) {
+		subscribe(onNext, onError, onComplete, null);
+	}
+
+	/**
+	 * Subscribes an array of Subscribers to this {@link ParallelFlux} and triggers the
+	 * execution chain for all 'rails'.
+	 *
+	 * @param onNext
+	 * @param onError
+	 * @param onComplete
+	 * @param onSubscribe
+	 * must be equal to the parallelism level of this ParallelFlux
+	 */
+	public void subscribe(Consumer<? super T> onNext, Consumer<? super Throwable>
+			onError, Runnable onComplete, Consumer<? super Subscription> onSubscribe){
 
 		@SuppressWarnings("unchecked")
 		Subscriber<T>[] subscribers = new Subscriber[parallelism()];
 
 		int i = 0;
 		while(i < subscribers.length){
-			subscribers[i++] = new LambdaSubscriber<>(onNext, onError, onComplete);
+			subscribers[i++] = new LambdaSubscriber<>(onNext, onError, onComplete, onSubscribe);
 		}
 
 		subscribe(subscribers);

--- a/src/test/java/reactor/core/publisher/LambdaFirstSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/LambdaFirstSubscriberTest.java
@@ -1,0 +1,103 @@
+package reactor.core.publisher;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class LambdaFirstSubscriberTest {
+
+	@Test
+	public void consumeOnSubscriptionNotifiesError() {
+		AtomicReference<Throwable> errorHolder = new AtomicReference<>(null);
+
+		LambdaSubscriber<String> tested = new LambdaSubscriber<>(
+				value -> {},
+				errorHolder::set,
+				() -> {},
+				subscription -> { throw new IllegalArgumentException(); });
+
+		TestSubscription testSubscription = new TestSubscription();
+
+		//the error is expected to be propagated through onError
+		tested.onSubscribe(testSubscription);
+
+		assertThat("unexpected exception in onError",
+				errorHolder.get(), is(instanceOf(IllegalArgumentException.class)));
+		assertThat("subscription has been cancelled",
+				testSubscription.isCancelled, is(not(true)));
+		assertThat("unexpected request",
+				testSubscription.requested, is(equalTo(-1L)));
+	}
+
+	@Test
+	public void consumeOnSubscriptionThrowsFatal() {
+		AtomicReference<Throwable> errorHolder = new AtomicReference<>(null);
+
+		LambdaSubscriber<String> tested = new LambdaSubscriber<>(
+				value -> {},
+				errorHolder::set,
+				() -> {},
+				subscription -> { throw new OutOfMemoryError(); });
+
+		TestSubscription testSubscription = new TestSubscription();
+
+		//the error is expected to be thrown as it is fatal
+		try {
+			tested.onSubscribe(testSubscription);
+			fail("Expected OutOfMemoryError to be thrown");
+		}
+		catch (OutOfMemoryError e) {
+			//expected
+		}
+
+		assertThat("unexpected onError", errorHolder.get(), is(nullValue()));
+		assertThat("subscription has been cancelled",
+				testSubscription.isCancelled, is(not(true)));
+		assertThat("unexpected request",
+				testSubscription.requested, is(equalTo(-1L)));
+	}
+
+	@Test
+	public void consumeOnSubscriptionReceivesSubscription() {
+		AtomicReference<Throwable> errorHolder = new AtomicReference<>(null);
+		AtomicReference<Subscription> subscriptionHolder = new AtomicReference<>(null);
+		LambdaSubscriber<String> tested = new LambdaSubscriber<>(
+				value -> {},
+				errorHolder::set,
+				() -> { },
+				subscriptionHolder::set);
+		TestSubscription testSubscription = new TestSubscription();
+
+		tested.onSubscribe(testSubscription);
+
+		assertThat("unexpected onError", errorHolder.get(), is(nullValue()));
+		assertThat("subscription has been cancelled",
+				testSubscription.isCancelled, is(not(true)));
+		assertThat("didn't consume the subscription",
+				subscriptionHolder.get(), is(equalTo(testSubscription)));
+		assertThat("didn't request the subscription",
+				testSubscription.requested, is(equalTo(Long.MAX_VALUE)));
+	}
+
+	private static class TestSubscription implements Subscription {
+
+		volatile boolean isCancelled = false;
+		volatile long    requested   = -1L;
+
+		@Override
+		public void request(long n) {
+			this.requested = n;
+		}
+
+		@Override
+		public void cancel() {
+			this.isCancelled = true;
+		}
+	}
+
+}

--- a/src/test/java/reactor/core/publisher/LambdaFirstSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/LambdaFirstSubscriberTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import java.util.concurrent.atomic.AtomicReference;

--- a/src/test/java/reactor/core/publisher/LambdaSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/LambdaSubscriberTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import java.util.concurrent.atomic.AtomicReference;

--- a/src/test/java/reactor/core/publisher/LambdaSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/LambdaSubscriberTest.java
@@ -1,0 +1,103 @@
+package reactor.core.publisher;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class LambdaSubscriberTest {
+
+	@Test
+	public void consumeOnSubscriptionNotifiesError() {
+		AtomicReference<Throwable> errorHolder = new AtomicReference<>(null);
+
+		LambdaSubscriber<String> tested = new LambdaSubscriber<>(
+				value -> {},
+				errorHolder::set,
+				() -> {},
+				subscription -> { throw new IllegalArgumentException(); });
+
+		TestSubscription testSubscription = new TestSubscription();
+
+		//the error is expected to be propagated through onError
+		tested.onSubscribe(testSubscription);
+
+		assertThat("unexpected exception in onError",
+				errorHolder.get(), is(instanceOf(IllegalArgumentException.class)));
+		assertThat("subscription has been cancelled",
+				testSubscription.isCancelled, is(not(true)));
+		assertThat("unexpected request",
+				testSubscription.requested, is(equalTo(-1L)));
+	}
+
+	@Test
+	public void consumeOnSubscriptionThrowsFatal() {
+		AtomicReference<Throwable> errorHolder = new AtomicReference<>(null);
+
+		LambdaSubscriber<String> tested = new LambdaSubscriber<>(
+				value -> {},
+				errorHolder::set,
+				() -> {},
+				subscription -> { throw new OutOfMemoryError(); });
+
+		TestSubscription testSubscription = new TestSubscription();
+
+		//the error is expected to be thrown as it is fatal
+		try {
+			tested.onSubscribe(testSubscription);
+			fail("Expected OutOfMemoryError to be thrown");
+		}
+		catch (OutOfMemoryError e) {
+			//expected
+		}
+
+		assertThat("unexpected onError", errorHolder.get(), is(nullValue()));
+		assertThat("subscription has been cancelled",
+				testSubscription.isCancelled, is(not(true)));
+		assertThat("unexpected request",
+				testSubscription.requested, is(equalTo(-1L)));
+	}
+
+	@Test
+	public void consumeOnSubscriptionReceivesSubscription() {
+		AtomicReference<Throwable> errorHolder = new AtomicReference<>(null);
+		AtomicReference<Subscription> subscriptionHolder = new AtomicReference<>(null);
+		LambdaSubscriber<String> tested = new LambdaSubscriber<>(
+				value -> {},
+				errorHolder::set,
+				() -> { },
+				subscriptionHolder::set);
+		TestSubscription testSubscription = new TestSubscription();
+
+		tested.onSubscribe(testSubscription);
+
+		assertThat("unexpected onError", errorHolder.get(), is(nullValue()));
+		assertThat("subscription has been cancelled",
+				testSubscription.isCancelled, is(not(true)));
+		assertThat("didn't consume the subscription",
+				subscriptionHolder.get(), is(equalTo(testSubscription)));
+		assertThat("didn't request the subscription",
+				testSubscription.requested, is(equalTo(Long.MAX_VALUE)));
+	}
+
+	private static class TestSubscription implements Subscription {
+
+		volatile boolean isCancelled = false;
+		volatile long    requested   = -1L;
+
+		@Override
+		public void request(long n) {
+			this.requested = n;
+		}
+
+		@Override
+		public void cancel() {
+			this.isCancelled = true;
+		}
+	}
+
+}

--- a/src/test/java/reactor/core/publisher/LambdaSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/LambdaSubscriberTest.java
@@ -63,14 +63,17 @@ public class LambdaSubscriberTest {
 	}
 
 	@Test
-	public void consumeOnSubscriptionReceivesSubscription() {
+	public void consumeOnSubscriptionReceivesSubscriptionAndRequests32() {
 		AtomicReference<Throwable> errorHolder = new AtomicReference<>(null);
 		AtomicReference<Subscription> subscriptionHolder = new AtomicReference<>(null);
 		LambdaSubscriber<String> tested = new LambdaSubscriber<>(
 				value -> {},
 				errorHolder::set,
 				() -> { },
-				subscriptionHolder::set);
+				s -> {
+					subscriptionHolder.set(s);
+					s.request(32);
+				});
 		TestSubscription testSubscription = new TestSubscription();
 
 		tested.onSubscribe(testSubscription);
@@ -81,6 +84,27 @@ public class LambdaSubscriberTest {
 		assertThat("didn't consume the subscription",
 				subscriptionHolder.get(), is(equalTo(testSubscription)));
 		assertThat("didn't request the subscription",
+				testSubscription.requested, is(equalTo(32L)));
+	}
+
+	@Test
+	public void noSubscriptionConsumerTriggersRequestOfMax() {
+		AtomicReference<Throwable> errorHolder = new AtomicReference<>(null);
+		LambdaSubscriber<String> tested = new LambdaSubscriber<>(
+				value -> {},
+				errorHolder::set,
+				() -> {},
+				null); //defaults to initial request of max
+		TestSubscription testSubscription = new TestSubscription();
+
+		tested.onSubscribe(testSubscription);
+
+		assertThat("unexpected onError", errorHolder.get(), is(nullValue()));
+		assertThat("subscription has been cancelled",
+				testSubscription.isCancelled, is(not(true)));
+		assertThat("didn't request the subscription",
+				testSubscription.requested, is(not(equalTo(-1L))));
+		assertThat("didn't request max",
 				testSubscription.requested, is(equalTo(Long.MAX_VALUE)));
 	}
 


### PR DESCRIPTION
@smaldini I'm wondering if in case of an error during `Subscription` consumption by the new `Consumer`, the Subscription should be `cancel()`led...