### PR TITLE
fix #516 Rename Mono.then(function) to Mono.mapWhen, deprecate old name

### DIFF
--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -1195,7 +1195,7 @@ public abstract class Mono<T> implements Publisher<T> {
 			BiFunction<T, T2, O> combinator) {
 		Objects.requireNonNull(rightGenerator, "rightGenerator function is mandatory to get the right-hand side Mono");
 		Objects.requireNonNull(combinator, "combinator function is mandatory to combine results from both Monos");
-		return then(t -> rightGenerator.apply(t).map(t2 -> combinator.apply(t, t2)));
+		return thenMap(t -> rightGenerator.apply(t).map(t2 -> combinator.apply(t, t2)));
 	}
 
 	/**
@@ -2738,9 +2738,25 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param <R> the result type bound
 	 *
 	 * @return a new {@link Mono} containing the merged values
+	 * @deprecated replace with equivalent {@link #thenMap(Function)}. Will be removed in 3.1.0.RELEASE.
 	 */
-	public final <R> Mono<R> then(Function<? super T, ? extends Mono<? extends R>>
-			transformer) {
+	@Deprecated
+	public final <R> Mono<R> then(Function<? super T, ? extends Mono<? extends R>> transformer) {
+		return thenMap(transformer);
+	}
+
+	/**
+	 * Convert the value of {@link Mono} to another {@link Mono} possibly with another value type.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/then.png" alt="">
+	 * <p>
+	 * @param transformer the function to dynamically bind a new {@link Mono}
+	 * @param <R> the result type bound
+	 *
+	 * @return a new {@link Mono} containing the merged values
+	 */
+	public final <R> Mono<R> thenMap(Function<? super T, ? extends Mono<? extends R>> transformer) {
 		return onAssembly(new MonoThenMap<>(this, transformer));
 	}
 

--- a/src/test/java/reactor/HooksTest.java
+++ b/src/test/java/reactor/HooksTest.java
@@ -280,7 +280,7 @@ public class HooksTest {
 		Hooks.onOperator(hooks -> hooks.operatorStacktrace());
 		try {
 			Mono.just(1)
-			    .then(d ->
+			    .thenMap(d ->
 				    Mono.error(new RuntimeException())
 			    )
 			    .filter(d -> true)
@@ -293,7 +293,7 @@ public class HooksTest {
 			Assert.assertTrue(e.getSuppressed()[0].getMessage().contains
 					("HooksTest.java:"));
 			Assert.assertTrue(e.getSuppressed()[0].getMessage().contains("|_\tMono" +
-					".then" +
+					".thenMap" +
 					"(HooksTest.java:"));
 			return;
 		}

--- a/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -835,7 +835,7 @@ public class FluxFlatMapTest {
 	@Test
 	public void suppressFusionIfExpected() {
 		StepVerifier.create(Mono.just(1)
-		                        .then(d -> Mono.just(d)
+		                        .thenMap(d -> Mono.just(d)
 		                                       .hide()))
 		            .consumeSubscriptionWith(s -> {
 			            assertThat(s).isInstanceOf(FluxHide.SuppressFuseableSubscriber.class);
@@ -861,7 +861,7 @@ public class FluxFlatMapTest {
 	@Test
 	public void suppressFusionIfExpectedError() {
 		StepVerifier.create(Mono.just(1)
-		                        .then(d -> Mono.error(new Exception("test"))
+		                        .thenMap(d -> Mono.error(new Exception("test"))
 		                                       .hide()))
 		            .consumeSubscriptionWith(s -> {
 			            assertThat(s).isInstanceOf(FluxHide.SuppressFuseableSubscriber.class);

--- a/src/test/java/reactor/core/publisher/MonoFilterTest.java
+++ b/src/test/java/reactor/core/publisher/MonoFilterTest.java
@@ -146,7 +146,7 @@ public class MonoFilterTest {
 
 		Mono.just(1)
 		    .hide()
-		    .then(w -> up.filter(v -> (v & 1) == 0))
+		    .thenMap(w -> up.filter(v -> (v & 1) == 0))
 		    .subscribe(ts);
 
 		up.onNext(2);

--- a/src/test/java/reactor/core/publisher/MonoProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/MonoProcessorTest.java
@@ -184,7 +184,7 @@ public class MonoProcessorTest {
 
 		mp.onNext(1);
 
-		MonoProcessor<Integer> mp2 = mp.then(s -> Mono.just(s * 2))
+		MonoProcessor<Integer> mp2 = mp.thenMap(s -> Mono.just(s * 2))
 		                               .subscribe();
 
 		assertThat(mp2.isTerminated()).isTrue();

--- a/src/test/java/reactor/core/publisher/MonoThenMapTest.java
+++ b/src/test/java/reactor/core/publisher/MonoThenMapTest.java
@@ -11,7 +11,7 @@ public class MonoThenMapTest {
     public void normalHidden() {
         AssertSubscriber<Integer> ts = AssertSubscriber.create();
         
-        Mono.just(1).hide().then(v -> Mono.just(2).hide()).subscribe(ts);
+        Mono.just(1).hide().thenMap(v -> Mono.just(2).hide()).subscribe(ts);
         
         ts.assertValues(2)
         .assertComplete()
@@ -23,7 +23,7 @@ public class MonoThenMapTest {
         TestPublisher<String> cancelTester = TestPublisher.create();
 
         cancelTester.mono()
-                    .then(s -> Mono.just(s.length()))
+                    .thenMap(s -> Mono.just(s.length()))
                     .subscribe()
                     .cancel();
 

--- a/src/test/java/reactor/core/publisher/scenarios/MonoTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/MonoTests.java
@@ -158,7 +158,7 @@ public class MonoTests {
 		                             .log("time1")
 		                             .map(d -> "Spring wins")
 		                             .or(Mono.delay(Duration.ofMillis(2000)).log("time2").map(d -> "Spring Reactive"))
-		                             .then(t -> Mono.just(t+ " world"))
+		                             .thenMap(t -> Mono.just(t+ " world"))
 		                             .elapsed()
 		                             .block();
 		assertThat("Alternate mono not seen", h.getT2(), is("Spring Reactive world"));


### PR DESCRIPTION
2nd part will be to remove old signature in 3.1.0.RELEASE (reopen #516
after merging this).