### PR TITLE
Better synchronize then/thenMany API between Flux and Mono

### DIFF
--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -5729,29 +5729,49 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Return a {@link Flux} that emits the completion of the supplied {@link Publisher}
-	 * when this {@link Flux} onComplete
-	 * or onError. If an error occur, append after the supplied {@link Publisher} is terminated.
+	 * Return a {@code Mono<Void>} that waits for this {@link Flux} to complete then
+	 * for a supplied {@link Publisher Publisher&lt;Void&gt;} to also complete. The
+	 * second completion signal is replayed, or any error signal that occurs instead.
 	 * <p>
-	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethens.png"
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethen.png"
 	 * alt="">
 	 *
-	 * @param other a {@link Publisher} to emit from after termination
-	 *
-	 * @return a new {@link Flux} emitting eventually from the supplied {@link Publisher}
+	 * @param other a {@link Publisher} to wait for after this Flux's termination
+	 * @return a new {@link Mono} completing when both publishers have completed in
+	 * sequence
 	 */
 	public final Mono<Void> then(Publisher<Void> other) {
 		return MonoSource.wrap(concat(then(), other));
 	}
 
 	/**
-	 * Return a {@link Flux} that emits the completion of the supplied {@link Publisher} when this {@link Flux} onComplete
-	 * or onError. If an error occur, append after the supplied {@link Publisher} is terminated.
+	 * Return a {@link Mono} that waits for this {@link Flux} to complete, then appends
+	 * the value from the supplied Mono. If an error occurs, the append is terminated and
+	 * the error signal propagated.
 	 * <p>
-	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethens.png"
-	 * alt="">
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethen1.png" alt="">
 	 *
-	 * @param afterSupplier a {@link Supplier} of {@link Publisher} to emit from after termination
+	 * @param other the {@link Mono} supplying a single value to emit after this Flux terminates
+	 * @param <V> the type of the emitted value
+	 * @return a new {@link Mono} emitting eventually from the supplied {@link Mono}
+	 * @see #then(Publisher) when attempting to append a {@code Mono<Void>}, will need
+	 * a cast to {@code Publisher<Void>}...
+	 */
+	public final <V> Mono<V> then(Mono<V> other) {
+		MonoIgnoreThen<T> ignored = new MonoIgnoreThen<>(this);
+		Mono<V> then = ignored.then(other);
+		return Mono.onAssembly(then);
+	}
+
+	/**
+	 * Return a {@link Flux} that emits the completion signal of the supplied
+	 * {@link Publisher} when this {@link Flux} onComplete or onError. If an error occur,
+	 * the error signal is replayed after the supplied {@link Publisher} is terminated.
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethen.png" alt="">
+	 *
+	 * @param afterSupplier a {@link Supplier} of {@link Publisher} to wait for after
+	 * this Flux termination
 	 *
 	 * @return a new {@link Flux} emitting eventually from the supplied {@link Publisher}
 	 */
@@ -5760,11 +5780,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Return a {@link Flux} that emits the sequence of the supplied {@link Publisher} when this {@link Flux} onComplete
-	 * or onError. If an error occur, append after the supplied {@link Publisher} is terminated.
+	 * Return a {@link Flux} that emits the sequence of the supplied {@link Publisher}
+	 * after this {@link Flux} completes, ignoring this flux elements. If an error
+	 * occurs it immediately terminates the resulting flux.
 	 * <p>
-	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethens.png"
-	 * alt="">
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethens.png" alt="">
 	 *
 	 * @param other a {@link Publisher} to emit from after termination
 	 * @param <V> the supplied produced type
@@ -5778,11 +5798,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Return a {@link Flux} that emits the sequence of the supplied {@link Publisher} when this {@link Flux} onComplete
-	 * or onError. If an error occur, append after the supplied {@link Publisher} is terminated.
+	 * Return a {@link Flux} that emits the sequence of the supplied {@link Publisher}
+	 * after this {@link Flux} completes, ignoring this flux elements. If an error occurs
+	 * it immediately terminates the resulting flux.
 	 * <p>
-	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethens.png"
-	 * alt="">
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethens.png" alt="">
 	 *
 	 * @param afterSupplier a {@link Supplier} of {@link Publisher} to emit from after termination
 	 * @param <V> the supplied produced type

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -2462,10 +2462,11 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Return a {@code Mono<Void>} which only listens for complete and error signals from this {@link Mono} completes.
+	 * Return a {@code Mono<Void>} which only replays complete and error signals
+	 * from this {@link Mono}.
 	 *
 	 * <p>
-	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethen1.png" alt="">
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethen.png" alt="">
 	 * <p>
 	 * @return a {@link Mono} igoring its payload (actively dropping)
 	 */
@@ -2490,8 +2491,9 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Transform the terminal signal (error or completion) into {@code Mono<V>} that will emit at most one result in the
-	 * returned {@link Mono}.
+	 * Ignore element from this {@link Mono} and transform its completion signal into the
+	 * emission and completion signal of a provided {@code Mono<V>}. Error signal is
+	 * replayed in the resulting {@code Mono<V>}.
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethen1.png" alt="">
@@ -2510,8 +2512,9 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Transform the terminal signal (error or completion) into {@code Mono<V>} that will emit at most one result in the
-	 * returned {@link Mono}.
+	 * Ignore element from this {@link Mono} and transform its completion signal into the
+	 * emission and completion signal of a supplied {@code Mono<V>}. Error signal is
+	 * replayed in the resulting {@code Mono<V>}.
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethen1.png" alt="">
@@ -2526,16 +2529,17 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Transform the terminal signal (error or completion) into {@code Publisher<V>} that will emit at most one result in the
-	 * returned {@link Flux}.
+	 * Ignore element from this mono and transform the completion signal into a
+	 * {@code Flux<V>} that will emit elements from the provided {@link Publisher}.
 	 *
 	 * <p>
-	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethen1.png" alt="">
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethens.png" alt="">
 	 *
 	 * @param other a {@link Publisher} to emit from after termination
-	 * @param <V> the element type of the supplied Mono
+	 * @param <V> the element type of the supplied Publisher
 	 *
-	 * @return a new {@link Flux} that emits from the supplied {@link Publisher}
+	 * @return a new {@link Flux} that emits from the supplied {@link Publisher} after
+	 * this Mono completes.
 	 */
 	public final <V> Flux<V> thenMany(Publisher<V> other) {
 		@SuppressWarnings("unchecked")
@@ -2544,20 +2548,20 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Transform the terminal signal (error or completion) into {@code Publisher<V>} that will emit at most one result in the
-	 * returned {@link Flux}.
+	 * Ignore element from this mono and transform the completion signal into a
+	 * {@code Flux<V>} that will emit elements from the supplier-provided {@link Publisher}.
 	 *
 	 * <p>
-	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethen1.png" alt="">
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethens.png" alt="">
 	 *
-	 * @param sourceSupplier a {@link Supplier} of {@link Publisher} to emit from after
-	 * termination
-	 * @param <V> the element type of the supplied Mono
+	 * @param afterSupplier a {@link Supplier} of {@link Publisher} to emit from after
+	 * completion
+	 * @param <V> the element type of the supplied Publisher
 	 *
 	 * @return a new {@link Flux} that emits from the supplied {@link Publisher}
 	 */
-	public final <V> Flux<V> thenMany(final Supplier<? extends Mono<V>> sourceSupplier) {
-		return thenMany(defer(sourceSupplier));
+	public final <V> Flux<V> thenMany(final Supplier<? extends Publisher<V>> afterSupplier) {
+		return thenMany(Flux.defer(afterSupplier));
 	}
 
 	/**

--- a/src/test/java/reactor/core/publisher/scenarios/MonoTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/MonoTests.java
@@ -19,9 +19,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
 import reactor.core.scheduler.Schedulers;
+import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.function.Tuple2;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -33,6 +35,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class MonoTests {
 
 
+	@Test
+	public void testMonoThenManySupplier() {
+		AssertSubscriber<String> ts = AssertSubscriber.create();
+		Flux<String> test = Mono.just(1).thenMany(() -> Flux.just("A", "B"));
+
+		test.subscribe(ts);
+		ts.assertValues("A", "B");
+		ts.assertComplete();
+	}
 
 	// test issue https://github.com/reactor/reactor/issues/485
 	@Test


### PR DESCRIPTION
See #198, which might have to be split into a second issue for the
optimization side of it.

 - a `then(Mono<V>)` method was added to Flux.
 - the `thenMany(Supplier<Mono>)` method in Mono now accepts a
 `Supplier<Publisher>` instead (the signature is now more permissive but
 backward compatible).