### PR TITLE
fix #212 Cancel Subscription on consumer error

### DIFF
--- a/src/main/java/reactor/core/publisher/LambdaFirstSubscriber.java
+++ b/src/main/java/reactor/core/publisher/LambdaFirstSubscriber.java
@@ -147,7 +147,6 @@ final class LambdaFirstSubscriber<T>
 				consumer.accept(x);
 			}
 			catch (Throwable t) {
-				S.get(this).cancel();
 				Exceptions.throwIfFatal(t);
 				onError(t);
 				return;

--- a/src/main/java/reactor/core/publisher/LambdaFirstSubscriber.java
+++ b/src/main/java/reactor/core/publisher/LambdaFirstSubscriber.java
@@ -82,8 +82,8 @@ final class LambdaFirstSubscriber<T>
 				}
 			}
 			catch (Throwable t) {
-				s.cancel();
 				Exceptions.throwIfFatal(t);
+				s.cancel();
 				onError(t);
 			}
 		}

--- a/src/main/java/reactor/core/publisher/LambdaFirstSubscriber.java
+++ b/src/main/java/reactor/core/publisher/LambdaFirstSubscriber.java
@@ -74,8 +74,6 @@ final class LambdaFirstSubscriber<T>
 		if (Operators.validate(subscription, s)) {
 			this.subscription = s;
 			try {
-				//note that unlike in RxJava 2.0.0 an error on accept doesn't trigger
-				// cancellation of s
 				if (subscriptionConsumer != null) {
 					subscriptionConsumer.accept(s);
 				}
@@ -84,6 +82,7 @@ final class LambdaFirstSubscriber<T>
 				}
 			}
 			catch (Throwable t) {
+				s.cancel();
 				Exceptions.throwIfFatal(t);
 				onError(t);
 			}
@@ -148,6 +147,7 @@ final class LambdaFirstSubscriber<T>
 				consumer.accept(x);
 			}
 			catch (Throwable t) {
+				S.get(this).cancel();
 				Exceptions.throwIfFatal(t);
 				onError(t);
 				return;

--- a/src/main/java/reactor/core/publisher/LambdaSubscriber.java
+++ b/src/main/java/reactor/core/publisher/LambdaSubscriber.java
@@ -74,8 +74,6 @@ final class LambdaSubscriber<T>
 		if (Operators.validate(subscription, s)) {
 			this.subscription = s;
 			try {
-				//note that unlike in RxJava 2.0.0 an error on accept doesn't trigger
-				// cancellation of s
 				if (subscriptionConsumer != null) {
 					subscriptionConsumer.accept(s);
 				}
@@ -84,6 +82,7 @@ final class LambdaSubscriber<T>
 				}
 			}
 			catch (Throwable t) {
+				s.cancel();
 				Exceptions.throwIfFatal(t);
 				onError(t);
 			}
@@ -141,6 +140,7 @@ final class LambdaSubscriber<T>
 			}
 		}
 		catch (Throwable t) {
+			S.get(this).cancel();
 			Exceptions.throwIfFatal(t);
 			onError(t);
 		}

--- a/src/main/java/reactor/core/publisher/LambdaSubscriber.java
+++ b/src/main/java/reactor/core/publisher/LambdaSubscriber.java
@@ -82,8 +82,8 @@ final class LambdaSubscriber<T>
 				}
 			}
 			catch (Throwable t) {
-				s.cancel();
 				Exceptions.throwIfFatal(t);
+				s.cancel();
 				onError(t);
 			}
 		}
@@ -140,8 +140,8 @@ final class LambdaSubscriber<T>
 			}
 		}
 		catch (Throwable t) {
-			S.get(this).cancel();
 			Exceptions.throwIfFatal(t);
+			this.subscription.cancel();
 			onError(t);
 		}
 	}

--- a/src/test/java/reactor/core/publisher/LambdaFirstSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/LambdaFirstSubscriberTest.java
@@ -72,8 +72,8 @@ public class LambdaFirstSubscriberTest {
 		}
 
 		assertThat("unexpected onError", errorHolder.get(), is(nullValue()));
-		assertThat("subscription has not been cancelled",
-				testSubscription.isCancelled, is(true));
+		assertThat("subscription has been cancelled despite fatal exception",
+				testSubscription.isCancelled, is(not(true)));
 		assertThat("unexpected request",
 				testSubscription.requested, is(equalTo(-1L)));
 	}

--- a/src/test/java/reactor/core/publisher/LambdaFirstSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/LambdaFirstSubscriberTest.java
@@ -31,7 +31,7 @@ public class LambdaFirstSubscriberTest {
 	public void consumeOnSubscriptionNotifiesError() {
 		AtomicReference<Throwable> errorHolder = new AtomicReference<>(null);
 
-		LambdaSubscriber<String> tested = new LambdaSubscriber<>(
+		LambdaFirstSubscriber<String> tested = new LambdaFirstSubscriber<>(
 				value -> {},
 				errorHolder::set,
 				() -> {},
@@ -54,7 +54,7 @@ public class LambdaFirstSubscriberTest {
 	public void consumeOnSubscriptionThrowsFatal() {
 		AtomicReference<Throwable> errorHolder = new AtomicReference<>(null);
 
-		LambdaSubscriber<String> tested = new LambdaSubscriber<>(
+		LambdaFirstSubscriber<String> tested = new LambdaFirstSubscriber<>(
 				value -> {},
 				errorHolder::set,
 				() -> {},
@@ -82,7 +82,7 @@ public class LambdaFirstSubscriberTest {
 	public void consumeOnSubscriptionReceivesSubscriptionAndRequests32() {
 		AtomicReference<Throwable> errorHolder = new AtomicReference<>(null);
 		AtomicReference<Subscription> subscriptionHolder = new AtomicReference<>(null);
-		LambdaSubscriber<String> tested = new LambdaSubscriber<>(
+		LambdaFirstSubscriber<String> tested = new LambdaFirstSubscriber<>(
 				value -> {},
 				errorHolder::set,
 				() -> { },
@@ -106,7 +106,7 @@ public class LambdaFirstSubscriberTest {
 	@Test
 	public void noSubscriptionConsumerTriggersRequestOfMax() {
 		AtomicReference<Throwable> errorHolder = new AtomicReference<>(null);
-		LambdaSubscriber<String> tested = new LambdaSubscriber<>(
+		LambdaFirstSubscriber<String> tested = new LambdaFirstSubscriber<>(
 				value -> {},
 				errorHolder::set,
 				() -> {},

--- a/src/test/java/reactor/core/publisher/LambdaFirstSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/LambdaFirstSubscriberTest.java
@@ -44,8 +44,8 @@ public class LambdaFirstSubscriberTest {
 
 		assertThat("unexpected exception in onError",
 				errorHolder.get(), is(instanceOf(IllegalArgumentException.class)));
-		assertThat("subscription has been cancelled",
-				testSubscription.isCancelled, is(not(true)));
+		assertThat("subscription has not been cancelled",
+				testSubscription.isCancelled, is(true));
 		assertThat("unexpected request",
 				testSubscription.requested, is(equalTo(-1L)));
 	}
@@ -72,8 +72,8 @@ public class LambdaFirstSubscriberTest {
 		}
 
 		assertThat("unexpected onError", errorHolder.get(), is(nullValue()));
-		assertThat("subscription has been cancelled",
-				testSubscription.isCancelled, is(not(true)));
+		assertThat("subscription has not been cancelled",
+				testSubscription.isCancelled, is(true));
 		assertThat("unexpected request",
 				testSubscription.requested, is(equalTo(-1L)));
 	}

--- a/src/test/java/reactor/core/publisher/LambdaSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/LambdaSubscriberTest.java
@@ -72,8 +72,8 @@ public class LambdaSubscriberTest {
 		}
 
 		assertThat("unexpected onError", errorHolder.get(), is(nullValue()));
-		assertThat("subscription has not been cancelled",
-				testSubscription.isCancelled, is(true));
+		assertThat("subscription has been cancelled despite fatal exception",
+				testSubscription.isCancelled, is(not(true)));
 		assertThat("unexpected request",
 				testSubscription.requested, is(equalTo(-1L)));
 	}

--- a/src/test/java/reactor/core/publisher/LambdaSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/LambdaSubscriberTest.java
@@ -44,8 +44,8 @@ public class LambdaSubscriberTest {
 
 		assertThat("unexpected exception in onError",
 				errorHolder.get(), is(instanceOf(IllegalArgumentException.class)));
-		assertThat("subscription has been cancelled",
-				testSubscription.isCancelled, is(not(true)));
+		assertThat("subscription has not been cancelled",
+				testSubscription.isCancelled, is(true));
 		assertThat("unexpected request",
 				testSubscription.requested, is(equalTo(-1L)));
 	}
@@ -72,8 +72,8 @@ public class LambdaSubscriberTest {
 		}
 
 		assertThat("unexpected onError", errorHolder.get(), is(nullValue()));
-		assertThat("subscription has been cancelled",
-				testSubscription.isCancelled, is(not(true)));
+		assertThat("subscription has not been cancelled",
+				testSubscription.isCancelled, is(true));
 		assertThat("unexpected request",
 				testSubscription.requested, is(equalTo(-1L)));
 	}


### PR DESCRIPTION
This commit triggers a cancellation of the upstream Subscription of a
`LambdaSubscriber` or `LambdaFirstSubscriber` whenever an Exception
occurs during onSubscribe or onNext. That is true both when the error
is propagated to onError (non-fatal) or thrown (fatal).