### PR TITLE
Introduce Mono.delayElement, prepare move to Flux.delayElements

### DIFF
--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -2845,10 +2845,16 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param delay duration to delay each {@link Subscriber#onNext} call
 	 *
 	 * @return a throttled {@link Flux}
-	 *
+	 * @deprecated will be replaced by {@link #delayElements(Duration)} in 3.1.0
+	 * @see #delaySubscription(Duration) delaySubscription to introduce a delay at the beginning of the sequence only
 	 */
+	@Deprecated
 	public final Flux<T> delay(Duration delay) {
-		return delayMillis(delay.toMillis());
+		return delayElements(delay);
+	}
+
+	public final Flux<T> delayElements(Duration delay) {
+		return delayElementsMillis(delay.toMillis());
 	}
 
 	/**
@@ -2862,8 +2868,13 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a throttled {@link Flux}
 	 *
 	 */
+	@Deprecated
 	public final Flux<T> delayMillis(long delay) {
-		return delayMillis(delay, Schedulers.timer());
+		return delayElementsMillis(delay);
+	}
+
+	public final Flux<T> delayElementsMillis(long delay) {
+		return delayElementsMillis(delay, Schedulers.timer());
 	}
 
 	/**
@@ -2878,7 +2889,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a throttled {@link Flux}
 	 *
 	 */
+	@Deprecated
 	public final Flux<T> delayMillis(long delay, TimedScheduler timer) {
+		return delayElementsMillis(delay, timer);
+	}
+	public final Flux<T> delayElementsMillis(long delay, TimedScheduler timer) {
 		return concatMap(t ->  Mono.delayMillis(delay, timer).map(i -> t));
 	}
 

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -2837,14 +2837,14 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Delay this {@link Flux} signals to {@link Subscriber#onNext} until the given period elapses.
+	 * Delay each of this {@link Flux} elements ({@link Subscriber#onNext} signals)
+	 * by a given duration.
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/delayonnext.png" alt="">
 	 *
-	 * @param delay duration to delay each {@link Subscriber#onNext} call
-	 *
-	 * @return a throttled {@link Flux}
+	 * @param delay duration to delay each {@link Subscriber#onNext} signal
+	 * @return a delayed {@link Flux}
 	 * @deprecated will be replaced by {@link #delayElements(Duration)} in 3.1.0
 	 * @see #delaySubscription(Duration) delaySubscription to introduce a delay at the beginning of the sequence only
 	 */
@@ -2853,46 +2853,79 @@ public abstract class Flux<T> implements Publisher<T> {
 		return delayElements(delay);
 	}
 
+	/**
+	 * Delay each of this {@link Flux} elements ({@link Subscriber#onNext} signals)
+	 * by a given duration.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/delayonnext.png" alt="">
+	 *
+	 * @param delay duration to delay each {@link Subscriber#onNext} signal
+	 * @return a delayed {@link Flux}
+	 * @see #delaySubscription(Duration) delaySubscription to introduce a delay at the beginning of the sequence only
+	 */
 	public final Flux<T> delayElements(Duration delay) {
 		return delayElementsMillis(delay.toMillis());
 	}
 
 	/**
-	 * Delay this {@link Flux} signals to {@link Subscriber#onNext} until the given period in milliseconds elapses.
+	 * Delay each of this {@link Flux} elements ({@link Subscriber#onNext} signals)
+	 * by a given duration in milliseconds.
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/delayonnext.png" alt="">
 	 *
-	 * @param delay period to delay each {@link Subscriber#onNext} call in milliseconds
-	 *
-	 * @return a throttled {@link Flux}
-	 *
+	 * @param delay period to delay each {@link Subscriber#onNext} signal, in milliseconds
+	 * @deprecated will be replaced by {@link #delayElementsMillis(long)} in 3.1.0
+	 * @return a delayed {@link Flux}
 	 */
 	@Deprecated
 	public final Flux<T> delayMillis(long delay) {
 		return delayElementsMillis(delay);
 	}
 
+	/**
+	 * Delay each of this {@link Flux} elements ({@link Subscriber#onNext} signals)
+	 * by a given duration in milliseconds.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/delayonnext.png" alt="">
+	 *
+	 * @param delay period to delay each {@link Subscriber#onNext} signal, in milliseconds
+	 * @return a delayed {@link Flux}
+	 */
 	public final Flux<T> delayElementsMillis(long delay) {
 		return delayElementsMillis(delay, Schedulers.timer());
 	}
 
 	/**
-	 * Delay this {@link Flux} signals to {@link Subscriber#onNext} until the given period in milliseconds elapses.
+	 * Delay each of this {@link Flux} elements ({@link Subscriber#onNext} signals)
+	 * by a given duration in milliseconds.
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/delayonnext.png" alt="">
 	 *
-	 * @param delay period to delay each {@link Subscriber#onNext} call in milliseconds
+	 * @param delay period to delay each {@link Subscriber#onNext} signal, in milliseconds
 	 * @param timer the timed scheduler to use for delaying each signal
-	 *
-	 * @return a throttled {@link Flux}
-	 *
+	 * @deprecated will be replaced by {@link #delayElementsMillis(long, TimedScheduler)} in 3.1.0
+	 * @return a delayed {@link Flux}
 	 */
 	@Deprecated
 	public final Flux<T> delayMillis(long delay, TimedScheduler timer) {
 		return delayElementsMillis(delay, timer);
 	}
+
+	/**
+	 * Delay each of this {@link Flux} elements ({@link Subscriber#onNext} signals)
+	 * by a given duration in milliseconds.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/delayonnext.png" alt="">
+	 *
+	 * @param delay period to delay each {@link Subscriber#onNext} signal, in milliseconds
+	 * @param timer the timed scheduler to use for delaying each signal
+	 * @return a delayed {@link Flux}
+	 */
 	public final Flux<T> delayElementsMillis(long delay, TimedScheduler timer) {
 		return concatMap(t ->  Mono.delayMillis(delay, timer).map(i -> t));
 	}

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -1328,16 +1328,62 @@ public abstract class Mono<T> implements Publisher<T> {
 		return onAssembly(new MonoDefaultIfEmpty<>(this, defaultV));
 	}
 
+	/**
+	 * Delay this {@link Flux} element ({@link Subscriber#onNext} signal) by a given
+	 * duration. Empty monos or error signals are not delayed.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/delayonnext.png" alt="">
+	 *
+	 * <p>
+	 * Note that the scheduler on which the mono chain continues execution will be the
+	 * time scheduler used if the mono is valued, or the current scheduler if the mono
+	 * completes empty or errors.
+	 *
+	 * @param delay period to delay each {@link Subscriber#onNext} signal
+	 * @return a delayed {@link Mono}
+	 */
 	public final Mono<T> delayElement(Duration delay) {
 		return delayElementMillis(delay.toMillis());
 	}
 
+	/**
+	 * Delay this {@link Flux} element ({@link Subscriber#onNext} signal) by a given
+	 * duration, in milliseconds. Empty monos or error signals are not delayed.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/delayonnext.png" alt="">
+	 *
+	 * <p>
+	 * Note that the scheduler on which the mono chain continues execution will be the
+	 * time scheduler used if the mono is valued, or the current scheduler if the mono
+	 * completes empty or errors.
+	 *
+	 * @param delay period to delay each {@link Subscriber#onNext} signal, in milliseconds
+	 * @return a delayed {@link Mono}
+	 */
 	public final Mono<T> delayElementMillis(long delay) {
 		return delayElementMillis(delay, Schedulers.timer());
 	}
 
-	public final Mono<T> delayElementMillis(long delay, TimedScheduler timerScheduler) {
-		return new MonoDelayElement(this, delay, TimeUnit.MILLISECONDS, timerScheduler);
+	/**
+	 * Delay this {@link Flux} element ({@link Subscriber#onNext} signal) by a given
+	 * duration, in milliseconds. Empty monos or error signals are not delayed.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/delayonnext.png" alt="">
+	 *
+	 * <p>
+	 * Note that the scheduler on which the mono chain continues execution will be the
+	 * time scheduler used if the mono is valued, or the current scheduler if the mono
+	 * completes empty or errors.
+	 *
+	 * @param delay period to delay each {@link Subscriber#onNext} signal, in milliseconds
+	 * @param timer the timed scheduler to use for delaying the value signal
+	 * @return a delayed {@link Mono}
+	 */
+	public final Mono<T> delayElementMillis(long delay, TimedScheduler timer) {
+		return onAssembly(new MonoDelayElement<>(this, delay, TimeUnit.MILLISECONDS, timer));
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -1328,6 +1328,17 @@ public abstract class Mono<T> implements Publisher<T> {
 		return onAssembly(new MonoDefaultIfEmpty<>(this, defaultV));
 	}
 
+	public final Mono<T> delayElement(Duration delay) {
+		return delayElementMillis(delay.toMillis());
+	}
+
+	public final Mono<T> delayElementMillis(long delay) {
+		return delayElementMillis(delay, Schedulers.timer());
+	}
+
+	public final Mono<T> delayElementMillis(long delay, TimedScheduler timerScheduler) {
+		return new MonoDelayElement(this, delay, TimeUnit.MILLISECONDS, timerScheduler);
+	}
 
 	/**
 	 * Delay the {@link Mono#subscribe(Subscriber) subscription} to this {@link Mono} source until the given

--- a/src/main/java/reactor/core/publisher/MonoDelayElement.java
+++ b/src/main/java/reactor/core/publisher/MonoDelayElement.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Cancellation;
+import reactor.core.Exceptions;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.TimedScheduler;
+
+/**
+ * Emits the first value emitted by a given source publisher, delayed by some time amount
+ * with the help of a ScheduledExecutorService instance or a generic function callback that
+ * wraps other form of async-delayed execution of tasks.
+ *
+ * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
+ * @author Simon Baslé
+ */
+final class MonoDelayElement<T> extends MonoSource<T, T> {
+
+	final TimedScheduler timedScheduler;
+
+	final long delay;
+
+	final TimeUnit unit;
+
+	public MonoDelayElement(Publisher<? extends T> source, long delay, TimeUnit unit, TimedScheduler timedScheduler) {
+		super(source);
+		this.delay = delay;
+		this.unit = Objects.requireNonNull(unit, "unit");
+		this.timedScheduler = Objects.requireNonNull(timedScheduler, "timedScheduler");
+	}
+
+	@Override
+	public void subscribe(Subscriber<? super T> s) {
+		MonoDelayElementSubscriber r = new MonoDelayElementSubscriber<>(s, timedScheduler, delay, unit);
+		source.subscribe(r);
+	}
+
+	static final class MonoDelayElementSubscriber<T> extends Operators.MonoSubscriber<T,T>
+			implements Subscription  {
+
+		final long delay;
+		final TimedScheduler scheduler;
+		final TimeUnit unit;
+
+		private Cancellation task;
+		private boolean done;
+
+		public MonoDelayElementSubscriber(Subscriber<? super T> actual, TimedScheduler scheduler,
+				long delay, TimeUnit unit) {
+			super(actual);
+			this.scheduler = scheduler;
+			this.delay = delay;
+			this.unit = unit;
+		}
+		Subscription s;
+
+		@Override
+		public void cancel() {
+			super.cancel();
+			s.cancel();
+			if (task != null) {
+				task.dispose();
+			}
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.validate(this.s, s)) {
+				this.s = s;
+
+				actual.onSubscribe(this);
+				s.request(1);
+			}
+		}
+
+		@Override
+		public void onNext(T t) {
+			if (done) {
+				Operators.onNextDropped(t);
+				return;
+			}
+			this.done = true;
+			s.cancel();
+			//FIXME handle REJECTED
+			this.task = scheduler.schedule(() -> complete(t), delay, unit);
+		}
+
+		@Override
+		public void onComplete() {
+			if (done) {
+				return;
+			}
+			this.done = true;
+			actual.onComplete();
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			if (done) {
+				Operators.onErrorDropped(t);
+				return;
+			}
+			this.done = true;
+			actual.onError(t);
+		}
+
+		@Override
+		public Object upstream() {
+			return s;
+		}
+	}
+}

--- a/src/main/java/reactor/core/publisher/MonoDelayElement.java
+++ b/src/main/java/reactor/core/publisher/MonoDelayElement.java
@@ -62,6 +62,8 @@ final class MonoDelayElement<T> extends MonoSource<T, T> {
 		final TimedScheduler scheduler;
 		final TimeUnit unit;
 
+		Subscription s;
+
 		volatile Cancellation task;
 		volatile boolean done;
 
@@ -72,7 +74,7 @@ final class MonoDelayElement<T> extends MonoSource<T, T> {
 			this.delay = delay;
 			this.unit = unit;
 		}
-		Subscription s;
+
 
 		@Override
 		public void cancel() {

--- a/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
+++ b/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
@@ -246,7 +246,7 @@ public class FluxBufferBoundaryTest {
 
 	Flux<List<Integer>> scenario_bufferWillSubdivideAnInputFluxTime() {
 		return Flux.just(1, 2, 3, 4, 5, 6, 7, 8)
-		           .delay(Duration.ofMillis(99))
+		           .delayElements(Duration.ofMillis(99))
 		           .buffer(Duration.ofMillis(200));
 	}
 
@@ -263,7 +263,7 @@ public class FluxBufferBoundaryTest {
 
 	Flux<List<Integer>> scenario_bufferWillSubdivideAnInputFluxTime2() {
 		return Flux.just(1, 2, 3, 4, 5, 6, 7, 8)
-		           .delay(Duration.ofMillis(99))
+		           .delayElements(Duration.ofMillis(99))
 		           .bufferMillis(200);
 	}
 

--- a/src/test/java/reactor/core/publisher/FluxBufferStartEndTest.java
+++ b/src/test/java/reactor/core/publisher/FluxBufferStartEndTest.java
@@ -162,7 +162,7 @@ public class FluxBufferStartEndTest {
 
 	Flux<List<Integer>> scenario_bufferWillSubdivideAnInputFluxOverlapTime() {
 		return Flux.just(1, 2, 3, 4, 5, 6, 7, 8)
-		           .delay(Duration.ofMillis(99))
+		           .delayElements(Duration.ofMillis(99))
 		           .buffer(Duration.ofMillis(300), Duration.ofMillis(200));
 	}
 
@@ -179,7 +179,7 @@ public class FluxBufferStartEndTest {
 
 	Flux<List<Integer>> scenario_bufferWillSubdivideAnInputFluxOverlapTime2() {
 		return Flux.just(1, 2, 3, 4, 5, 6, 7, 8)
-		           .delay(Duration.ofMillis(99))
+		           .delayElements(Duration.ofMillis(99))
 		           .bufferMillis(300L, 200L);//FIXME review signature
 	}
 
@@ -196,7 +196,7 @@ public class FluxBufferStartEndTest {
 
 	Flux<List<Integer>> scenario_bufferWillSubdivideAnInputFluxSameTime() {
 		return Flux.just(1, 2, 3, 4, 5, 6, 7, 8)
-		           .delay(Duration.ofMillis(99))
+		           .delayElements(Duration.ofMillis(99))
 		           .bufferMillis(300L, 300L);
 	}
 
@@ -212,7 +212,7 @@ public class FluxBufferStartEndTest {
 
 	Flux<List<Integer>> scenario_bufferWillSubdivideAnInputFluxGapTime() {
 		return Flux.just(1, 2, 3, 4, 5, 6, 7, 8)
-		           .delay(Duration.ofMillis(99))
+		           .delayElements(Duration.ofMillis(99))
 		           .buffer(Duration.ofMillis(200), Duration.ofMillis(300));
 	}
 

--- a/src/test/java/reactor/core/publisher/FluxBufferTimeOrSizeTest.java
+++ b/src/test/java/reactor/core/publisher/FluxBufferTimeOrSizeTest.java
@@ -27,7 +27,7 @@ public class FluxBufferTimeOrSizeTest {
 
 	Flux<List<Integer>> scenario_bufferWithTimeoutAccumulateOnTimeOrSize() {
 		return Flux.range(1, 6)
-		           .delay(Duration.ofMillis(300))
+		           .delayElements(Duration.ofMillis(300))
 		           .buffer(5, Duration.ofMillis(2000));
 	}
 
@@ -43,7 +43,7 @@ public class FluxBufferTimeOrSizeTest {
 
 	Flux<List<Integer>> scenario_bufferWithTimeoutAccumulateOnTimeOrSize2() {
 		return Flux.range(1, 6)
-		           .delay(Duration.ofMillis(300))
+		           .delayElements(Duration.ofMillis(300))
 		           .bufferMillis(5, 2000);
 	}
 

--- a/src/test/java/reactor/core/publisher/FluxCacheTest.java
+++ b/src/test/java/reactor/core/publisher/FluxCacheTest.java
@@ -31,7 +31,7 @@ public class FluxCacheTest {
 			VirtualTimeScheduler vts = VirtualTimeScheduler.enable(false);
 
 			Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-			                                         .delayMillis(1000)
+			                                         .delayElementsMillis(1000)
 			                                         .cache()
 			                                         .elapsed();
 
@@ -60,7 +60,7 @@ public class FluxCacheTest {
 			VirtualTimeScheduler vts = VirtualTimeScheduler.enable(false);
 
 			Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-			                                         .delayMillis(1000)
+			                                         .delayElementsMillis(1000)
 			                                         .cache(Duration.ofMillis(2000))
 			                                         .elapsed();
 
@@ -88,7 +88,7 @@ public class FluxCacheTest {
 			VirtualTimeScheduler vts = VirtualTimeScheduler.enable(false);
 
 			Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-			                                         .delayMillis(1000)
+			                                         .delayElementsMillis(1000)
 			                                         .cache(2, Duration.ofMillis(2000))
 			                                         .elapsed();
 

--- a/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -902,7 +902,7 @@ public class FluxFlatMapTest {
 	Flux<Integer> scenario_backpressuredThenCancel() {
 		return Flux.just(1, 2, 3)
 		           .flatMap(f -> Flux.range(1, 10)
-		                             .delayMillis(10L))
+		                             .delayElementsMillis(10L))
 		           .hide();
 	}
 

--- a/src/test/java/reactor/core/publisher/FluxReplayTest.java
+++ b/src/test/java/reactor/core/publisher/FluxReplayTest.java
@@ -30,7 +30,7 @@ public class FluxReplayTest {
 			VirtualTimeScheduler vts = VirtualTimeScheduler.enable(false);
 
 			Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-			                                         .delayMillis(1000)
+			                                         .delayElementsMillis(1000)
 			                                         .replay()
 			                                         .autoConnect()
 			                                         .elapsed();
@@ -60,7 +60,7 @@ public class FluxReplayTest {
 			VirtualTimeScheduler vts = VirtualTimeScheduler.enable(false);
 
 			Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-			                                         .delayMillis(1000)
+			                                         .delayElementsMillis(1000)
 			                                         .replay(Duration.ofMillis(2000))
 			                                         .autoConnect()
 			                                         .elapsed();
@@ -89,7 +89,7 @@ public class FluxReplayTest {
 			VirtualTimeScheduler vts = VirtualTimeScheduler.enable(false);
 
 			Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-			                                         .delayMillis(1000)
+			                                         .delayElementsMillis(1000)
 			                                         .replayMillis(2000, vts)
 			                                         .autoConnect()
 			                                         .elapsed();
@@ -118,7 +118,7 @@ public class FluxReplayTest {
 			VirtualTimeScheduler vts = VirtualTimeScheduler.enable(false);
 
 			Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-			                                         .delayMillis(1000)
+			                                         .delayElementsMillis(1000)
 			                                         .replay(2, Duration.ofMillis(2000))
 			                                         .autoConnect()
 			                                         .elapsed();

--- a/src/test/java/reactor/core/publisher/FluxSampleFirstTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSampleFirstTest.java
@@ -160,7 +160,7 @@ public class FluxSampleFirstTest {
 
 	Flux<Integer> scenario_sampleFirstTime(){
 		return Flux.range(1, 10)
-	        .delayMillis(200)
+	        .delayElementsMillis(200)
 	        .sampleFirst(Duration.ofSeconds(1));
 	}
 

--- a/src/test/java/reactor/core/publisher/FluxSampleTimeoutTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSampleTimeoutTest.java
@@ -129,7 +129,7 @@ public class FluxSampleTimeoutTest {
 
 	Flux<Integer> scenario_sampleTimeoutTime(){
 		return Flux.range(1, 10)
-		           .delayMillis(300)
+		           .delayElementsMillis(300)
 		           .sampleTimeout(d -> Mono.delay(Duration.ofMillis(100*d)), 1);
 	}
 
@@ -142,7 +142,7 @@ public class FluxSampleTimeoutTest {
 	}
 	Flux<Integer> scenario_sampleTimeoutTime2(){
 		return Flux.range(1, 10)
-		           .delayMillis(300)
+		           .delayElementsMillis(300)
 		           .sampleTimeout(d -> Mono.delay(Duration.ofMillis(100*d)), Integer.MAX_VALUE);
 	}
 

--- a/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
+++ b/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
@@ -199,7 +199,7 @@ public class FluxWindowBoundaryTest {
 
 	Flux<List<Integer>> scenario_windowWillSubdivideAnInputFluxTime() {
 		return Flux.just(1, 2, 3, 4, 5, 6, 7, 8)
-		           .delay(Duration.ofMillis(99))
+		           .delayElements(Duration.ofMillis(99))
 		           .window(Duration.ofMillis(200))
 		           .concatMap(Flux::buffer);
 	}

--- a/src/test/java/reactor/core/publisher/FluxWindowStartEndTest.java
+++ b/src/test/java/reactor/core/publisher/FluxWindowStartEndTest.java
@@ -202,7 +202,7 @@ public class FluxWindowStartEndTest {
 
 	Flux<List<Integer>> scenario_windowWillSubdivideAnInputFluxOverlapTime() {
 		return Flux.just(1, 2, 3, 4, 5, 6, 7, 8)
-		           .delay(Duration.ofMillis(99))
+		           .delayElements(Duration.ofMillis(99))
 		           .window(Duration.ofMillis(300), Duration.ofMillis(200))
 		           .concatMap(Flux::buffer);
 	}
@@ -221,7 +221,7 @@ public class FluxWindowStartEndTest {
 
 	Flux<List<Integer>> scenario_windowWillSubdivideAnInputFluxSameTime() {
 		return Flux.just(1, 2, 3, 4, 5, 6, 7, 8)
-		           .delay(Duration.ofMillis(99))
+		           .delayElements(Duration.ofMillis(99))
 		           .window(Duration.ofMillis(300), Duration.ofMillis(300))
 		           .concatMap(Flux::buffer);
 	}
@@ -238,7 +238,7 @@ public class FluxWindowStartEndTest {
 
 	Flux<List<Integer>> scenario_windowWillSubdivideAnInputFluxGapTime() {
 		return Flux.just(1, 2, 3, 4, 5, 6, 7, 8)
-		           .delay(Duration.ofMillis(99))
+		           .delayElements(Duration.ofMillis(99))
 		           .window(Duration.ofMillis(200), Duration.ofMillis(300))
 		           .concatMap(Flux::buffer);
 	}

--- a/src/test/java/reactor/core/publisher/FluxWindowTimeOrSizeTest.java
+++ b/src/test/java/reactor/core/publisher/FluxWindowTimeOrSizeTest.java
@@ -27,7 +27,7 @@ public class FluxWindowTimeOrSizeTest {
 
 	Flux<List<Integer>> scenario_windowWithTimeoutAccumulateOnTimeOrSize() {
 		return Flux.range(1, 6)
-		           .delay(Duration.ofMillis(300))
+		           .delayElements(Duration.ofMillis(300))
 		           .window(5, Duration.ofMillis(2000))
 		           .concatMap(Flux::buffer);
 	}
@@ -44,7 +44,7 @@ public class FluxWindowTimeOrSizeTest {
 
 	Flux<List<Integer>> scenario_windowWithTimeoutAccumulateOnTimeOrSize2() {
 		return Flux.range(1, 6)
-		           .delay(Duration.ofMillis(300))
+		           .delayElements(Duration.ofMillis(300))
 		           .windowMillis(5, 2000)
 		           .concatMap(Flux::buffer);
 	}

--- a/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
+++ b/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+import reactor.test.publisher.TestPublisher;
+import reactor.test.scheduler.VirtualTimeScheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MonoDelayElementTest {
+
+	@Test
+	public void normalIsDelayed() {
+		Mono<String> source = Mono.just("foo").log().hide();
+
+		StepVerifier.withVirtualTime(() -> new MonoDelayElement<>(source, 2, TimeUnit.SECONDS,
+				Schedulers.timer()).log())
+	                .expectSubscription()
+	                .expectNoEvent(Duration.ofSeconds(2))
+	                .expectNext("foo")
+	                .verifyComplete();
+	}
+
+	@Test
+	public void cancelDuringDelay() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		AtomicBoolean emitted = new AtomicBoolean();
+		Mono<String> source = Mono.just("foo").log().hide();
+
+		StepVerifier.withVirtualTime(
+				() -> new MonoDelayElement<>(source, 2, TimeUnit.SECONDS, vts)
+						.log()
+						.doOnNext(n -> emitted.set(true)),
+				() -> vts, Long.MAX_VALUE)
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofSeconds(1))
+		            .thenCancel()
+		            .verify();
+
+		vts.advanceTimeBy(Duration.ofHours(1));
+		assertThat(emitted.get()).isFalse();
+	}
+
+	@Test(timeout = 5000L)
+	public void emptyIsImmediate() {
+		Mono<String> source = Mono.<String>empty().log().hide();
+
+		Duration d = StepVerifier.create(new MonoDelayElement<>(source, 10, TimeUnit.SECONDS,
+				Schedulers.timer()).log())
+		            .expectSubscription()
+		            .verifyComplete();
+
+		assertThat(d).isLessThan(Duration.ofSeconds(1));
+	}
+
+	@Test
+	public void errorIsImmediate() {
+		Mono<String> source = Mono.<String>error(new IllegalStateException("boom")).hide();
+
+		Duration d = StepVerifier.create(new MonoDelayElement<>(source, 10, TimeUnit.SECONDS, Schedulers.timer()).log())
+		                         .expectSubscription()
+		                         .verifyErrorMessage("boom");
+
+		assertThat(d).isLessThan(Duration.ofSeconds(1));
+	}
+
+	@Test
+	public void errorAfterNextIsNeverTriggered() {
+		TestPublisher<String> source = TestPublisher.create();
+		AtomicReference<Throwable> errorDropped = new AtomicReference<>();
+		Hooks.onErrorDropped(errorDropped::set);
+
+		try {
+			StepVerifier.withVirtualTime(() ->
+					new MonoDelayElement<>(source, 2, TimeUnit.SECONDS, Schedulers.timer()))
+			            .expectSubscription()
+			            .then(() -> source.next("foo").error(new IllegalStateException("boom")))
+			            .expectNoEvent(Duration.ofSeconds(2))
+			            .expectNext("foo")
+			            .verifyComplete();
+		} finally {
+			Hooks.resetOnErrorDropped();
+		}
+
+		assertThat(errorDropped.get()).isNull();
+	}
+
+}

--- a/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
+++ b/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
@@ -39,6 +39,8 @@ public class MonoDelayElementTest {
 
 	@After
 	public void reset() {
+		//TODO remove once the StepVerifier explicitly resets VirtualTimeScheduler
+		//see https://github.com/reactor/reactor-addons/issues/70
 		VirtualTimeScheduler.reset();
 	}
 

--- a/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
+++ b/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
@@ -17,21 +17,30 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.assertj.core.api.Assertions;
+import org.junit.After;
 import org.junit.Test;
-import org.reactivestreams.Subscription;
+import reactor.core.Exceptions;
 import reactor.core.scheduler.Schedulers;
+import reactor.core.scheduler.TimedScheduler;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.scheduler.VirtualTimeScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class MonoDelayElementTest {
+
+	@After
+	public void reset() {
+		VirtualTimeScheduler.reset();
+	}
 
 	@Test
 	public void normalIsDelayed() {
@@ -49,10 +58,12 @@ public class MonoDelayElementTest {
 	public void cancelDuringDelay() {
 		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 		AtomicBoolean emitted = new AtomicBoolean();
+		AtomicBoolean cancelled = new AtomicBoolean();
 		Mono<String> source = Mono.just("foo").log().hide();
 
 		StepVerifier.withVirtualTime(
 				() -> new MonoDelayElement<>(source, 2, TimeUnit.SECONDS, vts)
+						.doOnCancel(() -> cancelled.set(true))
 						.log()
 						.doOnNext(n -> emitted.set(true)),
 				() -> vts, Long.MAX_VALUE)
@@ -63,6 +74,7 @@ public class MonoDelayElementTest {
 
 		vts.advanceTimeBy(Duration.ofHours(1));
 		assertThat(emitted.get()).isFalse();
+		assertThat(cancelled.get()).isTrue();
 	}
 
 	@Test(timeout = 5000L)
@@ -107,6 +119,73 @@ public class MonoDelayElementTest {
 		}
 
 		assertThat(errorDropped.get()).isNull();
+	}
+
+	@Test
+	public void onNextOnDisposedSchedulerThrows() {
+		TimedScheduler scheduler = Schedulers.newTimer("onNextOnDisposedSchedulerThrows");
+		scheduler.dispose();
+		Mono<String> source = Mono.just("foo").hide();
+
+		try {
+			StepVerifier.create(new MonoDelayElement<>(source, 2, TimeUnit.SECONDS, scheduler))
+			            .expectSubscription()
+			            .verifyComplete(); //complete not relevant
+			fail("expected exception here");
+		}
+		catch (Throwable e) {
+			Throwable t = Exceptions.unwrap(e);
+
+			assertThat(t).isNotEqualTo(e)
+		                 .isInstanceOf(RejectedExecutionException.class)
+		                 .hasMessage("Scheduler unavailable");
+
+			assertThat(e).satisfies(Exceptions::isBubbling);
+		}
+	}
+
+	@Test
+	public void cancelUpstreamOnceWhenCancelled() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		AtomicLong upstreamCancelCount = new AtomicLong();
+
+		Mono<String> source = Mono.just("foo").log().hide()
+				.doOnCancel(() -> upstreamCancelCount.incrementAndGet());
+
+		StepVerifier.withVirtualTime(
+				() -> new MonoDelayElement<>(source, 2, TimeUnit.SECONDS, vts),
+				() -> vts, Long.MAX_VALUE)
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofSeconds(1))
+		            .thenCancel()
+		            .verify();
+
+		vts.advanceTimeBy(Duration.ofHours(1));
+		assertThat(upstreamCancelCount.get()).isEqualTo(1);
+	}
+
+	@Test
+	public void cancelUpstreamOnceWhenRejected() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		vts.dispose();
+		AtomicLong upstreamCancelCount = new AtomicLong();
+
+		Mono<String> source = Mono.just("foo").log().hide()
+		                          .doOnCancel(upstreamCancelCount::incrementAndGet);
+
+		try {
+			StepVerifier.withVirtualTime(
+					() -> new MonoDelayElement<>(source, 2, TimeUnit.SECONDS, vts).log(),
+					() -> vts, Long.MAX_VALUE)
+			            .expectSubscription()
+			            .verifyComplete();
+		}
+		catch (Throwable e) {
+			assertThat(e).hasMessageContaining("Scheduler unavailable");
+		}
+		finally {
+			assertThat(upstreamCancelCount.get()).isEqualTo(1);
+		}
 	}
 
 }

--- a/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
+++ b/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
@@ -274,29 +274,20 @@ public class MonoDelayElementTest {
 
 	@Test
 	public void guardedAgainstOnComplete() {
-		AtomicReference<Object> dropped = new AtomicReference<>();
-		Hooks.onNextDropped(dropped::set);
-
 		Flux<String> source = Flux.from(s -> {
 			s.onSubscribe(Operators.emptySubscription());
 			s.onNext("foo");
 			s.onComplete();
 		});
 
-		try {
-			StepVerifier.withVirtualTime(() -> new MonoDelayElement<>(source,
-					2,
-					TimeUnit.SECONDS,
-					Schedulers.timer()))
-			            .expectSubscription()
-			            .expectNoEvent(Duration.ofSeconds(2))
-			            .expectNext("foo")
-			            .verifyComplete();
-		}
-		finally {
-			Hooks.resetOnNextDropped();
-		}
-		assertThat(dropped.get()).isEqualTo("bar");
+		StepVerifier.withVirtualTime(() -> new MonoDelayElement<>(source,
+				2,
+				TimeUnit.SECONDS,
+				Schedulers.timer()))
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofSeconds(2))
+		            .expectNext("foo")
+		            .verifyComplete();
 	}
 
 	@Test

--- a/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
+++ b/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
@@ -340,4 +340,25 @@ public class MonoDelayElementTest {
 
 		assertThat(upstream.get()).isInstanceOf(FluxRange.RangeSubscription.class);
 	}
+
+	@Test
+	public void testDeprecatedFluxApi() {
+		StepVerifier.withVirtualTime(() -> Flux.just("foo").delay(Duration.ofSeconds(2)))
+	                .expectSubscription()
+	                .expectNoEvent(Duration.ofSeconds(2))
+	                .expectNext("foo")
+	                .verifyComplete();
+
+		StepVerifier.withVirtualTime(() -> Flux.just("foo").delayMillis(2000L))
+	                .expectSubscription()
+	                .expectNoEvent(Duration.ofSeconds(2))
+	                .expectNext("foo")
+	                .verifyComplete();
+
+		StepVerifier.withVirtualTime(() -> Flux.just("foo").delayMillis(2000L, VirtualTimeScheduler.get()))
+	                .expectSubscription()
+	                .expectNoEvent(Duration.ofSeconds(2))
+	                .expectNext("foo")
+	                .verifyComplete();
+	}
 }

--- a/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
+++ b/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
@@ -190,4 +190,35 @@ public class MonoDelayElementTest {
 		}
 	}
 
+	@Test
+	public void monoApiTestDuration() {
+		StepVerifier.withVirtualTime(() -> Mono.just("foo").delayElement(Duration.ofHours(1)))
+	                .expectSubscription()
+	                .expectNoEvent(Duration.ofHours(1))
+	                .expectNext("foo")
+	                .verifyComplete();
+	}
+
+	@Test
+	public void monoApiTestMillis() {
+		StepVerifier.withVirtualTime(() -> Mono.just("foo").delayElementMillis(5000L))
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofSeconds(5))
+		            .expectNext("foo")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void monoApiTestMillisAndTimer() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+
+		StepVerifier.withVirtualTime(
+				() -> Mono.just("foo").delayElementMillis(5000L, vts),
+				() -> vts, Long.MAX_VALUE)
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofSeconds(5))
+		            .expectNext("foo")
+		            .verifyComplete();
+	}
+
 }

--- a/src/test/java/reactor/core/publisher/scenarios/CombinationTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/CombinationTests.java
@@ -339,8 +339,8 @@ public class CombinationTests {
 		CountDownLatch latch = new CountDownLatch(elements / 2 - 2);
 
 		Flux.combineLatest(
-				sensorOdd().cache().delay(Duration.ofMillis(100)),
-				sensorEven().cache().delay(Duration.ofMillis(200)),
+				sensorOdd().cache().delayElements(Duration.ofMillis(100)),
+				sensorEven().cache().delayElements(Duration.ofMillis(200)),
 				this::computeMin)
 		                        .log("combineLatest")
 		                        .subscribe(i -> latch.countDown(), null, latch::countDown);

--- a/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
@@ -225,7 +225,7 @@ public class FluxSpecTests {
 
 	Flux<Integer> scenario_rangeTimedSample() {
 		return Flux.range(1, Integer.MAX_VALUE)
-		           .delayMillis(100)
+		           .delayElementsMillis(100)
 		           .sample(Duration.ofSeconds(4))
 		           .take(1);
 	}
@@ -240,7 +240,7 @@ public class FluxSpecTests {
 
 	Flux<Integer> scenario_rangeTimedTake() {
 		return Flux.range(1, Integer.MAX_VALUE)
-		           .delayMillis(100)
+		           .delayElementsMillis(100)
 		           .take(Duration.ofSeconds(4))
 		           .takeLast(1);
 	}
@@ -1038,7 +1038,7 @@ public class FluxSpecTests {
 	Flux<List<Integer>> scenario_delayItems() {
 		return Flux.range(1, 4)
 		           .buffer(2)
-		           .delay(Duration.ofMillis(1000));
+		           .delayElements(Duration.ofMillis(1000));
 	}
 
 	@Test
@@ -1054,7 +1054,7 @@ public class FluxSpecTests {
 
 	Mono<Long> scenario_fluxItemCanBeShiftedByTime() {
 		return Flux.range(0, 10000)
-		           .delay(Duration.ofMillis(150))
+		           .delayElements(Duration.ofMillis(150))
 		           .elapsed()
 		           .take(10)
 		           .reduce(0L,
@@ -1073,7 +1073,7 @@ public class FluxSpecTests {
 
 	Mono<Long> scenario_fluxItemCanBeShiftedByTime2() {
 		return Flux.range(0, 10000)
-		           .delay(Duration.ofMillis(150))
+		           .delayElements(Duration.ofMillis(150))
 		           .elapsed()
 		           .take(10)
 		           .reduce(0L,


### PR DESCRIPTION
`Flux.delay` to be renamed `delayElements`. For consistency, adds a `Mono.delayElement` instance method.

This includes a first pass at the new MonoDelayElement operator.