### PR TITLE
Rename Mono#otherwise[Empty] to switch[onError/IfEmpty]

### DIFF
--- a/src/main/java/reactor/core/publisher/MonoSwitchIfEmpty.java
+++ b/src/main/java/reactor/core/publisher/MonoSwitchIfEmpty.java
@@ -25,11 +25,11 @@ import org.reactivestreams.Subscriber;
  * @param <T> the value type
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
-final class MonoOtherwiseIfEmpty<T> extends MonoSource<T, T> {
+final class MonoSwitchIfEmpty<T> extends MonoSource<T, T> {
 
     final Mono<? extends T> other;
 
-	public MonoOtherwiseIfEmpty(Mono<? extends T> source, Mono<? extends T> other) {
+	public MonoSwitchIfEmpty(Mono<? extends T> source, Mono<? extends T> other) {
 		super(source);
 		this.other = Objects.requireNonNull(other, "other");
 	}

--- a/src/main/java/reactor/core/publisher/MonoSwitchOnError.java
+++ b/src/main/java/reactor/core/publisher/MonoSwitchOnError.java
@@ -28,11 +28,11 @@ import org.reactivestreams.Subscriber;
  * @param <T> the value type
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
-final class MonoOtherwise<T> extends MonoSource<T, T> {
+final class MonoSwitchOnError<T> extends MonoSource<T, T> {
 
 	final Function<? super Throwable, ? extends Publisher<? extends T>> nextFactory;
 
-	MonoOtherwise(Mono<? extends T> source,
+	MonoSwitchOnError(Mono<? extends T> source,
 						   Function<? super Throwable, ? extends Mono<? extends T>>
 								   nextFactory) {
 		super(source);

--- a/src/test/java/reactor/HooksTest.java
+++ b/src/test/java/reactor/HooksTest.java
@@ -17,16 +17,13 @@
 package reactor;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.logging.Level;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.reactivestreams.Subscriber;
 import reactor.core.publisher.ConnectableFlux;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
@@ -36,10 +33,7 @@ import reactor.core.publisher.ParallelFlux;
 import reactor.core.publisher.SignalType;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
-import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Stephane Maldini
@@ -161,7 +155,7 @@ public class HooksTest {
 				new String[]{"FluxJust: 1", "{ \"operator\" : \"MapFuseable\" }: 2",
 						"{ \"operator\" : \"PeekFuseable\" }! false",
 						"{ \"operator\" : \"CollectList\" }! true", "MonoJust: [2]",
-						"{ \"operator\" : \"Otherwise\" }: [2]"});
+						"{ \"operator\" : \"SwitchOnError\" }: [2]"});
 
 		q.clear();
 
@@ -178,7 +172,7 @@ public class HooksTest {
 				new String[]{"FluxJust: 1", "{ \"operator\" : \"MapFuseable\" }: 2",
 						"{ \"operator\" : \"PeekFuseable\" }! false",
 						"{ \"operator\" : \"CollectList\" }! false", "MonoJust: [2]",
-						"{ \"operator\" : \"Otherwise\" }: [2]"});
+						"{ \"operator\" : \"SwitchOnError\" }: [2]"});
 
 		q.clear();
 

--- a/src/test/java/reactor/core/publisher/MonoSwitchIfEmptyTest.java
+++ b/src/test/java/reactor/core/publisher/MonoSwitchIfEmptyTest.java
@@ -18,17 +18,17 @@ package reactor.core.publisher;
 import org.junit.Test;
 import reactor.test.subscriber.AssertSubscriber;
 
-public class MonoOtherwiseIfEmptyTest {
+public class MonoSwitchIfEmptyTest {
 
 	@Test(expected = NullPointerException.class)
 	public void sourceNull() {
-		new MonoOtherwiseIfEmpty<>(null, Mono.never());
+		new MonoSwitchIfEmpty<>(null, Mono.never());
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void otherNull() {
 		Mono.never()
-		    .otherwiseIfEmpty(null);
+		    .switchIfEmpty(null);
 	}
 
 	@Test
@@ -36,7 +36,7 @@ public class MonoOtherwiseIfEmptyTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		Mono.just(1)
-		    .otherwiseIfEmpty(Mono.just(10))
+		    .switchIfEmpty(Mono.just(10))
 		    .subscribe(ts);
 
 		ts.assertValues(1)
@@ -49,7 +49,7 @@ public class MonoOtherwiseIfEmptyTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
 		Mono.just(1)
-		    .otherwiseIfEmpty(Mono.just(10))
+		    .switchIfEmpty(Mono.just(10))
 		    .subscribe(ts);
 
 		ts.assertNoValues()
@@ -68,7 +68,7 @@ public class MonoOtherwiseIfEmptyTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		Mono.<Integer>empty()
-		    .otherwiseIfEmpty(Mono.just(10))
+		    .switchIfEmpty(Mono.just(10))
 		    .subscribe(ts);
 
 		ts.assertValues(10)
@@ -81,7 +81,7 @@ public class MonoOtherwiseIfEmptyTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
 		Mono.<Integer>empty()
-		    .otherwiseIfEmpty(Mono.just(10))
+		    .switchIfEmpty(Mono.just(10))
 		    .subscribe(ts);
 
 		ts.assertNoValues()

--- a/src/test/java/reactor/core/publisher/MonoSwitchOnErrorTest.java
+++ b/src/test/java/reactor/core/publisher/MonoSwitchOnErrorTest.java
@@ -23,7 +23,7 @@ import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MonoOtherwiseTest {
+public class MonoSwitchOnErrorTest {
 /*
 	@Test
 	public void constructors() {
@@ -40,7 +40,7 @@ public class MonoOtherwiseTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		Mono.just(1)
-		    .otherwise(v -> Mono.just(2))
+		    .switchOnError(v -> Mono.just(2))
 		    .subscribe(ts);
 
 		ts.assertValues(1)
@@ -53,7 +53,7 @@ public class MonoOtherwiseTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
 		Mono.just(1)
-		    .otherwise(v -> Mono.just(2))
+		    .switchOnError(v -> Mono.just(2))
 		    .subscribe(ts);
 
 		ts.assertNoValues()
@@ -71,7 +71,7 @@ public class MonoOtherwiseTest {
 	public void error() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Mono.<Integer>error(new RuntimeException("forced failure")).otherwise(v -> Mono.just(
+		Mono.<Integer>error(new RuntimeException("forced failure")).switchOnError(v -> Mono.just(
 				2))
 		                                                           .subscribe(ts);
 
@@ -85,7 +85,7 @@ public class MonoOtherwiseTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		Mono.<Integer>error(new RuntimeException("forced failure"))
-				.otherwise(e -> e.getMessage().equals("forced failure"), v -> Mono.just(2))
+				.switchOnError(e -> e.getMessage().equals("forced failure"), v -> Mono.just(2))
 				.subscribe(ts);
 
 		ts.assertValues(2)
@@ -112,7 +112,7 @@ public class MonoOtherwiseTest {
 	public void errorBackpressured() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
-		Mono.<Integer>error(new RuntimeException("forced failure")).otherwise(v -> Mono.just(
+		Mono.<Integer>error(new RuntimeException("forced failure")).switchOnError(v -> Mono.just(
 				2))
 		                                                           .subscribe(ts);
 
@@ -130,7 +130,7 @@ public class MonoOtherwiseTest {
 	public void nextFactoryThrows() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
-		Mono.<Integer>error(new RuntimeException("forced failure")).otherwise(v -> {
+		Mono.<Integer>error(new RuntimeException("forced failure")).switchOnError(v -> {
 			throw new RuntimeException("forced failure 2");
 		})
 		                                                           .subscribe(ts);
@@ -146,7 +146,7 @@ public class MonoOtherwiseTest {
 	public void nextFactoryReturnsNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
-		Mono.<Integer>error(new RuntimeException("forced failure")).otherwise(v -> null)
+		Mono.<Integer>error(new RuntimeException("forced failure")).switchOnError(v -> null)
 		                                                           .subscribe(ts);
 
 		ts.assertNoValues()
@@ -172,7 +172,7 @@ public class MonoOtherwiseTest {
 	public void otherwiseErrorFilter() {
 		MonoProcessor<Integer> mp = MonoProcessor.create();
 		StepVerifier.create(Mono.<Integer>error(new TestException())
-				.otherwise(TestException.class, e -> Mono.just(1))
+				.switchOnError(TestException.class, e -> Mono.just(1))
 				.subscribeWith(mp))
 		            .then(() -> assertThat(mp.isError()).isFalse())
 		            .then(() -> assertThat(mp.isSuccess()).isTrue())
@@ -185,7 +185,7 @@ public class MonoOtherwiseTest {
 	public void otherwiseErrorUnfilter() {
 		MonoProcessor<Integer> mp = MonoProcessor.create();
 		StepVerifier.create(Mono.<Integer>error(new TestException())
-				.otherwise(RuntimeException.class, e -> Mono.just(1))
+				.switchOnError(RuntimeException.class, e -> Mono.just(1))
 				.subscribeWith(mp))
 		            .then(() -> assertThat(mp.isError()).isTrue())
 		            .then(() -> assertThat(mp.isSuccess()).isFalse())


### PR DESCRIPTION
More explicit, more discoverable and more consistent with Flux API.

Fixes #531