### PR TITLE
fix #281 Add onBackpressureBuffer with strategy

### DIFF
--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -4071,6 +4071,13 @@ public abstract class Flux<T> implements Publisher<T> {
 		return onAssembly(new FluxOnBackpressureBuffer<>(this, maxSize, false, onOverflow));
 	}
 
+	public final Flux<T> onBackpressureBuffer(int maxSize, Consumer<? super T> onOverflow,
+			OverflowStrategy overflowStrategy) {
+		Objects.requireNonNull(onOverflow, "onOverflow");
+		return onAssembly(new FluxOnBackpressureBuffer<>(this, maxSize, false, onOverflow)
+		.onBackpressureError());
+	}
+
 	/**
 	 * Request an unbounded demand and push the returned {@link Flux}, or drop the observed elements if not enough
 	 * demand is requested downstream.

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -4071,11 +4071,34 @@ public abstract class Flux<T> implements Publisher<T> {
 		return onAssembly(new FluxOnBackpressureBuffer<>(this, maxSize, false, onOverflow));
 	}
 
+	/**
+	 * Request an unbounded demand and push the returned {@link Flux}, or park the observed
+	 * elements if not enough demand is requested downstream, within a {@code maxSize}
+	 * limit. Over that limit, the overflow strategy is applied (see
+	 * {@link FluxOnBackpressureBufferStrategy.OverflowStrategy}).
+	 * <p>
+	 * A {@link Consumer} is immediately invoked when there is an overflow, receiving the
+	 * value that was discarded because of the overflow (which can be different from the
+	 * latest element emitted by the source in case of a {@code DROP_OLDEST} strategy).
+	 * <p>
+	 * Note that for the {@code ERROR} strategy, the overflow error will be delayed
+	 * after the current backlog is consumed. The consumer is still invoked immediately.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/onbackpressurebuffer.png" alt="">
+	 *
+	 * @param maxSize maximum buffer backlog size before overflow callback is called
+	 * @param onOverflow callback to invoke on overflow
+	 * @param overflowStrategy strategy to apply to overflowing elements
+	 *
+	 * @return a buffering {@link Flux}
+	 */
 	public final Flux<T> onBackpressureBuffer(int maxSize, Consumer<? super T> onOverflow,
-			OverflowStrategy overflowStrategy) {
+			FluxOnBackpressureBufferStrategy.OverflowStrategy overflowStrategy) {
 		Objects.requireNonNull(onOverflow, "onOverflow");
-		return onAssembly(new FluxOnBackpressureBuffer<>(this, maxSize, false, onOverflow)
-		.onBackpressureError());
+		Objects.requireNonNull(overflowStrategy, "overflowStrategy");
+		return onAssembly(new FluxOnBackpressureBufferStrategy<>(this, maxSize,
+				onOverflow, overflowStrategy));
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
+++ b/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
@@ -1,0 +1,398 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.function.Consumer;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Exceptions;
+import reactor.core.Fuseable;
+import reactor.core.Producer;
+import reactor.core.Receiver;
+import reactor.core.Trackable;
+
+/**
+ * @author Stephane Maldini
+ * @author Simon Baslé
+ */
+final class FluxOnBackpressureBufferStrategy<O> extends FluxSource<O, O> implements Fuseable {
+
+	public enum OverflowStrategy {
+		/**
+		 * Propagate an {@link IllegalStateException} when the buffer is full.
+		 */
+		ERROR,
+		/**
+		 * Drop the new element without propagating an error when the buffer is full.
+		 */
+		DROP_ELEMENT,
+		/**
+		 * When the buffer is full, remove the oldest element from it and offer the
+		 * new element at the end instead. Do not propagate an error.
+		 */
+		DROP_OLDEST
+	}
+
+	final Consumer<? super O>       onOverflow;
+	final int                       bufferSize;
+	final boolean                   delayError;
+	final OverflowStrategy          overflowStrategy;
+
+	public FluxOnBackpressureBufferStrategy(Publisher<? extends O> source,
+			int bufferSize,
+			Consumer<? super O> onOverflow,
+			OverflowStrategy overflowStrategy) {
+		super(source);
+		this.bufferSize = bufferSize;
+		this.onOverflow = onOverflow;
+		this.overflowStrategy = overflowStrategy;
+		this.delayError = onOverflow != null;
+	}
+
+	@Override
+	public void subscribe(Subscriber<? super O> s) {
+//		if (overflowStrategy == OverflowStrategy.DROP_OLDEST) {
+			source.subscribe(new BackpressureBufferDropOldestSubscriber<>(s,
+					bufferSize,
+					delayError,
+					onOverflow,
+					overflowStrategy));
+//		}
+//		else {
+//			source.subscribe(new FluxOnBackpressureBuffer.BackpressureBufferSubscriber<>(
+//					s, bufferSize, false, delayError, onOverflow));
+//		}
+	}
+
+	@Override
+	public long getPrefetch() {
+		return Long.MAX_VALUE;
+	}
+
+	static final class BackpressureBufferDropOldestSubscriber<T>
+			implements Subscriber<T>, Subscription, Trackable, Producer,
+			           Receiver {
+
+		final Subscriber<? super T> actual;
+		final int                   bufferSize;
+		final Deque<T>              queue;
+		final Consumer<? super T>   onOverflow;
+		final boolean               delayError;
+		final OverflowStrategy      overflowStrategy;
+
+		Subscription s;
+
+		volatile boolean cancelled;
+
+		volatile boolean done;
+		Throwable error;
+
+		volatile int wip;
+		static final AtomicIntegerFieldUpdater<BackpressureBufferDropOldestSubscriber> WIP =
+				AtomicIntegerFieldUpdater.newUpdater(BackpressureBufferDropOldestSubscriber.class,
+						"wip");
+
+		volatile long requested;
+		static final AtomicLongFieldUpdater<BackpressureBufferDropOldestSubscriber> REQUESTED =
+				AtomicLongFieldUpdater.newUpdater(BackpressureBufferDropOldestSubscriber.class,
+						"requested");
+
+		public BackpressureBufferDropOldestSubscriber(Subscriber<? super T> actual,
+				int bufferSize,
+				boolean delayError,
+				Consumer<? super T> onOverflow,
+				OverflowStrategy overflowStrategy) {
+			this.actual = actual;
+			this.delayError = delayError;
+			this.onOverflow = onOverflow;
+			this.overflowStrategy = overflowStrategy;
+			this.bufferSize = bufferSize;
+			this.queue = new ArrayDeque<>(bufferSize);
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.validate(this.s, s)) {
+				this.s = s;
+				actual.onSubscribe(this);
+				s.request(Long.MAX_VALUE);
+			}
+		}
+
+		@Override
+		public void onNext(T t) {
+			if (done) {
+				Operators.onNextDropped(t);
+				return;
+			}
+
+			boolean callOnOverflow = false;
+			boolean callOnError = false;
+			T overflowElement = t;
+			Deque<T> dq = queue;
+			synchronized (dq) {
+				if (dq.size() == bufferSize) {
+					callOnOverflow = true;
+					switch (overflowStrategy) {
+						case ERROR:
+							callOnError = true;
+							break;
+						case DROP_OLDEST:
+							overflowElement = dq.pollFirst();
+							dq.offer(t);
+							break;
+						case DROP_ELEMENT:
+							//do nothing
+							break;
+					}
+				}
+				else {
+					dq.offer(t);
+				}
+			}
+
+			if (callOnOverflow && onOverflow != null) {
+				try {
+					onOverflow.accept(overflowElement);
+				}
+				catch (Throwable e) {
+					Throwable ex = Operators.onOperatorError(s, e, overflowElement);
+					onError(ex);
+					return;
+				}
+			}
+
+			if (callOnError) {
+				Throwable ex = Operators.onOperatorError(s, Exceptions.failWithOverflow(), overflowElement);
+				onError(ex);
+			}
+
+			if (!callOnError && !callOnOverflow) {
+				drain();
+			}
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			if (done) {
+				Operators.onErrorDropped(t);
+				return;
+			}
+			error = t;
+			done = true;
+			drain();
+		}
+
+		@Override
+		public void onComplete() {
+			if (done) {
+				return;
+			}
+			done = true;
+			drain();
+		}
+
+		void drain() {
+			if (WIP.getAndIncrement(this) != 0) {
+				return;
+			}
+
+			int missed = 1;
+
+			for (; ; ) {
+				Subscriber<? super T> a = actual;
+				if (a != null) {
+					drainRegular(a);
+					return;
+				}
+
+				missed = WIP.addAndGet(this, -missed);
+				if (missed == 0) {
+					break;
+				}
+			}
+		}
+
+		void drainRegular(Subscriber<? super T> a) {
+			int missed = 1;
+
+			final Queue<T> q = queue;
+
+			for (; ; ) {
+
+				long r = requested;
+				long e = 0L;
+
+				while (r != e) {
+					boolean d = done;
+
+					T t;
+					synchronized (q) {
+						t = q.poll();
+					}
+					boolean empty = t == null;
+
+					if (checkTerminated(d, empty, a)) {
+						return;
+					}
+
+					if (empty) {
+						break;
+					}
+
+					a.onNext(t);
+
+					e++;
+				}
+
+				if (r == e) {
+					boolean empty;
+					synchronized (q) {
+						empty = q.isEmpty();
+					}
+					if (checkTerminated(done, empty, a)) {
+						return;
+					}
+				}
+
+				if (e != 0 && r != Long.MAX_VALUE) {
+					REQUESTED.addAndGet(this, -e);
+				}
+
+				missed = WIP.addAndGet(this, -missed);
+				if (missed == 0) {
+					break;
+				}
+			}
+		}
+
+		@Override
+		public void request(long n) {
+			if (Operators.validate(n)) {
+				Operators.getAndAddCap(REQUESTED, this, n);
+				drain();
+			}
+		}
+
+		@Override
+		public void cancel() {
+			if (!cancelled) {
+				cancelled = true;
+
+				s.cancel();
+
+				if (WIP.getAndIncrement(this) == 0) {
+					clear(queue);
+				}
+			}
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return cancelled;
+		}
+
+		@Override
+		public boolean isStarted() {
+			return s != null;
+		}
+
+		@Override
+		public boolean isTerminated() {
+			return done;
+		}
+
+		@Override
+		public Throwable getError() {
+			return error;
+		}
+
+		@Override
+		public Object downstream() {
+			return actual;
+		}
+
+		@Override
+		public Object upstream() {
+			return s;
+		}
+
+		@Override
+		public long getCapacity() {
+			return Long.MAX_VALUE;
+		}
+
+		@Override
+		public long getPending() {
+			return queue.size();
+		}
+
+		@Override
+		public long requestedFromDownstream() {
+			return requested;
+		}
+
+		boolean checkTerminated(boolean d, boolean empty, Subscriber<? super T> a) {
+			if (cancelled) {
+				s.cancel();
+				clear(queue);
+				return true;
+			}
+			if (d) {
+				if (delayError) {
+					if (empty) {
+						Throwable e = error;
+						if (e != null) {
+							a.onError(e);
+						}
+						else {
+							a.onComplete();
+						}
+						return true;
+					}
+				}
+				else {
+					Throwable e = error;
+					if (e != null) {
+						clear(queue);
+						a.onError(e);
+						return true;
+					}
+					else if (empty) {
+						a.onComplete();
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+
+		void clear(Deque<T> dq) {
+			synchronized (dq) {
+				dq.clear();
+			}
+		}
+
+	}
+}

--- a/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
+++ b/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
@@ -33,26 +33,14 @@ import reactor.core.Trackable;
 import reactor.core.publisher.FluxSink.OverflowStrategy;
 
 /**
+ * Buffers values if the subscriber doesn't request fast enough, bounding the
+ * buffer to a choosen size. If the buffer overflows, apply a pre-determined
+ * overflow strategy.
+
  * @author Stephane Maldini
  * @author Simon Baslé
  */
 final class FluxOnBackpressureBufferStrategy<O> extends FluxSource<O, O> {
-
-//	public enum OverflowStrategy {
-//		/**
-//		 * Propagate an {@link IllegalStateException} when the buffer is full.
-//		 */
-//		ERROR,
-//		/**
-//		 * Drop the new element without propagating an error when the buffer is full.
-//		 */
-//		DROP_ELEMENT,
-//		/**
-//		 * When the buffer is full, remove the oldest element from it and offer the
-//		 * new element at the end instead. Do not propagate an error.
-//		 */
-//		DROP_OLDEST
-//	}
 
 	final Consumer<? super O> onBufferOverflow;
 	final int                 bufferSize;

--- a/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
+++ b/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
@@ -27,7 +27,6 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Exceptions;
-import reactor.core.Fuseable;
 import reactor.core.Producer;
 import reactor.core.Receiver;
 import reactor.core.Trackable;
@@ -36,7 +35,7 @@ import reactor.core.Trackable;
  * @author Stephane Maldini
  * @author Simon Baslé
  */
-final class FluxOnBackpressureBufferStrategy<O> extends FluxSource<O, O> implements Fuseable {
+final class FluxOnBackpressureBufferStrategy<O> extends FluxSource<O, O> {
 
 	public enum OverflowStrategy {
 		/**
@@ -72,17 +71,11 @@ final class FluxOnBackpressureBufferStrategy<O> extends FluxSource<O, O> impleme
 
 	@Override
 	public void subscribe(Subscriber<? super O> s) {
-//		if (overflowStrategy == OverflowStrategy.DROP_OLDEST) {
-			source.subscribe(new BackpressureBufferDropOldestSubscriber<>(s,
-					bufferSize,
-					delayError,
-					onOverflow,
-					overflowStrategy));
-//		}
-//		else {
-//			source.subscribe(new FluxOnBackpressureBuffer.BackpressureBufferSubscriber<>(
-//					s, bufferSize, false, delayError, onOverflow));
-//		}
+		source.subscribe(new BackpressureBufferDropOldestSubscriber<>(s,
+				bufferSize,
+				delayError,
+				onOverflow,
+				overflowStrategy));
 	}
 
 	@Override
@@ -223,7 +216,7 @@ final class FluxOnBackpressureBufferStrategy<O> extends FluxSource<O, O> impleme
 			for (; ; ) {
 				Subscriber<? super T> a = actual;
 				if (a != null) {
-					drainRegular(a);
+					innerDrain(a);
 					return;
 				}
 
@@ -234,7 +227,7 @@ final class FluxOnBackpressureBufferStrategy<O> extends FluxSource<O, O> impleme
 			}
 		}
 
-		void drainRegular(Subscriber<? super T> a) {
+		void innerDrain(Subscriber<? super T> a) {
 			int missed = 1;
 
 			final Queue<T> q = queue;

--- a/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
+++ b/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import reactor.test.StepVerifier;
+
+import static org.junit.Assert.*;
+import static reactor.core.publisher.FluxOnBackpressureBufferStrategy.OverflowStrategy.*;
+
+public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
+                                                             BiFunction<Throwable, Object, Throwable> {
+
+	private String droppedValue;
+	private Object hookCapturedValue;
+	private Throwable hookCapturedError;
+
+	@Override
+	public void accept(String s) {
+		this.droppedValue = s;
+	}
+
+	@Override
+	public Throwable apply(Throwable throwable, Object o) {
+		this.hookCapturedValue = o;
+		this.hookCapturedError = throwable;
+		return throwable;
+	}
+
+	@Before
+	public void before() {
+		this.droppedValue = null;
+		this.hookCapturedError = null;
+		this.hookCapturedValue = null;
+		Hooks.onOperatorError(this);
+	}
+
+	@After
+	public void after() {
+		Hooks.resetOnOperatorError();
+	}
+
+	@Test
+	public void drop() {
+		DirectProcessor<String> processor = DirectProcessor.create();
+
+		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
+				processor, 2, this, DROP_ELEMENT);
+
+		StepVerifier.create(flux, 0)
+		            .thenRequest(1)
+		            .then(() -> {
+			            processor.onNext("normal");
+			            processor.onNext("over1");
+			            processor.onNext("over2");
+			            processor.onNext("over3");
+			            processor.onComplete();
+		            })
+		            .expectNext("normal")
+		            .thenAwait()
+		            .thenRequest(3)
+		            .expectNext("over1", "over2")
+		            .expectComplete()
+		            .verify();
+
+		assertEquals("over3", droppedValue);
+		assertNull("unexpected hookCapturedValue", hookCapturedValue);
+		assertNull("unexpected hookCapturedError",hookCapturedError);
+	}
+
+	@Test
+	public void dropOldest() {
+		DirectProcessor<String> processor = DirectProcessor.create();
+
+		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
+				processor, 2, this, DROP_OLDEST);
+
+		StepVerifier.create(flux, 0)
+		            .thenRequest(1)
+		            .then(() -> {
+			            processor.onNext("normal");
+			            processor.onNext("over1");
+			            processor.onNext("over2");
+			            processor.onNext("over3");
+			            processor.onComplete();
+		            })
+		            .expectNext("normal")
+		            .thenAwait()
+		            .thenRequest(3)
+		            .expectNext("over2", "over3")
+		            .expectComplete()
+		            .verify();
+
+		assertEquals("over1", droppedValue);
+		assertNull("unexpected hookCapturedValue",hookCapturedValue);
+		assertNull("unexpected hookCapturedError",hookCapturedError);
+	}
+
+	@Test
+	public void error() {
+		DirectProcessor<String> processor = DirectProcessor.create();
+
+		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
+				processor, 2, this, ERROR);
+
+		StepVerifier.create(flux, 0)
+		            .thenRequest(1)
+		            .then(() -> {
+			            processor.onNext("normal");
+			            processor.onNext("over1");
+			            processor.onNext("over2");
+			            processor.onNext("over3");
+			            processor.onComplete();
+		            })
+		            .expectNext("normal")
+		            .thenAwait()
+		            .thenRequest(3)
+		            .expectNext("over1", "over2")
+		            .expectErrorMessage("The receiver is overrun by more signals than expected (bounded queue...)")
+		            .verify();
+
+		assertEquals("over3", droppedValue);
+		assertEquals("over3", hookCapturedValue);
+		assertTrue("unexpected hookCapturedError: " + hookCapturedError, hookCapturedError instanceof IllegalStateException);
+	}
+
+	@Test
+	public void dropCallbackError() {
+		DirectProcessor<String> processor = DirectProcessor.create();
+
+		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
+				processor, 2, v -> { throw new IllegalArgumentException("boom"); },
+				DROP_ELEMENT);
+
+		StepVerifier.create(flux, 0)
+		            .thenRequest(1)
+		            .then(() -> {
+			            processor.onNext("normal");
+			            processor.onNext("over1");
+			            processor.onNext("over2");
+			            processor.onNext("over3");
+			            processor.onComplete();
+		            })
+		            .expectNext("normal")
+		            .thenAwait()
+		            .thenRequest(3)
+		            .expectNext("over1", "over2")
+		            .expectErrorMessage("boom")
+		            .verify();
+
+		assertNull("unexpected droppedValue", droppedValue);
+		assertEquals("over3", hookCapturedValue);
+		assertTrue("unexpected hookCapturedError: " + hookCapturedError, hookCapturedError instanceof IllegalArgumentException);
+		assertEquals("boom", hookCapturedError.getMessage());
+	}
+
+	@Test
+	public void dropOldestCallbackError() {
+		DirectProcessor<String> processor = DirectProcessor.create();
+
+		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
+				processor, 2, v -> { throw new IllegalArgumentException("boom"); },
+				DROP_OLDEST);
+
+		StepVerifier.create(flux, 0)
+		            .thenRequest(1)
+		            .then(() -> {
+			            processor.onNext("normal");
+			            processor.onNext("over1");
+			            processor.onNext("over2");
+			            processor.onNext("over3");
+			            processor.onComplete();
+		            })
+		            .expectNext("normal")
+		            .thenAwait()
+		            .thenRequest(3)
+		            .expectNext("over2", "over3")
+		            .expectErrorMessage("boom")
+		            .verify();
+
+		assertNull("unexpected droppedValue", droppedValue);
+		assertEquals("over1", hookCapturedValue);
+		assertTrue("unexpected hookCapturedError: " + hookCapturedError, hookCapturedError instanceof IllegalArgumentException);
+		assertEquals("boom", hookCapturedError.getMessage());
+	}
+
+	@Test
+	public void errorCallbackError() {
+		DirectProcessor<String> processor = DirectProcessor.create();
+
+		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
+				processor, 2, v -> { throw new IllegalArgumentException("boom"); },
+				ERROR);
+
+		StepVerifier.create(flux, 0)
+		            .thenRequest(1)
+		            .then(() -> {
+			            processor.onNext("normal");
+			            processor.onNext("over1");
+			            processor.onNext("over2");
+			            processor.onNext("over3");
+			            processor.onComplete();
+		            })
+		            .expectNext("normal")
+		            .thenAwait()
+		            .thenRequest(3)
+		            .expectNext("over1", "over2")
+		            .expectErrorMessage("boom")
+		            .verify();
+
+		assertNull("unexpected droppedValue", droppedValue);
+		assertEquals("over3", hookCapturedValue);
+		assertTrue("unexpected hookCapturedError: " + hookCapturedError, hookCapturedError instanceof IllegalArgumentException);
+		assertEquals("boom", hookCapturedError.getMessage());
+	}
+
+	@Test
+	public void noCallbackWithErrorStrategyOnErrorImmediately() {
+		DirectProcessor<String> processor = DirectProcessor.create();
+
+		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
+				processor, 2, null, ERROR);
+
+		StepVerifier.create(flux, 0)
+		            .thenRequest(1)
+		            .then(() -> {
+			            processor.onNext("normal");
+			            processor.onNext("over1");
+			            processor.onNext("over2");
+			            processor.onNext("over3");
+			            processor.onComplete();
+		            })
+		            .expectNext("normal")
+		            .thenAwait()
+		            .thenRequest(1)
+		            .expectErrorMessage("The receiver is overrun by more signals than expected (bounded queue...)")
+		            .verify();
+
+		assertNull("unexpected droppedValue", droppedValue);
+		assertEquals("over3", hookCapturedValue);
+		assertTrue("unexpected hookCapturedError: " + hookCapturedError, hookCapturedError instanceof IllegalStateException);
+		assertEquals("The receiver is overrun by more signals than expected (bounded queue...)", hookCapturedError.getMessage());
+	}
+
+	@Test
+	public void noCallbackWithDropStrategyNoError() {
+		DirectProcessor<String> processor = DirectProcessor.create();
+
+		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
+				processor, 2, null, DROP_ELEMENT);
+
+		StepVerifier.create(flux, 0)
+		            .thenRequest(1)
+		            .then(() -> {
+			            processor.onNext("normal");
+			            processor.onNext("over1");
+			            processor.onNext("over2");
+			            processor.onNext("over3");
+			            processor.onComplete();
+		            })
+		            .expectNext("normal")
+		            .thenAwait()
+		            .thenRequest(3)
+		            .expectNext("over1", "over2")
+		            .expectComplete()
+		            .verify();
+
+		assertNull("unexpected droppedValue", droppedValue);
+		assertNull("unexpected hookCapturedValue", hookCapturedValue);
+		assertNull("unexpected hookCapturedError",hookCapturedError);
+	}
+
+	@Test
+	public void noCallbackWithDropOldestStrategyNoError() {
+		DirectProcessor<String> processor = DirectProcessor.create();
+
+		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
+				processor, 2, null, DROP_OLDEST);
+
+		StepVerifier.create(flux, 0)
+		            .thenRequest(1)
+		            .then(() -> {
+			            processor.onNext("normal");
+			            processor.onNext("over1");
+			            processor.onNext("over2");
+			            processor.onNext("over3");
+			            processor.onComplete();
+		            })
+		            .expectNext("normal")
+		            .thenAwait()
+		            .thenRequest(3)
+		            .expectNext("over2", "over3")
+		            .expectComplete()
+		            .verify();
+
+		assertNull("unexpected droppedValue", droppedValue);
+		assertNull("unexpected hookCapturedValue",hookCapturedValue);
+		assertNull("unexpected hookCapturedError",hookCapturedError);
+	}
+
+}

--- a/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
+++ b/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
@@ -317,4 +317,30 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 		assertNull("unexpected hookCapturedError",hookCapturedError);
 	}
 
+	@Test
+	public void fluxOnBackpressureBufferStrategyRequiresCallback() {
+		try {
+			Flux.just("foo").onBackpressureBuffer(1,
+					null,
+					FluxOnBackpressureBufferStrategy.OverflowStrategy.ERROR);
+			fail("expected NullPointerException");
+		}
+		catch (NullPointerException e) {
+			assertEquals("onOverflow", e.getMessage());
+		}
+	}
+
+	@Test
+	public void fluxOnBackpressureBufferStrategyRequiresStrategy() {
+		try {
+			Flux.just("foo").onBackpressureBuffer(1,
+					v -> { },
+					null);
+			fail("expected NullPointerException");
+		}
+		catch (NullPointerException e) {
+			assertEquals("overflowStrategy", e.getMessage());
+		}
+	}
+
 }


### PR DESCRIPTION
mvp version derived from FluxBackpressureBuffer but without `Fuseable` and with `Deque`.
@smaldini can you review?