### PR TITLE
Fix typos in javadoc of multiple files and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Most of this cool stuff uses bounded ring buffer implementation under the hood t
 -------------------------------------
 
 ## Javadoc
-http://projectreactor.io/core/docs/api/
+https://projectreactor.io/docs/core/release/api/
 
 ## Getting started with Flux and Mono
 https://github.com/reactor/lite-rx-api-hands-on

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -558,7 +558,8 @@ public abstract class Flux<T> implements Publisher<T> {
      * <code></pre>
      *
 	 * @param <T> the value type
-	 * @param backpressure the backpressure mode, see {@link OverflowStrategy} for the avilable backpressure modes
+	 * @param backpressure the backpressure mode, see {@link OverflowStrategy} for the
+	 * available backpressure modes
 	 * @param emitter the consumer that will receive a FluxSink for each individual Subscriber.
 	 * @return a {@link Flux}
 	 */
@@ -569,7 +570,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	/**
 	 * Supply a {@link Publisher} everytime subscribe is called on the returned flux. The passed {@link Supplier}
 	 * will be invoked and it's up to the developer to choose to return a new instance of a {@link Publisher} or reuse
-	 * one effecitvely behaving like {@link #from(Publisher)}.
+	 * one effectively behaving like {@link #from(Publisher)}.
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/defer.png" alt="">
@@ -1877,7 +1878,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/bufferboundary.png"
 	 * alt="">
 	 *
-	 * @param other the other {@link Publisher}  to subscribe to for emiting and recycling receiving bucket
+	 * @param other the other {@link Publisher}  to subscribe to for emitting and recycling receiving bucket
 	 * @param bufferSupplier the collection to use for each data segment
 	 * @param <C> the supplied {@link Collection} type
 	 *
@@ -4342,7 +4343,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Prepare to consume this {@link Flux} on parallallism number of 'rails'
+	 * Prepare to consume this {@link Flux} on parallelism number of 'rails'
 	 * in round-robin fashion.
 	 *
 	 * <p>
@@ -4357,7 +4358,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Prepare to consume this {@link Flux} on parallallism number of 'rails'
+	 * Prepare to consume this {@link Flux} on parallelism number of 'rails'
 	 * in round-robin fashion and use custom prefetch amount and queue
 	 * for dealing with the source {@link Flux}'s values.
 	 *
@@ -4565,7 +4566,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/repeat.png" alt="">
 	 *
-	 * @return an indefinitively repeated {@link Flux} on onComplete
+	 * @return an indefinitely repeated {@link Flux} on onComplete
 	 */
 	public final Flux<T> repeat() {
 		return repeat(ALWAYS_BOOLEAN_SUPPLIER);

--- a/src/main/java/reactor/core/publisher/FluxDistinct.java
+++ b/src/main/java/reactor/core/publisher/FluxDistinct.java
@@ -36,7 +36,7 @@ import reactor.core.Trackable;
  * filters out duplicates.
  *
  * @param <T> the source value type
- * @param <K> the key extacted from the source value to be used for duplicate testing
+ * @param <K> the key extracted from the source value to be used for duplicate testing
  * @param <C> the collection type whose add() method is used for testing for duplicates
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */

--- a/src/main/java/reactor/core/publisher/FluxDistinctFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxDistinctFuseable.java
@@ -30,7 +30,7 @@ import reactor.core.publisher.FluxDistinct.DistinctFuseableSubscriber;
  * filters out duplicates.
  *
  * @param <T> the source value type
- * @param <K> the key extacted from the source value to be used for duplicate testing
+ * @param <K> the key extracted from the source value to be used for duplicate testing
  * @param <C> the collection type whose add() method is used for testing for duplicates
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */

--- a/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -43,7 +43,7 @@ import reactor.util.concurrent.QueueSupplier;
  * Abstract base class for Parallel publishers that take an array of Subscribers.
  * <p>
  * Use {@code from()} to start processing a regular Publisher in 'rails'. Use {@code
- * runOn()} to introduce where each 'rail' shoud run on thread-vise.
+ * runOn()} to introduce where each 'rail' should run on thread-vise.
  * Use {@code sequential()} to merge the sources back into a single {@link Flux} or if
  * you simply want to subscribe to the merged sequence use {@link #subscribe(Subscriber)}.
  *
@@ -68,7 +68,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Take a Publisher and prepare to consume it on parallallism number of 'rails' ,
+	 * Take a Publisher and prepare to consume it on parallelism number of 'rails' ,
 	 * possibly ordered and round-robin fashion.
 	 *
 	 * @param <T> the value type
@@ -85,7 +85,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Take a Publisher and prepare to consume it on parallallism number of 'rails'
+	 * Take a Publisher and prepare to consume it on parallelism number of 'rails'
 	 * and round-robin fashion and use custom prefetch amount and queue
 	 * for dealing with the source Publisher's values.
 	 *
@@ -154,7 +154,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	 *
 	 * @param <C> the collection type
 	 * @param collectionSupplier the supplier of the collection in each rail
-	 * @param collector the collector, taking the per-rali collection and the current
+	 * @param collector the collector, taking the per-rail collection and the current
 	 * item
 	 *
 	 * @return the new {@link ParallelFlux} instance
@@ -172,7 +172,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	 *
 	 * @param comparator the comparator to compare elements
 	 *
-	 * @return the new Flux instannce
+	 * @return the new Flux instance
 	 */
 	public final Mono<List<T>> collectSortedList(Comparator<? super T> comparator) {
 		return collectSortedList(comparator, 16);
@@ -187,7 +187,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	 * @param comparator the comparator to compare elements
 	 * @param capacityHint the expected number of total elements
 	 *
-	 * @return the new Mono instannce
+	 * @return the new Mono instance
 	 */
 	public final Mono<List<T>> collectSortedList(Comparator<? super T> comparator,
 			int capacityHint) {
@@ -710,7 +710,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	 * ParallelFlux's parallelism level is.
 	 * <p>
 	 * No assumptions are made about the Scheduler's parallelism level, if the Scheduler's
-	 * parallelism level is lwer than the ParallelFlux's, some rails may end up on
+	 * parallelism level is lower than the ParallelFlux's, some rails may end up on
 	 * the same thread/worker.
 	 * <p>
 	 * This operator doesn't require the Scheduler to be trampolining as it does its own
@@ -735,7 +735,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	 * ParallelFlux's parallelism level is.
 	 * <p>
 	 * No assumptions are made about the Scheduler's parallelism level, if the Scheduler's
-	 * parallelism level is lwer than the ParallelFlux's, some rails may end up on
+	 * parallelism level is lower than the ParallelFlux's, some rails may end up on
 	 * the same thread/worker.
 	 * <p>
 	 * This operator doesn't require the Scheduler to be trampolining as it does its own

--- a/src/main/java/reactor/core/publisher/Signal.java
+++ b/src/main/java/reactor/core/publisher/Signal.java
@@ -15,7 +15,6 @@
  */
 package reactor.core.publisher;
 
-import java.io.Serializable;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -72,7 +71,7 @@ public abstract class Signal<T> implements Supplier<T>, Consumer<Subscriber<? su
 
 	/**
 	 * @param o is the given object a complete {@link Signal}
-	 * @return true if completition signal
+	 * @return true if completion signal
 	 */
 	public static boolean isComplete(Object o){
 		return o == ON_COMPLETE;
@@ -80,7 +79,7 @@ public abstract class Signal<T> implements Supplier<T>, Consumer<Subscriber<? su
 
 	/**
 	 * @param o is the given object a complete {@link Signal}
-	 * @return true if completition signal
+	 * @return true if completion signal
 	 */
 	public static boolean isError(Object o){
 		return o instanceof Signal && ((Signal)o).getType() == SignalType.ON_ERROR;

--- a/src/main/java/reactor/core/publisher/TopicProcessor.java
+++ b/src/main/java/reactor/core/publisher/TopicProcessor.java
@@ -72,7 +72,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	/**
 	 * Create a new TopicProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and auto-cancel. <p> A new Cached ThreadExecutorPool will be
-	 * implicitely created.
+	 * implicitly created.
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
 	 */
@@ -84,7 +84,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 
 	/**
 	 * Create a new {@link TopicProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size, blockingWait
-	 * Strategy and auto-cancel. <p> A new Cached ThreadExecutorPool will be implicitely created.
+	 * Strategy and auto-cancel. <p> A new Cached ThreadExecutorPool will be implicitly created.
 	 * @param name processor thread logical name
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
@@ -97,7 +97,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	/**
 	 * Create a new TopicProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and the passed auto-cancel setting. <p> A new Cached
-	 * ThreadExecutorPool will be implicitely created.
+	 * ThreadExecutorPool will be implicitly created.
 	 * @param autoCancel Should this propagate cancellation when unregistered by all
 	 * subscribers ?
 	 * @param <E> Type of processed signals
@@ -141,7 +141,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	/**
 	 * Create a new TopicProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and the passed auto-cancel setting. <p> A new Cached
-	 * ThreadExecutorPool will be implicitely created and will use the passed name to
+	 * ThreadExecutorPool will be implicitly created and will use the passed name to
 	 * qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
@@ -202,7 +202,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 
 	/**
 	 * Create a new TopicProcessor using passed backlog size, wait strategy and will
-	 * auto-cancel. <p> A new Cached ThreadExecutorPool will be implicitely created and
+	 * auto-cancel. <p> A new Cached ThreadExecutorPool will be implicitly created and
 	 * will use the passed name to qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
@@ -220,7 +220,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	/**
 	 * Create a new TopicProcessor using passed backlog size, wait strategy, signal
 	 * supplier. The created processor is not shared and will auto-cancel. <p> A new
-	 * Cached ThreadExecutorPool will be implicitely created and will use the passed name
+	 * Cached ThreadExecutorPool will be implicitly created and will use the passed name
 	 * to qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
@@ -247,7 +247,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 
 	/**
 	 * Create a new TopicProcessor using passed backlog size, wait strategy and
-	 * auto-cancel settings. <p> A new Cached ThreadExecutorPool will be implicitely
+	 * auto-cancel settings. <p> A new Cached ThreadExecutorPool will be implicitly
 	 * created and will use the passed name to qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
@@ -318,7 +318,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * Create a new TopicProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and the passed auto-cancel setting. <p> A Shared Processor
 	 * authorizes concurrent onNext calls and is suited for multi-threaded publisher that
-	 * will fan-in data. <p> A new Cached ThreadExecutorPool will be implicitely created.
+	 * will fan-in data. <p> A new Cached ThreadExecutorPool will be implicitly created.
 	 * @param autoCancel Should this propagate cancellation when unregistered by all
 	 * subscribers ?
 	 * @param <E> Type of processed signals
@@ -366,7 +366,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * Create a new TopicProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and the passed auto-cancel setting. <p> A Shared Processor
 	 * authorizes concurrent onNext calls and is suited for multi-threaded publisher that
-	 * will fan-in data. <p> A new Cached ThreadExecutorPool will be implicitely created
+	 * will fan-in data. <p> A new Cached ThreadExecutorPool will be implicitly created
 	 * and will use the passed name to qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
@@ -435,7 +435,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * Create a new TopicProcessor using passed backlog size, wait strategy and will
 	 * auto-cancel. <p> A Shared Processor authorizes concurrent onNext calls and is
 	 * suited for multi-threaded publisher that will fan-in data. <p> A new Cached
-	 * ThreadExecutorPool will be implicitely created and will use the passed name to
+	 * ThreadExecutorPool will be implicitly created and will use the passed name to
 	 * qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
@@ -455,7 +455,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * signal supplier. The created processor will auto-cancel and is shared. <p> A Shared
 	 * Processor authorizes concurrent onNext calls and is suited for multi-threaded
 	 * publisher that will fan-in data. <p> A new Cached ThreadExecutorPool will be
-	 * implicitely created and will use the passed name to qualify the created threads.
+	 * implicitly created and will use the passed name to qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
 	 * @param bufferSize A Backlog Size to mitigate slow subscribers
@@ -474,7 +474,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * signal supplier. The created processor will auto-cancel and is shared. <p> A Shared
 	 * Processor authorizes concurrent onNext calls and is suited for multi-threaded
 	 * publisher that will fan-in data. <p> A new Cached ThreadExecutorPool will be
-	 * implicitely created and will use the passed name to qualify the created threads.
+	 * implicitly created and will use the passed name to qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
 	 * @param bufferSize A Backlog Size to mitigate slow subscribers
@@ -501,7 +501,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * Create a new TopicProcessor using passed backlog size, wait strategy and
 	 * auto-cancel settings. <p> A Shared Processor authorizes concurrent onNext calls and
 	 * is suited for multi-threaded publisher that will fan-in data. <p> A new Cached
-	 * ThreadExecutorPool will be implicitely created and will use the passed name to
+	 * ThreadExecutorPool will be implicitly created and will use the passed name to
 	 * qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads

--- a/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
+++ b/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
@@ -66,7 +66,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	/**
 	 * Create a new WorkQueueProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and auto-cancel. <p> A new Cached ThreadExecutorPool will be
-	 * implicitely created.
+	 * implicitly created.
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
 	 */
@@ -79,7 +79,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	/**
 	 * Create a new WorkQueueProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and the passed auto-cancel setting. <p> A new Cached
-	 * ThreadExecutorPool will be implicitely created.
+	 * ThreadExecutorPool will be implicitly created.
 	 * @param autoCancel Should this propagate cancellation when unregistered by all
 	 * subscribers ?
 	 * @param <E> Type of processed signals
@@ -123,7 +123,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 
 	/**
 	 * Create a new TopicProcessor using the default buffer size 32, blockingWait
-	 * Strategy and auto-cancel. <p> A new Cached ThreadExecutorPool will be implicitely
+	 * Strategy and auto-cancel. <p> A new Cached ThreadExecutorPool will be implicitly
 	 * created and will use the passed name to qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
@@ -136,7 +136,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 
 	/**
 	 * Create a new TopicProcessor using the passed buffer size, blockingWait
-	 * Strategy and auto-cancel. <p> A new Cached ThreadExecutorPool will be implicitely
+	 * Strategy and auto-cancel. <p> A new Cached ThreadExecutorPool will be implicitly
 	 * created and will use the passed name to qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
@@ -151,7 +151,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	/**
 	 * Create a new TopicProcessor using the passed buffer size, blockingWait
 	 * Strategy and the passed auto-cancel setting. <p> A new Cached ThreadExecutorPool
-	 * will be implicitely created and will use the passed name to qualify the created
+	 * will be implicitly created and will use the passed name to qualify the created
 	 * threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
@@ -198,7 +198,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 
 	/**
 	 * Create a new WorkQueueProcessor using the passed buffer size, blockingWait
-	 * Strategy and auto-cancel. <p> A new Cached ThreadExecutorPool will be implicitely
+	 * Strategy and auto-cancel. <p> A new Cached ThreadExecutorPool will be implicitly
 	 * created and will use the passed name to qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
@@ -216,7 +216,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	/**
 	 * Create a new WorkQueueProcessor using the passed buffer size, blockingWait
 	 * Strategy and auto-cancel settings. <p> A new Cached ThreadExecutorPool will be
-	 * implicitely created and will use the passed name to qualify the created threads.
+	 * implicitly created and will use the passed name to qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
 	 * @param bufferSize A Backlog Size to mitigate slow subscribers
@@ -280,7 +280,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * Create a new WorkQueueProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and the passed auto-cancel setting. <p> A Shared Processor
 	 * authorizes concurrent onNext calls and is suited for multi-threaded publisher that
-	 * will fan-in data. <p> A new Cached ThreadExecutorPool will be implicitely created.
+	 * will fan-in data. <p> A new Cached ThreadExecutorPool will be implicitly created.
 	 * @param autoCancel Should this propagate cancellation when unregistered by all
 	 * subscribers ?
 	 * @param <E> Type of processed signals
@@ -327,7 +327,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * Create a new TopicProcessor using the passed buffer size, blockingWait
 	 * Strategy and auto-cancel. <p> A Shared Processor authorizes concurrent onNext calls
 	 * and is suited for multi-threaded publisher that will fan-in data. <p> A new Cached
-	 * ThreadExecutorPool will be implicitely created and will use the passed name to
+	 * ThreadExecutorPool will be implicitly created and will use the passed name to
 	 * qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
@@ -343,7 +343,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * Create a new TopicProcessor using the passed buffer size, blockingWait
 	 * Strategy and the passed auto-cancel setting. <p> A Shared Processor authorizes
 	 * concurrent onNext calls and is suited for multi-threaded publisher that will fan-in
-	 * data. <p> A new Cached ThreadExecutorPool will be implicitely created and will use
+	 * data. <p> A new Cached ThreadExecutorPool will be implicitly created and will use
 	 * the passed name to qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
@@ -396,7 +396,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * Create a new WorkQueueProcessor using the passed buffer size, blockingWait
 	 * Strategy and auto-cancel. <p> A Shared Processor authorizes concurrent onNext calls
 	 * and is suited for multi-threaded publisher that will fan-in data. <p> A new Cached
-	 * ThreadExecutorPool will be implicitely created and will use the passed name to
+	 * ThreadExecutorPool will be implicitly created and will use the passed name to
 	 * qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
@@ -415,7 +415,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * Create a new WorkQueueProcessor using the passed buffer size, blockingWait
 	 * Strategy and auto-cancel settings. <p> A Shared Processor authorizes concurrent
 	 * onNext calls and is suited for multi-threaded publisher that will fan-in data. <p>
-	 * A new Cached ThreadExecutorPool will be implicitely created and will use the passed
+	 * A new Cached ThreadExecutorPool will be implicitly created and will use the passed
 	 * name to qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads

--- a/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -18,7 +18,7 @@ package reactor.core.scheduler;
 import reactor.core.Cancellation;
 
 /**
- * Provides an abstract asychronous boundary to operators.
+ * Provides an abstract asynchronous boundary to operators.
  */
 public interface Scheduler {
 	/**

--- a/src/main/java/reactor/core/scheduler/TimedScheduler.java
+++ b/src/main/java/reactor/core/scheduler/TimedScheduler.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 import reactor.core.Cancellation;
 
 /**
- * Provides an abstract, timed asychronous boundary to operators.
+ * Provides an abstract, timed asynchronous boundary to operators.
  */
 public interface TimedScheduler extends Scheduler {
 	

--- a/src/main/java/reactor/util/concurrent/WaitStrategy.java
+++ b/src/main/java/reactor/util/concurrent/WaitStrategy.java
@@ -188,7 +188,7 @@ public abstract class WaitStrategy
     /**
      * Wait for the given sequence to be available.  It is possible for this method to return a value
      * less than the sequence number supplied depending on the implementation of the WaitStrategy.  A common
-     * use for this is to signal a timeout.  Any EventProcessor that is using a WaitStragegy to get notifications
+     * use for this is to signal a timeout.  Any EventProcessor that is using a WaitStrategy to get notifications
      * about message becoming available should remember to handle this case.
      *
      * @param sequence to be waited on.

--- a/src/main/java/reactor/util/function/Tuple2.java
+++ b/src/main/java/reactor/util/function/Tuple2.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
  * A tuple that holds two values
  *
  * @param <T1> The type of the first value held by this tuple
- * @param <T2> The type of the second balue held by this tuple
+ * @param <T2> The type of the second value held by this tuple
  * @author Jon Brisbin
  * @author Stephane Maldini
  */
@@ -36,8 +36,8 @@ public class Tuple2<T1, T2> implements Iterable, Serializable {
 
 	/** */
     private static final long serialVersionUID = 4839927936743208499L;
-    
-    final T1 t1;
+
+	final T1 t1;
 	final T2 t2;
 
 	Tuple2(T1 t1, T2 t2) {

--- a/src/test/java/reactor/core/publisher/tck/EmitterProcessorVerification.java
+++ b/src/test/java/reactor/core/publisher/tck/EmitterProcessorVerification.java
@@ -20,13 +20,12 @@ import java.util.concurrent.TimeUnit;
 import org.reactivestreams.Processor;
 import org.testng.annotations.AfterClass;
 import reactor.core.publisher.EmitterProcessor;
-import reactor.core.publisher.FluxProcessor;
 
 /**
  * @author Stephane Maldini
  */
 @org.testng.annotations.Test
-public class EmitterProcessorVerficiation extends AbstractProcessorVerification {
+public class EmitterProcessorVerification extends AbstractProcessorVerification {
 
 	@Override
 	public Processor<Long, Long> createProcessor(int bufferSize) {

--- a/src/test/java/reactor/test/subscriber/AssertSubscriber.java
+++ b/src/test/java/reactor/test/subscriber/AssertSubscriber.java
@@ -319,7 +319,7 @@ public class AssertSubscriber<T>
 				T t2 = expected.next();
 				if (!values.contains(t2)) {
 					throw new AssertionError("The element is not contained in the " +
-							"received resuls" +
+							"received results" +
 							" = " + valueAndClass(t2), null);
 				}
 			}
@@ -955,7 +955,7 @@ public class AssertSubscriber<T>
 	}
 
 	/**
-	 * Setup what fusion mode should be requested from the incomining
+	 * Setup what fusion mode should be requested from the incoming
 	 * Subscription if it happens to be QueueSubscription
 	 * @param requestMode the mode to request, see Fuseable constants
 	 * @return this


### PR DESCRIPTION
- correct typos in javadoc
- modify the link of reactor-core javadoc in README.md