### PR TITLE
Fixes #275 Poor handling of RejectedExecutionException during processing

### DIFF
--- a/src/main/java/reactor/core/scheduler/ExecutorScheduler.java
+++ b/src/main/java/reactor/core/scheduler/ExecutorScheduler.java
@@ -47,12 +47,9 @@ final class ExecutorScheduler implements Scheduler {
 	public Cancellation schedule(Runnable task) {
 		Objects.requireNonNull(task, "task");
 		ExecutorPlainRunnable r = new ExecutorPlainRunnable(task);
-		try {
-			executor.execute(r);
-		}
-		catch (RejectedExecutionException ex) {
-			return REJECTED;
-		}
+
+		executor.execute(r);
+
 		return r;
 	}
 


### PR DESCRIPTION
@smaldini If exception is going to be bubbled, can we at least call hook