### PR TITLE
fix #357 Add fromCompletionStage generalization of fromFuture

### DIFF
--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -349,17 +349,33 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
+	 * Create a {@link Mono} producing the value for the {@link Mono} using the given {@link CompletionStage}.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/fromfuture.png" alt="">
+	 * <p>
+	 * @param completionStage {@link CompletionStage} that will produce the value or null to
+	 * complete immediately
+	 * @param <T> type of the expected value
+	 * @return A {@link Mono}.
+	 */
+	public static <T> Mono<T> fromCompletionStage(CompletionStage<? extends T> completionStage) {
+		return onAssembly(new MonoCompletionStage<>(completionStage));
+	}
+
+	/**
 	 * Create a {@link Mono} producing the value for the {@link Mono} using the given {@link CompletableFuture}.
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/fromfuture.png" alt="">
 	 * <p>
-	 * @param future {@link CompletionStage} that will produce the value or null to
+	 * @param future {@link CompletableFuture} that will produce the value or null to
 	 * complete immediately
 	 * @param <T> type of the expected value
 	 * @return A {@link Mono}.
+	 * @see #fromCompletionStage(CompletionStage) fromCompletionStage for a generalization
 	 */
-	public static <T> Mono<T> fromFuture(CompletionStage<? extends T> future) {
+	public static <T> Mono<T> fromFuture(CompletableFuture<? extends T> future) {
 		return onAssembly(new MonoCompletionStage<>(future));
 	}
 

--- a/src/test/java/reactor/core/publisher/MonoCompletionStageTest.java
+++ b/src/test/java/reactor/core/publisher/MonoCompletionStageTest.java
@@ -16,6 +16,12 @@
 package reactor.core.publisher;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.junit.Test;
 
@@ -30,5 +36,13 @@ public class MonoCompletionStageTest {
 
 		assertThat(Mono.fromFuture(f)
 		               .block()).isEqualToIgnoringCase("helloFuture");
+	}
+
+	@Test
+	public void fromCompletionStage() {
+		CompletionStage<String> completionStage = CompletableFuture.supplyAsync(() -> "helloFuture");
+
+		assertThat(Mono.fromCompletionStage(completionStage).block())
+				.isEqualTo("helloFuture");
 	}
 }


### PR DESCRIPTION
Both are kept as fromFuture is likely to have better discoverability,
but this adds the option to use different other kind of "futures" that
just implement CompletionStage.