### PR TITLE
Fix #338 - Exception when trying to zip an iterable of several FluxJust-s

### DIFF
--- a/src/main/java/reactor/util/function/Tuples.java
+++ b/src/main/java/reactor/util/function/Tuples.java
@@ -50,6 +50,8 @@ public abstract class Tuples implements Function {
 				return of(list[0], list[1], list[2], list[3], list[4], list[5]);
 			case 7:
 				return of(list[0], list[1], list[2], list[3], list[4], list[5], list[6]);
+			case 8:
+				return of(list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7]);
 		}
 		throw new IllegalArgumentException("too many arguments ("+list.length+"), 8 " +
 				"maximum supported");

--- a/src/test/java/reactor/util/function/TupleTests.java
+++ b/src/test/java/reactor/util/function/TupleTests.java
@@ -65,5 +65,16 @@ public class TupleTests {
 		assertThat("Tuples of different length are not equal.", t2, is(Matchers.not((Tuple2<String, Long>) t3)));
 	}
 
+	@Test
+	public void tuplesCanBeCreatedFromAnArrayOfLength8() {
+		Tuple2 tuple2 = Tuples.fromArray(new Object[8]);
+		assertThat("Tuple created from array of length 8 is Tuple8", Tuple8.class.isInstance(tuple2));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void tuplesCanNotBeCreatedFromAnArrayLongerThen8() {
+		Tuples.fromArray(new Object[9]);
+	}
+
 
 }


### PR DESCRIPTION
Fix issue #338, which is about getting IllegalArgumentException from Tuples::fromArray method, when it is called from FluxZip::handleBoth

Make Tuples create Tuple8 from array of length 8