### PR TITLE
fix #283 Add transformGroup to ParallelFlux

### DIFF
--- a/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -40,12 +40,18 @@ import reactor.util.Logger;
 import reactor.util.concurrent.QueueSupplier;
 
 /**
- * Abstract base class for Parallel publishers that take an array of Subscribers.
+ * A ParallelFlux publishes to an array of Subscribers, in parallel 'rails' (or
+ * {@link #groups() 'groups'}).
  * <p>
- * Use {@code from()} to start processing a regular Publisher in 'rails'. Use {@code
- * runOn()} to introduce where each 'rail' should run on thread-vise.
- * Use {@code sequential()} to merge the sources back into a single {@link Flux} or if
- * you simply want to subscribe to the merged sequence use {@link #subscribe(Subscriber)}.
+ * Use {@code from()} to start processing a regular Publisher in 'rails', which each
+ * cover a subset of the original Publisher's data. {@link Flux#parallel()} is a
+ * convenient shortcut to achieve that on a {@link Flux}. Use {@code runOn()} to
+ * introduce where each 'rail' should run on thread-vise.
+ * Use {@code sequential()} to merge the sources back into a single {@link Flux} or
+ * {@link #subscribe(Subscriber)} if you simply want to subscribe to the merged sequence.
+ * Note that other variants like {@link #subscribe(Consumer)} instead do multiple
+ * subscribes, one on each rail (which means that the lambdas should be as stateless and
+ * side-effect free as possible).
  *
  * @param <T> the value type
  */
@@ -1049,6 +1055,12 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 		return -1L;
 	}
 
+	/**
+	 * Merge the rails into a {@link #sequential()} Flux and
+	 * {@link Flux#subscribe(Subscriber) subscribe} to said Flux.
+	 *
+	 * @param s the subscriber to use on {@link #sequential()} Flux
+	 */
 	@Override
 	public final void subscribe(Subscriber<? super T> s) {
 		sequential().subscribe(s);

--- a/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -947,6 +947,23 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	}
 
 	/**
+	 * Allows transformation of the 'rails', as individual {@link GroupedFlux} instances keyed by
+	 * the rail index (zero based). The transformed groups are {@link Flux#parallel parallelized} back
+	 * once the transformation has been applied.
+	 * <p>
+	 * Note that like in {@link #groups()}, requests and cancellation compose through, and
+	 * cancelling only one rail may result in undefined behavior.
+	 *
+	 * @param transformer the transformation function to apply on each {@link GroupedFlux rail}
+	 * @param <U> the type of the resulting parallelized flux
+	 * @return a {@link ParallelFlux} of the transformed groups
+	 */
+	public final <U> ParallelFlux<U> transformGroup(Function<? super GroupedFlux<Integer, T>,
+			? extends Publisher<? extends U>> transformer) {
+		return from(groups().flatMap(transformer::apply));
+	}
+
+	/**
 	 * Validates the number of subscribers and returns true if their number matches the
 	 * parallelism level of this ParallelFlux.
 	 *

--- a/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -947,20 +947,20 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Allows transformation of the 'rails', as individual {@link GroupedFlux} instances keyed by
-	 * the rail index (zero based). The transformed groups are {@link Flux#parallel parallelized} back
+	 * Allows composing operators off the 'rails', as individual {@link GroupedFlux} instances keyed by
+	 * the zero based rail's index. The transformed groups are {@link Flux#parallel parallelized} back
 	 * once the transformation has been applied.
 	 * <p>
 	 * Note that like in {@link #groups()}, requests and cancellation compose through, and
 	 * cancelling only one rail may result in undefined behavior.
 	 *
-	 * @param transformer the transformation function to apply on each {@link GroupedFlux rail}
+	 * @param composer the composition function to apply on each {@link GroupedFlux rail}
 	 * @param <U> the type of the resulting parallelized flux
-	 * @return a {@link ParallelFlux} of the transformed groups
+	 * @return a {@link ParallelFlux} of the composed groups
 	 */
-	public final <U> ParallelFlux<U> transformGroup(Function<? super GroupedFlux<Integer, T>,
-			? extends Publisher<? extends U>> transformer) {
-		return from(groups().flatMap(transformer::apply));
+	public final <U> ParallelFlux<U> composeGroup(Function<? super GroupedFlux<Integer, T>,
+			? extends Publisher<? extends U>> composer) {
+		return from(groups().flatMap(composer::apply));
 	}
 
 	/**

--- a/src/test/java/reactor/core/publisher/ParallelFluxTest.java
+++ b/src/test/java/reactor/core/publisher/ParallelFluxTest.java
@@ -539,15 +539,15 @@ public class ParallelFluxTest {
 
 
 	@Test
-	public void transformGroup() {
+	public void composeGroup() {
 		Set<Integer> values = new ConcurrentSkipListSet<>();
 
 		Flux<Integer> flux = Flux.range(1, 10)
 		                         .parallel(3)
 		                         .runOn(Schedulers.parallel())
 		                         .doOnNext(values::add)
-		                         .transformGroup(p -> p.log("rail" + p.key())
-		                                               .map(i -> (p.key() + 1) * 100 + i))
+		                         .composeGroup(p -> p.log("rail" + p.key())
+		                                             .map(i -> (p.key() + 1) * 100 + i))
 		                         .sequential();
 
 		StepVerifier.create(flux.sort())

--- a/src/test/java/reactor/core/publisher/ParallelFluxTest.java
+++ b/src/test/java/reactor/core/publisher/ParallelFluxTest.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -536,4 +537,30 @@ public class ParallelFluxTest {
 		          .withMessage("Multiple completions: 3");
 	}
 
+
+	@Test
+	public void transformGroup() {
+		Set<Integer> values = new ConcurrentSkipListSet<>();
+
+		Flux<Integer> flux = Flux.range(1, 10)
+		                         .parallel(3)
+		                         .runOn(Schedulers.parallel())
+		                         .doOnNext(values::add)
+		                         .transformGroup(p -> p.log("rail" + p.key())
+		                                               .map(i -> (p.key() + 1) * 100 + i))
+		                         .sequential();
+
+		StepVerifier.create(flux.sort())
+		            .assertNext(i -> Assertions.assertThat(i - 100).isBetween(1, 10))
+		            .thenConsumeWhile(i -> i / 100 == 1)
+		            .assertNext(i -> Assertions.assertThat(i - 200).isBetween(1, 10))
+		            .thenConsumeWhile(i -> i / 100 == 2)
+		            .assertNext(i -> Assertions.assertThat(i - 300).isBetween(1, 10))
+		            .thenConsumeWhile(i -> i / 100 == 3)
+		            .verifyComplete();
+
+		Assertions.assertThat(values)
+				.hasSize(10)
+	            .contains(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+	}
 }


### PR DESCRIPTION
@dfeist as suggested by @smaldini, went the `GroupedFlux` way hence the renaming to `transformGroup`.

Btw @smaldini I wonder if `transform` prefix is correct, isn't it closer to a `compose`, through the use of `groups()` and `flatMap()`?