### PR TITLE
Light checkpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ buildscript {
 
 plugins {
   id 'org.asciidoctor.convert' version '1.5.2'
+  id "me.champeau.gradle.jmh" version "0.3.1"
 }
 
 description = 'Non-Blocking Reactive Foundation for the JVM'

--- a/src/docs/asciidoc/debugging.adoc
+++ b/src/docs/asciidoc/debugging.adoc
@@ -276,12 +276,23 @@ which serviceability is critical, *a mix of both world can be achieved with the
 You can chain this operator towards their end. The `checkpoint` operator will
 work like the hook version, but only for its link of that particular chain.
 
-There is also a `checkpoint(String)` variant that allows you to add a
-description to the assembly traceback. It could for example be a static
-identifier or user-readable description, or a wider *correlation ID* coming from
-a header in the case of an HTTP request for instance...
+There is also a `checkpoint(String)` lighter variant that allows you to add a
+unique String identifier to the assembly traceback. This way, the stack trace is
+omitted and you rely on the description to identify the assembly site.
 
-That information appears in the first line of the traceback:
+That information appears in the first line of the traceback, which changes to reflect the
+fact that it is "light":
+
+----
+...
+	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException:
+Assembly site of producer [reactor.core.publisher.FluxElapsed] is identified by light checkpoint [light checkpoint identifier].
+----
+
+Last but not least, if you want to add a more generic description to the checkpoint but
+still rely on the stack trace mechanism to identify the assembly site, you can force that
+behavior using the `checkpoint("foo", true)` version. We're now back to the initial message
+for the traceback, augmented with the `description`:
 
 ----
 Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException:
@@ -293,15 +304,8 @@ Error has been observed by the following operator(s):
 ----
 <1> `fooCorrelation1234` is the description provided in `checkpoint`
 
-Last but not least, the checkpoint can also be made in a lightweight manner: using a unique
-enough description, the stack trace filling in omitted when using `checkpointLight(String, boolean)`
-with the second parameter set to `true`. The traceback then changes to only contain one line:
-
-----
-...
-	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException:
-Assembly site of producer [reactor.core.publisher.FluxElapsed] is identified by light checkpoint [light checkpoint identifier].
-----
+Said description could for example be a static identifier or user-readable description,
+or a wider *correlation ID* coming from a header in the case of an HTTP request for instance...
 
 Note that When both global debugging and local `checkpoint()` are enabled, checkpointed snapshot
 stacks will be appended as suppressed error after the observing operator graph and

--- a/src/docs/asciidoc/debugging.adoc
+++ b/src/docs/asciidoc/debugging.adoc
@@ -294,8 +294,8 @@ Error has been observed by the following operator(s):
 <1> `fooCorrelation1234` is the description provided in `checkpoint`
 
 Last but not least, the checkpoint can also be made in a lightweight manner: using a unique
-enough description, the stack trace filling in omitted when using `checkpointLight(String)`.
-The traceback changes to only contain one line:
+enough description, the stack trace filling in omitted when using `checkpointLight(String, boolean)`
+with the second parameter set to `true`. The traceback then changes to only contain one line:
 
 ----
 ...

--- a/src/docs/asciidoc/debugging.adoc
+++ b/src/docs/asciidoc/debugging.adoc
@@ -276,7 +276,7 @@ which serviceability is critical, *a mix of both world can be achieved with the
 You can chain this operator towards their end. The `checkpoint` operator will
 work like the hook version, but only for its link of that particular chain.
 
-Additionally, there is a `checkpoint(String)` variant that allows you to add a
+There is also a `checkpoint(String)` variant that allows you to add a
 description to the assembly traceback. It could for example be a static
 identifier or user-readable description, or a wider *correlation ID* coming from
 a header in the case of an HTTP request for instance...
@@ -293,7 +293,17 @@ Error has been observed by the following operator(s):
 ----
 <1> `fooCorrelation1234` is the description provided in `checkpoint`
 
-When both global debugging and local `checkpoint()` are enabled, checkpointed snapshot
+Last but not least, the checkpoint can also be made in a lightweight manner: using a unique
+enough description, the stack trace filling in omitted when using `checkpointLight(String)`.
+The traceback changes to only contain one line:
+
+----
+...
+	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException:
+Assembly site of producer [reactor.core.publisher.FluxElapsed] is identified by light checkpoint [light checkpoint identifier].
+----
+
+Note that When both global debugging and local `checkpoint()` are enabled, checkpointed snapshot
 stacks will be appended as suppressed error after the observing operator graph and
 following the same declarative order.
 

--- a/src/jmh/java/reactor/CheckpointBenchmark.java
+++ b/src/jmh/java/reactor/CheckpointBenchmark.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import reactor.core.publisher.Flux;
+import reactor.guide.FakeRepository;
+import reactor.guide.FakeUtils1;
+import reactor.guide.FakeUtils2;
+
+/**
+ * @author Simon Baslé
+ */
+public class CheckpointBenchmark {
+
+	@Benchmark()
+	@BenchmarkMode({Mode.Throughput, Mode.SampleTime})
+	public void withFullCheckpoint() {
+		FakeRepository.findAllUserByName(Flux.just("pedro", "simon", "stephane"))
+		              .transform(FakeUtils1.applyFilters)
+		              .transform(FakeUtils2.enrichUser)
+		              .checkpoint("checkpoint description")
+		              .subscribe(System.out::println,
+		                      t -> {}
+                      );
+	}
+
+	@Benchmark
+	@BenchmarkMode({Mode.Throughput, Mode.SampleTime})
+	public void withLightCheckpoint() {
+		FakeRepository.findAllUserByName(Flux.just("pedro", "simon", "stephane"))
+		              .transform(FakeUtils1.applyFilters)
+		              .transform(FakeUtils2.enrichUser)
+		              .checkpointLight("light checkpoint identifier")
+		              .subscribe(System.out::println,
+				              t -> {}
+		              );
+	}
+
+	public static void main(String[] args) {
+		final CheckpointBenchmark benchmark = new CheckpointBenchmark();
+		benchmark.withFullCheckpoint();
+		benchmark.withLightCheckpoint();
+	}
+
+}

--- a/src/jmh/java/reactor/CheckpointBenchmark.java
+++ b/src/jmh/java/reactor/CheckpointBenchmark.java
@@ -47,16 +47,9 @@ public class CheckpointBenchmark {
 		FakeRepository.findAllUserByName(Flux.just("pedro", "simon", "stephane"))
 		              .transform(FakeUtils1.applyFilters)
 		              .transform(FakeUtils2.enrichUser)
-		              .checkpointLight("light checkpoint identifier")
+		              .checkpoint("light checkpoint identifier", true)
 		              .subscribe(System.out::println,
 				              t -> {}
 		              );
 	}
-
-	public static void main(String[] args) {
-		final CheckpointBenchmark benchmark = new CheckpointBenchmark();
-		benchmark.withFullCheckpoint();
-		benchmark.withLightCheckpoint();
-	}
-
 }

--- a/src/jmh/java/reactor/CheckpointBenchmark.java
+++ b/src/jmh/java/reactor/CheckpointBenchmark.java
@@ -16,9 +16,6 @@
 
 package reactor;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;

--- a/src/jmh/java/reactor/CheckpointBenchmark.java
+++ b/src/jmh/java/reactor/CheckpointBenchmark.java
@@ -35,7 +35,7 @@ public class CheckpointBenchmark {
 		FakeRepository.findAllUserByName(Flux.just("pedro", "simon", "stephane"))
 		              .transform(FakeUtils1.applyFilters)
 		              .transform(FakeUtils2.enrichUser)
-		              .checkpoint("checkpoint description")
+		              .checkpoint("checkpoint description", true)
 		              .subscribe(System.out::println,
 		                      t -> {}
                       );
@@ -47,7 +47,7 @@ public class CheckpointBenchmark {
 		FakeRepository.findAllUserByName(Flux.just("pedro", "simon", "stephane"))
 		              .transform(FakeUtils1.applyFilters)
 		              .transform(FakeUtils2.enrichUser)
-		              .checkpoint("light checkpoint identifier", true)
+		              .checkpoint("light checkpoint identifier")
 		              .subscribe(System.out::println,
 				              t -> {}
 		              );

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -2475,7 +2475,8 @@ public abstract class Flux<T> implements Publisher<T> {
 
 	/**
 	 * Activate assembly tracing for this particular {@link Flux}, in case of an error
-	 * upstream of the checkpoint.
+	 * upstream of the checkpoint. Tracing incurs the cost of an exception stack trace
+	 * creation.
 	 * <p>
 	 * It should be placed towards the end of the reactive chain, as errors
 	 * triggered downstream of it cannot be observed and augmented with assembly trace.
@@ -2489,13 +2490,15 @@ public abstract class Flux<T> implements Publisher<T> {
 	/**
 	 * Activate assembly tracing for this particular {@link Flux} and give it
 	 * a description that will be reflected in the assembly traceback in case
-	 * of an error upstream of the checkpoint.
+	 * of an error upstream of the checkpoint. Tracing incurs the cost of an
+	 * exception stack trace creation.
 	 * <p>
 	 * It should be placed towards the end of the reactive chain, as errors
 	 * triggered downstream of it cannot be observed and augmented with assembly trace.
 	 * <p>
 	 * The description could for example be a meaningful name for the assembled
-	 * flux or a wider correlation ID.
+	 * flux or a wider correlation ID, since the stack trace will always provide enough
+	 * information to locate where this Flux was assembled.
 	 *
 	 * @param description a description to include in the assembly traceback.
 	 * @return the assembly tracing {@link Flux}.
@@ -2504,6 +2507,23 @@ public abstract class Flux<T> implements Publisher<T> {
 		return new FluxOnAssembly<>(this, description);
 	}
 
+	/**
+	 * Activate assembly marker for this particular {@link Flux} by giving it
+	 * a description that will be reflected in the assembly traceback in case
+	 * of an error upstream of the checkpoint. Note that unlike {@link #checkpoint(String)},
+	 * this doesn't create a filled stack trace, avoiding the main cost of said operator.
+	 * However, as a trade-off the description must be unique enough for the user to find
+	 * out where this Flux was assembled.
+	 * <p>
+	 * It should be placed towards the end of the reactive chain, as errors
+	 * triggered downstream of it cannot be observed and augmented with assembly marker.
+	 *
+	 * @param description a unique enough description to locate assembly site of this Flux.
+	 * @return the assembly marked {@link Flux}.
+	 */
+	public final Flux<T> checkpointLight(String description) {
+		return new FluxOnAssembly<>(this, description, true);
+	}
 
 	/**
 	 * Collect all elements emitted by this {@link Flux} into a user-defined container,

--- a/src/main/java/reactor/core/publisher/Flux.java
+++ b/src/main/java/reactor/core/publisher/Flux.java
@@ -2508,21 +2508,24 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Activate assembly marker for this particular {@link Flux} by giving it
-	 * a description that will be reflected in the assembly traceback in case
-	 * of an error upstream of the checkpoint. Note that unlike {@link #checkpoint(String)},
-	 * this doesn't create a filled stack trace, avoiding the main cost of said operator.
+	 * By setting the {@code light} parameter to {@literal true}, activate assembly
+	 * marker for this particular {@link Flux} by giving it a description that
+	 * will be reflected in the assembly traceback in case of an error upstream of the
+	 * checkpoint. Note that unlike {@link #checkpoint(String)}, this doesn't create a
+	 * filled stack trace, avoiding the main cost of the operator.
 	 * However, as a trade-off the description must be unique enough for the user to find
-	 * out where this Flux was assembled.
+	 * out where this Flux was assembled. Having {@code light} set to {@literal false}
+	 * is the same as calling {@link #checkpoint(String)}.
 	 * <p>
 	 * It should be placed towards the end of the reactive chain, as errors
 	 * triggered downstream of it cannot be observed and augmented with assembly marker.
 	 *
 	 * @param description a unique enough description to locate assembly site of this Flux.
+	 * @param light true to make a light checkpoint without a stacktrace.
 	 * @return the assembly marked {@link Flux}.
 	 */
-	public final Flux<T> checkpointLight(String description) {
-		return new FluxOnAssembly<>(this, description, true);
+	public final Flux<T> checkpoint(String description, boolean light) {
+		return new FluxOnAssembly<>(this, description, light);
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -1344,44 +1344,53 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Activate assembly tracing for this particular {@link Mono} and give it
-	 * a description that will be reflected in the assembly traceback, in case of an error
-	 * upstream of the checkpoint. Tracing incurs the cost of an
-	 * exception stack trace creation.
+	 * Activate assembly marker for this particular {@link Mono} by giving it a description that
+	 * will be reflected in the assembly traceback in case of an error upstream of the
+	 * checkpoint. Note that unlike {@link #checkpoint()}, this doesn't create a
+	 * filled stack trace, avoiding the main cost of the operator.
+	 * However, as a trade-off the description must be unique enough for the user to find
+	 * out where this Mono was assembled. If you only want a generic description, and
+	 * still rely on the stack trace to find the assembly site, use the
+	 * {@link #checkpoint(String, boolean)} variant.
 	 * <p>
 	 * It should be placed towards the end of the reactive chain, as errors
 	 * triggered downstream of it cannot be observed and augmented with assembly trace.
-	 * <p>
-	 * The description could for example be a meaningful name for the assembled
-	 * mono or a wider correlation ID, since the stack trace will always provide enough
-	 * information to locate where this Flux was assembled.
 	 *
-	 * @param description a description to include in the assembly traceback.
-	 * @return the assembly tracing {@link Mono}
+	 * @param description a unique enough description to include in the light assembly traceback.
+	 * @return the assembly marked {@link Mono}
 	 */
 	public final Mono<T> checkpoint(String description) {
-		return new MonoOnAssembly<>(this, description);
+		return new MonoOnAssembly<>(this, description, true);
 	}
 
 	/**
-	 * By setting the {@code light} parameter to {@literal true}, activate assembly
-	 * marker for this particular {@link Mono} by giving it a description that
+	 * Activate assembly tracing or the lighter assembly marking depending on the
+	 * {@code forceStackTrace} option.
+	 * <p>
+	 * By setting the {@code forceStackTrace} parameter to {@literal true}, activate assembly
+	 * tracing for this particular {@link Mono} and give it a description that
 	 * will be reflected in the assembly traceback in case of an error upstream of the
-	 * checkpoint. Note that unlike {@link #checkpoint(String)}, this doesn't create a
-	 * filled stack trace, avoiding the main cost of the operator.
-	 * However, as a trade-off the description must be unique enough for the user to find
-	 * out where this Mono was assembled. Having {@code light} set to {@literal false}
-	 * is the same as calling {@link #checkpoint(String)}.
+	 * checkpoint. Note that unlike {@link #checkpoint(String)}, this will incur
+	 * the cost of an exception stack trace creation. The description could for
+	 * example be a meaningful name for the assembled mono or a wider correlation ID,
+	 * since the stack trace will always provide enough information to locate where this
+	 * Flux was assembled.
+	 * <p>
+	 * By setting {@code forceStackTrace} to {@literal false}, behaves like
+	 * {@link #checkpoint(String)} and is subject to the same caveat in choosing the
+	 * description.
 	 * <p>
 	 * It should be placed towards the end of the reactive chain, as errors
 	 * triggered downstream of it cannot be observed and augmented with assembly marker.
 	 *
-	 * @param description a unique enough description to locate assembly site of this Mono.
-	 * @param light true to make a light checkpoint without a stacktrace.
+	 * @param description a description (must be unique enough if forceStackTrace is set
+	 * to false).
+	 * @param forceStackTrace false to make a light checkpoint without a stacktrace, true
+	 * to use a stack trace.
 	 * @return the assembly marked {@link Mono}.
 	 */
-	public final Mono<T> checkpoint(String description, boolean light) {
-		return new MonoOnAssembly<>(this, description, light);
+	public final Mono<T> checkpoint(String description, boolean forceStackTrace) {
+		return new MonoOnAssembly<>(this, description, !forceStackTrace);
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -1364,21 +1364,24 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Activate assembly marker for this particular {@link Mono} by giving it
-	 * a description that will be reflected in the assembly traceback in case
-	 * of an error upstream of the checkpoint. Note that unlike {@link #checkpoint(String)},
-	 * this doesn't create a filled stack trace, avoiding the main cost of said operator.
+	 * By setting the {@code light} parameter to {@literal true}, activate assembly
+	 * marker for this particular {@link Mono} by giving it a description that
+	 * will be reflected in the assembly traceback in case of an error upstream of the
+	 * checkpoint. Note that unlike {@link #checkpoint(String)}, this doesn't create a
+	 * filled stack trace, avoiding the main cost of the operator.
 	 * However, as a trade-off the description must be unique enough for the user to find
-	 * out where this Mono was assembled.
+	 * out where this Mono was assembled. Having {@code light} set to {@literal false}
+	 * is the same as calling {@link #checkpoint(String)}.
 	 * <p>
 	 * It should be placed towards the end of the reactive chain, as errors
 	 * triggered downstream of it cannot be observed and augmented with assembly marker.
 	 *
 	 * @param description a unique enough description to locate assembly site of this Mono.
+	 * @param light true to make a light checkpoint without a stacktrace.
 	 * @return the assembly marked {@link Mono}.
 	 */
-	public final Mono<T> checkpointLight(String description) {
-		return new MonoOnAssembly<>(this, description, true);
+	public final Mono<T> checkpoint(String description, boolean light) {
+		return new MonoOnAssembly<>(this, description, light);
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -1331,7 +1331,8 @@ public abstract class Mono<T> implements Publisher<T> {
 
 	/**
 	 * Activate assembly tracing for this particular {@link Mono}, in case of an error
-	 * upstream of the checkpoint.
+	 * upstream of the checkpoint. Tracing incurs the cost of an exception stack trace
+	 * creation.
 	 * <p>
 	 * It should be placed towards the end of the reactive chain, as errors
 	 * triggered downstream of it cannot be observed and augmented with assembly trace.
@@ -1345,19 +1346,39 @@ public abstract class Mono<T> implements Publisher<T> {
 	/**
 	 * Activate assembly tracing for this particular {@link Mono} and give it
 	 * a description that will be reflected in the assembly traceback, in case of an error
-	 * upstream of the checkpoint.
+	 * upstream of the checkpoint. Tracing incurs the cost of an
+	 * exception stack trace creation.
 	 * <p>
 	 * It should be placed towards the end of the reactive chain, as errors
 	 * triggered downstream of it cannot be observed and augmented with assembly trace.
 	 * <p>
 	 * The description could for example be a meaningful name for the assembled
-	 * mono or a wider correlation ID.
+	 * mono or a wider correlation ID, since the stack trace will always provide enough
+	 * information to locate where this Flux was assembled.
 	 *
 	 * @param description a description to include in the assembly traceback.
 	 * @return the assembly tracing {@link Mono}
 	 */
 	public final Mono<T> checkpoint(String description) {
 		return new MonoOnAssembly<>(this, description);
+	}
+
+	/**
+	 * Activate assembly marker for this particular {@link Mono} by giving it
+	 * a description that will be reflected in the assembly traceback in case
+	 * of an error upstream of the checkpoint. Note that unlike {@link #checkpoint(String)},
+	 * this doesn't create a filled stack trace, avoiding the main cost of said operator.
+	 * However, as a trade-off the description must be unique enough for the user to find
+	 * out where this Mono was assembled.
+	 * <p>
+	 * It should be placed towards the end of the reactive chain, as errors
+	 * triggered downstream of it cannot be observed and augmented with assembly marker.
+	 *
+	 * @param description a unique enough description to locate assembly site of this Mono.
+	 * @return the assembly marked {@link Mono}.
+	 */
+	public final Mono<T> checkpointLight(String description) {
+		return new MonoOnAssembly<>(this, description, true);
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/MonoOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/MonoOnAssembly.java
@@ -54,6 +54,21 @@ final class MonoOnAssembly<T> extends MonoSource<T, T> implements Fuseable, Asse
 		this.stacktrace = new AssemblySnapshotException(description);
 	}
 
+	/**
+	 * Create a potentially light assembly trace augmented with a description (that must
+	 * be unique enough to identify the assembly site in case of light mode),
+	 * wrapping a {@link ParallelFlux}.
+	 */
+	MonoOnAssembly(Mono<? extends T> source, String description, boolean light) {
+		super(source);
+		if (light) {
+			this.stacktrace = new FluxOnAssembly.AssemblyLightSnapshotException(description);
+		}
+		else {
+			this.stacktrace = new AssemblySnapshotException(description);
+		}
+	}
+
 	@Override
 	public void subscribe(Subscriber<? super T> s) {
 		FluxOnAssembly.subscribe(s, source, stacktrace);

--- a/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -148,7 +148,8 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 
 	/**
 	 * Activate assembly tracing for this particular {@link ParallelFlux}, in case of an
-	 * error upstream of the checkpoint.
+	 * error upstream of the checkpoint. Tracing incurs the cost of an exception stack trace
+	 * creation.
 	 * <p>
 	 * It should be placed towards the end of the reactive chain, as errors
 	 * triggered downstream of it cannot be observed and augmented with assembly trace.
@@ -162,19 +163,39 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	/**
 	 * Activate assembly tracing for this particular {@link ParallelFlux} and give it
 	 * a description that will be reflected in the assembly traceback, in case of an error
-	 * upstream of the checkpoint.
+	 * upstream of the checkpoint. Tracing incurs the cost of an
+	 * exception stack trace creation.
 	 * <p>
 	 * It should be placed towards the end of the reactive chain, as errors
 	 * triggered downstream of it cannot be observed and augmented with assembly trace.
 	 * <p>
 	 * The description could for example be a meaningful name for the assembled
-	 * flux or a wider correlation ID.
+	 * flux or a wider correlation ID, since the stack trace will always provide enough
+	 * information to locate where this Flux was assembled.
 	 *
 	 * @param description a description to include in the assembly traceback.
 	 * @return the assembly tracing {@link ParallelFlux}
 	 */
 	public final ParallelFlux<T> checkpoint(String description) {
 		return new ParallelFluxOnAssembly<>(this, description);
+	}
+
+	/**
+	 * Activate assembly marker for this particular {@link Flux} by giving it
+	 * a description that will be reflected in the assembly traceback in case
+	 * of an error upstream of the checkpoint. Note that unlike {@link #checkpoint(String)},
+	 * this doesn't create a filled stack trace, avoiding the main cost of said operator.
+	 * However, as a trade-off the description must be unique enough for the user to find
+	 * out where this Flux was assembled.
+	 * <p>
+	 * It should be placed towards the end of the reactive chain, as errors
+	 * triggered downstream of it cannot be observed and augmented with assembly marker.
+	 *
+	 * @param description a unique enough description to locate assembly site of this Flux.
+	 * @return the assembly marked {@link Flux}.
+	 */
+	public final ParallelFlux<T> checkpointLight(String description) {
+		return new ParallelFluxOnAssembly<>(this, description, true);
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -161,44 +161,53 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Activate assembly tracing for this particular {@link ParallelFlux} and give it
-	 * a description that will be reflected in the assembly traceback, in case of an error
-	 * upstream of the checkpoint. Tracing incurs the cost of an
-	 * exception stack trace creation.
+	 * Activate assembly marker for this particular {@link ParallelFlux} by giving it a description that
+	 * will be reflected in the assembly traceback in case of an error upstream of the
+	 * checkpoint. Note that unlike {@link #checkpoint()}, this doesn't create a
+	 * filled stack trace, avoiding the main cost of the operator.
+	 * However, as a trade-off the description must be unique enough for the user to find
+	 * out where this ParallelFlux was assembled. If you only want a generic description, and
+	 * still rely on the stack trace to find the assembly site, use the
+	 * {@link #checkpoint(String, boolean)} variant.
 	 * <p>
 	 * It should be placed towards the end of the reactive chain, as errors
 	 * triggered downstream of it cannot be observed and augmented with assembly trace.
-	 * <p>
-	 * The description could for example be a meaningful name for the assembled
-	 * flux or a wider correlation ID, since the stack trace will always provide enough
-	 * information to locate where this Flux was assembled.
 	 *
-	 * @param description a description to include in the assembly traceback.
-	 * @return the assembly tracing {@link ParallelFlux}
+	 * @param description a unique enough description to include in the light assembly traceback.
+	 * @return the assembly marked {@link ParallelFlux}
 	 */
 	public final ParallelFlux<T> checkpoint(String description) {
-		return new ParallelFluxOnAssembly<>(this, description);
+		return new ParallelFluxOnAssembly<>(this, description, true);
 	}
 
 	/**
-	 * By setting the {@code light} parameter to {@literal true}, activate assembly
-	 * marker for this particular {@link ParallelFlux} by giving it a description that
+	 * Activate assembly tracing or the lighter assembly marking depending on the
+	 * {@code forceStackTrace} option.
+	 * <p>
+	 * By setting the {@code forceStackTrace} parameter to {@literal true}, activate assembly
+	 * tracing for this particular {@link ParallelFlux} and give it a description that
 	 * will be reflected in the assembly traceback in case of an error upstream of the
-	 * checkpoint. Note that unlike {@link #checkpoint(String)}, this doesn't create a
-	 * filled stack trace, avoiding the main cost of the operator.
-	 * However, as a trade-off the description must be unique enough for the user to find
-	 * out where this ParallelFlux was assembled. Having {@code light} set to {@literal false}
-	 * is the same as calling {@link #checkpoint(String)}.
+	 * checkpoint. Note that unlike {@link #checkpoint(String)}, this will incur
+	 * the cost of an exception stack trace creation. The description could for
+	 * example be a meaningful name for the assembled ParallelFlux or a wider correlation ID,
+	 * since the stack trace will always provide enough information to locate where this
+	 * ParallelFlux was assembled.
+	 * <p>
+	 * By setting {@code forceStackTrace} to {@literal false}, behaves like
+	 * {@link #checkpoint(String)} and is subject to the same caveat in choosing the
+	 * description.
 	 * <p>
 	 * It should be placed towards the end of the reactive chain, as errors
 	 * triggered downstream of it cannot be observed and augmented with assembly marker.
 	 *
-	 * @param description a unique enough description to locate assembly site of this ParallelFlux.
-	 * @param light true to make a light checkpoint without a stacktrace.
+	 * @param description a description (must be unique enough if forceStackTrace is set
+	 * to false).
+	 * @param forceStackTrace false to make a light checkpoint without a stacktrace, true
+	 * to use a stack trace.
 	 * @return the assembly marked {@link ParallelFlux}.
 	 */
-	public final ParallelFlux<T> checkpoint(String description, boolean light) {
-		return new ParallelFluxOnAssembly<>(this, description, light);
+	public final ParallelFlux<T> checkpoint(String description, boolean forceStackTrace) {
+		return new ParallelFluxOnAssembly<>(this, description, !forceStackTrace);
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -181,21 +181,24 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Activate assembly marker for this particular {@link Flux} by giving it
-	 * a description that will be reflected in the assembly traceback in case
-	 * of an error upstream of the checkpoint. Note that unlike {@link #checkpoint(String)},
-	 * this doesn't create a filled stack trace, avoiding the main cost of said operator.
+	 * By setting the {@code light} parameter to {@literal true}, activate assembly
+	 * marker for this particular {@link ParallelFlux} by giving it a description that
+	 * will be reflected in the assembly traceback in case of an error upstream of the
+	 * checkpoint. Note that unlike {@link #checkpoint(String)}, this doesn't create a
+	 * filled stack trace, avoiding the main cost of the operator.
 	 * However, as a trade-off the description must be unique enough for the user to find
-	 * out where this Flux was assembled.
+	 * out where this ParallelFlux was assembled. Having {@code light} set to {@literal false}
+	 * is the same as calling {@link #checkpoint(String)}.
 	 * <p>
 	 * It should be placed towards the end of the reactive chain, as errors
 	 * triggered downstream of it cannot be observed and augmented with assembly marker.
 	 *
-	 * @param description a unique enough description to locate assembly site of this Flux.
-	 * @return the assembly marked {@link Flux}.
+	 * @param description a unique enough description to locate assembly site of this ParallelFlux.
+	 * @param light true to make a light checkpoint without a stacktrace.
+	 * @return the assembly marked {@link ParallelFlux}.
 	 */
-	public final ParallelFlux<T> checkpointLight(String description) {
-		return new ParallelFluxOnAssembly<>(this, description, true);
+	public final ParallelFlux<T> checkpoint(String description, boolean light) {
+		return new ParallelFluxOnAssembly<>(this, description, light);
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/ParallelFluxOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/ParallelFluxOnAssembly.java
@@ -19,6 +19,7 @@ package reactor.core.publisher;
 import org.reactivestreams.Subscriber;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
+import reactor.core.publisher.FluxOnAssembly.AssemblyLightSnapshotException;
 import reactor.core.publisher.FluxOnAssembly.AssemblySnapshotException;
 
 /**
@@ -55,6 +56,21 @@ final class ParallelFluxOnAssembly<T> extends ParallelFlux<T>
 	ParallelFluxOnAssembly(ParallelFlux<T> source, String description) {
 		this.source = source;
 		this.stacktrace = new AssemblySnapshotException(description);
+	}
+
+	/**
+	 * Create a potentially light assembly trace augmented with a description (that must
+	 * be unique enough to identify the assembly site in case of light mode),
+	 * wrapping a {@link ParallelFlux}.
+	 */
+	ParallelFluxOnAssembly(ParallelFlux<T> source, String description, boolean light) {
+		this.source = source;
+		if (light) {
+			 this.stacktrace = new AssemblyLightSnapshotException(description);
+		}
+		else {
+			this.stacktrace = new AssemblySnapshotException(description);
+		}
 	}
 
 	@Override

--- a/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
+++ b/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
@@ -131,7 +131,7 @@ public class FluxOnAssemblyTest {
 		Flux<Integer> tested = Flux.range(1, 10)
 		                           .map(i -> i < 3 ? i : null)
 		                           .filter(i -> i % 2 == 0)
-		                           .checkpointLight("foo")
+		                           .checkpoint("foo", true)
 		                           .doOnError(t -> t.printStackTrace(new PrintWriter(sw)));
 
 		StepVerifier.create(tested)
@@ -183,7 +183,7 @@ public class FluxOnAssemblyTest {
 		Mono<Object> tested = Mono.just(1)
 		                          .map(i -> null)
 		                          .filter(Objects::nonNull)
-		                          .checkpointLight("foo")
+		                          .checkpoint("foo", true)
 		                          .doOnError(t -> t.printStackTrace(new PrintWriter(sw)));
 
 		StepVerifier.create(tested)
@@ -236,7 +236,7 @@ public class FluxOnAssemblyTest {
 		Flux<Integer> tested = Flux.range(1, 10)
 		                           .parallel(2)
 		                           .composeGroup(g -> g.map(i -> (Integer) null))
-		                           .checkpointLight("foo")
+		                           .checkpoint("foo", true)
 		                           .sequential()
 		                           .doOnError(t -> t.printStackTrace(new PrintWriter(sw)));
 

--- a/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
+++ b/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
@@ -108,12 +108,12 @@ public class FluxOnAssemblyTest {
 	}
 
 	@Test
-	public void checkpointDescription() {
+	public void checkpointDescriptionAndForceStack() {
 		StringWriter sw = new StringWriter();
 		Flux<Integer> tested = Flux.range(1, 10)
 		                           .map(i -> i < 3 ? i : null)
 		                           .filter(i -> i % 2 == 0)
-		                           .checkpoint("foo")
+		                           .checkpoint("foo", true)
 		                           .doOnError(t -> t.printStackTrace(new PrintWriter(sw)));
 
 		StepVerifier.create(tested)
@@ -126,12 +126,12 @@ public class FluxOnAssemblyTest {
 	}
 
 	@Test
-	public void checkpointLight() {
+	public void checkpointWithDescriptionIsLight() {
 		StringWriter sw = new StringWriter();
 		Flux<Integer> tested = Flux.range(1, 10)
 		                           .map(i -> i < 3 ? i : null)
 		                           .filter(i -> i % 2 == 0)
-		                           .checkpoint("foo", true)
+		                           .checkpoint("foo")
 		                           .doOnError(t -> t.printStackTrace(new PrintWriter(sw)));
 
 		StepVerifier.create(tested)
@@ -161,12 +161,12 @@ public class FluxOnAssemblyTest {
 	}
 
 	@Test
-	public void monoCheckpointDescription() {
+	public void monoCheckpointDescriptionAndForceStack() {
 		StringWriter sw = new StringWriter();
 		Mono<Object> tested = Mono.just(1)
 		                          .map(i -> null)
 		                          .filter(Objects::nonNull)
-		                          .checkpoint("foo")
+		                          .checkpoint("foo", true)
 		                          .doOnError(t -> t.printStackTrace(new PrintWriter(sw)));
 
 		StepVerifier.create(tested)
@@ -178,12 +178,12 @@ public class FluxOnAssemblyTest {
 	}
 
 	@Test
-	public void monoCheckpointLight() {
+	public void monoCheckpointWithDescriptionIsLight() {
 		StringWriter sw = new StringWriter();
 		Mono<Object> tested = Mono.just(1)
 		                          .map(i -> null)
 		                          .filter(Objects::nonNull)
-		                          .checkpoint("foo", true)
+		                          .checkpoint("foo")
 		                          .doOnError(t -> t.printStackTrace(new PrintWriter(sw)));
 
 		StepVerifier.create(tested)
@@ -213,12 +213,12 @@ public class FluxOnAssemblyTest {
 	}
 
 	@Test
-	public void parallelFluxCheckpointDescription() {
+	public void parallelFluxCheckpointDescriptionAndForceStack() {
 		StringWriter sw = new StringWriter();
 		Flux<Integer> tested = Flux.range(1, 10)
 		                           .parallel(2)
 		                           .composeGroup(g -> g.map(i -> (Integer) null))
-		                           .checkpoint("foo")
+		                           .checkpoint("foo", true)
 		                           .sequential()
 		                           .doOnError(t -> t.printStackTrace(new PrintWriter(sw)));
 
@@ -231,12 +231,12 @@ public class FluxOnAssemblyTest {
 	}
 
 	@Test
-	public void parallelFluxCheckpointLight() {
+	public void parallelFluxCheckpointDescriptionIsLight() {
 		StringWriter sw = new StringWriter();
 		Flux<Integer> tested = Flux.range(1, 10)
 		                           .parallel(2)
 		                           .composeGroup(g -> g.map(i -> (Integer) null))
-		                           .checkpoint("foo", true)
+		                           .checkpoint("foo")
 		                           .sequential()
 		                           .doOnError(t -> t.printStackTrace(new PrintWriter(sw)));
 


### PR DESCRIPTION
- [x] offer the variant, eg. `.checkpointLight(String description)`
- [x] quantify the cost difference
- [x] unit tests?
- [x] document the variant in the error handling part of the reference guide
- [x] ~consider making the description `Scannable` via a dedicated `Attr`~ (isolated in #579)
- [x] expose in `Mono`, `ParallelFlux`, etc... as well