### PR TITLE
Anticipate #516 by introducing Mono#flatMapMany, deprecation

### DIFF
--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -61,9 +61,8 @@ import reactor.util.function.Tuples;
  * <p>
  *
  * <p>The rx operators will offer aliases for input {@link Mono} type to preserve the "at most one"
- * property of the resulting {@link Mono}. For instance {@link Mono#flatMap flatMap} returns a {@link Flux} with 
- * possibly
- * more than 1 emission. Its alternative enforcing {@link Mono} input is {@link Mono#then then}.
+ * property of the resulting {@link Mono}. For instance {@link Mono#flatMap flatMap} returns a
+ * {@link Mono}, while there is a {@link Mono#flatMapMany} alias with possibly more than 1 emission.
  *
  * <p>{@code Mono<Void>} should be used for {@link Publisher} that just completes without any value.
  *
@@ -1986,8 +1985,52 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param <R> the merged sequence type
 	 *
 	 * @return a new {@link Flux} as the sequence is not guaranteed to be single at most
+	 * @deprecated will change signature and behavior in 3.1 to reflect current {@link #then(Function)}.
+	 * flatMap will be renamed {@link #flatMapMany(Function)}, so use that instead.
 	 */
+	@Deprecated
 	public final <R> Flux<R> flatMap(Function<? super T, ? extends Publisher<? extends R>> mapper) {
+		return this.flatMapMany(mapper);
+	}
+
+	/**
+	 * Transform the signals emitted by this {@link Mono} into a Publisher, then forward
+	 * its emissions into the returned {@link Flux}.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/flatmaps1.png" alt="">
+	 * <p>
+	 * @param mapperOnNext the {@link Function} to call on next data and returning a sequence to merge
+	 * @param mapperOnError the {@link Function} to call on error signal and returning a sequence to merge
+	 * @param mapperOnComplete the {@link Function} to call on complete signal and returning a sequence to merge
+	 * @param <R> the type of the produced inner sequence
+	 *
+	 * @return a new {@link Flux} as the sequence is not guaranteed to be single at most
+	 *
+	 * @see Flux#flatMap(Function, Function, Supplier)
+	 * @deprecated will change signature and behavior in 3.1 to reflect current {@link #then(Function)}.
+	 * flatMap will be renamed {@link #flatMapMany(Function, Function, Supplier)}, so use that instead.
+	 */
+	@Deprecated
+	public final <R> Flux<R> flatMap(Function<? super T, ? extends Publisher<? extends R>> mapperOnNext,
+			Function<Throwable, ? extends Publisher<? extends R>> mapperOnError,
+			Supplier<? extends Publisher<? extends R>> mapperOnComplete) {
+		return this.flatMapMany(mapperOnNext, mapperOnError, mapperOnComplete);
+	}
+	/**
+	 * Transform the item emitted by this {@link Mono} into a Publisher, then forward
+	 * its emissions into the returned {@link Flux}.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/flatmap1.png" alt="">
+	 * <p>
+	 * @param mapper the
+	 * {@link Function} to produce a sequence of R from the the eventual passed {@link Subscriber#onNext}
+	 * @param <R> the merged sequence type
+	 *
+	 * @return a new {@link Flux} as the sequence is not guaranteed to be single at most
+	 */
+	public final <R> Flux<R> flatMapMany(Function<? super T, ? extends Publisher<? extends R>> mapper) {
 		return Flux.onAssembly(new MonoFlatMap<>(this, mapper));
 	}
 
@@ -2007,7 +2050,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 *
 	 * @see Flux#flatMap(Function, Function, Supplier)
 	 */
-	public final <R> Flux<R> flatMap(Function<? super T, ? extends Publisher<? extends R>> mapperOnNext,
+	public final <R> Flux<R> flatMapMany(Function<? super T, ? extends Publisher<? extends R>> mapperOnNext,
 			Function<Throwable, ? extends Publisher<? extends R>> mapperOnError,
 			Supplier<? extends Publisher<? extends R>> mapperOnComplete) {
 
@@ -2929,6 +2972,9 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param <R> the result type bound
 	 *
 	 * @return a new {@link Mono} containing the merged values
+	 * @deprecated in 3.1.0.M1 this method will be renamed `flatMap`. However, until
+	 * then the behavior of {@link #flatMap(Function)} remains the current one, so it is
+	 * not yet possible to anticipate this migration.
 	 */
 	public final <R> Mono<R> then(Function<? super T, ? extends Mono<? extends R>>
 			transformer) {

--- a/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -528,14 +528,14 @@ public class FluxFlatMapTest {
 		StepVerifier.create(Mono.fromCallable(() -> {
 			throw new Exception("test");
 		})
-		                        .flatMap(Flux::just))
+		                        .flatMapMany(Flux::just))
 		            .verifyErrorMessage("test");
 	}
 
 	@Test
 	public void failScalarMap() {
 		StepVerifier.create(Mono.just(1)
-		                        .flatMap(f -> {
+		                        .flatMapMany(f -> {
 			                        throw new RuntimeException("test");
 		                        }))
 		            .verifyErrorMessage("test");
@@ -544,14 +544,14 @@ public class FluxFlatMapTest {
 	@Test
 	public void failScalarMapNull() {
 		StepVerifier.create(Mono.just(1)
-		                        .flatMap(f -> null))
+		                        .flatMapMany(f -> null))
 		            .verifyError(NullPointerException.class);
 	}
 
 	@Test
 	public void failScalarMapCallableError() {
 		StepVerifier.create(Mono.just(1)
-		                        .flatMap(f -> Mono.fromCallable(() -> {
+		                        .flatMapMany(f -> Mono.fromCallable(() -> {
 			                        throw new Exception("test");
 		                        })))
 		            .verifyErrorMessage("test");
@@ -560,21 +560,21 @@ public class FluxFlatMapTest {
 	@Test
 	public void failMapCallableNullError() {
 		StepVerifier.create(Mono.just(1)
-		                        .flatMap(f -> Mono.fromCallable(() -> null)))
+		                        .flatMapMany(f -> Mono.fromCallable(() -> null)))
 		            .verifyError(NullPointerException.class);
 	}
 
 	@Test
 	public void prematureScalarMapCallableNullComplete() {
 		StepVerifier.create(Mono.just(1)
-		                        .flatMap(f -> Mono.empty()))
+		                        .flatMapMany(f -> Mono.empty()))
 		            .verifyComplete();
 	}
 
 	@Test
 	public void prematureScalarMapCallableJust() {
 		StepVerifier.create(Mono.just(1)
-		                        .flatMap(f -> Mono.fromCallable(() -> 2)))
+		                        .flatMapMany(f -> Mono.fromCallable(() -> 2)))
 		            .expectNext(2)
 		            .verifyComplete();
 	}

--- a/src/test/java/reactor/core/publisher/FluxIntervalTest.java
+++ b/src/test/java/reactor/core/publisher/FluxIntervalTest.java
@@ -82,7 +82,7 @@ public class FluxIntervalTest {
 		    .flatMap(v -> Flux.fromIterable(Arrays.asList("A"))
 		                      .flatMap(w -> Mono.fromCallable(() -> Arrays.asList(1, 2))
 		                                        .subscribeOn(Schedulers.parallel())
-		                                        .flatMap(Flux::fromIterable))).log();
+		                                        .flatMapMany(Flux::fromIterable))).log();
 	}
 
 	@Test

--- a/src/test/java/reactor/core/publisher/FluxMapSignalTest.java
+++ b/src/test/java/reactor/core/publisher/FluxMapSignalTest.java
@@ -116,7 +116,7 @@ public class FluxMapSignalTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void flatMapSignal2() {
 		StepVerifier.create(Mono.just(1)
-		                        .flatMap(d -> Flux.just(d * 2),
+		                        .flatMapMany(d -> Flux.just(d * 2),
 				                        e -> Flux.just(99),
 				                        () -> Flux.just(10)))
 		            .expectNext(2, 10)

--- a/src/test/java/reactor/core/publisher/MonoFlatMapTest.java
+++ b/src/test/java/reactor/core/publisher/MonoFlatMapTest.java
@@ -25,7 +25,7 @@ public class MonoFlatMapTest {
     public void normal() {
         AssertSubscriber<Integer> ts = AssertSubscriber.create();
         
-        Mono.just(1).hide().flatMap(v -> Flux.just(2).hide())
+        Mono.just(1).hide().flatMapMany(v -> Flux.just(2).hide())
         .subscribe(ts);
         
         ts.assertValues(2)
@@ -37,7 +37,7 @@ public class MonoFlatMapTest {
     public void normalInnerJust() {
         AssertSubscriber<Integer> ts = AssertSubscriber.create();
         
-        Mono.just(1).hide().flatMap(v -> Flux.just(2))
+        Mono.just(1).hide().flatMapMany(v -> Flux.just(2))
         .subscribe(ts);
         
         ts.assertValues(2)
@@ -49,7 +49,7 @@ public class MonoFlatMapTest {
     public void normalInnerEmpty() {
         AssertSubscriber<Integer> ts = AssertSubscriber.create();
         
-        Mono.just(1).hide().flatMap(v -> Flux.<Integer>empty())
+        Mono.just(1).hide().flatMapMany(v -> Flux.<Integer>empty())
         .subscribe(ts);
         
         ts.assertNoValues()

--- a/src/test/java/reactor/core/publisher/MonoPublishMulticastTest.java
+++ b/src/test/java/reactor/core/publisher/MonoPublishMulticastTest.java
@@ -89,12 +89,12 @@ public class MonoPublishMulticastTest {
 
     @Test
     public void syncCancelBeforeComplete() {
-        assertThat(Mono.just(Mono.just(1).publish(v -> v)).flatMap(v -> v).blockLast()).isEqualTo(1);
+        assertThat(Mono.just(Mono.just(1).publish(v -> v)).flatMapMany(v -> v).blockLast()).isEqualTo(1);
     }
 
     @Test
     public void normalCancelBeforeComplete() {
-        assertThat(Mono.just(Mono.just(1).hide().publish(v -> v)).flatMap(v -> v).blockLast()).isEqualTo(1);
+        assertThat(Mono.just(Mono.just(1).hide().publish(v -> v)).flatMapMany(v -> v).blockLast()).isEqualTo(1);
     }
 
 }

--- a/src/test/java/reactor/core/publisher/MonoSubscribeOnValueTest.java
+++ b/src/test/java/reactor/core/publisher/MonoSubscribeOnValueTest.java
@@ -32,7 +32,7 @@ public class MonoSubscribeOnValueTest {
 	public void testSubscribeOnValueFusion() {
 
 		StepVerifier.create(Mono.just(1)
-		                        .flatMap(f -> Mono.just(f + 1)
+		                        .flatMapMany(f -> Mono.just(f + 1)
 		                                          .subscribeOn(Schedulers.parallel())
 		                                          .map(this::slow)))
 		            .expectFusion(Fuseable.ASYNC, Fuseable.NONE)

--- a/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -428,7 +428,7 @@ public class FluxTests extends AbstractReactorTest {
 								  .flatMap(w -> w.count().map(c -> Tuples.of(w.key(), c)))
 		                          .log("elapsed")
 		                          .collectSortedList((a, b) -> a.getT1().compareTo(b.getT1()))
-		                          .flatMap(Flux::fromIterable)
+		                          .flatMapMany(Flux::fromIterable)
 		                          .reduce(-1L, (acc, next) -> acc > 0l ? ((next.getT1() + acc) / 2) : next.getT1())
 		                          .log("reduced-elapsed")
 		                          .cache();

--- a/src/test/java/reactor/core/publisher/scenarios/PopularTagTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/PopularTagTests.java
@@ -66,7 +66,7 @@ public class PopularTagTests extends AbstractReactorTest {
 		         .flatMap(s -> s.groupBy(w -> w)
 		                       .flatMap(w -> w.count().map(c -> Tuples.of(w.key(), c)))
 		                       .collectSortedList((a, b) -> -a.getT2().compareTo(b.getT2()))
-		                        .flatMap(Flux::fromIterable)
+		                        .flatMapMany(Flux::fromIterable)
 		                       .take(10)
 		                       .doAfterTerminate(() -> LOG.info("------------------------ window terminated" +
 						      "----------------------"))


### PR DESCRIPTION
This commit anticipate on #516 in 3.1.0 by marking Mono.flatMap as
deprecated, introducing the alternative of flatMapMany. In 3.1.0,
it will replace flatMap, which in turn will replace Mono#then(Function).