### PR TITLE
doFinally and fix BaseSubscriber hookFinally

### DIFF
--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -3108,6 +3108,18 @@ public abstract class Flux<T> implements Publisher<T> {
 				null);
 	}
 
+	public final Flux<T> doFinally(Consumer<SignalType> onFinally) {
+		Objects.requireNonNull(onFinally, "onFinally");
+		Flux<T> fluxDoFinally;
+		if (this instanceof Fuseable) {
+			fluxDoFinally = new FluxDoFinallyFuseable<>(this, onFinally);
+		}
+		else {
+			fluxDoFinally = new FluxDoFinally<>(this, onFinally);
+		}
+		return onAssembly(fluxDoFinally);
+	}
+
 	/**
 	 * Map this {@link Flux} sequence into {@link reactor.util.function.Tuple2} of T1 {@link Long} timemillis and T2
 	 * {@code T} associated data. The timemillis corresponds to the elapsed time between the subscribe and the first

--- a/src/main/java/reactor/core/publisher/FluxDoFinally.java
+++ b/src/main/java/reactor/core/publisher/FluxDoFinally.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.function.Consumer;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Exceptions;
+import reactor.core.Fuseable;
+import reactor.core.Fuseable.ConditionalSubscriber;
+import reactor.core.Fuseable.QueueSubscription;
+import reactor.core.Producer;
+import reactor.core.Receiver;
+
+/**
+ * Hook into the lifecycle events and signals of a {@link Flux} and execute
+ * a provided callback after any of onComplete, onError and cancel events.
+ * The hook is executed only once and receives the event type that triggered
+ * it ({@link SignalType#ON_COMPLETE}, {@link SignalType#ON_ERROR} or
+ * {@link SignalType#CANCEL}).
+ * <p>
+ * Note that any exception thrown by the hook are caught and bubbled up
+ * using {@link Operators#onErrorDropped(Throwable)}.
+ *
+ * @param <T> the value type
+ * @author Simon Baslé
+ */
+final class FluxDoFinally<T> extends FluxSource<T, T> {
+
+	final Consumer<SignalType> onFinally;
+
+	static <T> Subscriber<T> createSubscriber(Publisher<? extends T> source,
+			Subscriber<? super T> s, Consumer<SignalType> onFinally) {
+		Subscriber<T> subscriber;
+		if (source instanceof Fuseable && s instanceof ConditionalSubscriber) {
+			subscriber = new DoFinallyFuseableConditionalSubscriber<T>((ConditionalSubscriber<? super T>) s, onFinally);
+		}
+		else if (source instanceof Fuseable) {
+			subscriber = new DoFinallyFuseableSubscriber<>(s, onFinally);
+		}
+		else if (s instanceof ConditionalSubscriber) {
+			subscriber = new DoFinallyConditionalSubscriber<>((ConditionalSubscriber<? super T>) s, onFinally);
+		}
+		else {
+			subscriber = new DoFinallySubscriber<>(s, onFinally);
+		}
+		return subscriber;
+	}
+
+	public FluxDoFinally(Publisher<? extends T> source, Consumer<SignalType> onFinally) {
+		super(source);
+		this.onFinally = onFinally;
+	}
+
+	@Override
+	public void subscribe(Subscriber<? super T> s) {
+		source.subscribe(createSubscriber(source, s, onFinally));
+	}
+
+	static class DoFinallySubscriber<T> implements Subscriber<T>,
+	                                               Receiver, Producer,
+	                                               Subscription {
+
+		final Subscriber<? super T> actual;
+
+		final Consumer<SignalType> onFinally;
+
+		volatile int once;
+
+		static final AtomicIntegerFieldUpdater<DoFinallySubscriber> ONCE =
+			AtomicIntegerFieldUpdater.newUpdater(DoFinallySubscriber.class, "once");
+
+		QueueSubscription<T> qs;
+
+		Subscription s;
+
+		boolean syncFused;
+
+		DoFinallySubscriber(Subscriber<? super T> actual, Consumer<SignalType> onFinally) {
+			this.actual = actual;
+			this.onFinally = onFinally;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.validate(this.s, s)) {
+				this.s = s;
+				if (s instanceof QueueSubscription) {
+					this.qs = (QueueSubscription<T>)s;
+				}
+
+				actual.onSubscribe(this);
+			}
+		}
+
+		@Override
+		public void onNext(T t) {
+			actual.onNext(t);
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			actual.onError(t);
+			runFinally(SignalType.ON_ERROR);
+		}
+
+		@Override
+		public void onComplete() {
+			actual.onComplete();
+			runFinally(SignalType.ON_COMPLETE);
+		}
+
+		@Override
+		public void cancel() {
+			s.cancel();
+			runFinally(SignalType.CANCEL);
+		}
+
+		@Override
+		public void request(long n) {
+			s.request(n);
+		}
+
+		void runFinally(SignalType signalType) {
+			if (ONCE.compareAndSet(this, 0, 1)) {
+				try {
+					onFinally.accept(signalType);
+				} catch (Throwable ex) {
+					Exceptions.throwIfFatal(ex);
+					Operators.onErrorDropped(ex);
+				}
+			}
+		}
+
+		@Override
+		public Object downstream() {
+			return actual;
+		}
+
+		@Override
+		public Object upstream() {
+			return s;
+		}
+	}
+
+	static class DoFinallyFuseableSubscriber<T> extends DoFinallySubscriber<T>
+		implements Fuseable, QueueSubscription<T> {
+
+		public DoFinallyFuseableSubscriber(Subscriber<? super T> actual, Consumer<SignalType> onFinally) {
+			super(actual, onFinally);
+		}
+
+		@Override
+		public int requestFusion(int mode) {
+			QueueSubscription<T> qs = this.qs;
+			if (qs != null && (mode & Fuseable.THREAD_BARRIER) == 0) {
+				int m = qs.requestFusion(mode);
+				if (m != Fuseable.NONE) {
+					syncFused = m == Fuseable.SYNC;
+				}
+				return m;
+			}
+			return Fuseable.NONE;
+		}
+
+		@Override
+		public void clear() {
+			if (qs != null) {
+				qs.clear();
+			}
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return qs == null || qs.isEmpty();
+		}
+
+		@Override
+		public T poll() {
+			if (qs == null) {
+				return null;
+			}
+			T v = qs.poll();
+			if (v == null && syncFused) {
+				runFinally(SignalType.ON_COMPLETE);
+			}
+			return v;
+		}
+
+		@Override
+		public int size() {
+			return qs == null ? 0 : qs.size();
+		}
+	}
+
+	static final class DoFinallyConditionalSubscriber<T> extends DoFinallySubscriber<T>
+			implements ConditionalSubscriber<T> {
+
+		DoFinallyConditionalSubscriber(ConditionalSubscriber<? super T> actual,
+				Consumer<SignalType> onFinally) {
+			super(actual, onFinally);
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public boolean tryOnNext(T t) {
+			return ((ConditionalSubscriber<? super T>)actual).tryOnNext(t);
+		}
+	}
+
+	static final class DoFinallyFuseableConditionalSubscriber<T> extends DoFinallyFuseableSubscriber<T>
+		implements ConditionalSubscriber<T> {
+
+		DoFinallyFuseableConditionalSubscriber(ConditionalSubscriber<? super T> actual,
+				Consumer<SignalType> onFinally) {
+			super(actual, onFinally);
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public boolean tryOnNext(T t) {
+			return ((ConditionalSubscriber<? super T>)actual).tryOnNext(t);
+		}
+	}
+}

--- a/src/main/java/reactor/core/publisher/FluxDoFinallyFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxDoFinallyFuseable.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.function.Consumer;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import reactor.core.Fuseable;
+
+/**
+ * Hook with fusion into the lifecycle events and signals of a {@link Flux}
+ * and execute a provided callback after any of onComplete, onError and cancel events.
+ * The hook is executed only once and receives the event type that triggered
+ * it ({@link SignalType#ON_COMPLETE}, {@link SignalType#ON_ERROR} or
+ * {@link SignalType#CANCEL}).
+ * <p>
+ * Note that any exception thrown by the hook are caught and bubbled up
+ * using {@link Operators#onErrorDropped(Throwable)}.
+ *
+ * @param <T> the value type
+ * @author Simon Baslé
+ */
+final class FluxDoFinallyFuseable<T> extends FluxSource<T, T> implements Fuseable {
+
+	final Consumer<SignalType> onFinally;
+
+	public FluxDoFinallyFuseable(Publisher<? extends T> source, Consumer<SignalType> onFinally) {
+		super(source);
+		this.onFinally = onFinally;
+	}
+
+	@Override
+	public void subscribe(Subscriber<? super T> s) {
+		source.subscribe(FluxDoFinally.createSubscriber(source, s, onFinally));
+	}
+}

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -1380,6 +1380,18 @@ public abstract class Mono<T> implements Publisher<T> {
 					null);
 	}
 
+	public final Mono<T> doFinally(Consumer<SignalType> onFinally) {
+		Objects.requireNonNull(onFinally, "onFinally");
+		Mono<T> monoDoFinally;
+		if (this instanceof Fuseable) {
+			monoDoFinally = new MonoDoFinallyFuseable<>(this, onFinally);
+		}
+		else {
+			monoDoFinally = new MonoDoFinally<>(this, onFinally);
+		}
+		return onAssembly(monoDoFinally);
+	}
+
 	/**
 	 * Triggered when the {@link Mono} is cancelled.
 	 *

--- a/src/main/java/reactor/core/publisher/MonoDoFinally.java
+++ b/src/main/java/reactor/core/publisher/MonoDoFinally.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.function.Consumer;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+
+/**
+ * Hook into the lifecycle events and signals of a {@link Mono} and execute
+ * a provided callback after any of onComplete, onError and cancel events.
+ * The hook is executed only once and receives the event type that triggered
+ * it ({@link SignalType#ON_COMPLETE}, {@link SignalType#ON_ERROR} or
+ * {@link SignalType#CANCEL}).
+ * <p>
+ * Note that any exception thrown by the hook are caught and bubbled up
+ * using {@link Operators#onErrorDropped(Throwable)}.
+ *
+ * @param <T> the value type
+ * @author Simon Baslé
+ */
+final class MonoDoFinally<T> extends MonoSource<T, T> {
+
+	final Consumer<SignalType> onFinally;
+
+	public MonoDoFinally(Publisher<? extends T> source, Consumer<SignalType> onFinally) {
+		super(source);
+		this.onFinally = onFinally;
+	}
+
+	@Override
+	public void subscribe(Subscriber<? super T> s) {
+		source.subscribe(FluxDoFinally.createSubscriber(source, s, onFinally));
+	}
+
+}

--- a/src/main/java/reactor/core/publisher/MonoDoFinallyFuseable.java
+++ b/src/main/java/reactor/core/publisher/MonoDoFinallyFuseable.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.function.Consumer;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import reactor.core.Fuseable;
+
+/**
+ * Hook with fusion into the lifecycle events and signals of a {@link Mono}
+ * and execute a provided callback after any of onComplete, onError and cancel events.
+ * The hook is executed only once and receives the event type that triggered
+ * it ({@link SignalType#ON_COMPLETE}, {@link SignalType#ON_ERROR} or
+ * {@link SignalType#CANCEL}).
+ * <p>
+ * Note that any exception thrown by the hook are caught and bubbled up
+ * using {@link Operators#onErrorDropped(Throwable)}.
+ *
+ * @param <T> the value type
+ * @author Simon Baslé
+ */
+final class MonoDoFinallyFuseable<T> extends MonoSource<T, T> implements Fuseable {
+
+	final Consumer<SignalType> onFinally;
+
+	public MonoDoFinallyFuseable(Publisher<? extends T> source, Consumer<SignalType> onFinally) {
+		super(source);
+		this.onFinally = onFinally;
+	}
+
+	@Override
+	public void subscribe(Subscriber<? super T> s) {
+		source.subscribe(FluxDoFinally.createSubscriber(source, s, onFinally));
+	}
+
+}

--- a/src/test/java/reactor/core/publisher/FluxDoFinallyTest.java
+++ b/src/test/java/reactor/core/publisher/FluxDoFinallyTest.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.function.Consumer;
+
+import org.junit.Before;
+import org.junit.Test;
+import reactor.core.Exceptions;
+import reactor.test.StepVerifier;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static reactor.core.Fuseable.*;
+
+public class FluxDoFinallyTest implements Consumer<SignalType> {
+
+	volatile SignalType signalType;
+	volatile int calls;
+
+	@Before
+	public void before() {
+		signalType = null;
+		calls = 0;
+	}
+
+	@Override
+	public void accept(SignalType signalType) {
+		this.signalType = signalType;
+		this.calls++;
+	}
+
+	@Test
+	public void normalJust() {
+		StepVerifier.create(Flux.just(1).hide().doFinally(this))
+		            .expectNoFusionSupport()
+		            .expectNext(1)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test
+	public void normalEmpty() {
+		StepVerifier.create(Flux.empty().doFinally(this))
+		            .expectNoFusionSupport()
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test
+	public void normalError() {
+		StepVerifier.create(Flux.error(new IllegalArgumentException()).doFinally(this))
+		            .expectNoFusionSupport()
+		            .expectError(IllegalArgumentException.class)
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_ERROR, signalType);
+	}
+
+	@Test
+	public void normalCancel() {
+		StepVerifier.create(Flux.range(1, 10).hide().doFinally(this).take(5))
+		            .expectNoFusionSupport()
+		            .expectNext(1, 2, 3, 4, 5)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.CANCEL, signalType);
+	}
+
+	@Test
+	public void normalTake() {
+		StepVerifier.create(Flux.range(1, 5)
+		                        .hide()
+		                        .doFinally(this))
+		            .expectNoFusionSupport()
+		            .expectNext(1, 2, 3, 4, 5)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test
+	public void syncFused() {
+		StepVerifier.create(Flux.range(1, 5).doFinally(this))
+		            .expectFusion(SYNC)
+		            .expectNext(1, 2, 3, 4, 5)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls); assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test
+	public void syncFusedThreadBarrier() {
+		StepVerifier.create(Flux.range(1, 5).doFinally(this))
+		            .expectFusion(SYNC | THREAD_BARRIER , NONE)
+		            .expectNext(1, 2, 3, 4, 5)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test
+	public void asyncFused() {
+		UnicastProcessor<Integer> up = UnicastProcessor.create();
+		up.onNext(1);
+		up.onNext(2);
+		up.onNext(3);
+		up.onNext(4);
+		up.onNext(5);
+		up.onComplete();
+
+		StepVerifier.create(up.doFinally(this))
+		            .expectFusion(ASYNC)
+		            .expectNext(1, 2, 3, 4, 5)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test
+	public void asyncFusedThreadBarrier() {
+		UnicastProcessor<Integer> up = UnicastProcessor.create();
+		up.onNext(1);
+		up.onNext(2);
+		up.onNext(3);
+		up.onNext(4);
+		up.onNext(5);
+		up.onComplete();
+
+		StepVerifier.create(up.doFinally(this))
+		            .expectFusion(ASYNC | THREAD_BARRIER, NONE)
+		            .expectNext(1, 2, 3, 4, 5)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test
+	public void normalJustConditional() {
+		StepVerifier.create(Flux.just(1)
+		                        .hide()
+		                        .doFinally(this)
+		                        .filter(i -> true))
+		            .expectNoFusionSupport()
+		            .expectNext(1)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test
+	public void normalEmptyConditional() {
+		StepVerifier.create(Flux.empty()
+		                        .hide()
+		                        .doFinally(this)
+		                        .filter(i -> true))
+		            .expectNoFusionSupport()
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test
+	public void normalErrorConditional() {
+		StepVerifier.create(Flux.error(new IllegalArgumentException())
+		                        .hide()
+		                        .doFinally(this)
+		                        .filter(i -> true))
+		            .expectNoFusionSupport()
+		            .expectError(IllegalArgumentException.class)
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_ERROR, signalType);
+	}
+
+	@Test
+	public void normalCancelConditional() {
+		StepVerifier.create(Flux.range(1, 10)
+		                        .hide()
+		                        .doFinally(this)
+		                        .filter(i -> true)
+		                        .take(5))
+		            .expectNoFusionSupport()
+		            .expectNext(1, 2, 3, 4, 5)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.CANCEL, signalType);
+	}
+
+	@Test
+	public void normalTakeConditional() {
+		StepVerifier.create(Flux.range(1, 5)
+		                        .hide()
+		                        .doFinally(this)
+		                        .filter(i -> true))
+		            .expectNoFusionSupport()
+		            .expectNext(1, 2, 3, 4, 5)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test
+	public void syncFusedConditional() {
+		StepVerifier.create(Flux.range(1, 5)
+		                        .doFinally(this)
+		                        .filter(i -> true))
+		            .expectFusion(SYNC)
+		            .expectNext(1, 2, 3, 4, 5)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test
+	public void syncFusedThreadBarrierConditional() {
+		StepVerifier.create(Flux.range(1, 5)
+		                        .doFinally(this)
+		                        .filter(i -> true))
+		            .expectFusion(SYNC | THREAD_BARRIER, NONE)
+		            .expectNext(1, 2, 3, 4, 5)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test
+	public void asyncFusedConditional() {
+		UnicastProcessor<Integer> up = UnicastProcessor.create();
+		up.onNext(1);
+		up.onNext(2);
+		up.onNext(3);
+		up.onNext(4);
+		up.onNext(5);
+		up.onComplete();
+
+		StepVerifier.create(up.doFinally(this)
+		                      .filter(i -> true))
+		            .expectFusion(ASYNC)
+		            .expectNext(1, 2, 3, 4, 5)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test
+	public void asyncFusedThreadBarrierConditional() {
+		UnicastProcessor<Integer> up = UnicastProcessor.create();
+		up.onNext(1);
+		up.onNext(2);
+		up.onNext(3);
+		up.onNext(4);
+		up.onNext(5);
+		up.onComplete();
+
+		StepVerifier.create(up.doFinally(this)
+		                      .filter(i -> true))
+		            .expectFusion(ASYNC | THREAD_BARRIER, NONE)
+		            .expectNext(1, 2, 3, 4, 5)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void nullCallback() {
+		Flux.just(1).doFinally(null);
+	}
+
+	@Test
+	public void callbackThrows() {
+		try {
+			StepVerifier.create(Flux.just(1)
+			                        .doFinally(signal -> {
+				                        throw new IllegalStateException();
+			                        }))
+			            .expectNext(1)
+			            .expectComplete()
+			            .verify();
+		}
+		catch (Throwable e) {
+			Throwable _e = Exceptions.unwrap(e);
+			assertNotEquals(e, _e);
+			assertThat(_e, is(instanceOf(IllegalStateException.class)));
+		}
+	}
+
+	@Test
+	public void callbackThrowsConditional() {
+		try {
+			StepVerifier.create(Flux.just(1)
+			                        .doFinally(signal -> {
+				                        throw new IllegalStateException();
+			                        })
+			                        .filter(i -> true))
+			            .expectNext(1)
+			            .expectComplete()
+			            .verify();
+		}
+		catch (Throwable e) {
+			Throwable _e = Exceptions.unwrap(e);
+			assertNotEquals(e, _e);
+			assertThat(_e, is(instanceOf(IllegalStateException.class)));
+		}
+	}
+
+	//TODO test multiple subscriptions?
+
+}

--- a/src/test/java/reactor/core/publisher/MonoDoFinallyTest.java
+++ b/src/test/java/reactor/core/publisher/MonoDoFinallyTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import org.junit.Before;
+import org.junit.Test;
+import reactor.core.Exceptions;
+import reactor.test.StepVerifier;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
+import static reactor.core.Fuseable.SYNC;
+
+/**
+ * Note: as {@link MonoDoFinally} and {@link MonoDoFinallyFuseable} delegate to
+ * subscribers in {@link FluxDoFinally}, these tests are kind of duplicates of
+ * {@link FluxDoFinallyTest} and thus are less numerous.
+ */
+public class MonoDoFinallyTest implements Consumer<SignalType> {
+
+	volatile SignalType signalType;
+	volatile int calls;
+
+	@Before
+	public void before() {
+		signalType = null;
+		calls = 0;
+	}
+
+	@Override
+	public void accept(SignalType signalType) {
+		this.signalType = signalType;
+		this.calls++;
+	}
+
+	@Test
+	public void normalJust() {
+		StepVerifier.create(Mono.just(1).hide().doFinally(this))
+		            .expectNoFusionSupport()
+		            .expectNext(1)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test
+	public void normalEmpty() {
+		StepVerifier.create(Mono.empty().doFinally(this))
+		            .expectNoFusionSupport()
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test
+	public void normalError() {
+		StepVerifier.create(Mono.error(new IllegalArgumentException()).doFinally(this))
+		            .expectNoFusionSupport()
+		            .expectError(IllegalArgumentException.class)
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_ERROR, signalType);
+	}
+
+
+	@Test
+	public void normalCancel() {
+		AtomicBoolean cancelCheck = new AtomicBoolean(false);
+
+		StepVerifier.create(Mono.just(1).hide()
+		                        .doOnCancel(() -> cancelCheck.set(true))
+		                        .doFinally(this))
+		            .expectNoFusionSupport()
+		            .expectNext(1)
+		            .thenCancel()
+		            .verify();
+		
+		assertEquals("expected doFinally to be invoked exactly once", 1, calls);
+		assertEquals(SignalType.CANCEL, signalType);
+		assertTrue("expected tested mono to be cancelled", cancelCheck.get());
+	}
+
+	@Test
+	public void normalJustConditional() {
+		StepVerifier.create(Mono.just(1)
+		                        .hide()
+		                        .doFinally(this)
+		                        .filter(i -> true))
+		            .expectNoFusionSupport()
+		            .expectNext(1)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls);
+		assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test
+	public void syncFused() {
+		StepVerifier.create(Mono.just(1).doFinally(this))
+		            .expectFusion(SYNC)
+		            .expectNext(1)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls); assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+	@Test
+	public void syncFusedConditional() {
+		StepVerifier.create(Mono.just(1).doFinally(this).filter(i -> true))
+		            .expectFusion(SYNC)
+		            .expectNext(1)
+		            .expectComplete()
+		            .verify();
+
+		assertEquals(1, calls); assertEquals(SignalType.ON_COMPLETE, signalType);
+	}
+
+
+	@Test(expected = NullPointerException.class)
+	public void nullCallback() {
+		Mono.just(1).doFinally(null);
+	}
+
+	@Test
+	public void callbackThrows() {
+		try {
+			StepVerifier.create(Mono.just(1)
+			                        .doFinally(signal -> {
+				                        throw new IllegalStateException();
+			                        }))
+			            .expectNext(1)
+			            .expectComplete()
+			            .verify();
+		}
+		catch (Throwable e) {
+			Throwable _e = Exceptions.unwrap(e);
+			assertNotEquals(e, _e);
+			assertThat(_e, is(instanceOf(IllegalStateException.class)));
+		}
+	}
+
+	@Test
+	public void callbackThrowsConditional() {
+		try {
+			StepVerifier.create(Mono.just(1)
+			                        .doFinally(signal -> {
+				                        throw new IllegalStateException();
+			                        })
+			                        .filter(i -> true))
+			            .expectNext(1)
+			            .expectComplete()
+			            .verify();
+		}
+		catch (Throwable e) {
+			Throwable _e = Exceptions.unwrap(e);
+			assertNotEquals(e, _e);
+			assertThat(_e, is(instanceOf(IllegalStateException.class)));
+		}
+	}
+
+}


### PR DESCRIPTION
this PR contains 2 fixes:
 * #251 addition of the doFinally operator
 * #279 fix of the BaseSubscriber `hookFinally` not being called in a `finally` block