### PR TITLE
fix #351 CachedTimedScheduler.now() delegates to underlying

### DIFF
--- a/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -778,5 +778,10 @@ public class Schedulers {
 		public TimedScheduler get() {
 			return cachedTimed;
 		}
+
+		@Override
+		public long now(TimeUnit unit) {
+			return cachedTimed.now(unit);
+		}
 	}
 }


### PR DESCRIPTION
Found through [this stackoverflow question](http://stackoverflow.com/questions/41553604/mono-elapse-does-not-work-with-stepverifier/)