### PR TITLE
fix #260 Deprecate window(), add windowUntil/windowWhile

### DIFF
--- a/src/docs/asciidoc/operatorChoice.adoc
+++ b/src/docs/asciidoc/operatorChoice.adoc
@@ -204,6 +204,9 @@ I want to deal with: <<which.create>>, <<which.values>>, <<which.peeking>>,
 ** of time `window(Duration)`
 *** ...with overlapping or dropping windows: `window(Duration, Duration)`
 ** of size OR time (window closes when count is reached or timeout elapsed): `window(int, Duration)`
+** based on a predicate on elements: `windowUntil`
+*** ...…emitting the element that triggered the boundary in the next window (`cutBefore` variant): `.windowUntil(predicate, true)`
+*** ...keeping the window open while elements match a predicate: `windowWhile` (non-matching elements are not emitted)
 ** driven by an arbitrary boundary represented by onNexts in a control Publisher: `window(Publisher)`
 
 * I want to split a `Flux<T>` and buffer elements within boundaries together...

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -6717,8 +6717,12 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * predicate. A new window is opened each time the predicate returns true.
 	 * <p>
 	 * If {@code cutBefore} is true, the old window will onComplete and the triggering
-	 * element will be emitted in the new window. Otherwise, the triggering element will
-	 * be emitted in the old window before it does onComplete.
+	 * element will be emitted in the new window. Note it can mean that an empty window is
+	 * sometimes emitted, eg. if the first element in the sequence immediately matches the
+	 * predicate.
+	 * <p>
+	 * Otherwise, the triggering element will be emitted in the old window before it does
+	 * onComplete, similar to {@link #windowUntil(Predicate)}.
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/windowsize.png" alt="">
@@ -6740,7 +6744,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	/**
 	 * Split this {@link Flux} sequence into multiple {@link Flux} windows that stay open
 	 * while a given predicate matches the source elements. Once the predicate returns
-	 * false, the window closes with an onComplete, the triggering element is discarded
+	 * false, the window closes with an onComplete and the triggering element is discarded.
+	 * <p>
+	 * Note that for a sequence starting with a separator, or having several subsequent
+	 * separators anywhere in the sequence, each occurrence will lead to an empty window.
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/windowsize.png" alt="">

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -6705,9 +6705,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/windowsize.png" alt="">
 	 *
 	 * @param boundaryTrigger a predicate that triggers the next window when it becomes true.
-	 * @return a windowing {@link Flux} of {@link Flux} windows, bounded depending on the predicate
+	 * @return a windowing {@link Flux} of {@link GroupedFlux} windows, bounded depending
+	 * on the predicate and keyed with the value that triggered the new window.
 	 */
-	public final Flux<Flux<T>> windowUntil(Predicate<T> boundaryTrigger) {
+	public final Flux<GroupedFlux<T, T>> windowUntil(Predicate<T> boundaryTrigger) {
 		return windowUntil(boundaryTrigger, false);
 	}
 
@@ -6724,11 +6725,15 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * @param boundaryTrigger a predicate that triggers the next window when it becomes true.
 	 * @param cutBefore set to true to include the triggering element in the new window rather than the old.
-	 * @return a windowing {@link Flux} of {@link Flux} windows, bounded depending on the predicate
+	 * @return a windowing {@link Flux} of {@link GroupedFlux} windows, bounded depending
+	 * on the predicate and keyed with the value that triggered the new window.
 	 */
-	public final Flux<Flux<T>> windowUntil(Predicate<T> boundaryTrigger, boolean cutBefore) {
-		return onAssembly(new FluxWindowPredicate<T>(this, boundaryTrigger,
-				QueueSupplier.xs(),
+	public final Flux<GroupedFlux<T, T>> windowUntil(Predicate<T> boundaryTrigger, boolean cutBefore) {
+		return onAssembly(new FluxWindowPredicate<>(this,
+				QueueSupplier.small(),
+				QueueSupplier.unbounded(),
+				QueueSupplier.SMALL_BUFFER_SIZE,
+				boundaryTrigger,
 				cutBefore ? FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE : FluxBufferPredicate.Mode.UNTIL));
 	}
 
@@ -6741,11 +6746,16 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/windowsize.png" alt="">
 	 *
 	 * @param inclusionPredicate a predicate that triggers the next window when it becomes false.
-	 * @return a windowing {@link Flux} of {@link Flux} windows, each containing subsequent elements that all passed a predicate
+	 * @return a windowing {@link Flux} of {@link GroupedFlux} windows, each containing
+	 * subsequent elements that all passed a predicate, and keyed with a separator element.
 	 */
-	public final Flux<Flux<T>> windowWhile(Predicate<T> inclusionPredicate) {
-		return onAssembly(new FluxWindowPredicate<T>(this, inclusionPredicate,
-				QueueSupplier.xs(), FluxBufferPredicate.Mode.WHILE));
+	public final Flux<GroupedFlux<T, T>> windowWhile(Predicate<T> inclusionPredicate) {
+		return onAssembly(new FluxWindowPredicate<>(this,
+				QueueSupplier.small(),
+				QueueSupplier.unbounded(),
+				QueueSupplier.SMALL_BUFFER_SIZE,
+				inclusionPredicate,
+				FluxBufferPredicate.Mode.WHILE));
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
+++ b/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.core.publisher;
+
+import java.util.AbstractQueue;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Disposable;
+import reactor.core.Exceptions;
+import reactor.core.Fuseable.ConditionalSubscriber;
+import reactor.core.MultiProducer;
+import reactor.core.Producer;
+import reactor.core.Receiver;
+import reactor.core.Trackable;
+import reactor.core.publisher.FluxBufferPredicate.Mode;
+import reactor.util.concurrent.QueueSupplier;
+
+/**
+ * Cut a sequence into non-overlapping windows where each window boundary is determined by
+ * a {@link Predicate} on the values. The predicate can be used in several modes:
+ * <ul>
+ *     <li>{@code Until}: A new window starts when the predicate returns true. The
+ *     element that just matched the predicate is the last in the previous window.</li>
+ *     <li>{@code UntilOther}: A new window starts when the predicate returns true. The
+ *     element that just matched the predicate is the first in the new window.</li>
+ *     <li>{@code While}: A new window starts when the predicate stops matching. The
+ *     non-matching elements that delimit each window are simply discarded.</li>
+ * </ul>
+ *
+ * @param <T> the source and window value type
+ * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
+ */
+final class FluxWindowPredicate<T>
+		extends FluxSource<T, Flux<T>> {
+
+	final Supplier<? extends Queue<T>> processorQueueSupplier;
+
+	final Predicate<? super T> predicate;
+
+	final Mode mode;
+
+	public FluxWindowPredicate(Publisher<? extends T> source, Predicate<? super T> predicate,
+			Supplier<? extends Queue<T>> processorQueueSupplier, Mode mode) {
+		super(source);
+		this.predicate = Objects.requireNonNull(predicate, "predicate");
+		this.processorQueueSupplier = Objects.requireNonNull(processorQueueSupplier, "processorQueueSupplier");
+		this.mode = mode;
+	}
+
+	@Override
+	public long getPrefetch() {
+		return 1; //this operator changes the downstream request to 1 in the source
+	}
+
+	@Override
+	public void subscribe(Subscriber<? super Flux<T>> s) {
+		source.subscribe(new WindowPredicateSubscriber<>(s, predicate, mode, processorQueueSupplier));
+	}
+
+	static final class WindowPredicateSubscriber<T>
+			implements Subscriber<T>, Subscription, Disposable, Producer, Receiver,
+			           MultiProducer, Trackable {
+
+		final Subscriber<? super Flux<T>> actual;
+
+		final Mode mode;
+
+		final Supplier<? extends Queue<T>> processorQueueSupplier;
+
+		final Predicate<? super T> predicate;
+
+		volatile int wip;
+		@SuppressWarnings("rawtypes")
+		static final AtomicIntegerFieldUpdater<WindowPredicateSubscriber>
+				WIP =
+				AtomicIntegerFieldUpdater.newUpdater(WindowPredicateSubscriber.class, "wip");
+
+		volatile int once;
+		@SuppressWarnings("rawtypes")
+		static final AtomicIntegerFieldUpdater<WindowPredicateSubscriber> ONCE =
+				AtomicIntegerFieldUpdater.newUpdater(WindowPredicateSubscriber.class, "once");
+
+		boolean done;
+
+		boolean newWindow;
+
+		Subscription s;
+
+		UnicastProcessor<T> window;
+
+		public WindowPredicateSubscriber(Subscriber<? super Flux<T>> actual, Predicate<? super T> predicate,
+				Mode mode, Supplier<? extends Queue<T>> processorQueueSupplier) {
+			this.actual = actual;
+			this.mode = mode;
+			this.predicate = predicate;
+			this.processorQueueSupplier = processorQueueSupplier;
+			this.wip = 1;
+			this.newWindow = true;
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.validate(this.s, s)) {
+				this.s = s;
+				actual.onSubscribe(this);
+			}
+		}
+
+		@Override
+		public void onNext(T t) {
+			if (done) {
+				Operators.onNextDropped(t);
+				return;
+			}
+
+			if (newWindow) {
+				if (!triggerNewWindow()) {
+					return;
+				}
+			}
+
+			UnicastProcessor<T> w = window;
+			boolean match;
+			try {
+				match = predicate.test(t);
+			}
+			catch (Throwable ex) {
+				WIP.decrementAndGet(this);
+				done = true;
+				cancel();
+				actual.onError(ex);
+				return;
+			}
+
+			if (mode == Mode.UNTIL && match) {
+				newWindow = true;
+				window = null;
+				w.onNext(t);
+				w.onComplete();
+			}
+			else if (mode == Mode.UNTIL_CUT_BEFORE && match) {
+				w.onComplete();
+				if (!triggerNewWindow()) {
+					return;
+				}
+				w = window;
+				w.onNext(t);
+			}
+			else if (mode == Mode.WHILE && !match) {
+				w.onComplete();
+				if (!triggerNewWindow()) {
+					return;
+				}
+			}
+			else {
+				w.onNext(t);
+			}
+		}
+
+		private boolean triggerNewWindow() {
+			newWindow = false;
+			WIP.getAndIncrement(this);
+
+			Queue<T> q;
+
+			try {
+				q = processorQueueSupplier.get();
+			}
+			catch (Throwable ex) {
+				WIP.decrementAndGet(this);
+				done = true;
+				cancel();
+
+				actual.onError(ex);
+				return false;
+			}
+
+			if (q == null) {
+				WIP.decrementAndGet(this);
+				done = true;
+				cancel();
+
+				actual.onError(new NullPointerException(
+						"The processorQueueSupplier returned a null queue"));
+				return false;
+			}
+
+			UnicastProcessor<T> w = new UnicastProcessor<>(q, this);
+			window = w;
+			actual.onNext(w);
+			return true;
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			if (done) {
+				Operators.onErrorDropped(t);
+				return;
+			}
+			Processor<T, T> w = window;
+			if (w != null) {
+				window = null;
+				w.onError(t);
+			}
+
+			actual.onError(t);
+		}
+
+		@Override
+		public void onComplete() {
+			if (done) {
+				return;
+			}
+
+			Processor<T, T> w = window;
+			if (w != null) {
+				window = null;
+				w.onComplete();
+			}
+
+			actual.onComplete();
+		}
+
+		@Override
+		public void request(long n) {
+			if (Operators.validate(n)) {
+				s.request(n);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			if (ONCE.compareAndSet(this, 0, 1)) {
+				dispose();
+			}
+		}
+
+		@Override
+		public void dispose() {
+			if (WIP.decrementAndGet(this) == 0) {
+				s.cancel();
+			}
+		}
+
+		@Override
+		public Object downstream() {
+			return actual;
+		}
+
+		@Override
+		public boolean isStarted() {
+			return s != null && !done;
+		}
+
+		@Override
+		public boolean isTerminated() {
+			return done;
+		}
+
+		@Override
+		public Object upstream() {
+			return s;
+		}
+
+		@Override
+		public Iterator<?> downstreams() {
+			return Collections.singletonList(window)
+			                  .iterator();
+		}
+
+		@Override
+		public long downstreamCount() {
+			return window != null ? 1L : 0L;
+		}
+
+		@Override
+		public String toString() {
+			return "FluxWindowPredicate";
+		}
+	}
+}

--- a/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
+++ b/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
@@ -194,7 +194,7 @@ final class FluxWindowPredicate<T>
 			}
 
 			if (q == null) {
-				ERROR.compareAndSet(this, null, new NullPointerException("The groupQueueSupplier returned a null queue"));
+				ERROR.compareAndSet(this, null, new NullPointerException("The groupQueueSupplier returned a null queue for initial window"));
 				return;
 			}
 
@@ -216,7 +216,7 @@ final class FluxWindowPredicate<T>
 				}
 
 				if (q == null) {
-					onError(Operators.onOperatorError(s, new NullPointerException("The mainQueueSupplier returned a null queue"), key));
+					onError(Operators.onOperatorError(s, new NullPointerException("The groupQueueSupplier returned a null queue for window \'" + key + "\'"), key));
 					return false;
 				}
 

--- a/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
+++ b/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
@@ -15,25 +15,19 @@
  */
 package reactor.core.publisher;
 
-import java.util.AbstractQueue;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import java.util.function.BooleanSupplier;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.MultiProducer;

--- a/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
+++ b/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
@@ -20,15 +20,11 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.function.Predicate;
 
-import org.junit.Ignore;
 import org.junit.Test;
-import org.reactivestreams.Subscription;
 import reactor.core.publisher.FluxBufferPredicate.Mode;
 import reactor.test.StepVerifier;
-import reactor.test.StepVerifierOptions;
 import reactor.util.concurrent.QueueSupplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -606,10 +602,7 @@ public class FluxWindowPredicateTest {
 		StepVerifier.create(Flux.just("red", "green", "#", "orange", "blue", "#", "black", "white")
 		                        .hide()
 		                        .windowWhile(color -> !color.equals("#"))
-		                        .flatMap(w -> w, 1),
-				new StepVerifierOptions()
-						.initialRequest(1)
-						.checkUnderRequesting(false))
+		                        .flatMap(w -> w, 1), 1)
 	                .expectNext("red")
 	                .thenRequest(1)
 	                .expectNext("green")

--- a/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
+++ b/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
@@ -17,25 +17,15 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.atomic.LongAdder;
-import java.util.function.Supplier;
 
-import org.junit.Assert;
 import org.junit.Test;
 import reactor.core.publisher.FluxBufferPredicate.Mode;
-import reactor.core.scheduler.Scheduler;
-import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.util.concurrent.QueueSupplier;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 
 public class FluxWindowPredicateTest {
 
@@ -43,6 +33,18 @@ public class FluxWindowPredicateTest {
 	public void apiUntil() {
 		StepVerifier.create(Flux.just("red", "green", "#", "orange", "blue", "#", "black", "white")
 		                        .windowUntil(color -> color.equals("#"))
+		                        .flatMap(Flux::materialize)
+		                        .map(s -> s.isOnComplete() ? "WINDOW CLOSED" : s.get()))
+		            .expectNext("red", "green", "#", "WINDOW CLOSED")
+		            .expectNext("orange", "blue", "#", "WINDOW CLOSED")
+		            .expectNext("black", "white", "WINDOW CLOSED")
+	                .verifyComplete();
+	}
+
+	@Test
+	public void apiUntilCutAfter() {
+		StepVerifier.create(Flux.just("red", "green", "#", "orange", "blue", "#", "black", "white")
+		                        .windowUntil(color -> color.equals("#"), false)
 		                        .flatMap(Flux::materialize)
 		                        .map(s -> s.isOnComplete() ? "WINDOW CLOSED" : s.get()))
 		            .expectNext("red", "green", "#", "WINDOW CLOSED")
@@ -85,18 +87,21 @@ public class FluxWindowPredicateTest {
 		StepVerifier.create(windowUntil.flatMap(Flux::materialize))
 		            .expectSubscription()
 		            .then(() -> sp1.onNext(1))
+		            .expectNext(Signal.next(1))
 				    .then(() -> sp1.onNext(2))
-		            .expectNext(Signal.next(1), Signal.next(2))
+		            .expectNext(Signal.next(2))
 				    .then(() -> sp1.onNext(3))
 		            .expectNext(Signal.next(3), Signal.complete())
 				    .then(() -> sp1.onNext(4))
+				    .expectNext(Signal.next(4))
 				    .then(() -> sp1.onNext(5))
-				    .expectNext(Signal.next(4), Signal.next(5))
+				    .expectNext(Signal.next(5))
 				    .then(() -> sp1.onNext(6))
 				    .expectNext(Signal.next(6), Signal.complete())
 				    .then(() -> sp1.onNext(7))
+				    .expectNext(Signal.next(7))
 				    .then(() -> sp1.onNext(8))
-				    .expectNext(Signal.next(7), Signal.next(8))
+				    .expectNext(Signal.next(8))
 				    .then(sp1::onComplete)
 		            .expectNext(Signal.complete())
 				    .verifyComplete();
@@ -104,82 +109,85 @@ public class FluxWindowPredicateTest {
 		assertFalse(sp1.hasDownstreams());
 	}
 
-//	@Test
-//	@SuppressWarnings("unchecked")
-//	public void onCompletionBeforeLastBoundaryBufferEmitted() {
-//		Flux<Integer> source = Flux.just(1, 2);
-//
-//		FluxBufferPredicate<Integer, List<Integer>> bufferUntil =
-//				new FluxBufferPredicate<>(source, i -> i >= 3, Flux.listSupplier(),
-//						FluxBufferPredicate.Mode.UNTIL);
-//
-//		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther =
-//				new FluxBufferPredicate<>(source, i -> i >= 3, Flux.listSupplier(),
-//						FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE);
-//
-//		FluxBufferPredicate<Integer, List<Integer>> bufferWhile =
-//				new FluxBufferPredicate<>(source, i -> i < 3, Flux.listSupplier(),
-//						FluxBufferPredicate.Mode.WHILE);
-//
-//		StepVerifier.create(bufferUntil)
-//				.expectNext(Arrays.asList(1, 2))
-//				.expectComplete()
-//				.verify();
-//
-//		StepVerifier.create(bufferUntilOther)
-//		            .expectNext(Arrays.asList(1, 2))
-//		            .expectComplete()
-//		            .verify();
-//
-//		StepVerifier.create(bufferWhile)
-//		            .expectNext(Arrays.asList(1, 2))
-//		            .expectComplete()
-//		            .verify();
-//	}
-//
-//	@Test
-//	@SuppressWarnings("unchecked")
-//	public void mainErrorUntil() {
-//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-//		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
-//				sp1, i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL);
-//
-//		StepVerifier.create(bufferUntil)
-//		            .expectSubscription()
-//		            .then(() -> sp1.onNext(1))
-//		            .then(() -> sp1.onNext(2))
-//		            .then(() -> sp1.onNext(3))
-//		            .expectNext(Arrays.asList(1, 2, 3))
-//		            .then(() -> sp1.onNext(4))
-//		            .then(() -> sp1.onError(new RuntimeException("forced failure")))
-//		            .expectErrorMessage("forced failure")
-//		            .verify();
-//		assertFalse(sp1.hasDownstreams());
-//	}
-//
-//	@Test
-//	@SuppressWarnings("unchecked")
-//	public void predicateErrorUntil() {
-//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-//		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
-//				sp1,
-//				i -> {
-//					if (i == 5) throw new IllegalStateException("predicate failure");
-//					return i % 3 == 0;
-//				}, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL);
-//
-//		StepVerifier.create(bufferUntil)
-//					.expectSubscription()
-//					.then(() -> sp1.onNext(1))
-//					.then(() -> sp1.onNext(2))
-//					.then(() -> sp1.onNext(3))
-//					.expectNext(Arrays.asList(1, 2, 3))
-//					.then(() -> sp1.onNext(4))
-//					.then(() -> sp1.onNext(5))
-//					.expectErrorMessage("predicate failure")
-//					.verify();
-//		assertFalse(sp1.hasDownstreams());
-//	}
+	@Test
+	@SuppressWarnings("unchecked")
+	public void onCompletionBeforeLastBoundaryWindowEmitted() {
+		Flux<Integer> source = Flux.just(1, 2);
+
+		FluxWindowPredicate<Integer> windowUntil =
+				new FluxWindowPredicate<>(source, i -> i >= 3, QueueSupplier.small(), Mode.UNTIL);
+
+		FluxWindowPredicate<Integer> windowUntilOther =
+				new FluxWindowPredicate<>(source, i -> i >= 3, QueueSupplier.small(), Mode.UNTIL_CUT_BEFORE);
+
+		FluxWindowPredicate<Integer> windowWhile =
+				new FluxWindowPredicate<>(source, i -> i < 3, QueueSupplier.small(), Mode.WHILE);
+
+		StepVerifier.create(windowUntil.flatMap(Flux::collectList))
+				.expectNext(Arrays.asList(1, 2))
+				.expectComplete()
+				.verify();
+
+		StepVerifier.create(windowUntilOther.flatMap(Flux::collectList))
+		            .expectNext(Arrays.asList(1, 2))
+		            .expectComplete()
+		            .verify();
+
+		StepVerifier.create(windowWhile.flatMap(Flux::collectList))
+		            .expectNext(Arrays.asList(1, 2))
+		            .expectComplete()
+		            .verify();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void mainErrorUntilIsPropagatedToBothWindowAndMain() {
+		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(
+				sp1, i -> i % 3 == 0, QueueSupplier.small(), Mode.UNTIL);
+
+		StepVerifier.create(windowUntil.flatMap(Flux::materialize))
+		            .expectSubscription()
+		            .then(() -> sp1.onNext(1))
+		            .expectNext(Signal.next(1))
+		            .then(() -> sp1.onNext(2))
+		            .expectNext(Signal.next(2))
+		            .then(() -> sp1.onNext(3))
+		            .expectNext(Signal.next(3), Signal.complete())
+		            .then(() -> sp1.onNext(4))
+		            .expectNext(Signal.next(4))
+		            .then(() -> sp1.onError(new RuntimeException("forced failure")))
+		            //this is the error in the window:
+		            .expectNextMatches(s -> s.isOnError() && s.getThrowable().getMessage().equals("forced failure"))
+		            //this is the error in the main:
+		            .expectErrorMessage("forced failure")
+		            .verify();
+		assertFalse(sp1.hasDownstreams());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void predicateErrorUntil() {
+		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(
+				sp1,
+				i -> {
+					if (i == 5) throw new IllegalStateException("predicate failure");
+					return i % 3 == 0;
+				}, QueueSupplier.small(), Mode.UNTIL);
+
+		StepVerifier.create(windowUntil.flatMap(Flux::collectList))
+					.expectSubscription()
+					.then(() -> sp1.onNext(1))
+					.then(() -> sp1.onNext(2))
+					.then(() -> sp1.onNext(3))
+					.expectNext(Arrays.asList(1, 2, 3))
+					.then(() -> sp1.onNext(4))
+					.then(() -> sp1.onNext(5))
+					.expectErrorMessage("predicate failure")
+					.verify();
+		assertFalse(sp1.hasDownstreams());
+	}
 
 	@Test
 	@SuppressWarnings("unchecked")
@@ -191,514 +199,297 @@ public class FluxWindowPredicateTest {
 		StepVerifier.create(windowUntilOther.flatMap(Flux::materialize))
 				.expectSubscription()
 				    .then(() -> sp1.onNext(1))
+				    .expectNext(Signal.next(1))
 				    .then(() -> sp1.onNext(2))
-				    .expectNext(Signal.next(1), Signal.next(2))
+				    .expectNext(Signal.next(2))
 				    .then(() -> sp1.onNext(3))
 				    .expectNext(Signal.complete(), Signal.next(3))
 				    .then(() -> sp1.onNext(4))
+				    .expectNext(Signal.next(4))
 				    .then(() -> sp1.onNext(5))
-				    .expectNext(Signal.next(4), Signal.next(5))
+				    .expectNext(Signal.next(5))
 				    .then(() -> sp1.onNext(6))
 				    .expectNext(Signal.complete(), Signal.next(6))
 				    .then(() -> sp1.onNext(7))
+				    .expectNext(Signal.next(7))
 				    .then(() -> sp1.onNext(8))
-				    .expectNext(Signal.next(7), Signal.next(8))
+				    .expectNext(Signal.next(8))
 				    .then(sp1::onComplete)
 				    .expectNext(Signal.complete())
 				    .verifyComplete();
 		assertFalse(sp1.hasDownstreams());
 	}
-//
-//	@Test
-//	@SuppressWarnings("unchecked")
-//	public void mainErrorUntilOther() {
-//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-//		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther =
-//				new FluxBufferPredicate<>(sp1, i -> i % 3 == 0, Flux.listSupplier(),
-//						FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE);
-//
-//		StepVerifier.create(bufferUntilOther)
-//		            .expectSubscription()
-//		            .then(() -> sp1.onNext(1))
-//		            .then(() -> sp1.onNext(2))
-//		            .then(() -> sp1.onNext(3))
-//		            .expectNext(Arrays.asList(1, 2))
-//		            .then(() -> sp1.onNext(4))
-//		            .then(() -> sp1.onError(new RuntimeException("forced failure")))
-//		            .expectErrorMessage("forced failure")
-//		            .verify();
-//		assertFalse(sp1.hasDownstreams());
-//	}
-//
-//	@Test
-//	@SuppressWarnings("unchecked")
-//	public void predicateErrorUntilOther() {
-//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-//		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther =
-//				new FluxBufferPredicate<>(sp1,
-//				i -> {
-//					if (i == 5) throw new IllegalStateException("predicate failure");
-//					return i % 3 == 0;
-//				}, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE);
-//
-//		StepVerifier.create(bufferUntilOther)
-//					.expectSubscription()
-//					.then(() -> sp1.onNext(1))
-//					.then(() -> sp1.onNext(2))
-//					.then(() -> sp1.onNext(3))
-//					.expectNext(Arrays.asList(1, 2))
-//					.then(() -> sp1.onNext(4))
-//					.then(() -> sp1.onNext(5))
-//					.expectErrorMessage("predicate failure")
-//					.verify();
-//		assertFalse(sp1.hasDownstreams());
-//	}
-//
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void mainErrorUntilOtherIsPropagatedToBothWindowAndMain() {
+		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxWindowPredicate<Integer> windowUntilOther =
+				new FluxWindowPredicate<>(sp1, i -> i % 3 == 0, QueueSupplier.small(),
+						Mode.UNTIL_CUT_BEFORE);
+
+		StepVerifier.create(windowUntilOther.flatMap(Flux::materialize))
+		            .expectSubscription()
+		            .then(() -> sp1.onNext(1))
+		            .expectNext(Signal.next(1))
+		            .then(() -> sp1.onNext(2))
+		            .expectNext(Signal.next(2))
+		            .then(() -> sp1.onNext(3))
+		            .expectNext(Signal.complete())
+		            .expectNext(Signal.next(3))
+		            .then(() -> sp1.onNext(4))
+		            .expectNext(Signal.next(4))
+		            .then(() -> sp1.onError(new RuntimeException("forced failure")))
+		            //this is the error in the window:
+		            .expectNextMatches(signal -> signal.isOnError() && signal.getThrowable().getMessage().equals("forced failure"))
+		            //this is the error in the main:
+		            .expectErrorMessage("forced failure")
+		            .verify();
+		assertFalse(sp1.hasDownstreams());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void predicateErrorUntilOther() {
+		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxWindowPredicate<Integer> windowUntilOther =
+				new FluxWindowPredicate<>(sp1,
+				i -> {
+					if (i == 5) throw new IllegalStateException("predicate failure");
+					return i % 3 == 0;
+				}, QueueSupplier.small(), Mode.UNTIL_CUT_BEFORE);
+
+		StepVerifier.create(windowUntilOther.flatMap(Flux::collectList))
+					.expectSubscription()
+					.then(() -> sp1.onNext(1))
+					.then(() -> sp1.onNext(2))
+					.then(() -> sp1.onNext(3))
+					.expectNext(Arrays.asList(1, 2))
+					.then(() -> sp1.onNext(4))
+					.then(() -> sp1.onNext(5))
+					.expectErrorMessage("predicate failure")
+					.verify();
+		assertFalse(sp1.hasDownstreams());
+	}
+
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalWhile() {
 		DirectProcessor<Integer> sp1 = DirectProcessor.create();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
 				sp1, i -> i % 3 != 0, QueueSupplier.small(),
-				FluxBufferPredicate.Mode.WHILE);
+				Mode.WHILE);
 
 		StepVerifier.create(windowWhile.flatMap(Flux::materialize))
 		            .expectSubscription()
 		            .then(() -> sp1.onNext(1))
+		            .expectNext(Signal.next(1))
 		            .then(() -> sp1.onNext(2))
-		            .expectNext(Signal.next(1), Signal.next(2))
+		            .expectNext(Signal.next(2))
 		            .then(() -> sp1.onNext(3))
 		            .expectNext(Signal.complete())
 		            .then(() -> sp1.onNext(4))
+		            .expectNext(Signal.next(4))
 		            .then(() -> sp1.onNext(5))
-		            .expectNext(Signal.next(4), Signal.next(5))
+		            .expectNext(Signal.next(5))
 		            .then(() -> sp1.onNext(6))
 		            .expectNext(Signal.complete())
 		            .then(() -> sp1.onNext(7))
+		            .expectNext(Signal.next(7))
 		            .then(() -> sp1.onNext(8))
-		            .expectNext(Signal.next(7), Signal.next(8))
+		            .expectNext(Signal.next(8))
 		            .then(sp1::onComplete)
 		            .expectNext(Signal.complete())
 		            .verifyComplete();
 		assertFalse(sp1.hasDownstreams());
 	}
-//
-//	@Test
-//	@SuppressWarnings("unchecked")
-//	public void normalWhileDoesntInitiallyMatch() {
-//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-//		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
-//				sp1, i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
-//
-//		StepVerifier.create(bufferWhile)
-//				.expectSubscription()
-//				.expectNoEvent(Duration.ofMillis(10))
-//				.then(() -> sp1.onNext(1))
-//				.then(() -> sp1.onNext(2))
-//				.then(() -> sp1.onNext(3))
-//				.expectNoEvent(Duration.ofMillis(10))
-//				.then(() -> sp1.onNext(4))
-//				.expectNext(Arrays.asList(3)) //emission of 4 triggers the buffer emit
-//				.then(() -> sp1.onNext(5))
-//				.then(() -> sp1.onNext(6))
-//				.expectNoEvent(Duration.ofMillis(10))
-//				.then(() -> sp1.onNext(7)) // emission of 7 triggers the buffer emit
-//				.expectNext(Arrays.asList(6))
-//				.then(() -> sp1.onNext(8))
-//				.then(() -> sp1.onNext(9))
-//				.expectNoEvent(Duration.ofMillis(10))
-//				.then(sp1::onComplete) // completion triggers the buffer emit
-//			    .expectNext(Collections.singletonList(9))
-//				.expectComplete()
-//				.verify(Duration.ofSeconds(1));
-//		assertFalse(sp1.hasDownstreams());
-//	}
-//
-//	@Test
-//	@SuppressWarnings("unchecked")
-//	public void normalWhileDoesntMatch() {
-//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-//		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
-//				sp1, i -> i > 4, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
-//
-//		StepVerifier.create(bufferWhile)
-//		            .expectSubscription()
-//		            .expectNoEvent(Duration.ofMillis(10))
-//		            .then(() -> sp1.onNext(1))
-//		            .then(() -> sp1.onNext(2))
-//		            .then(() -> sp1.onNext(3))
-//		            .then(() -> sp1.onNext(4))
-//		            .expectNoEvent(Duration.ofMillis(10))
-//		            .then(() -> sp1.onNext(1))
-//		            .then(() -> sp1.onNext(2))
-//		            .then(() -> sp1.onNext(3))
-//		            .then(() -> sp1.onNext(4))
-//		            .expectNoEvent(Duration.ofMillis(10))
-//		            .then(sp1::onComplete)
-//		            .expectComplete()
-//		            .verify(Duration.ofSeconds(1));
-//		assertFalse(sp1.hasDownstreams());
-//	}
-//
-//	@Test
-//	@SuppressWarnings("unchecked")
-//	public void mainErrorWhile() {
-//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-//		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
-//				sp1, i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
-//
-//		StepVerifier.create(bufferWhile)
-//		            .expectSubscription()
-//		            .then(() -> sp1.onNext(1))
-//		            .then(() -> sp1.onNext(2))
-//		            .then(() -> sp1.onNext(3))
-//		            .then(() -> sp1.onNext(4))
-//		            .expectNext(Arrays.asList(3))
-//		            .then(() -> sp1.onError(new RuntimeException("forced failure")))
-//		            .expectErrorMessage("forced failure")
-//		            .verify(Duration.ofMillis(100));
-//		assertFalse(sp1.hasDownstreams());
-//	}
-//
-//	@Test
-//	@SuppressWarnings("unchecked")
-//	public void predicateErrorWhile() {
-//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-//		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
-//				sp1,
-//				i -> {
-//					if (i == 3) return true;
-//					if (i == 5) throw new IllegalStateException("predicate failure");
-//					return false;
-//				}, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
-//
-//		StepVerifier.create(bufferWhile)
-//					.expectSubscription()
-//					.then(() -> sp1.onNext(1)) //ignored
-//					.then(() -> sp1.onNext(2)) //ignored
-//					.then(() -> sp1.onNext(3)) //buffered
-//					.then(() -> sp1.onNext(4)) //ignored, emits buffer
-//					.expectNext(Arrays.asList(3))
-//					.then(() -> sp1.onNext(5)) //fails
-//					.expectErrorMessage("predicate failure")
-//					.verify(Duration.ofMillis(100));
-//		assertFalse(sp1.hasDownstreams());
-//	}
-//
-//	@Test
-//	@SuppressWarnings("unchecked")
-//	public void bufferSupplierThrows() {
-//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-//		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
-//				sp1, i -> i % 3 == 0,
-//				() -> { throw new RuntimeException("supplier failure"); },
-//				FluxBufferPredicate.Mode.UNTIL);
-//
-//		Assert.assertFalse("sp1 has subscribers?", sp1.hasDownstreams());
-//
-//		StepVerifier.create(bufferUntil)
-//		            .expectErrorMessage("supplier failure")
-//		            .verify();
-//	}
-//
-//	@Test
-//	public void bufferSupplierThrowsLater() {
-//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-//		int count[] = {1};
-//		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
-//				sp1, i -> i % 3 == 0,
-//				() -> {
-//					if (count[0]-- > 0) {
-//						return new ArrayList<>();
-//					}
-//					throw new RuntimeException("supplier failure");
-//				},
-//				FluxBufferPredicate.Mode.UNTIL);
-//
-//		Assert.assertFalse("sp1 has subscribers?", sp1.hasDownstreams());
-//
-//		StepVerifier.create(bufferUntil)
-//		            .then(() -> sp1.onNext(1))
-//		            .then(() -> sp1.onNext(2))
-//		            .expectNoEvent(Duration.ofMillis(10))
-//		            .then(() -> sp1.onNext(3))
-//		            .expectErrorMessage("supplier failure")
-//		            .verify();
-//	}
-//
-//	@Test
-//	public void bufferSupplierReturnsNull() {
-//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-//		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
-//				sp1, i -> i % 3 == 0,
-//				() -> null,
-//				FluxBufferPredicate.Mode.UNTIL);
-//
-//		Assert.assertFalse("sp1 has subscribers?", sp1.hasDownstreams());
-//
-//		StepVerifier.create(bufferUntil)
-//		            .then(() -> sp1.onNext(1))
-//		            .expectErrorMatches(t -> t instanceof NullPointerException &&
-//		                "The bufferSupplier returned a null initial buffer".equals(t.getMessage()))
-//		            .verify();
-//	}
-//
-//	@Test
-//	@SuppressWarnings("unchecked")
-//	public void multipleTriggersOfEmptyBufferKeepInitialBuffer() {
-//		//this is best demonstrated with bufferWhile:
-//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-//		LongAdder bufferCount = new LongAdder();
-//		Supplier<List<Integer>> bufferSupplier = () -> {
-//			bufferCount.increment();
-//			return new ArrayList<>();
-//		};
-//
-//		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new
-//				FluxBufferPredicate<>(
-//				sp1, i -> i >= 10,
-//				bufferSupplier,
-//				FluxBufferPredicate.Mode.WHILE);
-//
-//		StepVerifier.create(bufferWhile)
-//		            .then(() -> assertThat(bufferCount.intValue(), is(1)))
-//		            .then(() -> sp1.onNext(1))
-//		            .then(() -> sp1.onNext(2))
-//		            .then(() -> sp1.onNext(3))
-//		            .then(() -> assertThat(bufferCount.intValue(), is(1)))
-//		            .expectNoEvent(Duration.ofMillis(10))
-//		            .then(() -> sp1.onNext(10))
-//		            .then(() -> sp1.onNext(11))
-//		            .then(sp1::onComplete)
-//		            .expectNext(Arrays.asList(10, 11))
-//		            .then(() -> assertThat(bufferCount.intValue(), is(1)))
-//		            .expectComplete()
-//		            .verify();
-//
-//		assertThat(bufferCount.intValue(), is(1));
-//	}
-//
-//	@Test
-//	@SuppressWarnings("unchecked")
-//	public void requestBounded() {
-//		LongAdder requestCallCount = new LongAdder();
-//		LongAdder totalRequest = new LongAdder();
-//		Flux<Integer> source = Flux.range(1, 10).hide()
-//		                           .doOnRequest(r -> requestCallCount.increment())
-//		                           .doOnRequest(totalRequest::add);
-//
-//		StepVerifier.withVirtualTime( //start with a request for 1 buffer
-//				() -> new FluxBufferPredicate<>(source, i -> i % 3 == 0,
-//				Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL), 1)
-//		            .expectSubscription()
-//		            .expectNext(Arrays.asList(1, 2, 3))
-//		            .expectNoEvent(Duration.ofSeconds(1))
-//		            .thenRequest(2)
-//		            .expectNext(Arrays.asList(4, 5, 6), Arrays.asList(7, 8, 9))
-//		            .expectNoEvent(Duration.ofSeconds(1))
-//		            .thenRequest(3)
-//		            .expectNext(Collections.singletonList(10))
-//		            .expectComplete()
-//		            .verify();
-//
-//		assertThat(requestCallCount.intValue(), is(11)); //10 elements then the completion
-//		assertThat(totalRequest.longValue(), is(11L)); //ignores the main requests
-//	}
-//
-//	@Test
-//	@SuppressWarnings("unchecked")
-//	public void requestBoundedSeveralInitial() {
-//		LongAdder requestCallCount = new LongAdder();
-//		LongAdder totalRequest = new LongAdder();
-//		Flux<Integer> source = Flux.range(1, 10).hide()
-//		                           .doOnRequest(r -> requestCallCount.increment())
-//		                           .doOnRequest(totalRequest::add);
-//
-//		StepVerifier.withVirtualTime( //start with a request for 2 buffers
-//				() -> new FluxBufferPredicate<>(source, i -> i % 3 == 0,
-//				Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL), 2)
-//		            .expectSubscription()
-//		            .expectNext(Arrays.asList(1, 2, 3), Arrays.asList(4, 5, 6))
-//		            .expectNoEvent(Duration.ofSeconds(1))
-//		            .thenRequest(2)
-//					.expectNext(Arrays.asList(7, 8, 9))
-//		            .expectNext(Collections.singletonList(10))
-//		            .expectComplete()
-//		            .verify(Duration.ofSeconds(1));
-//
-//		assertThat(requestCallCount.intValue(), is(11)); //10 elements then the completion
-//		assertThat(totalRequest.longValue(), is(11L)); //ignores the main requests
-//	}
-//
-//	@Test
-//	@SuppressWarnings("unchecked")
-//	public void requestRemainingBuffersAfterBufferEmission() {
-//		LongAdder requestCallCount = new LongAdder();
-//		LongAdder totalRequest = new LongAdder();
-//		Flux<Integer> source = Flux.range(1, 10).hide()
-//		                           .doOnRequest(r -> requestCallCount.increment())
-//		                           .doOnRequest(totalRequest::add);
-//
-//		StepVerifier.withVirtualTime( //start with a request for 3 buffers
-//				() -> new FluxBufferPredicate<>(source, i -> i % 3 == 0,
-//						Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL), 3)
-//		            .expectSubscription()
-//		            .expectNext(Arrays.asList(1, 2, 3), Arrays.asList(4, 5, 6), Arrays.asList(7, 8, 9))
-//		            .expectNoEvent(Duration.ofSeconds(1))
-//		            .thenRequest(1)
-//		            .expectNext(Collections.singletonList(10))
-//		            .expectComplete()
-//		            .verify(Duration.ofSeconds(1));
-//
-//		assertThat(requestCallCount.intValue(), is(11)); //10 elements then the completion
-//		assertThat(totalRequest.longValue(), is(11L)); //ignores the main requests
-//	}
-//
-//	@Test
-//	@SuppressWarnings("unchecked")
-//	public void requestUnboundedFromStartRequestsSourceOnce() {
-//		LongAdder requestCallCount = new LongAdder();
-//		LongAdder totalRequest = new LongAdder();
-//		Flux<Integer> source = Flux.range(1, 10).hide()
-//		                           .doOnRequest(r -> requestCallCount.increment())
-//		                           .doOnRequest(totalRequest::add);
-//
-//		StepVerifier.withVirtualTime(//start with an unbounded request
-//				() -> new FluxBufferPredicate<>(source, i -> i % 3 == 0,
-//						Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL))
-//		            .expectSubscription()
-//		            .expectNext(Arrays.asList(1, 2, 3))
-//		            .expectNext(Arrays.asList(4, 5, 6), Arrays.asList(7, 8, 9))
-//		            .expectNext(Collections.singletonList(10))
-//		            .expectComplete()
-//		            .verify();
-//
-//		assertThat(requestCallCount.intValue(), is(1));
-//		assertThat(totalRequest.longValue(), is(Long.MAX_VALUE)); //also unbounded
-//	}
-//
-//	@Test
-//	@SuppressWarnings("unchecked")
-//	public void requestSwitchingToMaxRequestsSourceOnlyOnceMore() {
-//		LongAdder requestCallCount = new LongAdder();
-//		LongAdder totalRequest = new LongAdder();
-//		Flux<Integer> source = Flux.range(1, 10).hide()
-//		                           .doOnRequest(r -> requestCallCount.increment())
-//		                           .doOnRequest(r -> totalRequest.add(r < Long.MAX_VALUE ? r : 1000L));
-//
-//		StepVerifier.withVirtualTime( //start with a single request
-//				() -> new FluxBufferPredicate<>(source, i -> i % 3 == 0,
-//						Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL), 1)
-//		            .expectSubscription()
-//		            .expectNext(Arrays.asList(1, 2, 3))
-//		            .expectNoEvent(Duration.ofSeconds(1))
-//		            .then(() -> assertThat(requestCallCount.intValue(), is(3)))
-//		            .thenRequest(Long.MAX_VALUE)
-//		            .expectNext(Arrays.asList(4, 5, 6), Arrays.asList(7, 8, 9))
-//		            .expectNext(Collections.singletonList(10))
-//		            .expectComplete()
-//		            .verify();
-//
-//		assertThat(requestCallCount.intValue(), is(4));
-//		assertThat(totalRequest.longValue(), is(1003L)); //the switch to unbounded is translated to 1000
-//	}
-//
-//	@Test
-//	@SuppressWarnings("unchecked")
-//	public void requestBoundedConditionalFusesDemands() {
-//		LongAdder requestCallCount = new LongAdder();
-//		LongAdder totalRequest = new LongAdder();
-//		Flux<Integer> source = Flux.range(1, 10)
-//		                           .doOnRequest(r -> requestCallCount.increment())
-//		                           .doOnRequest(totalRequest::add);
-//
-//		StepVerifier.withVirtualTime(
-//				() -> new FluxBufferPredicate<>(source, i -> i % 3 == 0,
-//						Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL), 1)
-//		            .expectSubscription()
-//		            .expectNext(Arrays.asList(1, 2, 3))
-//		            .thenRequest(1)
-//					.expectNext(Arrays.asList(4, 5, 6))
-//		            .thenRequest(1)
-//					.expectNext(Arrays.asList(7, 8, 9))
-////		            .expectNoEvent(Duration.ofSeconds(1))
-//		            .thenRequest(1)
-//		            .expectNext(Collections.singletonList(10))
-//		            .expectComplete()
-//		            .verify();
-//
-//		//despite the 1 by 1 demand, only 1 fused request per buffer, 4 buffers
-//		assertThat(requestCallCount.intValue(), is(4));
-//		assertThat(totalRequest.longValue(), is(4L)); //ignores the main requests
-//	}
-//
-//
-//	@Test
-//	public void testBufferPredicateUntilIncludesBoundaryLast() {
-//		String[] colorSeparated = new String[]{"red", "green", "blue", "#", "green", "green", "#", "blue", "cyan"};
-//
-//		Flux<List<String>> colors = Flux
-//				.fromArray(colorSeparated)
-//				.bufferUntil(val -> val.equals("#"))
-//				.log();
-//
-//		StepVerifier.create(colors)
-//		            .consumeNextWith(l1 -> Assert.assertThat(l1, contains("red", "green", "blue", "#")))
-//		            .consumeNextWith(l2 -> Assert.assertThat(l2, contains("green", "green", "#")))
-//		            .consumeNextWith(l3 -> Assert.assertThat(l3, contains("blue", "cyan")))
-//		            .expectComplete()
-//		            .verify();
-//	}
-//
-//	@Test
-//	public void testBufferPredicateUntilIncludesBoundaryLastAfter() {
-//		String[] colorSeparated = new String[]{"red", "green", "blue", "#", "green", "green", "#", "blue", "cyan"};
-//
-//		Flux<List<String>> colors = Flux
-//				.fromArray(colorSeparated)
-//				.bufferUntil(val -> val.equals("#"), false)
-//				.log();
-//
-//		StepVerifier.create(colors)
-//		            .consumeNextWith(l1 -> Assert.assertThat(l1, contains("red", "green", "blue", "#")))
-//		            .consumeNextWith(l2 -> Assert.assertThat(l2, contains("green", "green", "#")))
-//		            .consumeNextWith(l3 -> Assert.assertThat(l3, contains("blue", "cyan")))
-//		            .expectComplete()
-//		            .verify();
-//	}
-//
-//	@Test
-//	public void testBufferPredicateUntilCutBeforeIncludesBoundaryFirst() {
-//		String[] colorSeparated = new String[]{"red", "green", "blue", "#", "green", "green", "#", "blue", "cyan"};
-//
-//		Flux<List<String>> colors = Flux
-//				.fromArray(colorSeparated)
-//				.bufferUntil(val -> val.equals("#"), true)
-//				.log();
-//
-//		StepVerifier.create(colors)
-//		            .thenRequest(1)
-//		            .consumeNextWith(l1 -> Assert.assertThat(l1, contains("red", "green", "blue")))
-//		            .consumeNextWith(l2 -> Assert.assertThat(l2, contains("#", "green", "green")))
-//		            .consumeNextWith(l3 -> Assert.assertThat(l3, contains("#", "blue", "cyan")))
-//		            .expectComplete()
-//		            .verify();
-//	}
-//
-//	@Test
-//	public void testBufferPredicateWhileDoesntIncludeBoundary() {
-//		String[] colorSeparated = new String[]{"red", "green", "blue", "#", "green", "green", "#", "blue", "cyan"};
-//
-//		Flux<List<String>> colors = Flux
-//				.fromArray(colorSeparated)
-//				.bufferWhile(val -> !val.equals("#"))
-//				.log();
-//
-//		StepVerifier.create(colors)
-//		            .consumeNextWith(l1 -> Assert.assertThat(l1, contains("red", "green", "blue")))
-//		            .consumeNextWith(l2 -> Assert.assertThat(l2, contains("green", "green")))
-//		            .consumeNextWith(l3 -> Assert.assertThat(l3, contains("blue", "cyan")))
-//		            .expectComplete()
-//		            .verify();
-//	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void normalWhileDoesntInitiallyMatch() {
+		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
+				sp1, i -> i % 3 == 0, QueueSupplier.small(), Mode.WHILE);
+
+		StepVerifier.create(windowWhile.flatMap(Flux::collectList))
+				.expectSubscription()
+				.expectNoEvent(Duration.ofMillis(10))
+				.then(() -> sp1.onNext(1))
+				.then(() -> sp1.onNext(2))
+				.then(() -> sp1.onNext(3))
+				.expectNoEvent(Duration.ofMillis(10))
+				.then(() -> sp1.onNext(4))
+				.expectNext(Arrays.asList(3)) //emission of 4 completes the list
+				.then(() -> sp1.onNext(5))
+				.then(() -> sp1.onNext(6))
+				.expectNoEvent(Duration.ofMillis(10))
+				.then(() -> sp1.onNext(7)) // emission of 7 completes the list
+				.expectNext(Arrays.asList(6))
+				.then(() -> sp1.onNext(8))
+				.then(() -> sp1.onNext(9))
+				.expectNoEvent(Duration.ofMillis(10))
+				.then(sp1::onComplete) // completion triggers completion of the window / list
+			    .expectNext(Collections.singletonList(9))
+				.expectComplete()
+				.verify(Duration.ofSeconds(1));
+		assertFalse(sp1.hasDownstreams());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void normalWhileDoesntMatch() {
+		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
+				sp1, i -> i > 4, QueueSupplier.small(), Mode.WHILE);
+
+		StepVerifier.create(windowWhile.flatMap(Flux::collectList).log())
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofMillis(10))
+		            .then(() -> sp1.onNext(1))
+		            .then(() -> sp1.onNext(2))
+		            .then(() -> sp1.onNext(3))
+		            .then(() -> sp1.onNext(4))
+		            .expectNoEvent(Duration.ofMillis(10))
+		            .then(() -> sp1.onNext(1))
+		            .then(() -> sp1.onNext(2))
+		            .then(() -> sp1.onNext(3))
+		            .then(() -> sp1.onNext(4))
+		            .expectNoEvent(Duration.ofMillis(10))
+		            .then(sp1::onComplete)
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(1));
+		assertFalse(sp1.hasDownstreams());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void mainErrorWhile() {
+		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
+				sp1, i -> i % 3 == 0, QueueSupplier.small(), Mode.WHILE);
+
+		StepVerifier.create(windowWhile.flatMap(Flux::collectList))
+		            .expectSubscription()
+		            .then(() -> sp1.onNext(1))
+		            .then(() -> sp1.onNext(2))
+		            .then(() -> sp1.onNext(3))
+		            .then(() -> sp1.onNext(4))
+		            .expectNext(Arrays.asList(3))
+		            .then(() -> sp1.onError(new RuntimeException("forced failure")))
+		            .expectErrorMessage("forced failure")
+		            .verify(Duration.ofMillis(100));
+		assertFalse(sp1.hasDownstreams());
+	}
+
+	@Test
+	public void whileStartingSeveralSeparatorsDontCreateWindow() {
+		StepVerifier.create(Flux.just("#")
+		                        .repeat(10)
+		                        .concatWith(Flux.just("other", "value"))
+		                        .windowWhile(s -> !s.equals("#"))
+		                        .flatMap(Flux::count)
+		)
+		            .expectNext(2L)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void whileOnlySeparatorsGivesEmptySequence() {
+		StepVerifier.create(Flux.just("#")
+		                        .repeat(10)
+		                        .windowWhile(s -> !s.equals("#")))
+	                .verifyComplete();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void predicateErrorWhile() {
+		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
+				sp1,
+				i -> {
+					if (i == 3) return true;
+					if (i == 5) throw new IllegalStateException("predicate failure");
+					return false;
+				}, QueueSupplier.small(), Mode.WHILE);
+
+		Flux<Signal<Integer>> flux = windowWhile.flatMap(Flux::materialize)
+		                                        .log();
+
+		StepVerifier.create(flux)
+					.expectSubscription()
+					.then(() -> sp1.onNext(1)) //ignored, window not emitted
+					.then(() -> sp1.onNext(2)) //ignored, window not emitted
+					.then(() -> sp1.onNext(3)) //window opens
+					.expectNext(Signal.next(3))
+					.then(() -> sp1.onNext(4)) //ignored, window closes
+					.expectNext(Signal.complete())
+					.then(() -> sp1.onNext(5)) //fails
+					.expectErrorMessage("predicate failure")
+					.verify(Duration.ofMillis(100));
+		assertFalse(sp1.hasDownstreams());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void queueSupplierThrows() {
+		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(
+				sp1, i -> i % 3 == 0,
+				() -> { throw new RuntimeException("supplier failure"); },
+				Mode.UNTIL);
+
+		assertFalse("sp1 has subscribers?", sp1.hasDownstreams());
+
+		StepVerifier.create(windowUntil)
+		            .then(() -> sp1.onNext(1))
+		            .expectErrorMessage("supplier failure")
+		            .verify();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void queueSupplierThrowsLater() {
+		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		int count[] = {1};
+		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(
+				sp1, i -> i % 3 == 0,
+				() -> {
+					if (count[0]-- > 0) {
+						return QueueSupplier.<Integer>small().get();
+					}
+					throw new RuntimeException("supplier failure");
+				},
+				Mode.UNTIL);
+
+		assertFalse("sp1 has subscribers?", sp1.hasDownstreams());
+
+		StepVerifier.create(windowUntil.flatMap(Flux::collectList))
+		            .then(() -> sp1.onNext(1))
+		            .then(() -> sp1.onNext(2))
+		            .expectNoEvent(Duration.ofMillis(10))
+		            .then(() -> sp1.onNext(3))
+		            .expectNext(Arrays.asList(1, 2, 3))
+		            .then(() -> sp1.onNext(4))
+		            .expectErrorMessage("supplier failure")
+		            .verify();
+	}
+
+	@Test
+	public void queueSupplierReturnsNull() {
+		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(
+				sp1, i -> i % 3 == 0,
+				() -> null,
+				Mode.UNTIL);
+
+		assertFalse("sp1 has subscribers?", sp1.hasDownstreams());
+
+		StepVerifier.create(windowUntil)
+		            .then(() -> sp1.onNext(1))
+		            .expectErrorMatches(t -> t instanceof NullPointerException &&
+		                "The processorQueueSupplier returned a null queue".equals(t.getMessage()))
+		            .verify();
+	}
+
 }

--- a/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
+++ b/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
@@ -659,4 +659,37 @@ public class FluxWindowPredicateTest {
 
 		assertThat(keys).containsExactly(null, "#1", "#2");
 	}
+
+	@Test
+	public void mismatchAtBeginningUntil() {
+		StepVerifier.create(Flux.just("#", "red", "green")
+		                        .windowUntil(s -> s.equals("#"))
+		                        .flatMap(Flux::materialize)
+		                        .map(sig -> sig.isOnComplete() ? "END" : sig.get()))
+	                .expectNext("#", "END")
+	                .expectNext("red", "green", "END")
+	                .verifyComplete();
+	}
+
+	@Test
+	public void mismatchAtBeginningUntilCutBefore() {
+		StepVerifier.create(Flux.just("#", "red", "green")
+		                        .windowUntil(s -> s.equals("#"), true)
+		                        .flatMap(Flux::materialize)
+		                        .map(sig -> sig.isOnComplete() ? "END" : sig.get()))
+	                .expectNext("END")
+	                .expectNext("#", "red", "green", "END")
+	                .verifyComplete();
+	}
+
+	@Test
+	public void mismatchAtBeginningWhile() {
+		StepVerifier.create(Flux.just("#", "red", "green")
+		                        .windowWhile(s -> !s.equals("#"))
+		                        .flatMap(Flux::materialize)
+		                        .map(sig -> sig.isOnComplete() ? "END" : sig.get()))
+	                .expectNext("END")
+	                .expectNext("red", "green", "END")
+	                .verifyComplete();
+	}
 }

--- a/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
+++ b/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
@@ -1,0 +1,704 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Supplier;
+
+import org.junit.Assert;
+import org.junit.Test;
+import reactor.core.publisher.FluxBufferPredicate.Mode;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+import reactor.util.concurrent.QueueSupplier;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+public class FluxWindowPredicateTest {
+
+	@Test
+	public void apiUntil() {
+		StepVerifier.create(Flux.just("red", "green", "#", "orange", "blue", "#", "black", "white")
+		                        .windowUntil(color -> color.equals("#"))
+		                        .flatMap(Flux::materialize)
+		                        .map(s -> s.isOnComplete() ? "WINDOW CLOSED" : s.get()))
+		            .expectNext("red", "green", "#", "WINDOW CLOSED")
+		            .expectNext("orange", "blue", "#", "WINDOW CLOSED")
+		            .expectNext("black", "white", "WINDOW CLOSED")
+	                .verifyComplete();
+	}
+
+	@Test
+	public void apiUntilCutBefore() {
+		StepVerifier.create(Flux.just("red", "green", "#", "orange", "blue", "#", "black", "white")
+		                        .windowUntil(color -> color.equals("#"), true)
+		                        .flatMap(Flux::materialize)
+		                        .map(s -> s.isOnComplete() ? "WINDOW CLOSED" : s.get()))
+		            .expectNext("red", "green", "WINDOW CLOSED", "#")
+		            .expectNext("orange", "blue", "WINDOW CLOSED", "#")
+		            .expectNext("black", "white", "WINDOW CLOSED")
+	                .verifyComplete();
+	}
+
+	@Test
+	public void apiWhile() {
+		StepVerifier.create(Flux.just("red", "green", "#", "orange", "blue", "#", "black", "white")
+		                        .windowWhile(color -> !color.equals("#"))
+		                        .flatMap(Flux::materialize)
+		                        .map(s -> s.isOnComplete() ? "WINDOW CLOSED" : s.get()))
+		            .expectNext("red", "green", "WINDOW CLOSED")
+		            .expectNext("orange", "blue", "WINDOW CLOSED")
+		            .expectNext("black", "white", "WINDOW CLOSED")
+	                .verifyComplete();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void normalUntil() {
+		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(sp1, i -> i % 3 == 0,
+				QueueSupplier.small(), Mode.UNTIL);
+
+		StepVerifier.create(windowUntil.flatMap(Flux::materialize))
+		            .expectSubscription()
+		            .then(() -> sp1.onNext(1))
+				    .then(() -> sp1.onNext(2))
+		            .expectNext(Signal.next(1), Signal.next(2))
+				    .then(() -> sp1.onNext(3))
+		            .expectNext(Signal.next(3), Signal.complete())
+				    .then(() -> sp1.onNext(4))
+				    .then(() -> sp1.onNext(5))
+				    .expectNext(Signal.next(4), Signal.next(5))
+				    .then(() -> sp1.onNext(6))
+				    .expectNext(Signal.next(6), Signal.complete())
+				    .then(() -> sp1.onNext(7))
+				    .then(() -> sp1.onNext(8))
+				    .expectNext(Signal.next(7), Signal.next(8))
+				    .then(sp1::onComplete)
+		            .expectNext(Signal.complete())
+				    .verifyComplete();
+
+		assertFalse(sp1.hasDownstreams());
+	}
+
+//	@Test
+//	@SuppressWarnings("unchecked")
+//	public void onCompletionBeforeLastBoundaryBufferEmitted() {
+//		Flux<Integer> source = Flux.just(1, 2);
+//
+//		FluxBufferPredicate<Integer, List<Integer>> bufferUntil =
+//				new FluxBufferPredicate<>(source, i -> i >= 3, Flux.listSupplier(),
+//						FluxBufferPredicate.Mode.UNTIL);
+//
+//		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther =
+//				new FluxBufferPredicate<>(source, i -> i >= 3, Flux.listSupplier(),
+//						FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE);
+//
+//		FluxBufferPredicate<Integer, List<Integer>> bufferWhile =
+//				new FluxBufferPredicate<>(source, i -> i < 3, Flux.listSupplier(),
+//						FluxBufferPredicate.Mode.WHILE);
+//
+//		StepVerifier.create(bufferUntil)
+//				.expectNext(Arrays.asList(1, 2))
+//				.expectComplete()
+//				.verify();
+//
+//		StepVerifier.create(bufferUntilOther)
+//		            .expectNext(Arrays.asList(1, 2))
+//		            .expectComplete()
+//		            .verify();
+//
+//		StepVerifier.create(bufferWhile)
+//		            .expectNext(Arrays.asList(1, 2))
+//		            .expectComplete()
+//		            .verify();
+//	}
+//
+//	@Test
+//	@SuppressWarnings("unchecked")
+//	public void mainErrorUntil() {
+//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+//		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
+//				sp1, i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL);
+//
+//		StepVerifier.create(bufferUntil)
+//		            .expectSubscription()
+//		            .then(() -> sp1.onNext(1))
+//		            .then(() -> sp1.onNext(2))
+//		            .then(() -> sp1.onNext(3))
+//		            .expectNext(Arrays.asList(1, 2, 3))
+//		            .then(() -> sp1.onNext(4))
+//		            .then(() -> sp1.onError(new RuntimeException("forced failure")))
+//		            .expectErrorMessage("forced failure")
+//		            .verify();
+//		assertFalse(sp1.hasDownstreams());
+//	}
+//
+//	@Test
+//	@SuppressWarnings("unchecked")
+//	public void predicateErrorUntil() {
+//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+//		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
+//				sp1,
+//				i -> {
+//					if (i == 5) throw new IllegalStateException("predicate failure");
+//					return i % 3 == 0;
+//				}, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL);
+//
+//		StepVerifier.create(bufferUntil)
+//					.expectSubscription()
+//					.then(() -> sp1.onNext(1))
+//					.then(() -> sp1.onNext(2))
+//					.then(() -> sp1.onNext(3))
+//					.expectNext(Arrays.asList(1, 2, 3))
+//					.then(() -> sp1.onNext(4))
+//					.then(() -> sp1.onNext(5))
+//					.expectErrorMessage("predicate failure")
+//					.verify();
+//		assertFalse(sp1.hasDownstreams());
+//	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void normalUntilOther() {
+		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxWindowPredicate<Integer> windowUntilOther = new FluxWindowPredicate<>(sp1, i -> i % 3 == 0,
+				QueueSupplier.small(), Mode.UNTIL_CUT_BEFORE);
+
+		StepVerifier.create(windowUntilOther.flatMap(Flux::materialize))
+				.expectSubscription()
+				    .then(() -> sp1.onNext(1))
+				    .then(() -> sp1.onNext(2))
+				    .expectNext(Signal.next(1), Signal.next(2))
+				    .then(() -> sp1.onNext(3))
+				    .expectNext(Signal.complete(), Signal.next(3))
+				    .then(() -> sp1.onNext(4))
+				    .then(() -> sp1.onNext(5))
+				    .expectNext(Signal.next(4), Signal.next(5))
+				    .then(() -> sp1.onNext(6))
+				    .expectNext(Signal.complete(), Signal.next(6))
+				    .then(() -> sp1.onNext(7))
+				    .then(() -> sp1.onNext(8))
+				    .expectNext(Signal.next(7), Signal.next(8))
+				    .then(sp1::onComplete)
+				    .expectNext(Signal.complete())
+				    .verifyComplete();
+		assertFalse(sp1.hasDownstreams());
+	}
+//
+//	@Test
+//	@SuppressWarnings("unchecked")
+//	public void mainErrorUntilOther() {
+//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+//		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther =
+//				new FluxBufferPredicate<>(sp1, i -> i % 3 == 0, Flux.listSupplier(),
+//						FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE);
+//
+//		StepVerifier.create(bufferUntilOther)
+//		            .expectSubscription()
+//		            .then(() -> sp1.onNext(1))
+//		            .then(() -> sp1.onNext(2))
+//		            .then(() -> sp1.onNext(3))
+//		            .expectNext(Arrays.asList(1, 2))
+//		            .then(() -> sp1.onNext(4))
+//		            .then(() -> sp1.onError(new RuntimeException("forced failure")))
+//		            .expectErrorMessage("forced failure")
+//		            .verify();
+//		assertFalse(sp1.hasDownstreams());
+//	}
+//
+//	@Test
+//	@SuppressWarnings("unchecked")
+//	public void predicateErrorUntilOther() {
+//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+//		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther =
+//				new FluxBufferPredicate<>(sp1,
+//				i -> {
+//					if (i == 5) throw new IllegalStateException("predicate failure");
+//					return i % 3 == 0;
+//				}, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE);
+//
+//		StepVerifier.create(bufferUntilOther)
+//					.expectSubscription()
+//					.then(() -> sp1.onNext(1))
+//					.then(() -> sp1.onNext(2))
+//					.then(() -> sp1.onNext(3))
+//					.expectNext(Arrays.asList(1, 2))
+//					.then(() -> sp1.onNext(4))
+//					.then(() -> sp1.onNext(5))
+//					.expectErrorMessage("predicate failure")
+//					.verify();
+//		assertFalse(sp1.hasDownstreams());
+//	}
+//
+	@Test
+	@SuppressWarnings("unchecked")
+	public void normalWhile() {
+		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
+				sp1, i -> i % 3 != 0, QueueSupplier.small(),
+				FluxBufferPredicate.Mode.WHILE);
+
+		StepVerifier.create(windowWhile.flatMap(Flux::materialize))
+		            .expectSubscription()
+		            .then(() -> sp1.onNext(1))
+		            .then(() -> sp1.onNext(2))
+		            .expectNext(Signal.next(1), Signal.next(2))
+		            .then(() -> sp1.onNext(3))
+		            .expectNext(Signal.complete())
+		            .then(() -> sp1.onNext(4))
+		            .then(() -> sp1.onNext(5))
+		            .expectNext(Signal.next(4), Signal.next(5))
+		            .then(() -> sp1.onNext(6))
+		            .expectNext(Signal.complete())
+		            .then(() -> sp1.onNext(7))
+		            .then(() -> sp1.onNext(8))
+		            .expectNext(Signal.next(7), Signal.next(8))
+		            .then(sp1::onComplete)
+		            .expectNext(Signal.complete())
+		            .verifyComplete();
+		assertFalse(sp1.hasDownstreams());
+	}
+//
+//	@Test
+//	@SuppressWarnings("unchecked")
+//	public void normalWhileDoesntInitiallyMatch() {
+//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+//		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
+//				sp1, i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
+//
+//		StepVerifier.create(bufferWhile)
+//				.expectSubscription()
+//				.expectNoEvent(Duration.ofMillis(10))
+//				.then(() -> sp1.onNext(1))
+//				.then(() -> sp1.onNext(2))
+//				.then(() -> sp1.onNext(3))
+//				.expectNoEvent(Duration.ofMillis(10))
+//				.then(() -> sp1.onNext(4))
+//				.expectNext(Arrays.asList(3)) //emission of 4 triggers the buffer emit
+//				.then(() -> sp1.onNext(5))
+//				.then(() -> sp1.onNext(6))
+//				.expectNoEvent(Duration.ofMillis(10))
+//				.then(() -> sp1.onNext(7)) // emission of 7 triggers the buffer emit
+//				.expectNext(Arrays.asList(6))
+//				.then(() -> sp1.onNext(8))
+//				.then(() -> sp1.onNext(9))
+//				.expectNoEvent(Duration.ofMillis(10))
+//				.then(sp1::onComplete) // completion triggers the buffer emit
+//			    .expectNext(Collections.singletonList(9))
+//				.expectComplete()
+//				.verify(Duration.ofSeconds(1));
+//		assertFalse(sp1.hasDownstreams());
+//	}
+//
+//	@Test
+//	@SuppressWarnings("unchecked")
+//	public void normalWhileDoesntMatch() {
+//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+//		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
+//				sp1, i -> i > 4, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
+//
+//		StepVerifier.create(bufferWhile)
+//		            .expectSubscription()
+//		            .expectNoEvent(Duration.ofMillis(10))
+//		            .then(() -> sp1.onNext(1))
+//		            .then(() -> sp1.onNext(2))
+//		            .then(() -> sp1.onNext(3))
+//		            .then(() -> sp1.onNext(4))
+//		            .expectNoEvent(Duration.ofMillis(10))
+//		            .then(() -> sp1.onNext(1))
+//		            .then(() -> sp1.onNext(2))
+//		            .then(() -> sp1.onNext(3))
+//		            .then(() -> sp1.onNext(4))
+//		            .expectNoEvent(Duration.ofMillis(10))
+//		            .then(sp1::onComplete)
+//		            .expectComplete()
+//		            .verify(Duration.ofSeconds(1));
+//		assertFalse(sp1.hasDownstreams());
+//	}
+//
+//	@Test
+//	@SuppressWarnings("unchecked")
+//	public void mainErrorWhile() {
+//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+//		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
+//				sp1, i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
+//
+//		StepVerifier.create(bufferWhile)
+//		            .expectSubscription()
+//		            .then(() -> sp1.onNext(1))
+//		            .then(() -> sp1.onNext(2))
+//		            .then(() -> sp1.onNext(3))
+//		            .then(() -> sp1.onNext(4))
+//		            .expectNext(Arrays.asList(3))
+//		            .then(() -> sp1.onError(new RuntimeException("forced failure")))
+//		            .expectErrorMessage("forced failure")
+//		            .verify(Duration.ofMillis(100));
+//		assertFalse(sp1.hasDownstreams());
+//	}
+//
+//	@Test
+//	@SuppressWarnings("unchecked")
+//	public void predicateErrorWhile() {
+//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+//		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
+//				sp1,
+//				i -> {
+//					if (i == 3) return true;
+//					if (i == 5) throw new IllegalStateException("predicate failure");
+//					return false;
+//				}, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
+//
+//		StepVerifier.create(bufferWhile)
+//					.expectSubscription()
+//					.then(() -> sp1.onNext(1)) //ignored
+//					.then(() -> sp1.onNext(2)) //ignored
+//					.then(() -> sp1.onNext(3)) //buffered
+//					.then(() -> sp1.onNext(4)) //ignored, emits buffer
+//					.expectNext(Arrays.asList(3))
+//					.then(() -> sp1.onNext(5)) //fails
+//					.expectErrorMessage("predicate failure")
+//					.verify(Duration.ofMillis(100));
+//		assertFalse(sp1.hasDownstreams());
+//	}
+//
+//	@Test
+//	@SuppressWarnings("unchecked")
+//	public void bufferSupplierThrows() {
+//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+//		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
+//				sp1, i -> i % 3 == 0,
+//				() -> { throw new RuntimeException("supplier failure"); },
+//				FluxBufferPredicate.Mode.UNTIL);
+//
+//		Assert.assertFalse("sp1 has subscribers?", sp1.hasDownstreams());
+//
+//		StepVerifier.create(bufferUntil)
+//		            .expectErrorMessage("supplier failure")
+//		            .verify();
+//	}
+//
+//	@Test
+//	public void bufferSupplierThrowsLater() {
+//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+//		int count[] = {1};
+//		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
+//				sp1, i -> i % 3 == 0,
+//				() -> {
+//					if (count[0]-- > 0) {
+//						return new ArrayList<>();
+//					}
+//					throw new RuntimeException("supplier failure");
+//				},
+//				FluxBufferPredicate.Mode.UNTIL);
+//
+//		Assert.assertFalse("sp1 has subscribers?", sp1.hasDownstreams());
+//
+//		StepVerifier.create(bufferUntil)
+//		            .then(() -> sp1.onNext(1))
+//		            .then(() -> sp1.onNext(2))
+//		            .expectNoEvent(Duration.ofMillis(10))
+//		            .then(() -> sp1.onNext(3))
+//		            .expectErrorMessage("supplier failure")
+//		            .verify();
+//	}
+//
+//	@Test
+//	public void bufferSupplierReturnsNull() {
+//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+//		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
+//				sp1, i -> i % 3 == 0,
+//				() -> null,
+//				FluxBufferPredicate.Mode.UNTIL);
+//
+//		Assert.assertFalse("sp1 has subscribers?", sp1.hasDownstreams());
+//
+//		StepVerifier.create(bufferUntil)
+//		            .then(() -> sp1.onNext(1))
+//		            .expectErrorMatches(t -> t instanceof NullPointerException &&
+//		                "The bufferSupplier returned a null initial buffer".equals(t.getMessage()))
+//		            .verify();
+//	}
+//
+//	@Test
+//	@SuppressWarnings("unchecked")
+//	public void multipleTriggersOfEmptyBufferKeepInitialBuffer() {
+//		//this is best demonstrated with bufferWhile:
+//		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+//		LongAdder bufferCount = new LongAdder();
+//		Supplier<List<Integer>> bufferSupplier = () -> {
+//			bufferCount.increment();
+//			return new ArrayList<>();
+//		};
+//
+//		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new
+//				FluxBufferPredicate<>(
+//				sp1, i -> i >= 10,
+//				bufferSupplier,
+//				FluxBufferPredicate.Mode.WHILE);
+//
+//		StepVerifier.create(bufferWhile)
+//		            .then(() -> assertThat(bufferCount.intValue(), is(1)))
+//		            .then(() -> sp1.onNext(1))
+//		            .then(() -> sp1.onNext(2))
+//		            .then(() -> sp1.onNext(3))
+//		            .then(() -> assertThat(bufferCount.intValue(), is(1)))
+//		            .expectNoEvent(Duration.ofMillis(10))
+//		            .then(() -> sp1.onNext(10))
+//		            .then(() -> sp1.onNext(11))
+//		            .then(sp1::onComplete)
+//		            .expectNext(Arrays.asList(10, 11))
+//		            .then(() -> assertThat(bufferCount.intValue(), is(1)))
+//		            .expectComplete()
+//		            .verify();
+//
+//		assertThat(bufferCount.intValue(), is(1));
+//	}
+//
+//	@Test
+//	@SuppressWarnings("unchecked")
+//	public void requestBounded() {
+//		LongAdder requestCallCount = new LongAdder();
+//		LongAdder totalRequest = new LongAdder();
+//		Flux<Integer> source = Flux.range(1, 10).hide()
+//		                           .doOnRequest(r -> requestCallCount.increment())
+//		                           .doOnRequest(totalRequest::add);
+//
+//		StepVerifier.withVirtualTime( //start with a request for 1 buffer
+//				() -> new FluxBufferPredicate<>(source, i -> i % 3 == 0,
+//				Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL), 1)
+//		            .expectSubscription()
+//		            .expectNext(Arrays.asList(1, 2, 3))
+//		            .expectNoEvent(Duration.ofSeconds(1))
+//		            .thenRequest(2)
+//		            .expectNext(Arrays.asList(4, 5, 6), Arrays.asList(7, 8, 9))
+//		            .expectNoEvent(Duration.ofSeconds(1))
+//		            .thenRequest(3)
+//		            .expectNext(Collections.singletonList(10))
+//		            .expectComplete()
+//		            .verify();
+//
+//		assertThat(requestCallCount.intValue(), is(11)); //10 elements then the completion
+//		assertThat(totalRequest.longValue(), is(11L)); //ignores the main requests
+//	}
+//
+//	@Test
+//	@SuppressWarnings("unchecked")
+//	public void requestBoundedSeveralInitial() {
+//		LongAdder requestCallCount = new LongAdder();
+//		LongAdder totalRequest = new LongAdder();
+//		Flux<Integer> source = Flux.range(1, 10).hide()
+//		                           .doOnRequest(r -> requestCallCount.increment())
+//		                           .doOnRequest(totalRequest::add);
+//
+//		StepVerifier.withVirtualTime( //start with a request for 2 buffers
+//				() -> new FluxBufferPredicate<>(source, i -> i % 3 == 0,
+//				Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL), 2)
+//		            .expectSubscription()
+//		            .expectNext(Arrays.asList(1, 2, 3), Arrays.asList(4, 5, 6))
+//		            .expectNoEvent(Duration.ofSeconds(1))
+//		            .thenRequest(2)
+//					.expectNext(Arrays.asList(7, 8, 9))
+//		            .expectNext(Collections.singletonList(10))
+//		            .expectComplete()
+//		            .verify(Duration.ofSeconds(1));
+//
+//		assertThat(requestCallCount.intValue(), is(11)); //10 elements then the completion
+//		assertThat(totalRequest.longValue(), is(11L)); //ignores the main requests
+//	}
+//
+//	@Test
+//	@SuppressWarnings("unchecked")
+//	public void requestRemainingBuffersAfterBufferEmission() {
+//		LongAdder requestCallCount = new LongAdder();
+//		LongAdder totalRequest = new LongAdder();
+//		Flux<Integer> source = Flux.range(1, 10).hide()
+//		                           .doOnRequest(r -> requestCallCount.increment())
+//		                           .doOnRequest(totalRequest::add);
+//
+//		StepVerifier.withVirtualTime( //start with a request for 3 buffers
+//				() -> new FluxBufferPredicate<>(source, i -> i % 3 == 0,
+//						Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL), 3)
+//		            .expectSubscription()
+//		            .expectNext(Arrays.asList(1, 2, 3), Arrays.asList(4, 5, 6), Arrays.asList(7, 8, 9))
+//		            .expectNoEvent(Duration.ofSeconds(1))
+//		            .thenRequest(1)
+//		            .expectNext(Collections.singletonList(10))
+//		            .expectComplete()
+//		            .verify(Duration.ofSeconds(1));
+//
+//		assertThat(requestCallCount.intValue(), is(11)); //10 elements then the completion
+//		assertThat(totalRequest.longValue(), is(11L)); //ignores the main requests
+//	}
+//
+//	@Test
+//	@SuppressWarnings("unchecked")
+//	public void requestUnboundedFromStartRequestsSourceOnce() {
+//		LongAdder requestCallCount = new LongAdder();
+//		LongAdder totalRequest = new LongAdder();
+//		Flux<Integer> source = Flux.range(1, 10).hide()
+//		                           .doOnRequest(r -> requestCallCount.increment())
+//		                           .doOnRequest(totalRequest::add);
+//
+//		StepVerifier.withVirtualTime(//start with an unbounded request
+//				() -> new FluxBufferPredicate<>(source, i -> i % 3 == 0,
+//						Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL))
+//		            .expectSubscription()
+//		            .expectNext(Arrays.asList(1, 2, 3))
+//		            .expectNext(Arrays.asList(4, 5, 6), Arrays.asList(7, 8, 9))
+//		            .expectNext(Collections.singletonList(10))
+//		            .expectComplete()
+//		            .verify();
+//
+//		assertThat(requestCallCount.intValue(), is(1));
+//		assertThat(totalRequest.longValue(), is(Long.MAX_VALUE)); //also unbounded
+//	}
+//
+//	@Test
+//	@SuppressWarnings("unchecked")
+//	public void requestSwitchingToMaxRequestsSourceOnlyOnceMore() {
+//		LongAdder requestCallCount = new LongAdder();
+//		LongAdder totalRequest = new LongAdder();
+//		Flux<Integer> source = Flux.range(1, 10).hide()
+//		                           .doOnRequest(r -> requestCallCount.increment())
+//		                           .doOnRequest(r -> totalRequest.add(r < Long.MAX_VALUE ? r : 1000L));
+//
+//		StepVerifier.withVirtualTime( //start with a single request
+//				() -> new FluxBufferPredicate<>(source, i -> i % 3 == 0,
+//						Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL), 1)
+//		            .expectSubscription()
+//		            .expectNext(Arrays.asList(1, 2, 3))
+//		            .expectNoEvent(Duration.ofSeconds(1))
+//		            .then(() -> assertThat(requestCallCount.intValue(), is(3)))
+//		            .thenRequest(Long.MAX_VALUE)
+//		            .expectNext(Arrays.asList(4, 5, 6), Arrays.asList(7, 8, 9))
+//		            .expectNext(Collections.singletonList(10))
+//		            .expectComplete()
+//		            .verify();
+//
+//		assertThat(requestCallCount.intValue(), is(4));
+//		assertThat(totalRequest.longValue(), is(1003L)); //the switch to unbounded is translated to 1000
+//	}
+//
+//	@Test
+//	@SuppressWarnings("unchecked")
+//	public void requestBoundedConditionalFusesDemands() {
+//		LongAdder requestCallCount = new LongAdder();
+//		LongAdder totalRequest = new LongAdder();
+//		Flux<Integer> source = Flux.range(1, 10)
+//		                           .doOnRequest(r -> requestCallCount.increment())
+//		                           .doOnRequest(totalRequest::add);
+//
+//		StepVerifier.withVirtualTime(
+//				() -> new FluxBufferPredicate<>(source, i -> i % 3 == 0,
+//						Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL), 1)
+//		            .expectSubscription()
+//		            .expectNext(Arrays.asList(1, 2, 3))
+//		            .thenRequest(1)
+//					.expectNext(Arrays.asList(4, 5, 6))
+//		            .thenRequest(1)
+//					.expectNext(Arrays.asList(7, 8, 9))
+////		            .expectNoEvent(Duration.ofSeconds(1))
+//		            .thenRequest(1)
+//		            .expectNext(Collections.singletonList(10))
+//		            .expectComplete()
+//		            .verify();
+//
+//		//despite the 1 by 1 demand, only 1 fused request per buffer, 4 buffers
+//		assertThat(requestCallCount.intValue(), is(4));
+//		assertThat(totalRequest.longValue(), is(4L)); //ignores the main requests
+//	}
+//
+//
+//	@Test
+//	public void testBufferPredicateUntilIncludesBoundaryLast() {
+//		String[] colorSeparated = new String[]{"red", "green", "blue", "#", "green", "green", "#", "blue", "cyan"};
+//
+//		Flux<List<String>> colors = Flux
+//				.fromArray(colorSeparated)
+//				.bufferUntil(val -> val.equals("#"))
+//				.log();
+//
+//		StepVerifier.create(colors)
+//		            .consumeNextWith(l1 -> Assert.assertThat(l1, contains("red", "green", "blue", "#")))
+//		            .consumeNextWith(l2 -> Assert.assertThat(l2, contains("green", "green", "#")))
+//		            .consumeNextWith(l3 -> Assert.assertThat(l3, contains("blue", "cyan")))
+//		            .expectComplete()
+//		            .verify();
+//	}
+//
+//	@Test
+//	public void testBufferPredicateUntilIncludesBoundaryLastAfter() {
+//		String[] colorSeparated = new String[]{"red", "green", "blue", "#", "green", "green", "#", "blue", "cyan"};
+//
+//		Flux<List<String>> colors = Flux
+//				.fromArray(colorSeparated)
+//				.bufferUntil(val -> val.equals("#"), false)
+//				.log();
+//
+//		StepVerifier.create(colors)
+//		            .consumeNextWith(l1 -> Assert.assertThat(l1, contains("red", "green", "blue", "#")))
+//		            .consumeNextWith(l2 -> Assert.assertThat(l2, contains("green", "green", "#")))
+//		            .consumeNextWith(l3 -> Assert.assertThat(l3, contains("blue", "cyan")))
+//		            .expectComplete()
+//		            .verify();
+//	}
+//
+//	@Test
+//	public void testBufferPredicateUntilCutBeforeIncludesBoundaryFirst() {
+//		String[] colorSeparated = new String[]{"red", "green", "blue", "#", "green", "green", "#", "blue", "cyan"};
+//
+//		Flux<List<String>> colors = Flux
+//				.fromArray(colorSeparated)
+//				.bufferUntil(val -> val.equals("#"), true)
+//				.log();
+//
+//		StepVerifier.create(colors)
+//		            .thenRequest(1)
+//		            .consumeNextWith(l1 -> Assert.assertThat(l1, contains("red", "green", "blue")))
+//		            .consumeNextWith(l2 -> Assert.assertThat(l2, contains("#", "green", "green")))
+//		            .consumeNextWith(l3 -> Assert.assertThat(l3, contains("#", "blue", "cyan")))
+//		            .expectComplete()
+//		            .verify();
+//	}
+//
+//	@Test
+//	public void testBufferPredicateWhileDoesntIncludeBoundary() {
+//		String[] colorSeparated = new String[]{"red", "green", "blue", "#", "green", "green", "#", "blue", "cyan"};
+//
+//		Flux<List<String>> colors = Flux
+//				.fromArray(colorSeparated)
+//				.bufferWhile(val -> !val.equals("#"))
+//				.log();
+//
+//		StepVerifier.create(colors)
+//		            .consumeNextWith(l1 -> Assert.assertThat(l1, contains("red", "green", "blue")))
+//		            .consumeNextWith(l2 -> Assert.assertThat(l2, contains("green", "green")))
+//		            .consumeNextWith(l3 -> Assert.assertThat(l3, contains("blue", "cyan")))
+//		            .expectComplete()
+//		            .verify();
+//	}
+}


### PR DESCRIPTION
@smaldini first pass at windowUntil/windowWhile. Took inspiration from both `FluxBufferPredicate` and `FluxWindow`,
which makes it simpler than the buffer one (no fancy request rewriting nor fusion support).

Do you think we should strive to make it support conditional/fuseable right now (if at all)?