### PR TITLE
#442 Avoid extraneous cancel in Mono flows

### DIFF
--- a/src/main/java/reactor/core/publisher/BlockingIterable.java
+++ b/src/main/java/reactor/core/publisher/BlockingIterable.java
@@ -146,8 +146,6 @@ final class BlockingIterable<T> implements Iterable<T>, Receiver, Trackable {
 		volatile boolean done;
 		Throwable error;
 
-		volatile boolean cancelled;
-
 		 SubscriberIterator(Queue<T> queue, long batchSize) {
 			this.queue = queue;
 			this.batchSize = batchSize;
@@ -159,9 +157,6 @@ final class BlockingIterable<T> implements Iterable<T>, Receiver, Trackable {
 		@Override
 		public boolean hasNext() {
 			for (; ; ) {
-				if (cancelled) {
-					return false;
-				}
 				boolean d = done;
 				boolean empty = queue.isEmpty();
 				if (d) {
@@ -176,7 +171,7 @@ final class BlockingIterable<T> implements Iterable<T>, Receiver, Trackable {
 				if (empty) {
 					lock.lock();
 					try {
-						while (!cancelled && !done && queue.isEmpty()) {
+						while (!done && queue.isEmpty()) {
 							condition.await();
 						}
 					}

--- a/src/main/java/reactor/core/publisher/BlockingMonoSubscriber.java
+++ b/src/main/java/reactor/core/publisher/BlockingMonoSubscriber.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Disposable;
+import reactor.core.Exceptions;
+import reactor.core.Receiver;
+import reactor.core.Trackable;
+
+/**
+ * Blocks assuming the upstream is a Mono, until it signals its value or completes.
+ * Compared to {@link BlockingFirstSubscriber}, this variant doesn't cancel the upstream.
+ *
+ * @param <T> the value type
+ * @see <a href="https://github.com/reactor/reactive-streams-commons">https://github.com/reactor/reactive-streams-commons</a>
+ */
+final class BlockingMonoSubscriber<T> extends BlockingSingleSubscriber<T> {
+
+	@Override
+	public void onNext(T t) {
+		if (value == null) {
+			value = t;
+			dispose();
+			countDown();
+		}
+	}
+
+	@Override
+	public void onError(Throwable t) {
+		if (value == null) {
+			error = t;
+		}
+		countDown();
+	}
+
+	@Override
+	protected void upstreamCancel(Subscription s) {
+		//NO-OP
+	}
+}

--- a/src/main/java/reactor/core/publisher/BlockingMonoSubscriber.java
+++ b/src/main/java/reactor/core/publisher/BlockingMonoSubscriber.java
@@ -16,20 +16,10 @@
 
 package reactor.core.publisher;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
-import reactor.core.Disposable;
-import reactor.core.Exceptions;
-import reactor.core.Receiver;
-import reactor.core.Trackable;
-
 /**
  * Blocks assuming the upstream is a Mono, until it signals its value or completes.
- * Compared to {@link BlockingFirstSubscriber}, this variant doesn't cancel the upstream.
+ * Compared to {@link BlockingFirstSubscriber}, this variant doesn't cancel the upstream
+ * in onNext.
  *
  * @param <T> the value type
  * @see <a href="https://github.com/reactor/reactive-streams-commons">https://github.com/reactor/reactive-streams-commons</a>
@@ -40,7 +30,6 @@ final class BlockingMonoSubscriber<T> extends BlockingSingleSubscriber<T> {
 	public void onNext(T t) {
 		if (value == null) {
 			value = t;
-			dispose();
 			countDown();
 		}
 	}
@@ -51,10 +40,5 @@ final class BlockingMonoSubscriber<T> extends BlockingSingleSubscriber<T> {
 			error = t;
 		}
 		countDown();
-	}
-
-	@Override
-	protected void upstreamCancel(Subscription s) {
-		//NO-OP
 	}
 }

--- a/src/main/java/reactor/core/publisher/BlockingSingleSubscriber.java
+++ b/src/main/java/reactor/core/publisher/BlockingSingleSubscriber.java
@@ -69,8 +69,12 @@ abstract class BlockingSingleSubscriber<T> extends CountDownLatch
 		cancelled = true;
 		Subscription s = this.s;
 		if (S.compareAndSet(this, s, null)) {
-			s.cancel();
+			upstreamCancel(s);
 		}
+	}
+
+	protected void upstreamCancel(Subscription s) {
+		s.cancel();
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -1245,7 +1245,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @return T the result
 	 */
 	public T block() {
-		BlockingFirstSubscriber<T> subscriber = new BlockingFirstSubscriber<>();
+		BlockingMonoSubscriber<T> subscriber = new BlockingMonoSubscriber<>();
 		subscribe(subscriber);
 		return subscriber.blockingGet();
 	}
@@ -1267,7 +1267,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @return T the result
 	 */
 	public T block(Duration timeout) {
-		BlockingFirstSubscriber<T> subscriber = new BlockingFirstSubscriber<>();
+		BlockingMonoSubscriber<T> subscriber = new BlockingMonoSubscriber<>();
 		subscribe(subscriber);
 		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
 	}

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -2782,7 +2782,7 @@ public abstract class Mono<T> implements Publisher<T> {
 			Consumer<? super Throwable> errorConsumer,
 			Runnable completeConsumer,
 			Consumer<? super Subscription> subscriptionConsumer) {
-		return subscribeWith(new LambdaFirstSubscriber<>(consumer, errorConsumer,
+		return subscribeWith(new LambdaMonoSubscriber<>(consumer, errorConsumer,
 				completeConsumer, subscriptionConsumer));
 	}
 

--- a/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -295,7 +295,7 @@ public final class MonoProcessor<O> extends Mono<O>
 		if(value != null) {
 			finalState = STATE_SUCCESS_VALUE;
 			this.value = value;
-			if (s != null) {
+			if (s != null && !(source instanceof Mono)) {
 				s.cancel();
 			}
 		}

--- a/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -295,7 +295,7 @@ public final class MonoProcessor<O> extends Mono<O>
 		if(value != null) {
 			finalState = STATE_SUCCESS_VALUE;
 			this.value = value;
-			if (s != null && source != null) {
+			if (s != null && !(source instanceof Mono)) {
 				s.cancel();
 			}
 		}

--- a/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -295,7 +295,7 @@ public final class MonoProcessor<O> extends Mono<O>
 		if(value != null) {
 			finalState = STATE_SUCCESS_VALUE;
 			this.value = value;
-			if (s != null && !(source instanceof Mono)) {
+			if (s != null && source != null) {
 				s.cancel();
 			}
 		}

--- a/src/test/java/reactor/core/publisher/BlockingIterableTest.java
+++ b/src/test/java/reactor/core/publisher/BlockingIterableTest.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.function.Supplier;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/src/test/java/reactor/core/publisher/BlockingTests.java
+++ b/src/test/java/reactor/core/publisher/BlockingTests.java
@@ -204,4 +204,14 @@ public class BlockingTests {
 
 		assertThat(cancelCount.get()).isEqualTo(0);
 	}
+
+	@Test
+	public void monoBlockDoesntCancel() {
+		AtomicLong cancelCount = new AtomicLong();
+		Mono.just("data")
+	        .doOnCancel(cancelCount::incrementAndGet)
+	        .block();
+
+		assertThat(cancelCount.get()).isEqualTo(0);
+	}
 }

--- a/src/test/java/reactor/core/publisher/BlockingTests.java
+++ b/src/test/java/reactor/core/publisher/BlockingTests.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -183,4 +184,24 @@ public class BlockingTests {
 		    })
 		    .subscribe(System.out::println);
 	}*/
+
+	@Test
+	public void fluxBlockFirstCancelsOnce() {
+		AtomicLong cancelCount = new AtomicLong();
+		Flux.range(1, 10)
+	        .doOnCancel(cancelCount::incrementAndGet)
+	        .blockFirst();
+
+		assertThat(cancelCount.get()).isEqualTo(1);
+	}
+
+	@Test
+	public void fluxBlockLastDoesntCancel() {
+		AtomicLong cancelCount = new AtomicLong();
+		Flux.range(1, 10)
+	        .doOnCancel(cancelCount::incrementAndGet)
+	        .blockLast();
+
+		assertThat(cancelCount.get()).isEqualTo(0);
+	}
 }

--- a/src/test/java/reactor/core/publisher/MonoAnyTest.java
+++ b/src/test/java/reactor/core/publisher/MonoAnyTest.java
@@ -16,10 +16,16 @@
 
 package reactor.core.publisher;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.junit.Assert;
 import org.junit.Test;
+import reactor.core.Disposable;
 import reactor.test.StepVerifier;
+import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoAnyTest {
 
@@ -152,4 +158,15 @@ public class MonoAnyTest {
 		  });
 	}
 
+	@Test
+	public void cancel() {
+		TestPublisher<String> cancelTester = TestPublisher.create();
+
+		cancelTester.flux()
+		            .any(s -> s.length() > 100)
+		            .subscribe()
+		            .cancel();
+
+		cancelTester.assertCancelled();
+	}
 }

--- a/src/test/java/reactor/core/publisher/MonoElementAtTest.java
+++ b/src/test/java/reactor/core/publisher/MonoElementAtTest.java
@@ -16,8 +16,13 @@
 
 package reactor.core.publisher;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.junit.Test;
+import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoElementAtTest {
 
@@ -197,4 +202,15 @@ public class MonoElementAtTest {
 		  .assertComplete();
 	}
 
+	@Test
+	public void cancel() {
+		TestPublisher<String> cancelTester = TestPublisher.create();
+
+		cancelTester.flux()
+		            .elementAt(1000)
+		            .subscribe()
+		            .cancel();
+
+		cancelTester.assertCancelled();
+	}
 }

--- a/src/test/java/reactor/core/publisher/MonoHasElementsTest.java
+++ b/src/test/java/reactor/core/publisher/MonoHasElementsTest.java
@@ -16,8 +16,13 @@
 
 package reactor.core.publisher;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.junit.Test;
+import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoHasElementsTest {
 
@@ -80,5 +85,31 @@ public class MonoHasElementsTest {
 		ts.assertValues(true)
 		  .assertComplete()
 		  .assertNoError();
+	}
+
+	@Test
+	public void fluxSourceIsCancelled() {
+		AtomicLong cancelCount = new AtomicLong();
+
+		StepVerifier.create(Flux.range(1, 10)
+		                        .doOnCancel(cancelCount::incrementAndGet)
+		                        .hasElements())
+	                .expectNext(true)
+	                .verifyComplete();
+
+		assertThat(cancelCount.get()).isEqualTo(1);
+	}
+
+	@Test
+	public void monoSourceIsNotCancelled() {
+		AtomicLong cancelCount = new AtomicLong();
+
+		StepVerifier.create(Mono.just(1)
+		                        .doOnCancel(cancelCount::incrementAndGet)
+		                        .hasElement())
+		            .expectNext(true)
+		            .verifyComplete();
+
+		assertThat(cancelCount.get()).isEqualTo(0);
 	}
 }

--- a/src/test/java/reactor/core/publisher/MonoNextTest.java
+++ b/src/test/java/reactor/core/publisher/MonoNextTest.java
@@ -16,6 +16,7 @@
 package reactor.core.publisher;
 
 import org.junit.Test;
+import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 
 public class MonoNextTest {
@@ -41,5 +42,17 @@ public class MonoNextTest {
 		ts.request(1);
 		ts.assertValues(1)
 		  .assertComplete();
+	}
+
+	@Test
+	public void cancel() {
+		TestPublisher<String> cancelTester = TestPublisher.create();
+
+		cancelTester.flux()
+		            .next()
+		            .subscribe()
+		            .cancel();
+
+		cancelTester.assertCancelled();
 	}
 }

--- a/src/test/java/reactor/core/publisher/MonoProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/MonoProcessorTest.java
@@ -16,6 +16,7 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
@@ -350,6 +351,27 @@ public class MonoProcessorTest {
 		            .then(() -> assertThat(mp2.getError()).hasMessage("test"))
 		            .then(() -> assertThat(mp2.isTerminated()).isTrue())
 		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void fluxCancelledByMonoProcessor() {
+		AtomicLong cancelCounter = new AtomicLong();
+		Flux.range(1, 10)
+		    .doOnCancel(cancelCounter::incrementAndGet)
+		    .publishNext()
+		    .subscribe();
+
+		assertThat(cancelCounter.get()).isEqualTo(1);
+	}
+
+	@Test
+	public void monoNotCancelledByMonoProcessor() {
+		AtomicLong cancelCounter = new AtomicLong();
+		MonoProcessor<String> monoProcessor = Mono.just("foo")
+		                                          .doOnCancel(cancelCounter::incrementAndGet)
+		                                          .subscribe();
+
+		assertThat(cancelCounter.get()).isEqualTo(0);
 	}
 
 }

--- a/src/test/java/reactor/core/publisher/MonoThenIgnoreTest.java
+++ b/src/test/java/reactor/core/publisher/MonoThenIgnoreTest.java
@@ -16,10 +16,14 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 import reactor.test.StepVerifier;
+import reactor.test.publisher.TestPublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoThenIgnoreTest {
 
@@ -62,5 +66,17 @@ public class MonoThenIgnoreTest {
 		StepVerifier.withVirtualTime(this::scenario)
 		            .thenAwait(Duration.ofSeconds(123))
 		            .expectComplete();
+	}
+
+	@Test
+	public void cancel() {
+		TestPublisher<String> cancelTester = TestPublisher.create();
+
+		cancelTester.flux()
+		            .then()
+		            .subscribe()
+		            .cancel();
+
+		cancelTester.assertCancelled();
 	}
 }

--- a/src/test/java/reactor/core/publisher/MonoThenMapTest.java
+++ b/src/test/java/reactor/core/publisher/MonoThenMapTest.java
@@ -2,6 +2,7 @@ package reactor.core.publisher;
 
 import org.junit.Test;
 
+import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 
 public class MonoThenMapTest {
@@ -15,5 +16,17 @@ public class MonoThenMapTest {
         ts.assertValues(2)
         .assertComplete()
         .assertNoError();
+    }
+
+    @Test
+    public void cancel() {
+        TestPublisher<String> cancelTester = TestPublisher.create();
+
+        cancelTester.mono()
+                    .then(s -> Mono.just(s.length()))
+                    .subscribe()
+                    .cancel();
+
+        cancelTester.assertCancelled();
     }
 }


### PR DESCRIPTION
Done in:
 * `MonoProcessor` (IF source is a `Mono`)
 * `Mono#hasElement` (but not `Flux#hasElements`)
 * `LambdaMonoSubscriber` (which was renamed from LambdaFirstSubscriber)
 * `Mono.block`

This PR also prevents double cancel in Flux#blockingFirst.