### PR TITLE
Fix 4 bugs with Mono.sequenceEqual

### DIFF
--- a/src/main/java/reactor/core/publisher/MonoSequenceEqual.java
+++ b/src/main/java/reactor/core/publisher/MonoSequenceEqual.java
@@ -51,6 +51,7 @@ final class MonoSequenceEqual<T> extends Mono<Boolean> {
 	@Override
 	public void subscribe(Subscriber<? super Boolean> s) {
 		EqualCoordinator<T> ec = new EqualCoordinator<>(s, bufferSize, first, second, comparer);
+		s.onSubscribe(ec);
 		ec.subscribe();
 	}
 

--- a/src/test/java/reactor/core/publisher/MonoSequenceEqualTest.java
+++ b/src/test/java/reactor/core/publisher/MonoSequenceEqualTest.java
@@ -15,11 +15,126 @@
  */
 package reactor.core.publisher;
 
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
+
+import org.junit.Assert;
 import org.junit.Test;
+import org.reactivestreams.Subscription;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+import reactor.util.concurrent.QueueSupplier;
 
 public class MonoSequenceEqualTest {
 
 	@Test
-	public void normal() {
+	public void sequenceEquals() {
+		StepVerifier.create(Mono.sequenceEqual(
+						Flux.just("one", "two", "three"),
+						Flux.just("one", "two", "three")))
+		            .expectNext(Boolean.TRUE)
+		            .verifyComplete();
 	}
+
+	@Test
+	public void sequenceLongerLeft() {
+		StepVerifier.create(Mono.sequenceEqual(
+						Flux.just("one", "two", "three", "four"),
+						Flux.just("one", "two", "three")))
+		            .expectNext(Boolean.FALSE)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void sequenceLongerRight() {
+		StepVerifier.create(Mono.sequenceEqual(
+						Flux.just("one", "two", "three"),
+						Flux.just("one", "two", "three", "four")))
+		            .expectNext(Boolean.FALSE)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void sequenceErrorsLeft() {
+		StepVerifier.create(Mono.sequenceEqual(
+						Flux.just("one", "two").concatWith(Mono.error(new IllegalStateException())),
+						Flux.just("one", "two", "three")))
+		            .verifyError(IllegalStateException.class);
+	}
+
+	@Test
+	public void sequenceErrorsRight() {
+		StepVerifier.create(Mono.sequenceEqual(
+						Flux.just("one", "two", "three"),
+						Flux.just("one", "two").concatWith(Mono.error(new IllegalStateException()))))
+		            .verifyError(IllegalStateException.class);
+	}
+
+	@Test
+	public void sequenceErrorsBothPropagatesLeftError() {
+		StepVerifier.create(Mono.sequenceEqual(
+						Flux.just("one", "two", "three").concatWith(Mono.error(new IllegalArgumentException("left"))).hide(),
+						Flux.just("one", "two").concatWith(Mono.error(new IllegalArgumentException("right"))).hide()))
+		            .verifyErrorMessage("left");
+	}
+
+	@Test
+	public void sequenceEmptyLeft() {
+		StepVerifier.create(Mono.sequenceEqual(
+				Flux.empty(),
+				Flux.just("one", "two", "three")))
+		            .expectNext(Boolean.FALSE)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void sequenceEmptyRight() {
+		StepVerifier.create(Mono.sequenceEqual(
+				Flux.just("one", "two", "three"),
+				Flux.empty()))
+		            .expectNext(Boolean.FALSE)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void sequenceEmptyBoth() {
+		StepVerifier.create(Mono.sequenceEqual(
+				Flux.empty(),
+				Flux.empty()))
+		            .expectNext(Boolean.TRUE)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void equalPredicateFailure() {
+		StepVerifier.create(Mono.sequenceEqual(Mono.just("one"), Mono.just("one"),
+						(s1, s2) -> { throw new IllegalStateException("boom"); }))
+		            .verifyErrorMessage("boom");
+	}
+
+	@Test
+	public void largeSequence() {
+		Flux<Integer> source = Flux.range(1, QueueSupplier.SMALL_BUFFER_SIZE * 4).subscribeOn(Schedulers.elastic());
+
+		StepVerifier.create(Mono.sequenceEqual(source, source))
+		            .expectNext(Boolean.TRUE)
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(5));
+	}
+
+		@Test
+	public void syncFusedCrash() {
+		Flux<Integer> source = Flux.range(1, 10).map(i -> { throw new IllegalArgumentException("boom"); });
+
+		StepVerifier.create(Mono.sequenceEqual(source, Flux.range(1, 10).hide()))
+		            .verifyErrorMessage("boom");
+
+		StepVerifier.create(Mono.sequenceEqual(Flux.range(1, 10).hide(), source))
+		            .verifyErrorMessage("boom");
+	}
+
+	//TODO multithreaded race between cancel and onNext, between cancel and drain, source overflow, error dropping to hook
 }

--- a/src/test/java/reactor/core/publisher/MonoSequenceEqualTest.java
+++ b/src/test/java/reactor/core/publisher/MonoSequenceEqualTest.java
@@ -76,9 +76,22 @@ public class MonoSequenceEqualTest {
 	@Test
 	public void sequenceErrorsBothPropagatesLeftError() {
 		StepVerifier.create(Mono.sequenceEqual(
-						Flux.just("one", "two", "three").concatWith(Mono.error(new IllegalArgumentException("left"))).hide(),
+						Flux.just("one", "two", "three", "four").concatWith(Mono.error(new IllegalArgumentException("left"))).hide(),
 						Flux.just("one", "two").concatWith(Mono.error(new IllegalArgumentException("right"))).hide()))
 		            .verifyErrorMessage("left");
+	}
+
+	@Test
+	public void sequenceErrorsBothPropagatesLeftErrorWithSmallRequest() {
+		StepVerifier.create(Mono.sequenceEqual(
+						Flux.just("one", "two", "three", "four")
+						    .concatWith(Mono.error(new IllegalArgumentException("left")))
+						    .hide(),
+						Flux.just("one", "two")
+						    .concatWith(Mono.error(new IllegalArgumentException("right")))
+						    .hide(),
+						Objects::equals, 1))
+		            .verifyErrorMessage("right");
 	}
 
 	@Test
@@ -145,7 +158,7 @@ public class MonoSequenceEqualTest {
 		Flux<Integer> source1 = Flux.range(1, 5).doOnCancel(() -> sub1.set(true));
 		Flux<Integer> source2 = Flux.just(1, 2, 3, 7, 8).doOnCancel(() -> sub2.set(true));
 
-		StepVerifier.create(Mono.sequenceEqual(source1.log(), source2.log()))
+		StepVerifier.create(Mono.sequenceEqual(source1, source2))
 		            .expectNext(Boolean.FALSE)
 		            .verifyComplete();
 


### PR DESCRIPTION
#328: no subscription signal
 #329:
  - no cancellation of right inner
  - no cancellation of inners when draining (eg on completion of 1 source)
  - requesting before subscribe leads to double subscription of inners