### PR TITLE
Fix publish index out of bounds in terminal cases

### DIFF
--- a/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
+++ b/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
@@ -306,6 +306,7 @@ final class FluxPublishMulticast<T, R> extends FluxSource<T, R> implements Fusea
 								error = Operators.onOperatorError(s, ex);
 								queue.clear();
 								a = SUBSCRIBERS.getAndSet(this, TERMINATED);
+								n = a.length;
 								for (int i = 0; i < n; i++) {
 									a[i].actual.onError(ex);
 								}
@@ -314,6 +315,7 @@ final class FluxPublishMulticast<T, R> extends FluxSource<T, R> implements Fusea
 
 							if (v == null) {
 								a = SUBSCRIBERS.getAndSet(this, TERMINATED);
+								n = a.length;
 								for (int i = 0; i < n; i++) {
 									a[i].actual.onComplete();
 								}
@@ -333,6 +335,7 @@ final class FluxPublishMulticast<T, R> extends FluxSource<T, R> implements Fusea
 						}
 						if (queue.isEmpty()) {
 							a = SUBSCRIBERS.getAndSet(this, TERMINATED);
+							n = a.length;
 							for (int i = 0; i < n; i++) {
 								a[i].actual.onComplete();
 							}
@@ -400,6 +403,7 @@ final class FluxPublishMulticast<T, R> extends FluxSource<T, R> implements Fusea
 								queue.clear();
 								error = Operators.onOperatorError(s, ex);
 								a = SUBSCRIBERS.getAndSet(this, TERMINATED);
+								n = a.length;
 								for (int i = 0; i < n; i++) {
 									a[i].actual.onError(ex);
 								}
@@ -413,6 +417,7 @@ final class FluxPublishMulticast<T, R> extends FluxSource<T, R> implements Fusea
 								if (ex != null) {
 									queue.clear();
 									a = SUBSCRIBERS.getAndSet(this, TERMINATED);
+									n = a.length;
 									for (int i = 0; i < n; i++) {
 										a[i].actual.onError(ex);
 									}
@@ -420,6 +425,7 @@ final class FluxPublishMulticast<T, R> extends FluxSource<T, R> implements Fusea
 								}
 								else if (empty) {
 									a = SUBSCRIBERS.getAndSet(this, TERMINATED);
+									n = a.length;
 									for (int i = 0; i < n; i++) {
 										a[i].actual.onComplete();
 									}
@@ -456,6 +462,7 @@ final class FluxPublishMulticast<T, R> extends FluxSource<T, R> implements Fusea
 								if (ex != null) {
 									queue.clear();
 									a = SUBSCRIBERS.getAndSet(this, TERMINATED);
+									n = a.length;
 									for (int i = 0; i < n; i++) {
 										a[i].actual.onError(ex);
 									}
@@ -463,6 +470,7 @@ final class FluxPublishMulticast<T, R> extends FluxSource<T, R> implements Fusea
 								}
 								else if (queue.isEmpty()) {
 									a = SUBSCRIBERS.getAndSet(this, TERMINATED);
+									n = a.length;
 									for (int i = 0; i < n; i++) {
 										a[i].actual.onComplete();
 									}

--- a/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
+++ b/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
@@ -265,4 +265,14 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
 
 		sfs.clear(); //NOOP
 	}
+
+	@Test
+	public void syncCancelBeforeComplete() {
+	    assertThat(Flux.just(Flux.just(1).publish(v -> v)).flatMap(v -> v).blockLast()).isEqualTo(1);
+	}
+
+    @Test
+    public void normalCancelBeforeComplete() {
+        assertThat(Flux.just(Flux.just(1).hide().publish(v -> v)).flatMap(v -> v).blockLast()).isEqualTo(1);
+    }
 }

--- a/src/test/java/reactor/core/publisher/MonoPublishMulticastTest.java
+++ b/src/test/java/reactor/core/publisher/MonoPublishMulticastTest.java
@@ -16,6 +16,8 @@
 
 package reactor.core.publisher;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
@@ -83,5 +85,16 @@ public class MonoPublishMulticastTest {
 
 		Assert.assertFalse("Still subscribed?", sp.isCancelled());
 	}
+
+
+    @Test
+    public void syncCancelBeforeComplete() {
+        assertThat(Mono.just(Mono.just(1).publish(v -> v)).flatMap(v -> v).blockLast()).isEqualTo(1);
+    }
+
+    @Test
+    public void normalCancelBeforeComplete() {
+        assertThat(Mono.just(Mono.just(1).hide().publish(v -> v)).flatMap(v -> v).blockLast()).isEqualTo(1);
+    }
 
 }


### PR DESCRIPTION
This PR fixes #438 by re-reading the array length before emitting events to the remaining subscribers.