### PR TITLE
fix #465 Add Mono.untilOther

### DIFF
--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -624,6 +624,38 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
+	 * Subscribe to this Mono and another Publisher, which will be used as a trigger for
+	 * the emission of this Mono's element. That is to say, this Mono's element is delayed
+	 * until the trigger Publisher emits for the first time (or terminates empty).
+	 *
+	 * @param anyPublisher the publisher which first emission or termination will trigger
+	 * the emission of this Mono's value.
+	 * @return this Mono, but delayed until the given publisher emits first or terminates.
+	 */
+	public Mono<T> untilOther(Publisher<?> anyPublisher) {
+		Objects.requireNonNull(anyPublisher, "anyPublisher required");
+		return onAssembly(new MonoUntilOther<>(false, this, anyPublisher, Function.identity()));
+	}
+
+	/**
+	 * Subscribe to this Mono and another Publisher, which will be used as a trigger for
+	 * the emission of this Mono's element, mapped through a provided function.
+	 * That is to say, this Mono's element is delayed until the trigger Publisher emits
+	 * for the first time (or terminates empty), and is then transformed by the provided
+	 * mapper function.
+	 *
+	 * @param anyPublisher the publisher which first emission or termination will trigger
+	 * the emission of this Mono's value.
+	 * @param mapper the function through which to transform this Mono's value.
+	 * @return a transformed Mono, delayed until the given publisher emits first or terminates.
+	 */
+	public <R> Mono<R> untilOther(Publisher<?> anyPublisher, Function<? super T, ? extends R> mapper) {
+		Objects.requireNonNull(anyPublisher, "anyPublisher required");
+		Objects.requireNonNull(mapper, "mapper required");
+		return onAssembly(new MonoUntilOther<>(false, this, anyPublisher, mapper));
+	}
+
+	/**
 	 * Merge given monos into a new a {@literal Mono} that will be fulfilled when all of the given {@literal Monos}
 	 * have been fulfilled. An error will cause pending results to be cancelled and immediate error emission to the
 	 * returned {@link Mono}.

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -634,6 +634,10 @@ public abstract class Mono<T> implements Publisher<T> {
 	 */
 	public Mono<T> untilOther(Publisher<?> anyPublisher) {
 		Objects.requireNonNull(anyPublisher, "anyPublisher required");
+		if (this instanceof MonoUntilOther) {
+			((MonoUntilOther) this).addTrigger(anyPublisher);
+			return this;
+		}
 		return onAssembly(new MonoUntilOther<>(false, this, anyPublisher, Function.identity()));
 	}
 

--- a/src/main/java/reactor/core/publisher/MonoUntilOther.java
+++ b/src/main/java/reactor/core/publisher/MonoUntilOther.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Function;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * Waits for a Mono source to produce a value or terminate, as well as a Publisher source
+ * for which first production or termination will be used as a trigger. If the Mono source
+ * produced a value, emit that value after the Mono has completed and the Publisher source
+ * has either emitted once or completed. Otherwise terminate empty.
+ *
+ * @param <T> the source value type
+ * @param <R> the transformed value type
+ *
+ * @author Simon Baslé
+ */
+final class MonoUntilOther<T, R> extends Mono<R> {
+
+	final boolean cancelOnTriggerValue;
+
+	final boolean delayError;
+
+	final Mono<T> source;
+
+	final Publisher<?> other;
+
+	final Function<? super T, ? extends R> mapper;
+
+	public MonoUntilOther(boolean delayError,
+			Mono<T> monoSource,
+			Publisher<?> triggerPublisher,
+			Function<? super T, ? extends R> mapper) {
+		this.delayError = delayError;
+		this.source = Objects.requireNonNull(monoSource, "monoSource");
+		this.other = Objects.requireNonNull(triggerPublisher, "triggerPublisher");
+		this.mapper = Objects.requireNonNull(mapper, "mapper");
+		this.cancelOnTriggerValue = !(other instanceof Mono);
+	}
+
+	@Override
+	public void subscribe(Subscriber<? super R> s) {
+		MonoUntilOtherCoordinator<T, R> parent = new MonoUntilOtherCoordinator<>(s, delayError, mapper, cancelOnTriggerValue);
+		s.onSubscribe(parent);
+		parent.subscribe(source, other);
+	}
+
+	static final class MonoUntilOtherCoordinator<T, R>
+			extends Operators.MonoSubscriber<T, R> implements Subscription {
+
+		final boolean                           cancelOnTriggerValue;
+		final boolean                           delayError;
+		final Function<? super T, ? extends R>  mapper;
+		final MonoUntilOtherSourceSubscriber<T> sourceSubscriber;
+		final MonoUntilOtherTriggerSubscriber   triggerSubscriber;
+
+		volatile int done;
+		static final AtomicIntegerFieldUpdater<MonoUntilOtherCoordinator> DONE =
+				AtomicIntegerFieldUpdater.newUpdater(MonoUntilOtherCoordinator.class, "done");
+
+		MonoUntilOtherCoordinator(Subscriber<? super R> subscriber,
+				boolean delayError,
+				Function<? super T, ? extends R> mapper,
+				boolean cancelOnFirstTriggerValue) {
+			super(subscriber);
+			this.cancelOnTriggerValue = cancelOnFirstTriggerValue;
+			this.delayError = delayError;
+			this.mapper = mapper;
+			sourceSubscriber = new MonoUntilOtherSourceSubscriber<>(this);
+			triggerSubscriber = new MonoUntilOtherTriggerSubscriber(this);
+		}
+
+		void subscribe(Publisher<T> source, Publisher<?> trigger) {
+			source.subscribe(sourceSubscriber);
+			trigger.subscribe(triggerSubscriber);
+		}
+
+		void signalError(Throwable t) {
+			if (delayError) {
+				signal();
+			} else {
+				if (DONE.getAndSet(this, 2) != 2) {
+					cancel();
+					actual.onError(t);
+				}
+			}
+		}
+
+		void signal() {
+			if (DONE.incrementAndGet(this) != 2) {
+				return;
+			}
+
+			T o = null;
+			Throwable error = null;
+			Throwable compositeError = null;
+			boolean hasEmpty = false;
+
+			MonoUntilOtherSourceSubscriber<T> ms = sourceSubscriber;
+			T v = ms.value;
+			if (v != null) {
+				o = v;
+			} else {
+				Throwable e = ms.error;
+				if (e != null) {
+					if (compositeError != null) {
+						compositeError.addSuppressed(e);
+					} else if (error != null) {
+						compositeError = new Throwable("Multiple errors");
+						compositeError.addSuppressed(error);
+						compositeError.addSuppressed(e);
+					} else {
+						error = e;
+					}
+				} else {
+					hasEmpty = true;
+				}
+			}
+
+			MonoUntilOtherTriggerSubscriber mt = triggerSubscriber;
+			Throwable e = mt.error;
+			if (e != null) {
+				if (compositeError != null) {
+					compositeError.addSuppressed(e);
+				} else
+				if (error != null) {
+					compositeError = new Throwable("Multiple errors");
+					compositeError.addSuppressed(error);
+					compositeError.addSuppressed(e);
+				} else {
+					error = e;
+				}
+				//else the trigger publisher was empty, but we'll ignore that
+			}
+
+			if (compositeError != null) {
+				actual.onError(compositeError);
+			} else
+			if (error != null) {
+				actual.onError(error);
+			} else
+			if (hasEmpty) {
+				actual.onComplete();
+			} else {
+				R r;
+				try {
+					r = Objects.requireNonNull(mapper.apply(o), "mapper produced a null value");
+				}
+				catch (Throwable t) {
+					actual.onError(Operators.onOperatorError(null, t, o));
+					return;
+				}
+				complete(r);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			if (!isCancelled()) {
+				super.cancel();
+				sourceSubscriber.cancel();
+				triggerSubscriber.cancel();
+			}
+		}
+	}
+
+	static final class MonoUntilOtherSourceSubscriber<T> implements Subscriber<T> {
+
+		final MonoUntilOtherCoordinator<T, ?> parent;
+
+		volatile Subscription s;
+		@SuppressWarnings("rawtypes")
+		static final AtomicReferenceFieldUpdater<MonoUntilOtherSourceSubscriber, Subscription> S =
+				AtomicReferenceFieldUpdater.newUpdater(MonoUntilOtherSourceSubscriber.class, Subscription.class, "s");
+
+		T value;
+		Throwable error;
+
+		public MonoUntilOtherSourceSubscriber(MonoUntilOtherCoordinator<T, ?> parent) {
+			this.parent = parent;
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.setOnce(S, this, s)) {
+				s.request(Long.MAX_VALUE);
+			} else {
+				s.cancel();
+			}
+		}
+
+		@Override
+		public void onNext(T t) {
+			if (value == null) {
+				value = t;
+				parent.signal();
+			}
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			error = t;
+			parent.signalError(t);
+		}
+
+		@Override
+		public void onComplete() {
+			if (value == null) {
+				parent.signal();
+			}
+		}
+
+		void cancel() {
+			Operators.terminate(S, this);
+		}
+	}
+
+	static final class MonoUntilOtherTriggerSubscriber implements Subscriber<Object> {
+
+		final MonoUntilOtherCoordinator<?, ?> parent;
+
+		volatile Subscription s;
+		@SuppressWarnings("rawtypes")
+		static final AtomicReferenceFieldUpdater<MonoUntilOtherTriggerSubscriber, Subscription> S =
+				AtomicReferenceFieldUpdater.newUpdater(MonoUntilOtherTriggerSubscriber.class, Subscription.class, "s");
+
+		boolean done;
+		Throwable error;
+
+		public MonoUntilOtherTriggerSubscriber(MonoUntilOtherCoordinator<?, ?> parent) {
+			this.parent = parent;
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.setOnce(S, this, s)) {
+				s.request(1);
+			} else {
+				s.cancel();
+			}
+		}
+
+		@Override
+		public void onNext(Object t) {
+			if (!done) {
+				done = true;
+				parent.signal();
+				if (parent.cancelOnTriggerValue) {
+					s.cancel();
+				}
+			}
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			error = t;
+			parent.signalError(t);
+		}
+
+		@Override
+		public void onComplete() {
+			if (!done) {
+				done = true;
+				parent.signal();
+			}
+		}
+
+		void cancel() {
+			Operators.terminate(S, this);
+		}
+	}
+}

--- a/src/test/java/reactor/core/publisher/MonoUntilOtherTest.java
+++ b/src/test/java/reactor/core/publisher/MonoUntilOtherTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MonoUntilOtherTest {
+
+	@Test
+	public void testMonoValuedAndPublisherVoid() {
+		Publisher<Void> voidPublisher = Mono.fromRunnable(() -> { });
+		StepVerifier.create(new MonoUntilOther<>(false, Mono.just("foo"), voidPublisher, Function.identity()))
+		            .expectNext("foo")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void testMonoEmptyAndPublisherVoid() {
+		Publisher<Void> voidPublisher = Mono.fromRunnable(() -> { });
+		StepVerifier.create(new MonoUntilOther<>(false, Mono.<String>empty(), voidPublisher, Function.identity()))
+		            .verifyComplete();
+	}
+
+	@Test
+	public void testMonoValuedAndPublisherVoidMapped() {
+		Publisher<Void> voidPublisher = Mono.fromRunnable(() -> { });
+		StepVerifier.create(new MonoUntilOther<>(false, Mono.just("foo"), voidPublisher, s -> s.length()))
+		            .expectNext(3)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void mapperNull() {
+		StepVerifier.withVirtualTime(() -> new MonoUntilOther<>(false,
+				Mono.just("foo"), Mono.delay(Duration.ofMillis(500)), s -> null))
+	                .expectSubscription()
+	                .expectNoEvent(Duration.ofMillis(500))
+	                .verifyErrorMatches(e -> e instanceof NullPointerException &&
+			                "mapper produced a null value".equals(e.getMessage()));
+	}
+
+	@Test
+	public void triggerSequenceHasMultipleValuesCancelled() {
+		AtomicBoolean triggerCancelled = new AtomicBoolean();
+		StepVerifier.create(new MonoUntilOther<>(false,
+				Mono.just("foo").hide(),
+				Flux.just(1, 2, 3)
+				    .delayElements(Duration.ofMillis(500))
+				    .doOnCancel(() -> triggerCancelled.set(true))
+				    .log(),
+				s -> s))
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofMillis(500))
+		            .expectNext("foo")
+		            .verifyComplete();
+		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		assertThat(triggerCancelled.get()).isTrue();
+	}
+
+	@Test
+	public void triggerSequenceHasSingleValueNotCancelled() {
+		AtomicBoolean triggerCancelled = new AtomicBoolean();
+		StepVerifier.create(new MonoUntilOther<>(false,
+				Mono.just("foo"),
+				Mono.delay(Duration.ofMillis(500))
+				    .doOnCancel(() -> triggerCancelled.set(true))
+				    .log(),
+				s -> s))
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofMillis(500))
+		            .expectNext("foo")
+		            .verifyComplete();
+		assertThat(triggerCancelled.get()).isFalse();
+	}
+
+	@Test
+	public void triggerSequenceDoneFirst() {
+		StepVerifier.withVirtualTime(() -> new MonoUntilOther<>(false,
+				Mono.delay(Duration.ofSeconds(2)),
+				Mono.just("foo"),
+				s -> s))
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofSeconds(2))
+		            .expectNext(0L)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void sourceHasError() {
+		StepVerifier.create(new MonoUntilOther<>(false,
+				Mono.<String>error(new IllegalStateException("boom")),
+				Mono.just("foo"),
+				s -> s))
+		            .verifyErrorMessage("boom");
+	}
+
+	@Test
+	public void triggerHasError() {
+		StepVerifier.create(new MonoUntilOther<>(false,
+				Mono.just("foo"),
+				Mono.<String>error(new IllegalStateException("boom")),
+				s -> s))
+		            .verifyErrorMessage("boom");
+	}
+
+	@Test
+	public void sourceAndTriggerHaveErrorsNotDelayed() {
+		StepVerifier.create(new MonoUntilOther<>(false,
+				Mono.<String>error(new IllegalStateException("boom1")),
+				Mono.<Integer>error(new IllegalStateException("boom2")),
+				s -> s))
+		            .verifyErrorMessage("boom1");
+	}
+
+	@Test
+	public void sourceAndTriggerHaveErrorsDelayed() {
+		IllegalStateException boom1 = new IllegalStateException("boom1");
+		IllegalStateException boom2 = new IllegalStateException("boom2");
+		StepVerifier.create(new MonoUntilOther<>(true,
+				Mono.<String>error(boom1),
+				Mono.<Integer>error(boom2),
+				s -> s))
+		            .verifyErrorMatches(e -> e.getMessage().equals("Multiple errors") &&
+				            e.getSuppressed()[0] == boom1 &&
+				            e.getSuppressed()[1] == boom2);
+	}
+
+	@Test
+	public void testAPIUntilOther() {
+		StepVerifier.withVirtualTime(() -> Mono.just("foo")
+		                                       .untilOther(Mono.delay(Duration.ofSeconds(2))))
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofSeconds(2))
+		            .expectNext("foo")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void testAPIUntilOtherMapper() {
+		StepVerifier.withVirtualTime(() -> Mono.just("foo")
+		                                       .untilOther(Mono.delay(Duration.ofSeconds(2)),
+				                                       s -> s + s.length()))
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofSeconds(2))
+		            .expectNext("foo3")
+		            .verifyComplete();
+	}
+}


### PR DESCRIPTION
After discussing this with @smaldini, we came to the conclusion that this use case needs a new underlying operator. We also agreed on the name `untilOther` rather than making it part of the `and` family. The added benefit is that it works with any `Publisher` as the "other", triggering the emission of the `Mono` source as soon as the other publisher either emits something or completes.