### PR TITLE
fix #417 Add checkpoint() operator to force single assembly tracing

### DIFF
--- a/src/docs/asciidoc/debugging.adoc
+++ b/src/docs/asciidoc/debugging.adoc
@@ -115,42 +115,11 @@ application.
 Later on, if an exception occurs, the failing operator will be able to refer
 to that capture and append it to the stacktrace.
 
-.Cost of debug mode
-****
-We are dealing with a form of instrumentation here, and creating a
-stacktrace is costly. That is why this debugging feature should only be
-activated in a controlled manner, as a last resort.
-There are ways of limiting the impact of that feature by restricting the hook to
-the type of operator that is causing an issue.
-
-The filter to use is best determined by looking at the class in the stack trace,
-after removing any `Parallel`, `Flux` and `Mono` prefixes and the `Fuseable`
-suffix. For instance in our case:
-
-----
-at reactor.core.publisher.MonoSingle$SingleSubscriber.onNext(MonoSingle.java:120)
-----
-
-We have `MonoSingle.java:120`, so `MonoSingle` operator implementation and
-`single` as the filtering keyword.
-
-So we could only instrument uses of the incriminating operator by doing:
-
-[source,java]
-----
-Hooks.onOperator(providedHook -> providedHook.ifName("single") <1>
-                                             .operatorStackTrace());
-----
-<1> Only activate for operator classes named "single", ignoring case and the
-"Parallel", "Flux" or "Mono" prefixes, as well as "Fuseable" suffix (as seen in
-stacktrace)
-****
-
-In the next section, we'll see how it differs and how to interpret that new
-information.
+In the next section, we'll see how the stacktrace differs and how to interpret
+that new information.
 
 == Reading a stack trace in debug mode
-Reusing the example from above, but activating the `operatorStackTrace` debug
+Reusing our initial example but activating the `operatorStackTrace` debug
 feature, here is the stack we now get:
 
 [source]
@@ -250,6 +219,76 @@ of the section of the chain that gets notified of the error:
     `applyFilters` utility method).
  4. finally it is seen by an `elapsed` and a `transform`. Once again, elapsed is
     what is applied by the transformation function of that second transform.
+
+=== Cost of debug mode
+We are dealing with a form of instrumentation here, and creating a
+stacktrace is costly. That is why this debugging feature should only be
+activated in a controlled manner, as a last resort.
+There are ways of limiting the impact of that feature by restricting the hook to
+the type of operator that is causing an issue.
+
+The filter to use is best determined by looking at the class in the stack trace,
+after removing any `Parallel`, `Flux` and `Mono` prefixes and the `Fuseable`
+suffix. For instance in our case:
+
+----
+at reactor.core.publisher.MonoSingle$SingleSubscriber.onNext(MonoSingle.java:120)
+----
+
+We have `MonoSingle.java:120`, so `MonoSingle` operator implementation and
+`single` as the filtering keyword.
+
+So we could only instrument uses of the incriminating operator by doing:
+
+[source,java]
+----
+Hooks.onOperator(providedHook -> providedHook.ifName("single") <1>
+                                             .operatorStackTrace());
+----
+<1> Only activate for operator classes named "single", ignoring case and the
+"Parallel", "Flux" or "Mono" prefixes, as well as "Fuseable" suffix (as seen in
+stacktrace)
+
+=== The `checkpoint()` alternative
+The debug mode is global and affects every single operator assembled into a
+`Flux` or `Mono` inside the application. This has the benefit of allowing
+*after the fact debugging*: whatever the error, we will obtain additional info
+to debug it.
+
+As we saw in the "Cost of debug mode" above, this is at the cost of an impact on
+performance (due to the number of populated stacktraces). That cost can be
+reduced if we have an idea of likely problematic operators. But usually this
+isn't known unless we observed an error in the wild, saw we were missing
+assembly information and then modified the code to activate assembly tracking,
+hoping we can observe the same error again...
+
+In that scenario, we have to switch into debugging gear and make preparations
+in order to better observe a second occurrence of the error, this time capturing
+all the additional information.
+
+If you can identify reactive chains that you assemble in your application for
+which serviceability is critical, *a mix of both world can be achieved with the
+`checkpoint()` operator.*
+
+You can chain this operator towards their end. The `checkpoint` operator will
+work like the hook version, but only for its link of that particular chain.
+
+Additionally, there is a `checkpoint(String)` variant that allows you to add a
+description to the assembly traceback. It could for example be a static
+identifier or user-readable description, or a wider *correlation ID* coming from
+a header in the case of an HTTP request for instance...
+
+That information appears in the first line of the traceback:
+
+----
+Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException:
+Assembly trace from producer [reactor.core.publisher.ParallelSource], described as [fooCorrelation1234] : <1>
+	reactor.core.publisher.ParallelFlux.checkpoint(ParallelFlux.java:174)
+	reactor.core.publisher.FluxOnAssemblyTest.parallelFluxCheckpointDescription(FluxOnAssemblyTest.java:159)
+Observed operator chain, starting from the origin :
+	|_	ParallelFlux.checkpointnull
+----
+<1> `fooCorrelation1234` is the description provided in `checkpoint`
 
 == Logging a stream
 Additionally to stacktrace debugging and analysis, another powerful tool to have

--- a/src/docs/asciidoc/debugging.adoc
+++ b/src/docs/asciidoc/debugging.adoc
@@ -142,7 +142,7 @@ Assembly trace from producer [reactor.core.publisher.MonoSingle] : <4>
 	reactor.guide.GuideTests.populateDebug(GuideTests.java:702)
 	org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
 	org.junit.rules.RunRules.evaluate(RunRules.java:20)
-Observed operator chain, starting from the origin : <5>
+Error has been observed by the following operators, starting from the origin : <5>
 	|_	Flux.single(TestWatcher.java:55) <6>
 ----
 <1> This is new: what we see here is the wrapper operator that captures the
@@ -183,6 +183,9 @@ that line, we find out he meant to use the less restrictive `take(1)` instead...
 
 Congratulations, *we solved our problem*!
 
+[quote]
+Error has been observed by the following operators, starting from the origin :
+
 That second part of the debug stacktrace was not necessarily very interesting in
 this particular example, because the error was actually happening in the last
 operator in the chain (the one closest to `subscribe`). Taking another example
@@ -199,7 +202,7 @@ Now imagine that inside `findAllUserByName` there is a `map` that fails. Here we
 would see the following final traceback:
 [source,java]
 ----
-Observed operator chain, starting from the origin :
+Error has been observed by the following operators, starting from the origin :
 	|_	Flux.map(FakeRepository.java:27)
 	|_	Flux.map(FakeRepository.java:28)
 	|_	Flux.filter(FakeUtils1.java:29)
@@ -285,7 +288,7 @@ Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException:
 Assembly trace from producer [reactor.core.publisher.ParallelSource], described as [fooCorrelation1234] : <1>
 	reactor.core.publisher.ParallelFlux.checkpoint(ParallelFlux.java:174)
 	reactor.core.publisher.FluxOnAssemblyTest.parallelFluxCheckpointDescription(FluxOnAssemblyTest.java:159)
-Observed operator chain, starting from the origin :
+Error has been observed by the following operators, starting from the origin :
 	|_	ParallelFlux.checkpointnull
 ----
 <1> `fooCorrelation1234` is the description provided in `checkpoint`

--- a/src/main/java/reactor/core/publisher/ConnectableFluxOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/ConnectableFluxOnAssembly.java
@@ -49,7 +49,7 @@ final class ConnectableFluxOnAssembly<T> extends ConnectableFlux<T> implements
 
 	ConnectableFluxOnAssembly(ConnectableFlux<T> source) {
 		this.source = source;
-		this.stacktrace = new AssemblySnapshotException(null, null);
+		this.stacktrace = new AssemblySnapshotException();
 	}
 	
 	@Override

--- a/src/main/java/reactor/core/publisher/ConnectableFluxOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/ConnectableFluxOnAssembly.java
@@ -20,6 +20,7 @@ import java.util.function.Consumer;
 import org.reactivestreams.Subscriber;
 import reactor.core.Disposable;
 import reactor.core.Fuseable;
+import reactor.core.publisher.FluxOnAssembly.AssemblySnapshotException;
 
 /**
  * Captures the current stacktrace when this connectable publisher is created and
@@ -44,11 +45,11 @@ final class ConnectableFluxOnAssembly<T> extends ConnectableFlux<T> implements
 
 	final ConnectableFlux<T> source;
 
-	final Exception stacktrace;
+	final AssemblySnapshotException stacktrace;
 
 	ConnectableFluxOnAssembly(ConnectableFlux<T> source) {
 		this.source = source;
-		this.stacktrace = new Exception();
+		this.stacktrace = new AssemblySnapshotException(null, null);
 	}
 	
 	@Override

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -2461,20 +2461,20 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Activate assembly tracking for this particular {@link Flux}, in case of an error
+	 * Activate assembly tracing for this particular {@link Flux}, in case of an error
 	 * upstream of the checkpoint.
 	 * <p>
 	 * It should be placed towards the end of the reactive chain, as errors
 	 * triggered downstream of it cannot be observed and augmented with assembly trace.
 	 *
-	 * @return the assembly tracking {@link Flux}.
+	 * @return the assembly tracing {@link Flux}.
 	 */
 	public final Flux<T> checkpoint() {
 		return new FluxOnAssembly<>(this);
 	}
 
 	/**
-	 * Activate assembly tracking for this particular {@link Flux} and give it
+	 * Activate assembly tracing for this particular {@link Flux} and give it
 	 * a description that will be reflected in the assembly traceback in case
 	 * of an error upstream of the checkpoint.
 	 * <p>
@@ -2485,7 +2485,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * flux or a wider correlation ID.
 	 *
 	 * @param description a description to include in the assembly traceback.
-	 * @return the assembly tracking {@link Flux}.
+	 * @return the assembly tracing {@link Flux}.
 	 */
 	public final Flux<T> checkpoint(String description) {
 		return new FluxOnAssembly<>(this, description);
@@ -4104,7 +4104,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param category to be mapped into logger configuration (e.g. org.springframework
 	 * .reactor). If category ends with "." like "reactor.", a generated operator
 	 * suffix will complete, e.g. "reactor.Flux.Map".
-	 * @param level the level to enforce for this tracing Flux
+	 * @param level the {@link Level} to enforce for this tracing Flux (only FINEST, FINE,
+	 * INFO, WARNING and SEVERE are taken into account)
 	 * @param options a vararg {@link SignalType} option to filter log messages
 	 *
 	 * @return a new unaltered {@link Flux}
@@ -4130,7 +4131,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param category to be mapped into logger configuration (e.g. org.springframework
 	 * .reactor). If category ends with "." like "reactor.", a generated operator
 	 * suffix will complete, e.g. "reactor.Flux.Map".
-	 * @param level the level to enforce for this tracing Flux
+	 * @param level the {@link Level} to enforce for this tracing Flux (only FINEST, FINE,
+	 * INFO, WARNING and SEVERE are taken into account)
 	 * @param showOperatorLine capture the current stack to display operator
 	 * class/line number.
 	 * @param options a vararg {@link SignalType} option to filter log messages

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -2492,6 +2492,21 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
+	 *
+	 * @param description
+	 * @param minLevel the minimum {@link Level} required for the assembly tracing (only
+	 * FINEST, FINE, INFO, WARNING and SEVERE are taken into account)
+	 * @return
+	 */
+	public final Flux<T> checkpoint(String description, Level minLevel) {
+		if (minLevel == null || FluxOnAssembly.CHECKPOINT_LOGGER.isLevelEnabled(minLevel)) {
+			return checkpoint(description);
+		}
+		return this;
+	}
+
+
+	/**
 	 * Collect the {@link Flux} sequence with the given collector and supplied container on subscribe.
 	 * The collected result will be emitted when this sequence completes.
 	 *

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -2460,16 +2460,26 @@ public abstract class Flux<T> implements Publisher<T> {
 		return onAssembly(new FluxCancelOn<>(this, scheduler));
 	}
 
+	/**
+	 * Activate assembly tracking for this particular {@link Flux}.
+	 *
+	 * @return the assembly tracking {@link Flux}.
+	 */
 	public final Flux<T> checkpoint() {
-		return checkpoint(null);
+		return new FluxOnAssembly<>(this);
 	}
 
+	/**
+	 * Activate assembly tracking for this particular {@link Flux} and give it
+	 * a description that will be reflected in the stacktrace assembly traceback in case
+	 * of error. The description could for example be a meaningful name for the assembled
+	 * flux or a wider correlation ID.
+	 *
+	 * @param description a description to include in the assembly traceback.
+	 * @return the assembly tracking {@link Flux}.
+	 */
 	public final Flux<T> checkpoint(String description) {
-		return checkpoint(description, null);
-	}
-
-	public final Flux<T> checkpoint(String description, String correlationId) {
-		return new FluxOnAssembly<T>(this, description, correlationId);
+		return new FluxOnAssembly<>(this, description);
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -2460,6 +2460,18 @@ public abstract class Flux<T> implements Publisher<T> {
 		return onAssembly(new FluxCancelOn<>(this, scheduler));
 	}
 
+	public final Flux<T> checkpoint() {
+		return checkpoint(null);
+	}
+
+	public final Flux<T> checkpoint(String description) {
+		return checkpoint(description, null);
+	}
+
+	public final Flux<T> checkpoint(String description, String correlationId) {
+		return new FluxOnAssembly<T>(this, description, correlationId);
+	}
+
 	/**
 	 * Collect the {@link Flux} sequence with the given collector and supplied container on subscribe.
 	 * The collected result will be emitted when this sequence completes.

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -2461,7 +2461,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Activate assembly tracking for this particular {@link Flux}.
+	 * Activate assembly tracking for this particular {@link Flux}, in case of an error
+	 * upstream of the checkpoint.
+	 * <p>
+	 * It should be placed towards the end of the reactive chain, as errors
+	 * triggered downstream of it cannot be observed and augmented with assembly trace.
 	 *
 	 * @return the assembly tracking {@link Flux}.
 	 */
@@ -2471,8 +2475,13 @@ public abstract class Flux<T> implements Publisher<T> {
 
 	/**
 	 * Activate assembly tracking for this particular {@link Flux} and give it
-	 * a description that will be reflected in the stacktrace assembly traceback in case
-	 * of error. The description could for example be a meaningful name for the assembled
+	 * a description that will be reflected in the assembly traceback in case
+	 * of an error upstream of the checkpoint.
+	 * <p>
+	 * It should be placed towards the end of the reactive chain, as errors
+	 * triggered downstream of it cannot be observed and augmented with assembly trace.
+	 * <p>
+	 * The description could for example be a meaningful name for the assembled
 	 * flux or a wider correlation ID.
 	 *
 	 * @param description a description to include in the assembly traceback.

--- a/src/main/java/reactor/core/publisher/FluxCallableOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/FluxCallableOnAssembly.java
@@ -43,7 +43,7 @@ final class FluxCallableOnAssembly<T> extends FluxSource<T, T>
 
 	FluxCallableOnAssembly(Publisher<? extends T> source) {
 		super(source);
-		this.stacktrace = new AssemblySnapshotException(null, null);
+		this.stacktrace = new AssemblySnapshotException();
 	}
 
 	@Override

--- a/src/main/java/reactor/core/publisher/FluxCallableOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/FluxCallableOnAssembly.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Callable;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import reactor.core.Fuseable;
+import reactor.core.publisher.FluxOnAssembly.AssemblySnapshotException;
 
 /**
  * Captures the current stacktrace when this publisher is created and makes it
@@ -38,11 +39,11 @@ import reactor.core.Fuseable;
 final class FluxCallableOnAssembly<T> extends FluxSource<T, T>
 		implements Fuseable, Callable<T>, AssemblyOp {
 
-	final Exception stacktrace;
+	final AssemblySnapshotException stacktrace;
 
 	FluxCallableOnAssembly(Publisher<? extends T> source) {
 		super(source);
-		this.stacktrace = new Exception();
+		this.stacktrace = new AssemblySnapshotException(null, null);
 	}
 
 	@Override

--- a/src/main/java/reactor/core/publisher/FluxOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/FluxOnAssembly.java
@@ -57,9 +57,21 @@ final class FluxOnAssembly<T> extends FluxSource<T, T> implements Fuseable, Asse
 			"reactor.trace.assembly.fullstacktrace",
 			"false"));
 
-	FluxOnAssembly(Publisher<? extends T> source, String description, String correlationId) {
+	/**
+	 * Create an assembly trace decorated as a {@link Flux}.
+	 */
+	FluxOnAssembly(Publisher<? extends T> source) {
 		super(source);
-		this.snapshotStack = new AssemblySnapshotException(description, correlationId);
+		this.snapshotStack = new AssemblySnapshotException();
+	}
+
+	/**
+	 * Create an assembly trace augmented with a custom description (eg. a name for a Flux
+	 * or a wider correlation ID) and exposed as a {@link Flux}.
+	 */
+	FluxOnAssembly(Publisher<? extends T> source, String description) {
+		super(source);
+		this.snapshotStack = new AssemblySnapshotException(description);
 	}
 
 	static String getStacktrace(Publisher<?> source, AssemblySnapshotException snapshotStack) {
@@ -157,15 +169,9 @@ final class FluxOnAssembly<T> extends FluxSource<T, T> implements Fuseable, Asse
 		  .append(sourceClass.getName())
 		  .append("]");
 
-		if (ase.description != null) {
+		if (ase.getMessage() != null) {
 			sb.append(", described as [")
-			  .append(ase.description)
-			  .append("]");
-		}
-
-		if (ase.correlationId != null) {
-			sb.append(", correlationId [")
-			  .append(ase.correlationId)
+			  .append(ase.getMessage())
 			  .append("]");
 		}
 
@@ -220,16 +226,17 @@ final class FluxOnAssembly<T> extends FluxSource<T, T> implements Fuseable, Asse
 
 	/**
 	 * The exception that captures assembly context, possibly with a user-readable
-	 * description and / or a wider correlation ID.
+	 * description or a wider correlation ID (which serves as the exception's
+	 * {@link #getMessage() message} and should not be null).
 	 */
 	static final class AssemblySnapshotException extends RuntimeException {
 
-		final String description;
-		final String correlationId;
+		AssemblySnapshotException() {
+			super();
+		}
 
-		public AssemblySnapshotException(String description, String correlationId) {
-			this.description = description;
-			this.correlationId = correlationId;
+		AssemblySnapshotException(String description) {
+			super(description);
 		}
 	}
 

--- a/src/main/java/reactor/core/publisher/FluxOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/FluxOnAssembly.java
@@ -227,7 +227,8 @@ final class FluxOnAssembly<T> extends FluxSource<T, T> implements Fuseable, Asse
 	/**
 	 * The exception that captures assembly context, possibly with a user-readable
 	 * description or a wider correlation ID (which serves as the exception's
-	 * {@link #getMessage() message} and should not be null).
+	 * {@link #getMessage() message}). Use the empty constructor if the later is not
+	 * relevant.
 	 */
 	static final class AssemblySnapshotException extends RuntimeException {
 
@@ -235,6 +236,10 @@ final class FluxOnAssembly<T> extends FluxSource<T, T> implements Fuseable, Asse
 			super();
 		}
 
+		/**
+		 * @param description a description for the assembly traceback.
+		 * Use {@link #AssemblySnapshotException()} rather than null if not relevant.
+		 */
 		AssemblySnapshotException(String description) {
 			super(description);
 		}

--- a/src/main/java/reactor/core/publisher/FluxOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/FluxOnAssembly.java
@@ -24,6 +24,8 @@ import org.reactivestreams.Subscription;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Receiver;
+import reactor.util.Logger;
+import reactor.util.Loggers;
 import reactor.util.function.Tuple3;
 import reactor.util.function.Tuples;
 
@@ -56,6 +58,10 @@ final class FluxOnAssembly<T> extends FluxSource<T, T> implements Fuseable, Asse
 	static final boolean fullStackTrace = Boolean.parseBoolean(System.getProperty(
 			"reactor.trace.assembly.fullstacktrace",
 			"false"));
+
+	static final String CHECKPOINT_LOGGER_NAME = "reactor.checkpoint";
+
+	static final Logger CHECKPOINT_LOGGER = Loggers.getLogger(CHECKPOINT_LOGGER_NAME);
 
 	/**
 	 * Create an assembly trace decorated as a {@link Flux}.
@@ -476,6 +482,7 @@ final class FluxOnAssembly<T> extends FluxSource<T, T> implements Fuseable, Asse
 		}
 
 	}
+
 }
 interface AssemblyOp {
 }

--- a/src/main/java/reactor/core/publisher/FluxOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/FluxOnAssembly.java
@@ -310,7 +310,7 @@ final class FluxOnAssembly<T> extends FluxSource<T, T> implements Fuseable, Asse
 		@Override
 		public String getMessage() {
 			StringBuilder sb = new StringBuilder(super.getMessage()).append(
-					"Observed operator chain, starting from the origin :\n");
+					"Error has been observed by the following operators, starting from the origin :\n");
 
 			synchronized (chainOrder) {
 				for(Tuple3<Integer, String, Integer> t : chainOrder) {

--- a/src/main/java/reactor/core/publisher/Hooks.java
+++ b/src/main/java/reactor/core/publisher/Hooks.java
@@ -543,12 +543,12 @@ public abstract class Hooks {
 							return new FluxCallableOnAssembly<>(publisher);
 						}
 						if (publisher instanceof Mono) {
-							return new MonoOnAssembly<>(publisher);
+							return new MonoOnAssembly<>(publisher, null, null);
 						}
 						if (publisher instanceof ParallelFlux){
 							return new ParallelFluxOnAssembly<>((ParallelFlux<T>) publisher);
 						}
-						return new FluxOnAssembly<>(publisher);
+						return new FluxOnAssembly<>(publisher, null, null);
 					}
 					return publisher;
 				}

--- a/src/main/java/reactor/core/publisher/Hooks.java
+++ b/src/main/java/reactor/core/publisher/Hooks.java
@@ -543,12 +543,12 @@ public abstract class Hooks {
 							return new FluxCallableOnAssembly<>(publisher);
 						}
 						if (publisher instanceof Mono) {
-							return new MonoOnAssembly<>(publisher, null, null);
+							return new MonoOnAssembly<>(publisher);
 						}
 						if (publisher instanceof ParallelFlux){
 							return new ParallelFluxOnAssembly<>((ParallelFlux<T>) publisher);
 						}
-						return new FluxOnAssembly<>(publisher, null, null);
+						return new FluxOnAssembly<>(publisher);
 					}
 					return publisher;
 				}

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -1273,16 +1273,26 @@ public abstract class Mono<T> implements Publisher<T> {
 		return onAssembly(new MonoCancelOn<>(this, scheduler));
 	}
 
+	/**
+	 * Activate assembly tracking for this particular {@link Mono}.
+	 *
+	 * @return the assembly tracking {@link Mono}
+	 */
 	public final Mono<T> checkpoint() {
-		return checkpoint(null);
+		return new MonoOnAssembly<>(this);
 	}
 
+	/**
+	 * Activate assembly tracking for this particular {@link Mono} and give it
+	 * a description that will be reflected in the stacktrace assembly traceback in case
+	 * of error. The description could for example be a meaningful name for the assembled
+	 * mono or a wider correlation ID.
+	 *
+	 * @param description a description to include in the assembly traceback.
+	 * @return the assembly tracking {@link Mono}
+	 */
 	public final Mono<T> checkpoint(String description) {
-		return checkpoint(description, null);
-	}
-
-	public final Mono<T> checkpoint(String description, String correlationId) {
-		return new MonoOnAssembly<>(this, description, correlationId);
+		return new MonoOnAssembly<>(this, description);
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -1274,7 +1274,11 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Activate assembly tracking for this particular {@link Mono}.
+	 * Activate assembly tracking for this particular {@link Mono}, in case of an error
+	 * upstream of the checkpoint.
+	 * <p>
+	 * It should be placed towards the end of the reactive chain, as errors
+	 * triggered downstream of it cannot be observed and augmented with assembly trace.
 	 *
 	 * @return the assembly tracking {@link Mono}
 	 */
@@ -1284,8 +1288,13 @@ public abstract class Mono<T> implements Publisher<T> {
 
 	/**
 	 * Activate assembly tracking for this particular {@link Mono} and give it
-	 * a description that will be reflected in the stacktrace assembly traceback in case
-	 * of error. The description could for example be a meaningful name for the assembled
+	 * a description that will be reflected in the assembly traceback, in case of an error
+	 * upstream of the checkpoint.
+	 * <p>
+	 * It should be placed towards the end of the reactive chain, as errors
+	 * triggered downstream of it cannot be observed and augmented with assembly trace.
+	 * <p>
+	 * The description could for example be a meaningful name for the assembled
 	 * mono or a wider correlation ID.
 	 *
 	 * @param description a description to include in the assembly traceback.

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -1273,6 +1273,18 @@ public abstract class Mono<T> implements Publisher<T> {
 		return onAssembly(new MonoCancelOn<>(this, scheduler));
 	}
 
+	public final Mono<T> checkpoint() {
+		return checkpoint(null);
+	}
+
+	public final Mono<T> checkpoint(String description) {
+		return checkpoint(description, null);
+	}
+
+	public final Mono<T> checkpoint(String description, String correlationId) {
+		return new MonoOnAssembly<>(this, description, correlationId);
+	}
+
 	/**
 	 * Defer the given transformation to this {@link Mono} in order to generate a
 	 * target {@link Mono} type. A transformation will occur for each

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -1305,6 +1305,20 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
+	 *
+	 * @param description
+	 * @param minLevel the minimum {@link Level} required for the assembly tracing (only
+	 * FINEST, FINE, INFO, WARNING and SEVERE are taken into account)
+	 * @return
+	 */
+	public final Mono<T> checkpoint(String description, Level minLevel) {
+		if (minLevel == null || FluxOnAssembly.CHECKPOINT_LOGGER.isLevelEnabled(minLevel)) {
+			return checkpoint(description);
+		}
+		return this;
+	}
+
+	/**
 	 * Defer the given transformation to this {@link Mono} in order to generate a
 	 * target {@link Mono} type. A transformation will occur for each
 	 * {@link Subscriber}.

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -1274,20 +1274,20 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Activate assembly tracking for this particular {@link Mono}, in case of an error
+	 * Activate assembly tracing for this particular {@link Mono}, in case of an error
 	 * upstream of the checkpoint.
 	 * <p>
 	 * It should be placed towards the end of the reactive chain, as errors
 	 * triggered downstream of it cannot be observed and augmented with assembly trace.
 	 *
-	 * @return the assembly tracking {@link Mono}
+	 * @return the assembly tracing {@link Mono}
 	 */
 	public final Mono<T> checkpoint() {
 		return new MonoOnAssembly<>(this);
 	}
 
 	/**
-	 * Activate assembly tracking for this particular {@link Mono} and give it
+	 * Activate assembly tracing for this particular {@link Mono} and give it
 	 * a description that will be reflected in the assembly traceback, in case of an error
 	 * upstream of the checkpoint.
 	 * <p>
@@ -1298,7 +1298,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * mono or a wider correlation ID.
 	 *
 	 * @param description a description to include in the assembly traceback.
-	 * @return the assembly tracking {@link Mono}
+	 * @return the assembly tracing {@link Mono}
 	 */
 	public final Mono<T> checkpoint(String description) {
 		return new MonoOnAssembly<>(this, description);
@@ -1946,10 +1946,9 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Observe Reactive Streams signals matching the passed flags {@code options} and use {@link Logger} support to
-	 * handle trace
-	 * implementation. Default will
-	 * use the passed {@link Level} and java.util.logging. If SLF4J is available, it will be used instead.
+	 * Observe Reactive Streams signals matching the passed flags {@code options} and use
+	 * {@link Logger} support to handle trace implementation. Default will use the passed
+	 * {@link Level} and java.util.logging. If SLF4J is available, it will be used instead.
 	 *
 	 * Options allow fine grained filtering of the traced signal, for instance to only capture onNext and onError:
 	 * <pre>
@@ -1960,7 +1959,8 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param category to be mapped into logger configuration (e.g. org.springframework
 	 * .reactor). If category ends with "." like "reactor.", a generated operator
 	 * suffix will complete, e.g. "reactor.Flux.Map".
-	 * @param level the level to enforce for this tracing Flux
+	 * @param level the {@link Level} to enforce for this tracing Mono (only FINEST, FINE,
+	 * INFO, WARNING and SEVERE are taken into account)
 	 * @param options a vararg {@link SignalType} option to filter log messages
 	 *
 	 * @return a new {@link Mono}
@@ -1986,7 +1986,8 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param category to be mapped into logger configuration (e.g. org.springframework
 	 * .reactor). If category ends with "." like "reactor.", a generated operator
 	 * suffix will complete, e.g. "reactor.Mono.Map".
-	 * @param level the level to enforce for this tracing Mono
+	 * @param level the {@link Level} to enforce for this tracing Mono (only FINEST, FINE,
+	 * INFO, WARNING and SEVERE are taken into account)
 	 * @param showOperatorLine capture the current stack to display operator
 	 * class/line number.
 	 * @param options a vararg {@link SignalType} option to filter log messages

--- a/src/main/java/reactor/core/publisher/MonoCallableOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/MonoCallableOnAssembly.java
@@ -22,6 +22,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
+import reactor.core.publisher.FluxOnAssembly.AssemblySnapshotException;
 
 /**
  * Captures the current stacktrace when this publisher is created and makes it
@@ -40,11 +41,11 @@ import reactor.core.Fuseable;
 final class MonoCallableOnAssembly<T> extends MonoSource<T, T>
 		implements Callable<T>, AssemblyOp {
 
-	final Exception stacktrace;
+	final AssemblySnapshotException stacktrace;
 
 	MonoCallableOnAssembly(Publisher<? extends T> source) {
 		super(source);
-		this.stacktrace = new Exception();
+		this.stacktrace = new AssemblySnapshotException(null, null);
 	}
 
 	@Override

--- a/src/main/java/reactor/core/publisher/MonoCallableOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/MonoCallableOnAssembly.java
@@ -45,7 +45,7 @@ final class MonoCallableOnAssembly<T> extends MonoSource<T, T>
 
 	MonoCallableOnAssembly(Publisher<? extends T> source) {
 		super(source);
-		this.stacktrace = new AssemblySnapshotException(null, null);
+		this.stacktrace = new AssemblySnapshotException();
 	}
 
 	@Override

--- a/src/main/java/reactor/core/publisher/MonoOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/MonoOnAssembly.java
@@ -38,9 +38,21 @@ final class MonoOnAssembly<T> extends MonoSource<T, T> implements Fuseable, Asse
 
 	final AssemblySnapshotException stacktrace;
 
-	MonoOnAssembly(Publisher<? extends T> source, String description, String correlationId) {
+	/**
+	 * Create an assembly trace exposed as a {@link Mono}.
+	 */
+	MonoOnAssembly(Publisher<? extends T> source) {
 		super(source);
-		this.stacktrace = new AssemblySnapshotException(description, correlationId);
+		this.stacktrace = new AssemblySnapshotException();
+	}
+
+	/**
+	 * Create an assembly trace augmented with a custom description (eg. a name for a Mono
+	 * or a wider correlation ID) and exposed as a {@link Mono}.
+	 */
+	MonoOnAssembly(Publisher<? extends T> source, String description) {
+		super(source);
+		this.stacktrace = new AssemblySnapshotException(description);
 	}
 
 	@Override

--- a/src/main/java/reactor/core/publisher/MonoOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/MonoOnAssembly.java
@@ -19,6 +19,7 @@ package reactor.core.publisher;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import reactor.core.Fuseable;
+import reactor.core.publisher.FluxOnAssembly.AssemblySnapshotException;
 
 /**
  * Captures the current stacktrace when this publisher is created and makes it
@@ -35,11 +36,11 @@ import reactor.core.Fuseable;
  */
 final class MonoOnAssembly<T> extends MonoSource<T, T> implements Fuseable, AssemblyOp {
 
-	final Exception stacktrace;
+	final AssemblySnapshotException stacktrace;
 
-	MonoOnAssembly(Publisher<? extends T> source) {
+	MonoOnAssembly(Publisher<? extends T> source, String description, String correlationId) {
 		super(source);
-		this.stacktrace = new Exception();
+		this.stacktrace = new AssemblySnapshotException(description, correlationId);
 	}
 
 	@Override

--- a/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -144,20 +144,20 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Activate assembly tracking for this particular {@link ParallelFlux}, in case of an
+	 * Activate assembly tracing for this particular {@link ParallelFlux}, in case of an
 	 * error upstream of the checkpoint.
 	 * <p>
 	 * It should be placed towards the end of the reactive chain, as errors
 	 * triggered downstream of it cannot be observed and augmented with assembly trace.
 	 *
-	 * @return the assembly tracking {@link ParallelFlux}
+	 * @return the assembly tracing {@link ParallelFlux}
 	 */
 	public final ParallelFlux<T> checkpoint() {
 		return new ParallelFluxOnAssembly<>(this);
 	}
 
 	/**
-	 * Activate assembly tracking for this particular {@link ParallelFlux} and give it
+	 * Activate assembly tracing for this particular {@link ParallelFlux} and give it
 	 * a description that will be reflected in the assembly traceback, in case of an error
 	 * upstream of the checkpoint.
 	 * <p>
@@ -168,7 +168,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	 * flux or a wider correlation ID.
 	 *
 	 * @param description a description to include in the assembly traceback.
-	 * @return the assembly tracking {@link ParallelFlux}
+	 * @return the assembly tracing {@link ParallelFlux}
 	 */
 	public final ParallelFlux<T> checkpoint(String description) {
 		return new ParallelFluxOnAssembly<>(this, description);
@@ -650,7 +650,8 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	 * @param category to be mapped into logger configuration (e.g. org.springframework
 	 * .reactor). If category ends with "." like "reactor.", a generated operator
 	 * suffix will complete, e.g. "reactor.Parallel.Map".
-	 * @param level the level to enforce for this tracing ParallelFlux
+	 * @param level the {@link Level} to enforce for this tracing ParallelFlux (only
+	 * FINEST, FINE, INFO, WARNING and SEVERE are taken into account)
 	 * @param options a vararg {@link SignalType} option to filter log messages
 	 *
 	 * @return a new unaltered {@link ParallelFlux}
@@ -679,7 +680,8 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	 * @param category to be mapped into logger configuration (e.g. org.springframework
 	 * .reactor). If category ends with "." like "reactor.", a generated operator
 	 * suffix will complete, e.g. "reactor.ParallelFlux.Map".
-	 * @param level the level to enforce for this tracing ParallelFlux
+	 * @param level the {@link Level} to enforce for this tracing ParallelFlux (only
+	 * FINEST, FINE, INFO, WARNING and SEVERE are taken into account)
 	 * @param showOperatorLine capture the current stack to display operator
 	 * class/line number.
 	 * @param options a vararg {@link SignalType} option to filter log messages

--- a/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -144,7 +144,11 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Activate assembly tracking for this particular {@link ParallelFlux}.
+	 * Activate assembly tracking for this particular {@link ParallelFlux}, in case of an
+	 * error upstream of the checkpoint.
+	 * <p>
+	 * It should be placed towards the end of the reactive chain, as errors
+	 * triggered downstream of it cannot be observed and augmented with assembly trace.
 	 *
 	 * @return the assembly tracking {@link ParallelFlux}
 	 */
@@ -154,8 +158,13 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 
 	/**
 	 * Activate assembly tracking for this particular {@link ParallelFlux} and give it
-	 * a description that will be reflected in the stacktrace assembly traceback in case
-	 * of error. The description could for example be a meaningful name for the assembled
+	 * a description that will be reflected in the assembly traceback, in case of an error
+	 * upstream of the checkpoint.
+	 * <p>
+	 * It should be placed towards the end of the reactive chain, as errors
+	 * triggered downstream of it cannot be observed and augmented with assembly trace.
+	 * <p>
+	 * The description could for example be a meaningful name for the assembled
 	 * flux or a wider correlation ID.
 	 *
 	 * @param description a description to include in the assembly traceback.

--- a/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -175,6 +175,20 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	}
 
 	/**
+	 *
+	 * @param description
+	 * @param minLevel the minimum {@link Level} required for the assembly tracing (only
+	 * FINEST, FINE, INFO, WARNING and SEVERE are taken into account)
+	 * @return
+	 */
+	public final ParallelFlux<T> checkpoint(String description, Level minLevel) {
+		if (minLevel == null || FluxOnAssembly.CHECKPOINT_LOGGER.isLevelEnabled(minLevel)) {
+			return checkpoint(description);
+		}
+		return this;
+	}
+
+	/**
 	 * Collect the elements in each rail into a collection supplied via a
 	 * collectionSupplier and collected into with a collector action, emitting the
 	 * collection at the end.

--- a/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -144,6 +144,28 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	}
 
 	/**
+	 * Activate assembly tracking for this particular {@link ParallelFlux}.
+	 *
+	 * @return the assembly tracking {@link ParallelFlux}
+	 */
+	public final ParallelFlux<T> checkpoint() {
+		return new ParallelFluxOnAssembly<>(this);
+	}
+
+	/**
+	 * Activate assembly tracking for this particular {@link ParallelFlux} and give it
+	 * a description that will be reflected in the stacktrace assembly traceback in case
+	 * of error. The description could for example be a meaningful name for the assembled
+	 * flux or a wider correlation ID.
+	 *
+	 * @param description a description to include in the assembly traceback.
+	 * @return the assembly tracking {@link ParallelFlux}
+	 */
+	public final ParallelFlux<T> checkpoint(String description) {
+		return new ParallelFluxOnAssembly<>(this, description);
+	}
+
+	/**
 	 * Collect the elements in each rail into a collection supplied via a
 	 * collectionSupplier and collected into with a collector action, emitting the
 	 * collection at the end.

--- a/src/main/java/reactor/core/publisher/ParallelFluxOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/ParallelFluxOnAssembly.java
@@ -19,6 +19,7 @@ package reactor.core.publisher;
 import org.reactivestreams.Subscriber;
 import reactor.core.Fuseable;
 import reactor.core.Receiver;
+import reactor.core.publisher.FluxOnAssembly.AssemblySnapshotException;
 
 /**
  * Captures the current stacktrace when this connectable publisher is created and makes it
@@ -36,13 +37,12 @@ import reactor.core.Receiver;
 final class ParallelFluxOnAssembly<T> extends ParallelFlux<T>
 		implements Fuseable, AssemblyOp, Receiver {
 
-	final ParallelFlux<T>                                                          source;
-
-	final Exception stacktrace;
+	final ParallelFlux<T>           source;
+	final AssemblySnapshotException stacktrace;
 
 	ParallelFluxOnAssembly(ParallelFlux<T> source) {
 		this.source = source;
-		this.stacktrace = new Exception();
+		this.stacktrace = new AssemblySnapshotException(null, null);
 	}
 
 	@Override

--- a/src/main/java/reactor/core/publisher/ParallelFluxOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/ParallelFluxOnAssembly.java
@@ -40,9 +40,21 @@ final class ParallelFluxOnAssembly<T> extends ParallelFlux<T>
 	final ParallelFlux<T>           source;
 	final AssemblySnapshotException stacktrace;
 
+	/**
+	 * Create an assembly trace wrapping a {@link ParallelFlux}.
+	 */
 	ParallelFluxOnAssembly(ParallelFlux<T> source) {
 		this.source = source;
-		this.stacktrace = new AssemblySnapshotException(null, null);
+		this.stacktrace = new AssemblySnapshotException();
+	}
+
+	/**
+	 * Create an assembly trace augmented with a custom description (eg. a name for a
+	 * ParallelFlux or a wider correlation ID), wrapping a {@link ParallelFlux}.
+	 */
+	ParallelFluxOnAssembly(ParallelFlux<T> source, String description) {
+		this.source = source;
+		this.stacktrace = new AssemblySnapshotException(description);
 	}
 
 	@Override

--- a/src/main/java/reactor/core/publisher/SignalLogger.java
+++ b/src/main/java/reactor/core/publisher/SignalLogger.java
@@ -26,6 +26,7 @@ import java.util.logging.Level;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.Fuseable;
+import reactor.core.publisher.FluxOnAssembly.AssemblySnapshotException;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 
@@ -82,7 +83,9 @@ final class SignalLogger<IN> implements SignalPeek<IN> {
 		this.fuseable = source instanceof Fuseable;
 
 		if(correlateStack){
-			operatorLine = FluxOnAssembly.extract(FluxOnAssembly.getStacktrace(null, new Exception()),false);
+			operatorLine = FluxOnAssembly.extract(FluxOnAssembly.getStacktrace(null,
+					new AssemblySnapshotException(null, null)),
+					false);
 		}
 		else{
 			operatorLine = null;

--- a/src/main/java/reactor/core/publisher/SignalLogger.java
+++ b/src/main/java/reactor/core/publisher/SignalLogger.java
@@ -84,7 +84,7 @@ final class SignalLogger<IN> implements SignalPeek<IN> {
 
 		if(correlateStack){
 			operatorLine = FluxOnAssembly.extract(FluxOnAssembly.getStacktrace(null,
-					new AssemblySnapshotException(null, null)),
+					new AssemblySnapshotException()),
 					false);
 		}
 		else{

--- a/src/main/java/reactor/core/publisher/SignalLogger.java
+++ b/src/main/java/reactor/core/publisher/SignalLogger.java
@@ -32,7 +32,9 @@ import reactor.util.Loggers;
 
 
 /**
- * A logging interceptor that intercepts all reactive calls and trace them
+ * A logging interceptor that intercepts all reactive calls and trace them.
+ * The logging level can be tuned using {@link Level}, but only FINEST, FINE, INFO,
+ * WARNING and SEVERE are taken into account.
  *
  * @author Stephane Maldini
  */

--- a/src/main/java/reactor/util/Logger.java
+++ b/src/main/java/reactor/util/Logger.java
@@ -15,6 +15,8 @@
  */
 package reactor.util;
 
+import java.util.logging.Level;
+
 /**
  * Logger interface designed for internal Reactor usage.
  */

--- a/src/main/java/reactor/util/Loggers.java
+++ b/src/main/java/reactor/util/Loggers.java
@@ -208,6 +208,11 @@ public abstract class Loggers {
 		}
 
 		@Override
+		public boolean isLevelEnabled(Level level) {
+			return logger.isLoggable(level);
+		}
+
+		@Override
 		public boolean isTraceEnabled() {
 			return logger.isLoggable(Level.FINEST);
 		}

--- a/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
+++ b/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import org.junit.Test;
+import reactor.core.publisher.FluxOnAssembly.AssemblySnapshotException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FluxOnAssemblyTest {
+
+	@Test
+	public void stacktraceHeaderTraceEmpty() {
+		StringBuilder sb = new StringBuilder();
+		AssemblySnapshotException e = new AssemblySnapshotException(null, null);
+
+		FluxOnAssembly.fillStacktraceHeader(sb, String.class, e);
+
+		assertThat(sb.toString())
+				.isEqualTo("\nAssembly trace from producer [java.lang.String] :\n");
+	}
+
+	@Test
+	public void stacktraceHeaderTraceDescription() {
+		StringBuilder sb = new StringBuilder();
+		AssemblySnapshotException e = new AssemblySnapshotException("This is readable", null);
+
+		FluxOnAssembly.fillStacktraceHeader(sb, String.class, e);
+
+		assertThat(sb.toString())
+				.startsWith("\nAssembly trace from producer [java.lang.String]")
+				.endsWith(", described as [This is readable] :\n");
+	}
+
+	@Test
+	public void stacktraceHeaderTraceCorrelation() {
+		StringBuilder sb = new StringBuilder();
+		AssemblySnapshotException e = new AssemblySnapshotException(null, "1234");
+
+		FluxOnAssembly.fillStacktraceHeader(sb, String.class, e);
+
+		assertThat(sb.toString())
+				.startsWith("\nAssembly trace from producer [java.lang.String]")
+				.endsWith(", correlationId [1234] :\n");
+	}
+
+	@Test
+	public void stacktraceHeaderTraceDescriptionAndCorrelation() {
+		StringBuilder sb = new StringBuilder();
+		AssemblySnapshotException e = new AssemblySnapshotException("This is readable", "1234");
+
+		FluxOnAssembly.fillStacktraceHeader(sb, String.class, e);
+
+		assertThat(sb.toString())
+				.startsWith("\nAssembly trace from producer [java.lang.String]")
+				.endsWith(", described as [This is readable], correlationId [1234] :\n");
+	}
+
+	@Test
+	public void checkpointEmpty() {
+		StringWriter sw = new StringWriter();
+
+		Flux.range(1, 10)
+		    .map(i -> null)
+		    .checkpoint()
+		    .subscribe(System.out::println, t -> t.printStackTrace(new PrintWriter(sw)));
+
+		String debugStack = sw.toString();
+
+		assertThat(debugStack).contains("Assembly trace from producer [reactor.core.publisher.FluxMapFuseable] :");
+	}
+
+	@Test
+	public void checkpointDescription() {
+		StringWriter sw = new StringWriter();
+
+		Flux.range(1, 10)
+		    .map(i -> null)
+		    .checkpoint("foo")
+		    .subscribe(System.out::println, t -> t.printStackTrace(new PrintWriter(sw)));
+
+		String debugStack = sw.toString();
+
+		assertThat(debugStack).contains("Assembly trace from producer [reactor.core.publisher.FluxMapFuseable], described as [foo] :");
+	}
+
+	@Test
+	public void checkpointCorrelation() {
+		StringWriter sw = new StringWriter();
+
+		Flux.range(1, 10)
+		    .map(i -> null)
+		    .checkpoint(null, "1234")
+		    .subscribe(System.out::println, t -> t.printStackTrace(new PrintWriter(sw)));
+
+		String debugStack = sw.toString();
+
+		assertThat(debugStack).contains("Assembly trace from producer [reactor.core.publisher.FluxMapFuseable], correlationId [1234] :");
+	}
+
+	@Test
+	public void checkpointDescriptionCorrelation() {
+		StringWriter sw = new StringWriter();
+
+		Flux.range(1, 10)
+		    .map(i -> null)
+		    .checkpoint("foo", "1234")
+		    .subscribe(System.out::println, t -> t.printStackTrace(new PrintWriter(sw)));
+
+		String debugStack = sw.toString();
+
+		assertThat(debugStack).contains("Assembly trace from producer [reactor.core.publisher.FluxMapFuseable], described as [foo], correlationId [1234] :");
+	}
+
+	@Test
+	public void monoCheckpointEmpty() {
+		StringWriter sw = new StringWriter();
+
+		Mono.just(1)
+		    .map(i -> null)
+		    .checkpoint()
+		    .subscribe(System.out::println, t -> t.printStackTrace(new PrintWriter(sw)));
+
+		String debugStack = sw.toString();
+
+		assertThat(debugStack).contains("Assembly trace from producer [reactor.core.publisher.MonoMapFuseable] :");
+	}
+
+	@Test
+	public void monoCheckpointDescription() {
+		StringWriter sw = new StringWriter();
+
+		Mono.just(1)
+		    .map(i -> null)
+		    .checkpoint("foo")
+		    .subscribe(System.out::println, t -> t.printStackTrace(new PrintWriter(sw)));
+
+		String debugStack = sw.toString();
+
+		assertThat(debugStack).contains("Assembly trace from producer [reactor.core.publisher.MonoMapFuseable], described as [foo] :");
+	}
+
+	@Test
+	public void monoCheckpointCorrelation() {
+		StringWriter sw = new StringWriter();
+
+		Mono.just(1)
+		    .map(i -> null)
+		    .checkpoint(null, "1234")
+		    .subscribe(System.out::println, t -> t.printStackTrace(new PrintWriter(sw)));
+
+		String debugStack = sw.toString();
+
+		assertThat(debugStack).contains("Assembly trace from producer [reactor.core.publisher.MonoMapFuseable], correlationId [1234] :");
+	}
+
+	@Test
+	public void monoCheckpointDescriptionCorrelation() {
+		StringWriter sw = new StringWriter();
+
+		Mono.just(1)
+		    .map(i -> null)
+		    .checkpoint("foo", "1234")
+		    .subscribe(System.out::println, t -> t.printStackTrace(new PrintWriter(sw)));
+
+		String debugStack = sw.toString();
+
+		assertThat(debugStack).contains("Assembly trace from producer [reactor.core.publisher.MonoMapFuseable], described as [foo], correlationId [1234] :");
+	}
+
+}

--- a/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
+++ b/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
@@ -20,7 +20,10 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Objects;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.FluxOnAssembly.AssemblySnapshotException;
 import reactor.test.StepVerifier;
 

--- a/src/test/java/reactor/guide/GuideDebuggingExtraTests.java
+++ b/src/test/java/reactor/guide/GuideDebuggingExtraTests.java
@@ -25,7 +25,7 @@ import reactor.core.publisher.Hooks;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-//this "test" is here to have a runnable demonstration of a more advanced traceback in
+//this test is here to have a runnable demonstration of a more advanced traceback in
 // debugging mode. it was put outside of reactor.core package so that the traceback shows
 // more details
 public class GuideDebuggingExtraTests {
@@ -46,15 +46,13 @@ public class GuideDebuggingExtraTests {
 			String debugStack = sw.toString();
 
 			assertThat(debugStack)
-					.endsWith("Observed operator chain, starting from the origin :\n"
+					.endsWith("Error has been observed by the following operators, starting from the origin :\n"
 							+ "\t|_\tFlux.map(FakeRepository.java:27)\n"
 							+ "\t|_\tFlux.map(FakeRepository.java:28)\n"
 							+ "\t|_\tFlux.filter(FakeUtils1.java:29)\n"
 							+ "\t|_\tFlux.transform(GuideDebuggingExtraTests.java:40)\n"
 							+ "\t|_\tFlux.elapsed(FakeUtils2.java:30)\n"
 							+ "\t|_\tFlux.transform(GuideDebuggingExtraTests.java:41)\n\n");
-
-			System.out.println(debugStack);
 		}
 		finally {
 			Hooks.resetOnOperator();


### PR DESCRIPTION
This commit adds a new `checkpoint` operator that allows to
assembly-trace a particular Flux or Mono.

Additionally, one can specify a `description` and/or `correlationId`
that will both appear in the trace.

The usual path to assembly tracing (the debug mode hook) doesn't define
such a description nor id.

TODO: add operator to Flux derivatives, javadoc