### PR TITLE
fix #493 Add a toCallable converter to Mono

### DIFF
--- a/src/docs/asciidoc/operatorChoice.adoc
+++ b/src/docs/asciidoc/operatorChoice.adoc
@@ -244,3 +244,4 @@ TIP: Note that this returns a `Flux<GroupedFlux<K, T>>`, each inner `GroupedFlux
 ** to block until I can get the value: `Mono#block`
 *** ...with a timeout: `Mono#block(Duration)`
 ** a `CompletableFuture<T>`: `Mono#toFuture`
+** a `Callable<T>` that will subscribe and block on first `call()`: `Mono#toCallable`

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -3173,6 +3173,16 @@ public abstract class Mono<T> implements Publisher<T> {
 		return subscribeWith(new MonoToCompletableFuture<>());
 	}
 
+	/**
+	 * Transform this {@link Mono} into a {@link Callable}, which will automatically
+	 * subscribe to this Mono upon first invoking {@link Callable#call()}. Until the
+	 * call() is made, nothing happens with the Callable.
+	 * <p>
+	 * Subsequently the state of the Mono (valued/empty/errored) will be captured and
+	 * replayed on {@link Callable#call()}.
+	 *
+	 * @return a {@link Callable}
+	 */
 	public final Callable<T> toCallable() {
 		return new MonoToCallable<>(this);
 	}

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -3173,6 +3173,10 @@ public abstract class Mono<T> implements Publisher<T> {
 		return subscribeWith(new MonoToCompletableFuture<>());
 	}
 
+	public final Callable<T> toCallable() {
+		return new MonoToCallable<>(this);
+	}
+
 	/**
 	 * Transform this {@link Mono} in order to generate a target {@link Mono}. Unlike {@link #compose(Function)}, the
 	 * provided function is executed as part of assembly.

--- a/src/main/java/reactor/core/publisher/MonoToCallable.java
+++ b/src/main/java/reactor/core/publisher/MonoToCallable.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.core.publisher;
+
+import java.util.concurrent.Callable;
+
+import org.reactivestreams.Subscription;
+
+/**
+ * A {@link Callable} derived from a {@link Mono} that will both {@link Mono#subscribe()}
+ * to the Mono and {@link #blockingGet() block} until the Mono is fulfilled when
+ * triggering the {@link #call()}.
+ * <p>
+ * Note that since the source is expected to be always a Mono, the upstream isn't
+ * {@link Subscription#cancel() cancelled} during onNext.
+ *
+ * @author Simon Basle
+ */
+final class MonoToCallable<T> extends BlockingSingleSubscriber<T> implements Callable<T> {
+
+	final Mono<T> upstream;
+
+	MonoToCallable(Mono<T> upstream) {
+		super();
+		this.upstream = upstream;
+	}
+
+	@Override
+	public T call() throws Exception {
+		upstream.subscribe(this);
+		return blockingGet();
+	}
+
+	@Override
+	public void onNext(T t) {
+		if (value == null) {
+			value = t;
+			//we don't dispose as this operator is expected to only be used with Mono
+			countDown();
+		}
+	}
+
+	@Override
+	public void onError(Throwable t) {
+		if (value == null) {
+			error = t;
+		}
+		countDown();
+	}
+}

--- a/src/test/java/reactor/core/publisher/MonoToCallableTest.java
+++ b/src/test/java/reactor/core/publisher/MonoToCallableTest.java
@@ -27,9 +27,6 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-/**
- * @author Simon Baslé
- */
 public class MonoToCallableTest {
 
 	@Test

--- a/src/test/java/reactor/core/publisher/MonoToCallableTest.java
+++ b/src/test/java/reactor/core/publisher/MonoToCallableTest.java
@@ -17,10 +17,10 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Test;
 
@@ -77,4 +77,19 @@ public class MonoToCallableTest {
 		assertThat(callable.call()).isNull();
 	}
 
+	@Test
+	public void multipleCallSubscribesOnce() throws Exception {
+		AtomicLong subscribed = new AtomicLong();
+
+		Mono<String> source = Mono.just("foo")
+		                          .doOnSubscribe(s -> subscribed.incrementAndGet());
+
+		Callable<String> callable = source.toCallable();
+		callable.call();
+		callable.call();
+		callable.call();
+		callable.call();
+
+		assertThat(subscribed.get()).isEqualTo(1);
+	}
 }

--- a/src/test/java/reactor/core/publisher/MonoToCallableTest.java
+++ b/src/test/java/reactor/core/publisher/MonoToCallableTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * @author Simon Baslé
+ */
+public class MonoToCallableTest {
+
+	@Test
+	public void testDelayed() throws Exception {
+		Callable<String> callable = Mono.just("foo")
+		                                .delayElement(Duration.ofMillis(500))
+		                                .toCallable();
+
+		long start = System.nanoTime();
+		assertThat(callable.call())
+				.isEqualTo("foo");
+		assertThat(System.nanoTime() - start)
+				.overridingErrorMessage("Call took less than 500ms")
+				.isGreaterThanOrEqualTo(TimeUnit.MILLISECONDS.toNanos(500));
+	}
+
+	@Test
+	public void testDelayedNotSubscribedIfNotCalled() {
+		AtomicBoolean subscribed = new AtomicBoolean();
+
+		Mono<String> source = Mono.just("foo")
+		                          .delayElement(Duration.ofMillis(500))
+		                          .doOnSubscribe(s -> subscribed.set(true));
+
+		Callable<String> callable = source.toCallable();
+
+		assertThat(subscribed.get()).isFalse();
+	}
+
+	@Test
+	public void testError() {
+		Callable<String> callable = Mono.<String>error(new IllegalArgumentException("boom"))
+				.toCallable();
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(callable::call)
+	            .withMessage("boom");
+	}
+
+	@Test
+	public void testEmpty() throws Exception {
+		Callable<String> callable = Mono.<String>empty()
+				.toCallable();
+
+		assertThat(callable.call()).isNull();
+	}
+
+}


### PR DESCRIPTION
This converter defers subscription to the `Mono` until `call()` is invoked for the first time.