### PR TITLE
Backport of FluxProcessor rework:

### DIFF
--- a/src/main/java/reactor/core/publisher/BlockingSink.java
+++ b/src/main/java/reactor/core/publisher/BlockingSink.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
+import java.util.function.LongConsumer;
 import java.util.function.Predicate;
 
 import org.reactivestreams.Subscriber;
@@ -47,7 +48,14 @@ import reactor.core.Trackable;
  *
  * @author Stephane Maldini
  * @param <E> the element type
+ * @deprecated Will be removed in 3.1.0. There is no general replacement for BlockingSink in 3.1 but its major
+ * user {@link FluxProcessor} now offers {@link FluxProcessor#sink} that directly exposes
+ *{@link FluxSink}. In general the blocking publishing methods here can be directly
+ * addressed via the behavior of {@link FluxProcessor#sink} in a safer way. There is
+ * also {@link FluxSink#onRequest(LongConsumer)} available to now proactively deal with
+ * backpressure even in the context of producing to an arbitrary processor.
  */
+@Deprecated
 public final class BlockingSink<E>
 		implements Subscription, Consumer<E>, Disposable, Producer, Trackable, Closeable {
 	/**

--- a/src/main/java/reactor/core/publisher/DelegateProcessor.java
+++ b/src/main/java/reactor/core/publisher/DelegateProcessor.java
@@ -67,6 +67,14 @@ final class DelegateProcessor<IN, OUT> extends FluxProcessor<IN, OUT>  {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
+	public boolean isSerialized() {
+		return upstream instanceof SerializedSubscriber ||
+				(upstream instanceof FluxProcessor &&
+						((FluxProcessor<?, ?>)upstream).isSerialized());
+	}
+
+	@Override
 	public Stream<? extends Scannable> inners() {
 		return Scannable.from(upstream)
 		                .inners();

--- a/src/main/java/reactor/core/publisher/DelegateProcessor.java
+++ b/src/main/java/reactor/core/publisher/DelegateProcessor.java
@@ -86,6 +86,7 @@ final class DelegateProcessor<IN, OUT> extends FluxProcessor<IN, OUT>  {
 
 	@Override
 	@SuppressWarnings("unchecked")
+	@Deprecated
 	public boolean isStarted() {
 		return !(upstream instanceof FluxProcessor) || ((FluxProcessor<OUT, ?>) upstream).isStarted();
 	}

--- a/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -29,28 +29,28 @@ import reactor.core.Scannable;
 import reactor.util.concurrent.QueueSupplier;
 
 /**
- ** An implementation of a RingBuffer backed message-passing Processor implementing publish-subscribe with
- * synchronous (thread-stealing and happen-before interactions) drain loops.
+ * * An implementation of a RingBuffer backed message-passing Processor implementing
+ * publish-subscribe with synchronous (thread-stealing and happen-before interactions)
+ * drain loops.
  * <p>
  *     The default {@link #create} factories will only produce the new elements observed in
- *     the
- *     parent sequence after a given {@link Subscriber} is subscribed.
- *
+ * the parent sequence after a given {@link Subscriber} is subscribed.
  * <p>
  * <img width="640" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/emitter.png" alt="">
  * <p>
  *
- * @author Stephane Maldini
- *
  * @param <T> the input and output value type
+ *
+ * @author Stephane Maldini
  */
 public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Receiver {
 
 	/**
-	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size, blockingWait
-	 * Strategy and auto-cancel.
+	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE}
+	 * backlog size, blockingWait Strategy and auto-cancel.
 	 *
 	 * @param <E> Type of processed signals
+	 *
 	 * @return a fresh processor
 	 */
 	public static <E> EmitterProcessor<E> create() {
@@ -58,10 +58,12 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 	}
 
 	/**
-	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size, blockingWait
-	 * Strategy and auto-cancel.
+	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE}
+	 * backlog size, blockingWait Strategy and auto-cancel.
+	 *
 	 * @param <E> Type of processed signals
      * @param autoCancel automatically cancel
+	 *
 	 * @return a fresh processor
 	 */
 	public static <E> EmitterProcessor<E> create(boolean autoCancel) {
@@ -69,10 +71,12 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 	}
 
 	/**
-	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size, blockingWait
-	 * Strategy and auto-cancel.
+	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE}
+	 * backlog size, blockingWait Strategy and auto-cancel.
+	 *
 	 * @param <E> Type of processed signals
      * @param bufferSize the internal buffer size to hold signals
+	 *
 	 * @return a fresh processor
 	 */
 	public static <E> EmitterProcessor<E> create(int bufferSize) {
@@ -80,23 +84,29 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 	}
 
 	/**
-	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size, blockingWait
-	 * Strategy and auto-cancel.
+	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE}
+	 * backlog size, blockingWait Strategy and auto-cancel.
+	 *
 	 * @param <E> Type of processed signals
      * @param bufferSize the internal buffer size to hold signals
      * @param concurrency the concurrency level of the emission
+	 *
 	 * @return a fresh processor
+	 * @deprecated concurrency in EmitterProcessor will be removed in 3.1.0
 	 */
+	@Deprecated
 	public static <E> EmitterProcessor<E> create(int bufferSize, int concurrency) {
 		return create(bufferSize, concurrency, true);
 	}
 
 	/**
-	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size, blockingWait
-	 * Strategy and auto-cancel. 
+	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE}
+	 * backlog size, blockingWait Strategy and auto-cancel.
+	 *
 	 * @param <E> Type of processed signals
      * @param bufferSize the internal buffer size to hold signals
      * @param autoCancel automatically cancel
+	 *
 	 * @return a fresh processor
 	 */
 	public static <E> EmitterProcessor<E> create(int bufferSize, boolean autoCancel) {
@@ -104,15 +114,21 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 	}
 
 	/**
-	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size, blockingWait
-	 * Strategy and auto-cancel. 
+	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE}
+	 * backlog size, blockingWait Strategy and auto-cancel.
+	 *
 	 * @param <E> Type of processed signals
 	 * @param bufferSize the internal buffer size to hold signals
 	 * @param concurrency the concurrency level of the emission
 	 * @param autoCancel automatically cancel
+	 *
 	 * @return a fresh processor
+	 * @deprecated concurrency in EmitterProcessor will be removed in 3.1.0
 	 */
-	public static <E> EmitterProcessor<E> create(int bufferSize, int concurrency, boolean autoCancel) {
+	@Deprecated
+	public static <E> EmitterProcessor<E> create(int bufferSize,
+			int concurrency,
+			boolean autoCancel) {
 		return new EmitterProcessor<>(autoCancel, concurrency, bufferSize);
 	}
 
@@ -127,6 +143,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 	private volatile boolean done;
 
 	@Override
+	@Deprecated
 	public Subscription upstream() {
 		return upstreamSubscription;
 	}
@@ -199,11 +216,17 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 	}
 
 	@Override
+	@Deprecated
 	public EmitterProcessor<T> connect() {
 		onSubscribe(Operators.emptySubscription());
 		return this;
 	}
 
+	/**
+	 * Return the number of parked elements in the emitter backlog.
+	 *
+	 * @return the number of parked elements in the emitter backlog.
+	 */
 	@Override
 	public long getPending() {
 		return (emitBuffer == null ? -1L :
@@ -351,6 +374,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 	}
 
 	@Override
+	@Deprecated
 	public boolean isStarted() {
 		return upstreamSubscription != null;
 	}

--- a/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -16,24 +16,29 @@
 
 package reactor.core.publisher;
 
+import java.util.Queue;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.concurrent.locks.LockSupport;
 import java.util.stream.Stream;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Exceptions;
 import reactor.core.Receiver;
+import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.util.concurrent.QueueSupplier;
+
+import static reactor.core.publisher.FluxPublish.PublishSubscriber.EMPTY;
+import static reactor.core.publisher.FluxPublish.PublishSubscriber.TERMINATED;
 
 /**
  * * An implementation of a RingBuffer backed message-passing Processor implementing
  * publish-subscribe with synchronous (thread-stealing and happen-before interactions)
  * drain loops.
  * <p>
- *     The default {@link #create} factories will only produce the new elements observed in
+ * The default {@link #create} factories will only produce the new elements observed in
  * the parent sequence after a given {@link Subscriber} is subscribed.
  * <p>
  * <img width="640" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/emitter.png" alt="">
@@ -62,7 +67,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 	 * backlog size, blockingWait Strategy and auto-cancel.
 	 *
 	 * @param <E> Type of processed signals
-     * @param autoCancel automatically cancel
+	 * @param autoCancel automatically cancel
 	 *
 	 * @return a fresh processor
 	 */
@@ -75,7 +80,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 	 * backlog size, blockingWait Strategy and auto-cancel.
 	 *
 	 * @param <E> Type of processed signals
-     * @param bufferSize the internal buffer size to hold signals
+	 * @param bufferSize the internal buffer size to hold signals
 	 *
 	 * @return a fresh processor
 	 */
@@ -88,8 +93,8 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 	 * backlog size, blockingWait Strategy and auto-cancel.
 	 *
 	 * @param <E> Type of processed signals
-     * @param bufferSize the internal buffer size to hold signals
-     * @param concurrency the concurrency level of the emission
+	 * @param bufferSize the internal buffer size to hold signals
+	 * @param concurrency the concurrency level of the emission
 	 *
 	 * @return a fresh processor
 	 * @deprecated concurrency in EmitterProcessor will be removed in 3.1.0
@@ -104,8 +109,8 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 	 * backlog size, blockingWait Strategy and auto-cancel.
 	 *
 	 * @param <E> Type of processed signals
-     * @param bufferSize the internal buffer size to hold signals
-     * @param autoCancel automatically cancel
+	 * @param bufferSize the internal buffer size to hold signals
+	 * @param autoCancel automatically cancel
 	 *
 	 * @return a fresh processor
 	 */
@@ -133,26 +138,39 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 	}
 
 	final int maxConcurrency;
-	final int bufferSize;
-	final int limit;
+	final int prefetch;
+
 	final boolean autoCancel;
-	Subscription upstreamSubscription;
 
-	private volatile RingBuffer<EventLoopProcessor.Slot<T>> emitBuffer;
+	volatile Subscription s;
+	@SuppressWarnings("rawtypes")
+	static final AtomicReferenceFieldUpdater<EmitterProcessor, Subscription> S =
+			AtomicReferenceFieldUpdater.newUpdater(EmitterProcessor.class,
+					Subscription.class,
+					"s");
 
-	private volatile boolean done;
+	volatile FluxPublish.PubSubInner<T>[] subscribers;
 
-	@Override
-	@Deprecated
-	public Subscription upstream() {
-		return upstreamSubscription;
-	}
+	@SuppressWarnings("rawtypes")
+	static final AtomicReferenceFieldUpdater<EmitterProcessor, FluxPublish.PubSubInner[]>
+			SUBSCRIBERS = AtomicReferenceFieldUpdater.newUpdater(EmitterProcessor.class,
+			FluxPublish.PubSubInner[].class,
+			"subscribers");
 
-	static final EmitterInner<?>[] EMPTY = new EmitterInner<?>[0];
+	@SuppressWarnings("unused")
+	volatile int wip;
 
-	static final EmitterInner<?>[] CANCELLED = new EmitterInner<?>[0];
+	@SuppressWarnings("rawtypes")
+	static final AtomicIntegerFieldUpdater<EmitterProcessor> WIP =
+			AtomicIntegerFieldUpdater.newUpdater(EmitterProcessor.class, "wip");
 
-	private volatile Throwable error;
+	volatile Queue<T> queue;
+
+	int sourceMode;
+
+	volatile boolean done;
+
+	volatile Throwable error;
 
 	@SuppressWarnings("rawtypes")
 	static final AtomicReferenceFieldUpdater<EmitterProcessor, Throwable> ERROR =
@@ -160,38 +178,20 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 					Throwable.class,
 					"error");
 
-	volatile EmitterInner<?>[] subscribers;
-
-	@SuppressWarnings("rawtypes")
-	static final AtomicReferenceFieldUpdater<EmitterProcessor, EmitterInner[]> SUBSCRIBERS =
-			AtomicReferenceFieldUpdater.newUpdater(EmitterProcessor.class,
-					EmitterInner[].class,
-					"subscribers");
-	@SuppressWarnings("unused")
-	private volatile int running;
-
-	@SuppressWarnings("rawtypes")
-	static final AtomicIntegerFieldUpdater<EmitterProcessor> RUNNING =
-			AtomicIntegerFieldUpdater.newUpdater(EmitterProcessor.class, "running");
-
-	private volatile int outstanding;
-
-	@SuppressWarnings("rawtypes")
-	static final AtomicIntegerFieldUpdater<EmitterProcessor> OUTSTANDING =
-			AtomicIntegerFieldUpdater.newUpdater(EmitterProcessor.class, "outstanding");
-	boolean firstDrain = true;
-
-	EmitterProcessor(boolean autoCancel, int maxConcurrency, int bufferSize) {
-		if (bufferSize < 1){
-			throw new IllegalArgumentException("bufferSize must be strictly positive, " +
-					"was: "+bufferSize);
+	EmitterProcessor(boolean autoCancel, int maxConcurrency, int prefetch) {
+		if (prefetch < 1) {
+			throw new IllegalArgumentException("bufferSize must be strictly positive, " + "was: " + prefetch);
 		}
 		this.autoCancel = autoCancel;
 		this.maxConcurrency = maxConcurrency;
-		this.bufferSize = bufferSize;
-		this.limit = Math.max(1, bufferSize / 2);
-		OUTSTANDING.lazySet(this, bufferSize);
+		this.prefetch = prefetch;
 		SUBSCRIBERS.lazySet(this, EMPTY);
+	}
+
+	@Override
+	@Deprecated
+	public Subscription upstream() {
+		return s;
 	}
 
 	@Override
@@ -204,14 +204,27 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 		if (s == null) {
 			throw Exceptions.argumentIsNullException();
 		}
-		EmitterInner<T> inner = new EmitterInner<>(this, s);
-		if(addInner(inner)) {
-			if (upstreamSubscription != null) {
-				inner.start();
-			}
+		EmitterInner<T> inner = new EmitterInner<>(s, this);
+		s.onSubscribe(inner);
+
+		if (inner.isCancelled()) {
+			return;
 		}
-		else{
-			Operators.complete(inner.actual);
+
+		if (add(inner)) {
+			if (inner.isCancelled()) {
+				remove(inner);
+			}
+			drain();
+		}
+		else {
+			Throwable e = error;
+			if (e != null) {
+				inner.actual.onError(e);
+			}
+			else {
+				inner.actual.onComplete();
+			}
 		}
 	}
 
@@ -229,91 +242,78 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 	 */
 	@Override
 	public long getPending() {
-		return (emitBuffer == null ? -1L :
-				emitBuffer.getPending());
+		Queue<T> q = queue;
+		return q != null ? q.size() : 0;
+	}
+
+	@Override
+	public void onSubscribe(final Subscription s) {
+		if (Operators.setOnce(S, this, s)) {
+			if (s instanceof Fuseable.QueueSubscription) {
+				@SuppressWarnings("unchecked") Fuseable.QueueSubscription<T> f =
+						(Fuseable.QueueSubscription<T>) s;
+
+				int m = f.requestFusion(Fuseable.ANY);
+				if (m == Fuseable.SYNC) {
+					sourceMode = m;
+					queue = f;
+					done = true;
+					drain();
+					return;
+				}
+				else if (m == Fuseable.ASYNC) {
+					sourceMode = m;
+					queue = f;
+					s.request(prefetch);
+					return;
+				}
+			}
+
+			queue = QueueSupplier.<T>get(prefetch).get();
+
+			s.request(prefetch);
+		}
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
 	public void onNext(T t) {
-		if (t == null) {
+		if (t == null && sourceMode == Fuseable.NONE) {
 			throw Exceptions.argumentIsNullException();
 		}
 
-		EmitterInner<?>[] inner = subscribers;
-		if (inner == CANCELLED) {
-			//FIXME should entorse to the spec and throw Exceptions.failWithCancel
+		if (done) {
+			return;
+		}
+		if (sourceMode == Fuseable.ASYNC) {
+			drain();
 			return;
 		}
 
-		int n = inner.length;
-		if (n != 0) {
+		Queue<T> q = queue;
 
-			long seq = -1L;
-
-			int outstanding;
-			if (upstreamSubscription != Operators.emptySubscription()) {
-
-				outstanding = this.outstanding;
-				if (outstanding != 0) {
-					OUTSTANDING.decrementAndGet(this);
-				}
-				else {
-					buffer(t);
-					drain();
-					return;
-				}
+		if (q == null) {
+			if (Operators.setOnce(S, this, Operators.emptySubscription())) {
+				q = QueueSupplier.<T>get(prefetch).get();
+				queue = q;
 			}
-
-			for (int i = 0; i < n; i++) {
-
-				EmitterInner<T> is = (EmitterInner<T>) inner[i];
-
-				if (is.done) {
-					removeInner(is, autoCancel ? CANCELLED : EMPTY);
-
-					if (autoCancel && subscribers == CANCELLED) {
-						if (RUNNING.compareAndSet(this, 0, 1)) {
-							cancel();
-						}
+			else {
+				for (; ; ) {
+					if (isDisposed()) {
 						return;
 					}
-					continue;
+					q = queue;
+					if (q != null) {
+						break;
+					}
 				}
-					long r = is.requested;
-					is.unbounded = r == Long.MAX_VALUE;
-					RingBuffer.Sequence poll = is.unbounded ? null : is.pollCursor;
-
-					//no tracking and remaining demand positive
-					if (r > 0L && poll == null) {
-						if (r != Long.MAX_VALUE) {
-							EmitterInner.REQUESTED.decrementAndGet(is);
-						}
-						is.actual.onNext(t);
-					}
-					//if failed, we buffer if not previously buffered and we assign a tracking cursor to that slot
-					else {
-						if (seq == -1L) {
-							seq = buffer(t);
-							startAllTrackers(inner, seq, i + 1);
-						}
-						else if(poll == null){
-							is.startTracking(seq);
-						}
-					}
-
 			}
-
-			if (RUNNING.getAndIncrement(this) != 0) {
-				return;
-			}
-
-			drainLoop();
-
 		}
-		else {
-			buffer(t);
+
+		while (!q.offer(t)) {
+			LockSupport.parkNanos(10);
 		}
+		drain();
 	}
 
 	@Override
@@ -323,10 +323,15 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 		}
 		if (done) {
 			Operators.onErrorDropped(t);
+			return;
 		}
-		reportError(t);
-		done = true;
-		drain();
+		if (Exceptions.addThrowable(ERROR, this, t)) {
+			done = true;
+			drain();
+		}
+		else {
+			Operators.onErrorDropped(t);
+		}
 	}
 
 	@Override
@@ -336,19 +341,6 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 		}
 		done = true;
 		drain();
-	}
-
-	@Override
-	public void onSubscribe(final Subscription s) {
-		if (Operators.validate(upstreamSubscription, s)) {
-			this.upstreamSubscription = s;
-			EmitterInner<?>[] innerSubscribers = subscribers;
-			if (innerSubscribers != CANCELLED && innerSubscribers.length != 0) {
-				for (int i = 0; i < innerSubscribers.length; i++) {
-					innerSubscribers[i].start();
-				}
-			}
-		}
 	}
 
 	@Override
@@ -365,206 +357,199 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 	 * shutdown argument been set to true.
 	 */
 	public boolean isCancelled() {
-		return subscribers == CANCELLED;
+		return Operators.cancelledSubscription() == s;
 	}
 
 	@Override
 	final public int getBufferSize() {
-		return bufferSize;
+		return prefetch;
 	}
 
 	@Override
 	@Deprecated
 	public boolean isStarted() {
-		return upstreamSubscription != null;
+		return s != null;
 	}
 
 	@Override
 	public boolean isTerminated() {
-		return done && (emitBuffer == null || emitBuffer.getPending() == 0);
+		return done && getPending() == 0;
 	}
 
 	@Override
 	public Object scan(Attr key) {
 		switch (key) {
 			case PARENT:
-				return upstreamSubscription;
+				return s;
 			case BUFFERED:
-				return emitBuffer == null ? 0 : emitBuffer.getPending();
+				return (int) getPending();
 			case CANCELLED:
 				return isCancelled();
 		}
 		return super.scan(key);
 	}
 
-	RingBuffer<EventLoopProcessor.Slot<T>> getMainQueue() {
-		RingBuffer<EventLoopProcessor.Slot<T>> q = emitBuffer;
-		if (q == null) {
-			q = EventLoopProcessor.createSingleProducer(bufferSize);
-			emitBuffer = q;
-		}
-		return q;
-	}
-
-	final long buffer(T value) {
-		RingBuffer<EventLoopProcessor.Slot<T>> q = getMainQueue();
-
-		long seq = q.next();
-
-		q.get(seq).value = value;
-		q.publish(seq);
-		return seq;
-	}
-
 	final void drain() {
-		if (RUNNING.getAndIncrement(this) == 0) {
-			drainLoop();
+		if (WIP.getAndIncrement(this) != 0) {
+			return;
 		}
-	}
 
-	final void drainLoop() {
 		int missed = 1;
-		RingBuffer<EventLoopProcessor.Slot<T>> q = null;
+
 		for (; ; ) {
-			EmitterInner<?>[] inner = subscribers;
-			if (inner == CANCELLED) {
-				cancel();
-				return;
-			}
+
 			boolean d = done;
 
-			if (d && inner == EMPTY) {
+			Queue<T> q = queue;
+
+			boolean empty = q == null || q.isEmpty();
+
+			if (checkTerminated(d, empty)) {
 				return;
 			}
 
-			int n = inner.length;
+			if (!empty) {
+				FluxPublish.PubSubInner<T>[] a = subscribers;
+				long maxRequested = Long.MAX_VALUE;
 
-			if (n != 0) {
-				RingBuffer.Sequence innerSequence;
-				long _r;
+				int len = a.length;
+				int cancel = 0;
 
-				for (int i = 0; i < n; i++) {
-					@SuppressWarnings("unchecked") EmitterInner<T> is = (EmitterInner<T>) inner[i];
-
-					long r = is.requested;
-
-					if (is.done) {
-						removeInner(is, autoCancel ? CANCELLED : EMPTY);
-						if (autoCancel && subscribers == CANCELLED) {
-							cancel();
-							return;
-						}
-						continue;
+				for (FluxPublish.PubSubInner<T> inner : a) {
+					long r = inner.requested;
+					if (r >= 0L) {
+						maxRequested = Math.min(maxRequested, r);
 					}
-
-					if (q == null) {
-						q = emitBuffer;
-					}
-					innerSequence = is.pollCursor;
-					if (!is.unbounded && innerSequence != null && r > 0) {
-						_r = r;
-
-						boolean unbounded = _r == Long.MAX_VALUE;
-						T oo;
-
-						long cursor = innerSequence.getAsLong();
-						long max = q.getCursor();
-						while (_r != 0L) {
-							cursor++;
-							if (max >= cursor) {
-								oo = q.get(cursor).value;
-							}
-							else {
-								break;
-							}
-
-							innerSequence.set(cursor);
-							is.actual.onNext(oo);
-
-							if (!unbounded) {
-								_r--;
-							}
-						}
-
-						if (!unbounded && r > _r) {
-							EmitterInner.REQUESTED.addAndGet(is, _r - r);
-						}
-
-					}
-					else {
-						_r = 0L;
-					}
-
-					if (d) {
-						checkTerminal(is, innerSequence, _r);
+					else { //Long.MIN == PublishInner.CANCEL_REQUEST
+						cancel++;
 					}
 				}
 
-				if (!done && firstDrain) {
-					Subscription s = upstreamSubscription;
-					if (s != null) {
-						firstDrain = false;
-						s.request(bufferSize);
+				if (len == cancel) {
+					T v;
+
+					try {
+						v = q.poll();
 					}
+					catch (Throwable ex) {
+						Exceptions.addThrowable(ERROR,
+								this,
+								Operators.onOperatorError(s, ex));
+						d = true;
+						v = null;
+					}
+					if (checkTerminated(d, v == null)) {
+						return;
+					}
+					if (sourceMode != Fuseable.SYNC) {
+						s.request(1);
+					}
+					continue;
 				}
-				else {
-					if (q != null) {
-						requestMore(q.getPending());
+
+				int e = 0;
+
+				while (e < maxRequested && cancel != Integer.MIN_VALUE) {
+					d = done;
+					T v;
+
+					try {
+						v = q.poll();
 					}
-					else {
-						requestMore(0);
+					catch (Throwable ex) {
+						Exceptions.addThrowable(ERROR,
+								this,
+								Operators.onOperatorError(s, ex));
+						d = true;
+						v = null;
 					}
+
+					empty = v == null;
+
+					if (checkTerminated(d, empty)) {
+						return;
+					}
+
+					if (empty) {
+						break;
+					}
+
+					for (FluxPublish.PubSubInner<T> inner : a) {
+						inner.actual.onNext(v);
+						if (FluxPublish.PubSubInner.produced(inner,
+								1) == FluxPublish.PublishInner.CANCEL_REQUEST) {
+							cancel = Integer.MIN_VALUE;
+						}
+					}
+
+					e++;
+				}
+
+				if (e != 0 && sourceMode != Fuseable.SYNC) {
+					s.request(e);
+				}
+
+				if (maxRequested != 0L && !empty) {
+					continue;
 				}
 			}
 
-			missed = RUNNING.addAndGet(this, -missed);
+			missed = WIP.addAndGet(this, -missed);
 			if (missed == 0) {
 				break;
 			}
 		}
 	}
 
-	final void checkTerminal(EmitterInner<T> is, RingBuffer.Sequence innerSequence, long r) {
-		Throwable e = error;
-		if ((e != null && r == 0) || innerSequence == null || is.unbounded || innerSequence.getAsLong() >= emitBuffer.getCursor()) {
-			removeInner(is, EMPTY);
-			if (!is.done) {
-				if (e == null) {
-					is.actual.onComplete();
-				}
-				else {
-					is.actual.onError(e);
+	@SuppressWarnings("unchecked")
+	FluxPublish.PubSubInner<T>[] terminate() {
+		return SUBSCRIBERS.getAndSet(this, TERMINATED);
+	}
+
+	boolean checkTerminated(boolean d, boolean empty) {
+		if (s == Operators.cancelledSubscription()) {
+			if (autoCancel) {
+				terminate();
+				Queue<T> q = queue;
+				if (q != null) {
+					q.clear();
 				}
 			}
+			return true;
 		}
-	}
-
-	final void startAllTrackers(EmitterInner<?>[] inner, long seq, int size) {
-		RingBuffer.Sequence poll;
-		for (int i = 0; i < size - 1; i++) {
-			poll = inner[i].pollCursor;
-			if (poll == null) {
-				inner[i].startTracking(seq + 1);
+		if (d) {
+			Throwable e = error;
+			if (e != null && e != Exceptions.TERMINATED) {
+				Queue<T> q = queue;
+				if (q != null) {
+					q.clear();
+				}
+				for (FluxPublish.PubSubInner<T> inner : terminate()) {
+					inner.actual.onError(e);
+				}
+				return true;
+			}
+			else if (empty) {
+				for (FluxPublish.PubSubInner<T> inner : terminate()) {
+					inner.actual.onComplete();
+				}
+				return true;
 			}
 		}
-		inner[size - 1].startTracking(seq);
+		return false;
 	}
 
-	final void reportError(Throwable t) {
-		ERROR.compareAndSet(this, null, t);
-	}
-
-	final boolean addInner(EmitterInner<T> inner) {
+	final boolean add(EmitterInner<T> inner) {
 		for (; ; ) {
-			EmitterInner<?>[] a = subscribers;
-			if (a == CANCELLED) {
+			FluxPublish.PubSubInner<T>[] a = subscribers;
+			if (a == TERMINATED) {
 				return false;
 			}
 			int n = a.length;
 			if (n + 1 > maxConcurrency) {
-				throw Exceptions.failWithOverflow();
+				throw new IllegalStateException("Cannot subscribe more than " + "" + maxConcurrency + " subscribers.");
 			}
-			EmitterInner<?>[] b = new EmitterInner[n + 1];
+			FluxPublish.PubSubInner<?>[] b = new FluxPublish.PubSubInner[n + 1];
 			System.arraycopy(a, 0, b, 0, n);
 			b[n] = inner;
 			if (SUBSCRIBERS.compareAndSet(this, a, b)) {
@@ -573,65 +558,47 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 		}
 	}
 
-	final void removeInner(EmitterInner<?> inner, EmitterInner<?>[] lastRemoved) {
+	final void remove(FluxPublish.PubSubInner<T> inner) {
 		for (; ; ) {
-			EmitterInner<?>[] a = subscribers;
-			if (a == CANCELLED || a == EMPTY) {
+			FluxPublish.PubSubInner<T>[] a = subscribers;
+			if (a == TERMINATED || a == EMPTY) {
 				return;
 			}
 			int n = a.length;
-			int j = 0;
+			int j = -1;
 			for (int i = 0; i < n; i++) {
 				if (a[i] == inner) {
 					j = i;
 					break;
 				}
 			}
-			EmitterInner<?>[] b;
+
+			if (j < 0) {
+				return;
+			}
+
+			FluxPublish.PubSubInner<?>[] b;
 			if (n == 1) {
-				b = lastRemoved;
+				b = EMPTY;
 			}
 			else {
-				b = new EmitterInner<?>[n - 1];
+				b = new FluxPublish.PubSubInner<?>[n - 1];
 				System.arraycopy(a, 0, b, 0, j);
 				System.arraycopy(a, j + 1, b, j, n - j - 1);
 			}
 			if (SUBSCRIBERS.compareAndSet(this, a, b)) {
-				RingBuffer.Sequence poll = inner.pollCursor;
-				if (poll != null) {
-					getMainQueue().removeGatingSequence(poll);
+				if (autoCancel && b == EMPTY && Operators.terminate(S, this)) {
+					if (WIP.getAndIncrement(this) != 0) {
+						return;
+					}
+					terminate();
+					Queue<T> q = queue;
+					if (q != null) {
+						q.clear();
+					}
 				}
-				return;
 			}
-		}
-	}
-
-	final void requestMore(int buffered) {
-		Subscription subscription = upstreamSubscription;
-		if (subscription == Operators.emptySubscription()) {
 			return;
-		}
-
-		if (buffered < bufferSize) {
-			int r = outstanding;
-			if (r > limit) {
-				return;
-			}
-			int toRequest = (bufferSize - r) - buffered;
-			if (toRequest > 0 && subscription != null) {
-				OUTSTANDING.addAndGet(this, toRequest);
-				subscription.request(toRequest);
-			}
-		}
-	}
-
-	final void cancel() {
-		if (!done) {
-			Subscription s = upstreamSubscription;
-			if (s != null) {
-				upstreamSubscription = null;
-				s.cancel();
-			}
 		}
 	}
 
@@ -640,97 +607,24 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Re
 		return subscribers.length;
 	}
 
-	@Override
-	public String toString() {
-		return "{" +
-				"done: " + done +
-				(error != null ? ", error: '" + error.getMessage() + "', " : "") +
-				", outstanding: " + outstanding +
-				", pending: " + emitBuffer +
-				'}';
-	}
+	static final class EmitterInner<T> extends FluxPublish.PubSubInner<T> {
 
-	static final class EmitterInner<T>
-			implements InnerProducer<T> {
+		final EmitterProcessor<T> parent;
 
-		static final long MASK_NOT_SUBSCRIBED = Long.MIN_VALUE;
-		final EmitterProcessor<T>   parent;
-		final Subscriber<? super T> actual;
-
-		volatile boolean done;
-
-		boolean unbounded = false;
-
-		private volatile long requested = MASK_NOT_SUBSCRIBED;
-
-		@SuppressWarnings("rawtypes")
-		static final AtomicLongFieldUpdater<EmitterInner> REQUESTED =
-				AtomicLongFieldUpdater.newUpdater(EmitterInner.class, "requested");
-
-		volatile RingBuffer.Sequence pollCursor;
-
-		@SuppressWarnings("rawtypes")
-        static final AtomicReferenceFieldUpdater<EmitterInner, RingBuffer.Sequence> CURSOR =
-				AtomicReferenceFieldUpdater.newUpdater(EmitterInner.class,
-						RingBuffer.Sequence.class,
-						"pollCursor");
-
-		EmitterInner(EmitterProcessor<T> parent, final Subscriber<? super T> actual) {
-			this.actual = actual;
+		EmitterInner(Subscriber<? super T> actual, EmitterProcessor<T> parent) {
+			super(actual);
 			this.parent = parent;
 		}
 
 		@Override
-		public void request(long n) {
-			if (Operators.checkRequest(n, actual)) {
-				Operators.getAndAddCap(REQUESTED, this, n);
-				if (EmitterProcessor.RUNNING.getAndIncrement(parent) == 0) {
-					parent.drainLoop();
-				}
-			}
-		}
-
-		@Override
-		public void cancel() {
-			done = true;
+		void drainParent() {
 			parent.drain();
 		}
 
 		@Override
-		public final Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return parent;
-				case TERMINATED:
-				case CANCELLED:
-					return done;
-				case BUFFERED:
-					return pollCursor == null || done ? -1L : parent.emitBuffer.getCursor() - pollCursor.getAsLong();
-			}
-			return InnerProducer.super.scan(key);
-		}
-
-		void startTracking(long seq) {
-			RingBuffer.Sequence pollSequence = RingBuffer.newSequence(seq - 1L);
-			if (CURSOR.compareAndSet(this, null, pollSequence)) {
-				parent.emitBuffer.addGatingSequence(pollSequence);
-			}
-		}
-
-		void start() {
-			if (REQUESTED.compareAndSet(this, MASK_NOT_SUBSCRIBED, 0)) {
-				RingBuffer<EventLoopProcessor.Slot<T>> ringBuffer = parent.emitBuffer;
-				if (ringBuffer != null) {
-					startTracking(Math.max(0L, ringBuffer.getMinimumGatingSequence() + 1L));
-				}
-
-				actual.onSubscribe(this);
-			}
-		}
-
-		@Override
-		public Subscriber<? super T> actual() {
-			return actual;
+		void removeAndDrainParent() {
+			parent.remove(this);
+			parent.drain();
 		}
 	}
 

--- a/src/main/java/reactor/core/publisher/EventLoopProcessor.java
+++ b/src/main/java/reactor/core/publisher/EventLoopProcessor.java
@@ -221,10 +221,10 @@ abstract class EventLoopProcessor<IN> extends FluxProcessor<IN, IN>
 		return r;
 	}
 
-	final ExecutorService executor;
+	final ExecutorService  executor;
 	final EventLoopContext contextClassLoader;
-	final String          name;
-	final boolean         autoCancel;
+	final String           name;
+	final boolean          autoCancel;
 
 	final RingBuffer<Slot<IN>> ringBuffer;
 	final WaitStrategy readWait = WaitStrategy.liteBlocking();

--- a/src/main/java/reactor/core/publisher/FluxCreate.java
+++ b/src/main/java/reactor/core/publisher/FluxCreate.java
@@ -63,32 +63,29 @@ final class FluxCreate<T> extends Flux<T> {
 		this.createMode = createMode;
 	}
 
-	@Override
-	public void subscribe(Subscriber<? super T> t) {
-		BaseSink<T> sink;
-
+	static <T> BaseSink<T> createSink(Subscriber<? super T> t, OverflowStrategy
+			backpressure){
 		switch (backpressure) {
 			case IGNORE: {
-				sink = new IgnoreSink<>(t);
-				break;
+				return new IgnoreSink<>(t);
 			}
 			case ERROR: {
-				sink = new ErrorAsyncSink<>(t);
-				break;
+				return new ErrorAsyncSink<>(t);
 			}
 			case DROP: {
-				sink = new DropAsyncSink<>(t);
-				break;
+				return new DropAsyncSink<>(t);
 			}
 			case LATEST: {
-				sink = new LatestAsyncSink<>(t);
-				break;
+				return new LatestAsyncSink<>(t);
 			}
 			default: {
-				sink = new BufferAsyncSink<>(t, QueueSupplier.SMALL_BUFFER_SIZE);
-				break;
+				return new BufferAsyncSink<>(t, QueueSupplier.SMALL_BUFFER_SIZE);
 			}
 		}
+	}
+	@Override
+	public void subscribe(Subscriber<? super T> t) {
+		BaseSink<T> sink = createSink(t, backpressure);
 
 		t.onSubscribe(sink);
 		try {

--- a/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -88,7 +88,11 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 	 * Note that {@link org.reactivestreams.Processor} can extend this behavior to effectively start its subscribers.
 	 *
 	 * @return this
+	 * @deprecated Will be removed in 3.1.0 where {@link FluxProcessor#onSubscribe(Subscription)} is not required by
+	 * default anymore and brings no benefit given the private scope of the
+	 * Subscription.
 	 */
+	@Deprecated
 	public FluxProcessor<IN, OUT> connect() {
 		onSubscribe(Operators.emptySubscription());
 		return this;
@@ -98,7 +102,9 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 	 * Create a {@link BlockingSink} and attach it via {@link #onSubscribe(Subscription)}.
 	 *
 	 * @return a new subscribed {@link BlockingSink}
+	 * @deprecated Will be removed in 3.1.0, use {@link #sink()}
 	 */
+	@Deprecated
 	public final BlockingSink<IN> connectSink() {
 		return connectSink(true);
 	}
@@ -109,9 +115,25 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 	 *
 	 * @param autostart automatically start?
 	 * @return a new {@link BlockingSink}
+	 * @deprecated Will be removed in 3.1.0, use {@link #sink()}
 	 */
+	@Deprecated
 	public final BlockingSink<IN> connectSink(boolean autostart) {
 		return BlockingSink.create(this, autostart);
+	}
+
+	@Override
+	public void dispose() {
+		onError(new CancellationException("Disposed"));
+	}
+
+	/**
+	 * Return the number of active {@link Subscriber} or {@literal -1} if untracked.
+	 *
+	 * @return the number of active {@link Subscriber} or {@literal -1} if untracked
+	 */
+	public long downstreamCount(){
+		return inners().count();
 	}
 
 	/**
@@ -124,6 +146,7 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 	}
 
 	@Override
+	@Deprecated
 	public final long getCapacity() {
 		return getBufferSize();
 	}
@@ -138,35 +161,27 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 	}
 
 	/**
-	 * Create a {@link FluxProcessor} that safely gates multi-threaded producer
-	 * {@link Subscriber#onNext(Object)}.
+	 * Return true if any {@link Subscriber} is actively subscribed
 	 *
-	 * @return a serializing {@link FluxProcessor}
+	 * @return true if any {@link Subscriber} is actively subscribed
 	 */
-	public final FluxProcessor<IN, OUT> serialize() {
-		return new DelegateProcessor<>(this, Operators.serialize(this));
-	}
-
-	/**
-	 * Note: From 3.1 this is to be left unimplemented
-	 */
-	@Override
-	public void subscribe(Subscriber<? super OUT> s) {
-		if (s == null) {
-			throw Exceptions.argumentIsNullException();
-		}
+	public boolean hasDownstreams() {
+		return downstreamCount() != 0L;
 	}
 
 	@Override
-	public void dispose() {
-		onError(new CancellationException("Disposed"));
+	public Stream<? extends Scannable> inners() {
+		return Stream.empty();
 	}
 
 	/**
 	 * Has this upstream started or "onSubscribed" ?
 	 *
 	 * @return has this upstream started or "onSubscribed" ?
+	 * @deprecated Will be removed in 3.1.0. Processor are stateful and started by default which means you can
+	 * onNext them directly
 	 */
+	@Deprecated
 	public boolean isStarted() {
 		return true;
 	}
@@ -181,31 +196,12 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 	}
 
 	/**
-	 * Return the number of active {@link Subscriber} or {@literal -1} if untracked.
+	 * Return true if this {@link FluxProcessor} supports multithread producing
 	 *
-	 * @return the number of active {@link Subscriber} or {@literal -1} if untracked
+	 * @return true if this {@link FluxProcessor} supports multithread producing
 	 */
-	public long downstreamCount(){
-		return inners().count();
-	}
-
-	/**
-	 * Return true if any {@link Subscriber} is actively subscribed
-	 *
-	 * @return true if any {@link Subscriber} is actively subscribed
-	 */
-	public boolean hasDownstreams() {
-		return downstreamCount() != 0L;
-	}
-
-	@Override
-	public Iterator<?> downstreams() {
-		return inners().iterator();
-	}
-
-	@Override
-	public Stream<? extends Scannable> inners() {
-		return Stream.empty();
+	public boolean isSerialized() {
+		return false;
 	}
 
 	@Override
@@ -219,5 +215,56 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 				return getBufferSize();
 		}
 		return null;
+	}
+
+	@Override
+	@Deprecated
+	public Iterator<?> downstreams() {
+		return inners().iterator();
+	}
+
+	/**
+	 * Create a {@link FluxProcessor} that safely gates multi-threaded producer
+	 * {@link Subscriber#onNext(Object)}.
+	 *
+	 * @return a serializing {@link FluxProcessor}
+	 */
+	public final FluxProcessor<IN, OUT> serialize() {
+		return new DelegateProcessor<>(this, Operators.serialize(this));
+	}
+
+	/**
+	 * Create a {@link FluxSink} that safely gates multi-threaded producer
+	 * {@link Subscriber#onNext(Object)}.
+	 *
+	 * <p> The returned {@link FluxSink} will not apply any
+	 * {@link FluxSink.OverflowStrategy} and overflowing {@link FluxSink#next(Object)}
+	 * will behave in two possible ways depending on the Processor:
+	 * <ul>
+	 * <li> an unbounded processor will handle the overflow itself by dropping or
+	 * buffering </li>
+	 * <li> a bounded processor will block/spin</li>
+	 * </ul>
+	 *
+	 * @return a serializing {@link FluxSink}
+	 */
+	public final FluxSink<IN> sink() {
+		FluxCreate.IgnoreSink<IN> s = new FluxCreate.IgnoreSink<>(this);
+		onSubscribe(s);
+		if(s.isCancelled() ||
+				(isSerialized() && getBufferSize() == Integer.MAX_VALUE)){
+			return s;
+		}
+		return new FluxCreate.SerializedSink<>(s);
+	}
+
+	/**
+	 * Note: From 3.1 this is to be left unimplemented
+	 */
+	@Override
+	public void subscribe(Subscriber<? super OUT> s) {
+		if (s == null) {
+			throw Exceptions.argumentIsNullException();
+		}
 	}
 }

--- a/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -89,7 +89,7 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 	 * Note that {@link org.reactivestreams.Processor} can extend this behavior to effectively start its subscribers.
 	 *
 	 * @return this
-	 * @deprecated Will be removed in 3.1.0 where {@link FluxProcessor#onSubscribe(Subscription)} is not required by
+	 * @deprecated Will be removed in 3.1.0. {@link FluxProcessor#onSubscribe(Subscription)} is not required by
 	 * default anymore and brings no benefit given the private scope of the
 	 * Subscription.
 	 */

--- a/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -18,8 +18,10 @@ package reactor.core.publisher;
 
 import java.util.Objects;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -45,6 +47,912 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 	final Scheduler scheduler;
 
 	volatile ReplaySubscriber<T> connection;
+
+	interface ReplaySubscription<T> extends QueueSubscription<T>, InnerProducer<T> {
+
+		Subscriber<? super T> actual();
+
+		boolean enter();
+
+		int leave(int missed);
+
+		void produced(long n);
+
+		void node(Object node);
+
+		Object node();
+
+		int tailIndex();
+
+		void tailIndex(int tailIndex);
+
+		int index();
+
+		void index(int index);
+
+		int fusionMode();
+
+		boolean isCancelled();
+
+		long requested();
+	}
+
+	interface ReplayBuffer<T> {
+
+		void add(T value);
+
+		void onError(Throwable ex);
+
+		Throwable getError();
+
+		void onComplete();
+
+		void replay(ReplaySubscription<T> rs);
+
+		boolean isDone();
+
+		T poll(ReplaySubscription<T> rs);
+
+		void clear(ReplaySubscription<T> rs);
+
+		boolean isEmpty(ReplaySubscription<T> rs);
+
+		int size(ReplaySubscription<T> rs);
+
+		int size();
+
+		int capacity();
+	}
+
+	static final class SizeAndTimeBoundReplayBuffer<T> implements ReplayBuffer<T> {
+
+		static final class TimedNode<T> extends AtomicReference<TimedNode<T>> {
+
+			final T    value;
+			final long time;
+
+			TimedNode(T value, long time) {
+				this.value = value;
+				this.time = time;
+			}
+		}
+
+		final int            limit;
+		final long           maxAge;
+		final Scheduler scheduler;
+		int size;
+
+		volatile TimedNode<T> head;
+
+		TimedNode<T> tail;
+
+		Throwable error;
+		volatile boolean done;
+
+		SizeAndTimeBoundReplayBuffer(int limit,
+				long maxAge,
+				Scheduler scheduler) {
+			this.limit = limit;
+			this.maxAge = maxAge;
+			this.scheduler = scheduler;
+			TimedNode<T> h = new TimedNode<>(null, 0L);
+			this.tail = h;
+			this.head = h;
+		}
+
+		@SuppressWarnings("unchecked")
+		void replayNormal(ReplaySubscription<T> rs) {
+			int missed = 1;
+			final Subscriber<? super T> a = rs.actual();
+
+			for (; ; ) {
+				@SuppressWarnings("unchecked") TimedNode<T> node =
+						(TimedNode<T>) rs.node();
+				if (node == null) {
+					node = head;
+					if (!done) {
+						// skip old entries
+						long limit = scheduler.now(TimeUnit.MILLISECONDS) - maxAge;
+						TimedNode<T> next = node;
+						while (next != null) {
+							long ts = next.time;
+							if (ts > limit) {
+								break;
+							}
+							node = next;
+							next = node.get();
+						}
+					}
+				}
+
+				long r = rs.requested();
+				long e = 0L;
+
+				while (e != r) {
+					if (rs.isCancelled()) {
+						rs.node(null);
+						return;
+					}
+
+					boolean d = done;
+					TimedNode<T> next = node.get();
+					boolean empty = next == null;
+
+					if (d && empty) {
+						rs.node(null);
+						Throwable ex = error;
+						if (ex != null) {
+							a.onError(ex);
+						}
+						else {
+							a.onComplete();
+						}
+						return;
+					}
+
+					if (empty) {
+						break;
+					}
+
+					a.onNext(next.value);
+
+					e++;
+					node = next;
+				}
+
+				if (e == r) {
+					if (rs.isCancelled()) {
+						rs.node(null);
+						return;
+					}
+
+					boolean d = done;
+					boolean empty = node.get() == null;
+
+					if (d && empty) {
+						rs.node(null);
+						Throwable ex = error;
+						if (ex != null) {
+							a.onError(ex);
+						}
+						else {
+							a.onComplete();
+						}
+						return;
+					}
+				}
+
+				if (e != 0L) {
+					if (r != Long.MAX_VALUE) {
+						rs.produced(e);
+					}
+				}
+
+				rs.node(node);
+
+				missed = rs.leave(missed);
+				if (missed == 0) {
+					break;
+				}
+			}
+		}
+
+		void replayFused(ReplaySubscription<T> rs) {
+			int missed = 1;
+
+			final Subscriber<? super T> a = rs.actual();
+
+			for (; ; ) {
+
+				if (rs.isCancelled()) {
+					rs.node(null);
+					return;
+				}
+
+				boolean d = done;
+
+				a.onNext(null);
+
+				if (d) {
+					Throwable ex = error;
+					if (ex != null) {
+						a.onError(ex);
+					}
+					else {
+						a.onComplete();
+					}
+					return;
+				}
+
+				missed = rs.leave(missed);
+				if (missed == 0) {
+					break;
+				}
+			}
+		}
+
+		@Override
+		public void onError(Throwable ex) {
+			done = true;
+			error = ex;
+		}
+
+		@Override
+		public Throwable getError() {
+			return error;
+		}
+
+		@Override
+		public void onComplete() {
+			done = true;
+		}
+
+		@Override
+		public boolean isDone() {
+			return done;
+		}
+
+		@SuppressWarnings("unchecked")
+		TimedNode<T> latestHead(ReplaySubscription<T> rs) {
+			long now = scheduler.now(TimeUnit.MILLISECONDS) - maxAge;
+
+			TimedNode<T> h = (TimedNode<T>) rs.node();
+			if (h == null) {
+				h = head;
+			}
+			TimedNode<T> n;
+			while ((n = h.get()) != null) {
+				if (n.time > now) {
+					break;
+				}
+				h = n;
+			}
+			return h;
+		}
+
+		@Override
+		public T poll(ReplaySubscription<T> rs) {
+			TimedNode<T> node = latestHead(rs);
+			TimedNode<T> next;
+			long now = scheduler.now(TimeUnit.MILLISECONDS) - maxAge;
+			while ((next = node.get()) != null) {
+				if (next.time > now) {
+					node = next;
+					break;
+				}
+				node = next;
+			}
+			if (next == null) {
+				return null;
+			}
+			rs.node(next);
+
+			return node.value;
+		}
+
+		@Override
+		public void clear(ReplaySubscription<T> rs) {
+			rs.node(null);
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public boolean isEmpty(ReplaySubscription<T> rs) {
+			TimedNode<T> node = latestHead(rs);
+			return node.get() == null;
+		}
+
+		@Override
+		public int size(ReplaySubscription<T> rs) {
+			TimedNode<T> node = latestHead(rs);
+			int count = 0;
+
+			TimedNode<T> next;
+			while ((next = node.get()) != null && count != Integer.MAX_VALUE) {
+				count++;
+				node = next;
+			}
+
+			return count;
+		}
+
+		@Override
+		public int size() {
+			TimedNode<T> node = head;
+			int count = 0;
+
+			TimedNode<T> next;
+			while ((next = node.get()) != null && count != Integer.MAX_VALUE) {
+				count++;
+				node = next;
+			}
+
+			return count;
+		}
+
+		@Override
+		public int capacity() {
+			return limit;
+		}
+
+		@Override
+		public void add(T value) {
+			TimedNode<T> n = new TimedNode<>(value, scheduler.now(TimeUnit.MILLISECONDS));
+			tail.set(n);
+			tail = n;
+			int s = size;
+			if (s == limit) {
+				head = head.get();
+			}
+			else {
+				size = s + 1;
+			}
+			long limit = scheduler.now(TimeUnit.MILLISECONDS) - maxAge;
+
+			TimedNode<T> h = head;
+			TimedNode<T> next;
+			int removed = 0;
+			for (; ; ) {
+				next = h.get();
+				if (next == null) {
+					break;
+				}
+
+				if (next.time > limit) {
+					if (removed != 0) {
+						size = size - removed;
+						head = h;
+					}
+					break;
+				}
+
+				h = next;
+				removed++;
+			}
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public void replay(ReplaySubscription<T> rs) {
+			if (!rs.enter()) {
+				return;
+			}
+
+			if (rs.fusionMode() == NONE) {
+				replayNormal(rs);
+			}
+			else {
+				replayFused(rs);
+			}
+		}
+	}
+
+	static final class UnboundedReplayBuffer<T> implements ReplayBuffer<T> {
+
+		final int batchSize;
+
+		volatile int size;
+
+		final Object[] head;
+
+		Object[] tail;
+
+		int tailIndex;
+
+		volatile boolean done;
+		Throwable error;
+
+		UnboundedReplayBuffer(int batchSize) {
+			this.batchSize = batchSize;
+			Object[] n = new Object[batchSize + 1];
+			this.tail = n;
+			this.head = n;
+		}
+
+		@Override
+		public Throwable getError() {
+			return error;
+		}
+
+		@Override
+		public int capacity() {
+			return Integer.MAX_VALUE;
+		}
+
+		@Override
+		public void add(T value) {
+			int i = tailIndex;
+			Object[] a = tail;
+			if (i == a.length - 1) {
+				Object[] b = new Object[a.length];
+				b[0] = value;
+				tailIndex = 1;
+				a[i] = b;
+				tail = b;
+			}
+			else {
+				a[i] = value;
+				tailIndex = i + 1;
+			}
+			size++;
+		}
+
+		@Override
+		public void onError(Throwable ex) {
+			error = ex;
+			done = true;
+		}
+
+		@Override
+		public void onComplete() {
+			done = true;
+		}
+
+		void replayNormal(ReplaySubscription<T> rs) {
+			int missed = 1;
+
+			final Subscriber<? super T> a = rs.actual();
+			final int n = batchSize;
+
+			for (; ; ) {
+
+				long r = rs.requested();
+				long e = 0L;
+
+				Object[] node = (Object[]) rs.node();
+				if (node == null) {
+					node = head;
+				}
+				int tailIndex = rs.tailIndex();
+				int index = rs.index();
+
+				while (e != r) {
+					if (rs.isCancelled()) {
+						rs.node(null);
+						return;
+					}
+
+					boolean d = done;
+					boolean empty = index == size;
+
+					if (d && empty) {
+						rs.node(null);
+						Throwable ex = error;
+						if (ex != null) {
+							a.onError(ex);
+						}
+						else {
+							a.onComplete();
+						}
+						return;
+					}
+
+					if (empty) {
+						break;
+					}
+
+					if (tailIndex == n) {
+						node = (Object[]) node[tailIndex];
+						tailIndex = 0;
+					}
+
+					@SuppressWarnings("unchecked") T v = (T) node[tailIndex];
+
+					a.onNext(v);
+
+					e++;
+					tailIndex++;
+					index++;
+				}
+
+				if (e == r) {
+					if (rs.isCancelled()) {
+						rs.node(null);
+						return;
+					}
+
+					boolean d = done;
+					boolean empty = index == size;
+
+					if (d && empty) {
+						rs.node(null);
+						Throwable ex = error;
+						if (ex != null) {
+							a.onError(ex);
+						}
+						else {
+							a.onComplete();
+						}
+						return;
+					}
+				}
+
+				if (e != 0L) {
+					if (r != Long.MAX_VALUE) {
+						rs.produced(e);
+					}
+				}
+
+				rs.index(index);
+				rs.tailIndex(tailIndex);
+				rs.node(node);
+
+				missed = rs.leave(missed);
+				if (missed == 0) {
+					break;
+				}
+			}
+		}
+
+		void replayFused(ReplaySubscription<T> rs) {
+			int missed = 1;
+
+			final Subscriber<? super T> a = rs.actual();
+
+			for (; ; ) {
+
+				if (rs.isCancelled()) {
+					rs.node(null);
+					return;
+				}
+
+				boolean d = done;
+
+				a.onNext(null);
+
+				if (d) {
+					Throwable ex = error;
+					if (ex != null) {
+						a.onError(ex);
+					}
+					else {
+						a.onComplete();
+					}
+					return;
+				}
+
+				missed = rs.leave(missed);
+				if (missed == 0) {
+					break;
+				}
+			}
+		}
+
+		@Override
+		public void replay(ReplaySubscription<T> rs) {
+			if (!rs.enter()) {
+				return;
+			}
+
+			if (rs.fusionMode() == NONE) {
+				replayNormal(rs);
+			}
+			else {
+				replayFused(rs);
+			}
+		}
+
+		@Override
+		public boolean isDone() {
+			return done;
+		}
+
+		@Override
+		public T poll(ReplaySubscription<T> rs) {
+			int index = rs.index();
+			if (index == size) {
+				return null;
+			}
+			Object[] node = (Object[]) rs.node();
+			if (node == null) {
+				node = head;
+				rs.node(node);
+			}
+			int tailIndex = rs.tailIndex();
+			if (tailIndex == batchSize) {
+				node = (Object[]) node[tailIndex];
+				tailIndex = 0;
+				rs.node(node);
+			}
+			@SuppressWarnings("unchecked") T v = (T) node[tailIndex];
+			rs.index(index + 1);
+			rs.tailIndex(tailIndex + 1);
+			return v;
+		}
+
+		@Override
+		public void clear(ReplaySubscription<T> rs) {
+			rs.node(null);
+		}
+
+		@Override
+		public boolean isEmpty(ReplaySubscription<T> rs) {
+			return rs.index() == size;
+		}
+
+		@Override
+		public int size(ReplaySubscription<T> rs) {
+			return size - rs.index();
+		}
+
+		@Override
+		public int size() {
+			return size;
+		}
+
+	}
+
+	static final class SizeBoundReplayBuffer<T> implements ReplayBuffer<T> {
+
+		final int limit;
+
+		volatile Node<T> head;
+
+		Node<T> tail;
+
+		int size;
+
+		volatile boolean done;
+		Throwable error;
+
+		SizeBoundReplayBuffer(int limit) {
+			if(limit < 0){
+				throw new IllegalArgumentException("Limit cannot be negative");
+			}
+			this.limit = limit;
+			Node<T> n = new Node<>(null);
+			this.tail = n;
+			this.head = n;
+		}
+
+		@Override
+		public int capacity() {
+			return limit;
+		}
+
+		@Override
+		public void add(T value) {
+			Node<T> n = new Node<>(value);
+			tail.set(n);
+			tail = n;
+			int s = size;
+			if (s == limit) {
+				head = head.get();
+			}
+			else {
+				size = s + 1;
+			}
+		}
+
+		@Override
+		public void onError(Throwable ex) {
+			error = ex;
+			done = true;
+		}
+
+		@Override
+		public void onComplete() {
+			done = true;
+		}
+
+		void replayNormal(ReplaySubscription<T> rs) {
+			final Subscriber<? super T> a = rs.actual();
+
+			int missed = 1;
+
+			for (; ; ) {
+
+				long r = rs.requested();
+				long e = 0L;
+
+				@SuppressWarnings("unchecked") Node<T> node = (Node<T>) rs.node();
+				if (node == null) {
+					node = head;
+				}
+
+				while (e != r) {
+					if (rs.isCancelled()) {
+						rs.node(null);
+						return;
+					}
+
+					boolean d = done;
+					Node<T> next = node.get();
+					boolean empty = next == null;
+
+					if (d && empty) {
+						rs.node(null);
+						Throwable ex = error;
+						if (ex != null) {
+							a.onError(ex);
+						}
+						else {
+							a.onComplete();
+						}
+						return;
+					}
+
+					if (empty) {
+						break;
+					}
+
+					a.onNext(next.value);
+
+					e++;
+					node = next;
+				}
+
+				if (e == r) {
+					if (rs.isCancelled()) {
+						rs.node(null);
+						return;
+					}
+
+					boolean d = done;
+					boolean empty = node.get() == null;
+
+					if (d && empty) {
+						rs.node(null);
+						Throwable ex = error;
+						if (ex != null) {
+							a.onError(ex);
+						}
+						else {
+							a.onComplete();
+						}
+						return;
+					}
+				}
+
+				if (e != 0L) {
+					if (r != Long.MAX_VALUE) {
+						rs.produced(e);
+					}
+				}
+
+				rs.node(node);
+
+				missed = rs.leave(missed);
+				if (missed == 0) {
+					break;
+				}
+			}
+		}
+
+		void replayFused(ReplaySubscription<T> rs) {
+			int missed = 1;
+
+			final Subscriber<? super T> a = rs.actual();
+
+			for (; ; ) {
+
+				if (rs.isCancelled()) {
+					rs.node(null);
+					return;
+				}
+
+				boolean d = done;
+
+				a.onNext(null);
+
+				if (d) {
+					Throwable ex = error;
+					if (ex != null) {
+						a.onError(ex);
+					}
+					else {
+						a.onComplete();
+					}
+					return;
+				}
+
+				missed = rs.leave(missed);
+				if (missed == 0) {
+					break;
+				}
+			}
+		}
+
+		@Override
+		public void replay(ReplaySubscription<T> rs) {
+			if (!rs.enter()) {
+				return;
+			}
+
+			if (rs.fusionMode() == NONE) {
+				replayNormal(rs);
+			}
+			else {
+				replayFused(rs);
+			}
+		}
+
+		@Override
+		public Throwable getError() {
+			return error;
+		}
+
+		@Override
+		public boolean isDone() {
+			return done;
+		}
+
+		static final class Node<T> extends AtomicReference<Node<T>> {
+
+			/** */
+			private static final long serialVersionUID = 3713592843205853725L;
+
+			final T value;
+
+			Node(T value) {
+				this.value = value;
+			}
+		}
+
+		@Override
+		public T poll(ReplaySubscription<T> rs) {
+			@SuppressWarnings("unchecked") Node<T> node = (Node<T>) rs.node();
+			if (node == null) {
+				node = head;
+				rs.node(node);
+			}
+
+			Node<T> next = node.get();
+			if (next == null) {
+				return null;
+			}
+			rs.node(next);
+
+			return next.value;
+		}
+
+		@Override
+		public void clear(ReplaySubscription<T> rs) {
+			rs.node(null);
+		}
+
+		@Override
+		public boolean isEmpty(ReplaySubscription<T> rs) {
+			@SuppressWarnings("unchecked") Node<T> node = (Node<T>) rs.node();
+			if (node == null) {
+				node = head;
+				rs.node(node);
+			}
+			return node.get() == null;
+		}
+
+		@Override
+		public int size(ReplaySubscription<T> rs) {
+			@SuppressWarnings("unchecked") Node<T> node = (Node<T>) rs.node();
+			if (node == null) {
+				node = head;
+			}
+			int count = 0;
+
+			Node<T> next;
+			while ((next = node.get()) != null && count != Integer.MAX_VALUE) {
+				count++;
+				node = next;
+			}
+
+			return count;
+		}
+
+		@Override
+		public int size() {
+			Node<T> node = head;
+			int count = 0;
+
+			Node<T> next;
+			while ((next = node.get()) != null && count != Integer.MAX_VALUE) {
+				count++;
+				node = next;
+			}
+
+			return count;
+		}
+	}
+
 	@SuppressWarnings("rawtypes")
 	static final AtomicReferenceFieldUpdater<FluxReplay, ReplaySubscriber> CONNECTION =
 			AtomicReferenceFieldUpdater.newUpdater(FluxReplay.class,
@@ -74,16 +982,16 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 
 	ReplaySubscriber<T> newState() {
 		if (scheduler != null) {
-			return new ReplaySubscriber<>(new ReplayProcessor.SizeAndTimeBoundReplayBuffer<>(history,
+			return new ReplaySubscriber<>(new SizeAndTimeBoundReplayBuffer<>(history,
 					ttl,
 					scheduler),
 					this);
 		}
 		if (history != Integer.MAX_VALUE) {
-			return new ReplaySubscriber<>(new ReplayProcessor.SizeBoundReplayBuffer<>(history),
+			return new ReplaySubscriber<>(new SizeBoundReplayBuffer<>(history),
 					this);
 		}
-		return new ReplaySubscriber<>(new ReplayProcessor.UnboundedReplayBuffer<>(QueueSupplier.SMALL_BUFFER_SIZE),
+		return new ReplaySubscriber<>(new UnboundedReplayBuffer<>(QueueSupplier.SMALL_BUFFER_SIZE),
 					this);
 	}
 
@@ -156,8 +1064,8 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 	static final class ReplaySubscriber<T>
 			implements InnerConsumer<T>, Disposable {
 
-		final FluxReplay<T>                   parent;
-		final ReplayProcessor.ReplayBuffer<T> buffer;
+		final FluxReplay<T>   parent;
+		final ReplayBuffer<T> buffer;
 
 		volatile Subscription s;
 		@SuppressWarnings("rawtypes")
@@ -166,7 +1074,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 						Subscription.class,
 						"s");
 
-		volatile ReplayInner<T>[] subscribers;
+		volatile ReplaySubscription<T>[] subscribers;
 
 		volatile int wip;
 		@SuppressWarnings("rawtypes")
@@ -179,14 +1087,14 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 				AtomicIntegerFieldUpdater.newUpdater(ReplaySubscriber.class, "connected");
 
 		@SuppressWarnings("rawtypes")
-		static final ReplayInner[] EMPTY      = new ReplayInner[0];
+		static final ReplaySubscription[] EMPTY      = new ReplaySubscription[0];
 		@SuppressWarnings("rawtypes")
-		static final ReplayInner[] TERMINATED = new ReplayInner[0];
+		static final ReplaySubscription[] TERMINATED = new ReplaySubscription[0];
 
 		volatile boolean cancelled;
 
 		@SuppressWarnings("unchecked")
-		ReplaySubscriber(ReplayProcessor.ReplayBuffer<T> buffer,
+		ReplaySubscriber(ReplayBuffer<T> buffer,
 				FluxReplay<T> parent) {
 			this.buffer = buffer;
 			this.parent = parent;
@@ -205,13 +1113,13 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 
 		@Override
 		public void onNext(T t) {
-			ReplayProcessor.ReplayBuffer<T> b = buffer;
+			ReplayBuffer<T> b = buffer;
 			if (b.isDone()) {
 				Operators.onNextDropped(t);
 			}
 			else {
 				b.add(t);
-				for (ReplayInner<T> rs : subscribers) {
+				for (ReplaySubscription<T> rs : subscribers) {
 					b.replay(rs);
 				}
 			}
@@ -219,16 +1127,16 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 
 		@Override
 		public void onError(Throwable t) {
-			ReplayProcessor.ReplayBuffer<T> b = buffer;
+			ReplayBuffer<T> b = buffer;
 			if (b.isDone()) {
 				Operators.onErrorDropped(t);
 			}
 			else {
 				b.onError(t);
 
-				ReplayInner<T>[] a = subscribers;
+				ReplaySubscription<T>[] a = subscribers;
 
-				for (ReplayInner<T> rs : a) {
+				for (ReplaySubscription<T> rs : a) {
 					b.replay(rs);
 				}
 			}
@@ -236,13 +1144,13 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 
 		@Override
 		public void onComplete() {
-			ReplayProcessor.ReplayBuffer<T> b = buffer;
+			ReplayBuffer<T> b = buffer;
 			if (!b.isDone()) {
 				b.onComplete();
 
-				ReplayInner<T>[] a = subscribers;
+				ReplaySubscription<T>[] a = subscribers;
 
-				for (ReplayProcessor.ReplaySubscription<T> rs : a) {
+				for (ReplaySubscription<T> rs : a) {
 					b.replay(rs);
 				}
 			}
@@ -265,8 +1173,8 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 		void disconnectAction() {
 			CancellationException ex = new CancellationException("Disconnected");
 			buffer.onError(ex);
-			for (ReplayInner<T> inner : terminate()) {
-				inner.actual.onError(ex);
+			for (ReplaySubscription<T> inner : terminate()) {
+				inner.actual().onError(ex);
 			}
 		}
 
@@ -275,7 +1183,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 				return false;
 			}
 			synchronized (this) {
-				ReplayInner<T>[] a = subscribers;
+				ReplaySubscription<T>[] a = subscribers;
 				if (a == TERMINATED) {
 					return false;
 				}
@@ -292,8 +1200,8 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 		}
 
 		@SuppressWarnings("unchecked")
-		void remove(ReplayInner<T> inner) {
-			ReplayInner<T>[] a = subscribers;
+		void remove(ReplaySubscription<T> inner) {
+			ReplaySubscription<T>[] a = subscribers;
 			if (a == TERMINATED || a == EMPTY) {
 				return;
 			}
@@ -315,7 +1223,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 					return;
 				}
 
-				ReplayInner<T>[] b;
+				ReplaySubscription<T>[] b;
 				if (n == 1) {
 					b = EMPTY;
 				}
@@ -330,8 +1238,8 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 		}
 
 		@SuppressWarnings("unchecked")
-		ReplayInner<T>[] terminate() {
-			ReplayInner<T>[] a = subscribers;
+		ReplaySubscription<T>[] terminate() {
+			ReplaySubscription<T>[] a = subscribers;
 			if (a == TERMINATED) {
 				return a;
 			}
@@ -400,7 +1308,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 	}
 
 	static final class ReplayInner<T>
-			implements ReplayProcessor.ReplaySubscription<T> {
+			implements ReplaySubscription<T> {
 
 		final Subscriber<? super T> actual;
 
@@ -462,7 +1370,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 				case REQUESTED_FROM_DOWNSTREAM:
 					return isCancelled() ? 0L : requested;
 			}
-			return ReplayProcessor.ReplaySubscription.super.scan(key);
+			return ReplaySubscription.super.scan(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/Operators.java
+++ b/src/main/java/reactor/core/publisher/Operators.java
@@ -558,13 +558,14 @@ public abstract class Operators {
 	 * @return true if successful, false if the target was not empty or has been cancelled
 	 */
 	public static <F> boolean setOnce(AtomicReferenceFieldUpdater<F, Subscription> field, F instance, Subscription s) {
+		Objects.requireNonNull(s, "subscription");
 		Subscription a = field.get(instance);
 		if (a == CancelledSubscription.INSTANCE) {
 			s.cancel();
 			return false;
 		}
 		if (a != null) {
-			a.cancel();
+			s.cancel();
 			reportSubscriptionSet();
 			return false;
 		}

--- a/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -430,6 +430,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	}
 
 	@Override
+	@Deprecated
 	public int getBufferSize() {
 		return buffer.capacity();
 	}
@@ -440,6 +441,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	}
 
 	@Override
+	@Deprecated
 	public boolean isStarted() {
 		return subscription != null;
 	}
@@ -561,6 +563,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	}
 
 	@Override
+	@Deprecated
 	public ReplayProcessor<T> connect() {
 		onSubscribe(Operators.emptySubscription());
 		return this;

--- a/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -18,10 +18,8 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.stream.Stream;
 
@@ -35,6 +33,9 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.core.scheduler.TimedScheduler;
 import reactor.util.concurrent.QueueSupplier;
+
+import static reactor.core.publisher.FluxReplay.ReplaySubscriber.EMPTY;
+import static reactor.core.publisher.FluxReplay.ReplaySubscriber.TERMINATED;
 
 /**
  * Replays all or the last N items to Subscribers.
@@ -125,12 +126,12 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * @return a fresh processor
 	 */
 	public static <E> ReplayProcessor<E> create(int historySize, boolean unbounded) {
-		ReplayBuffer<E> buffer;
+		FluxReplay.ReplayBuffer<E> buffer;
 		if (unbounded) {
-			buffer = new UnboundedReplayBuffer<>(historySize);
+			buffer = new FluxReplay.UnboundedReplayBuffer<>(historySize);
 		}
 		else {
-			buffer = new SizeBoundReplayBuffer<>(historySize);
+			buffer = new FluxReplay.SizeBoundReplayBuffer<>(historySize);
 		}
 		return new ReplayProcessor<>(buffer);
 	}
@@ -363,28 +364,23 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 		if (size <= 0) {
 			throw new IllegalArgumentException("size > 0 required but it was " + size);
 		}
-		return new ReplayProcessor<>(new SizeAndTimeBoundReplayBuffer<>(size,
+		return new ReplayProcessor<>(new FluxReplay.SizeAndTimeBoundReplayBuffer<>(size,
 				maxAge.toMillis(),
 				scheduler));
 	}
 
-	final ReplayBuffer<T> buffer;
+	final FluxReplay.ReplayBuffer<T> buffer;
 
 	Subscription subscription;
 
-	volatile ReplaySubscription<T>[] subscribers;
+	volatile FluxReplay.ReplaySubscription<T>[] subscribers;
 	@SuppressWarnings("rawtypes")
-	static final AtomicReferenceFieldUpdater<ReplayProcessor, ReplaySubscription[]>
+	static final AtomicReferenceFieldUpdater<ReplayProcessor, FluxReplay.ReplaySubscription[]>
 			SUBSCRIBERS = AtomicReferenceFieldUpdater.newUpdater(ReplayProcessor.class,
-			ReplaySubscription[].class,
+			FluxReplay.ReplaySubscription[].class,
 			"subscribers");
 
-	@SuppressWarnings("rawtypes")
-	static final ReplaySubscription[] EMPTY      = new ReplaySubscription[0];
-	@SuppressWarnings("rawtypes")
-	static final ReplaySubscription[] TERMINATED = new ReplaySubscription[0];
-
-	ReplayProcessor(ReplayBuffer<T> buffer) {
+	ReplayProcessor(FluxReplay.ReplayBuffer<T> buffer) {
 		this.buffer = buffer;
 		SUBSCRIBERS.lazySet(this, EMPTY);
 	}
@@ -394,7 +390,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 		if (s == null) {
 			throw Exceptions.argumentIsNullException();
 		}
-		ReplaySubscription<T> rs = new ReplayInner<>(s, this);
+		FluxReplay.ReplaySubscription<T> rs = new ReplayInner<>(s, this);
 		s.onSubscribe(rs);
 
 		if (add(rs)) {
@@ -446,15 +442,15 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 		return subscription != null;
 	}
 
-	boolean add(ReplaySubscription<T> rs) {
+	boolean add(FluxReplay.ReplaySubscription<T> rs) {
 		for (; ; ) {
-			ReplaySubscription<T>[] a = subscribers;
+			FluxReplay.ReplaySubscription<T>[] a = subscribers;
 			if (a == TERMINATED) {
 				return false;
 			}
 			int n = a.length;
 
-			@SuppressWarnings("unchecked") ReplaySubscription<T>[] b =
+			@SuppressWarnings("unchecked") FluxReplay.ReplaySubscription<T>[] b =
 					new ReplayInner[n + 1];
 			System.arraycopy(a, 0, b, 0, n);
 			b[n] = rs;
@@ -465,10 +461,10 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	}
 
 	@SuppressWarnings("unchecked")
-	void remove(ReplaySubscription<T> rs) {
+	void remove(FluxReplay.ReplaySubscription<T> rs) {
 		outer:
 		for (; ; ) {
-			ReplaySubscription<T>[] a = subscribers;
+			FluxReplay.ReplaySubscription<T>[] a = subscribers;
 			if (a == TERMINATED || a == EMPTY) {
 				return;
 			}
@@ -476,7 +472,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 
 			for (int i = 0; i < n; i++) {
 				if (a[i] == rs) {
-					ReplaySubscription<T>[] b;
+					FluxReplay.ReplaySubscription<T>[] b;
 
 					if (n == 1) {
 						b = EMPTY;
@@ -517,13 +513,13 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 
 	@Override
 	public void onNext(T t) {
-		ReplayBuffer<T> b = buffer;
+		FluxReplay.ReplayBuffer<T> b = buffer;
 		if (b.isDone()) {
 			Operators.onNextDropped(t);
 		}
 		else {
 			b.add(t);
-			for (ReplaySubscription<T> rs : subscribers) {
+			for (FluxReplay.ReplaySubscription<T> rs : subscribers) {
 				b.replay(rs);
 			}
 		}
@@ -531,17 +527,17 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 
 	@Override
 	public void onError(Throwable t) {
-		ReplayBuffer<T> b = buffer;
+		FluxReplay.ReplayBuffer<T> b = buffer;
 		if (b.isDone()) {
 			Operators.onErrorDropped(t);
 		}
 		else {
 			b.onError(t);
 
-			@SuppressWarnings("unchecked") ReplaySubscription<T>[] a =
+			@SuppressWarnings("unchecked") FluxReplay.ReplaySubscription<T>[] a =
 					SUBSCRIBERS.getAndSet(this, TERMINATED);
 
-			for (ReplaySubscription<T> rs : a) {
+			for (FluxReplay.ReplaySubscription<T> rs : a) {
 				b.replay(rs);
 			}
 		}
@@ -549,14 +545,14 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 
 	@Override
 	public void onComplete() {
-		ReplayBuffer<T> b = buffer;
+		FluxReplay.ReplayBuffer<T> b = buffer;
 		if (!b.isDone()) {
 			b.onComplete();
 
-			@SuppressWarnings("unchecked") ReplaySubscription<T>[] a =
+			@SuppressWarnings("unchecked") FluxReplay.ReplaySubscription<T>[] a =
 					SUBSCRIBERS.getAndSet(this, TERMINATED);
 
-			for (ReplaySubscription<T> rs : a) {
+			for (FluxReplay.ReplaySubscription<T> rs : a) {
 				b.replay(rs);
 			}
 		}
@@ -569,919 +565,14 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 		return this;
 	}
 
-	interface ReplayBuffer<T> {
-
-		void add(T value);
-
-		void onError(Throwable ex);
-
-		Throwable getError();
-
-		void onComplete();
-
-		void replay(ReplaySubscription<T> rs);
-
-		boolean isDone();
-
-		T poll(ReplaySubscription<T> rs);
-
-		void clear(ReplaySubscription<T> rs);
-
-		boolean isEmpty(ReplaySubscription<T> rs);
-
-		int size(ReplaySubscription<T> rs);
-
-		int size();
-
-		int capacity();
-	}
-
-	static final class UnboundedReplayBuffer<T> implements ReplayBuffer<T> {
-
-		final int batchSize;
-
-		volatile int size;
-
-		final Object[] head;
-
-		Object[] tail;
-
-		int tailIndex;
-
-		volatile boolean done;
-		Throwable error;
-
-		UnboundedReplayBuffer(int batchSize) {
-			this.batchSize = batchSize;
-			Object[] n = new Object[batchSize + 1];
-			this.tail = n;
-			this.head = n;
-		}
-
-		@Override
-		public Throwable getError() {
-			return error;
-		}
-
-		@Override
-		public int capacity() {
-			return Integer.MAX_VALUE;
-		}
-
-		@Override
-		public void add(T value) {
-			int i = tailIndex;
-			Object[] a = tail;
-			if (i == a.length - 1) {
-				Object[] b = new Object[a.length];
-				b[0] = value;
-				tailIndex = 1;
-				a[i] = b;
-				tail = b;
-			}
-			else {
-				a[i] = value;
-				tailIndex = i + 1;
-			}
-			size++;
-		}
-
-		@Override
-		public void onError(Throwable ex) {
-			error = ex;
-			done = true;
-		}
-
-		@Override
-		public void onComplete() {
-			done = true;
-		}
-
-		void replayNormal(ReplaySubscription<T> rs) {
-			int missed = 1;
-
-			final Subscriber<? super T> a = rs.actual();
-			final int n = batchSize;
-
-			for (; ; ) {
-
-				long r = rs.requested();
-				long e = 0L;
-
-				Object[] node = (Object[]) rs.node();
-				if (node == null) {
-					node = head;
-				}
-				int tailIndex = rs.tailIndex();
-				int index = rs.index();
-
-				while (e != r) {
-					if (rs.isCancelled()) {
-						rs.node(null);
-						return;
-					}
-
-					boolean d = done;
-					boolean empty = index == size;
-
-					if (d && empty) {
-						rs.node(null);
-						Throwable ex = error;
-						if (ex != null) {
-							a.onError(ex);
-						}
-						else {
-							a.onComplete();
-						}
-						return;
-					}
-
-					if (empty) {
-						break;
-					}
-
-					if (tailIndex == n) {
-						node = (Object[]) node[tailIndex];
-						tailIndex = 0;
-					}
-
-					@SuppressWarnings("unchecked") T v = (T) node[tailIndex];
-
-					a.onNext(v);
-
-					e++;
-					tailIndex++;
-					index++;
-				}
-
-				if (e == r) {
-					if (rs.isCancelled()) {
-						rs.node(null);
-						return;
-					}
-
-					boolean d = done;
-					boolean empty = index == size;
-
-					if (d && empty) {
-						rs.node(null);
-						Throwable ex = error;
-						if (ex != null) {
-							a.onError(ex);
-						}
-						else {
-							a.onComplete();
-						}
-						return;
-					}
-				}
-
-				if (e != 0L) {
-					if (r != Long.MAX_VALUE) {
-						rs.produced(e);
-					}
-				}
-
-				rs.index(index);
-				rs.tailIndex(tailIndex);
-				rs.node(node);
-
-				missed = rs.leave(missed);
-				if (missed == 0) {
-					break;
-				}
-			}
-		}
-
-		void replayFused(ReplaySubscription<T> rs) {
-			int missed = 1;
-
-			final Subscriber<? super T> a = rs.actual();
-
-			for (; ; ) {
-
-				if (rs.isCancelled()) {
-					rs.node(null);
-					return;
-				}
-
-				boolean d = done;
-
-				a.onNext(null);
-
-				if (d) {
-					Throwable ex = error;
-					if (ex != null) {
-						a.onError(ex);
-					}
-					else {
-						a.onComplete();
-					}
-					return;
-				}
-
-				missed = rs.leave(missed);
-				if (missed == 0) {
-					break;
-				}
-			}
-		}
-
-		@Override
-		public void replay(ReplaySubscription<T> rs) {
-			if (!rs.enter()) {
-				return;
-			}
-
-			if (rs.fusionMode() == NONE) {
-				replayNormal(rs);
-			}
-			else {
-				replayFused(rs);
-			}
-		}
-
-		@Override
-		public boolean isDone() {
-			return done;
-		}
-
-		@Override
-		public T poll(ReplaySubscription<T> rs) {
-			int index = rs.index();
-			if (index == size) {
-				return null;
-			}
-			Object[] node = (Object[]) rs.node();
-			if (node == null) {
-				node = head;
-				rs.node(node);
-			}
-			int tailIndex = rs.tailIndex();
-			if (tailIndex == batchSize) {
-				node = (Object[]) node[tailIndex];
-				tailIndex = 0;
-				rs.node(node);
-			}
-			@SuppressWarnings("unchecked") T v = (T) node[tailIndex];
-			rs.index(index + 1);
-			rs.tailIndex(tailIndex + 1);
-			return v;
-		}
-
-		@Override
-		public void clear(ReplaySubscription<T> rs) {
-			rs.node(null);
-		}
-
-		@Override
-		public boolean isEmpty(ReplaySubscription<T> rs) {
-			return rs.index() == size;
-		}
-
-		@Override
-		public int size(ReplaySubscription<T> rs) {
-			return size - rs.index();
-		}
-
-		@Override
-		public int size() {
-			return size;
-		}
-
-	}
-
-	static final class SizeBoundReplayBuffer<T> implements ReplayBuffer<T> {
-
-		final int limit;
-
-		volatile Node<T> head;
-
-		Node<T> tail;
-
-		int size;
-
-		volatile boolean done;
-		Throwable error;
-
-		SizeBoundReplayBuffer(int limit) {
-			if(limit < 0){
-				throw new IllegalArgumentException("Limit cannot be negative");
-			}
-			this.limit = limit;
-			Node<T> n = new Node<>(null);
-			this.tail = n;
-			this.head = n;
-		}
-
-		@Override
-		public int capacity() {
-			return limit;
-		}
-
-		@Override
-		public void add(T value) {
-			Node<T> n = new Node<>(value);
-			tail.set(n);
-			tail = n;
-			int s = size;
-			if (s == limit) {
-				head = head.get();
-			}
-			else {
-				size = s + 1;
-			}
-		}
-
-		@Override
-		public void onError(Throwable ex) {
-			error = ex;
-			done = true;
-		}
-
-		@Override
-		public void onComplete() {
-			done = true;
-		}
-
-		void replayNormal(ReplaySubscription<T> rs) {
-			final Subscriber<? super T> a = rs.actual();
-
-			int missed = 1;
-
-			for (; ; ) {
-
-				long r = rs.requested();
-				long e = 0L;
-
-				@SuppressWarnings("unchecked") Node<T> node = (Node<T>) rs.node();
-				if (node == null) {
-					node = head;
-				}
-
-				while (e != r) {
-					if (rs.isCancelled()) {
-						rs.node(null);
-						return;
-					}
-
-					boolean d = done;
-					Node<T> next = node.get();
-					boolean empty = next == null;
-
-					if (d && empty) {
-						rs.node(null);
-						Throwable ex = error;
-						if (ex != null) {
-							a.onError(ex);
-						}
-						else {
-							a.onComplete();
-						}
-						return;
-					}
-
-					if (empty) {
-						break;
-					}
-
-					a.onNext(next.value);
-
-					e++;
-					node = next;
-				}
-
-				if (e == r) {
-					if (rs.isCancelled()) {
-						rs.node(null);
-						return;
-					}
-
-					boolean d = done;
-					boolean empty = node.get() == null;
-
-					if (d && empty) {
-						rs.node(null);
-						Throwable ex = error;
-						if (ex != null) {
-							a.onError(ex);
-						}
-						else {
-							a.onComplete();
-						}
-						return;
-					}
-				}
-
-				if (e != 0L) {
-					if (r != Long.MAX_VALUE) {
-						rs.produced(e);
-					}
-				}
-
-				rs.node(node);
-
-				missed = rs.leave(missed);
-				if (missed == 0) {
-					break;
-				}
-			}
-		}
-
-		void replayFused(ReplaySubscription<T> rs) {
-			int missed = 1;
-
-			final Subscriber<? super T> a = rs.actual();
-
-			for (; ; ) {
-
-				if (rs.isCancelled()) {
-					rs.node(null);
-					return;
-				}
-
-				boolean d = done;
-
-				a.onNext(null);
-
-				if (d) {
-					Throwable ex = error;
-					if (ex != null) {
-						a.onError(ex);
-					}
-					else {
-						a.onComplete();
-					}
-					return;
-				}
-
-				missed = rs.leave(missed);
-				if (missed == 0) {
-					break;
-				}
-			}
-		}
-
-		@Override
-		public void replay(ReplaySubscription<T> rs) {
-			if (!rs.enter()) {
-				return;
-			}
-
-			if (rs.fusionMode() == NONE) {
-				replayNormal(rs);
-			}
-			else {
-				replayFused(rs);
-			}
-		}
-
-		@Override
-		public Throwable getError() {
-			return error;
-		}
-
-		@Override
-		public boolean isDone() {
-			return done;
-		}
-
-		static final class Node<T> extends AtomicReference<Node<T>> {
-
-			/** */
-			private static final long serialVersionUID = 3713592843205853725L;
-
-			final T value;
-
-			Node(T value) {
-				this.value = value;
-			}
-		}
-
-		@Override
-		public T poll(ReplaySubscription<T> rs) {
-			@SuppressWarnings("unchecked") Node<T> node = (Node<T>) rs.node();
-			if (node == null) {
-				node = head;
-				rs.node(node);
-			}
-
-			Node<T> next = node.get();
-			if (next == null) {
-				return null;
-			}
-			rs.node(next);
-
-			return next.value;
-		}
-
-		@Override
-		public void clear(ReplaySubscription<T> rs) {
-			rs.node(null);
-		}
-
-		@Override
-		public boolean isEmpty(ReplaySubscription<T> rs) {
-			@SuppressWarnings("unchecked") Node<T> node = (Node<T>) rs.node();
-			if (node == null) {
-				node = head;
-				rs.node(node);
-			}
-			return node.get() == null;
-		}
-
-		@Override
-		public int size(ReplaySubscription<T> rs) {
-			@SuppressWarnings("unchecked") Node<T> node = (Node<T>) rs.node();
-			if (node == null) {
-				node = head;
-			}
-			int count = 0;
-
-			Node<T> next;
-			while ((next = node.get()) != null && count != Integer.MAX_VALUE) {
-				count++;
-				node = next;
-			}
-
-			return count;
-		}
-
-		@Override
-		public int size() {
-			Node<T> node = head;
-			int count = 0;
-
-			Node<T> next;
-			while ((next = node.get()) != null && count != Integer.MAX_VALUE) {
-				count++;
-				node = next;
-			}
-
-			return count;
-		}
-	}
-
-	static final class SizeAndTimeBoundReplayBuffer<T> implements ReplayBuffer<T> {
-
-		static final class TimedNode<T> extends AtomicReference<TimedNode<T>> {
-
-			final T    value;
-			final long time;
-
-			TimedNode(T value, long time) {
-				this.value = value;
-				this.time = time;
-			}
-		}
-
-		final int            limit;
-		final long           maxAge;
-		final Scheduler scheduler;
-		int size;
-
-		volatile TimedNode<T> head;
-
-		TimedNode<T> tail;
-
-		Throwable error;
-		volatile boolean done;
-
-		SizeAndTimeBoundReplayBuffer(int limit,
-				long maxAge,
-				Scheduler scheduler) {
-			this.limit = limit;
-			this.maxAge = maxAge;
-			this.scheduler = scheduler;
-			TimedNode<T> h = new TimedNode<>(null, 0L);
-			this.tail = h;
-			this.head = h;
-		}
-
-		@SuppressWarnings("unchecked")
-		void replayNormal(ReplaySubscription<T> rs) {
-			int missed = 1;
-			final Subscriber<? super T> a = rs.actual();
-
-			for (; ; ) {
-				@SuppressWarnings("unchecked") TimedNode<T> node =
-						(TimedNode<T>) rs.node();
-				if (node == null) {
-					node = head;
-					if (!done) {
-						// skip old entries
-						long limit = scheduler.now(TimeUnit.MILLISECONDS) - maxAge;
-						TimedNode<T> next = node;
-						while (next != null) {
-							long ts = next.time;
-							if (ts > limit) {
-								break;
-							}
-							node = next;
-							next = node.get();
-						}
-					}
-				}
-
-				long r = rs.requested();
-				long e = 0L;
-
-				while (e != r) {
-					if (rs.isCancelled()) {
-						rs.node(null);
-						return;
-					}
-
-					boolean d = done;
-					TimedNode<T> next = node.get();
-					boolean empty = next == null;
-
-					if (d && empty) {
-						rs.node(null);
-						Throwable ex = error;
-						if (ex != null) {
-							a.onError(ex);
-						}
-						else {
-							a.onComplete();
-						}
-						return;
-					}
-
-					if (empty) {
-						break;
-					}
-
-					a.onNext(next.value);
-
-					e++;
-					node = next;
-				}
-
-				if (e == r) {
-					if (rs.isCancelled()) {
-						rs.node(null);
-						return;
-					}
-
-					boolean d = done;
-					boolean empty = node.get() == null;
-
-					if (d && empty) {
-						rs.node(null);
-						Throwable ex = error;
-						if (ex != null) {
-							a.onError(ex);
-						}
-						else {
-							a.onComplete();
-						}
-						return;
-					}
-				}
-
-				if (e != 0L) {
-					if (r != Long.MAX_VALUE) {
-						rs.produced(e);
-					}
-				}
-
-				rs.node(node);
-
-				missed = rs.leave(missed);
-				if (missed == 0) {
-					break;
-				}
-			}
-		}
-
-		void replayFused(ReplaySubscription<T> rs) {
-			int missed = 1;
-
-			final Subscriber<? super T> a = rs.actual();
-
-			for (; ; ) {
-
-				if (rs.isCancelled()) {
-					rs.node(null);
-					return;
-				}
-
-				boolean d = done;
-
-				a.onNext(null);
-
-				if (d) {
-					Throwable ex = error;
-					if (ex != null) {
-						a.onError(ex);
-					}
-					else {
-						a.onComplete();
-					}
-					return;
-				}
-
-				missed = rs.leave(missed);
-				if (missed == 0) {
-					break;
-				}
-			}
-		}
-
-		@Override
-		public void onError(Throwable ex) {
-			done = true;
-			error = ex;
-		}
-
-		@Override
-		public Throwable getError() {
-			return error;
-		}
-
-		@Override
-		public void onComplete() {
-			done = true;
-		}
-
-		@Override
-		public boolean isDone() {
-			return done;
-		}
-
-		@SuppressWarnings("unchecked")
-		TimedNode<T> latestHead(ReplaySubscription<T> rs) {
-			long now = scheduler.now(TimeUnit.MILLISECONDS) - maxAge;
-
-			TimedNode<T> h = (TimedNode<T>) rs.node();
-			if (h == null) {
-				h = head;
-			}
-			TimedNode<T> n;
-			while ((n = h.get()) != null) {
-				if (n.time > now) {
-					break;
-				}
-				h = n;
-			}
-			return h;
-		}
-
-		@Override
-		public T poll(ReplaySubscription<T> rs) {
-			TimedNode<T> node = latestHead(rs);
-			TimedNode<T> next;
-			long now = scheduler.now(TimeUnit.MILLISECONDS) - maxAge;
-			while ((next = node.get()) != null) {
-				if (next.time > now) {
-					node = next;
-					break;
-				}
-				node = next;
-			}
-			if (next == null) {
-				return null;
-			}
-			rs.node(next);
-
-			return node.value;
-		}
-
-		@Override
-		public void clear(ReplaySubscription<T> rs) {
-			rs.node(null);
-		}
-
-		@Override
-		@SuppressWarnings("unchecked")
-		public boolean isEmpty(ReplaySubscription<T> rs) {
-			TimedNode<T> node = latestHead(rs);
-			return node.get() == null;
-		}
-
-		@Override
-		public int size(ReplaySubscription<T> rs) {
-			TimedNode<T> node = latestHead(rs);
-			int count = 0;
-
-			TimedNode<T> next;
-			while ((next = node.get()) != null && count != Integer.MAX_VALUE) {
-				count++;
-				node = next;
-			}
-
-			return count;
-		}
-
-		@Override
-		public int size() {
-			TimedNode<T> node = head;
-			int count = 0;
-
-			TimedNode<T> next;
-			while ((next = node.get()) != null && count != Integer.MAX_VALUE) {
-				count++;
-				node = next;
-			}
-
-			return count;
-		}
-
-		@Override
-		public int capacity() {
-			return limit;
-		}
-
-		@Override
-		public void add(T value) {
-			TimedNode<T> n = new TimedNode<>(value, scheduler.now(TimeUnit.MILLISECONDS));
-			tail.set(n);
-			tail = n;
-			int s = size;
-			if (s == limit) {
-				head = head.get();
-			}
-			else {
-				size = s + 1;
-			}
-			long limit = scheduler.now(TimeUnit.MILLISECONDS) - maxAge;
-
-			TimedNode<T> h = head;
-			TimedNode<T> next;
-			int removed = 0;
-			for (; ; ) {
-				next = h.get();
-				if (next == null) {
-					break;
-				}
-
-				if (next.time > limit) {
-					if (removed != 0) {
-						size = size - removed;
-						head = h;
-					}
-					break;
-				}
-
-				h = next;
-				removed++;
-			}
-		}
-
-		@Override
-		@SuppressWarnings("unchecked")
-		public void replay(ReplaySubscription<T> rs) {
-			if (!rs.enter()) {
-				return;
-			}
-
-			if (rs.fusionMode() == NONE) {
-				replayNormal(rs);
-			}
-			else {
-				replayFused(rs);
-			}
-		}
-	}
-
-	interface ReplaySubscription<T> extends QueueSubscription<T>, InnerProducer<T> {
-
-		Subscriber<? super T> actual();
-
-		boolean enter();
-
-		int leave(int missed);
-
-		void produced(long n);
-
-		void node(Object node);
-
-		Object node();
-
-		int tailIndex();
-
-		void tailIndex(int tailIndex);
-
-		int index();
-
-		void index(int index);
-
-		int fusionMode();
-
-		boolean isCancelled();
-
-		long requested();
-	}
-
 	static final class ReplayInner<T>
-			implements ReplaySubscription<T> {
+			implements FluxReplay.ReplaySubscription<T> {
 
 		final Subscriber<? super T> actual;
 
 		final ReplayProcessor<T> parent;
 
-		final ReplayBuffer<T> buffer;
+		final FluxReplay.ReplayBuffer<T> buffer;
 
 		int index;
 

--- a/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -441,6 +441,7 @@ public final class UnicastProcessor<T>
 	}
 
 	@Override
+	@Deprecated
 	public boolean isStarted() {
 		return once == 1 && !done && !cancelled;
 	}

--- a/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -54,9 +54,6 @@ public class EmitterProcessorTest {
 
 		Processor<Integer, Integer> processor = EmitterProcessor.create(16);
 
-		Flux.range(1, 10)
-		    .subscribe(processor);
-
 		List<Integer> list = new ArrayList<>();
 
 		processor.subscribe(new Subscriber<Integer>() {
@@ -90,6 +87,11 @@ public class EmitterProcessorTest {
 				latch.countDown();
 			}
 		});
+
+		Flux.range(1, 10)
+		    .subscribe(processor);
+
+
 		//stream.broadcastComplete();
 
 		latch.await(8, TimeUnit.SECONDS);
@@ -115,7 +117,7 @@ public class EmitterProcessorTest {
 		Processor<Integer, Integer> processor = EmitterProcessor.create(1024);
 
 		EmitterProcessor<Integer> stream = EmitterProcessor.create();
-		BlockingSink<Integer> session = BlockingSink.create(stream);
+		FluxSink<Integer> session = stream.sink();
 		stream.subscribe(processor);
 
 		processor.subscribe(new Subscriber<Integer>() {
@@ -142,8 +144,7 @@ public class EmitterProcessorTest {
 		});
 
 		for (int i = 0; i < elements; i++) {
-			if (session.submit(i, 1000) == -1) {
-			}
+			session.next(i);
 		}
 		//stream.then();
 
@@ -180,14 +181,11 @@ public class EmitterProcessorTest {
 	@Test
 	public void normal() {
 		EmitterProcessor<Integer> tp = EmitterProcessor.create();
-		tp.connect();
 		StepVerifier.create(tp)
 		            .then(() -> {
 			            Assert.assertTrue("No subscribers?", tp.hasDownstreams());
 			            Assert.assertFalse("Completed?", tp.isTerminated());
 			            Assert.assertNull("Has error?", tp.getError());
-			            Assert.assertTrue("Started?", tp.isStarted());
-			            Assert.assertNotNull("No upstream?", tp.upstream());
 		            })
 		            .then(() -> {
 			            tp.onNext(1);
@@ -210,7 +208,6 @@ public class EmitterProcessorTest {
 	@Test
 	public void normalBackpressured() {
 		EmitterProcessor<Integer> tp = EmitterProcessor.create();
-		tp.connect();
 		StepVerifier.create(tp, 0L)
 		            .then(() -> {
 			            Assert.assertTrue("No subscribers?", tp.hasDownstreams());
@@ -235,7 +232,6 @@ public class EmitterProcessorTest {
 	@Test
 	public void normalAtomicRingBufferBackpressured() {
 		EmitterProcessor<Integer> tp = EmitterProcessor.create(100);
-		tp.connect();
 		StepVerifier.create(tp, 0L)
 		            .then(() -> {
 			            Assert.assertTrue("No subscribers?", tp.hasDownstreams());
@@ -260,23 +256,19 @@ public class EmitterProcessorTest {
 	@Test
 	public void state(){
 		EmitterProcessor<Integer> tp = EmitterProcessor.create();
-		assertThat(tp.getPending()).isEqualTo(-1L);
-
-		tp.onNext(1);
 		assertThat(tp.getPending()).isEqualTo(0);
 		assertThat(tp.getBufferSize()).isEqualTo(QueueSupplier.SMALL_BUFFER_SIZE);
 		assertThat(tp.isCancelled()).isFalse();
-		assertThat(tp.downstreams()).isEmpty();
+		assertThat(tp.inners()).isEmpty();
 
 		Disposable d1 = tp.subscribe();
-		assertThat(tp.downstreams()).hasSize(1);
+		assertThat(tp.inners()).hasSize(1);
 
-		BlockingSink<Integer> s = tp.connectSink();
-		assertThat(tp.isStarted()).isTrue();
+		FluxSink<Integer> s = tp.sink();
 
-		s.accept(2);
-		s.accept(3);
-		s.accept(4);
+		s.next(2);
+		s.next(3);
+		s.next(4);
 		assertThat(tp.getPending()).isEqualTo(0);
 		AtomicReference<Subscription> d2 = new AtomicReference<>();
 		tp.subscribe(new Subscriber<Integer>() {
@@ -300,9 +292,9 @@ public class EmitterProcessorTest {
 
 			}
 		});
-		s.accept(5);
-		s.accept(6);
-		s.accept(7);
+		s.next(5);
+		s.next(6);
+		s.next(7);
 		assertThat(tp.scan(Scannable.Attr.BUFFERED)).isEqualTo(3);
 		assertThat(tp.isTerminated()).isFalse();
 		s.complete();
@@ -340,14 +332,11 @@ public class EmitterProcessorTest {
 	@Test
 	public void failDoubleError() {
 		EmitterProcessor<Integer> ep = EmitterProcessor.create();
-		ep.connect();
 		StepVerifier.create(ep)
 	                .then(() -> {
 		                assertThat(ep.getError()).isNull();
-		                assertThat(ep.toString()).doesNotContain("error");
 						ep.onError(new Exception("test"));
 						assertThat(ep.getError()).hasMessage("test");
-		                assertThat(ep.toString()).contains("error");
 						ep.onError(new Exception("test2"));
 	                })
 	                .expectErrorMessage("test")
@@ -358,13 +347,11 @@ public class EmitterProcessorTest {
 	@Test
 	public void failCompleteThenError() {
 		EmitterProcessor<Integer> ep = EmitterProcessor.create();
-		ep.connect();
 		StepVerifier.create(ep)
 	                .then(() -> {
 						ep.onComplete();
 						ep.onComplete();//noop
 						ep.onError(new Exception("test"));
-						ep.cancel(); //noop
 	                })
 	                .expectComplete()
 	                .verifyThenAssertThat()
@@ -374,8 +361,8 @@ public class EmitterProcessorTest {
 	@Test
 	public void ignoreDoubleOnSubscribe() {
 		EmitterProcessor<Integer> ep = EmitterProcessor.create();
-		ep.connectSink();
-		assertThat(ep.connectSink().isCancelled()).isTrue();
+		ep.sink();
+		assertThat(ep.sink().isCancelled()).isTrue();
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -527,9 +514,6 @@ public class EmitterProcessorTest {
 	@Test
 	public void testHanging() {
 		FluxProcessor<String, String> processor = EmitterProcessor.create(2);
-		Flux.fromIterable(DATA)
-		    .log()
-		    .subscribe(processor);
 
 		AssertSubscriber<String> first = AssertSubscriber.create(0);
 		processor.log("after-1").subscribe(first);
@@ -537,29 +521,42 @@ public class EmitterProcessorTest {
 		AssertSubscriber<String> second = AssertSubscriber.create(0);
 		processor.log("after-2").subscribe(second);
 
+		Flux.fromIterable(DATA)
+		    .log()
+		    .subscribe(processor);
+
 		second.request(1);
-		second.awaitAndAssertNextValues("1");
+		second.assertNoValues();
 
 		first.request(3);
+
+		second.awaitAndAssertNextValues("1");
+
+		second.cancel();
 		first.awaitAndAssertNextValues("1", "2", "3");
+		first.cancel();
+
+		assertThat(processor.scanOrDefault(Scannable.Attr.CANCELLED, false)).isTrue();
 	}
 
 	@Test
 	public void testNPE() {
 		FluxProcessor<String, String> processor = EmitterProcessor.create(8);
+		AssertSubscriber<String> first = AssertSubscriber.create(1);
+		processor.log().take(1).subscribe(first);
+
+		AssertSubscriber<String> second = AssertSubscriber.create(3);
+		processor.log().subscribe(second);
+
 		Flux.fromIterable(DATA)
 		    .log()
 		    .subscribe(processor);
 
-		AssertSubscriber<String> first = AssertSubscriber.create(1);
-		processor.subscribe(first);
 
 		first.awaitAndAssertNextValues("1");
 
-		AssertSubscriber<String> second = AssertSubscriber.create(3);
-		processor.subscribe(second);
 
-		second.awaitAndAssertNextValues("2", "3", "4");
+		second.awaitAndAssertNextValues("1", "2", "3");
 	}
 
 	static class MyThread extends Thread {

--- a/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -384,6 +384,7 @@ public class EmitterProcessorTest {
 	}
 
 	@Test(expected = IllegalStateException.class)
+	@Deprecated
 	public void failTooMuchSubscribers() {
 		EmitterProcessor<Integer> ep = EmitterProcessor.create(32, 2);
 		ep.subscribe();

--- a/src/test/java/reactor/core/publisher/FluxAutoConnectTest.java
+++ b/src/test/java/reactor/core/publisher/FluxAutoConnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,8 +38,7 @@ public class FluxAutoConnectTest {
 	@Test
 	public void connectImmediately() {
 		EmitterProcessor<Integer> e = EmitterProcessor.create();
-		e.connect();
-		
+
 		AtomicReference<Disposable> cancel = new AtomicReference<>();
 		
 		e.publish().autoConnect(0, cancel::set);
@@ -54,8 +53,7 @@ public class FluxAutoConnectTest {
 	@Test
 	public void connectAfterMany() {
 		EmitterProcessor<Integer> e = EmitterProcessor.create();
-		e.connect();
-		
+
 		AtomicReference<Disposable> cancel = new AtomicReference<>();
 		
 		Flux<Integer> p = e.publish().autoConnect(2, cancel::set);

--- a/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
+++ b/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -314,10 +314,10 @@ public class FluxBufferBoundaryTest
 	@Test
 	public void bufferWillAcumulateMultipleListsOfValues() {
 		//given: "a source and a collected flux"
-		EmitterProcessor<Integer> numbers = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> numbers = EmitterProcessor.create();
 
 		//non overlapping buffers
-		EmitterProcessor<Integer> boundaryFlux = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> boundaryFlux = EmitterProcessor.create();
 
 		Mono<List<List<Integer>>> res = numbers.buffer(boundaryFlux)
 		                                       .buffer()

--- a/src/test/java/reactor/core/publisher/FluxBufferStartEndTest.java
+++ b/src/test/java/reactor/core/publisher/FluxBufferStartEndTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,11 +132,11 @@ public class FluxBufferStartEndTest {
 	@Test
 	public void bufferWillAcumulateMultipleListsOfValuesOverlap() {
 		//given: "a source and a collected flux"
-		EmitterProcessor<Integer> numbers = EmitterProcessor.<Integer>create().connect();
-		EmitterProcessor<Integer> bucketOpening = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> numbers = EmitterProcessor.create();
+		EmitterProcessor<Integer> bucketOpening = EmitterProcessor.create();
 
 		//"overlapping buffers"
-		EmitterProcessor<Integer> boundaryFlux = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> boundaryFlux = EmitterProcessor.create();
 
 		Mono<List<List<Integer>>> res = numbers.buffer(bucketOpening, u -> boundaryFlux )
 		                                       .buffer()

--- a/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -331,9 +331,6 @@ public class FluxFlatMapTest {
 
 		source.flatMap(v -> v == 1 ? source1 : source2, 1, 32).subscribe(ts);
 
-		source1.connect();
-		source2.connect();
-		
 		Assert.assertEquals(1, emission.get());
 		
 		ts.assertNoValues()
@@ -368,9 +365,6 @@ public class FluxFlatMapTest {
 		EmitterProcessor<Integer> source2 = EmitterProcessor.create();
 		
 		source.flatMap(v -> v == 1 ? source1 : source2, Integer.MAX_VALUE, 32).subscribe(ts);
-
-		source1.connect();
-		source2.connect();
 
 		Assert.assertEquals(1000, emission.get());
 		

--- a/src/test/java/reactor/core/publisher/FluxProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/FluxProcessorTest.java
@@ -25,7 +25,6 @@ import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.Assert;
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
@@ -126,21 +125,13 @@ public class FluxProcessorTest {
 			         latch.countDown();
 		         }, 1);
 
-		BlockingSink<Integer> session = processor.connectSink();
-		long emission = session.submit(1);
-		if (emission == -1L) {
-			throw new IllegalStateException("Negatime " + emission);
-		}
+		FluxSink<Integer> session = processor.sink();
+		session.next(1);
 		//System.out.println(emission);
-		if (session.hasFailed()) {
-			session.getError()
-			       .printStackTrace();
-		}
-		session.finish();
+		session.complete();
 
 		latch.await(5, TimeUnit.SECONDS);
-		Assert.assertTrue("latch : " + count, count.get() == 1);
-		Assert.assertTrue("time : " + emission, emission >= 0);
+		Assert.assertTrue("latch : " + count, count.get() == 0);
 		scheduler.dispose();
 	}
 
@@ -158,20 +149,14 @@ public class FluxProcessorTest {
 			         .subscribe(d -> latch.countDown(), null, latch::countDown);
 		}
 
-		BlockingSink<Integer> session = processor.connectSink();
+		FluxSink<Integer> session = processor.sink();
 
 		for (int i = 0; i < n; i++) {
-			while (!session.emit(i)
-			               .isOk()) {
-				//System.out.println(emission);
-				if (session.hasFailed()) {
-					session.getError()
-					       .printStackTrace();
-					throw session.getError();
-				}
+			while (session.requestedFromDownstream() == 0) {
 			}
+			session.next(i);
 		}
-		session.finish();
+		session.complete();
 
 		boolean waited = latch.await(5, TimeUnit.SECONDS);
 		Assert.assertTrue( "latch : " + latch.getCount(), waited);
@@ -192,20 +177,14 @@ public class FluxProcessorTest {
 			         .subscribe(Integer.MAX_VALUE);
 		}
 
-		BlockingSink<Integer> session = processor.connectSink();
+		FluxSink<Integer> session = processor.sink();
 
 		for (int i = 0; i < n; i++) {
-			while (!session.emit(i)
-			               .isOk()) {
-				//System.out.println(emission);
-				if (session.hasFailed()) {
-					session.getError()
-					       .printStackTrace();
-					throw session.getError();
-				}
+			while (session.requestedFromDownstream() == 0) {
 			}
+			session.next(i);
 		}
-		session.finish();
+		session.complete();
 
 		boolean waited = latch.await(5, TimeUnit.SECONDS);
 		Assert.assertTrue( "latch : " + latch.getCount(), waited);

--- a/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
+++ b/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -191,7 +191,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
 		sp.publish(o -> Flux.<Integer>empty())
 		  .subscribe(ts);
 
-		Assert.assertFalse("Still subscribed?", sp.downstreamCount() == 0);
+		Assert.assertFalse("Still subscribed?", sp.downstreamCount() == 1);
 	}
 
 	@Test

--- a/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
+++ b/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
@@ -1127,7 +1127,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		final ConcurrentHashMap<Object, Long> seenConsumer = new ConcurrentHashMap<>();
 
 		EmitterProcessor<Integer> d = EmitterProcessor.create();
-		BlockingSink<Integer> s = BlockingSink.create(d);
+		FluxSink<Integer> s = d.sink();
 
 		/*Cancellation c = */
 		d.publishOn(Schedulers.parallel())
@@ -1177,7 +1177,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		                            }));
 
 		for (int i = 0; i < COUNT; i++) {
-			s.submit(i);
+			s.next(i);
 		}
 
 		internalLatch.await(5, TimeUnit.SECONDS);
@@ -1193,7 +1193,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		Random random = ThreadLocalRandom.current();
 
 		EmitterProcessor<String> d = EmitterProcessor.create();
-		BlockingSink<String> s = d.connectSink();
+		FluxSink<String> s = d.sink();
 
 		Flux<Integer> tasks = d.publishOn(Schedulers.parallel())
 		                       .parallel(8)
@@ -1217,7 +1217,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		});
 
 		for (int i = 1; i <= items; i++) {
-			s.submit(String.valueOf(i));
+			s.next(String.valueOf(i));
 		}
 		latch.await(15, TimeUnit.SECONDS);
 		assertTrue(latch.getCount() + " of " + items + " items were not counted down",

--- a/src/test/java/reactor/core/publisher/FluxPublishTest.java
+++ b/src/test/java/reactor/core/publisher/FluxPublishTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -343,7 +343,6 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		EmitterProcessor<Integer> e = EmitterProcessor.create();
-		e.connect();
 
 		ConnectableFlux<Integer> p = e.publish();
 		
@@ -368,7 +367,6 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
 		EmitterProcessor<Integer> e = EmitterProcessor.create();
-		e.connect();
 
 		ConnectableFlux<Integer> p = e.publish();
 		
@@ -390,7 +388,6 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		EmitterProcessor<Integer> e = EmitterProcessor.create();
-		e.connect();
 
 		ConnectableFlux<Integer> p = e.publish();
 		

--- a/src/test/java/reactor/core/publisher/FluxRefCountTest.java
+++ b/src/test/java/reactor/core/publisher/FluxRefCountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ public class FluxRefCountTest {
 	@Test
 	public void normal() {
 		EmitterProcessor<Integer> e = EmitterProcessor.create();
-		e.connect();
 
 		Flux<Integer> p = e.publish().refCount();
 		
@@ -75,7 +74,6 @@ public class FluxRefCountTest {
 	@Test
 	public void normalTwoSubscribers() {
 		EmitterProcessor<Integer> e = EmitterProcessor.create();
-		e.connect();
 
 		Flux<Integer> p = e.publish().refCount(2);
 		

--- a/src/test/java/reactor/core/publisher/FluxResumeTest.java
+++ b/src/test/java/reactor/core/publisher/FluxResumeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -157,8 +157,6 @@ public class FluxResumeTest {
 	public void someFirst() {
 		EmitterProcessor<Integer> tp = EmitterProcessor.create();
 
-		tp.connect();
-
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		tp.onErrorResumeWith(v -> Flux.range(11, 10))
@@ -179,8 +177,6 @@ public class FluxResumeTest {
 	@Test
 	public void someFirstBackpressured() {
 		EmitterProcessor<Integer> tp = EmitterProcessor.create();
-
-		tp.connect();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(10);
 

--- a/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
+++ b/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -218,10 +218,10 @@ public class FluxWindowBoundaryTest {
 	@Test
 	public void windowWillAcumulateMultipleListsOfValues() {
 		//given: "a source and a collected flux"
-		EmitterProcessor<Integer> numbers = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> numbers = EmitterProcessor.create();
 
 		//non overlapping buffers
-		EmitterProcessor<Integer> boundaryFlux = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> boundaryFlux = EmitterProcessor.create();
 
 		Mono<List<List<Integer>>> res = numbers.window(boundaryFlux)
 		                                       .concatMap(Flux::buffer)

--- a/src/test/java/reactor/core/publisher/FluxWindowStartEndTest.java
+++ b/src/test/java/reactor/core/publisher/FluxWindowStartEndTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -169,11 +169,11 @@ public class FluxWindowStartEndTest {
 	@Test
 	public void windowWillAcumulateMultipleListsOfValuesOverlap() {
 		//given: "a source and a collected flux"
-		EmitterProcessor<Integer> numbers = EmitterProcessor.<Integer>create().connect();
-		EmitterProcessor<Integer> bucketOpening = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> numbers = EmitterProcessor.create();
+		EmitterProcessor<Integer> bucketOpening = EmitterProcessor.create();
 
 		//"overlapping buffers"
-		EmitterProcessor<Integer> boundaryFlux = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> boundaryFlux = EmitterProcessor.create();
 
 		Mono<List<List<Integer>>> res = numbers.window(bucketOpening, u -> boundaryFlux )
 		                                       .flatMap(Flux::buffer)

--- a/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -451,8 +451,8 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 	public void multipleStreamValuesCanBeZipped() {
 //		"Multiple Stream"s values can be zipped"
 //		given: "source composables to merge, buffer and tap"
-		EmitterProcessor<Integer> source1 = EmitterProcessor.<Integer>create().connect();
-		EmitterProcessor<Integer> source2 = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> source1 = EmitterProcessor.create();
+		EmitterProcessor<Integer> source2 = EmitterProcessor.create();
 		Flux<Integer> zippedFlux = Flux.zip(source1, source2, (t1, t2) -> t1 + t2);
 		AtomicReference<Integer> tap = new AtomicReference<>();
 		zippedFlux.subscribe(it -> tap.set(it));

--- a/src/test/java/reactor/core/publisher/ReplayProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/ReplayProcessorTest.java
@@ -580,20 +580,15 @@ public class ReplayProcessorTest {
 		assertThat(s.isCancelled()).isFalse();
 		assertThat(s.isCancelled()).isFalse();
 
-		assertThat(rp.isStarted()).isFalse();
 		assertThat(rp.getPrefetch()).isEqualTo(Integer.MAX_VALUE);
 		if(rp.getBufferSize() != Integer.MAX_VALUE) {
 			assertThat(rp.getBufferSize()).isEqualTo(1);
 		}
-		BlockingSink<String> sink = rp.connectSink();
-		assertThat(rp.connectSink().isCancelled()).isTrue();
-		rp.onComplete();
-		assertThat(rp.connectSink().isCancelled()).isTrue();
-		assertThat(rp.isStarted()).isTrue();
-
+		FluxSink<String> sink = rp.sink();
+		sink.next("test");
 		rp.onComplete();
 
-		assertThat(sink.emit("test").isCancelled()).isTrue();
+		rp.onComplete();
 
 		Exception e = new RuntimeException("test");
 		try{

--- a/src/test/java/reactor/core/publisher/TopicProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/TopicProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,9 +33,7 @@ import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.concurrent.WaitStrategy;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Stephane Maldini
@@ -286,7 +284,7 @@ public class TopicProcessorTest {
 		CountDownLatch latch = new CountDownLatch(simultaneousSubscribers);
 		Scheduler scheduler = Schedulers.single();
 
-		BlockingSink<String> sink = broadcast.connectSink();
+		FluxSink<String> sink = broadcast.sink();
 		Flux<String> flux = broadcast.filter(Objects::nonNull)
 		                             .publishOn(scheduler)
 		                             .cache(1);
@@ -294,7 +292,7 @@ public class TopicProcessorTest {
 		for (int i = 0; i < simultaneousSubscribers; i++) {
 			flux.subscribe(s -> latch.countDown());
 		}
-		sink.submit("data", 1, TimeUnit.SECONDS);
+		sink.next("data");
 
 		assertThat(latch.await(4, TimeUnit.SECONDS))
 				.overridingErrorMessage("Data not received")
@@ -310,7 +308,7 @@ public class TopicProcessorTest {
 		CountDownLatch latch = new CountDownLatch(simultaneousSubscribers);
 		Scheduler scheduler = Schedulers.single();
 
-		BlockingSink<String> sink = broadcast.connectSink();
+		FluxSink<String> sink = broadcast.sink();
 		Flux<String> flux = broadcast.filter(Objects::nonNull)
 		                             .publishOn(scheduler)
 		                             .cache(1);
@@ -318,7 +316,7 @@ public class TopicProcessorTest {
 		for (int i = 0; i < simultaneousSubscribers; i++) {
 			flux.subscribe(s -> latch.countDown());
 		}
-		sink.submit("data", 1, TimeUnit.SECONDS);
+		sink.next("data");
 
 		assertThat(latch.await(4, TimeUnit.SECONDS))
 				.overridingErrorMessage("Data not received")

--- a/src/test/java/reactor/core/publisher/scenarios/CombinationTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/CombinationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,17 +20,13 @@ import java.time.Duration;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
-import reactor.util.Loggers;
-import reactor.core.publisher.BlockingSink;
 import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxProcessor;
@@ -41,6 +37,7 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.Logger;
+import reactor.util.Loggers;
 
 /**
  * @author Stephane Maldini
@@ -304,8 +301,6 @@ public class CombinationTests {
 		ts = AssertSubscriber.create();
 		emitter1 = ReplayProcessor.create();
 		emitter2 = ReplayProcessor.create();
-		emitter1.connect();
-		emitter2.connect();
 	}
 
 	private void emitValues() {

--- a/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,7 +24,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -34,20 +33,16 @@ import java.util.function.Consumer;
 
 import org.junit.Assert;
 import org.junit.Test;
-import reactor.core.Exceptions;
 import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxProcessor;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
 import reactor.core.publisher.ReplayProcessor;
-import reactor.core.publisher.Signal;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
-import reactor.test.scheduler.VirtualTimeScheduler;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.function.Tuple2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -404,7 +399,7 @@ public class FluxSpecTests {
 //		"Accepted values are passed to a registered Consumer"
 //		given: "a composable with a registered consumer"
 		EmitterProcessor<Integer> composable =
-				EmitterProcessor.<Integer>create().connect();
+				EmitterProcessor.create();
 		AtomicReference<Integer> value = new AtomicReference<>();
 
 		composable.subscribe(value::set);
@@ -427,7 +422,7 @@ public class FluxSpecTests {
 //		"Accepted errors are passed to a registered Consumer"
 //		given: "a composable with a registered consumer of RuntimeExceptions"
 		EmitterProcessor<Integer> composable =
-				EmitterProcessor.<Integer>create().connect();
+				EmitterProcessor.create();
 		LongAdder errors = new LongAdder();
 		composable.doOnError(e -> errors.increment()).subscribe();
 
@@ -448,7 +443,7 @@ public class FluxSpecTests {
 	public void whenAcceptedEventIsIterableSplitCanIterateOverValues() {
 //		"When the accepted event is Iterable, split can iterate over values"
 //		given: "a composable with a known number of values"
-		EmitterProcessor<Iterable<String>> d = EmitterProcessor.<Iterable<String>>create().connect();
+		EmitterProcessor<Iterable<String>> d = EmitterProcessor.create();
 		Flux<String> composable = d.flatMap(Flux::fromIterable);
 
 //		when: "accept list of Strings"
@@ -464,7 +459,7 @@ public class FluxSpecTests {
 	public void fluxValuesCanBeMapped() {
 //		"A Flux"s values can be mapped"
 //		given: "a source composable with a mapping function"
-		EmitterProcessor<Integer> source = EmitterProcessor.<Integer> create().connect();
+		EmitterProcessor<Integer> source = EmitterProcessor.create();
 		Flux<Integer> mapped = source.map(it -> it * 2);
 
 //		when: "the source accepts a value"
@@ -491,7 +486,7 @@ public class FluxSpecTests {
 //			when: "the source accepts a value"
 		MonoProcessor<Integer> value = mapped.next()
 		                                     .subscribe();
-		source.connectSink().emit(1);
+		source.sink().next(1);
 
 //		then: "the value is mapped"
 		int result = value.block(Duration.ofSeconds(5));
@@ -502,13 +497,13 @@ public class FluxSpecTests {
 	public void multipleStreamValuesCanBeMerged() {
 //		"Multiple Stream"s values can be merged"
 //		given: "source composables to merge, buffer and tap"
-		EmitterProcessor<Integer> source1 = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> source1 = EmitterProcessor.create();
 
-		EmitterProcessor<Integer> source2 = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> source2 = EmitterProcessor.create();
 		source2.map(it -> it)
 		       .map(it -> it);
 
-		EmitterProcessor<Integer> source3 = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> source3 = EmitterProcessor.create();
 
 		AtomicReference<List<Integer>> tap = new AtomicReference<>();
 		Flux.merge(source1, source2, source3).log().buffer(3)
@@ -556,9 +551,9 @@ public class FluxSpecTests {
 	public void combineLatestStreamData() {
 //		"Combine latest stream data"
 //		given: "source composables to combine, buffer and tap"
-		EmitterProcessor<String> w1 = EmitterProcessor.<String>create().connect();
-		EmitterProcessor<String> w2 = EmitterProcessor.<String>create().connect();
-		EmitterProcessor<String> w3 = EmitterProcessor.<String>create().connect();
+		EmitterProcessor<String> w1 = EmitterProcessor.create();
+		EmitterProcessor<String> w2 = EmitterProcessor.create();
+		EmitterProcessor<String> w3 = EmitterProcessor.create();
 
 //		when: "the sources are combined"
 		Flux<String> mergedFlux =
@@ -675,7 +670,7 @@ public class FluxSpecTests {
 	public void streamCanBeCounted() {
 //		"Stream can be counted"
 //		given: "source composables to count and tap"
-		EmitterProcessor<Integer> source = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> source = EmitterProcessor.create();
 		MonoProcessor<Long> tap = source.count()
 		                                .subscribeWith(MonoProcessor.create());
 
@@ -740,7 +735,7 @@ public class FluxSpecTests {
 	public void fluxValuesCanBeFiltered() {
 //		"A Flux"s values can be filtered"
 //		given: "a source composable with a filter that rejects odd values"
-		EmitterProcessor<Integer> source = EmitterProcessor.<Integer> create().connect();
+		EmitterProcessor<Integer> source = EmitterProcessor.create();
 		Flux<Integer> filtered = source.filter(it -> it % 2 == 0);
 
 //		when: "the source accepts an even value"
@@ -758,8 +753,7 @@ public class FluxSpecTests {
 		assertThat(value.get()).isEqualTo(2);
 
 //		when: "simple filter"
-		EmitterProcessor<Boolean> anotherSource =
-				EmitterProcessor.<Boolean>create().connect();
+		EmitterProcessor<Boolean> anotherSource = EmitterProcessor.create();
 		AtomicBoolean tap = new AtomicBoolean();
 		anotherSource.filter(it -> it).subscribe(tap::set);
 		anotherSource.onNext(true);
@@ -768,7 +762,7 @@ public class FluxSpecTests {
 		assertThat(tap.get()).isTrue();
 
 //		when: "simple filter nominal case"
-		anotherSource = EmitterProcessor.<Boolean> create().connect();
+		anotherSource = EmitterProcessor.create();
 		anotherSource.filter(it -> it).subscribe(tap::set);
 		anotherSource.onNext(false);
 
@@ -780,7 +774,7 @@ public class FluxSpecTests {
 	public void whenMappingFunctionThrowsMappedComposableAcceptsError() {
 //		"When a mapping function throws an exception, the mapped composable accepts the error"
 //		given: "a source composable with a mapping function that throws an error"
-		EmitterProcessor<Integer> source = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> source = EmitterProcessor.create();
 		Flux<String> mapped = source.map(it -> {
 					if (it == 1) {
 						throw new RuntimeException();
@@ -805,7 +799,7 @@ public class FluxSpecTests {
 	public void whenProcessorIsStreamed() {
 //		"When a processor is streamed"
 //		given: "a source composable and a async downstream"
-		ReplayProcessor<Integer> source = ReplayProcessor.<Integer>create().connect();
+		ReplayProcessor<Integer> source = ReplayProcessor.create();
 		Scheduler scheduler = Schedulers.newParallel("test", 2);
 
 		try {
@@ -837,7 +831,7 @@ public class FluxSpecTests {
 	public void whenFilterFunctionThrowsFilteredComposableAcceptsError() {
 //		"When a filter function throws an exception, the filtered composable accepts the error"
 //		given: "a source composable with a filter function that throws an error"
-		EmitterProcessor<Integer> source = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> source = EmitterProcessor.create();
 		Flux<Integer> filtered = source.filter(it -> {
 			if (it == 1) {
 				throw new RuntimeException();
@@ -893,7 +887,7 @@ public class FluxSpecTests {
 	public void whenReducingKnownNumberOfValuesOnlyFinalValueIsPassedToConsumers() {
 //		"When reducing a known number of values, only the final value is passed to consumers"
 //		given: "a composable with a known number of values and a reduce function"
-		EmitterProcessor<Integer> source = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> source = EmitterProcessor.create();
 		Mono<Integer> reduced = source.reduce(new Reduction());
 		List<Integer> values = new ArrayList<>();
 		reduced.doOnSuccess(values::add).subscribe();
@@ -914,7 +908,7 @@ public class FluxSpecTests {
 	public void knownNumberOfValuesCanBeReduced() {
 //		"A known number of values can be reduced"
 //		given: "a composable that will accept 5 values and a reduce function"
-		EmitterProcessor<Integer> source = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> source = EmitterProcessor.create();
 		Mono<Integer> reduced = source.reduce(new Reduction());
 		MonoProcessor<Integer> value = reduced.subscribeWith(MonoProcessor.create());
 
@@ -934,7 +928,7 @@ public class FluxSpecTests {
 	public void whenKnownNumberOfValuesIsReducedOnlyFinalValueMadeAvailable() {
 //		"When a known number of values is being reduced, only the final value is made available"
 //		given: "a composable that will accept 2 values and a reduce function"
-		EmitterProcessor<Integer> source = EmitterProcessor.<Integer>create().connect();
+		EmitterProcessor<Integer> source = EmitterProcessor.create();
 		MonoProcessor<Integer> value = source.reduce(new Reduction())
 		                                     .subscribeWith(MonoProcessor.create());
 
@@ -959,7 +953,7 @@ public class FluxSpecTests {
 //		"When an unknown number of values is being scanned, each reduction is passed to a consumer"
 //		given: "a composable with a reduce function"
 		FluxProcessor<Integer, Integer> source =
-				EmitterProcessor.<Integer>create().connect();
+				EmitterProcessor.create();
 		Flux<Integer> reduced = source.scan(new Reduction());
 		AtomicReference<Integer> value = new AtomicReference<>();
 		reduced.subscribe(value::set);
@@ -989,7 +983,7 @@ public class FluxSpecTests {
 //		"Reduce will accumulate a list of accepted values"
 //		given: "a composable"
 		FluxProcessor<Integer, Integer> source =
-				EmitterProcessor.<Integer>create().connect();
+				EmitterProcessor.create();
 		Mono<List<Integer>> reduced = source.collectList();
 		MonoProcessor<List<Integer>> value = reduced.subscribe();
 
@@ -1006,7 +1000,7 @@ public class FluxSpecTests {
 //		"When an unknown number of values is being reduced, each reduction is passed to a consumer on window"
 //		given: "a composable with a reduce function"
 		FluxProcessor<Integer, Integer> source =
-				EmitterProcessor.<Integer>create().connect();
+				EmitterProcessor.create();
 		Flux<Integer> reduced = source.window(2)
 		                              .log()
 		                              .flatMap(it -> it.log("lol")


### PR DESCRIPTION
- Deprecate #connect, unnecessary to onSubscribe
- Deprecate #connectSink in favor of #sink with default blocking behavior
- Add #sink
- Deprecate BlockingSink

(adapted from commit 6d8a93b in PR #525)