### PR TITLE
fix #540 Improve queue full backpressure error message

### DIFF
--- a/src/main/java/reactor/core/Exceptions.java
+++ b/src/main/java/reactor/core/Exceptions.java
@@ -31,7 +31,7 @@ public abstract class Exceptions {
 	 * A common error message used when a reactive streams source doesn't seem to respect
 	 * backpressure signals, resulting in an operator's internal queue to be full.
 	 */
-	public static final String BACKPRESSURE_ERROR_QUEUE_FULL = "Reactive Streams source doesn't seem to respect backpressure protocol, queue is full.";
+	public static final String BACKPRESSURE_ERROR_QUEUE_FULL = "Queue is full: Reactive Streams source doesn't respect back-pressure";
 
 	/**
 	 * A singleton instance of a Throwable indicating a terminal state for exceptions,

--- a/src/main/java/reactor/core/Exceptions.java
+++ b/src/main/java/reactor/core/Exceptions.java
@@ -31,7 +31,7 @@ public abstract class Exceptions {
 	 * A common error message used when a reactive streams source doesn't seem to respect
 	 * backpressure signals, resulting in an operator's internal queue to be full.
 	 */
-	public static final String BACKPRESSURE_ERROR_QUEUE_FULL = "Queue is full: Reactive Streams source doesn't respect back-pressure";
+	public static final String BACKPRESSURE_ERROR_QUEUE_FULL = "Queue is full: Reactive Streams source doesn't respect backpressure";
 
 	/**
 	 * A singleton instance of a Throwable indicating a terminal state for exceptions,

--- a/src/main/java/reactor/core/Exceptions.java
+++ b/src/main/java/reactor/core/Exceptions.java
@@ -28,6 +28,12 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 public abstract class Exceptions {
 
 	/**
+	 * A common error message used when a reactive streams source doesn't seem to respect
+	 * backpressure signals, resulting in an operator's internal queue to be full.
+	 */
+	public static final String BACKPRESSURE_ERROR_QUEUE_FULL = "Reactive Streams source doesn't seem to respect backpressure protocol, queue is full.";
+
+	/**
 	 * A singleton instance of a Throwable indicating a terminal state for exceptions,
 	 * don't leak this!
 	 */

--- a/src/main/java/reactor/core/publisher/BlockingIterable.java
+++ b/src/main/java/reactor/core/publisher/BlockingIterable.java
@@ -191,7 +191,7 @@ final class BlockingIterable<T> implements Iterable<T>, Scannable {
 				if (v == null) {
 					run();
 
-					throw new IllegalStateException("Queue empty?!");
+					throw new IllegalStateException("Expected one element to be available from the Reactive Streams source, queue is empty.");
 				}
 
 				long p = produced + 1;
@@ -221,7 +221,7 @@ final class BlockingIterable<T> implements Iterable<T>, Scannable {
 				Operators.terminate(S, this);
 
 				onError(Operators.onOperatorError(null,
-						Exceptions.failWithOverflow("Queue is full?!"),
+						Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL),
 						t));
 			}
 			else {

--- a/src/main/java/reactor/core/publisher/BlockingIterable.java
+++ b/src/main/java/reactor/core/publisher/BlockingIterable.java
@@ -191,7 +191,7 @@ final class BlockingIterable<T> implements Iterable<T>, Scannable {
 				if (v == null) {
 					run();
 
-					throw new IllegalStateException("Expected one element to be available from the Reactive Streams source, queue is empty.");
+					throw new IllegalStateException("Queue is empty: Expected one element to be available from the Reactive Streams source.");
 				}
 
 				long p = produced + 1;

--- a/src/main/java/reactor/core/publisher/FluxCombineLatest.java
+++ b/src/main/java/reactor/core/publisher/FluxCombineLatest.java
@@ -313,7 +313,7 @@ final class FluxCombineLatest<T, R> extends Flux<R> implements Fuseable {
 							new SourceAndArray(subscribers[index], os.clone());
 
 					if (!queue.offer(sa)) {
-						innerError(Operators.onOperatorError(this, Exceptions.failWithOverflow("Queue is full?!")));
+						innerError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL)));
 						return;
 					}
 

--- a/src/main/java/reactor/core/publisher/FluxConcatMap.java
+++ b/src/main/java/reactor/core/publisher/FluxConcatMap.java
@@ -236,7 +236,7 @@ final class FluxConcatMap<T, R> extends FluxSource<T, R> {
 				drain();
 			}
 			else if (!queue.offer(t)) {
-				onError(Operators.onOperatorError(s, Exceptions.failWithOverflow("Queue is full?!"), t));
+				onError(Operators.onOperatorError(s, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t));
 			}
 			else {
 				drain();
@@ -579,7 +579,7 @@ final class FluxConcatMap<T, R> extends FluxSource<T, R> {
 				drain();
 			}
 			else if (!queue.offer(t)) {
-				onError(Operators.onOperatorError(s, Exceptions.failWithOverflow("Queue is full?!"), t));
+				onError(Operators.onOperatorError(s, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t));
 			}
 			else {
 				drain();

--- a/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -760,7 +760,7 @@ final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 
 		boolean failOverflow(R v, Subscription toCancel){
 			Throwable e = Operators.onOperatorError(toCancel,
-					Exceptions.failWithOverflow("Scalar queue full?!"),
+					Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL),
 					v);
 
 			if (!Exceptions.addThrowable(ERROR, this, e)) {

--- a/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
+++ b/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
@@ -234,7 +234,7 @@ final class FluxFlattenIterable<T, R> extends FluxSource<T, R> implements Fuseab
 		public void onNext(T t) {
 			if (fusionMode != Fuseable.ASYNC) {
 				if (!queue.offer(t)) {
-					onError(Operators.onOperatorError(s,Exceptions.failWithOverflow("Queue is full?!")));
+					onError(Operators.onOperatorError(s,Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL)));
 					return;
 				}
 			}

--- a/src/main/java/reactor/core/publisher/FluxGroupBy.java
+++ b/src/main/java/reactor/core/publisher/FluxGroupBy.java
@@ -669,7 +669,7 @@ final class FluxGroupBy<T, K, V> extends FluxSource<T, GroupedFlux<K, V>>
 			Subscriber<? super V> a = actual;
 
 			if (!queue.offer(t)) {
-				onError(Operators.onOperatorError(this, Exceptions.failWithOverflow("Queue is full?!"), t));
+				onError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t));
 				return;
 			}
 			if (outputFused) {

--- a/src/main/java/reactor/core/publisher/FluxMergeSequential.java
+++ b/src/main/java/reactor/core/publisher/FluxMergeSequential.java
@@ -300,7 +300,7 @@ final class FluxMergeSequential<T, R> extends FluxSource<T, R> {
 			}
 			else {
 				inner.cancel();
-				onError(Operators.onOperatorError(null, Exceptions.failWithOverflow("Queue is full?!"), value));
+				onError(Operators.onOperatorError(null, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), value));
 			}
 		}
 

--- a/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -247,7 +247,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 
 			if (!queue.offer(t)) {
 				Throwable ex = Operators.onOperatorError(s,
-						Exceptions.failWithOverflow("Queue is full?!"),
+						Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL),
 						t);
 				if (!Exceptions.addThrowable(ERROR, this, ex)) {
 					Operators.onErrorDropped(ex);

--- a/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
+++ b/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
@@ -254,7 +254,7 @@ final class FluxPublishMulticast<T, R> extends FluxSource<T, R> implements Fusea
 			if (sourceMode != Fuseable.ASYNC) {
 				if (!queue.offer(t)) {
 					onError(Operators.onOperatorError(s,
-							Exceptions.failWithOverflow("Queue full?!"),
+							Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL),
 							t));
 					return;
 				}

--- a/src/main/java/reactor/core/publisher/FluxPublishOn.java
+++ b/src/main/java/reactor/core/publisher/FluxPublishOn.java
@@ -224,7 +224,7 @@ final class FluxPublishOn<T> extends FluxSource<T, T> implements Fuseable {
 			}
 			if (!queue.offer(t)) {
 				error = Operators.onOperatorError(s,
-						Exceptions.failWithOverflow("Queue is full?!"),
+						Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL),
 						t);
 				done = true;
 			}
@@ -711,7 +711,7 @@ final class FluxPublishOn<T> extends FluxSource<T, T> implements Fuseable {
 				return;
 			}
 			if (!queue.offer(t)) {
-				error = Operators.onOperatorError(s, Exceptions.failWithOverflow("Queue is full?!"), t);
+				error = Operators.onOperatorError(s, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t);
 				done = true;
 			}
 			if (trySchedule() == Scheduler.REJECTED) {

--- a/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
+++ b/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
@@ -194,7 +194,7 @@ final class FluxWindowPredicate<T> extends FluxSource<T, GroupedFlux<T, T>>
 				window = g;
 
 				if (!queue.offer(g)) {
-					onError(Operators.onOperatorError(this, Exceptions.failWithOverflow("Queue is full?!"), emitInNewWindow));
+					onError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), emitInNewWindow));
 					return;
 				}
 				drain();
@@ -687,7 +687,7 @@ final class FluxWindowPredicate<T> extends FluxSource<T, GroupedFlux<T, T>>
 			Subscriber<? super T> a = actual;
 
 			if (!queue.offer(t)) {
-				onError(Operators.onOperatorError(this, Exceptions.failWithOverflow("Queue is full?!"), t));
+				onError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t));
 				return;
 			}
 			if (enableOperatorFusion) {

--- a/src/main/java/reactor/core/publisher/FluxZip.java
+++ b/src/main/java/reactor/core/publisher/FluxZip.java
@@ -864,7 +864,7 @@ final class FluxZip<T, R> extends Flux<R> {
 		public void onNext(T t) {
 			if (sourceMode != ASYNC) {
 				if (!queue.offer(t)) {
-					onError(Operators.onOperatorError(s, Exceptions.failWithOverflow("Queue is full?!"), t));
+					onError(Operators.onOperatorError(s, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t));
 					return;
 				}
 			}

--- a/src/main/java/reactor/core/publisher/MonoSequenceEqual.java
+++ b/src/main/java/reactor/core/publisher/MonoSequenceEqual.java
@@ -330,7 +330,7 @@ final class MonoSequenceEqual<T> extends Mono<Boolean> {
 		public void onNext(T t) {
 			if (!queue.offer(t)) {
 				onError(Operators.onOperatorError(cachedSubscription, Exceptions
-						.failWithOverflow("Queue is full?!"), t));
+						.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t));
 				return;
 			}
 			parent.drain();

--- a/src/main/java/reactor/core/publisher/ParallelMergeSequential.java
+++ b/src/main/java/reactor/core/publisher/ParallelMergeSequential.java
@@ -183,7 +183,7 @@ final class ParallelMergeSequential<T> extends Flux<T> implements Scannable {
 					Queue<T> q = inner.getQueue(queueSupplier);
 
 					if(!q.offer(value)){
-						onError(Operators.onOperatorError(this, Exceptions.failWithOverflow("Queue is full?!"), value));
+						onError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), value));
 						return;
 					}
 				}
@@ -194,7 +194,7 @@ final class ParallelMergeSequential<T> extends Flux<T> implements Scannable {
 				Queue<T> q = inner.getQueue(queueSupplier);
 
 				if(!q.offer(value)){
-					onError(Operators.onOperatorError(this, Exceptions.failWithOverflow("Queue is full?!"), value));
+					onError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), value));
 					return;
 				}
 

--- a/src/main/java/reactor/core/publisher/ParallelSource.java
+++ b/src/main/java/reactor/core/publisher/ParallelSource.java
@@ -228,7 +228,7 @@ final class ParallelSource<T> extends ParallelFlux<T> implements Scannable {
 			}
 			if (sourceMode == Fuseable.NONE) {
 				if (!queue.offer(t)) {
-					onError(Operators.onOperatorError(s, Exceptions.failWithOverflow("Queue is full?!"), t));
+					onError(Operators.onOperatorError(s, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t));
 					return;
 				}
 			}


### PR DESCRIPTION
The message has been centralized in a constant in `Exceptions`.