### PR TITLE
fix #436 Deprecate all xxxMillis operators and adapt tests/doc

### DIFF
--- a/src/docs/asciidoc/coreFeatures.adoc
+++ b/src/docs/asciidoc/coreFeatures.adoc
@@ -215,8 +215,8 @@ tuned to facilitate the work-stealing that can happen in some Schedulers.
 
 Some operators use a specific Scheduler from `Schedulers` by default (and will
 usually give you the option of providing a different one). For instance, calling
-the factory method `Flux.intervalMillis(300)` will produces a `Flux<Long>` that
-ticks every 300ms. This is enabled by `Schedulers.timer()` by default.
+the factory method `Flux.interval(Duration.ofMillis(300))` will produces a `Flux<Long>`
+that ticks every 300ms. This is enabled by `Schedulers.timer()` by default.
 
 Reactor offers two means of switching execution context (or `Scheduler`) in a
 reactive chain: `publishOn` and `subscribeOn`. Both take a `Scheduler` and allow
@@ -484,7 +484,7 @@ with an increasing `Long`:
 [source,java]
 ----
 Flux<String> flux =
-Flux.intervalMillis(250)
+Flux.interval(Duration.ofMillis(250))
     .map(input -> {
 	    if (input < 3) return "tick " + input;
 	    throw new RuntimeException("boom");
@@ -494,7 +494,7 @@ Flux.intervalMillis(250)
 flux.subscribe(System.out::println);
 Thread.sleep(2100); // <1>
 ----
-<1> Note that `intervalMillis` executes on the *timer* `Scheduler` by default.
+<1> Note that `interval` executes on the *timer* `Scheduler` by default.
 Assuming we'd want to run that example in a main class, we add a sleep here so
 that the application doesn't exit immediately without any value being produced.
 
@@ -520,7 +520,7 @@ terminated. To verify that, we can re-use the previous example and append a
 `retry(1)` to retry once instead of the onErrorReturn:
 [source,java]
 ----
-Flux.intervalMillis(250)
+Flux.interval(Duration.ofMillis(250))
     .map(input -> {
         if (input < 3) return "tick " + input;
         throw new RuntimeException("boom");

--- a/src/docs/asciidoc/faq.adoc
+++ b/src/docs/asciidoc/faq.adoc
@@ -111,7 +111,7 @@ Flux.<String>error(new IllegalArgumentException())
           if (index < 4) return index;
           else throw Exceptions.propagate(error);
         })
-        .flatMap(index -> Mono.delayMillis(index * 100)) // <3>
+        .flatMap(index -> Mono.delay(Duration.ofMillis(index * 100))) // <3>
         .doOnNext(s -> System.out.println("retried at " + LocalTime.now())) // <4>
     );
 ----

--- a/src/docs/asciidoc/operatorChoice.adoc
+++ b/src/docs/asciidoc/operatorChoice.adoc
@@ -234,13 +234,13 @@ TIP: Note that this returns a `Flux<GroupedFlux<K, T>>`, each inner `GroupedFlux
 == Going back to the Synchronous world
 * I have a `Flux<T>` and I want to...
 ** block until I can get the first element: `Flux#blockFirst`
-*** ...with a timeout: `Flux#blockFirstMillis` / `Flux#blockFirst(Duration)`
+*** ...with a timeout: `Flux#blockFirst(Duration)`
 ** block until I can get the last element (or null if empty): `Flux#blockLast`
-*** ...with a timeout: `Flux#blockLastMillis` / `Flux#blockLast(Duration)`
+*** ...with a timeout: `Flux#blockLast(Duration)`
 ** synchronously switch to an `Iterable<T>`: `Flux#toIterable`
 ** synchronously switch to a Java 8 `Stream<T>`: `Flux#toStream`
 
 * I have a `Mono<T>` and I want...
 ** to block until I can get the value: `Mono#block`
-*** ...with a timeout: `Mono#blockMillis` / `Mono#block(Duration)`
+*** ...with a timeout: `Mono#block(Duration)`
 ** a `CompletableFuture<T>`: `Mono#toFuture`

--- a/src/docs/asciidoc/operatorChoice.adoc
+++ b/src/docs/asciidoc/operatorChoice.adoc
@@ -208,7 +208,7 @@ I want to deal with: <<which.create>>, <<which.values>>, <<which.peeking>>,
 *** ...with overlapping or dropping windows: `window(int, int)`
 ** of time `window(Duration)`
 *** ...with overlapping or dropping windows: `window(Duration, Duration)`
-** of size OR time (window closes when count is reached or timeout elapsed): `window(int, Duration)`
+** of size OR time (window closes when count is reached or timeout elapsed): `windowTimeout(int, Duration)`
 ** based on a predicate on elements: `windowUntil`
 *** ...…emitting the element that triggered the boundary in the next window (`cutBefore` variant): `.windowUntil(predicate, true)`
 *** ...keeping the window open while elements match a predicate: `windowWhile` (non-matching elements are not emitted)
@@ -220,7 +220,7 @@ I want to deal with: <<which.create>>, <<which.values>>, <<which.peeking>>,
 **** ...with overlapping or dropping buffers: `buffer(int, int)`
 *** by a duration boundary: `buffer(Duration)`
 **** ...with overlapping or dropping buffers: `buffer(Duration, Duration)`
-*** by a size OR duration boundary: `buffer(int, Duration)`
+*** by a size OR duration boundary: `bufferTimeout(int, Duration)`
 *** by an arbitrary criteria boundary: `bufferUntil(Predicate)`
 **** ...putting the element that triggered the boundary in the next buffer: `.bufferUntil(predicate, true)`
 **** ...buffering while predicate matches and dropping the element that triggered the boundary: `bufferWhile(Predicate)`

--- a/src/docs/asciidoc/operatorChoice.adoc
+++ b/src/docs/asciidoc/operatorChoice.adoc
@@ -145,8 +145,8 @@ I want to deal with: <<which.create>>, <<which.values>>, <<which.peeking>>,
 *** until a criteria is met (inclusive): `Flux#skipUntil` (predicate-based), `Flux#skipUntilOther` (companion publisher-based)
 *** while a criteria is met (exclusive): `Flux#skipWhile`
 ** by sampling items...
-*** by duration: `Flux#sample(Duration)`, `Flux#sampleMillis`
-**** but keeping the first element in the sampling window instead of the last: `sampleFirst`/`sampleFirstMillis`
+*** by duration: `Flux#sample(Duration)`
+**** but keeping the first element in the sampling window instead of the last: `sampleFirst`
 *** by a publisher-based window: `Flux#sample(Publisher)`
 *** based on a publisher "timing out": `Flux#sampleTimeout` (each element triggers a publisher, and is emitted if that publisher doesn't overlap with the next)
 

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -6551,7 +6551,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a per-item expirable {@link Flux}
 	 */
 	public final Flux<T> timeout(Duration timeout) {
-		return timeout(timeout, null);
+		return timeout(timeout, null, Schedulers.timer());
 	}
 
 	/**
@@ -6569,7 +6569,49 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a per-item expirable {@link Flux} with a fallback {@link Publisher}
 	 */
 	public final Flux<T> timeout(Duration timeout, Publisher<? extends T> fallback) {
-		return timeoutMillis(timeout.toMillis(), fallback, Schedulers.timer());
+		return timeout(timeout, fallback, Schedulers.timer());
+	}
+
+	/**
+	 * Signal a {@link java.util.concurrent.TimeoutException} error in case a per-item
+	 * period fires before the next item arrives from this {@link Flux}.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.5.RELEASE/src/docs/marble/timeouttime.png" alt="">
+	 *
+	 * @param timeout the timeout {@link Duration} between two signals from this {@link Flux}
+	 * @param timer the {@link TimedScheduler} to run on
+	 *
+	 * @return a per-item expirable {@link Flux}
+	 */
+	public final Flux<T> timeout(Duration timeout, TimedScheduler timer) {
+		return timeout(timeout, null, timer);
+	}
+
+	/**
+	 * Switch to a fallback {@link Publisher} in case a per-item period fires before the
+	 * next item arrives from this {@link Flux}.
+	 *
+	 * <p> If the given {@link Publisher} is null, signal a {@link java.util.concurrent.TimeoutException}.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.5.RELEASE/src/docs/marble/timeouttimefallback.png" alt="">
+	 *
+	 * @param timeout the timeout {@link Duration} between two signals from this {@link Flux}
+	 * @param fallback the fallback {@link Publisher} to subscribe when a timeout occurs
+	 * @param timer the {@link TimedScheduler} to run on
+	 *
+	 * @return a per-item expirable {@link Flux} with a fallback {@link Publisher}
+	 */
+	public final Flux<T> timeout(Duration timeout, Publisher<? extends T> fallback,
+			TimedScheduler timer) {
+		final Mono<Long> _timer = Mono.delay(timeout, timer).otherwiseReturn(0L);
+		final Function<T, Publisher<Long>> rest = o -> _timer;
+
+		if(fallback == null) {
+			return timeout(_timer, rest);
+		}
+		return timeout(_timer, rest, fallback);
 	}
 
 	/**
@@ -6647,7 +6689,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param timeout the timeout in milliseconds between two signals from this {@link Flux}
 	 *
 	 * @return a per-item expirable {@link Flux}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final Flux<T> timeoutMillis(long timeout) {
 		return timeoutMillis(timeout, null, Schedulers.timer());
 	}
@@ -6663,7 +6707,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param timer the {@link TimedScheduler} to run on
 	 *
 	 * @return a per-item expirable {@link Flux}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final Flux<T> timeoutMillis(long timeout, TimedScheduler timer) {
 		return timeoutMillis(timeout, null, timer);
 	}
@@ -6681,7 +6727,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param fallback the fallback {@link Publisher} to subscribe when a timeout occurs
 	 *
 	 * @return a per-item expirable {@link Flux} with a fallback {@link Publisher}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final Flux<T> timeoutMillis(long timeout, Publisher<? extends T> fallback) {
 		return timeoutMillis(timeout, fallback, Schedulers.timer());
 	}
@@ -6700,7 +6748,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param timer the {@link TimedScheduler} to run on
 	 *
 	 * @return a per-item expirable {@link Flux} with a fallback {@link Publisher}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final Flux<T> timeoutMillis(long timeout, Publisher<? extends T> fallback,
 			TimedScheduler timer) {
 		final Mono<Long> _timer = Mono.delayMillis(timeout, timer).otherwiseReturn(0L);

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -809,7 +809,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a new timed {@link Flux}
 	 */
 	public static Flux<Long> interval(Duration period) {
-		return intervalMillis(period.toMillis());
+		return interval(period, Schedulers.timer());
 	}
 
 	/**
@@ -826,7 +826,41 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a new timed {@link Flux}
 	 */
 	public static Flux<Long> interval(Duration delay, Duration period) {
-		return intervalMillis(delay.toMillis(), period.toMillis());
+		return interval(delay, period, Schedulers.timer());
+	}
+
+	/**
+	 * Create a new {@link Flux} that emits an ever incrementing long starting with 0 every {@link Duration} on
+	 * the given timer. If demand is not produced in time, an onError will be signalled. The {@link Flux} will never
+	 * complete.
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.5.RELEASE/src/docs/marble/interval.png" alt="">
+	 * <p>
+	 * @param period The {@link Duration} to wait before the next increment
+	 * @param timer a {@link TimedScheduler} instance
+	 *
+	 * @return a new timed {@link Flux}
+	 */
+	public static Flux<Long> interval(Duration period, TimedScheduler timer) {
+		return onAssembly(new FluxInterval(period.toMillis(), period.toMillis(), TimeUnit.MILLISECONDS, timer));
+	}
+
+	/**
+	 * Create a new {@link Flux} that emits an ever incrementing long starting with 0 every N period of time on
+	 * the given timer. If demand is not produced in time, an onError will be signalled. The {@link Flux} will never
+	 * complete.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.5.RELEASE/src/docs/marble/intervald.png" alt="">
+	 *
+	 * @param delay  the {@link Duration} to wait before emitting 0l
+	 * @param period the period {@link Duration} before each following increment
+	 * @param timer  the {@link TimedScheduler} to schedule on
+	 *
+	 * @return a new timed {@link Flux}
+	 */
+	public static Flux<Long> interval(Duration delay, Duration period, TimedScheduler timer) {
+		return onAssembly(new FluxInterval(delay.toMillis(), period.toMillis(), TimeUnit.MILLISECONDS, timer));
 	}
 
 	/**
@@ -839,9 +873,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param period The number of milliseconds to wait before the next increment
 	 *
 	 * @return a new timed {@link Flux}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public static Flux<Long> intervalMillis(long period) {
-		return intervalMillis(period, Schedulers.timer());
+		return interval(Duration.ofMillis(period));
 	}
 
 	/**
@@ -855,9 +891,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param timer a {@link TimedScheduler} instance
 	 *
 	 * @return a new timed {@link Flux}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public static Flux<Long> intervalMillis(long period, TimedScheduler timer) {
-		return onAssembly(new FluxInterval(period, period, TimeUnit.MILLISECONDS, timer));
+		return interval(Duration.ofMillis(period), timer);
 	}
 
 	/**
@@ -872,9 +910,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param period the period in milliseconds before each following increment
 	 *
 	 * @return a new timed {@link Flux}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public static Flux<Long> intervalMillis(long delay, long period) {
-		return intervalMillis(delay, period, Schedulers.timer());
+		return interval(Duration.ofMillis(delay), Duration.ofMillis(period));
 	}
 
 	/**
@@ -890,9 +930,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param timer  the {@link TimedScheduler} to schedule on
 	 *
 	 * @return a new timed {@link Flux}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public static Flux<Long> intervalMillis(long delay, long period, TimedScheduler timer) {
-		return onAssembly(new FluxInterval(delay, period, TimeUnit.MILLISECONDS, timer));
+		return interval(Duration.ofMillis(delay), Duration.ofMillis(period), timer);
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -2979,7 +2979,7 @@ public abstract class Flux<T> implements Publisher<T> {
 
 	/**
 	 * Delay each of this {@link Flux} elements ({@link Subscriber#onNext} signals)
-	 * by a given duration.
+	 * by a given {@link Duration}.
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.5.RELEASE/src/docs/marble/delayonnext.png" alt="">
@@ -2989,7 +2989,22 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @see #delaySubscription(Duration) delaySubscription to introduce a delay at the beginning of the sequence only
 	 */
 	public final Flux<T> delayElements(Duration delay) {
-		return delayElementsMillis(delay.toMillis());
+		return delayElements(delay, Schedulers.timer());
+	}
+
+	/**
+	 * Delay each of this {@link Flux} elements ({@link Subscriber#onNext} signals)
+	 * by a given {@link Duration}.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.5.RELEASE/src/docs/marble/delayonnext.png" alt="">
+	 *
+	 * @param delay period to delay each {@link Subscriber#onNext} signal
+	 * @param timer the timed scheduler to use for delaying each signal
+	 * @return a delayed {@link Flux}
+	 */
+	public final Flux<T> delayElements(Duration delay, TimedScheduler timer) {
+		return concatMap(t ->  Mono.delay(delay, timer).map(i -> t));
 	}
 
 	/**
@@ -3000,12 +3015,12 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.5.RELEASE/src/docs/marble/delayonnext.png" alt="">
 	 *
 	 * @param delay period to delay each {@link Subscriber#onNext} signal, in milliseconds
-	 * @deprecated will be replaced by {@link #delayElementsMillis(long)} in 3.1.0
+	 * @deprecated will be replaced by {@link #delayElements(Duration)} in 3.1.0
 	 * @return a delayed {@link Flux}
 	 */
 	@Deprecated
 	public final Flux<T> delayMillis(long delay) {
-		return delayElementsMillis(delay);
+		return delayElements(Duration.ofMillis(delay));
 	}
 
 	/**
@@ -3017,9 +3032,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * @param delay period to delay each {@link Subscriber#onNext} signal, in milliseconds
 	 * @return a delayed {@link Flux}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final Flux<T> delayElementsMillis(long delay) {
-		return delayElementsMillis(delay, Schedulers.timer());
+		return delayElements(Duration.ofMillis(delay));
 	}
 
 	/**
@@ -3031,12 +3048,12 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * @param delay period to delay each {@link Subscriber#onNext} signal, in milliseconds
 	 * @param timer the timed scheduler to use for delaying each signal
-	 * @deprecated will be replaced by {@link #delayElementsMillis(long, TimedScheduler)} in 3.1.0
+	 * @deprecated will be replaced by {@link #delayElements(Duration, TimedScheduler)} in 3.1.0
 	 * @return a delayed {@link Flux}
 	 */
 	@Deprecated
 	public final Flux<T> delayMillis(long delay, TimedScheduler timer) {
-		return delayElementsMillis(delay, timer);
+		return delayElements(Duration.ofMillis(delay), timer);
 	}
 
 	/**
@@ -3049,9 +3066,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param delay period to delay each {@link Subscriber#onNext} signal, in milliseconds
 	 * @param timer the timed scheduler to use for delaying each signal
 	 * @return a delayed {@link Flux}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final Flux<T> delayElementsMillis(long delay, TimedScheduler timer) {
-		return concatMap(t ->  Mono.delayMillis(delay, timer).map(i -> t));
+		return delayElements(Duration.ofMillis(delay), timer);
 	}
 
 	/**
@@ -3067,7 +3086,23 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 */
 	public final Flux<T> delaySubscription(Duration delay) {
-		return delaySubscriptionMillis(delay.toMillis(), Schedulers.timer());
+		return delaySubscription(delay, Schedulers.timer());
+	}
+
+	/**
+	 * Delay the {@link Flux#subscribe(Subscriber) subscription} to this {@link Flux} source until the given
+	 * period elapses.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.5.RELEASE/src/docs/marble/delaysubscription.png" alt="">
+	 *
+	 * @param delay {@link Duration} before subscribing this {@link Flux}
+	 * @param timer the {@link TimedScheduler} to run on
+	 *
+	 * @return a delayed {@link Flux}
+	 */
+	public final Flux<T> delaySubscription(Duration delay, TimedScheduler timer) {
+		return delaySubscription(Mono.delay(delay, timer));
 	}
 
 	/**
@@ -3087,7 +3122,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	public final <U> Flux<T> delaySubscription(Publisher<U> subscriptionDelay) {
 		return onAssembly(new FluxDelaySubscription<>(this, subscriptionDelay));
 	}
-	
+
 	/**
 	 * Delay the {@link Flux#subscribe(Subscriber) subscription} to this {@link Flux} source until the given
 	 * period elapses.
@@ -3098,10 +3133,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param delay period in milliseconds before subscribing this {@link Flux}
 	 *
 	 * @return a delayed {@link Flux}
-	 *
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final Flux<T> delaySubscriptionMillis(long delay) {
-		return delaySubscriptionMillis(delay, Schedulers.timer());
+		return delaySubscription(Duration.ofMillis(delay), Schedulers.timer());
 	}
 
 	/**
@@ -3115,8 +3151,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param timer the {@link TimedScheduler} to run on
 	 *
 	 * @return a delayed {@link Flux}
-	 *
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final Flux<T> delaySubscriptionMillis(long delay, TimedScheduler timer) {
 		return delaySubscription(Mono.delayMillis(delay, timer));
 	}

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -1713,7 +1713,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return the first value or null
 	 */
 	public final T blockFirst(Duration d) {
-		return blockFirstMillis(d.toMillis());
+		BlockingFirstSubscriber<T> subscriber = new BlockingFirstSubscriber<>();
+		subscribe(subscriber);
+		return subscriber.blockingGet(d.toMillis(), TimeUnit.MILLISECONDS);
 	}
 
 	/**
@@ -1721,11 +1723,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * @param timeout max duration timeout in millis to wait for.
 	 * @return the first value or null
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final T blockFirstMillis(long timeout) {
-		BlockingFirstSubscriber<T> subscriber = new BlockingFirstSubscriber<>();
-		subscribe(subscriber);
-		return subscriber.blockingGet(timeout, TimeUnit.MILLISECONDS);
+		return blockFirst(Duration.ofMillis(timeout));
 	}
 
 	/**
@@ -1747,7 +1749,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return the last value or null
 	 */
 	public final T blockLast(Duration d) {
-		return blockLastMillis(d.toMillis());
+		BlockingLastSubscriber<T> subscriber = new BlockingLastSubscriber<>();
+		subscribe(subscriber);
+		return subscriber.blockingGet(d.toMillis(), TimeUnit.MILLISECONDS);
 	}
 
 	/**
@@ -1755,11 +1759,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * @param timeout max duration timeout in millis to wait for.
 	 * @return the last value or null
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final T blockLastMillis(long timeout) {
-		BlockingLastSubscriber<T> subscriber = new BlockingLastSubscriber<>();
-		subscribe(subscriber);
-		return subscriber.blockingGet(timeout, TimeUnit.MILLISECONDS);
+		return blockLast(Duration.ofMillis(timeout));
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -194,7 +194,23 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @return a new {@link Mono}
 	 */
 	public static Mono<Long> delay(Duration duration) {
-		return delayMillis(duration.toMillis());
+		return delay(duration, Schedulers.timer());
+	}
+
+	/**
+	 * Create a Mono which delays an onNext signal by a given {@code duration} and completes.
+	 * If the demand cannot be produced in time, an onError will be signalled instead.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.5.RELEASE/src/docs/marble/delay.png" alt="">
+	 * <p>
+	 * @param duration the {@link Duration} of the delay
+	 * @param timer the {@link TimedScheduler} to run on
+	 *
+	 * @return a new {@link Mono}
+	 */
+	public static Mono<Long> delay(Duration duration, TimedScheduler timer) {
+		return onAssembly(new MonoDelay(duration.toMillis(), TimeUnit.MILLISECONDS, timer));
 	}
 
 	/**
@@ -207,9 +223,11 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param duration the duration in milliseconds of the delay
 	 *
 	 * @return a new {@link Mono}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public static Mono<Long> delayMillis(long duration) {
-		return delayMillis(duration, Schedulers.timer());
+		return delay(Duration.ofMillis(duration));
 	}
 
 	/**
@@ -223,10 +241,13 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param timer the {@link TimedScheduler} to run on
 	 *
 	 * @return a new {@link Mono}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public static Mono<Long> delayMillis(long duration, TimedScheduler timer) {
-		return onAssembly(new MonoDelay(duration, TimeUnit.MILLISECONDS, timer));
+		return delay(Duration.ofMillis(duration), timer);
 	}
+
 
 	/**
 	 * Create a {@link Mono} that completes without emitting any item.
@@ -1375,7 +1396,27 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @return a delayed {@link Mono}
 	 */
 	public final Mono<T> delayElement(Duration delay) {
-		return delayElementMillis(delay.toMillis());
+		return delayElement(delay, Schedulers.timer());
+	}
+
+	/**
+	 * Delay this {@link Flux} element ({@link Subscriber#onNext} signal) by a given
+	 * {@link Duration}. Empty monos or error signals are not delayed.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.5.RELEASE/src/docs/marble/delayonnext.png" alt="">
+	 *
+	 * <p>
+	 * Note that the scheduler on which the mono chain continues execution will be the
+	 * time scheduler used if the mono is valued, or the current scheduler if the mono
+	 * completes empty or errors.
+	 *
+	 * @param delay {@link Duration} to delay each {@link Subscriber#onNext} signal
+	 * @param timer the timed scheduler to use for delaying the value signal
+	 * @return a delayed {@link Mono}
+	 */
+	public final Mono<T> delayElement(Duration delay, TimedScheduler timer) {
+		return onAssembly(new MonoDelayElement<>(this, delay.toMillis(), TimeUnit.MILLISECONDS, timer));
 	}
 
 	/**
@@ -1392,9 +1433,11 @@ public abstract class Mono<T> implements Publisher<T> {
 	 *
 	 * @param delay period to delay each {@link Subscriber#onNext} signal, in milliseconds
 	 * @return a delayed {@link Mono}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final Mono<T> delayElementMillis(long delay) {
-		return delayElementMillis(delay, Schedulers.timer());
+		return delayElement(Duration.ofMillis(delay));
 	}
 
 	/**
@@ -1412,9 +1455,11 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param delay period to delay each {@link Subscriber#onNext} signal, in milliseconds
 	 * @param timer the timed scheduler to use for delaying the value signal
 	 * @return a delayed {@link Mono}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final Mono<T> delayElementMillis(long delay, TimedScheduler timer) {
-		return onAssembly(new MonoDelayElement<>(this, delay, TimeUnit.MILLISECONDS, timer));
+		return delayElement(Duration.ofMillis(delay), timer);
 	}
 
 	/**
@@ -1432,6 +1477,24 @@ public abstract class Mono<T> implements Publisher<T> {
 	public final Mono<T> delaySubscription(Duration delay) {
 		return delaySubscription(Mono.delay(delay));
 	}
+
+	/**
+	 * Delay the {@link Mono#subscribe(Subscriber) subscription} to this {@link Mono} source until the given
+	 * {@link Duration} elapses.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.5.RELEASE/src/docs/marble/delaysubscription1.png" alt="">
+	 *
+	 * @param delay {@link Duration} before subscribing this {@link Mono}
+	 * @param timer the {@link TimedScheduler} to run on
+	 *
+	 * @return a delayed {@link Mono}
+	 *
+	 */
+	public final Mono<T> delaySubscription(Duration delay, TimedScheduler timer) {
+		return delaySubscription(Mono.delay(delay, timer));
+	}
+
 	/**
 	 * Delay the subscription to this {@link Mono} until another {@link Publisher}
 	 * signals a value or completes.
@@ -1460,10 +1523,11 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param delay period in milliseconds before subscribing this {@link Mono}
 	 *
 	 * @return a delayed {@link Mono}
-	 *
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final Mono<T> delaySubscriptionMillis(long delay) {
-		return delaySubscriptionMillis(delay, Schedulers.timer());
+		return delaySubscription(Duration.ofMillis(delay));
 	}
 
 	/**
@@ -1477,10 +1541,11 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param timer the {@link TimedScheduler} to run on
 	 *
 	 * @return a delayed {@link Mono}
-	 *
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final Mono<T> delaySubscriptionMillis(long delay, TimedScheduler timer) {
-		return delaySubscription(Mono.delayMillis(delay, timer));
+		return delaySubscription(Duration.ofMillis(delay), timer);
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -2900,7 +2900,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @return an expirable {@link Mono}
 	 */
 	public final Mono<T> timeout(Duration timeout) {
-		return timeoutMillis(timeout.toMillis());
+		return timeout(timeout, null, Schedulers.timer());
 	}
 
 	/**
@@ -2917,7 +2917,46 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @return an expirable {@link Mono} with a fallback {@link Mono}
 	 */
 	public final Mono<T> timeout(Duration timeout, Mono<? extends T> fallback) {
-		return timeoutMillis(timeout.toMillis(), fallback);
+		return timeout(timeout, fallback, Schedulers.timer());
+	}
+
+	/**
+	 * Signal a {@link java.util.concurrent.TimeoutException} error in case an item doesn't arrive before the given period.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.5.RELEASE/src/docs/marble/timeouttime1.png" alt="">
+	 *
+	 * @param timeout the timeout before the onNext signal from this {@link Mono}
+	 * @param timer the {@link TimedScheduler} to run on
+	 *
+	 * @return an expirable {@link Mono}
+	 */
+	public final Mono<T> timeout(Duration timeout, TimedScheduler timer) {
+		return timeout(timeout, null, timer);
+	}
+
+	/**
+	 * Switch to a fallback {@link Mono} in case an item doesn't arrive before the given period.
+	 *
+	 * <p> If the given {@link Publisher} is null, signal a {@link java.util.concurrent.TimeoutException}.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.5.RELEASE/src/docs/marble/timeouttimefallback1.png" alt="">
+	 *
+	 * @param timeout the timeout before the onNext signal from this {@link Mono}
+	 * @param fallback the fallback {@link Mono} to subscribe when a timeout occurs
+	 * @param timer the {@link TimedScheduler} to run on
+	 *
+	 * @return an expirable {@link Mono} with a fallback {@link Mono}
+	 */
+	public final Mono<T> timeout(Duration timeout, Mono<? extends T> fallback,
+			TimedScheduler timer) {
+		final Mono<Long> _timer = Mono.delay(timeout, timer).otherwiseReturn(0L);
+
+		if(fallback == null) {
+			return onAssembly(new MonoTimeout<>(this, _timer));
+		}
+		return onAssembly(new MonoTimeout<>(this, _timer, fallback));
 	}
 
 	/**
@@ -2966,7 +3005,9 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param timeout the timeout before the onNext signal from this {@link Mono}
 	 *
 	 * @return an expirable {@link Mono}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final Mono<T> timeoutMillis(long timeout) {
 		return timeoutMillis(timeout, Schedulers.timer());
 	}
@@ -2981,7 +3022,9 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param timer the {@link TimedScheduler} to run on
 	 *
 	 * @return an expirable {@link Mono}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final Mono<T> timeoutMillis(long timeout, TimedScheduler timer) {
 		return timeoutMillis(timeout, null, timer);
 	}
@@ -2998,7 +3041,9 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param fallback the fallback {@link Mono} to subscribe when a timeout occurs
 	 *
 	 * @return an expirable {@link Mono} with a fallback {@link Mono}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final Mono<T> timeoutMillis(long timeout, Mono<? extends T> fallback) {
 		return timeoutMillis(timeout, fallback, Schedulers.timer());
 	}
@@ -3016,7 +3061,9 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param timer the {@link TimedScheduler} to run on
 	 *
 	 * @return an expirable {@link Mono} with a fallback {@link Mono}
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public final Mono<T> timeoutMillis(long timeout, Mono<? extends T> fallback,
 			TimedScheduler timer) {
 		final Mono<Long> _timer = Mono.delayMillis(timeout, timer).otherwiseReturn(0L);

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -1226,7 +1226,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 *
 	 * @return T the result
 	 */
-	public final T block(Duration timeout) {
+	public T block(Duration timeout) {
 		BlockingFirstSubscriber<T> subscriber = new BlockingFirstSubscriber<>();
 		subscribe(subscriber);
 		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
@@ -1250,7 +1250,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
 	@Deprecated
-	public T blockMillis(long timeout) {
+	public final T blockMillis(long timeout) {
 		return block(Duration.ofMillis(timeout));
 	}
 

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -1227,7 +1227,9 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @return T the result
 	 */
 	public final T block(Duration timeout) {
-		return blockMillis(timeout.toMillis());
+		BlockingFirstSubscriber<T> subscriber = new BlockingFirstSubscriber<>();
+		subscribe(subscriber);
+		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
 	}
 
 	/**
@@ -1245,11 +1247,11 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param timeout maximum time period to wait for in milliseconds before raising a {@link RuntimeException}
 	 *
 	 * @return T the result
+	 * @deprecated use the {@link Duration} based variants instead, will be removed in 3.1.0
 	 */
+	@Deprecated
 	public T blockMillis(long timeout) {
-		BlockingFirstSubscriber<T> subscriber = new BlockingFirstSubscriber<>();
-		subscribe(subscriber);
-		return subscriber.blockingGet(timeout, TimeUnit.MILLISECONDS);
+		return block(Duration.ofMillis(timeout));
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/MonoCallable.java
+++ b/src/main/java/reactor/core/publisher/MonoCallable.java
@@ -15,6 +15,7 @@
  */
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 
@@ -72,11 +73,12 @@ extends Mono<T>
 
 	@Override
 	public T block() {
-		return blockMillis(-1L);
+		//duration is ignored below
+		return block(Duration.ZERO);
 	}
 
 	@Override
-	public T blockMillis(long m) {
+	public T block(Duration m) {
 		try {
 			return Objects.requireNonNull(callable.call(),
 					"The callable source returned null");

--- a/src/main/java/reactor/core/publisher/MonoCallableOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/MonoCallableOnAssembly.java
@@ -16,6 +16,7 @@
 
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.concurrent.Callable;
 
 import org.reactivestreams.Publisher;
@@ -50,12 +51,13 @@ final class MonoCallableOnAssembly<T> extends MonoSource<T, T>
 
 	@Override
 	public T block() {
-		return blockMillis(-1L);
+		//duration is ignored below
+		return block(Duration.ZERO);
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public T blockMillis(long timeout) {
+	public T block(Duration timeout) {
 		try {
 			return ((Callable<T>) source).call();
 		}

--- a/src/main/java/reactor/core/publisher/MonoEmpty.java
+++ b/src/main/java/reactor/core/publisher/MonoEmpty.java
@@ -15,6 +15,8 @@
  */
 package reactor.core.publisher;
 
+import java.time.Duration;
+
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import reactor.core.Fuseable;
@@ -60,7 +62,7 @@ extends Mono<Object>
 	}
 
 	@Override
-	public Object blockMillis(long m) {
+	public Object block(Duration m) {
 		return null;
 	}
 

--- a/src/main/java/reactor/core/publisher/MonoError.java
+++ b/src/main/java/reactor/core/publisher/MonoError.java
@@ -15,6 +15,7 @@
  */
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -42,7 +43,7 @@ final class MonoError<T> extends Mono<T> implements Trackable {
 	}
 
 	@Override
-	public T blockMillis(long m) {
+	public T block(Duration m) {
 		throw Exceptions.propagate(getError());
 	}
 

--- a/src/main/java/reactor/core/publisher/MonoJust.java
+++ b/src/main/java/reactor/core/publisher/MonoJust.java
@@ -15,6 +15,7 @@
  */
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.Objects;
 
 import org.reactivestreams.Subscriber;
@@ -40,7 +41,7 @@ extends Mono<T>
 	}
 
 	@Override
-	public T blockMillis(long m) {
+	public T block(Duration m) {
 		return value;
 	}
 

--- a/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -16,6 +16,7 @@
 
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
@@ -134,20 +135,20 @@ public final class MonoProcessor<O> extends Mono<O>
 
 	@Override
 	public O block() {
-		return blockMillis(30_0000L);
+		return block(Duration.ofSeconds(300));
 	}
 
 	/**
 	 * Block the calling thread for the specified time, waiting for the completion of this {@code MonoProcessor}. If the
 	 * {@link MonoProcessor} is completed with an error a RuntimeException that wraps the error is thrown.
 	 *
-	 * @param timeout the timeout value in milliseconds
+	 * @param timeout the timeout value as a {@link Duration}
 	 *
 	 * @return the value of this {@code MonoProcessor} or {@code null} if the timeout is reached and the {@code MonoProcessor} has
 	 * not completed
 	 */
 	@Override
-	public O blockMillis(long timeout) {
+	public O block(Duration timeout) {
 		try {
 			if (!isPending()) {
 				return peek();
@@ -156,8 +157,7 @@ public final class MonoProcessor<O> extends Mono<O>
 				getOrStart();
 			}
 
-			long delay = System.nanoTime() + TimeUnit.NANOSECONDS.convert(timeout,
-					TimeUnit.MILLISECONDS);
+			long delay = System.nanoTime() + timeout.toNanos();
 
 			try {
 				long endState = waitStrategy.waitFor(STATE_SUCCESS_VALUE, this,	() -> {

--- a/src/main/java/reactor/core/publisher/MonoRunnable.java
+++ b/src/main/java/reactor/core/publisher/MonoRunnable.java
@@ -16,6 +16,7 @@
 
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 
@@ -44,7 +45,7 @@ final class MonoRunnable extends Mono<Void> implements Callable<Void> {
     }
     
     @Override
-    public Void blockMillis(long m) {
+    public Void block(Duration m) {
         run.run();
         return null;
     }

--- a/src/main/java/reactor/core/publisher/MonoSupplier.java
+++ b/src/main/java/reactor/core/publisher/MonoSupplier.java
@@ -15,6 +15,7 @@
  */
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
@@ -70,14 +71,15 @@ extends Mono<T>
 	}
 	
 	@Override
-	public T blockMillis(long m) {
+	public T block(Duration m) {
 		return Objects.requireNonNull(supplier.get(),
 				"The supplier source returned null");
 	}
 
 	@Override
 	public T block() {
-		return blockMillis(-1);
+		//the duration is ignored above
+		return block(Duration.ZERO);
 	}
 	
 	@Override

--- a/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
+++ b/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
@@ -297,7 +297,7 @@ public class FluxBufferBoundaryTest
 	Flux<List<Integer>> scenario_bufferWillSubdivideAnInputFluxTime2() {
 		return Flux.just(1, 2, 3, 4, 5, 6, 7, 8)
 		           .delayElements(Duration.ofMillis(99))
-		           .bufferMillis(200);
+		           .buffer(Duration.ofMillis(200));
 	}
 
 	@Test

--- a/src/test/java/reactor/core/publisher/FluxBufferStartEndTest.java
+++ b/src/test/java/reactor/core/publisher/FluxBufferStartEndTest.java
@@ -180,7 +180,7 @@ public class FluxBufferStartEndTest {
 	Flux<List<Integer>> scenario_bufferWillSubdivideAnInputFluxOverlapTime2() {
 		return Flux.just(1, 2, 3, 4, 5, 6, 7, 8)
 		           .delayElements(Duration.ofMillis(99))
-		           .bufferMillis(300L, 200L);//FIXME review signature
+		           .buffer(Duration.ofMillis(300L), Duration.ofMillis(200L));
 	}
 
 	@Test
@@ -197,7 +197,7 @@ public class FluxBufferStartEndTest {
 	Flux<List<Integer>> scenario_bufferWillSubdivideAnInputFluxSameTime() {
 		return Flux.just(1, 2, 3, 4, 5, 6, 7, 8)
 		           .delayElements(Duration.ofMillis(99))
-		           .bufferMillis(300L, 300L);
+		           .buffer(Duration.ofMillis(300L), Duration.ofMillis(300L));
 	}
 
 	@Test

--- a/src/test/java/reactor/core/publisher/FluxBufferTimeOrSizeTest.java
+++ b/src/test/java/reactor/core/publisher/FluxBufferTimeOrSizeTest.java
@@ -28,7 +28,7 @@ public class FluxBufferTimeOrSizeTest {
 	Flux<List<Integer>> scenario_bufferWithTimeoutAccumulateOnTimeOrSize() {
 		return Flux.range(1, 6)
 		           .delayElements(Duration.ofMillis(300))
-		           .buffer(5, Duration.ofMillis(2000));
+		           .bufferTimeout(5, Duration.ofMillis(2000));
 	}
 
 	@Test
@@ -44,7 +44,7 @@ public class FluxBufferTimeOrSizeTest {
 	Flux<List<Integer>> scenario_bufferWithTimeoutAccumulateOnTimeOrSize2() {
 		return Flux.range(1, 6)
 		           .delayElements(Duration.ofMillis(300))
-		           .bufferMillis(5, 2000);
+		           .bufferTimeout(5, Duration.ofMillis(2000));
 	}
 
 	@Test

--- a/src/test/java/reactor/core/publisher/FluxCacheTest.java
+++ b/src/test/java/reactor/core/publisher/FluxCacheTest.java
@@ -31,7 +31,7 @@ public class FluxCacheTest {
 			VirtualTimeScheduler vts = VirtualTimeScheduler.getOrSet(false);
 
 			Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-			                                         .delayElementsMillis(1000)
+			                                         .delayElements(Duration.ofMillis(1000))
 			                                         .cache()
 			                                         .elapsed();
 
@@ -60,7 +60,7 @@ public class FluxCacheTest {
 			VirtualTimeScheduler vts = VirtualTimeScheduler.getOrSet(false);
 
 			Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-			                                         .delayElementsMillis(1000)
+			                                         .delayElements(Duration.ofMillis(1000))
 			                                         .cache(Duration.ofMillis(2000))
 			                                         .elapsed();
 
@@ -88,7 +88,7 @@ public class FluxCacheTest {
 			VirtualTimeScheduler vts = VirtualTimeScheduler.getOrSet(false);
 
 			Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-			                                         .delayElementsMillis(1000)
+			                                         .delayElements(Duration.ofMillis(1000))
 			                                         .cache(2, Duration.ofMillis(2000))
 			                                         .elapsed();
 

--- a/src/test/java/reactor/core/publisher/FluxDelaySubscriptionTest.java
+++ b/src/test/java/reactor/core/publisher/FluxDelaySubscriptionTest.java
@@ -194,7 +194,7 @@ public class FluxDelaySubscriptionTest {
 
 	Flux<Integer> scenario_delayedTrigger2(){
 		return Flux.just(1)
-		           .delaySubscriptionMillis(50);
+		           .delaySubscription(Duration.ofMillis(50));
 	}
 
 	@Test

--- a/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -909,7 +909,7 @@ public class FluxFlatMapTest {
 	Flux<Integer> scenario_backpressuredThenCancel() {
 		return Flux.just(1, 2, 3)
 		           .flatMap(f -> Flux.range(1, 10)
-		                             .delayElementsMillis(10L))
+		                             .delayElements(Duration.ofMillis(10L)))
 		           .hide();
 	}
 

--- a/src/test/java/reactor/core/publisher/FluxIntervalTest.java
+++ b/src/test/java/reactor/core/publisher/FluxIntervalTest.java
@@ -51,7 +51,7 @@ public class FluxIntervalTest {
 			ts.values()
 			  .add(System.currentTimeMillis());
 
-			Flux.intervalMillis(100, 100, exec)
+			Flux.interval(Duration.ofMillis(100), Duration.ofMillis(100), exec)
 			    .take(5)
 			    .map(v -> System.currentTimeMillis())
 			    .subscribe(ts);
@@ -124,7 +124,7 @@ public class FluxIntervalTest {
 	}
 
 	Flux<Long> scenario4(){
-		return Flux.intervalMillis(500, 1000);
+		return Flux.interval(Duration.ofMillis(500), Duration.ofMillis(1000));
 	}
 
 	@Test

--- a/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
+++ b/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
@@ -646,8 +646,8 @@ public class FluxMergeSequentialTest {
 		long count = Flux.range(0, 500)
 		                 .flatMapSequential(i -> {
 			                 //ensure each pack of 100 is delayed in inverse order
-			                 long sleep = 600 - i % 100;
-			                 return Mono.delayMillis(sleep)
+			                 Duration sleep = Duration.ofMillis(600 - i % 100);
+			                 return Mono.delay(sleep)
 			                            .then(Mono.just(i))
 			                            .subscribeOn(scheduler);
 		                 })

--- a/src/test/java/reactor/core/publisher/FluxProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/FluxProcessorTest.java
@@ -15,6 +15,7 @@
  */
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -146,8 +147,8 @@ public class FluxProcessorTest {
 		CountDownLatch latch = new CountDownLatch(1);
 		Scheduler scheduler = Schedulers.parallel();
 		processor.publishOn(scheduler)
-		         .delaySubscriptionMillis(1000)
-		         .subscribe(d -> {
+		         .delaySubscription(Duration.ofMillis(1000))
+		                                    .subscribe(d -> {
 			         count.incrementAndGet();
 			         latch.countDown();
 		         }, 1);

--- a/src/test/java/reactor/core/publisher/FluxReplayTest.java
+++ b/src/test/java/reactor/core/publisher/FluxReplayTest.java
@@ -82,7 +82,7 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 	public void cacheFlux() {
 
 		Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-		                                         .delayElementsMillis(1000)
+		                                         .delayElements(Duration.ofMillis(1000))
 		                                         .replay()
 		                                         .autoConnect()
 		                                         .elapsed();
@@ -107,7 +107,7 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 	public void cacheFluxFused() {
 
 		Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-		                                         .delayElementsMillis(1000)
+		                                         .delayElements(Duration.ofMillis(1000))
 		                                         .replay()
 		                                         .autoConnect()
 		                                         .elapsed();
@@ -134,7 +134,7 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 	public void cacheFluxTTL() {
 
 		Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-		                                         .delayElementsMillis(1000)
+		                                         .delayElements(Duration.ofMillis(1000))
 		                                         .replay(Duration.ofMillis(2000))
 		                                         .autoConnect()
 		                                         .elapsed();
@@ -158,7 +158,7 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 	public void cacheFluxTTLFused() {
 
 		Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-		                                         .delayElementsMillis(1000)
+		                                         .delayElements(Duration.ofMillis(1000))
 		                                         .replay(Duration.ofMillis(2000))
 		                                         .autoConnect()
 		                                         .elapsed();
@@ -184,8 +184,8 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 	public void cacheFluxTTLMillis() {
 
 		Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-		                                         .delayElementsMillis(1000)
-		                                         .replayMillis(2000, vts)
+		                                         .delayElements(Duration.ofMillis(1000))
+		                                         .replay(Duration.ofMillis(2000), vts)
 		                                         .autoConnect()
 		                                         .elapsed();
 
@@ -208,7 +208,7 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 	public void cacheFluxHistoryTTL() {
 
 		Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-		                                         .delayElementsMillis(1000)
+		                                         .delayElements(Duration.ofMillis(1000))
 		                                         .replay(2, Duration.ofMillis(2000))
 		                                         .autoConnect()
 		                                         .elapsed();
@@ -232,7 +232,7 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 	public void cacheFluxHistoryTTLFused() {
 
 		Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-		                                         .delayElementsMillis(1000)
+		                                         .delayElements(Duration.ofMillis(1000))
 		                                         .replay(2, Duration.ofMillis(2000))
 		                                         .autoConnect()
 		                                         .elapsed();

--- a/src/test/java/reactor/core/publisher/FluxSampleFirstTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSampleFirstTest.java
@@ -160,7 +160,7 @@ public class FluxSampleFirstTest {
 
 	Flux<Integer> scenario_sampleFirstTime(){
 		return Flux.range(1, 10)
-	        .delayElementsMillis(200)
+	        .delayElements(Duration.ofMillis(200))
 	        .sampleFirst(Duration.ofSeconds(1));
 	}
 

--- a/src/test/java/reactor/core/publisher/FluxSampleTimeoutTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSampleTimeoutTest.java
@@ -129,7 +129,7 @@ public class FluxSampleTimeoutTest {
 
 	Flux<Integer> scenario_sampleTimeoutTime(){
 		return Flux.range(1, 10)
-		           .delayElementsMillis(300)
+		           .delayElements(Duration.ofMillis(300))
 		           .sampleTimeout(d -> Mono.delay(Duration.ofMillis(100*d)), 1);
 	}
 
@@ -142,7 +142,7 @@ public class FluxSampleTimeoutTest {
 	}
 	Flux<Integer> scenario_sampleTimeoutTime2(){
 		return Flux.range(1, 10)
-		           .delayElementsMillis(300)
+		           .delayElements(Duration.ofMillis(300))
 		           .sampleTimeout(d -> Mono.delay(Duration.ofMillis(100*d)), Integer.MAX_VALUE);
 	}
 

--- a/src/test/java/reactor/core/publisher/FluxSkipUntilOtherTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSkipUntilOtherTest.java
@@ -224,7 +224,7 @@ public class FluxSkipUntilOtherTest extends FluxOperatorTest<String, String> {
 
 	Flux<Integer> scenario_aFluxCanBeSkippedByTime2(){
 		return Flux.range(0, 1000)
-		           .skipMillis(2000);
+		           .skip(Duration.ofMillis(2000));
 	}
 
 	@Test
@@ -236,7 +236,7 @@ public class FluxSkipUntilOtherTest extends FluxOperatorTest<String, String> {
 
 	Flux<Integer> scenario_aFluxCanBeSkippedByTimeZero(){
 		return Flux.range(0, 1000)
-		           .skipMillis(0);
+		           .skip(Duration.ofMillis(0));
 	}
 
 	@Test

--- a/src/test/java/reactor/core/publisher/FluxTakeUntilOtherTest.java
+++ b/src/test/java/reactor/core/publisher/FluxTakeUntilOtherTest.java
@@ -168,7 +168,7 @@ public class FluxTakeUntilOtherTest {
 
 	Flux<Integer> scenario_aFluxCanBeLimitedByTime2(){
 		return Flux.range(0, 1000)
-		           .takeMillis(2000);
+		           .take(Duration.ofMillis(2000));
 	}
 
 	@Test
@@ -180,7 +180,7 @@ public class FluxTakeUntilOtherTest {
 	}
 	@Test
 	public void aFluxCanBeLimitedByTime3(){
-		StepVerifier.create(Flux.range(0, 1000).takeMillis(0L))
+		StepVerifier.create(Flux.range(0, 1000).take(Duration.ofMillis(0L)))
 		            .thenAwait(Duration.ofSeconds(2))
 		            .verifyComplete();
 	}

--- a/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
+++ b/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
@@ -270,7 +270,7 @@ public class FluxTimeoutTest {
 	}
 
 	Flux<Integer> scenario_timeoutCanBeBoundWithCallback2() {
-		return Flux.<Integer>never().timeoutMillis(500, Flux.just(-5));
+		return Flux.<Integer>never().timeout(Duration.ofMillis(500), Flux.just(-5));
 	}
 
 	@Test
@@ -283,7 +283,7 @@ public class FluxTimeoutTest {
 
 	Flux<?> scenario_timeoutThrown2() {
 		return Flux.never()
-		           .timeoutMillis(500);
+		           .timeout(Duration.ofMillis(500));
 	}
 
 	@Test
@@ -295,7 +295,7 @@ public class FluxTimeoutTest {
 
 	Flux<?> scenario_timeoutThrown3() {
 		return Flux.never()
-		           .timeoutMillis(500, Schedulers.timer());
+		           .timeout(Duration.ofMillis(500), Schedulers.timer());
 	}
 
 	@Test

--- a/src/test/java/reactor/core/publisher/FluxWindowTimeOrSizeTest.java
+++ b/src/test/java/reactor/core/publisher/FluxWindowTimeOrSizeTest.java
@@ -28,7 +28,7 @@ public class FluxWindowTimeOrSizeTest {
 	Flux<List<Integer>> scenario_windowWithTimeoutAccumulateOnTimeOrSize() {
 		return Flux.range(1, 6)
 		           .delayElements(Duration.ofMillis(300))
-		           .window(5, Duration.ofMillis(2000))
+		           .windowTimeout(5, Duration.ofMillis(2000))
 		           .concatMap(Flux::buffer);
 	}
 
@@ -45,7 +45,7 @@ public class FluxWindowTimeOrSizeTest {
 	Flux<List<Integer>> scenario_windowWithTimeoutAccumulateOnTimeOrSize2() {
 		return Flux.range(1, 6)
 		           .delayElements(Duration.ofMillis(300))
-		           .windowMillis(5, 2000)
+		           .windowTimeout(5, Duration.ofMillis(2000))
 		           .concatMap(Flux::buffer);
 	}
 

--- a/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
+++ b/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
@@ -85,7 +85,7 @@ public class MonoDelayElementTest {
 		AtomicBoolean emitted = new AtomicBoolean();
 		AtomicBoolean cancelled = new AtomicBoolean();
 
-		Mono<Long> source = Mono.delayMillis(1000, vts);
+		Mono<Long> source = Mono.delay(Duration.ofMillis(1000), vts);
 
 		StepVerifier.withVirtualTime(
 				() -> new MonoDelayElement<>(source, 2, TimeUnit.SECONDS, vts)
@@ -224,7 +224,7 @@ public class MonoDelayElementTest {
 
 	@Test
 	public void monoApiTestMillis() {
-		StepVerifier.withVirtualTime(() -> Mono.just("foo").delayElementMillis(5000L))
+		StepVerifier.withVirtualTime(() -> Mono.just("foo").delayElement(Duration.ofMillis(5000L)))
 		            .expectSubscription()
 		            .expectNoEvent(Duration.ofSeconds(5))
 		            .expectNext("foo")
@@ -236,7 +236,7 @@ public class MonoDelayElementTest {
 		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 
 		StepVerifier.withVirtualTime(
-				() -> Mono.just("foo").delayElementMillis(5000L, vts),
+				() -> Mono.just("foo").delayElement(Duration.ofMillis(5000L), vts),
 				() -> vts, Long.MAX_VALUE)
 		            .expectSubscription()
 		            .expectNoEvent(Duration.ofSeconds(5))

--- a/src/test/java/reactor/core/publisher/MonoDelaySubscriptionTest.java
+++ b/src/test/java/reactor/core/publisher/MonoDelaySubscriptionTest.java
@@ -63,7 +63,7 @@ public class MonoDelaySubscriptionTest {
 
 	Mono<Integer> scenario_delayedTrigger2(){
 		return Mono.just(1)
-		           .delaySubscriptionMillis(50);
+		           .delaySubscription(Duration.ofMillis(50));
 	}
 
 	@Test

--- a/src/test/java/reactor/core/publisher/MonoFirstTest.java
+++ b/src/test/java/reactor/core/publisher/MonoFirstTest.java
@@ -45,8 +45,8 @@ public class MonoFirstTest {
 	@Test//(timeout = 5000)
 	public void all2NonEmpty() {
 		Assert.assertEquals(Integer.MIN_VALUE,
-				Mono.first(Mono.delayMillis(150)
-				               .map(i -> Integer.MIN_VALUE), Mono.delayMillis(250))
+				Mono.first(Mono.delay(Duration.ofMillis(150))
+				               .map(i -> Integer.MIN_VALUE), Mono.delay(Duration.ofMillis(250)))
 				    .block());
 	}
 
@@ -83,8 +83,8 @@ public class MonoFirstTest {
 	@Test//(timeout = 5000)
 	public void all2NonEmptyIterable() {
 		Assert.assertEquals(Integer.MIN_VALUE,
-				Mono.first(Mono.delayMillis(150)
-				               .map(i -> Integer.MIN_VALUE), Mono.delayMillis(250))
+				Mono.first(Mono.delay(Duration.ofMillis(150))
+				               .map(i -> Integer.MIN_VALUE), Mono.delay(Duration.ofMillis(250)))
 				    .block());
 	}
 

--- a/src/test/java/reactor/core/publisher/MonoWhenTest.java
+++ b/src/test/java/reactor/core/publisher/MonoWhenTest.java
@@ -144,7 +144,7 @@ public class MonoWhenTest {
 	@Test//(timeout = 5000)
 	public void all2NonEmpty() {
 		Assert.assertEquals(Tuples.of(0L, 0L),
-				Mono.when(Mono.delayMillis(150), Mono.delayMillis(250))
+				Mono.when(Mono.delay(Duration.ofMillis(150)), Mono.delay(Duration.ofMillis(250)))
 				    .block());
 	}
 

--- a/src/test/java/reactor/core/publisher/WorkQueueProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/WorkQueueProcessorTest.java
@@ -16,6 +16,7 @@
 
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
@@ -153,7 +154,7 @@ public class WorkQueueProcessorTest {
 		WorkQueueProcessor<String> queueProcessor =
 				WorkQueueProcessor.share("Processor", 256, liteBlocking());
 		TimedScheduler timer = Schedulers.newTimer("Timer");
-		queueProcessor.bufferMillis(32, 2, timer)
+		queueProcessor.bufferTimeout(32, Duration.ofMillis(2), timer)
 		              .subscribe(new Subscriber<List<String>>() {
 			              int counter;
 

--- a/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
@@ -225,7 +225,7 @@ public class FluxSpecTests {
 
 	Flux<Integer> scenario_rangeTimedSample() {
 		return Flux.range(1, Integer.MAX_VALUE)
-		           .delayElementsMillis(100)
+		           .delayElements(Duration.ofMillis(100))
 		           .sample(Duration.ofSeconds(4))
 		           .take(1);
 	}
@@ -240,7 +240,7 @@ public class FluxSpecTests {
 
 	Flux<Integer> scenario_rangeTimedTake() {
 		return Flux.range(1, Integer.MAX_VALUE)
-		           .delayElementsMillis(100)
+		           .delayElements(Duration.ofMillis(100))
 		           .take(Duration.ofSeconds(4))
 		           .takeLast(1);
 	}
@@ -810,7 +810,7 @@ public class FluxSpecTests {
 
 		try {
 			Mono<List<Integer>> res = source.subscribeOn(scheduler)
-			                                .delaySubscriptionMillis(1L)
+			                                .delaySubscription(Duration.ofMillis(1L))
 			                                .log("streamed")
 			                                .map(it -> it * 2)
 			                                .buffer()

--- a/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
@@ -494,7 +494,7 @@ public class FluxSpecTests {
 		source.connectSink().emit(1);
 
 //		then: "the value is mapped"
-		int result = value.blockMillis(5_000);
+		int result = value.block(Duration.ofSeconds(5));
 		assertThat(result).isEqualTo(2);
 	}
 

--- a/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -517,7 +517,7 @@ public class FluxTests extends AbstractReactorTest {
 		        .parallel(8)
 		        .groups()
 		        .subscribe(stream -> stream.publishOn(asyncGroup)
-		                                 .buffer(1000 / 8, Duration.ofSeconds(1))
+		                                 .bufferTimeout(1000 / 8, Duration.ofSeconds(1))
 		                                 .subscribe(batch -> {
 			                                 for (int j = 0; j < batch.size(); j++) {
                                                 latch.countDown();
@@ -710,7 +710,7 @@ public class FluxTests extends AbstractReactorTest {
 		                 .parallel(PARALLEL_STREAMS)
 		                 .groups()
 		                 .subscribe(substream -> substream.hide().publishOn(asyncGroup)
-		                                                .buffer(BATCH_SIZE, Duration.ofMillis(TIMEOUT))
+		                                                .bufferTimeout(BATCH_SIZE, Duration.ofMillis(TIMEOUT))
 		                                                .subscribe(items -> {
 			                                                batchesDistribution.compute(items.size(),
 					                                                (key, value) -> value == null ? 1 : value + 1);
@@ -1049,7 +1049,7 @@ public class FluxTests extends AbstractReactorTest {
 		final EmitterProcessor<Integer> streamBatcher = EmitterProcessor.create();
 		streamBatcher.connect();
 		streamBatcher.publishOn(asyncGroup)
-		             .buffer(batchsize, Duration.ofSeconds(timeout))
+		             .bufferTimeout(batchsize, Duration.ofSeconds(timeout))
 		             .log("batched")
 		             .parallel(parallelStreams)
 		             .groups()
@@ -1162,7 +1162,7 @@ public class FluxTests extends AbstractReactorTest {
 
 	@Test
 	public void delayEach() throws InterruptedException {
-		StepVerifier.withVirtualTime(() -> Flux.range(1, 3).delayElementsMillis(1000))
+		StepVerifier.withVirtualTime(() -> Flux.range(1, 3).delayElements(Duration.ofMillis(1000)))
 		            .expectSubscription()
 		            .expectNoEvent(Duration.ofSeconds(1))
 		            .expectNext(1)
@@ -1438,7 +1438,7 @@ public class FluxTests extends AbstractReactorTest {
 
 		CountDownLatch latch = new CountDownLatch(1);
 		try {
-			Flux.intervalMillis(100)
+			Flux.interval(Duration.ofMillis(100))
 			    .take(1)
 			    .publishOn(Schedulers.parallel())
                 .doOnTerminate(() -> latch.countDown())
@@ -1495,6 +1495,6 @@ public class FluxTests extends AbstractReactorTest {
 
 	@Test
 	public void test() {
-		Flux.empty().delayElementsMillis(1000).log().blockLast();
+		Flux.empty().delayElements(Duration.ofMillis(1000)).log().blockLast();
 	}
 }

--- a/src/test/java/reactor/core/publisher/scenarios/MonoTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/MonoTests.java
@@ -15,6 +15,7 @@
  */
 package reactor.core.publisher.scenarios;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -153,10 +154,10 @@ public class MonoTests {
 
 	@Test
 	public void promiseDelays() throws Exception {
-		Tuple2<Long, String> h = Mono.delayMillis(3000)
+		Tuple2<Long, String> h = Mono.delay(Duration.ofMillis(3000))
 		                             .log("time1")
 		                             .map(d -> "Spring wins")
-		                             .or(Mono.delayMillis(2000).log("time2").map(d -> "Spring Reactive"))
+		                             .or(Mono.delay(Duration.ofMillis(2000)).log("time2").map(d -> "Spring Reactive"))
 		                             .then(t -> Mono.just(t+ " world"))
 		                             .elapsed()
 		                             .block();

--- a/src/test/java/reactor/core/publisher/tck/FluxBlackboxProcessorVerification.java
+++ b/src/test/java/reactor/core/publisher/tck/FluxBlackboxProcessorVerification.java
@@ -58,7 +58,7 @@ public class FluxBlackboxProcessorVerification extends AbstractFluxVerification 
 				                          .map(integer -> -integer)
 				                          .filter(integer -> integer <= 0)
 				                          .map(integer -> -integer)
-				                          .buffer(batch, Duration.ofMillis(50))
+				                          .bufferTimeout(batch, Duration.ofMillis(50))
 				                          .flatMap(Flux::fromIterable)
 				                          .flatMap(i -> Flux.zip(Flux.just(i), otherStream, combinator))
 				 )

--- a/src/test/java/reactor/core/publisher/tck/FluxWithProcessorVerification.java
+++ b/src/test/java/reactor/core/publisher/tck/FluxWithProcessorVerification.java
@@ -55,7 +55,7 @@ public class FluxWithProcessorVerification extends AbstractFluxVerification {
 				                          .map(integer -> -integer)
 				                          .filter(integer -> integer <= 0)
 				                          .map(integer -> -integer)
-				                          .buffer(batch, Duration.ofMillis(50))
+				                          .bufferTimeout(batch, Duration.ofMillis(50))
 				                          .flatMap(Flux::fromIterable)
 				                          .doOnNext(array -> cumulated.getAndIncrement())
 				                          .flatMap(i -> Flux.zip(Flux.just(i),

--- a/src/test/java/reactor/guide/GuideTests.java
+++ b/src/test/java/reactor/guide/GuideTests.java
@@ -396,7 +396,7 @@ public class GuideTests {
 		VirtualTimeScheduler.set(virtualTimeScheduler);
 
 		Flux<String> flux =
-		Flux.intervalMillis(250)
+		Flux.interval(Duration.ofMillis(250))
 		    .map(input -> {
 			    if (input < 3) return "tick " + input;
 			    throw new RuntimeException("boom");
@@ -423,7 +423,7 @@ public class GuideTests {
 		VirtualTimeScheduler.set(virtualTimeScheduler);
 
 		Flux<Tuple2<Long,String>> flux =
-		Flux.intervalMillis(250)
+		Flux.interval(Duration.ofMillis(250))
 		    .map(input -> {
 			    if (input < 3) return "tick " + input;
 			    throw new RuntimeException("boom");
@@ -491,7 +491,7 @@ public class GuideTests {
 							if (index < 4) return index;
 							else throw Exceptions.propagate(error);
 						})
-						.flatMap(index -> Mono.delayMillis(index * 100)) // <3>
+						.flatMap(index -> Mono.delay(Duration.ofMillis(index * 100))) // <3>
 						.doOnNext(s -> System.out.println("retried at " + LocalTime.now())) // <4>
 				);
 


### PR DESCRIPTION
This includes:

 - timeout
 - window, windowTimeout
 - buffer, bufferTimeout
 - replay
 - sample
 - skip
 - take
 - interval
 - block
 - delay

Additionally, I've locally deleted the millis variants to make sure everything is in order, which led to amending some tests and making subclasses of Mono override block instead of blockMillis (now final, not the other way around).