### PR TITLE
fix #496 UntilOther: fix test and mention in reference doc

### DIFF
--- a/src/docs/asciidoc/operatorChoice.adoc
+++ b/src/docs/asciidoc/operatorChoice.adoc
@@ -92,6 +92,9 @@ I want to deal with: <<which.create>>, <<which.values>>, <<which.peeking>>,
 ** ...and I want to switch to another `Mono` at the end: `Mono#then(mono)`
 ** ...and I want to switch to a `Flux` at the end: `thenMany`
 
+* I have a Mono for which I want to defer completion...
+** ...only when 1-N other publishers have all emitted (or completed): `Mono#untilOther`
+
 [[which.peeking]]
 == Peeking into a sequence
 * Without modifying the final sequence, I want to...

--- a/src/test/java/reactor/core/publisher/MonoUntilOtherTest.java
+++ b/src/test/java/reactor/core/publisher/MonoUntilOtherTest.java
@@ -18,7 +18,6 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 
 import org.junit.Test;
 import org.reactivestreams.Publisher;
@@ -44,15 +43,23 @@ public class MonoUntilOtherTest {
 	}
 
 	@Test
+	public void triggerSequenceWithDelays() {
+		Duration duration = StepVerifier.create(new MonoUntilOther<>(false,
+				Mono.just("foo"),
+				Flux.just(1, 2, 3).hide().delayElements(Duration.ofMillis(500))))
+		            .expectNext("foo")
+		            .verifyComplete();
+
+		assertThat(duration.toMillis()).isGreaterThanOrEqualTo(500);
+	}
+
+	@Test
 	public void triggerSequenceHasMultipleValuesCancelled() {
 		AtomicBoolean triggerCancelled = new AtomicBoolean();
 		StepVerifier.create(new MonoUntilOther<>(false,
 				Mono.just("foo"),
 				Flux.just(1, 2, 3).hide()
-				    .delayElements(Duration.ofMillis(500))
 				    .doOnCancel(() -> triggerCancelled.set(true))))
-		            .expectSubscription()
-		            .expectNoEvent(Duration.ofMillis(450))
 		            .expectNext("foo")
 		            .verifyComplete();
 		assertThat(triggerCancelled.get()).isTrue();
@@ -63,10 +70,8 @@ public class MonoUntilOtherTest {
 		AtomicBoolean triggerCancelled = new AtomicBoolean();
 		StepVerifier.create(new MonoUntilOther<>(false,
 				Mono.just("foo"),
-				Mono.delay(Duration.ofMillis(500))
+				Mono.just(1)
 				    .doOnCancel(() -> triggerCancelled.set(true))))
-		            .expectSubscription()
-		            .expectNoEvent(Duration.ofMillis(450))
 		            .expectNext("foo")
 		            .verifyComplete();
 		assertThat(triggerCancelled.get()).isFalse();


### PR DESCRIPTION
Remove time element from the cancellation tests, add to operator choice.