### PR TITLE
Fix memory leak in SingleScheduler.schedule

### DIFF
--- a/src/main/java/reactor/core/scheduler/SingleScheduler.java
+++ b/src/main/java/reactor/core/scheduler/SingleScheduler.java
@@ -190,7 +190,7 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 			try {
 				Future<?> f;
 				if (delay <= 0L) {
-					f = exec.submit(task);
+					f = exec.submit(sr);
 				}
 				else {
 					f = exec.schedule(sr, delay, unit);


### PR DESCRIPTION
This PR fixes the memory leak in `SingleScheduler` due to submitting the wrong thing on line 193.

Related: #578