### PR TITLE
backport #535 Deprecate, rework and align Flux/Mono error handling APIs

### DIFF
--- a/src/docs/asciidoc/coreFeatures.adoc
+++ b/src/docs/asciidoc/coreFeatures.adoc
@@ -344,7 +344,7 @@ Flux.just(10)
 
 ==== Fallback method
 If you want more than a single default value and you have an alternative safer
-way of processing your data, you can use `switchOnError`. This would be the
+way of processing your data, you can use `onErrorResume`. This would be the
 equivalent of *(2)*.
 
 For example, if your nominal process is fetching data from an external
@@ -355,24 +355,23 @@ be a bit more out of date but is more reliable, you could do the following:
 Flux.just("key1", "key2")
     .flatMap(k ->
         callExternalService(k) // <1>
-          .switchOnError(getFromCache(k)) // <2>
+          .onErrorResume(e -> getFromCache(k)) // <2>
     );
 ----
 <1> for each key, we asynchronously call the external service.
-<2> if the external service call fails, we fallback to the cache for that key.
+<2> if the external service call fails, we fallback to the cache for that key. Note we
+always apply the same fallback, whatever the source error `e` is.
 
-Unlike `onErrorReturn`, `switchOnError` always falls back to the same sequence.
-However it has variants that let you filter which exceptions to fallback on,
-based either on the exception's class or a `Predicate`.
-
-For more dynamic options, `onErrorResumeWith` is the more advanced alternative.
-It takes a `Function` that maps the error to the fallback sequence to switch to:
+Like `onErrorReturn`, `onErrorResume` has variants that let you filter which exceptions
+to fallback on, based either on the exception's class or a `Predicate`. The fact that it
+takes a `Function` also allows you to choose a different fallback sequence to switch to,
+depending on the error encountered:
 [source,java]
 ----
 Flux.just("timeout1", "unknown", "key2")
     .flatMap(k ->
         callExternalService(k)
-          .onErrorResumeWith(error -> { // <1>
+          .onErrorResume(error -> { // <1>
             if (error instanceof TimeoutException) // <2>
               return getFromCache(k);
             else if (error instanceof UnknownKeyException)  // <3>
@@ -394,9 +393,18 @@ That last line inside the previous `flatMap` gives us an hint as to how item
 ----
 Flux.just("timeout1")
     .flatMap(k -> callExternalService(k)
-        .onErrorResumeWith(original -> Flux.error(
+        .onErrorResume(original -> Flux.error(
             new BusinessException("oops, SLA exceeded", original))
         )
+    );
+----
+
+But actually, there is a more straightforward way of achieving the same with `onErrorMap`:
+[source,java]
+----
+Flux.just("timeout1")
+    .flatMap(k -> callExternalService(k)
+		    .onErrorMap(original -> new BusinessException("oops, SLA exceeded", original))
     );
 ----
 
@@ -420,7 +428,7 @@ Flux.just("unknown")
 		    	failureStat.increment();
 		    	log("uh oh, falling back, service failed for key " + k); // <2>
 		    })
-        .switchOnError(getFromCache(k)) // <3>
+        .onErrorResume(e -> getFromCache(k)) // <3>
     );
 ----
 <1> the external service call that can fail...

--- a/src/docs/asciidoc/operatorChoice.adoc
+++ b/src/docs/asciidoc/operatorChoice.adoc
@@ -84,7 +84,7 @@ I want to deal with: <<which.create>>, <<which.values>>, <<which.peeking>>,
 
 * I have an empty sequence but...
 ** I want a value instead: `defaultIfEmpty`
-** I want another sequence instead: `Flux#switchIfEmpty`, `Mono.otherwiseIfEmpty`
+** I want another sequence instead: `switchIfEmpty`
 
 * I have a sequence but I'm not interested in values: `ignoreElements`
 ** ...and I want the completion represented as a `Mono`: `then`
@@ -171,18 +171,18 @@ I want to deal with: <<which.create>>, <<which.values>>, <<which.peeking>>,
 * I want the try/catch equivalent of...
 ** throwing: `error`
 ** catching an exception...
-*** and falling back to a default value: `Flux#onErrorReturn`
-*** and falling back to another `Flux`: `Flux#onErrorResumeWith`
-*** and wrapping and re-throwing: `.onErrorResumeWith(t -> Flux.error(new RuntimeException(t)))`
+*** and falling back to a default value: `onErrorReturn`
+*** and falling back to another `Flux` or `Mono`: `onErrorResume`
+*** and wrapping and re-throwing: `.onErrorMap(t -> new RuntimeException(t))`
 ** the finally block: `doFinally`
 ** the using pattern from Java 7: `using` factory method
 
 * I want to recover from errors...
-** by falling back: `Flux#onErrorReturn`, `Flux#onErrorResumeWith`
-*** ...but from a Mono: `Mono#otherwiseReturn`, `Mono#otherwise`
+** by falling back...
+*** to a value: `onErrorReturn`
+*** to a `Publisher` or `Mono`, possibly different ones depending on the error: `Flux#onErrorResume` and `Mono#onErrorResume`
 ** by retrying: `retry`
 *** ...triggered by a companion control Flux: `retryWhen`
-** by switching to another `Flux` depending on the error type: `switchOnError`
 
 * I want to deal with backpressure "errors"footnote:[request max from upstream and apply the strategy when downstream doesn't produce enough request]...
 ** by throwing a special `IllegalStateException`: `Flux#onBackpressureError`

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -62,7 +62,6 @@ import reactor.util.function.Tuple3;
 import reactor.util.function.Tuple4;
 import reactor.util.function.Tuple5;
 import reactor.util.function.Tuple6;
-import reactor.util.function.Tuple8;
 import reactor.util.function.Tuples;
 
 /**
@@ -4728,9 +4727,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param mapper the error transforming {@link Function}
 	 *
 	 * @return a transformed {@link Flux}
+	 * @deprecated use {@link #onErrorMap} instead. Will be removed in 3.1.0.
 	 */
+	@Deprecated
 	public final Flux<T> mapError(Function<? super Throwable, ? extends Throwable> mapper) {
-		return onErrorResumeWith(e -> Mono.error(mapper.apply(e)));
+		return onErrorMap(mapper);
 	}
 
 	/**
@@ -4744,12 +4745,13 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param <E> the error type
 	 *
 	 * @return a transformed {@link Flux}
+	 * @deprecated use {@link #onErrorMap} instead. Will be removed in 3.1.0.
 	 */
+	@Deprecated
 	public final <E extends Throwable> Flux<T> mapError(Class<E> type,
 			Function<? super E, ? extends Throwable> mapper) {
-		@SuppressWarnings("unchecked")
-		Function<Throwable, Throwable> handler = (Function<Throwable, Throwable>)mapper;
-		return mapError(type::isInstance, handler);
+		return onErrorMap(type, mapper);
+
 	}
 
 	/**
@@ -4764,10 +4766,12 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param mapper the error transforming {@link Function}
 	 *
 	 * @return a transformed {@link Flux}
+	 * @deprecated use {@link #onErrorMap} instead. Will be removed in 3.1.0.
 	 */
+	@Deprecated
 	public final Flux<T> mapError(Predicate<? super Throwable> predicate,
 			Function<? super Throwable, ? extends Throwable> mapper) {
-		return onErrorResumeWith(predicate, e -> Mono.error(mapper.apply(e)));
+		return onErrorMap(predicate, mapper);
 	}
 
 	/**
@@ -4997,6 +5001,113 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
+	 * Transform the error emitted by this {@link Flux} by applying a function.
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/maperror.png"
+	 * alt="">
+	 * <p>
+	 *
+	 * @param mapper the error transforming {@link Function}
+	 *
+	 * @return a transformed {@link Flux}
+	 */
+	public final Flux<T> onErrorMap(Function<? super Throwable, ? extends Throwable> mapper) {
+		return onErrorResume(e -> Mono.error(mapper.apply(e)));
+	}
+
+	/**
+	 * Transform the error emitted by this {@link Flux} by applying a function if the
+	 * error matches the given type, otherwise let the error flow.
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/maperror.png" alt="">
+	 * <p>
+	 * @param type the class of the exception type to react to
+	 * @param mapper the error transforming {@link Function}
+	 * @param <E> the error type
+	 *
+	 * @return a transformed {@link Flux}
+	 */
+	public final <E extends Throwable> Flux<T> onErrorMap(Class<E> type,
+			Function<? super E, ? extends Throwable> mapper) {
+		@SuppressWarnings("unchecked")
+		Function<Throwable, Throwable> handler = (Function<Throwable, Throwable>)mapper;
+		return onErrorMap(type::isInstance, handler);
+	}
+
+	/**
+	 * Transform the error emitted by this {@link Flux} by applying a function if the
+	 * error matches the given predicate, otherwise let the error flow.
+	 * <p>
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/maperror.png"
+	 * alt="">
+	 *
+	 * @param predicate the error predicate
+	 * @param mapper the error transforming {@link Function}
+	 *
+	 * @return a transformed {@link Flux}
+	 */
+	public final Flux<T> onErrorMap(Predicate<? super Throwable> predicate,
+			Function<? super Throwable, ? extends Throwable> mapper) {
+		return onErrorResume(predicate, e -> Mono.error(mapper.apply(e)));
+	}
+
+	/**
+	 * Subscribe to a returned fallback publisher when any error occurs.
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/onerrorresumewith.png" alt="">
+	 * <p>
+	 * @param fallback the {@link Function} mapping the error to a new {@link Publisher} sequence
+	 *
+	 * @return a new {@link Flux}
+	 * @deprecated use {@link #onErrorResume(Function)} instead. Will be removed in 3.1.0.
+	 */
+	@Deprecated
+	public final Flux<T> onErrorResumeWith(Function<? super Throwable, ? extends Publisher<? extends T>> fallback) {
+		return onErrorResume(fallback);
+	}
+
+	/**
+	 * Subscribe to a returned fallback publisher when an error matching the given type
+	 * occurs.
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/onerrorresumewith.png"
+	 * alt="">
+	 *
+	 * @param type the error type to match
+	 * @param fallback the {@link Function} mapping the error to a new {@link Publisher}
+	 * sequence
+	 * @param <E> the error type
+	 *
+	 * @return a new {@link Flux}
+	 * @deprecated use {@link #onErrorResume(Class, Function)} instead. Will be removed in 3.1.0.
+	 */
+	@Deprecated
+	public final <E extends Throwable> Flux<T> onErrorResumeWith(Class<E> type,
+			Function<? super E, ? extends Publisher<? extends T>> fallback) {
+		return onErrorResume(type, fallback);
+	}
+
+	/**
+	 * Subscribe to a returned fallback publisher when an error matching the given type
+	 * occurs.
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/onerrorresumewith.png"
+	 * alt="">
+	 *
+	 * @param predicate the error predicate to match
+	 * @param fallback the {@link Function} mapping the error to a new {@link Publisher}
+	 * sequence
+	 *
+	 * @deprecated use {@link #onErrorResume(Predicate, Function)} instead. Will be removed in 3.1.0.
+	 */
+	@Deprecated
+	public final Flux<T> onErrorResumeWith(Predicate<? super Throwable> predicate,
+			Function<? super Throwable, ? extends Publisher<? extends T>> fallback) {
+		return onErrorResume(predicate, fallback);
+	}
+
+	/**
 	 * Subscribe to a returned fallback publisher when any error occurs.
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/onerrorresumewith.png" alt="">
@@ -5005,8 +5116,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * @return a new {@link Flux}
 	 */
-	public final Flux<T> onErrorResumeWith(Function<? super Throwable, ? extends Publisher<? extends T>> fallback) {
-		return onAssembly(new FluxResume<>(this, fallback));
+	public final Flux<T> onErrorResume(Function<? super Throwable, ? extends Publisher<? extends T>> fallback) {
+		return onAssembly(new FluxOnErrorResume<>(this, fallback));
 	}
 
 	/**
@@ -5023,13 +5134,13 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * @return a new {@link Flux}
 	 */
-	public final <E extends Throwable> Flux<T> onErrorResumeWith(Class<E> type,
+	public final <E extends Throwable> Flux<T> onErrorResume(Class<E> type,
 			Function<? super E, ? extends Publisher<? extends T>> fallback) {
 		Objects.requireNonNull(type, "type");
 		@SuppressWarnings("unchecked")
 		Function<? super Throwable, Publisher<? extends T>> handler = (Function<?
 				super Throwable, Publisher<? extends T>>)fallback;
-		return onErrorResumeWith(type::isInstance, handler);
+		return onErrorResume(type::isInstance, handler);
 	}
 
 	/**
@@ -5045,10 +5156,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * @return a new {@link Flux}
 	 */
-	public final Flux<T> onErrorResumeWith(Predicate<? super Throwable> predicate,
+	public final Flux<T> onErrorResume(Predicate<? super Throwable> predicate,
 			Function<? super Throwable, ? extends Publisher<? extends T>> fallback) {
 		Objects.requireNonNull(predicate, "predicate");
-		return onErrorResumeWith(e -> predicate.test(e) ? fallback.apply(e) : error(e));
+		return onErrorResume(e -> predicate.test(e) ? fallback.apply(e) : error(e));
 	}
 
 	/**
@@ -5061,7 +5172,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a new {@link Flux}
 	 */
 	public final Flux<T> onErrorReturn(T fallbackValue) {
-		return switchOnError(just(fallbackValue));
+		return onErrorResume(t -> just(fallbackValue));
 	}
 
 	/**
@@ -5077,7 +5188,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public final <E extends Throwable> Flux<T> onErrorReturn(Class<E> type,
 			T fallbackValue) {
-		return switchOnError(type, just(fallbackValue));
+		return onErrorResume(type, t -> just(fallbackValue));
 	}
 
 	/**
@@ -5095,7 +5206,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	public final <E extends Throwable> Flux<T> onErrorReturn(Predicate<? super Throwable>
 			predicate, T
 			fallbackValue) {
-		return switchOnError(predicate, just(fallbackValue));
+		return onErrorResume(predicate, t -> just(fallbackValue));
 	}
 
 	/**
@@ -6585,10 +6696,13 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param <E> the error type
 	 *
 	 * @return an alternating {@link Flux} on source onError
+	 * @deprecated use {@link #onErrorResume} with a {@code t -> fallback} lambda
+	 * instead. Will be removed in 3.1.0.
 	 */
+	@Deprecated
 	public final <E extends Throwable> Flux<T> switchOnError(Class<E> type,
 			Publisher<? extends T> fallback) {
-		return onErrorResumeWith(type, t -> fallback);
+		return onErrorResume(type, t -> fallback);
 	}
 
 	/**
@@ -6602,10 +6716,13 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param fallback the alternate {@link Publisher}
 	 *
 	 * @return an alternating {@link Flux} on source onError
+	 * @deprecated use {@link #onErrorResume} with a {@code t -> fallback} lambda
+	 * instead. Will be removed in 3.1.0.
 	 */
+	@Deprecated
 	public final Flux<T> switchOnError(Predicate<? super Throwable> predicate,
 			Publisher<? extends	T> fallback) {
-		return onErrorResumeWith(predicate, t -> fallback);
+		return onErrorResume(predicate, t -> fallback);
 	}
 
 	/**
@@ -6617,9 +6734,12 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param fallback the alternate {@link Publisher}
 	 *
 	 * @return an alternating {@link Flux} on source onError
+	 * @deprecated use {@link #onErrorResume} with a {@code t -> fallback} lambda
+	 * instead. Will be removed in 3.1.0.
 	 */
+	@Deprecated
 	public final Flux<T> switchOnError(Publisher<? extends T> fallback) {
-		return onErrorResumeWith(t -> fallback);
+		return onErrorResume(t -> fallback);
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/FluxOnErrorResume.java
+++ b/src/main/java/reactor/core/publisher/FluxOnErrorResume.java
@@ -31,11 +31,11 @@ import org.reactivestreams.Subscription;
  *
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
-final class FluxResume<T> extends FluxSource<T, T> {
+final class FluxOnErrorResume<T> extends FluxSource<T, T> {
 
 	final Function<? super Throwable, ? extends Publisher<? extends T>> nextFactory;
 
-	FluxResume(Flux<? extends T> source,
+	FluxOnErrorResume(Flux<? extends T> source,
 			Function<? super Throwable, ? extends Publisher<? extends T>> nextFactory) {
 		super(source);
 		this.nextFactory = Objects.requireNonNull(nextFactory, "nextFactory");

--- a/src/test/java/reactor/HooksTest.java
+++ b/src/test/java/reactor/HooksTest.java
@@ -17,16 +17,13 @@
 package reactor;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.logging.Level;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.reactivestreams.Subscriber;
 import reactor.core.publisher.ConnectableFlux;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
@@ -36,10 +33,7 @@ import reactor.core.publisher.ParallelFlux;
 import reactor.core.publisher.SignalType;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
-import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Stephane Maldini
@@ -161,7 +155,7 @@ public class HooksTest {
 				new String[]{"FluxJust: 1", "{ \"operator\" : \"MapFuseable\" }: 2",
 						"{ \"operator\" : \"PeekFuseable\" }! false",
 						"{ \"operator\" : \"CollectList\" }! true", "MonoJust: [2]",
-						"{ \"operator\" : \"Otherwise\" }: [2]"});
+						"{ \"operator\" : \"OnErrorResume\" }: [2]"});
 
 		q.clear();
 
@@ -178,7 +172,7 @@ public class HooksTest {
 				new String[]{"FluxJust: 1", "{ \"operator\" : \"MapFuseable\" }: 2",
 						"{ \"operator\" : \"PeekFuseable\" }! false",
 						"{ \"operator\" : \"CollectList\" }! false", "MonoJust: [2]",
-						"{ \"operator\" : \"Otherwise\" }: [2]"});
+						"{ \"operator\" : \"OnErrorResume\" }: [2]"});
 
 		q.clear();
 

--- a/src/test/java/reactor/core/publisher/MonoOnErrorResumeTest.java
+++ b/src/test/java/reactor/core/publisher/MonoOnErrorResumeTest.java
@@ -23,11 +23,11 @@ import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MonoOtherwiseTest {
+public class MonoOnErrorResumeTest {
 /*
 	@Test
 	public void constructors() {
-		ConstructorTestBuilder ctb = new ConstructorTestBuilder(FluxResume.class);
+		ConstructorTestBuilder ctb = new ConstructorTestBuilder(FluxOnErrorResume.class);
 		
 		ctb.addRef("source", Flux.never());
 		ctb.addRef("nextFactory", (Function<Throwable, Publisher<Object>>)e -> Flux.never());
@@ -40,7 +40,7 @@ public class MonoOtherwiseTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		Mono.just(1)
-		    .otherwise(v -> Mono.just(2))
+		    .onErrorResume(v -> Mono.just(2))
 		    .subscribe(ts);
 
 		ts.assertValues(1)
@@ -53,7 +53,7 @@ public class MonoOtherwiseTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
 		Mono.just(1)
-		    .otherwise(v -> Mono.just(2))
+		    .onErrorResume(v -> Mono.just(2))
 		    .subscribe(ts);
 
 		ts.assertNoValues()
@@ -71,7 +71,7 @@ public class MonoOtherwiseTest {
 	public void error() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Mono.<Integer>error(new RuntimeException("forced failure")).otherwise(v -> Mono.just(
+		Mono.<Integer>error(new RuntimeException("forced failure")).onErrorResume(v -> Mono.just(
 				2))
 		                                                           .subscribe(ts);
 
@@ -85,7 +85,7 @@ public class MonoOtherwiseTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		Mono.<Integer>error(new RuntimeException("forced failure"))
-				.otherwise(e -> e.getMessage().equals("forced failure"), v -> Mono.just(2))
+				.onErrorResume(e -> e.getMessage().equals("forced failure"), v -> Mono.just(2))
 				.subscribe(ts);
 
 		ts.assertValues(2)
@@ -97,7 +97,7 @@ public class MonoOtherwiseTest {
 	public void errorMap() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Mono.<Integer>error(new Exception()).mapError(d -> new RuntimeException("forced" +
+		Mono.<Integer>error(new Exception()).onErrorMap(d -> new RuntimeException("forced" +
 				" " +
 				"failure"))
 		                                    .subscribe(ts);
@@ -112,7 +112,7 @@ public class MonoOtherwiseTest {
 	public void errorBackpressured() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
-		Mono.<Integer>error(new RuntimeException("forced failure")).otherwise(v -> Mono.just(
+		Mono.<Integer>error(new RuntimeException("forced failure")).onErrorResume(v -> Mono.just(
 				2))
 		                                                           .subscribe(ts);
 
@@ -130,7 +130,7 @@ public class MonoOtherwiseTest {
 	public void nextFactoryThrows() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
-		Mono.<Integer>error(new RuntimeException("forced failure")).otherwise(v -> {
+		Mono.<Integer>error(new RuntimeException("forced failure")).onErrorResume(v -> {
 			throw new RuntimeException("forced failure 2");
 		})
 		                                                           .subscribe(ts);
@@ -146,7 +146,7 @@ public class MonoOtherwiseTest {
 	public void nextFactoryReturnsNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
-		Mono.<Integer>error(new RuntimeException("forced failure")).otherwise(v -> null)
+		Mono.<Integer>error(new RuntimeException("forced failure")).onErrorResume(v -> null)
 		                                                           .subscribe(ts);
 
 		ts.assertNoValues()
@@ -160,7 +160,7 @@ public class MonoOtherwiseTest {
 	public void mapError() {
 		MonoProcessor<Integer> mp = MonoProcessor.create();
 		StepVerifier.create(Mono.<Integer>error(new TestException())
-				.mapError(TestException.class, e -> new Exception("test"))
+				.onErrorMap(TestException.class, e -> new Exception("test"))
 				.subscribeWith(mp))
 		            .then(() -> assertThat(mp.isError()).isTrue())
 		            .then(() -> assertThat(mp.isSuccess()).isFalse())
@@ -172,7 +172,7 @@ public class MonoOtherwiseTest {
 	public void otherwiseErrorFilter() {
 		MonoProcessor<Integer> mp = MonoProcessor.create();
 		StepVerifier.create(Mono.<Integer>error(new TestException())
-				.otherwise(TestException.class, e -> Mono.just(1))
+				.onErrorResume(TestException.class, e -> Mono.just(1))
 				.subscribeWith(mp))
 		            .then(() -> assertThat(mp.isError()).isFalse())
 		            .then(() -> assertThat(mp.isSuccess()).isTrue())
@@ -185,7 +185,7 @@ public class MonoOtherwiseTest {
 	public void otherwiseErrorUnfilter() {
 		MonoProcessor<Integer> mp = MonoProcessor.create();
 		StepVerifier.create(Mono.<Integer>error(new TestException())
-				.otherwise(RuntimeException.class, e -> Mono.just(1))
+				.onErrorResume(RuntimeException.class, e -> Mono.just(1))
 				.subscribeWith(mp))
 		            .then(() -> assertThat(mp.isError()).isTrue())
 		            .then(() -> assertThat(mp.isSuccess()).isFalse())

--- a/src/test/java/reactor/core/publisher/MonoSwitchIfEmptyTest.java
+++ b/src/test/java/reactor/core/publisher/MonoSwitchIfEmptyTest.java
@@ -18,17 +18,17 @@ package reactor.core.publisher;
 import org.junit.Test;
 import reactor.test.subscriber.AssertSubscriber;
 
-public class MonoOtherwiseIfEmptyTest {
+public class MonoSwitchIfEmptyTest {
 
 	@Test(expected = NullPointerException.class)
 	public void sourceNull() {
-		new MonoOtherwiseIfEmpty<>(null, Mono.never());
+		new MonoSwitchIfEmpty<>(null, Mono.never());
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void otherNull() {
 		Mono.never()
-		    .otherwiseIfEmpty(null);
+		    .switchIfEmpty(null);
 	}
 
 	@Test
@@ -36,7 +36,7 @@ public class MonoOtherwiseIfEmptyTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		Mono.just(1)
-		    .otherwiseIfEmpty(Mono.just(10))
+		    .switchIfEmpty(Mono.just(10))
 		    .subscribe(ts);
 
 		ts.assertValues(1)
@@ -49,7 +49,7 @@ public class MonoOtherwiseIfEmptyTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
 		Mono.just(1)
-		    .otherwiseIfEmpty(Mono.just(10))
+		    .switchIfEmpty(Mono.just(10))
 		    .subscribe(ts);
 
 		ts.assertNoValues()
@@ -68,7 +68,7 @@ public class MonoOtherwiseIfEmptyTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		Mono.<Integer>empty()
-		    .otherwiseIfEmpty(Mono.just(10))
+		    .switchIfEmpty(Mono.just(10))
 		    .subscribe(ts);
 
 		ts.assertValues(10)
@@ -81,7 +81,7 @@ public class MonoOtherwiseIfEmptyTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
 		Mono.<Integer>empty()
-		    .otherwiseIfEmpty(Mono.just(10))
+		    .switchIfEmpty(Mono.just(10))
 		    .subscribe(ts);
 
 		ts.assertNoValues()


### PR DESCRIPTION
This commit is a backport of #535, adapted from commits 02e17c08,
bcbe5633, 094a4992 and b7c1da8d.

Mono API deprecations:

 - otherwise -> onErrorResume
 - otherwiseReturn -> onErrorReturn
 - otherwiseIfEmpty -> switchIfEmpty as per #533
 - mapError -> onErrorMap

Flux API deprecations:

 - onErrorResumeWith -> onErrorResume
 - mapError -> onErrorMap
 - switchOnError(x) -> onErrorResume(ignore -> x) (we don't keep a
   direct equivalent of the methods but they can be easily replaced by
   a lambda that ignores the left hand side)