### PR TITLE
fix test by removing publish from flatmap&retry sequence

### DIFF
--- a/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -37,7 +38,6 @@ import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.concurrent.QueueSupplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.equalTo;
 
 public class FluxFlatMapTest {
 
@@ -1208,7 +1208,7 @@ public class FluxFlatMapTest {
 	}
 
 	@Test
-	public void retryHotDelayErrors() throws Exception {
+	public void flatMapHotDelayErrors() throws Exception {
 		AtomicInteger onNextSignals = new AtomicInteger();
 
 		StepVerifier.create(Flux.range(0, 5).publish().autoConnect()
@@ -1216,24 +1216,19 @@ public class FluxFlatMapTest {
 		                                          .doOnNext(e -> onNextSignals.incrementAndGet()).<Integer>handle(
 						                        (s1, sink) -> {
 							                        if (s1 == 1 || s1 == 3) {
-								                        sink.error(new RuntimeException());
+								                        sink.error(new RuntimeException("Error: " + s1));
 							                        }
 							                        else {
 								                        sink.next(s1);
 							                        }
 						                        }).subscribeOn(Schedulers.parallel()),
-				                        true,
-				                        4,
-				                        4)
-		                        .retry())
-		            // TODO Need to add a expectNextUnordered() to fully assert this.
-		            .expectNextMatches(d -> d == 0 || d == 2 || d == 4)
-		            .expectNextMatches(d -> d == 0 || d == 2 || d == 4)
-		            .expectNextMatches(d -> d == 0 || d == 2 || d == 4)
-		            .thenCancel()
-		            .verify();
+				                        true, 4, 4))
+		            .recordWith(ArrayList::new)
+		            .expectNextCount(3)
+		            .consumeRecordedWith(c ->  assertThat((Collection) c).containsExactlyInAnyOrder(0, 2, 4))
+		            .verifyError();
 
-		Assert.assertThat(onNextSignals.get(), equalTo(5));
+		assertThat(onNextSignals.get()).isEqualTo(5);
 	}
 
 }


### PR DESCRIPTION
@smaldini @dfeist this test was randomly failing. It seems to me it doesn't make sense to publish() then retry() in this instance, and getting rid of that also gets rid of the `thenCancel()`.

This in turn ensures that the full sequence (values and error) is always evaluated by the StepVerifier`.

Note the random failure was that the flatMap didn't see the 5 source values. Before this change I could reproduce it after a few dozen test iterations, whereas now it passes all the time (thousands of iterations).