### PR TITLE
fix #218 Shutdown cached schedulers upon setFactory

### DIFF
--- a/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -375,8 +375,8 @@ public class Schedulers {
 	/**
 	 * Re-apply default factory to {@link Schedulers}
 	 */
-	public static void resetFactory() {
-		factory = DEFAULT;
+	public static void resetFactory(){
+		setFactory(DEFAULT);
 	}
 
 	/**
@@ -386,11 +386,15 @@ public class Schedulers {
 	 * including a {@link ThreadFactory} argument and should be instance methods.
 	 * <p>
 	 * This method should be called safely and with caution, typically on app startup.
+	 * <p>
+	 * Note that cached schedulers (like {@link #timer()}) are also shut down and will be
+	 * re-created from the new factory upon next use.
 	 *
 	 * @param factoryInstance an arbitrary {@link Factory} instance.
 	 */
 	public static void setFactory(Factory factoryInstance) {
 		Objects.requireNonNull(factoryInstance, "factoryInstance");
+		shutdownNow();
 		factory = factoryInstance;
 	}
 

--- a/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -615,7 +615,7 @@ public class Schedulers {
 		}
 	}
 
-	static class CachedScheduler implements Scheduler {
+	static class CachedScheduler implements Scheduler, Supplier<Scheduler> {
 
 		final Scheduler cached;
 		final String    key;
@@ -642,6 +642,17 @@ public class Schedulers {
 
 		@Override
 		public void shutdown() {
+		}
+
+		/**
+		 * Get the {@link Scheduler} that is cached and wrapped inside this
+		 * {@link CachedScheduler}.
+		 *
+		 * @return the cached Scheduler
+		 */
+		@Override
+		public Scheduler get() {
+			return null;
 		}
 
 		void _shutdown() {
@@ -704,6 +715,11 @@ public class Schedulers {
 		@Override
 		TimedScheduler asTimedScheduler() {
 			return this;
+		}
+
+		@Override
+		public TimedScheduler get() {
+			return cachedTimed;
 		}
 	}
 }

--- a/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -17,6 +17,7 @@
 package reactor.core.scheduler;
 
 import java.util.concurrent.ThreadFactory;
+import java.util.function.Supplier;
 
 import org.junit.After;
 import org.junit.Test;
@@ -88,7 +89,7 @@ public class SchedulersTest {
 		Schedulers.Factory ts1 = new Schedulers.Factory() { };
 		Schedulers.Factory ts2 = new TestSchedulers(false);
 		Schedulers.setFactory(ts1);
-		TimedScheduler cachedTimerOld = ((Schedulers.CachedTimedScheduler) Schedulers.timer()).cachedTimed;
+		TimedScheduler cachedTimerOld = ((Supplier<TimedScheduler>) Schedulers.timer()).get();
 		TimedScheduler standaloneTimer = Schedulers.newTimer("standaloneTimer");
 
 		Assert.assertNotEquals(cachedTimerOld, standaloneTimer);
@@ -96,7 +97,7 @@ public class SchedulersTest {
 		Assert.assertNotEquals(standaloneTimer.schedule(() -> {}), Scheduler.REJECTED);
 
 		Schedulers.setFactory(ts2);
-		TimedScheduler cachedTimerNew = ((Schedulers.CachedTimedScheduler) Schedulers.timer()).cachedTimed;
+		TimedScheduler cachedTimerNew = ((Supplier<TimedScheduler>) Schedulers.timer()).get();
 
 		Assert.assertEquals(cachedTimerNew, Schedulers.newTimer("unused"));
 		Assert.assertNotEquals(cachedTimerNew, cachedTimerOld);


### PR DESCRIPTION
@smaldini I don't think we need to do anything special for DEFAULT
(the cached schedulers of DEFAULT will be shut down the same, and new
ones will be recreated after #resetFactory).

I can also make `CachedScheduler` be a `Supplier<Scheduler>` for
convenience.