### PR TITLE
Fixes #275 Poor handling of RejectedExecutionException during processing

### DIFF
--- a/src/main/java/reactor/core/publisher/MonoPublishOn.java
+++ b/src/main/java/reactor/core/publisher/MonoPublishOn.java
@@ -16,6 +16,7 @@
 
 package reactor.core.publisher;
 
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import org.reactivestreams.*;
@@ -78,13 +79,23 @@ final class MonoPublishOn<T> extends MonoSource<T, T> {
         @Override
         public void onNext(T t) {
             value = t;
-            schedule();
+            try {
+              schedule();
+            }
+            catch (RejectedExecutionException ree) {
+              actual.onError(Operators.onOperatorError(s, ree, t));
+            }
         }
         
         @Override
         public void onError(Throwable t) {
             error = t;
-            schedule();
+            try {
+              schedule();
+            }
+            catch (RejectedExecutionException ree){
+              actual.onError(Operators.onOperatorError(s, ree, t));
+            }
         }
         
         @Override

--- a/src/main/java/reactor/core/scheduler/ExecutorScheduler.java
+++ b/src/main/java/reactor/core/scheduler/ExecutorScheduler.java
@@ -47,12 +47,9 @@ final class ExecutorScheduler implements Scheduler {
 	public Cancellation schedule(Runnable task) {
 		Objects.requireNonNull(task, "task");
 		ExecutorPlainRunnable r = new ExecutorPlainRunnable(task);
-		try {
-			executor.execute(r);
-		}
-		catch (RejectedExecutionException ex) {
-			return REJECTED;
-		}
+
+		executor.execute(r);
+
 		return r;
 	}
 


### PR DESCRIPTION
This pull request adds tests for the issue described in #275 as well as a potential fix.  For now, I have only tested/fixed MonoPublishOn behaviour and not touched Flux until I get some feedback.  Once I get some feedback on this, I can add tests for Flux too.

Not catching the RejectedExcutedException also resolves the inconsistency detailed in #274.