### PR TITLE
fix #566 Simplify Mono.subscribe, move the old behavior in toProcessor

### DIFF
--- a/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
+++ b/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
@@ -319,10 +319,11 @@ public class FluxBufferBoundaryTest
 		//non overlapping buffers
 		EmitterProcessor<Integer> boundaryFlux = EmitterProcessor.create();
 
-		Mono<List<List<Integer>>> res = numbers.buffer(boundaryFlux)
+		MonoProcessor<List<List<Integer>>> res = numbers.buffer(boundaryFlux)
 		                                       .buffer()
 		                                       .publishNext()
-		                                       .subscribe();
+		                                       .toProcessor();
+		res.subscribe();
 
 		numbers.onNext(1);
 		numbers.onNext(2);

--- a/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
+++ b/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
@@ -138,10 +138,11 @@ public class FluxBufferWhenTest {
 		//"overlapping buffers"
 		EmitterProcessor<Integer> boundaryFlux = EmitterProcessor.create();
 
-		Mono<List<List<Integer>>> res = numbers.bufferWhen(bucketOpening, u -> boundaryFlux )
+		MonoProcessor<List<List<Integer>>> res = numbers.bufferWhen(bucketOpening, u -> boundaryFlux )
 		                                       .buffer()
 		                                       .publishNext()
-		                                       .subscribe();
+		                                       .toProcessor();
+		res.subscribe();
 
 		numbers.onNext(1);
 		numbers.onNext(2);

--- a/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
+++ b/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
@@ -223,11 +223,12 @@ public class FluxWindowBoundaryTest {
 		//non overlapping buffers
 		EmitterProcessor<Integer> boundaryFlux = EmitterProcessor.create();
 
-		Mono<List<List<Integer>>> res = numbers.window(boundaryFlux)
+		MonoProcessor<List<List<Integer>>> res = numbers.window(boundaryFlux)
 		                                       .concatMap(Flux::buffer)
 		                                       .buffer()
 		                                       .publishNext()
-		                                       .subscribe();
+		                                       .toProcessor();
+		res.subscribe();
 
 		numbers.onNext(1);
 		numbers.onNext(2);

--- a/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
+++ b/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
@@ -175,11 +175,12 @@ public class FluxWindowWhenTest {
 		//"overlapping buffers"
 		EmitterProcessor<Integer> boundaryFlux = EmitterProcessor.create();
 
-		Mono<List<List<Integer>>> res = numbers.windowWhen(bucketOpening, u -> boundaryFlux )
+		MonoProcessor<List<List<Integer>>> res = numbers.windowWhen(bucketOpening, u -> boundaryFlux )
 		                                       .flatMap(Flux::buffer)
 		                                       .buffer()
 		                                       .publishNext()
-		                                       .subscribe();
+		                                       .toProcessor();
+		res.subscribe();
 
 		numbers.onNext(1);
 		numbers.onNext(2);

--- a/src/test/java/reactor/core/publisher/MonoAnyTest.java
+++ b/src/test/java/reactor/core/publisher/MonoAnyTest.java
@@ -162,10 +162,11 @@ public class MonoAnyTest {
 	public void cancel() {
 		TestPublisher<String> cancelTester = TestPublisher.create();
 
-		cancelTester.flux()
-		            .any(s -> s.length() > 100)
-		            .subscribe()
-		            .cancel();
+		MonoProcessor<Boolean> processor = cancelTester.flux()
+		                                               .any(s -> s.length() > 100)
+		                                               .toProcessor();
+		processor.subscribe();
+		processor.cancel();
 
 		cancelTester.assertCancelled();
 	}

--- a/src/test/java/reactor/core/publisher/MonoElementAtTest.java
+++ b/src/test/java/reactor/core/publisher/MonoElementAtTest.java
@@ -206,10 +206,11 @@ public class MonoElementAtTest {
 	public void cancel() {
 		TestPublisher<String> cancelTester = TestPublisher.create();
 
-		cancelTester.flux()
-		            .elementAt(1000)
-		            .subscribe()
-		            .cancel();
+		MonoProcessor<String> processor = cancelTester.flux()
+		                                              .elementAt(1000)
+		                                              .toProcessor();
+		processor.subscribe();
+		processor.cancel();
 
 		cancelTester.assertCancelled();
 	}

--- a/src/test/java/reactor/core/publisher/MonoFlatMapTest.java
+++ b/src/test/java/reactor/core/publisher/MonoFlatMapTest.java
@@ -22,10 +22,11 @@ public class MonoFlatMapTest {
     public void cancel() {
         TestPublisher<String> cancelTester = TestPublisher.create();
 
-        cancelTester.mono()
-                    .flatMap(s -> Mono.just(s.length()))
-                    .subscribe()
-                    .cancel();
+        MonoProcessor<Integer> processor = cancelTester.mono()
+                                                       .flatMap(s -> Mono.just(s.length()))
+                                                       .toProcessor();
+        processor.subscribe();
+        processor.cancel();
 
         cancelTester.assertCancelled();
     }

--- a/src/test/java/reactor/core/publisher/MonoNextTest.java
+++ b/src/test/java/reactor/core/publisher/MonoNextTest.java
@@ -48,10 +48,11 @@ public class MonoNextTest {
 	public void cancel() {
 		TestPublisher<String> cancelTester = TestPublisher.create();
 
-		cancelTester.flux()
-		            .next()
-		            .subscribe()
-		            .cancel();
+		MonoProcessor<String> processor = cancelTester.flux()
+		                                              .next()
+		                                              .toProcessor();
+		processor.subscribe();
+		processor.cancel();
 
 		cancelTester.assertCancelled();
 	}

--- a/src/test/java/reactor/core/publisher/MonoPeekTest.java
+++ b/src/test/java/reactor/core/publisher/MonoPeekTest.java
@@ -115,9 +115,10 @@ public class MonoPeekTest {
 		Mono<String> mp = Mono.error(new TestException());
 		AtomicReference<Throwable> ref = new AtomicReference<>();
 
-		assertThat(mp.doOnError(RuntimeException.class, ref::set)
-		             .subscribe()
-		             .getError()).isInstanceOf(TestException.class);
+		MonoProcessor<String> processor = mp.doOnError(RuntimeException.class, ref::set)
+		                                    .toProcessor();
+		processor.subscribe();
+		assertThat(processor.getError()).isInstanceOf(TestException.class);
 
 		assertThat(ref.get()).isNull();
 	}

--- a/src/test/java/reactor/core/publisher/MonoProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/MonoProcessorTest.java
@@ -171,7 +171,8 @@ public class MonoProcessorTest {
 		mp.onNext(1);
 
 		MonoProcessor<Integer> mp2 = mp.map(s -> s * 2)
-		                               .subscribe();
+		                               .toProcessor();
+		mp2.subscribe();
 
 		assertThat(mp2.isTerminated()).isTrue();
 		assertThat(mp2.isSuccess()).isTrue();
@@ -185,7 +186,8 @@ public class MonoProcessorTest {
 		mp.onNext(1);
 
 		MonoProcessor<Integer> mp2 = mp.flatMap(s -> Mono.just(s * 2))
-		                               .subscribe();
+		                               .toProcessor();
+		mp2.subscribe();
 
 		assertThat(mp2.isTerminated()).isTrue();
 		assertThat(mp2.isSuccess()).isTrue();
@@ -370,7 +372,8 @@ public class MonoProcessorTest {
 		AtomicLong cancelCounter = new AtomicLong();
 		MonoProcessor<String> monoProcessor = Mono.just("foo")
 		                                          .doOnCancel(cancelCounter::incrementAndGet)
-		                                          .subscribe();
+		                                          .toProcessor();
+		monoProcessor.subscribe();
 
 		assertThat(cancelCounter.get()).isEqualTo(0);
 	}

--- a/src/test/java/reactor/core/publisher/MonoThenIgnoreTest.java
+++ b/src/test/java/reactor/core/publisher/MonoThenIgnoreTest.java
@@ -16,14 +16,11 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoThenIgnoreTest {
 
@@ -72,10 +69,11 @@ public class MonoThenIgnoreTest {
 	public void cancel() {
 		TestPublisher<String> cancelTester = TestPublisher.create();
 
-		cancelTester.flux()
-		            .then()
-		            .subscribe()
-		            .cancel();
+		MonoProcessor<Void> processor = cancelTester.flux()
+		                                            .then()
+		                                            .toProcessor();
+		processor.subscribe();
+		processor.cancel();
 
 		cancelTester.assertCancelled();
 	}

--- a/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
@@ -257,7 +257,8 @@ public class FluxSpecTests {
 //		when:"the values are filtered and result is collected"
 		MonoProcessor<List<Integer>> tap = s.distinctUntilChanged()
 		                                    .collectList()
-		                                    .subscribe();
+		                                    .toProcessor();
+		tap.subscribe();
 
 //		then:"collected must remove duplicates"
 		assertThat(tap.block()).containsExactly(1, 2, 3);
@@ -272,7 +273,7 @@ public class FluxSpecTests {
 //		when:"the values are filtered and result is collected"
 		MonoProcessor<List<Integer>> tap = s.distinctUntilChanged(it -> it % 2 == 0)
 		                                    .collectList()
-		                                    .subscribe();
+		                                    .toProcessor();
 
 //		then:"collected must remove duplicates"
 		assertThat(tap.block()).containsExactly(2, 3, 2, 5);
@@ -287,7 +288,8 @@ public class FluxSpecTests {
 //		when:"the values are filtered and result is collected"
 		MonoProcessor<List<Integer>> tap = s.distinct()
 		                                    .collectList()
-		                                    .subscribe();
+		                                    .toProcessor();
+		tap.subscribe();
 
 //		then:"collected should be without duplicates"
 		assertThat(tap.block()).containsExactly(1, 2, 3, 4);
@@ -302,7 +304,8 @@ public class FluxSpecTests {
 //		when: "the values are filtered and result is collected"
 		MonoProcessor<List<Integer>> tap = s.distinct(it -> it % 3)
 		                                    .collectList()
-		                                    .subscribe();
+		                                    .toProcessor();
+		tap.subscribe();
 
 //		then: "collected should be without duplicates"
 		assertThat(tap.block()).containsExactly(1, 2, 3);
@@ -485,7 +488,8 @@ public class FluxSpecTests {
 
 //			when: "the source accepts a value"
 		MonoProcessor<Integer> value = mapped.next()
-		                                     .subscribe();
+		                                     .toProcessor();
+		value.subscribe();
 		source.sink().next(1);
 
 //		then: "the value is mapped"
@@ -985,7 +989,8 @@ public class FluxSpecTests {
 		FluxProcessor<Integer, Integer> source =
 				EmitterProcessor.create();
 		Mono<List<Integer>> reduced = source.collectList();
-		MonoProcessor<List<Integer>> value = reduced.subscribe();
+		MonoProcessor<List<Integer>> value = reduced.toProcessor();
+		value.subscribe();
 
 //		when: "the first value is accepted"
 		source.onNext(1);

--- a/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -1400,11 +1400,12 @@ public class FluxTests extends AbstractReactorTest {
 
 		final Semaphore doneSemaphore = new Semaphore(0);
 
-		final Mono<List<String>> listPromise = joinStream.flatMap(Flux::fromIterable)
+		final MonoProcessor<List<String>> listPromise = joinStream.flatMap(Flux::fromIterable)
 		                                                 .log("resultStream")
 		                                                 .collectList()
 		                                                 .doOnTerminate((v, e) -> doneSemaphore.release())
-		                                                 .subscribe();
+		                                                 .toProcessor();
+		listPromise.subscribe();
 
 		forkEmitterProcessor.onNext(1);
 		forkEmitterProcessor.onNext(2);


### PR DESCRIPTION
This commit simplifies the `subscribe()` method of Mono to align it with
Flux, returning a Disposable (that is actually a no-callback subscriber
similar to the one returned in callback-based subscribe methods).

If the current instance is a MonoProcessor, connect that MonoProcessor
like before.

The wrapping into a returned MonoProcessor is now accessible in the
`toProcessor` method. However to exactly reproduce the previous behavior
one will need to call .toProcessor() then .subscribe(). This won't
always be hinted at by a compilation error.