### PR TITLE
Fix BaseSubscriber dispose != cancel + add requestUnbounded

### DIFF
--- a/src/main/java/reactor/core/publisher/BaseSubscriber.java
+++ b/src/main/java/reactor/core/publisher/BaseSubscriber.java
@@ -66,9 +66,13 @@ public abstract class BaseSubscriber<T> implements Subscriber<T>, Subscription, 
 		return subscription == Operators.cancelledSubscription();
 	}
 
+	/**
+	 * {@link Disposable#dispose() Dispose} the {@link Subscription} by
+	 * {@link Subscription#cancel() cancelling} it.
+	 */
 	@Override
 	public void dispose() {
-		S.lazySet(this, Operators.cancelledSubscription());
+		cancel();
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/BaseSubscriber.java
+++ b/src/main/java/reactor/core/publisher/BaseSubscriber.java
@@ -77,9 +77,9 @@ public abstract class BaseSubscriber<T> implements Subscriber<T>, Subscription, 
 
 	/**
 	 * Hook for further processing of onSubscribe's Subscription. Implement this method
-	 * to call {@link #request(long)} as an initial request. Values other than the
-	 * unbounded {@code Long.MAX_VALUE} imply that you'll also call request in
-	 * {@link #hookOnNext(Object)}.
+	 * to call {@link #request(long)} or {@link #requestUnbounded()} as an initial request.
+	 * Values other than the unbounded {@code Long.MAX_VALUE} imply that you'll also call
+	 * request in {@link #hookOnNext(Object)}.
 	 *
 	 * @param subscription the subscription to optionally process
 	 */
@@ -214,6 +214,13 @@ public abstract class BaseSubscriber<T> implements Subscriber<T>, Subscription, 
 		catch (Throwable throwable) {
 			onError(Operators.onOperatorError(throwable));
 		}
+	}
+
+	/**
+	 * {@link #request(long) Request} an unbounded amount.
+	 */
+	public final void requestUnbounded() {
+		request(Long.MAX_VALUE);
 	}
 
 	@Override

--- a/src/test/java/reactor/core/publisher/BaseSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/BaseSubscriberTest.java
@@ -172,7 +172,7 @@ public class BaseSubscriberTest {
 		flux.subscribe(new BaseSubscriber<String>() {
 			@Override
 			protected void hookOnSubscribe(Subscription subscription) {
-				request(Long.MAX_VALUE);
+				requestUnbounded();
 			}
 
 			@Override
@@ -203,7 +203,7 @@ public class BaseSubscriberTest {
 		flux.subscribe(new BaseSubscriber<String>() {
 			@Override
 			protected void hookOnSubscribe(Subscription subscription) {
-				request(Long.MAX_VALUE);
+				requestUnbounded();
 			}
 
 			@Override
@@ -240,7 +240,7 @@ public class BaseSubscriberTest {
 		    .subscribe(new BaseSubscriber<String>() {
 			    @Override
 			    protected void hookOnSubscribe(Subscription subscription) {
-			    	request(Long.MAX_VALUE);
+			    	requestUnbounded();
 			    }
 
 			    @Override
@@ -276,7 +276,7 @@ public class BaseSubscriberTest {
 					.subscribe(new BaseSubscriber<String>() {
 						@Override
 						protected void hookOnSubscribe(Subscription subscription) {
-							request(Long.MAX_VALUE);
+							requestUnbounded();
 						}
 
 						@Override
@@ -345,7 +345,7 @@ public class BaseSubscriberTest {
 			@Override
 			protected void hookOnSubscribe(
 					Subscription subscription) {
-				request(Long.MAX_VALUE);
+				requestUnbounded();
 			}
 
 			@Override

--- a/src/test/java/reactor/core/publisher/ParallelFluxTest.java
+++ b/src/test/java/reactor/core/publisher/ParallelFluxTest.java
@@ -509,7 +509,7 @@ public class ParallelFluxTest {
 		for (int i = 0; i < subs.length; i++) {
 			subs[i] = new BaseSubscriber<Integer>() {
 				@Override
-				protected void hookOnSubscribe(Subscription subscription) { request(Long.MAX_VALUE); }
+				protected void hookOnSubscribe(Subscription subscription) { requestUnbounded(); }
 
 				@Override
 				protected void hookOnNext(Integer value) { }
@@ -768,7 +768,7 @@ public class ParallelFluxTest {
 		pf.subscribe(new BaseSubscriber<Integer>() {
 			@Override
 			protected void hookOnSubscribe(Subscription subscription) {
-				request(Long.MAX_VALUE);
+				requestUnbounded();
 			}
 
 			@Override

--- a/src/test/java/reactor/core/publisher/WorkQueueProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/WorkQueueProcessorTest.java
@@ -530,7 +530,7 @@ public class WorkQueueProcessorTest {
 
 		@Override
 		protected void hookOnSubscribe(Subscription subscription) {
-			request(Long.MAX_VALUE);
+			requestUnbounded();
 		}
 
 		@Override


### PR DESCRIPTION
This PR is two-part: first fix #461 then add an alias to `request(Long.MAX_VALUE)`.