### PR TITLE
fix #445 Ensure request min 1 when bufferSize is 1 in TopicProcessor

### DIFF
--- a/src/main/java/reactor/core/publisher/EventLoopProcessor.java
+++ b/src/main/java/reactor/core/publisher/EventLoopProcessor.java
@@ -543,7 +543,7 @@ abstract class EventLoopProcessor<IN> extends FluxProcessor<IN, IN>
 		@Override
 		public void run() {
 			final long bufferSize = prefetch;
-			final long limit = bufferSize - Math.max(bufferSize >> 2, 1);
+			final long limit = bufferSize == 1 ? bufferSize : bufferSize - Math.max(bufferSize >> 2, 1);
 			long cursor = -1;
 			try {
 				spinObserver.run();


### PR DESCRIPTION
This commit changes the EventLoopProcessor base class so it also affects
the WorkQueueProcessor. In RequestTask, it ensures the request(limit...)
isn't 0 for bufferSize of 1, but rather 1.