### PR TITLE
backport #542 Use when suffix to distinguish open+close buffer/window

### DIFF
--- a/src/docs/asciidoc/operatorChoice.adoc
+++ b/src/docs/asciidoc/operatorChoice.adoc
@@ -216,7 +216,7 @@ I want to deal with: <<which.create>>, <<which.values>>, <<which.peeking>>,
 ** based on a predicate on elements: `windowUntil`
 *** ...…emitting the element that triggered the boundary in the next window (`cutBefore` variant): `.windowUntil(predicate, true)`
 *** ...keeping the window open while elements match a predicate: `windowWhile` (non-matching elements are not emitted)
-** driven by an arbitrary boundary represented by onNexts in a control Publisher: `window(Publisher)`
+** driven by an arbitrary boundary represented by onNexts in a control Publisher: `window(Publisher)`, `windowWhen`
 
 * I want to split a `Flux<T>` and buffer elements within boundaries together...
 ** into `List`...
@@ -228,7 +228,7 @@ I want to deal with: <<which.create>>, <<which.values>>, <<which.peeking>>,
 *** by an arbitrary criteria boundary: `bufferUntil(Predicate)`
 **** ...putting the element that triggered the boundary in the next buffer: `.bufferUntil(predicate, true)`
 **** ...buffering while predicate matches and dropping the element that triggered the boundary: `bufferWhile(Predicate)`
-*** driven by an arbitrary boundary represented by onNexts in a control Publisher: `buffer(Publisher)`
+*** driven by an arbitrary boundary represented by onNexts in a control Publisher: `buffer(Publisher)`, `bufferWhen`
 ** into an arbitrary "collection" type `C`: use variants like `buffer(int, Supplier<C>)`
 
 * I want to split a `Flux<T>` so that element that share a characteristic end up in the same sub-flux: `groupBy(Function<T,K>)`

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -2200,10 +2200,12 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * @return a microbatched {@link Flux} of {@link List} delimited by an opening {@link Publisher} and a relative
 	 * closing {@link Publisher}
+	 * @deprecated will be removed in 3.1.0. Use {@link #bufferWhen(Publisher, Function)} instead.
 	 */
+	@Deprecated
 	public final <U, V> Flux<List<T>> buffer(Publisher<U> bucketOpening,
 			Function<? super U, ? extends Publisher<V>> closeSelector) {
-		return buffer(bucketOpening, closeSelector, listSupplier());
+		return bufferWhen(bucketOpening, closeSelector, listSupplier());
 	}
 
 	/**
@@ -2236,13 +2238,12 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * @return a microbatched {@link Flux} of {@link Collection} delimited by an opening {@link Publisher} and a relative
 	 * closing {@link Publisher}
+	 * @deprecated will be removed in 3.1.0. Use {@link #bufferWhen(Publisher, Function, Supplier)} instead.
 	 */
-	public final <U, V, C extends Collection<? super T>> Flux<C> buffer(Publisher<U>
-			bucketOpening,
-			Function<? super U, ? extends Publisher<V>> closeSelector,
-			Supplier<C> bufferSupplier) {
-		return onAssembly(new FluxBufferStartEnd<>(this, bucketOpening, closeSelector,
-				bufferSupplier, QueueSupplier.unbounded(QueueSupplier.XS_BUFFER_SIZE)));
+	@Deprecated
+	public final <U, V, C extends Collection<? super T>> Flux<C> buffer(Publisher<U> bucketOpening,
+			Function<? super U, ? extends Publisher<V>> closeSelector, Supplier<C> bufferSupplier) {
+		return bufferWhen(bucketOpening, closeSelector, bufferSupplier);
 	}
 
 	/**
@@ -2335,7 +2336,7 @@ public abstract class Flux<T> implements Publisher<T> {
 		if (timespan.equals(timeshift)) {
 			return buffer(timespan, timer);
 		}
-		return buffer(interval(Duration.ZERO, timeshift, timer), aLong -> Mono
+		return bufferWhen(interval(Duration.ZERO, timeshift, timer), aLong -> Mono
 				.delay(timespan, timer));
 	}
 
@@ -2732,6 +2733,77 @@ public abstract class Flux<T> implements Publisher<T> {
 	public final Flux<List<T>> bufferWhile(Predicate<? super T> predicate) {
 		return onAssembly(new FluxBufferPredicate<>(this, predicate,
 				listSupplier(), FluxBufferPredicate.Mode.WHILE));
+	}
+
+	/**
+	 * Collect incoming values into multiple {@link List} buffers started each time an opening
+	 * companion {@link Publisher} emits. Each buffer will last until the corresponding
+	 * closing companion {@link Publisher} emits, thus releasing the buffer to the resulting {@link Flux}.
+	 * <p>
+	 * When Open signal is strictly not overlapping Close signal : dropping buffers
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/bufferopenclose.png"
+	 * alt="">
+	 * <p>
+	 * When Open signal is strictly more frequent than Close signal : overlapping buffers
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/bufferopencloseover.png"
+	 * alt="">
+	 * <p>
+	 * When Open signal is exactly coordinated with Close signal : exact buffers
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/bufferboundary.png"
+	 * alt="">
+	 *
+	 * @param bucketOpening a companion {@link Publisher} to subscribe for buffer creation signals.
+	 * @param closeSelector a factory that, given a buffer opening signal, returns a companion
+	 * {@link Publisher} to subscribe to for buffer closure and emission signals.
+	 * @param <U> the element type of the buffer-opening sequence
+	 * @param <V> the element type of the buffer-closing sequence
+	 *
+	 * @return a microbatched {@link Flux} of {@link List} delimited by an opening {@link Publisher} and a relative
+	 * closing {@link Publisher}
+	 */
+	public final <U, V> Flux<List<T>> bufferWhen(Publisher<U> bucketOpening,
+			Function<? super U, ? extends Publisher<V>> closeSelector) {
+		return bufferWhen(bucketOpening, closeSelector, listSupplier());
+	}
+
+	/**
+	 * Collect incoming values into multiple user-defined {@link Collection} buffers started each time an opening
+	 * companion {@link Publisher} emits. Each buffer will last until the corresponding
+	 * closing companion {@link Publisher} emits, thus releasing the buffer to the resulting {@link Flux}.
+	 * <p>
+	 * When Open signal is strictly not overlapping Close signal : dropping buffers
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/bufferopenclose.png"
+	 * alt="">
+	 * <p>
+	 * When Open signal is strictly more frequent than Close signal : overlapping buffers
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/bufferopencloseover.png"
+	 * alt="">
+	 * <p>
+	 * When Open signal is exactly coordinated with Close signal : exact buffers
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/bufferboundary.png"
+	 * alt="">
+	 *
+	 * @param bucketOpening a companion {@link Publisher} to subscribe for buffer creation signals.
+	 * @param closeSelector a factory that, given a buffer opening signal, returns a companion
+	 * {@link Publisher} to subscribe to for buffer closure and emission signals.
+	 * @param bufferSupplier a {@link Supplier} of the concrete {@link Collection} to use for each buffer
+	 * @param <U> the element type of the buffer-opening sequence
+	 * @param <V> the element type of the buffer-closing sequence
+	 * @param <C> the {@link Collection} buffer type
+	 *
+	 * @return a microbatched {@link Flux} of {@link Collection} delimited by an opening {@link Publisher} and a relative
+	 * closing {@link Publisher}
+	 */
+	public final <U, V, C extends Collection<? super T>> Flux<C> bufferWhen(Publisher<U> bucketOpening,
+			Function<? super U, ? extends Publisher<V>> closeSelector, Supplier<C> bufferSupplier) {
+		return onAssembly(new FluxBufferWhen<>(this, bucketOpening, closeSelector,
+				bufferSupplier, QueueSupplier.unbounded(QueueSupplier.XS_BUFFER_SIZE)));
 	}
 
 	/**
@@ -7376,14 +7448,12 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * @return a windowing {@link Flux} delimiting its sub-sequences by a given {@link Publisher} and lasting until
 	 * a selected {@link Publisher} emits
+	 * @deprecated will be removed in 3.1.0. Use {@link #windowWhen(Publisher, Function)} instead.
 	 */
+	@Deprecated
 	public final <U, V> Flux<Flux<T>> window(Publisher<U> bucketOpening,
 			final Function<? super U, ? extends Publisher<V>> closeSelector) {
-		return onAssembly(new FluxWindowStartEnd<>(this,
-				bucketOpening,
-				closeSelector,
-				QueueSupplier.unbounded(QueueSupplier.XS_BUFFER_SIZE),
-				QueueSupplier.unbounded(QueueSupplier.XS_BUFFER_SIZE)));
+		return windowWhen(bucketOpening, closeSelector);
 	}
 
 	/**
@@ -7473,7 +7543,7 @@ public abstract class Flux<T> implements Publisher<T> {
 		if (timeshift.equals(timespan)) {
 			return window(timespan);
 		}
-		return window(interval(Duration.ZERO, timeshift, timer), aLong -> Mono.delay(timespan, timer));
+		return windowWhen(interval(Duration.ZERO, timeshift, timer), aLong -> Mono.delay(timespan, timer));
 	}
 
 	/**
@@ -7789,6 +7859,42 @@ public abstract class Flux<T> implements Publisher<T> {
 				prefetch,
 				inclusionPredicate,
 				FluxBufferPredicate.Mode.WHILE));
+	}
+
+	/**
+	 * Split this {@link Flux} sequence into potentially overlapping windows controlled by items of a
+	 * start {@link Publisher} and end {@link Publisher} derived from the start values.
+	 *
+	 * <p>
+	 * When Open signal is strictly not overlapping Close signal : dropping windows
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/windowopenclose.png" alt="">
+	 * <p>
+	 * When Open signal is strictly more frequent than Close signal : overlapping windows
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/windowopencloseover.png" alt="">
+	 * <p>
+	 * When Open signal is exactly coordinated with Close signal : exact windows
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.6.RELEASE/src/docs/marble/windowboundary.png" alt="">
+	 *
+	 * @param bucketOpening a {@link Publisher} to emit any item for a split signal and complete to terminate
+	 * @param closeSelector a {@link Function} given an opening signal and returning a {@link Publisher} that
+	 * emits to complete the window
+	 *
+	 * @param <U> the type of the sequence opening windows
+	 * @param <V> the type of the sequence closing windows opened by the bucketOpening Publisher's elements
+	 *
+	 * @return a windowing {@link Flux} delimiting its sub-sequences by a given {@link Publisher} and lasting until
+	 * a selected {@link Publisher} emits
+	 */
+	public final <U, V> Flux<Flux<T>> windowWhen(Publisher<U> bucketOpening,
+			final Function<? super U, ? extends Publisher<V>> closeSelector) {
+		return onAssembly(new FluxWindowWhen<>(this,
+				bucketOpening,
+				closeSelector,
+				QueueSupplier.unbounded(QueueSupplier.XS_BUFFER_SIZE),
+				QueueSupplier.unbounded(QueueSupplier.XS_BUFFER_SIZE)));
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/FluxBufferWhen.java
+++ b/src/main/java/reactor/core/publisher/FluxBufferWhen.java
@@ -46,7 +46,7 @@ import reactor.core.Exceptions;
  *
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
-final class FluxBufferStartEnd<T, U, V, C extends Collection<? super T>>
+final class FluxBufferWhen<T, U, V, C extends Collection<? super T>>
 		extends FluxSource<T, C> {
 
 	final Publisher<U> start;
@@ -57,7 +57,7 @@ final class FluxBufferStartEnd<T, U, V, C extends Collection<? super T>>
 
 	final Supplier<? extends Queue<C>> queueSupplier;
 
-	FluxBufferStartEnd(Flux<? extends T> source,
+	FluxBufferWhen(Flux<? extends T> source,
 			Publisher<U> start,
 			Function<? super U, ? extends Publisher<V>> end,
 			Supplier<C> bufferSupplier,

--- a/src/main/java/reactor/core/publisher/FluxWindowWhen.java
+++ b/src/main/java/reactor/core/publisher/FluxWindowWhen.java
@@ -42,7 +42,7 @@ import reactor.core.Exceptions;
  *
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
-final class FluxWindowStartEnd<T, U, V> extends FluxSource<T, Flux<T>> {
+final class FluxWindowWhen<T, U, V> extends FluxSource<T, Flux<T>> {
 
 	final Publisher<U> start;
 
@@ -52,7 +52,7 @@ final class FluxWindowStartEnd<T, U, V> extends FluxSource<T, Flux<T>> {
 
 	final Supplier<? extends Queue<T>> processorQueueSupplier;
 
-	FluxWindowStartEnd(Flux<? extends T> source,
+	FluxWindowWhen(Flux<? extends T> source,
 			Publisher<U> start,
 			Function<? super U, ? extends Publisher<V>> end,
 			Supplier<? extends Queue<Object>> drainQueueSupplier,

--- a/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
+++ b/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
@@ -27,7 +27,7 @@ import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FluxBufferStartEndTest {
+public class FluxBufferWhenTest {
 
 	@Test
 	public void normal() {
@@ -38,7 +38,7 @@ public class FluxBufferStartEndTest {
 		DirectProcessor<Integer> sp3 = DirectProcessor.create();
 		DirectProcessor<Integer> sp4 = DirectProcessor.create();
 
-		sp1.buffer(sp2, v -> v == 1 ? sp3 : sp4)
+		sp1.bufferWhen(sp2, v -> v == 1 ? sp3 : sp4)
 		   .subscribe(ts);
 
 		ts.assertNoValues()
@@ -94,7 +94,7 @@ public class FluxBufferStartEndTest {
 		DirectProcessor<Integer> sp2 = DirectProcessor.create();
 		DirectProcessor<Integer> sp3 = DirectProcessor.create();
 
-		sp1.buffer(sp2, v -> sp3)
+		sp1.bufferWhen(sp2, v -> sp3)
 		   .subscribe(ts);
 
 		ts.assertNoValues()
@@ -138,7 +138,7 @@ public class FluxBufferStartEndTest {
 		//"overlapping buffers"
 		EmitterProcessor<Integer> boundaryFlux = EmitterProcessor.create();
 
-		Mono<List<List<Integer>>> res = numbers.buffer(bucketOpening, u -> boundaryFlux )
+		Mono<List<List<Integer>>> res = numbers.bufferWhen(bucketOpening, u -> boundaryFlux )
 		                                       .buffer()
 		                                       .publishNext()
 		                                       .subscribe();

--- a/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
+++ b/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
@@ -28,7 +28,7 @@ import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FluxWindowStartEndTest {
+public class FluxWindowWhenTest {
 
 	static <T> AssertSubscriber<T> toList(Publisher<T> windows) {
 		AssertSubscriber<T> ts = AssertSubscriber.create();
@@ -53,7 +53,7 @@ public class FluxWindowStartEndTest {
 		DirectProcessor<Integer> sp3 = DirectProcessor.create();
 		DirectProcessor<Integer> sp4 = DirectProcessor.create();
 
-		sp1.window(sp2, v -> v == 1 ? sp3 : sp4)
+		sp1.windowWhen(sp2, v -> v == 1 ? sp3 : sp4)
 		   .subscribe(ts);
 
 		sp1.onNext(1);
@@ -96,7 +96,7 @@ public class FluxWindowStartEndTest {
 		DirectProcessor<Integer> sp3 = DirectProcessor.create();
 		DirectProcessor<Integer> sp4 = DirectProcessor.create();
 
-		sp1.window(sp2, v -> v == 1 ? sp3 : sp4)
+		sp1.windowWhen(sp2, v -> v == 1 ? sp3 : sp4)
 		   .subscribe(ts);
 
 		sp1.onNext(1);
@@ -139,7 +139,7 @@ public class FluxWindowStartEndTest {
 		DirectProcessor<Integer> sp3 = DirectProcessor.create();
 		DirectProcessor<Integer> sp4 = DirectProcessor.create();
 
-		sp1.window(sp2, v -> v == 1 ? sp3 : sp4)
+		sp1.windowWhen(sp2, v -> v == 1 ? sp3 : sp4)
 		   .subscribe(ts);
 
 		sp2.onNext(1);
@@ -175,7 +175,7 @@ public class FluxWindowStartEndTest {
 		//"overlapping buffers"
 		EmitterProcessor<Integer> boundaryFlux = EmitterProcessor.create();
 
-		Mono<List<List<Integer>>> res = numbers.window(bucketOpening, u -> boundaryFlux )
+		Mono<List<List<Integer>>> res = numbers.windowWhen(bucketOpening, u -> boundaryFlux )
 		                                       .flatMap(Flux::buffer)
 		                                       .buffer()
 		                                       .publishNext()


### PR DESCRIPTION
This commit deprecates buffer and window overloads that take a Publisher
and Function (opening and closing selectors), in favor of a bufferWhen
and windowWhen alias. This limits ambiguous lambda overloads further.

backported from 88de739