### PR TITLE
Add onCancel/onTerminate for Flux and Mono.create

### DIFF
--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -82,7 +82,7 @@ import reactor.util.function.Tuples;
  * should be avoided, as these may be shared between several {@link Subscriber Subscribers}.
  *
  * @param <T> the element type of this Reactive Streams {@link Publisher}
- * 
+ *
  * @author Sebastien Deleuze
  * @author Stephane Maldini
  * @author David Karnok
@@ -495,7 +495,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	public static <T> Flux<T> concatDelayError(Publisher<? extends T>... sources) {
 		return onAssembly(new FluxConcatArray<>(true, sources));
 	}
-	
+
 	/**
      * Creates a Flux with multi-emission capabilities (synchronous or asynchronous) through
      * the FluxSink API.
@@ -518,7 +518,7 @@ public abstract class Flux<T> implements Publisher<T> {
      *     // with cancellation support:
      *
      *     button.addActionListener(al);
-     *     emitter.setCancellation(() -> {
+     *     emitter.onTerminate(() -> {
      *         button.removeListener(al);
      *     });
      * });
@@ -552,7 +552,7 @@ public abstract class Flux<T> implements Publisher<T> {
      *     // with cancellation support:
      *
      *     button.addActionListener(al);
-     *     emitter.setCancellation(() -> {
+     *     emitter.onTerminate(() -> {
      *         button.removeListener(al);
      *     });
      * }, FluxSink.OverflowStrategy.LATEST);
@@ -688,7 +688,7 @@ public abstract class Flux<T> implements Publisher<T> {
 		}
 		return onAssembly(FluxSource.wrap(source));
 	}
-	
+
 	/**
 	 * Create a {@link Flux} that emits the items contained in the provided {@link Iterable}.
 	 * <p>
@@ -1034,7 +1034,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	public static <I> Flux<I> merge(Iterable<? extends Publisher<? extends I>> sources) {
 		return merge(fromIterable(sources));
 	}
-	
+
 	/**
 	 * Merge emitted {@link Publisher} sequences from the passed {@link Publisher} array into an interleaved merged
 	 * sequence.
@@ -2968,7 +2968,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	public final <V> Flux<V> concatMapDelayError(Function<? super T, Publisher<? extends V>> mapper) {
 		return concatMapDelayError(mapper, QueueSupplier.XS_BUFFER_SIZE);
 	}
-	
+
 	/**
 	 * Bind dynamic sequences given this input sequence like {@link #flatMap(Function)}, but preserve
 	 * ordering and concatenate emissions instead of merging (no interleave).
@@ -4339,7 +4339,7 @@ public abstract class Flux<T> implements Publisher<T> {
 				log.onRequestCall(),
 				log.onCancelCall());
 	}
-	
+
 	/**
 	 * Transform the items emitted by this {@link Flux} by applying a function to each item.
 	 * <p>

--- a/src/main/java/reactor/core/publisher/FluxSink.java
+++ b/src/main/java/reactor/core/publisher/FluxSink.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import org.reactivestreams.Subscriber;
 import reactor.core.Cancellation;
+import reactor.core.Disposable;
 
 /**
  * Wrapper API around a downstream Subscriber for emitting any number of
@@ -63,6 +64,24 @@ public interface FluxSink<T> {
 	 */
 	FluxSink<T> serialize();
 
+	/**
+	 * Associates a disposable resource with this FluxSink
+	 * that will be disposed in case the downstream cancels the sequence
+	 * via {@link org.reactivestreams.Subscription#cancel()}.
+	 * @param d the disposable callback to use
+	 * @return the {@link FluxSink} with resource to be disposed on cancel signal
+	 */
+	FluxSink<T> onCancel(Disposable d);
+
+	/**
+	 * Associates a disposable resource with this FluxSink
+	 * that will be disposed on the first terminate signal which may be
+	 * a cancel or complete signal.
+	 * @param d the disposable callback to use
+	 * @return the {@link FluxSink} with resource to be disposed on first terminate signal
+	 */
+	FluxSink<T> onTerminate(Disposable d);
+
 
     /**
      * Associate a cancellation-based resource with this FluxSink
@@ -70,6 +89,7 @@ public interface FluxSink<T> {
      * via {@link org.reactivestreams.Subscription#cancel()}.
      * @param c the cancellation callback to use
      */
+	@Deprecated
     void setCancellation(Cancellation c);
 
 	/**

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -116,7 +116,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 *     
 	 *     client.addListener(listener);
 	 *     
-	 *     sink.setCancellation(() -&gt; client.removeListener(listener));
+	 *     sink.onTerminate(() -&gt; client.removeListener(listener));
 	 * });
 	 * </code></pre>
 	 * Note that this works only with single-value emitting listeners. Otherwise,
@@ -148,7 +148,7 @@ public abstract class Mono<T> implements Publisher<T> {
      *     // with cancellation support:
      *     
      *     AutoCloseable cancel = client.call("query", callback);
-     *     sink.setCancellation(() -> {
+     *     sink.onTerminate(() -> {
      *         try {
      *             cancel.close();
      *         } catch (Exception ex) {

--- a/src/main/java/reactor/core/publisher/MonoSink.java
+++ b/src/main/java/reactor/core/publisher/MonoSink.java
@@ -16,6 +16,7 @@
 package reactor.core.publisher;
 
 import reactor.core.Cancellation;
+import reactor.core.Disposable;
 
 /**
  * Wrapper API around an actual downstream Subscriber
@@ -30,7 +31,7 @@ public interface MonoSink<T> {
      * terminating methods has no effect.
      */
     void success();
-    
+
     /**
      * Complete with the given value.
      * <p>Calling this method multiple times or after the other
@@ -40,7 +41,7 @@ public interface MonoSink<T> {
      * @param value the value to complete with
      */
     void success(T value);
-    
+
     /**
      * Terminate with the give exception
      * <p>Calling this method multiple times or after the other
@@ -48,12 +49,31 @@ public interface MonoSink<T> {
      * @param e the exception to complete with
      */
     void error(Throwable e);
-    
+
+	/**
+	 * Associates a disposable resource with this MonoSink that will be disposed on
+	 * downstream.cancel().
+	 *
+	 * @param d the disposable callback to use
+	 * @return the {@link MonoSink} with resource to be disposed on cancel signal
+	 */
+	MonoSink<T> onCancel(Disposable d);
+
+	/**
+	 * Associates a disposable resource with this MonoSink that will be disposed on the
+	 * first terminate signal which may be a cancel or complete signal.
+	 *
+	 * @param d the disposable callback to use
+	 * @return the {@link MonoSink} with resource to be disposed on first terminate signal
+	 */
+	MonoSink<T> onTerminate(Disposable d);
+
     /**
      * Sets a cancellation callback triggered by
      * downstreams cancel().
      * <p>Calling this method more than once has no effect.
      * @param c the cancellation callback
      */
-    void setCancellation(Cancellation c);
+	@Deprecated
+	void setCancellation(Cancellation c);
 }

--- a/src/test/java/reactor/core/publisher/FluxCancelOnTest.java
+++ b/src/test/java/reactor/core/publisher/FluxCancelOnTest.java
@@ -34,7 +34,7 @@ public class FluxCancelOnTest {
 		Schedulers.single().schedule(() -> threadHash.set(Thread.currentThread()));
 
 		Flux.create(sink -> {
-			sink.setCancellation(() -> {
+			sink.onTerminate(() -> {
 				if (threadHash.compareAndSet(Thread.currentThread(), null)) {
 					latch.countDown();
 				}

--- a/src/test/java/reactor/core/publisher/MonoCancelOnTest.java
+++ b/src/test/java/reactor/core/publisher/MonoCancelOnTest.java
@@ -34,7 +34,7 @@ public class MonoCancelOnTest {
 		Schedulers.single().schedule(() -> threadHash.set(Thread.currentThread()));
 
 		Mono.create(sink -> {
-			sink.setCancellation(() -> {
+			sink.onTerminate(() -> {
 				if (threadHash.compareAndSet(Thread.currentThread(), null)) {
 					latch.countDown();
 				}


### PR DESCRIPTION
Deprecate setCancellation in FluxSink/MonoSink and add onCancel to be invoked on cancel signal and onTerminate to be invoked on any cancel or completion signal.