### PR TITLE
fix #261 Callable returning null now always trigger onError(NPE)

### DIFF
--- a/src/main/java/reactor/core/publisher/FluxSubscribeOnCallable.java
+++ b/src/main/java/reactor/core/publisher/FluxSubscribeOnCallable.java
@@ -208,6 +208,12 @@ final class FluxSubscribeOnCallable<T> extends Flux<T> implements Fuseable {
 				return;
 			}
 
+			if (v == null) {
+				actual.onError(Operators.onOperatorError(this,
+						new NullPointerException("The callable returned null")));
+				return;
+			}
+
 			for (; ; ) {
 				int s = state;
 				if (s == CANCELLED || s == HAS_REQUEST_HAS_VALUE || s == NO_REQUEST_HAS_VALUE) {

--- a/src/test/java/reactor/core/publisher/FluxSubscribeOnCallableTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSubscribeOnCallableTest.java
@@ -15,11 +15,49 @@
  */
 package reactor.core.publisher;
 
+import java.io.IOException;
+import java.time.Duration;
+
 import org.junit.Test;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
 
 public class FluxSubscribeOnCallableTest {
 
 	@Test
+	public void callableReturnsNull() {
+		StepVerifier.create(new FluxSubscribeOnCallable<>(() -> null, Schedulers.single()))
+		            .expectError(NullPointerException.class)
+			        .verify();
+	}
+
+	@Test
 	public void normal() {
+		StepVerifier.create(new FluxSubscribeOnCallable<>(() -> 1, Schedulers.single()))
+		            .expectNext(1)
+		            .expectComplete()
+		            .verify();
+	}
+
+	@Test
+	public void normalBackpressured() {
+		StepVerifier.withVirtualTime(0, () -> new FluxSubscribeOnCallable<>(() -> 1,
+				Schedulers.single()))
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofSeconds(1))
+		            .thenRequest(1)
+		            .expectNext(1)
+		            .expectComplete()
+		            .verify();
+	}
+
+	@Test
+	public void callableThrows() {
+		StepVerifier.create(new FluxSubscribeOnCallable<>(() -> {
+			throw new IOException("forced failure");
+		}, Schedulers.single()))
+		            .expectErrorMatches(e -> e instanceof IOException
+				            && e.getMessage().equals("forced failure"))
+		            .verify();
 	}
 }


### PR DESCRIPTION
pinging @smaldini and @artembilan for review