### PR TITLE
fix #515 Return new instance when chaining Mono.untilOther

### DIFF
--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -3016,8 +3016,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	public Mono<T> untilOther(Publisher<?> anyPublisher) {
 		Objects.requireNonNull(anyPublisher, "anyPublisher required");
 		if (this instanceof MonoUntilOther) {
-			((MonoUntilOther<T>) this).addTrigger(anyPublisher);
-			return this;
+			return ((MonoUntilOther<T>) this).addTrigger(anyPublisher);
 		}
 		return onAssembly(new MonoUntilOther<>(false, this, anyPublisher));
 	}
@@ -3036,8 +3035,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	public Mono<T> untilOtherDelayError(Publisher<?> anyPublisher) {
 		Objects.requireNonNull(anyPublisher, "anyPublisher required");
 		if (this instanceof MonoUntilOther) {
-			((MonoUntilOther<T>) this).addTrigger(anyPublisher);
-			return this;
+			return ((MonoUntilOther<T>) this).addTrigger(anyPublisher);
 		}
 		return onAssembly(new MonoUntilOther<>(true, this, anyPublisher));
 	}

--- a/src/main/java/reactor/core/publisher/MonoUntilOther.java
+++ b/src/main/java/reactor/core/publisher/MonoUntilOther.java
@@ -53,15 +53,26 @@ final class MonoUntilOther<T> extends Mono<T> {
 		this.others = new Publisher[] { Objects.requireNonNull(triggerPublisher, "triggerPublisher")};
 	}
 
+	private MonoUntilOther(boolean delayError,
+			Mono<T> monoSource,
+			Publisher<?>[] triggerPublishers) {
+		this.delayError = delayError;
+		this.source = Objects.requireNonNull(monoSource, "monoSource");
+		this.others = triggerPublishers;
+	}
+
 	/**
 	 * Add a trigger to wait for.
 	 * @param trigger
+	 * @return a new {@link MonoUntilOther} instance with same source but additional trigger
 	 */
-	void addTrigger(Publisher<?> trigger) {
+	MonoUntilOther<T> addTrigger(Publisher<?> trigger) {
+		Objects.requireNonNull(trigger, "trigger");
 		Publisher<?>[] oldTriggers = this.others;
-		this.others = new Publisher[oldTriggers.length + 1];
-		System.arraycopy(oldTriggers, 0, this.others, 0, oldTriggers.length);
-		this.others[oldTriggers.length] = trigger;
+		Publisher<?>[] newTriggers = new Publisher[oldTriggers.length + 1];
+		System.arraycopy(oldTriggers, 0, newTriggers, 0, oldTriggers.length);
+		newTriggers[oldTriggers.length] = trigger;
+		return new MonoUntilOther<T>(this.delayError, this.source, newTriggers);
 	}
 
 	@Override


### PR DESCRIPTION
Previously it would mutate the same instance, which could have side
effects if the same original MonoUntilOther was chained with additional
untilOthers in 2 places at once.