### PR TITLE
fix #247 Improve doOn callback failures handling

### DIFF
--- a/src/main/java/reactor/core/publisher/FluxPeek.java
+++ b/src/main/java/reactor/core/publisher/FluxPeek.java
@@ -178,9 +178,8 @@ final class FluxPeek<T> extends FluxSource<T, T> implements SignalPeek<T> {
 					parent.onErrorCall().accept(t);
 				}
 				catch (Throwable e) {
-					Exceptions.throwIfFatal(e);
-					e.addSuppressed(t);
-					t = e;
+					//this performs a throwIfFatal or suppresses t in e
+					t = Operators.onOperatorError(null, e, t);
 				}
 			}
 

--- a/src/main/java/reactor/core/publisher/FluxPeek.java
+++ b/src/main/java/reactor/core/publisher/FluxPeek.java
@@ -173,7 +173,6 @@ final class FluxPeek<T> extends FluxSource<T, T> implements SignalPeek<T> {
 				return;
 			}
 			done = true;
-			boolean errorCallbackFailed = false;
 			if(parent.onErrorCall() != null) {
 				try {
 					parent.onErrorCall().accept(t);
@@ -182,7 +181,6 @@ final class FluxPeek<T> extends FluxSource<T, T> implements SignalPeek<T> {
 					Exceptions.throwIfFatal(e);
 					e.addSuppressed(t);
 					t = e;
-					errorCallbackFailed = true;
 				}
 			}
 
@@ -191,7 +189,6 @@ final class FluxPeek<T> extends FluxSource<T, T> implements SignalPeek<T> {
 			}
 			catch (UnsupportedOperationException use){
 				if(parent.onErrorCall() == null
-						|| errorCallbackFailed
 						|| !Exceptions.isErrorCallbackNotImplemented(use) && use.getCause() != t){
 					throw use;
 				}
@@ -203,12 +200,7 @@ final class FluxPeek<T> extends FluxSource<T, T> implements SignalPeek<T> {
 					parent.onAfterTerminateCall().run();
 				}
 				catch (Throwable e) {
-					Throwable _e = Operators.onOperatorError(null, e, t);
-					e.addSuppressed(t);
-					if(parent.onErrorCall() != null && !errorCallbackFailed) {
-						parent.onErrorCall().accept(_e);
-					}
-					Operators.onErrorDropped(_e);
+					afterErrorWithFailure(parent, e, t);
 				}
 			}
 		}
@@ -223,7 +215,7 @@ final class FluxPeek<T> extends FluxSource<T, T> implements SignalPeek<T> {
 					parent.onCompleteCall().run();
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(e));
+					onError(Operators.onOperatorError(s, e));
 					return;
 				}
 			}
@@ -236,11 +228,7 @@ final class FluxPeek<T> extends FluxSource<T, T> implements SignalPeek<T> {
 					parent.onAfterTerminateCall().run();
 				}
 				catch (Throwable e) {
-					Throwable _e = Operators.onOperatorError(e);
-					if(parent.onErrorCall() != null) {
-						parent.onErrorCall().accept(_e);
-					}
-					Operators.onErrorDropped(_e);
+					afterCompleteWithFailure(parent, e);
 				}
 			}
 		}
@@ -289,6 +277,76 @@ final class FluxPeek<T> extends FluxSource<T, T> implements SignalPeek<T> {
 	@Override
 	public Runnable onCancelCall() {
 		return onCancelCall;
+	}
+
+	/**
+	 * Common method for FluxPeek and FluxPeekFuseable to deal with a doAfterTerminate
+	 * callback that fails during onComplete. It invokes the error callback but
+	 * protects against the error callback also failing.
+	 * <ul>
+	 *     <li>The callback failure is thrown immediately if fatal.</li>
+	 *     <li>{@link Operators#onOperatorError(Throwable)} is called</li>
+	 *     <li>An attempt to execute the error callback is made</li>
+	 *     <li>{@link Operators#onErrorDropped(Throwable)} is called</li>
+	 * </ul>
+	 * <p>
+	 * Note that if the error callback fails too, its exception is made to
+	 * suppress the afterTerminate callback exception, and then onErrorDropped.
+	 *
+	 * @param parent the {@link SignalPeek} from which to get the callbacks
+	 * @param callbackFailure the afterTerminate callback failure
+	 */
+	static <T> void afterCompleteWithFailure(SignalPeek<T> parent,
+			Throwable callbackFailure) {
+		Exceptions.throwIfFatal(callbackFailure);
+		Throwable e = Operators.onOperatorError(callbackFailure);
+		try {
+			if(parent.onErrorCall() != null) {
+				parent.onErrorCall().accept(e);
+			}
+			Operators.onErrorDropped(e);
+		}
+		catch (Throwable t) {
+			t.addSuppressed(e);
+			Operators.onErrorDropped(t);
+		}
+	}
+
+	/**
+	 * Common method for FluxPeek and FluxPeekFuseable to deal with a doAfterTerminate
+	 * callback that fails during onError. It invokes the error callback but protects
+	 * against the error callback also failing.
+	 * <ul>
+	 *     <li>The callback failure is thrown immediately if fatal.</li>
+	 *     <li>{@link Operators#onOperatorError(Subscription, Throwable, Object)} is
+	 *     called, adding the original error as suppressed</li>
+	 *     <li>An attempt to execute the error callback is made</li>
+	 *     <li>{@link Operators#onErrorDropped(Throwable)} is called</li>
+	 * </ul>
+	 * <p>
+	 * Note that if the error callback fails too, its exception is made to
+	 * suppress both the decorated afterTerminate callback exception and the original
+	 * error, and then onErrorDropped.
+	 *
+	 * @param parent the {@link SignalPeek} from which to get the callbacks
+	 * @param callbackFailure the afterTerminate callback failure
+	 * @param originalError the onError throwable
+	 */
+	static <T> void afterErrorWithFailure(SignalPeek<T> parent,
+			Throwable callbackFailure, Throwable originalError) {
+		Exceptions.throwIfFatal(callbackFailure);
+		Throwable _e = Operators.onOperatorError(null, callbackFailure, originalError);
+		try {
+			if (parent.onErrorCall() != null) {
+				parent.onErrorCall().accept(_e);
+			}
+			Operators.onErrorDropped(_e);
+		}
+		catch (Throwable t) {
+			t.addSuppressed(_e);
+			t.addSuppressed(originalError);
+			Operators.onErrorDropped(t);
+		}
 	}
 
 }

--- a/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
@@ -184,18 +184,27 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 				return;
 			}
 			done = true;
+			boolean errorCallbackFailed = false;
 			if (parent.onErrorCall() != null) {
 				Exceptions.throwIfFatal(t);
-				parent.onErrorCall()
-				      .accept(t);
+				try {
+					parent.onErrorCall().accept(t);
+				}
+				catch (Throwable e) {
+					Exceptions.throwIfFatal(e);
+					e.addSuppressed(t);
+					t = e;
+					errorCallbackFailed = true;
+				}
 			}
 
 			try {
 				actual.onError(t);
 			}
 			catch (UnsupportedOperationException use) {
-				if (parent.onErrorCall() == null || !Exceptions.isErrorCallbackNotImplemented(
-						use) && use.getCause() != t) {
+				if (parent.onErrorCall() == null
+						|| errorCallbackFailed
+						|| !Exceptions.isErrorCallbackNotImplemented(use) && use.getCause() != t) {
 					throw use;
 				}
 			}
@@ -209,9 +218,8 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 					Exceptions.throwIfFatal(e);
 					Throwable _e = Operators.onOperatorError(null, e, t);
 					e.addSuppressed(t);
-					if (parent.onErrorCall() != null) {
-						parent.onErrorCall()
-						      .accept(_e);
+					if (parent.onErrorCall() != null && !errorCallbackFailed) {
+						parent.onErrorCall().accept(_e);
 					}
 					Operators.onErrorDropped(_e);
 				}
@@ -223,7 +231,6 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 			if (done) {
 				return;
 			}
-			done = true;
 			if (sourceMode == NONE) {
 				if (parent.onCompleteCall() != null) {
 					try {
@@ -236,6 +243,7 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 					}
 				}
 			}
+			done = true;
 
 			actual.onComplete();
 
@@ -445,33 +453,40 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 				return;
 			}
 			done = true;
+			boolean errorCallbackFailed = false;
 			if (parent.onErrorCall() != null) {
 				Exceptions.throwIfFatal(t);
-				parent.onErrorCall()
-				      .accept(t);
+				try {
+					parent.onErrorCall().accept(t);
+				}
+				catch (Throwable e) {
+					Exceptions.throwIfFatal(e);
+					e.addSuppressed(t);
+					t = e;
+					errorCallbackFailed = true;
+				}
 			}
 
 			try {
 				actual.onError(t);
 			}
 			catch (UnsupportedOperationException use) {
-				if (parent.onErrorCall() == null || !Exceptions.isErrorCallbackNotImplemented(
-						use) && use.getCause() != t) {
+				if (parent.onErrorCall() == null
+						|| errorCallbackFailed
+						|| !Exceptions.isErrorCallbackNotImplemented(use) && use.getCause() != t) {
 					throw use;
 				}
 			}
 
 			if (parent.onAfterTerminateCall() != null) {
 				try {
-					parent.onAfterTerminateCall()
-					      .run();
+					parent.onAfterTerminateCall().run();
 				}
 				catch (Throwable e) {
 					Throwable _e = Operators.onOperatorError(null, e, t);
 					e.addSuppressed(t);
-					if (parent.onErrorCall() != null) {
-						parent.onErrorCall()
-						      .accept(_e);
+					if (parent.onErrorCall() != null && !errorCallbackFailed) {
+						parent.onErrorCall().accept(_e);
 					}
 					Operators.onErrorDropped(_e);
 				}
@@ -483,7 +498,6 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 			if (done) {
 				return;
 			}
-			done = true;
 			if (sourceMode == NONE) {
 				if (parent.onCompleteCall() != null) {
 					try {
@@ -496,6 +510,7 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 					}
 				}
 			}
+			done = true;
 
 			actual.onComplete();
 
@@ -725,17 +740,27 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 				return;
 			}
 			done = true;
+			boolean errorCallbackFailed = false;
 			if (parent.onErrorCall() != null) {
 				Exceptions.throwIfFatal(t);
-				parent.onErrorCall()
-				      .accept(t);
+				try {
+					parent.onErrorCall().accept(t);
+				}
+				catch (Throwable e) {
+					Exceptions.throwIfFatal(e);
+					e.addSuppressed(t);
+					t = e;
+					errorCallbackFailed = true;
+				}
 			}
+
 			try {
 				actual.onError(t);
 			}
 			catch (UnsupportedOperationException use) {
-				if (parent.onErrorCall() == null || !Exceptions.isErrorCallbackNotImplemented(
-						use) && use.getCause() != t) {
+				if (parent.onErrorCall() == null
+						|| errorCallbackFailed
+						|| !Exceptions.isErrorCallbackNotImplemented(use) && use.getCause() != t) {
 					throw use;
 				}
 			}
@@ -749,7 +774,7 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 					Exceptions.throwIfFatal(e);
 					Throwable _e = Operators.onOperatorError(null, e, t);
 					e.addSuppressed(t);
-					if (parent.onErrorCall() != null) {
+					if (parent.onErrorCall() != null && !errorCallbackFailed) {
 						parent.onErrorCall()
 						      .accept(_e);
 					}
@@ -763,7 +788,6 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 			if (done) {
 				return;
 			}
-			done = true;
 			if (parent.onCompleteCall() != null) {
 				try {
 					parent.onCompleteCall()
@@ -774,6 +798,7 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 					return;
 				}
 			}
+			done = true;
 
 			actual.onComplete();
 

--- a/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
@@ -190,9 +190,8 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 					parent.onErrorCall().accept(t);
 				}
 				catch (Throwable e) {
-					Exceptions.throwIfFatal(e);
-					e.addSuppressed(t);
-					t = e;
+					//this performs a throwIfFatal or suppresses t in e
+					t = Operators.onOperatorError(null, e, t);
 				}
 			}
 
@@ -445,9 +444,8 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 					parent.onErrorCall().accept(t);
 				}
 				catch (Throwable e) {
-					Exceptions.throwIfFatal(e);
-					e.addSuppressed(t);
-					t = e;
+					//this performs a throwIfFatal or suppresses t in e
+					t = Operators.onOperatorError(null, e, t);
 				}
 			}
 
@@ -719,9 +717,8 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 					parent.onErrorCall().accept(t);
 				}
 				catch (Throwable e) {
-					Exceptions.throwIfFatal(e);
-					e.addSuppressed(t);
-					t = e;
+					//this performs a throwIfFatal or suppresses t in e
+					t = Operators.onOperatorError(null, e, t);
 				}
 			}
 

--- a/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
@@ -184,7 +184,6 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 				return;
 			}
 			done = true;
-			boolean errorCallbackFailed = false;
 			if (parent.onErrorCall() != null) {
 				Exceptions.throwIfFatal(t);
 				try {
@@ -194,7 +193,6 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 					Exceptions.throwIfFatal(e);
 					e.addSuppressed(t);
 					t = e;
-					errorCallbackFailed = true;
 				}
 			}
 
@@ -203,7 +201,6 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 			}
 			catch (UnsupportedOperationException use) {
 				if (parent.onErrorCall() == null
-						|| errorCallbackFailed
 						|| !Exceptions.isErrorCallbackNotImplemented(use) && use.getCause() != t) {
 					throw use;
 				}
@@ -215,13 +212,7 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 					      .run();
 				}
 				catch (Throwable e) {
-					Exceptions.throwIfFatal(e);
-					Throwable _e = Operators.onOperatorError(null, e, t);
-					e.addSuppressed(t);
-					if (parent.onErrorCall() != null && !errorCallbackFailed) {
-						parent.onErrorCall().accept(_e);
-					}
-					Operators.onErrorDropped(_e);
+					FluxPeek.afterErrorWithFailure(parent, e, t);
 				}
 			}
 		}
@@ -238,7 +229,7 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 						      .run();
 					}
 					catch (Throwable e) {
-						onError(Operators.onOperatorError(e));
+						onError(Operators.onOperatorError(s, e));
 						return;
 					}
 				}
@@ -254,12 +245,7 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 						      .run();
 					}
 					catch (Throwable e) {
-						Throwable _e = Operators.onOperatorError(e);
-						if (parent.onErrorCall() != null) {
-							parent.onErrorCall()
-							      .accept(_e);
-						}
-						Operators.onErrorDropped(_e);
+						FluxPeek.afterCompleteWithFailure(parent, e);
 					}
 				}
 			}
@@ -453,7 +439,6 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 				return;
 			}
 			done = true;
-			boolean errorCallbackFailed = false;
 			if (parent.onErrorCall() != null) {
 				Exceptions.throwIfFatal(t);
 				try {
@@ -463,7 +448,6 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 					Exceptions.throwIfFatal(e);
 					e.addSuppressed(t);
 					t = e;
-					errorCallbackFailed = true;
 				}
 			}
 
@@ -472,7 +456,6 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 			}
 			catch (UnsupportedOperationException use) {
 				if (parent.onErrorCall() == null
-						|| errorCallbackFailed
 						|| !Exceptions.isErrorCallbackNotImplemented(use) && use.getCause() != t) {
 					throw use;
 				}
@@ -483,12 +466,7 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 					parent.onAfterTerminateCall().run();
 				}
 				catch (Throwable e) {
-					Throwable _e = Operators.onOperatorError(null, e, t);
-					e.addSuppressed(t);
-					if (parent.onErrorCall() != null && !errorCallbackFailed) {
-						parent.onErrorCall().accept(_e);
-					}
-					Operators.onErrorDropped(_e);
+					FluxPeek.afterErrorWithFailure(parent, e, t);
 				}
 			}
 		}
@@ -505,7 +483,7 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 						      .run();
 					}
 					catch (Throwable e) {
-						onError(Operators.onOperatorError(e));
+						onError(Operators.onOperatorError(s, e));
 						return;
 					}
 				}
@@ -521,12 +499,7 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 						      .run();
 					}
 					catch (Throwable e) {
-						Throwable _e = Operators.onOperatorError(e);
-						if (parent.onErrorCall() != null) {
-							parent.onErrorCall()
-							      .accept(_e);
-						}
-						Operators.onErrorDropped(_e);
+						FluxPeek.afterCompleteWithFailure(parent, e);
 					}
 				}
 			}
@@ -740,7 +713,6 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 				return;
 			}
 			done = true;
-			boolean errorCallbackFailed = false;
 			if (parent.onErrorCall() != null) {
 				Exceptions.throwIfFatal(t);
 				try {
@@ -750,7 +722,6 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 					Exceptions.throwIfFatal(e);
 					e.addSuppressed(t);
 					t = e;
-					errorCallbackFailed = true;
 				}
 			}
 
@@ -759,7 +730,6 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 			}
 			catch (UnsupportedOperationException use) {
 				if (parent.onErrorCall() == null
-						|| errorCallbackFailed
 						|| !Exceptions.isErrorCallbackNotImplemented(use) && use.getCause() != t) {
 					throw use;
 				}
@@ -771,14 +741,7 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 					      .run();
 				}
 				catch (Throwable e) {
-					Exceptions.throwIfFatal(e);
-					Throwable _e = Operators.onOperatorError(null, e, t);
-					e.addSuppressed(t);
-					if (parent.onErrorCall() != null && !errorCallbackFailed) {
-						parent.onErrorCall()
-						      .accept(_e);
-					}
-					Operators.onErrorDropped(_e);
+					FluxPeek.afterErrorWithFailure(parent, e, t);
 				}
 			}
 		}
@@ -794,7 +757,7 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 					      .run();
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(e));
+					onError(Operators.onOperatorError(s, e));
 					return;
 				}
 			}
@@ -808,13 +771,7 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 					      .run();
 				}
 				catch (Throwable e) {
-					Exceptions.throwIfFatal(e);
-					Throwable _e = Operators.onOperatorError(e);
-					if (parent.onErrorCall() != null) {
-						parent.onErrorCall()
-						      .accept(_e);
-					}
-					Operators.onErrorDropped(_e);
+					FluxPeek.afterCompleteWithFailure(parent, e);
 				}
 			}
 		}

--- a/src/main/java/reactor/core/publisher/Operators.java
+++ b/src/main/java/reactor/core/publisher/Operators.java
@@ -286,7 +286,7 @@ public abstract class Operators {
 	}
 
 	/**
-	 * Take an unsignalled exception that is masking anowher one due to callback failure.
+	 * Take an unsignalled exception that is masking another one due to callback failure.
 	 *
 	 * @param e the exception to handle
 	 */

--- a/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
+++ b/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,11 +33,11 @@ import reactor.util.concurrent.QueueSupplier;
 import static java.lang.Thread.sleep;
 import static org.junit.Assert.assertEquals;
 
-public class FluxPeekTest {
+public class FluxPeekFuseableTest {
 
 	@Test(expected = NullPointerException.class)
 	public void nullSource() {
-		new FluxPeek<>(null, null, null, null, null, null, null, null);
+		new FluxPeekFuseable<>(null, null, null, null, null, null, null, null);
 	}
 
 	@Test
@@ -52,7 +52,7 @@ public class FluxPeekTest {
 		AtomicBoolean onAfterComplete = new AtomicBoolean();
 		AtomicBoolean onCancel = new AtomicBoolean();
 
-		new FluxPeek<>(Flux.just(1).hide(),
+		new FluxPeekFuseable<>(Flux.just(1),
 				onSubscribe::set,
 				onNext::set,
 				onError::set,
@@ -82,7 +82,7 @@ public class FluxPeekTest {
 		AtomicBoolean onAfterComplete = new AtomicBoolean();
 		AtomicBoolean onCancel = new AtomicBoolean();
 
-		new FluxPeek<>(new MonoError<>(new RuntimeException("forced failure")),
+		new FluxPeekFuseable<>(new MonoError<>(new RuntimeException("forced failure")),
 				onSubscribe::set,
 				onNext::set,
 				onError::set,
@@ -112,7 +112,7 @@ public class FluxPeekTest {
 		AtomicBoolean onAfterComplete = new AtomicBoolean();
 		AtomicBoolean onCancel = new AtomicBoolean();
 
-		new FluxPeek<>(MonoEmpty.instance(),
+		new FluxPeekFuseable<>(MonoEmpty.instance(),
 				onSubscribe::set,
 				onNext::set,
 				onError::set,
@@ -142,7 +142,7 @@ public class FluxPeekTest {
 		AtomicBoolean onAfterComplete = new AtomicBoolean();
 		AtomicBoolean onCancel = new AtomicBoolean();
 
-		new FluxPeek<>(Flux.never(),
+		new FluxPeekFuseable<>(Flux.never(),
 				onSubscribe::set,
 				onNext::set,
 				onError::set,
@@ -172,7 +172,7 @@ public class FluxPeekTest {
 		AtomicBoolean onAfterComplete = new AtomicBoolean();
 		AtomicBoolean onCancel = new AtomicBoolean();
 
-		new FluxPeek<>(Flux.never(),
+		new FluxPeekFuseable<>(Flux.never(),
 				onSubscribe::set,
 				onNext::set,
 				onError::set,
@@ -200,7 +200,7 @@ public class FluxPeekTest {
 
 		Throwable err = new Exception("test");
 
-		Flux.just(1).hide()
+		Flux.just(1)
 		    .doOnNext(d -> {
 			    throw Exceptions.propagate(err);
 		    })
@@ -212,7 +212,7 @@ public class FluxPeekTest {
 		ts = AssertSubscriber.create();
 
 		try {
-			Flux.just(1).hide()
+			Flux.just(1)
 			    .doOnNext(d -> {
 				    throw Exceptions.bubble(err);
 			    })
@@ -231,7 +231,7 @@ public class FluxPeekTest {
 
 		Throwable err = new Exception("test");
 
-		Flux.just(1).hide()
+		Flux.just(1)
 		    .doOnComplete(() -> {
 			    throw Exceptions.propagate(err);
 		    })
@@ -243,7 +243,7 @@ public class FluxPeekTest {
 		ts = AssertSubscriber.create();
 
 		try {
-			Flux.just(1).hide()
+			Flux.just(1)
 			    .doOnComplete(() -> {
 				    throw Exceptions.bubble(err);
 			    })
@@ -260,7 +260,7 @@ public class FluxPeekTest {
 	public void errorCallbackError() {
 		IllegalStateException err = new IllegalStateException("test");
 
-		FluxPeek<String> flux = new FluxPeek<>(
+		FluxPeekFuseable<String> flux = new FluxPeekFuseable<>(
 				Flux.error(new IllegalArgumentException("bar")), null, null,
 				e -> { throw err; },
 				null, null, null, null);
@@ -353,7 +353,7 @@ public class FluxPeekTest {
 
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-		Flux.range(1, 2).hide()
+		Flux.range(1, 2)
 		    .doOnComplete(() -> onComplete.set(true))
 		    .subscribe(ts);
 
@@ -370,7 +370,7 @@ public class FluxPeekTest {
 
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-		Flux.range(1, 2).hide()
+		Flux.range(1, 2)
 		    .doAfterTerminate(() -> onTerminate.set(true))
 		    .subscribe(ts);
 
@@ -390,7 +390,6 @@ public class FluxPeekTest {
 			                      .map(y -> blockingOp(x, y))
 			                      .subscribeOn(Schedulers.parallel())
 			                      .reduce((l, r) -> l + "_" + r)
-			                      .hide()
 			                      .doOnSuccess(s -> {
 				                      count.incrementAndGet();
 			                      }))
@@ -409,7 +408,6 @@ public class FluxPeekTest {
 			                      .map(y -> blockingOp(x, y))
 			                      .subscribeOn(Schedulers.parallel())
 			                      .reduce((l, r) -> l + "_" + r)
-			                      .hide()
 			                      .doOnSuccess(s -> {
 				                      count.incrementAndGet();
 			                      })

--- a/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
+++ b/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
@@ -31,7 +31,12 @@ import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.concurrent.QueueSupplier;
 
 import static java.lang.Thread.sleep;
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 
 public class FluxPeekFuseableTest {
 
@@ -272,6 +277,128 @@ public class FluxPeekFuseableTest {
 		ts.assertError(IllegalStateException.class);
 		ts.assertErrorWith(e -> e.getSuppressed()[0].getMessage().equals("bar"));
 	}
+
+	@Test
+	public void afterTerminateCallbackErrorDoesCallErrorCallback() {
+		IllegalStateException err = new IllegalStateException("test");
+		AtomicReference<Throwable> errorCallbackCapture = new AtomicReference<>();
+
+		FluxPeekFuseable<String> flux = new FluxPeekFuseable<>(
+				Flux.empty(), null, null, errorCallbackCapture::set, null,
+				() -> { throw err; }, null, null);
+
+		AssertSubscriber<String> ts = AssertSubscriber.create();
+
+		try {
+			flux.subscribe(ts);
+			fail("expected thrown exception");
+		}
+		catch (Exception e) {
+			e.getCause().getMessage().equals(err);
+		}
+		ts.assertNoValues();
+		ts.assertComplete();
+
+		assertThat(errorCallbackCapture.get(), is(err));
+	}
+
+	@Test
+	public void afterTerminateCallbackFatalIsThrownDirectly() {
+		AtomicReference<Throwable> errorCallbackCapture = new AtomicReference<>();
+		Error fatal = new LinkageError();
+		FluxPeekFuseable<String> flux = new FluxPeekFuseable<>(
+				Flux.empty(), null, null, errorCallbackCapture::set, null,
+				() -> { throw fatal; }, null, null);
+
+		AssertSubscriber<String> ts = AssertSubscriber.create();
+
+		try {
+			flux.subscribe(ts);
+			fail("expected thrown exception");
+		}
+		catch (Throwable e) {
+			assertSame(fatal, e);
+		}
+		ts.assertNoValues();
+		ts.assertComplete();
+
+		assertThat(errorCallbackCapture.get(), is(nullValue()));
+
+
+		//same with after error
+		errorCallbackCapture.set(null);
+		flux = new FluxPeekFuseable<>(
+				Flux.error(new NullPointerException()), null, null, errorCallbackCapture::set, null,
+				() -> { throw fatal; }, null, null);
+
+		ts = AssertSubscriber.create();
+
+		try {
+			flux.subscribe(ts);
+			fail("expected thrown exception");
+		}
+		catch (Throwable e) {
+			assertSame(fatal, e);
+		}
+		ts.assertNoValues();
+		ts.assertError(NullPointerException.class);
+
+		assertThat(errorCallbackCapture.get(), is(instanceOf(NullPointerException.class)));
+	}
+
+	@Test
+	public void afterTerminateCallbackErrorAndErrorCallbackError() {
+		IllegalStateException err = new IllegalStateException("afterTerminate");
+		IllegalArgumentException err2 = new IllegalArgumentException("error");
+
+		FluxPeekFuseable<String> flux = new FluxPeekFuseable<>(
+				Flux.empty(), null, null, e -> { throw err2; },
+				null,
+				() -> { throw err; }, null, null);
+
+		AssertSubscriber<String> ts = AssertSubscriber.create();
+
+		try {
+			flux.subscribe(ts);
+			fail("expected thrown exception");
+		}
+		catch (Exception e) {
+			assertSame(e.toString(), err2, e.getCause());
+			assertEquals(1, err2.getSuppressed().length);
+			assertEquals(err, err2.getSuppressed()[0]);
+		}
+		ts.assertNoValues();
+		ts.assertComplete();
+	}
+
+	@Test
+	public void afterTerminateCallbackErrorAndErrorCallbackError2() {
+		IllegalStateException afterTerminate = new IllegalStateException("afterTerminate");
+		IllegalArgumentException error = new IllegalArgumentException("error");
+		NullPointerException err = new NullPointerException();
+
+		FluxPeekFuseable<String> flux = new FluxPeekFuseable<>(
+				Flux.error(err),
+				null, null,
+				e -> { throw error; }, null, () -> { throw afterTerminate; },
+				null, null);
+
+		AssertSubscriber<String> ts = AssertSubscriber.create();
+
+		try {
+			flux.subscribe(ts);
+			fail("expected thrown exception");
+		}
+		catch (Exception e) {
+			assertSame(error, e.getCause());
+			assertEquals(2, error.getSuppressed().length);
+			assertEquals(err, error.getSuppressed()[0]);
+			assertEquals(afterTerminate, error.getSuppressed()[1]);
+		}
+		ts.assertNoValues();
+		ts.assertErrorMessage("error");
+	}
+
 
 	@Test
 	public void syncFusionAvailable() {


### PR DESCRIPTION
@smaldini we should probably improve on this by making sure all 3
variants of `FluxPeekFuseable` are tested (conditional, fuseable and
conditional-fuseable).

There is also the potential inconsistency of FluxPeekFuseableSubscriber
calling `throwIfFatal(t)` in onError(t) whereas FluxPeekSubscriber does
not...