### PR TITLE
Fixes #282 When FluxHandle sink.error(ex) is used the data value is n…

### DIFF
--- a/src/main/java/reactor/core/publisher/FluxHandle.java
+++ b/src/main/java/reactor/core/publisher/FluxHandle.java
@@ -139,7 +139,7 @@ final class FluxHandle<T, R> extends FluxSource<T, R> {
 			if(done){
 				s.cancel();
 				if(error != null){
-					actual.onError(error);
+					actual.onError(Operators.onOperatorError(s, error, t));
 					return false;
 				}
 				actual.onComplete();
@@ -276,7 +276,7 @@ final class FluxHandle<T, R> extends FluxSource<T, R> {
 			if(done){
 				s.cancel();
 				if(error != null){
-					actual.onError(error);
+					actual.onError(Operators.onOperatorError(s, error, t));
 					return;
 				}
 				actual.onComplete();

--- a/src/main/java/reactor/core/publisher/FluxHandle.java
+++ b/src/main/java/reactor/core/publisher/FluxHandle.java
@@ -107,7 +107,7 @@ final class FluxHandle<T, R> extends FluxSource<T, R> {
 			if(done){
 				s.cancel();
 				if(error != null){
-					actual.onError(error);
+					actual.onError(Operators.onOperatorError(s, error, t));
 					return;
 				}
 				actual.onComplete();
@@ -181,7 +181,7 @@ final class FluxHandle<T, R> extends FluxSource<T, R> {
 
 		@Override
 		public void error(Throwable e) {
-			error = Operators.onOperatorError(Objects.requireNonNull(e, "error"));
+			error = Objects.requireNonNull(e, "error");
 			done = true;
 		}
 
@@ -309,7 +309,7 @@ final class FluxHandle<T, R> extends FluxSource<T, R> {
 			if(done){
 				s.cancel();
 				if(error != null){
-					actual.onError(error);
+					actual.onError(Operators.onOperatorError(s, error, t));
 				}
 				else {
 					actual.onComplete();

--- a/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
@@ -112,7 +112,7 @@ final class FluxHandleFuseable<T, R> extends FluxSource<T, R>
 				if(done){
 					s.cancel();
 					if(error != null){
-						actual.onError(error);
+						actual.onError(Operators.onOperatorError(s, error, t));
 					}
 					else {
 						actual.onComplete();
@@ -161,7 +161,7 @@ final class FluxHandleFuseable<T, R> extends FluxSource<T, R>
 				if(done){
 					s.cancel();
 					if(error != null){
-						actual.onError(error);
+						actual.onError(Operators.onOperatorError(s, error, t));
 						return;
 					}
 					actual.onComplete();
@@ -253,7 +253,7 @@ final class FluxHandleFuseable<T, R> extends FluxSource<T, R>
 						if(done){
 							s.cancel();
 							if(error != null){
-								actual.onError(error);
+								actual.onError(Operators.onOperatorError(s, error, v));
 							}
 							return u;
 						}
@@ -333,7 +333,7 @@ final class FluxHandleFuseable<T, R> extends FluxSource<T, R>
 
 		@Override
 		public void error(Throwable e) {
-			error = Operators.onOperatorError(Objects.requireNonNull(e, "error"));
+			error = Objects.requireNonNull(e, "error");
 			done = true;
 		}
 
@@ -399,7 +399,7 @@ final class FluxHandleFuseable<T, R> extends FluxSource<T, R>
 				if(done){
 					s.cancel();
 					if(error != null){
-						actual.onError(error);
+						actual.onError(Operators.onOperatorError(s, error, t));
 						return;
 					}
 					actual.onComplete();
@@ -438,7 +438,7 @@ final class FluxHandleFuseable<T, R> extends FluxSource<T, R>
 				if(done){
 					s.cancel();
 					if(error != null){
-						actual.onError(error);
+						actual.onError(Operators.onOperatorError(s, error, t));
 					}
 					else {
 						actual.onComplete();
@@ -490,7 +490,7 @@ final class FluxHandleFuseable<T, R> extends FluxSource<T, R>
 
 		@Override
 		public void error(Throwable e) {
-			error = Operators.onOperatorError(Objects.requireNonNull(e, "error"));
+			error = Objects.requireNonNull(e, "error");
 			done = true;
 		}
 
@@ -557,7 +557,7 @@ final class FluxHandleFuseable<T, R> extends FluxSource<T, R>
 						if(done){
 							s.cancel();
 							if(error != null){
-								actual.onError(error);
+								actual.onError(Operators.onOperatorError(s, error, v));
 							}
 							else {
 								actual.onComplete();

--- a/src/test/java/reactor/core/publisher/FluxHandleTest.java
+++ b/src/test/java/reactor/core/publisher/FluxHandleTest.java
@@ -132,70 +132,74 @@ public class FluxHandleTest {
 		  .assertFusionMode(ASYNC);
 	}
 
-  @Test
-  public void errorSignal() {
+	@Test
+	public void errorSignal() {
 
-    int data = 1;
-    Exception exception = new IllegalStateException();
+		int data = 1;
+		Exception exception = new IllegalStateException();
 
-    final AtomicReference<Throwable> throwableInOnOperatorError = new AtomicReference<>();
-    final AtomicReference<Object> dataInOnOperatorError = new AtomicReference<>();
+		final AtomicReference<Throwable> throwableInOnOperatorError =
+				new AtomicReference<>();
+		final AtomicReference<Object> dataInOnOperatorError = new AtomicReference<>();
 
-    try {
-      Hooks.onOperatorError((t, d) -> {
-        throwableInOnOperatorError.set(t);
-        dataInOnOperatorError.set(d);
-        return t;
-      });
+		try {
+			Hooks.onOperatorError((t, d) -> {
+				throwableInOnOperatorError.set(t);
+				dataInOnOperatorError.set(d);
+				return t;
+			});
 
-      AssertSubscriber<Integer> ts = AssertSubscriber.create();
+			AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-      Flux.just(data).<Integer>handle((v, s) -> s.error(exception)).subscribe(ts);
+			Flux.just(data).<Integer>handle((v, s) -> s.error(exception)).subscribe(ts);
 
-      ts.await()
-          .assertNoValues()
-          .assertError(IllegalStateException.class)
-          .assertNotComplete();
+			ts.await()
+			  .assertNoValues()
+			  .assertError(IllegalStateException.class)
+			  .assertNotComplete();
 
-      Assert.assertSame(throwableInOnOperatorError.get(), exception);
-      Assert.assertSame(dataInOnOperatorError.get(), data);
-    } finally {
-      Hooks.resetOnOperatorError();
-    }
-  }
+			Assert.assertSame(throwableInOnOperatorError.get(), exception);
+			Assert.assertSame(dataInOnOperatorError.get(), data);
+		}
+		finally {
+			Hooks.resetOnOperatorError();
+		}
+	}
 
-  @Test
-  public void errorPropagated() {
+	@Test
+	public void errorPropagated() {
 
-    int data = 1;
-    IllegalStateException exception = new IllegalStateException();
+		int data = 1;
+		IllegalStateException exception = new IllegalStateException();
 
-    final AtomicReference<Throwable> throwableInOnOperatorError = new AtomicReference<>();
-    final AtomicReference<Object> dataInOnOperatorError = new AtomicReference<>();
+		final AtomicReference<Throwable> throwableInOnOperatorError =
+				new AtomicReference<>();
+		final AtomicReference<Object> dataInOnOperatorError = new AtomicReference<>();
 
-    try {
-      Hooks.onOperatorError((t, d) -> {
-        throwableInOnOperatorError.set(t);
-        dataInOnOperatorError.set(d);
-        return t;
-      });
+		try {
+			Hooks.onOperatorError((t, d) -> {
+				throwableInOnOperatorError.set(t);
+				dataInOnOperatorError.set(d);
+				return t;
+			});
 
-      AssertSubscriber<Integer> ts = AssertSubscriber.create();
+			AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-      Flux.just(data).<Integer>handle((v, s) -> {
-        throw exception;
-      }).subscribe(ts);
+			Flux.just(data).<Integer>handle((v, s) -> {
+				throw exception;
+			}).subscribe(ts);
 
-      ts.await()
-          .assertNoValues()
-          .assertError(IllegalStateException.class)
-          .assertNotComplete();
+			ts.await()
+			  .assertNoValues()
+			  .assertError(IllegalStateException.class)
+			  .assertNotComplete();
 
-      Assert.assertSame(throwableInOnOperatorError.get(), exception);
-      Assert.assertSame(dataInOnOperatorError.get(), data);
-    } finally {
-      Hooks.resetOnOperatorError();
-    }
-  }
+			Assert.assertSame(throwableInOnOperatorError.get(), exception);
+			Assert.assertSame(dataInOnOperatorError.get(), data);
+		}
+		finally {
+			Hooks.resetOnOperatorError();
+		}
+	}
 
 }

--- a/src/test/java/reactor/core/publisher/FluxHandleTest.java
+++ b/src/test/java/reactor/core/publisher/FluxHandleTest.java
@@ -19,7 +19,9 @@ package reactor.core.publisher;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.Assert;
 import org.junit.Test;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.subscriber.AssertSubscriber;
@@ -129,5 +131,71 @@ public class FluxHandleTest {
 		  .assertFuseableSource()
 		  .assertFusionMode(ASYNC);
 	}
+
+  @Test
+  public void errorSignal() {
+
+    int data = 1;
+    Exception exception = new IllegalStateException();
+
+    final AtomicReference<Throwable> throwableInOnOperatorError = new AtomicReference<>();
+    final AtomicReference<Object> dataInOnOperatorError = new AtomicReference<>();
+
+    try {
+      Hooks.onOperatorError((t, d) -> {
+        throwableInOnOperatorError.set(t);
+        dataInOnOperatorError.set(d);
+        return t;
+      });
+
+      AssertSubscriber<Integer> ts = AssertSubscriber.create();
+
+      Flux.just(data).<Integer>handle((v, s) -> s.error(exception)).subscribe(ts);
+
+      ts.await()
+          .assertNoValues()
+          .assertError(IllegalStateException.class)
+          .assertNotComplete();
+
+      Assert.assertSame(throwableInOnOperatorError.get(), exception);
+      Assert.assertSame(dataInOnOperatorError.get(), data);
+    } finally {
+      Hooks.resetOnOperatorError();
+    }
+  }
+
+  @Test
+  public void errorPropagated() {
+
+    int data = 1;
+    IllegalStateException exception = new IllegalStateException();
+
+    final AtomicReference<Throwable> throwableInOnOperatorError = new AtomicReference<>();
+    final AtomicReference<Object> dataInOnOperatorError = new AtomicReference<>();
+
+    try {
+      Hooks.onOperatorError((t, d) -> {
+        throwableInOnOperatorError.set(t);
+        dataInOnOperatorError.set(d);
+        return t;
+      });
+
+      AssertSubscriber<Integer> ts = AssertSubscriber.create();
+
+      Flux.just(data).<Integer>handle((v, s) -> {
+        throw exception;
+      }).subscribe(ts);
+
+      ts.await()
+          .assertNoValues()
+          .assertError(IllegalStateException.class)
+          .assertNotComplete();
+
+      Assert.assertSame(throwableInOnOperatorError.get(), exception);
+      Assert.assertSame(dataInOnOperatorError.get(), data);
+    } finally {
+      Hooks.resetOnOperatorError();
+    }
+  }
 
 }


### PR DESCRIPTION
…ot passed to onOperatorError hook enhancement.