### PR TITLE
see #238 Revert Flux.then(Mono<V>) introduction

### DIFF
--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -5739,28 +5739,28 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param other a {@link Publisher} to wait for after this Flux's termination
 	 * @return a new {@link Mono} completing when both publishers have completed in
 	 * sequence
+	 * @deprecated use {@link #thenEmpty(Publisher)} instead, this alias will be
+	 * removed in 3.1.0
 	 */
+	@Deprecated
 	public final Mono<Void> then(Publisher<Void> other) {
-		return MonoSource.wrap(concat(then(), other));
+		return thenEmpty(other);
 	}
 
 	/**
-	 * Return a {@link Mono} that waits for this {@link Flux} to complete, then appends
-	 * the value from the supplied Mono. If an error occurs, the append is terminated and
-	 * the error signal propagated.
+	 * Return a {@code Mono<Void>} that waits for this {@link Flux} to complete then
+	 * for a supplied {@link Publisher Publisher&lt;Void&gt;} to also complete. The
+	 * second completion signal is replayed, or any error signal that occurs instead.
 	 * <p>
-	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethen1.png" alt="">
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/ignorethen.png"
+	 * alt="">
 	 *
-	 * @param other the {@link Mono} supplying a single value to emit after this Flux terminates
-	 * @param <V> the type of the emitted value
-	 * @return a new {@link Mono} emitting eventually from the supplied {@link Mono}
-	 * @see #then(Publisher) when attempting to append a {@code Mono<Void>}, will need
-	 * a cast to {@code Publisher<Void>}...
+	 * @param other a {@link Publisher} to wait for after this Flux's termination
+	 * @return a new {@link Mono} completing when both publishers have completed in
+	 * sequence
 	 */
-	public final <V> Mono<V> then(Mono<V> other) {
-		MonoIgnoreThen<T> ignored = new MonoIgnoreThen<>(this);
-		Mono<V> then = ignored.then(other);
-		return Mono.onAssembly(then);
+	public final Mono<Void> thenEmpty(Publisher<Void> other) {
+		return MonoSource.wrap(concat(then(), other));
 	}
 
 	/**

--- a/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -80,12 +80,16 @@ public class FluxTests extends AbstractReactorTest {
 	static final String2Integer STRING_2_INTEGER = new String2Integer();
 
 	@Test
-	public void testThenMono() throws InterruptedException {
-		Mono<String> testSameType = Flux.just("A", "B").then(Mono.just("C"));
-		Mono<String> testDifferentType = Flux.just(1, 2).then(Mono.just("C"));
+	public void testThenPublisherVoid() throws InterruptedException {
+		Mono<Void> testVoidPublisher = Flux
+				.just("A", "B")
+				.thenEmpty(Mono.fromRunnable(() -> { }));
 
-		await(1, testSameType, is("C"));
-		await(1, testDifferentType, is("C"));
+		AssertSubscriber<Void> ts = AssertSubscriber.create();
+		testVoidPublisher.subscribe(ts);
+
+		ts.assertValueCount(0);
+		ts.assertComplete();
 	}
 
 	@Test


### PR DESCRIPTION
cc @sdeleuze @nebhale @ericbottard, temporary fix to remove the method
ambiguity, will be completed in 3.1 working toward completion of #238