### PR TITLE
Request 1 item using Flux.next()

### DIFF
--- a/src/main/java/reactor/core/publisher/MonoNext.java
+++ b/src/main/java/reactor/core/publisher/MonoNext.java
@@ -101,7 +101,7 @@ final class MonoNext<T> extends MonoSource<T, T> {
 		@Override
 		public void request(long n) {
 			if (WIP.compareAndSet(this, 0, 1)) {
-				s.request(Long.MAX_VALUE);
+				s.request(1);
 			}
 		}
 


### PR DESCRIPTION
Shouldn't MonoNext only request 1 item from its source instead of `Long.MAX_VALUE`? Or is there a valid reason for this?