### PR TITLE
see #264 Add Flux.doOnEach with Signal and individual consumers

### DIFF
--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -2986,39 +2986,14 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Triggers side-effects when the {@link Flux} emits an item, fails with an error or
-	 * completes successfully. This is provided as convenience to avoid using the
-	 * three corresponding {@code doOn} methods individually. Note that at least one
-	 * callback is required.
-	 *
-	 * @param nextConsumer the callback to call on {@link Subscriber#onNext(Object)}
-	 * @param errorConsumer the callback to call on {@link Subscriber#onError(Throwable)}
-	 * @param completeRunnable the callback to call on {@link Subscriber#onComplete()}
-	 * @return an observed {@link Flux}
-	 * @see #doOnNext(Consumer)
-	 * @see #doOnError(Consumer)
-	 * @see #doOnComplete(Runnable)
-	 */
-	public final Flux<T> doOnEach(Consumer<? super T> nextConsumer,
-			Consumer<? super Throwable> errorConsumer,
-			Runnable completeRunnable) {
-		if (nextConsumer == errorConsumer && errorConsumer == completeRunnable
-				&& completeRunnable == null) {
-			throw new NullPointerException("At least one side-effect callback must be non-null");
-		}
-		return doOnSignal(this, null,
-				nextConsumer, errorConsumer, completeRunnable,
-				null, null, null);
-	}
-
-	/**
-	 * Triggers side-effects when the {@link Flux} is subscribed, emits an item, fails
-	 * with an error or completes successfully. All these events are represented as a
-	 * {@link Signal} that is passed to the side-effect callback.
+	 * Triggers side-effects when the {@link Flux} emits an item, fails with an error
+	 * or completes successfully. All these events are represented as a {@link Signal}
+	 * that is passed to the side-effect callback. Note that this is an advanced operator,
+	 * typically used for monitoring of a Flux.
 	 *
 	 * @param signalConsumer the mandatory callback to call on
-	 *   {@link Subscriber#onSubscribe(Subscription)}, {@link Subscriber#onNext(Object)},
-	 *   {@link Subscriber#onError(Throwable)} and {@link Subscriber#onComplete()}
+	 *   {@link Subscriber#onNext(Object)}, {@link Subscriber#onError(Throwable)} and
+	 *   {@link Subscriber#onComplete()}
 	 * @return an observed {@link Flux}
 	 * @see #doOnNext(Consumer)
 	 * @see #doOnError(Consumer)
@@ -3027,9 +3002,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @see Signal
 	 */
 	public final Flux<T> doOnEach(Consumer<? super Signal<T>> signalConsumer) {
+		//TODO use a flyweight pattern for the onNext signals (re-use the same instance)?
 		Objects.requireNonNull(signalConsumer, "signalConsumer");
 		return doOnSignal(this,
-				s -> signalConsumer.accept(Signal.<T>subscribe(s)),
+				null,
 				t -> signalConsumer.accept(Signal.next(t)),
 				e -> signalConsumer.accept(Signal.<T>error(e)),
 				() -> signalConsumer.accept(Signal.<T>complete()),

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -2986,6 +2986,57 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
+	 * Triggers side-effects when the {@link Flux} emits an item, fails with an error or
+	 * completes successfully. This is provided as convenience to avoid using the
+	 * three corresponding {@code doOn} methods individually. Note that at least one
+	 * callback is required.
+	 *
+	 * @param nextConsumer the callback to call on {@link Subscriber#onNext(Object)}
+	 * @param errorConsumer the callback to call on {@link Subscriber#onError(Throwable)}
+	 * @param completeRunnable the callback to call on {@link Subscriber#onComplete()}
+	 * @return an observed {@link Flux}
+	 * @see #doOnNext(Consumer)
+	 * @see #doOnError(Consumer)
+	 * @see #doOnComplete(Runnable)
+	 */
+	public final Flux<T> doOnEach(Consumer<? super T> nextConsumer,
+			Consumer<? super Throwable> errorConsumer,
+			Runnable completeRunnable) {
+		if (nextConsumer == errorConsumer && errorConsumer == completeRunnable
+				&& completeRunnable == null) {
+			throw new NullPointerException("At least one side-effect callback must be non-null");
+		}
+		return doOnSignal(this, null,
+				nextConsumer, errorConsumer, completeRunnable,
+				null, null, null);
+	}
+
+	/**
+	 * Triggers side-effects when the {@link Flux} is subscribed, emits an item, fails
+	 * with an error or completes successfully. All these events are represented as a
+	 * {@link Signal} that is passed to the side-effect callback.
+	 *
+	 * @param signalConsumer the mandatory callback to call on
+	 *   {@link Subscriber#onSubscribe(Subscription)}, {@link Subscriber#onNext(Object)},
+	 *   {@link Subscriber#onError(Throwable)} and {@link Subscriber#onComplete()}
+	 * @return an observed {@link Flux}
+	 * @see #doOnNext(Consumer)
+	 * @see #doOnError(Consumer)
+	 * @see #doOnComplete(Runnable)
+	 * @see #materialize()
+	 * @see Signal
+	 */
+	public final Flux<T> doOnEach(Consumer<? super Signal<T>> signalConsumer) {
+		Objects.requireNonNull(signalConsumer, "signalConsumer");
+		return doOnSignal(this,
+				s -> signalConsumer.accept(Signal.<T>subscribe(s)),
+				t -> signalConsumer.accept(Signal.next(t)),
+				e -> signalConsumer.accept(Signal.<T>error(e)),
+				() -> signalConsumer.accept(Signal.<T>complete()),
+				null, null, null);
+	}
+
+	/**
 	 * Triggered when the {@link Flux} completes with an error.
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/doonerror.png" alt="">

--- a/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -61,9 +62,11 @@ import reactor.core.publisher.FluxProcessor;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
 import reactor.core.publisher.ReplayProcessor;
+import reactor.core.publisher.Signal;
 import reactor.core.publisher.TopicProcessor;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.Logger;
 import reactor.util.Loggers;
@@ -78,6 +81,101 @@ import static org.junit.Assert.*;
 public class FluxTests extends AbstractReactorTest {
 
 	static final String2Integer STRING_2_INTEGER = new String2Integer();
+
+	@Test
+	public void testDoOnEachSignal() {
+		List<Signal<Integer>> signals = new ArrayList<>(4);
+		Flux<Integer> flux = Flux.just(1, 2)
+		                         .doOnEach(signals::add);
+		StepVerifier.create(flux)
+		            .expectSubscription()
+		            .expectNext(1, 2)
+		            .expectComplete()
+		            .verify();
+
+		assertThat(signals.size(), is(4));
+		assertTrue("onSubscribe expected", signals.get(0).isOnSubscribe());
+		assertThat("onNext", signals.get(1).get(), is(1));
+		assertThat("onNext", signals.get(2).get(), is(2));
+		assertTrue("onComplete expected", signals.get(3).isOnComplete());
+	}
+
+	@Test
+	public void testDoOnEachSignalWithError() {
+		List<Signal<Integer>> signals = new ArrayList<>(4);
+		Flux<Integer> flux = Flux.<Integer>error(new IllegalArgumentException("foo"))
+		                         .doOnEach(signals::add);
+		StepVerifier.create(flux)
+		            .expectSubscription()
+		            .expectErrorMessage("foo")
+		            .verify();
+
+		assertThat(signals.size(), is(2));
+		assertTrue("onSubscribe expected", signals.get(0).isOnSubscribe());
+		assertTrue("onError expected", signals.get(1).isOnError());
+		assertThat("plain exception expected", signals.get(1).getThrowable().getMessage(),
+				is("foo"));
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testDoOnEachSignalNullConsumer() {
+		Flux.just(1).doOnEach(null);
+	}
+
+	@Test
+	public void testDoOnEach() {
+		LongAdder errorSignal = new LongAdder();
+		LongAdder nextSignals = new LongAdder();
+		AtomicBoolean completeSignal = new AtomicBoolean(false);
+
+		Flux<Integer> flux = Flux.just(1, 2)
+		                         .doOnEach(t -> nextSignals.increment(),
+				                         e -> errorSignal.increment(),
+				                         () -> completeSignal.set(true));
+
+		StepVerifier.create(flux)
+		            .expectSubscription()
+		            .expectNext(1, 2)
+		            .expectComplete()
+		            .verify();
+
+		assertThat("onNext x2 expected", nextSignals.intValue(), is(2));
+		assertThat("unexpected onError", errorSignal.intValue(), is(0));
+		assertTrue("onComplete expected", completeSignal.get());
+	}
+
+	@Test
+	public void testDoOnEachWithError() {
+		LongAdder errorSignal = new LongAdder();
+		LongAdder nextSignals = new LongAdder();
+		AtomicBoolean completeSignal = new AtomicBoolean(false);
+
+		Flux<Integer> flux = Flux.<Integer>error(new IllegalArgumentException("foo"))
+				.doOnEach(t -> nextSignals.increment(),
+						e -> errorSignal.increment(),
+						() -> completeSignal.set(true));
+
+		StepVerifier.create(flux)
+		            .expectSubscription()
+		            .expectErrorMessage("foo")
+		            .verify();
+
+		assertThat("no onNext expected", nextSignals.intValue(), is(0));
+		assertThat("expected onError", errorSignal.intValue(), is(1));
+		assertFalse("no onComplete expected", completeSignal.get());
+	}
+
+	@Test
+	public void testDoOnEachWithOnlyOneConsumer() {
+		Flux.just(1).doOnEach(t -> {}, null, null);
+		Flux.just(1).doOnEach(null, e -> {}, null);
+		Flux.just(1).doOnEach(null, null, () -> {});
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testDoOnEachNullConsumers() {
+		Flux.just(1).doOnEach(null, null, null);
+	}
 
 	@Test
 	public void testThenPublisherVoid() throws InterruptedException {


### PR DESCRIPTION
This is not the original ask from #264 but these `doOnEach` variants have value.