### PR TITLE
fix #453 Fix FluxFlattenIterable completes too early in async drain

### DIFF
--- a/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
+++ b/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
@@ -408,7 +408,7 @@ final class FluxFlattenIterable<T, R> extends FluxSource<T, R> implements Fuseab
 						}
 
 						boolean d = done;
-						boolean empty = q.isEmpty();
+						boolean empty = q.isEmpty() && it == null;
 
 						if (d && empty) {
 							current = null;


### PR DESCRIPTION
This manifested in using a `sort()` + a `zip()`, which has a prefetch
of 32 and would only output 32 values.