### PR TITLE
fix #504 Split Scannable attributes into typed categories

### DIFF
--- a/src/main/java/reactor/core/Scannable.java
+++ b/src/main/java/reactor/core/Scannable.java
@@ -38,16 +38,51 @@ import java.util.stream.StreamSupport;
 @FunctionalInterface
 public interface Scannable {
 
+	static Stream<? extends Scannable> recurse(Scannable _s, ScannableAttr key){
+		Scannable s = Scannable.from(_s.scan(key));
+		if(s == null){
+			return Stream.empty();
+		}
+		return StreamSupport.stream(Spliterators.spliteratorUnknownSize(new Iterator<Scannable>() {
+			Scannable c = s;
+
+			@Override
+			public boolean hasNext() {
+				return c != null;
+			}
+
+			@Override
+			public Scannable next() {
+				Scannable _c = c;
+				c = Scannable.from(c.scan(key));
+				return _c;
+			}
+		}, 0),false);
+	}
+
+	/**
+	 * Base interface for {@link Scannable} attributes, which all can define a meaningful
+	 * default.
+	 *
+	 * @param <T> the type of data associated with an attribute
+	 */
 	@FunctionalInterface
 	interface Attr<T> {
 
+		/**
+		 * Meaningful and always applicable default value for the attribute, returned
+		 * instead of {@literal null} when a specific value hasn't been defined for a
+		 * component. {@literal null} if no sensible generic default is available.
+		 *
+		 * @return the default value applicable to all components or null if none.
+		 */
 		T defaultValue();
 
 		/**
 		 * A constant that represents {@link Scannable} returned via {@link #from(Object)}
 		 * when the passed non-null reference is not a {@link Scannable}
 		 */
-		static final Scannable UNAVAILABLE_SCAN = new Scannable() {
+		Scannable UNAVAILABLE_SCAN = new Scannable() {
 			@Override
 			public Object scanUnsafe(Attr key) {
 				return null;
@@ -58,48 +93,31 @@ public interface Scannable {
 				return false;
 			}
 		};
-
-		static Stream<? extends Scannable> recurse(Scannable _s, ScannableAttr key){
-			Scannable s = Scannable.from(_s.scan(key));
-			if(s == null){
-				return Stream.empty();
-			}
-			return StreamSupport.stream(Spliterators.spliteratorUnknownSize(new Iterator<Scannable>() {
-				Scannable c = s;
-
-				@Override
-				public boolean hasNext() {
-					return c != null;
-				}
-
-				@Override
-				public Scannable next() {
-					Scannable _c = c;
-					c = Scannable.from(c.scan(key));
-					return _c;
-				}
-			}, 0),false);
-		}
 	}
 
+	/**
+	 * {@link Scannable} attributes associated with a {@link Scannable} component (eg.
+	 * parent or child) and can thus be used for traversal. See {@link Scannable#parents()},
+	 * {@link Scannable#inners()} and {@link Scannable#actuals()}.
+	 */
 	enum ScannableAttr implements Attr<Scannable> {
 
 		/**
 		 * Parent key exposes the direct upstream relationship of the scanned component.
 		 * It can be a Publisher source to an operator, a Subscription to a Subscriber
-		 * (main flow if ambiguous with
-		 * inner Subscriptions like flatMap), a Scheduler to a Worker.
+		 * (main flow if ambiguous with inner Subscriptions like flatMap), a Scheduler to
+		 * a Worker.
 		 * <p>
-		 *     {@link #parents()} can be used to navigate the parent chain.
+		 * {@link Scannable#parents()} can be used to navigate the parent chain.
 		 */
 		PARENT(null),
 
 		/**
-		 * The direct dependent component downstream reference if any. Operators in Flux/Mono for instance
-		 *  delegate to a target Subscriber, which is going to be the actual chain
-		 *  navigated with this reference key.
-		 *  <p>
-		 *      A reference chain downstream can be navigated via {@link #actuals()}.
+		 * The direct dependent component downstream reference if any. Operators in
+		 * Flux/Mono for instance delegate to a target Subscriber, which is going to be
+		 * the actual chain navigated with this reference key.
+		 * <p>
+		 *  A reference chain downstream can be navigated via {@link Scannable#actuals()}.
 		 */
 		ACTUAL(null);
 
@@ -115,17 +133,19 @@ public interface Scannable {
 		}
 	}
 
+	/**
+	 * {@link Scannable} attributes associated with an {@link Integer} value.
+	 */
 	enum IntAttr implements Attr<Integer> {
 
 		/**
 		 * Prefetch is an {@link Integer} attribute defining the rate of processing in a
-		 * component
-		 * which has capacity to request and hold a backlog of data. It
+		 * component which has capacity to request and hold a backlog of data. It
 		 * usually maps to a component capacity when no arbitrary {@link #CAPACITY} is
 		 * set. {@link Integer#MAX_VALUE} signal unlimited capacity and therefore
 		 * unbounded demand.
 		 * <p>
-		 *     Note: This attribute usually resolves to a constant value
+		 * Note: This attribute usually resolves to a constant value.
 		 */
 		PREFETCH(0),
 
@@ -134,7 +154,7 @@ public interface Scannable {
 		 * when an arbitrary maximum limit is applied to the backlog capacity of the
 		 * scanned component. {@link Integer#MAX_VALUE} signal unlimited capacity.
 		 * <p>
-		 *     Note: This attribute usually resolves to a constant value
+		 * Note: This attribute usually resolves to a constant value.
 		 */
 		CAPACITY(0),
 
@@ -157,13 +177,15 @@ public interface Scannable {
 		}
 	}
 
+	/**
+	 * {@link Scannable} attributes associated with a {@link Long} value.
+	 */
 	enum LongAttr implements Attr<Long> {
 
 		/**
 		 * A {@link Long} attribute exposing the current pending demand of a downstream
-		 * component. Note that {@link Long#MAX_VALUE} indicates an unbounded
-		 * (push-style) demand as specified in
-		 * {@link org.reactivestreams.Subscription#request(long)}.
+		 * component. Note that {@link Long#MAX_VALUE} indicates an unbounded (push-style)
+		 * demand as specified in {@link org.reactivestreams.Subscription#request(long)}.
 		 */
 		REQUESTED_FROM_DOWNSTREAM(0L);
 
@@ -179,6 +201,9 @@ public interface Scannable {
 		}
 	}
 
+	/**
+	 * {@link Scannable} attributes associated with a {@link Throwable} value.
+	 */
 	enum ThrowableAttr implements Attr<Throwable> {
 
 		/**
@@ -199,6 +224,9 @@ public interface Scannable {
 		}
 	}
 
+	/**
+	 * {@link Scannable} attributes associated with a {@link Boolean} value.
+	 */
 	enum BooleanAttr implements Attr<Boolean> {
 
 		/**
@@ -206,11 +234,9 @@ public interface Scannable {
 		 * actively supports error delaying if it manages a backlog instead of fast
 		 * error-passing which might drop pending backlog.
 		 * <p>
-		 *     Note: This attribute usually resolves to a constant value
+		 * Note: This attribute usually resolves to a constant value.
 		 */
 		DELAY_ERROR(false),
-
-
 
 		/**
 		 * A {@link Boolean} attribute indicating whether or not a downstream component
@@ -240,28 +266,10 @@ public interface Scannable {
 		}
 	}
 
-	enum StringAttr implements Attr<String> {
-
-		/**
-		 * a {@link String} attribute which indicates the sequence has been associated
-		 * with a name.
-		 */
-		NAME(null);
-
-		final String defaultValue;
-
-		StringAttr(String defaultValue) {
-			this.defaultValue = defaultValue;
-		}
-
-		@Override
-		public String defaultValue() {
-			return defaultValue;
-		}
-	}
-
 	/**
-	 * A list of reserved keys for component state scanning
+	 * Unclassified and dynamically defined {@link Scannable} attributes that can be
+	 * associated with any type of value. Should be reserved for internal or very
+	 * advanced use only.
 	 */
 	final class GenericAttr<T> implements Attr<T> {
 
@@ -307,7 +315,7 @@ public interface Scannable {
 	 * chain (downward)
 	 */
 	default Stream<? extends Scannable> actuals() {
-		return Attr.recurse(this, ScannableAttr.ACTUAL);
+		return recurse(this, ScannableAttr.ACTUAL);
 	}
 
 	/**
@@ -336,8 +344,23 @@ public interface Scannable {
 	 * chain (upward)
 	 */
 	default Stream<? extends Scannable> parents() {
-		return Attr.recurse(this, ScannableAttr.PARENT);
+		return recurse(this, ScannableAttr.PARENT);
 	}
+
+	/**
+	 * This method is used internally by components to define their key-value mappings
+	 * in a single place. Although it is ignoring the generic type of the {@link Attr} key,
+	 * implementors should take care to return values of the correct type, and return
+	 * {@literal null} if no specific value is available.
+	 * <p>
+	 * For public consumption of attributes, prefer using {@link #scan(Attr)}, which will
+	 * return a typed value and fall back to the key's default if the component didn't
+	 * define any mapping.
+	 *
+	 * @param key a {@link Attr} to resolve for the component.
+	 * @return the value associated to the key for that specific component, or null if none.
+	 */
+	Object scanUnsafe(Attr key);
 
 	/**
 	 * Introspect a component's specific state {@link Attr attribute}, returning an
@@ -345,7 +368,7 @@ public interface Scannable {
 	 * the key, or null if the attribute doesn't make sense for that particular component
 	 * and has no sensible default.
 	 *
-	 * @param key a {@link Attr} to resolve the value within the context
+	 * @param key a {@link Attr} to resolve for the component.
 	 * @return a value associated to the key or null if unmatched or unresolved
 	 *
 	 */
@@ -357,17 +380,16 @@ public interface Scannable {
 		return value;
 	}
 
-	Object scanUnsafe(Attr key);
-
 	/**
-	 * Introspect a component's specific state {@link Attr attribute}, returning the
-	 * provided default if the attribute maps to {@literal null} (which should mean it
-	 * doesn't make sense for that particular component).
+	 * Introspect a component's specific state {@link Attr attribute}. If there's no
+	 * specific value in the component for that key, first attempt to return the key's
+	 * global default. If there is no applicable default, fall back to returning the
+	 * provided default.
 	 *
-	 * @param key a {@link Attr} to resolve the value within the context
-	 * @param defaultValue a fallback value if key resolves to {@literal null}
+	 * @param key a {@link Attr} to resolve for the component.
+	 * @param defaultValue a fallback value if key and key's default both resolve to {@literal null}
 	 *
-	 * @return an eventual value or the default passed
+	 * @return a value associated to the key or the provided default if unmatched or unresolved
 	 */
 	default <T> T scanOrDefault(Attr<T> key, T defaultValue) {
 		T v = scan(key);

--- a/src/main/java/reactor/core/Scannable.java
+++ b/src/main/java/reactor/core/Scannable.java
@@ -17,7 +17,6 @@
 package reactor.core;
 
 import java.util.Iterator;
-import java.util.Objects;
 import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -39,95 +38,10 @@ import java.util.stream.StreamSupport;
 @FunctionalInterface
 public interface Scannable {
 
-	/**
-	 * A list of reserved keys for component state scanning
-	 */
-	enum Attr {
-		/**
-		 * Parent key exposes the direct upstream relationship of the scanned component.
-		 * It can be a Publisher source to an operator, a Subscription to a Subscriber
-		 * (main flow if ambiguous with
-		 * inner Subscriptions like flatMap), a Scheduler to a Worker.
-		 * <p>
-		 *     {@link #parents()} can be used to navigate the parent chain.
-		 */
-		PARENT,
+	@FunctionalInterface
+	interface Attr<T> {
 
-		/**
-		 * Delay_Error exposes a {@link Boolean} whether the scanned component
-		 * actively supports error delaying if it manages a backlog instead of fast
-		 * error-passing which might drop pending backlog.
-		 * <p>
-		 *     Note: This attribute usually resolves to a constant value
-		 */
-		DELAY_ERROR,
-
-		/**
-		 * Prefetch is an {@link Integer} attribute defining the rate of processing in a
-		 * component
-		 * which has capacity to request and hold a backlog of data. It
-		 * usually maps to a component capacity when no arbitrary {@link #CAPACITY} is
-		 * set. {@link Integer#MAX_VALUE} signal unlimited capacity and therefore
-		 * unbounded demand.
-		 * <p>
-		 *     Note: This attribute usually resolves to a constant value
-		 */
-		PREFETCH,
-
-		/**
-		 * Return an an {@link Integer} capacity when no {@link #PREFETCH} is defined or
-		 * when an arbitrary maximum limit is applied to the backlog capacity of the
-		 * scanned component. {@link Integer#MAX_VALUE} signal unlimited capacity.
-		 * <p>
-		 *     Note: This attribute usually resolves to a constant value
-		 */
-		CAPACITY,
-
-		/**
-		 * The direct dependent component downstream reference if any. Operators in Flux/Mono for instance
-		 *  delegate to a target Subscriber, which is going to be the actual chain
-		 *  navigated with this reference key.
-		 *  <p>
-		 *      A reference chain downstream can be navigated via {@link #actuals()}.
-		 */
-		ACTUAL,
-
-		/**
-		 * a {@link Throwable} attribute which indicate an error state if the scanned
-		 * component keeps track of it.
-		 */
-		ERROR,
-
-		/**
-		 * A {@link Integer} attribute implemented by components with a backlog
-		 * capacity. It will expose current queue size or similar related to
-		 * user-provided held data.
-		 */
-		BUFFERED,
-
-		/**
-		 * A {@link Long} attribute exposing the current pending demand of a downstream
-		 * component. Note that {@link Long#MAX_VALUE} indicates an unbounded
-		 * (push-style) demand as specified in
-		 * {@link org.reactivestreams.Subscription#request(long)}.
-		 */
-		REQUESTED_FROM_DOWNSTREAM,
-
-		/**
-		 * A {@link Boolean} attribute indicating whether or not a downstream component
-		 * has interrupted consuming this scanned component, e.g., a cancelled
-		 * subscription. Note that it differs from {@link #TERMINATED} which is
-		 * intended for "normal" shutdown cycles.
-		 */
-		CANCELLED,
-
-		/**
-		 * A {@link Boolean} attribute indicating whether or not an upstream component
-		 * terminated this scanned component. e.g. a post onComplete/onError subscriber.
-		 * By opposition to {@link #CANCELLED} which determines if a downstream
-		 * component interrupted this scanned component.
-		 */
-		TERMINATED;
+		T defaultValue();
 
 		/**
 		 * A constant that represents {@link Scannable} returned via {@link #from(Object)}
@@ -135,7 +49,7 @@ public interface Scannable {
 		 */
 		static final Scannable UNAVAILABLE_SCAN = new Scannable() {
 			@Override
-			public Object scan(Attr key) {
+			public Object scanUnsafe(Attr key) {
 				return null;
 			}
 
@@ -145,7 +59,7 @@ public interface Scannable {
 			}
 		};
 
-		static Stream<? extends Scannable> recurse(Scannable _s, Attr key){
+		static Stream<? extends Scannable> recurse(Scannable _s, ScannableAttr key){
 			Scannable s = Scannable.from(_s.scan(key));
 			if(s == null){
 				return Stream.empty();
@@ -165,6 +79,201 @@ public interface Scannable {
 					return _c;
 				}
 			}, 0),false);
+		}
+	}
+
+	enum ScannableAttr implements Attr<Scannable> {
+
+		/**
+		 * Parent key exposes the direct upstream relationship of the scanned component.
+		 * It can be a Publisher source to an operator, a Subscription to a Subscriber
+		 * (main flow if ambiguous with
+		 * inner Subscriptions like flatMap), a Scheduler to a Worker.
+		 * <p>
+		 *     {@link #parents()} can be used to navigate the parent chain.
+		 */
+		PARENT(null),
+
+		/**
+		 * The direct dependent component downstream reference if any. Operators in Flux/Mono for instance
+		 *  delegate to a target Subscriber, which is going to be the actual chain
+		 *  navigated with this reference key.
+		 *  <p>
+		 *      A reference chain downstream can be navigated via {@link #actuals()}.
+		 */
+		ACTUAL(null);
+
+		final Scannable defaultValue;
+
+		ScannableAttr(Scannable defaultValue) {
+			this.defaultValue = defaultValue;
+		}
+
+		@Override
+		public Scannable defaultValue() {
+			return defaultValue;
+		}
+	}
+
+	enum IntAttr implements Attr<Integer> {
+
+		/**
+		 * Prefetch is an {@link Integer} attribute defining the rate of processing in a
+		 * component
+		 * which has capacity to request and hold a backlog of data. It
+		 * usually maps to a component capacity when no arbitrary {@link #CAPACITY} is
+		 * set. {@link Integer#MAX_VALUE} signal unlimited capacity and therefore
+		 * unbounded demand.
+		 * <p>
+		 *     Note: This attribute usually resolves to a constant value
+		 */
+		PREFETCH(0),
+
+		/**
+		 * Return an an {@link Integer} capacity when no {@link #PREFETCH} is defined or
+		 * when an arbitrary maximum limit is applied to the backlog capacity of the
+		 * scanned component. {@link Integer#MAX_VALUE} signal unlimited capacity.
+		 * <p>
+		 *     Note: This attribute usually resolves to a constant value
+		 */
+		CAPACITY(0),
+
+		/**
+		 * A {@link Integer} attribute implemented by components with a backlog
+		 * capacity. It will expose current queue size or similar related to
+		 * user-provided held data.
+		 */
+		BUFFERED(0);
+
+		final Integer defaultValue;
+
+		IntAttr(Integer defaultValue) {
+			this.defaultValue = defaultValue;
+		}
+
+		@Override
+		public Integer defaultValue() {
+			return defaultValue;
+		}
+	}
+
+	enum LongAttr implements Attr<Long> {
+
+		/**
+		 * A {@link Long} attribute exposing the current pending demand of a downstream
+		 * component. Note that {@link Long#MAX_VALUE} indicates an unbounded
+		 * (push-style) demand as specified in
+		 * {@link org.reactivestreams.Subscription#request(long)}.
+		 */
+		REQUESTED_FROM_DOWNSTREAM(0L);
+
+		final Long defaultValue;
+
+		LongAttr(Long defaultValue) {
+			this.defaultValue = defaultValue;
+		}
+
+		@Override
+		public Long defaultValue() {
+			return defaultValue;
+		}
+	}
+
+	enum ThrowableAttr implements Attr<Throwable> {
+
+		/**
+		 * a {@link Throwable} attribute which indicate an error state if the scanned
+		 * component keeps track of it.
+		 */
+		ERROR(null);
+
+		final Throwable defaultValue;
+
+		ThrowableAttr(Throwable defaultValue) {
+			this.defaultValue = defaultValue;
+		}
+
+		@Override
+		public Throwable defaultValue() {
+			return defaultValue;
+		}
+	}
+
+	enum BooleanAttr implements Attr<Boolean> {
+
+		/**
+		 * Delay_Error exposes a {@link Boolean} whether the scanned component
+		 * actively supports error delaying if it manages a backlog instead of fast
+		 * error-passing which might drop pending backlog.
+		 * <p>
+		 *     Note: This attribute usually resolves to a constant value
+		 */
+		DELAY_ERROR(false),
+
+
+
+		/**
+		 * A {@link Boolean} attribute indicating whether or not a downstream component
+		 * has interrupted consuming this scanned component, e.g., a cancelled
+		 * subscription. Note that it differs from {@link #TERMINATED} which is
+		 * intended for "normal" shutdown cycles.
+		 */
+		CANCELLED(null),
+
+		/**
+		 * A {@link Boolean} attribute indicating whether or not an upstream component
+		 * terminated this scanned component. e.g. a post onComplete/onError subscriber.
+		 * By opposition to {@link #CANCELLED} which determines if a downstream
+		 * component interrupted this scanned component.
+		 */
+		TERMINATED(null);
+
+		final Boolean defaultValue;
+
+		BooleanAttr(Boolean defaultValue) {
+			this.defaultValue = defaultValue;
+		}
+
+		@Override
+		public Boolean defaultValue() {
+			return defaultValue;
+		}
+	}
+
+	enum StringAttr implements Attr<String> {
+
+		/**
+		 * a {@link String} attribute which indicates the sequence has been associated
+		 * with a name.
+		 */
+		NAME(null);
+
+		final String defaultValue;
+
+		StringAttr(String defaultValue) {
+			this.defaultValue = defaultValue;
+		}
+
+		@Override
+		public String defaultValue() {
+			return defaultValue;
+		}
+	}
+
+	/**
+	 * A list of reserved keys for component state scanning
+	 */
+	final class GenericAttr<T> implements Attr<T> {
+
+		final T defaultValue;
+
+		GenericAttr(T defaultValue) {
+			this.defaultValue = defaultValue;
+		}
+
+		@Override
+		public T defaultValue() {
+			return defaultValue;
 		}
 	}
 
@@ -198,7 +307,7 @@ public interface Scannable {
 	 * chain (downward)
 	 */
 	default Stream<? extends Scannable> actuals() {
-		return Attr.recurse(this, Attr.ACTUAL);
+		return Attr.recurse(this, ScannableAttr.ACTUAL);
 	}
 
 	/**
@@ -227,54 +336,41 @@ public interface Scannable {
 	 * chain (upward)
 	 */
 	default Stream<? extends Scannable> parents() {
-		return Attr.recurse(this, Attr.PARENT);
+		return Attr.recurse(this, ScannableAttr.PARENT);
 	}
 
 	/**
-	 * Introspect a component's specific state {@link Attr attribute}, returning a
-	 * best effort value or null if the attribute doesn't make sense for that particular
-	 * component.
-	 *
-	 * @param key an {@link Attr} to get the operator state
-	 *
-	 * @return an eventual value or null
-	 */
-	Object scan(Attr key);
-
-	/**
-	 * Introspect a component's specific state {@link Attr attribute}, returning a
-	 * best effort value casted to the provided class, or null if the attribute doesn't
-	 * make sense for that particular component.
+	 * Introspect a component's specific state {@link Attr attribute}, returning an
+	 * associated value specific to that component, or the default value associated with
+	 * the key, or null if the attribute doesn't make sense for that particular component
+	 * and has no sensible default.
 	 *
 	 * @param key a {@link Attr} to resolve the value within the context
-	 * @param type the attribute type
-	 * @return an eventual value or null if unmatched or unresolved
+	 * @return a value associated to the key or null if unmatched or unresolved
 	 *
 	 */
-	default <T> T scan(Attr key, Class<T> type) {
-		Objects.requireNonNull(type, "type");
-		Object v = scan(key);
-		if (v == null || !type.isAssignableFrom(v.getClass())) {
-			return null;
-		}
+	default <T> T scan(Attr<T> key) {
 		@SuppressWarnings("unchecked")
-		T r = (T)v;
-		return r;
+		T value = (T) scanUnsafe(key);
+		if (value == null)
+			return key.defaultValue();
+		return value;
 	}
 
+	Object scanUnsafe(Attr key);
+
 	/**
-	 * Introspect a component's specific state {@link Attr attribute}, returning a
-	 * best effort casted value or the provided default if the attribute doesn't make
-	 * sense for that particular component.
+	 * Introspect a component's specific state {@link Attr attribute}, returning the
+	 * provided default if the attribute maps to {@literal null} (which should mean it
+	 * doesn't make sense for that particular component).
 	 *
 	 * @param key a {@link Attr} to resolve the value within the context
-	 * @param defaultValue a fallback value if key doesn't resolve (also defining the return type)
+	 * @param defaultValue a fallback value if key resolves to {@literal null}
 	 *
 	 * @return an eventual value or the default passed
 	 */
-	default <T> T scanOrDefault(Attr key, T defaultValue) {
-		@SuppressWarnings("unchecked")
-		T v = (T) scan(key);
+	default <T> T scanOrDefault(Attr<T> key, T defaultValue) {
+		T v = scan(key);
 		if (v == null) {
 			return defaultValue;
 		}

--- a/src/main/java/reactor/core/Scannable.java
+++ b/src/main/java/reactor/core/Scannable.java
@@ -161,7 +161,12 @@ public interface Scannable {
 		/**
 		 * A {@link Integer} attribute implemented by components with a backlog
 		 * capacity. It will expose current queue size or similar related to
-		 * user-provided held data.
+		 * user-provided held data. Note that some operators and processors CAN keep
+		 * a backlog larger than {@code Integer.MAX_VALUE}, in which case
+		 * the {@link LongAttr#LARGE_BUFFERED LongAttr} {@literal LARGE_BUFFERED}
+		 * should be used instead. Such operators will attempt to serve a BUFFERED
+		 * query but will return {@link Integer#MIN_VALUE} when actual buffer size is
+		 * oversized for int.
 		 */
 		BUFFERED(0);
 
@@ -181,6 +186,19 @@ public interface Scannable {
 	 * {@link Scannable} attributes associated with a {@link Long} value.
 	 */
 	enum LongAttr implements Attr<Long> {
+
+		/**
+		 * Similar to {@link IntAttr#BUFFERED}, but reserved for operators that can hold
+		 * a backlog of items that can grow beyond {@literal Integer.MAX_VALUE}. These
+		 * operators will also answer to a {@link IntAttr#BUFFERED} query up to the point
+		 * where their buffer is actually too large, at which point they'll return
+		 * {@literal Integer.MIN_VALUE}, which serves as a signal that this attribute
+		 * should be used instead. Defaults to {@literal null}.
+		 * <p>
+		 * {@code Flux.flatMap}, {@code Flux.filterWhen}, {@link reactor.core.publisher.TopicProcessor},
+		 * and {@code Flux.window} (with overlap) are known to use this attribute.
+		 */
+		LARGE_BUFFERED(null),
 
 		/**
 		 * A {@link Long} attribute exposing the current pending demand of a downstream

--- a/src/main/java/reactor/core/publisher/BlockingIterable.java
+++ b/src/main/java/reactor/core/publisher/BlockingIterable.java
@@ -63,13 +63,10 @@ final class BlockingIterable<T> implements Iterable<T>, Scannable {
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PREFETCH:
-				return batchSize;
-			case PARENT:
-				return source;
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == IntAttr.PREFETCH) return batchSize;
+		if (key == ScannableAttr.PARENT) return source;
+
 		return null;
 	}
 
@@ -259,19 +256,13 @@ final class BlockingIterable<T> implements Iterable<T>, Scannable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-		 	switch (key){
-			    case TERMINATED:
-				    return done;
-			    case PARENT:
-				    return  s;
-			    case CANCELLED:
-			    	return s == Operators.cancelledSubscription();
-			    case PREFETCH:
-			    	return batchSize;
-			    case ERROR:
-			    	return error;
-		    }
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return  s;
+			if (key == BooleanAttr.CANCELLED) 			    	return s == Operators.cancelledSubscription();
+			if (key == IntAttr.PREFETCH) return batchSize;
+			if (key == ThrowableAttr.ERROR) return error;
+
 			return null;
 		}
 	}

--- a/src/main/java/reactor/core/publisher/BlockingIterable.java
+++ b/src/main/java/reactor/core/publisher/BlockingIterable.java
@@ -64,7 +64,7 @@ final class BlockingIterable<T> implements Iterable<T>, Scannable {
 
 	@Override
 	public Object scanUnsafe(Attr key) {
-		if (key == IntAttr.PREFETCH) return batchSize;
+		if (key == IntAttr.PREFETCH) return (int) Math.min(Integer.MAX_VALUE, batchSize); //FIXME should batchSize be forced to int?
 		if (key == ScannableAttr.PARENT) return source;
 
 		return null;
@@ -259,8 +259,8 @@ final class BlockingIterable<T> implements Iterable<T>, Scannable {
 		public Object scanUnsafe(Attr key) {
 			if (key == BooleanAttr.TERMINATED) return done;
 			if (key == ScannableAttr.PARENT) return  s;
-			if (key == BooleanAttr.CANCELLED) 			    	return s == Operators.cancelledSubscription();
-			if (key == IntAttr.PREFETCH) return batchSize;
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == IntAttr.PREFETCH) return (int) Math.min(Integer.MAX_VALUE, batchSize); //FIXME should batchSize be typed int?
 			if (key == ThrowableAttr.ERROR) return error;
 
 			return null;

--- a/src/main/java/reactor/core/publisher/BlockingSingleSubscriber.java
+++ b/src/main/java/reactor/core/publisher/BlockingSingleSubscriber.java
@@ -126,19 +126,13 @@ abstract class BlockingSingleSubscriber<T> extends CountDownLatch
 
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case TERMINATED:
-				return getCount() == 0;
-			case PARENT:
-				return  s;
-			case CANCELLED:
-				return cancelled;
-			case ERROR:
-				return error;
-			case PREFETCH:
-				return Integer.MAX_VALUE;
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == BooleanAttr.TERMINATED) return getCount() == 0;
+		if (key == ScannableAttr.PARENT) return  s;
+		if (key == BooleanAttr.CANCELLED) return cancelled;
+		if (key == ThrowableAttr.ERROR) return error;
+		if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+
 		return null;
 	}
 

--- a/src/main/java/reactor/core/publisher/ConnectableFluxOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/ConnectableFluxOnAssembly.java
@@ -66,13 +66,10 @@ final class ConnectableFluxOnAssembly<T> extends ConnectableFlux<T> implements
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PREFETCH:
-				return getPrefetch();
-			case PARENT:
-				return source;
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+		if (key == ScannableAttr.PARENT) return source;
+
 		return null;
 	}
 }

--- a/src/main/java/reactor/core/publisher/DelegateProcessor.java
+++ b/src/main/java/reactor/core/publisher/DelegateProcessor.java
@@ -83,27 +83,27 @@ final class DelegateProcessor<IN, OUT> extends FluxProcessor<IN, OUT>  {
 	@Override
 	public int getBufferSize() {
 		return Scannable.from(upstream)
-		                .scanOrDefault(Attr.CAPACITY, super.getBufferSize());
+		                .scanOrDefault(IntAttr.CAPACITY, super.getBufferSize());
 	}
 
 	@Override
 	public Throwable getError() {
 		return Scannable.from(upstream)
-		                .scanOrDefault(Attr.ERROR, super.getError());
+		                .scanOrDefault(ThrowableAttr.ERROR, super.getError());
 	}
 
 	@Override
 	public boolean isTerminated() {
 		return Scannable.from(upstream)
-		                .scanOrDefault(Attr.TERMINATED, super.isTerminated());
+		                .scanOrDefault(BooleanAttr.TERMINATED, super.isTerminated());
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		if(key == Attr.PARENT){
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) {
 			return downstream;
 		}
 		return Scannable.from(upstream)
-		                .scan(key);
+		                .scanUnsafe(key);
 	}
 }

--- a/src/main/java/reactor/core/publisher/DirectProcessor.java
+++ b/src/main/java/reactor/core/publisher/DirectProcessor.java
@@ -278,14 +278,11 @@ public final class DirectProcessor<T>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return parent;
-				case CANCELLED:
-					return cancelled;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return parent;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -384,6 +384,11 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	}
 
 	@Override
+	public int getPrefetch() {
+		return prefetch;
+	}
+
+	@Override
 	public Object scanUnsafe(Attr key) {
 		if (key == ScannableAttr.PARENT) return s;
 		if (key == IntAttr.BUFFERED) return getPending();

--- a/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -384,16 +384,12 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key) {
-			case PARENT:
-				return s;
-			case BUFFERED:
-				return getPending();
-			case CANCELLED:
-				return isCancelled();
-		}
-		return super.scan(key);
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return s;
+		if (key == IntAttr.BUFFERED) return getPending();
+		if (key == BooleanAttr.CANCELLED) return isCancelled();
+
+		return super.scanUnsafe(key);
 	}
 
 	final void drain() {

--- a/src/main/java/reactor/core/publisher/EventLoopProcessor.java
+++ b/src/main/java/reactor/core/publisher/EventLoopProcessor.java
@@ -280,12 +280,10 @@ abstract class EventLoopProcessor<IN> extends FluxProcessor<IN, IN>
 	public abstract long getPending();
 
 	@Override
-	public Object scan(Attr key) {
-		switch(key){
-			case PARENT:
-				return upstreamSubscription;
-		}
-		return super.scan(key);
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return upstreamSubscription;
+
+		return super.scanUnsafe(key);
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/FluxArray.java
+++ b/src/main/java/reactor/core/publisher/FluxArray.java
@@ -208,18 +208,13 @@ final class FluxArray<T> extends Flux<T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case TERMINATED:
-					return isEmpty();
-				case BUFFERED:
-					return size();
-				case CANCELLED:
-					return cancelled;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return isEmpty();
+			if (key == IntAttr.BUFFERED) return size();
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 	}
 
@@ -346,18 +341,13 @@ final class FluxArray<T> extends Flux<T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case TERMINATED:
-					return isEmpty();
-				case BUFFERED:
-					return size();
-				case CANCELLED:
-					return cancelled;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return isEmpty();
+			if (key == IntAttr.BUFFERED) return size();
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxAutoConnect.java
+++ b/src/main/java/reactor/core/publisher/FluxAutoConnect.java
@@ -69,13 +69,10 @@ final class FluxAutoConnect<T> extends Flux<T>
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PREFETCH:
-				return getPrefetch();
-			case PARENT:
-				return source;
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+		if (key == ScannableAttr.PARENT) return source;
+
 		return null;
 	}
 }

--- a/src/main/java/reactor/core/publisher/FluxAutoConnectFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxAutoConnectFuseable.java
@@ -70,13 +70,10 @@ final class FluxAutoConnectFuseable<T> extends Flux<T>
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PREFETCH:
-				return getPrefetch();
-			case PARENT:
-				return source;
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+		if (key == ScannableAttr.PARENT) return source;
+
 		return null;
 	}
 }

--- a/src/main/java/reactor/core/publisher/FluxAwaitOnSubscribe.java
+++ b/src/main/java/reactor/core/publisher/FluxAwaitOnSubscribe.java
@@ -130,16 +130,12 @@ final class FluxAwaitOnSubscribe<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 	}
 }

--- a/src/main/java/reactor/core/publisher/FluxBuffer.java
+++ b/src/main/java/reactor/core/publisher/FluxBuffer.java
@@ -190,7 +190,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxSource<T,
 			if (key == BooleanAttr.TERMINATED) return done;
 			if (key == IntAttr.CAPACITY) {
 				C b = buffer;
-				return b != null ? b.size() : 0L;
+				return b != null ? b.size() : 0;
 			}
 			if (key == IntAttr.PREFETCH) return size;
 
@@ -341,7 +341,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxSource<T,
 			if (key == BooleanAttr.TERMINATED) return done;
 			if (key == IntAttr.CAPACITY) {
 				C b = buffer;
-				return b != null ? b.size() : 0L;
+				return b != null ? b.size() : 0;
 			}
 			if (key == IntAttr.PREFETCH) return size;
 

--- a/src/main/java/reactor/core/publisher/FluxBuffer.java
+++ b/src/main/java/reactor/core/publisher/FluxBuffer.java
@@ -185,19 +185,16 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxSource<T,
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case CAPACITY:
-					C b = buffer;
-					return b != null ? b.size() : 0L;
-				case PREFETCH:
-					return size;
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == IntAttr.CAPACITY) {
+				C b = buffer;
+				return b != null ? b.size() : 0L;
 			}
-			return InnerOperator.super.scan(key);
+			if (key == IntAttr.PREFETCH) return size;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 	}
 
@@ -339,19 +336,16 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxSource<T,
 			return actual;
 		}
 
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case CAPACITY:
-					C b = buffer;
-					return b != null ? b.size() : 0L;
-				case PREFETCH:
-					return size;
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == IntAttr.CAPACITY) {
+				C b = buffer;
+				return b != null ? b.size() : 0L;
 			}
-			return InnerOperator.super.scan(key);
+			if (key == IntAttr.PREFETCH) return size;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 	}
 
@@ -523,22 +517,15 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxSource<T,
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case CANCELLED:
-					return cancelled;
-				case CAPACITY:
-					return size() * size;
-				case PREFETCH:
-					return Integer.MAX_VALUE;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == IntAttr.CAPACITY) return size() * size;
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 	}

--- a/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
+++ b/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
@@ -27,7 +27,6 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Exceptions;
 
-
 /**
  * Buffers elements into custom collections where the buffer boundary is signalled
  * by another publisher.
@@ -123,21 +122,17 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-				case CAPACITY:
-					C buffer = this.buffer;
-					return buffer != null ? buffer.size() : 0;
-				case PREFETCH:
-					return Integer.MAX_VALUE;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == IntAttr.CAPACITY) {
+				C buffer = this.buffer;
+				return buffer != null ? buffer.size() : 0;
 			}
-			return InnerOperator.super.scan(key);
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -307,11 +302,11 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			if (key == Attr.ACTUAL) {
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.ACTUAL) {
 				return main;
 			}
-			return super.scan(key);
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
+++ b/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
@@ -298,7 +298,7 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 			if (key == BooleanAttr.CANCELLED) return getAsBoolean();
 			if (key == IntAttr.CAPACITY) {
 				C b = buffer;
-				return b != null ? b.size() : 0L;
+				return b != null ? b.size() : 0;
 			}
 			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
 

--- a/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
+++ b/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
@@ -292,21 +292,17 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case CANCELLED:
-					return getAsBoolean();
-				case CAPACITY:
-					C b = buffer;
-					return b != null ? b.size() : 0L;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == BooleanAttr.CANCELLED) return getAsBoolean();
+			if (key == IntAttr.CAPACITY) {
+				C b = buffer;
+				return b != null ? b.size() : 0L;
 			}
-			return InnerOperator.super.scan(key);
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxBufferTimeOrSize.java
+++ b/src/main/java/reactor/core/publisher/FluxBufferTimeOrSize.java
@@ -183,22 +183,15 @@ final class FluxBufferTimeOrSize<T, C extends Collection<? super T>> extends Flu
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return subscription;
-				case CANCELLED:
-					return terminated == TERMINATED_WITH_CANCEL;
-				case TERMINATED:
-					return terminated == TERMINATED_WITH_ERROR || terminated == TERMINATED_WITH_SUCCESS;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case CAPACITY:
-					return batchSize;
-				case BUFFERED:
-					return batchSize - index;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return subscription;
+			if (key == BooleanAttr.CANCELLED) return terminated == TERMINATED_WITH_CANCEL;
+			if (key == BooleanAttr.TERMINATED) return terminated == TERMINATED_WITH_ERROR || terminated == TERMINATED_WITH_SUCCESS;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == IntAttr.CAPACITY) return batchSize;
+			if (key == IntAttr.BUFFERED) return batchSize - index;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxBufferWhen.java
+++ b/src/main/java/reactor/core/publisher/FluxBufferWhen.java
@@ -34,7 +34,6 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Exceptions;
 
-
 /**
  * buffers elements into possibly overlapping buffers whose boundaries are determined
  * by a start Publisher's element and a signal of a derived Publisher
@@ -474,25 +473,18 @@ final class FluxBufferWhen<T, U, V, C extends Collection<? super T>>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case CANCELLED:
-					return cancelled;
-				case PREFETCH:
-					return Integer.MAX_VALUE;
-				case BUFFERED:
-					return buffers.values()
-					              .stream()
-					              .mapToInt(Collection::size)
-					              .sum();
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+			if (key == IntAttr.BUFFERED) return buffers.values()
+			                                           .stream()
+			                                           .mapToInt(Collection::size)
+			                                           .sum();
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 	}
 
@@ -528,11 +520,11 @@ final class FluxBufferWhen<T, U, V, C extends Collection<? super T>>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			if (key == Attr.ACTUAL) {
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.ACTUAL) {
 				return main;
 			}
-			return super.scan(key);
+			return super.scanUnsafe(key);
 		}
 	}
 
@@ -554,11 +546,11 @@ final class FluxBufferWhen<T, U, V, C extends Collection<? super T>>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			if (key == Attr.ACTUAL) {
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.ACTUAL) {
 				return main;
 			}
-			return super.scan(key);
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxCancelOn.java
+++ b/src/main/java/reactor/core/publisher/FluxCancelOn.java
@@ -65,14 +65,11 @@ final class FluxCancelOn<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case CANCELLED:
-					return cancelled == 1;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.CANCELLED) return cancelled == 1;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxCombineLatest.java
+++ b/src/main/java/reactor/core/publisher/FluxCombineLatest.java
@@ -267,18 +267,13 @@ final class FluxCombineLatest<T, R> extends Flux<R> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case CANCELLED:
-					return cancelled;
-				case ERROR:
-					return error;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		void subscribe(Publisher<? extends T>[] sources, int n) {
@@ -620,17 +615,12 @@ final class FluxCombineLatest<T, R> extends Flux<R> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return  s;
-				case ACTUAL:
-					return parent;
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-				case PREFETCH:
-					return prefetch;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return  s;
+			if (key == ScannableAttr.ACTUAL) return parent;
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == IntAttr.PREFETCH) return prefetch;
+
 			return null;
 		}
 	}

--- a/src/main/java/reactor/core/publisher/FluxConcatArray.java
+++ b/src/main/java/reactor/core/publisher/FluxConcatArray.java
@@ -251,14 +251,11 @@ final class FluxConcatArray<T> extends Flux<T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch(key){
-				case DELAY_ERROR:
-					return true;
-				case ERROR:
-					return error;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.DELAY_ERROR) return true;
+			if (key == ThrowableAttr.ERROR) return error;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxConcatMap.java
+++ b/src/main/java/reactor/core/publisher/FluxConcatMap.java
@@ -175,22 +175,15 @@ final class FluxConcatMap<T, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case CANCELLED:
-					return cancelled;
-				case PREFETCH:
-					return prefetch;
-				case BUFFERED:
-					return queue != null ? queue.size() : 0;
-				case ERROR:
-					return error;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == IntAttr.PREFETCH) return prefetch;
+			if (key == IntAttr.BUFFERED) return queue != null ? queue.size() : 0;
+			if (key == ThrowableAttr.ERROR) return error;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -514,24 +507,16 @@ final class FluxConcatMap<T, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case CANCELLED:
-					return cancelled;
-				case PREFETCH:
-					return prefetch;
-				case BUFFERED:
-					return queue != null ? queue.size() : 0;
-				case ERROR:
-					return error;
-				case DELAY_ERROR:
-					return true;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == IntAttr.PREFETCH) return prefetch;
+			if (key == IntAttr.BUFFERED) return queue != null ? queue.size() : 0;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == BooleanAttr.DELAY_ERROR) return true;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxCreate.java
+++ b/src/main/java/reactor/core/publisher/FluxCreate.java
@@ -269,7 +269,7 @@ final class FluxCreate<T> extends Flux<T> {
 			if (key == ThrowableAttr.ERROR) return error;
 			if (key == BooleanAttr.TERMINATED) return done;
 
-			return null;
+			return sink.scanUnsafe(key);
 		}
 	}
 

--- a/src/main/java/reactor/core/publisher/FluxCreate.java
+++ b/src/main/java/reactor/core/publisher/FluxCreate.java
@@ -264,15 +264,11 @@ final class FluxCreate<T> extends Flux<T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case BUFFERED:
-					return queue.size();
-				case ERROR:
-					return error;
-				case TERMINATED:
-					return done;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == IntAttr.BUFFERED) return queue.size();
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == BooleanAttr.TERMINATED) return done;
+
 			return null;
 		}
 	}
@@ -436,15 +432,13 @@ final class FluxCreate<T> extends Flux<T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case TERMINATED:
-				case CANCELLED:
-					return disposable == CANCELLED;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED || key == BooleanAttr.CANCELLED) {
+				return disposable == CANCELLED;
 			}
-			return InnerProducer.super.scan(key);
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 	}
 
@@ -651,16 +645,12 @@ final class FluxCreate<T> extends Flux<T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case BUFFERED:
-					return queue.size();
-				case TERMINATED:
-					return done;
-				case ERROR:
-					return error;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == IntAttr.BUFFERED) return queue.size();
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ThrowableAttr.ERROR) return error;
+
+			return super.scanUnsafe(key);
 		}
 	}
 
@@ -792,16 +782,12 @@ final class FluxCreate<T> extends Flux<T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case BUFFERED:
-					return queue.get() == null ? 0 : 1;
-				case TERMINATED:
-					return done;
-				case ERROR:
-					return error;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == IntAttr.BUFFERED) return queue.get() == null ? 0 : 1;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ThrowableAttr.ERROR) return error;
+
+			return super.scanUnsafe(key);
 		}
 	}
 

--- a/src/main/java/reactor/core/publisher/FluxDefaultIfEmpty.java
+++ b/src/main/java/reactor/core/publisher/FluxDefaultIfEmpty.java
@@ -54,12 +54,10 @@ final class FluxDefaultIfEmpty<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxDelaySubscription.java
+++ b/src/main/java/reactor/core/publisher/FluxDelaySubscription.java
@@ -61,8 +61,7 @@ final class FluxDelaySubscription<T, U> extends FluxSource<T, T> {
 
 		boolean done;
 
-		DelaySubscriptionOtherSubscriber(Subscriber<? super T> actual, Publisher<?
-				extends T> source) {
+		DelaySubscriptionOtherSubscriber(Subscriber<? super T> actual, Publisher<? extends T> source) {
 			this.actual = actual;
 			this.source = source;
 
@@ -71,6 +70,7 @@ final class FluxDelaySubscription<T, U> extends FluxSource<T, T> {
 		@Override
 		public Object scanUnsafe(Attr key) {
 			if (key == ScannableAttr.PARENT) return s;
+			if (key == ScannableAttr.ACTUAL) return actual;
 			if (key == BooleanAttr.TERMINATED) return done;
 
 			return super.scanUnsafe(key);
@@ -132,48 +132,46 @@ final class FluxDelaySubscription<T, U> extends FluxSource<T, T> {
 		void subscribeSource() {
 			source.subscribe(new DelaySubscriptionMainSubscriber<>(actual, this));
 		}
+	}
 
-		static final class DelaySubscriptionMainSubscriber<T>
-				implements InnerConsumer<T> {
+	static final class DelaySubscriptionMainSubscriber<T>
+			implements InnerConsumer<T> {
 
-			final Subscriber<? super T> actual;
+		final Subscriber<? super T> actual;
 
-			final DelaySubscriptionOtherSubscriber<?, ?> arbiter;
+		final DelaySubscriptionOtherSubscriber<?, ?> arbiter;
 
-			DelaySubscriptionMainSubscriber(Subscriber<? super T> actual,
-					DelaySubscriptionOtherSubscriber<?, ?> arbiter) {
-				this.actual = actual;
-				this.arbiter = arbiter;
-			}
+		DelaySubscriptionMainSubscriber(Subscriber<? super T> actual,
+				DelaySubscriptionOtherSubscriber<?, ?> arbiter) {
+			this.actual = actual;
+			this.arbiter = arbiter;
+		}
 
-			@Override
-			public Object scanUnsafe(Attr key) {
-				if (key == ScannableAttr.ACTUAL) return actual;
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.ACTUAL) return actual;
 
-				return null;
-			}
+			return null;
+		}
 
-			@Override
-			public void onSubscribe(Subscription s) {
-				arbiter.set(s);
-			}
+		@Override
+		public void onSubscribe(Subscription s) {
+			arbiter.set(s);
+		}
 
-			@Override
-			public void onNext(T t) {
-				actual.onNext(t);
-			}
+		@Override
+		public void onNext(T t) {
+			actual.onNext(t);
+		}
 
-			@Override
-			public void onError(Throwable t) {
-				actual.onError(t);
-			}
+		@Override
+		public void onError(Throwable t) {
+			actual.onError(t);
+		}
 
-			@Override
-			public void onComplete() {
-				actual.onComplete();
-			}
-
-
+		@Override
+		public void onComplete() {
+			actual.onComplete();
 		}
 	}
 }

--- a/src/main/java/reactor/core/publisher/FluxDelaySubscription.java
+++ b/src/main/java/reactor/core/publisher/FluxDelaySubscription.java
@@ -69,14 +69,11 @@ final class FluxDelaySubscription<T, U> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override
@@ -150,11 +147,9 @@ final class FluxDelaySubscription<T, U> extends FluxSource<T, T> {
 			}
 
 			@Override
-			public Object scan(Attr key) {
-				switch (key){
-					case ACTUAL:
-						return actual;
-				}
+			public Object scanUnsafe(Attr key) {
+				if (key == ScannableAttr.ACTUAL) return actual;
+
 				return null;
 			}
 

--- a/src/main/java/reactor/core/publisher/FluxDematerialize.java
+++ b/src/main/java/reactor/core/publisher/FluxDematerialize.java
@@ -67,22 +67,15 @@ final class FluxDematerialize<T> extends FluxSource<Signal<T>, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case ERROR:
-					return error;
-				case CANCELLED:
-					return cancelled;
-				case BUFFERED:
-					return size();
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == IntAttr.BUFFERED) return size();
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxDetach.java
+++ b/src/main/java/reactor/core/publisher/FluxDetach.java
@@ -49,16 +49,12 @@ final class FluxDetach<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return actual == null;
-				case CANCELLED:
-					return actual == null && s == null;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return actual == null;
+			if (key == BooleanAttr.CANCELLED) return actual == null && s == null;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxDistinct.java
+++ b/src/main/java/reactor/core/publisher/FluxDistinct.java
@@ -188,14 +188,11 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 	}
 
@@ -335,14 +332,11 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 	}
 
@@ -473,14 +467,11 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return qs;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return qs;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
+++ b/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
@@ -133,14 +133,11 @@ final class FluxDistinctUntilChanged<T, K> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -241,14 +238,11 @@ final class FluxDistinctUntilChanged<T, K> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxDoFinally.java
+++ b/src/main/java/reactor/core/publisher/FluxDoFinally.java
@@ -95,15 +95,12 @@ final class FluxDoFinally<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-				case CANCELLED:
-					return once == 1;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED || key == BooleanAttr.CANCELLED)
+				return once == 1;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@SuppressWarnings("unchecked")

--- a/src/main/java/reactor/core/publisher/FluxElapsed.java
+++ b/src/main/java/reactor/core/publisher/FluxElapsed.java
@@ -60,12 +60,10 @@ final class FluxElapsed<T> extends FluxSource<T, Tuple2<Long, T>> implements Fus
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxError.java
+++ b/src/main/java/reactor/core/publisher/FluxError.java
@@ -85,15 +85,12 @@ final class FluxError<T> extends Flux<T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case ERROR:
-					return error;
-				case CANCELLED:
-				case TERMINATED:
-					return once == 1;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == BooleanAttr.CANCELLED || key == BooleanAttr.TERMINATED)
+				return once == 1;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 	}
 }

--- a/src/main/java/reactor/core/publisher/FluxFilter.java
+++ b/src/main/java/reactor/core/publisher/FluxFilter.java
@@ -142,14 +142,11 @@ final class FluxFilter<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -257,14 +254,11 @@ final class FluxFilter<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 

--- a/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
@@ -151,14 +151,11 @@ final class FluxFilterFuseable<T> extends FluxSource<T, T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -329,14 +326,11 @@ final class FluxFilterFuseable<T> extends FluxSource<T, T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxFilterWhen.java
+++ b/src/main/java/reactor/core/publisher/FluxFilterWhen.java
@@ -437,7 +437,7 @@ class FluxFilterWhen<T> extends FluxSource<T, T> {
 			if (key == BooleanAttr.CANCELLED) return sub == Operators.cancelledSubscription();
 			if (key == BooleanAttr.TERMINATED) return done;
 			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
-			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return done ? 0 : 1;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return done ? 0L : 1L;
 
 			return null;
 		}

--- a/src/main/java/reactor/core/publisher/FluxFilterWhen.java
+++ b/src/main/java/reactor/core/publisher/FluxFilterWhen.java
@@ -360,7 +360,12 @@ class FluxFilterWhen<T> extends FluxSource<T, T> {
 				return error;
 			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
 			if (key == IntAttr.CAPACITY) return toFilter.length();
-			if (key == IntAttr.BUFFERED) return (int) (producerIndex - consumerIndex);
+			if (key == LongAttr.LARGE_BUFFERED) return producerIndex - consumerIndex;
+			if (key == IntAttr.BUFFERED) {
+				long realBuffered = producerIndex - consumerIndex;
+				if (realBuffered <= Integer.MAX_VALUE) return (int) realBuffered;
+				return Integer.MIN_VALUE;
+			}
 			if (key == IntAttr.PREFETCH) return bufferSize;
 
 			return InnerOperator.super.scanUnsafe(key);

--- a/src/main/java/reactor/core/publisher/FluxFilterWhen.java
+++ b/src/main/java/reactor/core/publisher/FluxFilterWhen.java
@@ -352,28 +352,18 @@ class FluxFilterWhen<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return upstream;
-				case TERMINATED:
-					return done;
-				case CANCELLED:
-					return cancelled;
-				case ERROR:
-					//FIXME ERROR is often reset by Exceptions.terminate :(
-					return error;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case CAPACITY:
-					return toFilter.length();
-				case BUFFERED:
-					return producerIndex - consumerIndex;
-				case PREFETCH:
-					return bufferSize;
-				default:
-					return InnerOperator.super.scan(key);
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return upstream;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == ThrowableAttr.ERROR) //FIXME ERROR is often reset by Exceptions.terminate :(
+				return error;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == IntAttr.CAPACITY) return toFilter.length();
+			if (key == IntAttr.BUFFERED) return (int) (producerIndex - consumerIndex);
+			if (key == IntAttr.PREFETCH) return bufferSize;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -441,23 +431,15 @@ class FluxFilterWhen<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch(key) {
-				case PARENT:
-					return parent;
-				case ACTUAL:
-					return sub;
-				case CANCELLED:
-					return sub == Operators.cancelledSubscription();
-				case TERMINATED:
-					return done;
-				case PREFETCH:
-					return Integer.MAX_VALUE;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return done ? 0 : 1;
-				default:
-					return null;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return parent;
+			if (key == ScannableAttr.ACTUAL) return sub;
+			if (key == BooleanAttr.CANCELLED) return sub == Operators.cancelledSubscription();
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return done ? 0 : 1;
+
+			return null;
 		}
 	}
 }

--- a/src/main/java/reactor/core/publisher/FluxFirstEmitting.java
+++ b/src/main/java/reactor/core/publisher/FluxFirstEmitting.java
@@ -181,11 +181,9 @@ final class FluxFirstEmitting<T> extends Flux<T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case CANCELLED:
-					return cancelled;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+
 			return null;
 		}
 
@@ -292,14 +290,11 @@ final class FluxFirstEmitting<T> extends Flux<T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case CANCELLED:
-					return parent.cancelled;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.CANCELLED) return parent.cancelled;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -263,7 +263,12 @@ final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 			if (key == BooleanAttr.DELAY_ERROR) return delayError;
 			if (key == IntAttr.PREFETCH) return maxConcurrency;
 			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
-			if (key == IntAttr.BUFFERED) return (scalarQueue != null ? scalarQueue.size() : 0) + size;
+			if (key == LongAttr.LARGE_BUFFERED) return (scalarQueue != null ? (long) scalarQueue.size() : 0L) + size;
+			if (key == IntAttr.BUFFERED) {
+				long realBuffered = (scalarQueue != null ? (long) scalarQueue.size() : 0L) + size;
+				if (realBuffered <= Integer.MAX_VALUE) return (int) realBuffered;
+				return Integer.MIN_VALUE;
+			}
 
 			return InnerOperator.super.scanUnsafe(key);
 		}

--- a/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -255,26 +255,17 @@ final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case CANCELLED:
-					return cancelled;
-				case ERROR:
-					return error;
-				case TERMINATED:
-					return done && (scalarQueue == null || scalarQueue.isEmpty());
-				case DELAY_ERROR:
-					return delayError;
-				case PREFETCH:
-					return maxConcurrency;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case BUFFERED:
-					return (scalarQueue != null ? scalarQueue.size() : 0) + size;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == BooleanAttr.TERMINATED) return done && (scalarQueue == null || scalarQueue.isEmpty());
+			if (key == BooleanAttr.DELAY_ERROR) return delayError;
+			if (key == IntAttr.PREFETCH) return maxConcurrency;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == IntAttr.BUFFERED) return (scalarQueue != null ? scalarQueue.size() : 0) + size;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@SuppressWarnings("unchecked")
@@ -951,21 +942,14 @@ final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case ACTUAL:
-					return parent;
-				case TERMINATED:
-					return done && (queue == null || queue.isEmpty());
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-				case BUFFERED:
-					return queue == null ? 0 : queue.size();
-				case PREFETCH:
-					return prefetch;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == ScannableAttr.ACTUAL) return parent;
+			if (key == BooleanAttr.TERMINATED) return done && (queue == null || queue.isEmpty());
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == IntAttr.BUFFERED) return queue == null ? 0 : queue.size();
+			if (key == IntAttr.PREFETCH) return prefetch;
+
 			return null;
 		}
 	}

--- a/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
+++ b/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
@@ -166,24 +166,16 @@ final class FluxFlattenIterable<T, R> extends FluxSource<T, R> implements Fuseab
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case ERROR:
-					return error;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case CANCELLED:
-					return cancelled;
-				case PREFETCH:
-					return prefetch;
-				case BUFFERED:
-					return queue != null ? queue.size() : 0;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == IntAttr.PREFETCH) return prefetch;
+			if (key == IntAttr.BUFFERED) return queue != null ? queue.size() : 0;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxGenerate.java
+++ b/src/main/java/reactor/core/publisher/FluxGenerate.java
@@ -121,18 +121,13 @@ extends Flux<T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case TERMINATED:
-					return terminate;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case CANCELLED:
-					return cancelled;
-				case ERROR:
-					return generatedError;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return terminate;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == ThrowableAttr.ERROR) return generatedError;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxGroupBy.java
+++ b/src/main/java/reactor/core/publisher/FluxGroupBy.java
@@ -243,24 +243,16 @@ final class FluxGroupBy<T, K, V> extends FluxSource<T, GroupedFlux<K, V>>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case PREFETCH:
-					return prefetch;
-				case BUFFERED:
-					return queue.size();
-				case CANCELLED:
-					return cancelled == 1;
-				case ERROR:
-					return error;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == IntAttr.PREFETCH) return prefetch;
+			if (key == IntAttr.BUFFERED) return queue.size();
+			if (key == BooleanAttr.CANCELLED) return cancelled == 1;
+			if (key == ThrowableAttr.ERROR) return error;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -780,22 +772,15 @@ final class FluxGroupBy<T, K, V> extends FluxSource<T, GroupedFlux<K, V>>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return parent;
-				case TERMINATED:
-					return done;
-				case CANCELLED:
-					return cancelled;
-				case ERROR:
-					return error;
-				case BUFFERED:
-					return queue != null ? queue.size() : 0;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return parent;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == IntAttr.BUFFERED) return queue != null ? queue.size() : 0;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxGroupJoin.java
+++ b/src/main/java/reactor/core/publisher/FluxGroupJoin.java
@@ -220,20 +220,14 @@ final class FluxGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case CANCELLED:
-					return cancelled;
-				case BUFFERED:
-					return queue.size() / 2;
-				case TERMINATED:
-					return active == 0;
-				case ERROR:
-					return error;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == IntAttr.BUFFERED) return queue.size() / 2;
+			if (key == BooleanAttr.TERMINATED) return active == 0;
+			if (key == ThrowableAttr.ERROR) return error;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -553,15 +547,11 @@ final class FluxGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return subscription;
-				case ACTUAL:
-					return parent;
-				case CANCELLED:
-					return isDisposed();
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return subscription;
+			if (key == ScannableAttr.ACTUAL ) return parent;
+			if (key == BooleanAttr.CANCELLED) return isDisposed();
+
 			return null;
 		}
 
@@ -631,13 +621,10 @@ final class FluxGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return subscription;
-				case CANCELLED:
-					return isDisposed();
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return subscription;
+			if (key == BooleanAttr.CANCELLED) return isDisposed();
+
 			return null;
 		}
 

--- a/src/main/java/reactor/core/publisher/FluxHandle.java
+++ b/src/main/java/reactor/core/publisher/FluxHandle.java
@@ -183,16 +183,12 @@ final class FluxHandle<T, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case ERROR:
-					return error;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ThrowableAttr.ERROR) return error;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -359,16 +355,12 @@ final class FluxHandle<T, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case ERROR:
-					return error;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ThrowableAttr.ERROR) return error;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 	}
 

--- a/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
@@ -186,16 +186,12 @@ final class FluxHandleFuseable<T, R> extends FluxSource<T, R> implements Fuseabl
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case ERROR:
-					return error;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ThrowableAttr.ERROR) return error;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -467,16 +463,12 @@ final class FluxHandleFuseable<T, R> extends FluxSource<T, R> implements Fuseabl
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case ERROR:
-					return error;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ThrowableAttr.ERROR) return error;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxHide.java
+++ b/src/main/java/reactor/core/publisher/FluxHide.java
@@ -83,12 +83,10 @@ final class FluxHide<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 	}
 
@@ -114,12 +112,10 @@ final class FluxHide<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxInterval.java
+++ b/src/main/java/reactor/core/publisher/FluxInterval.java
@@ -91,12 +91,10 @@ final class FluxInterval extends Flux<Long> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch(key){
-				case CANCELLED:
-					return cancelled;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxIterable.java
+++ b/src/main/java/reactor/core/publisher/FluxIterable.java
@@ -274,16 +274,12 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch(key){
-				case CANCELLED:
-					return cancelled;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case TERMINATED:
-					return state == STATE_NO_NEXT;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == BooleanAttr.TERMINATED) return state == STATE_NO_NEXT;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -523,16 +519,12 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch(key){
-				case CANCELLED:
-					return cancelled;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case TERMINATED:
-					return state == STATE_NO_NEXT;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == BooleanAttr.TERMINATED) return state == STATE_NO_NEXT;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxJoin.java
+++ b/src/main/java/reactor/core/publisher/FluxJoin.java
@@ -181,20 +181,14 @@ final class FluxJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case CANCELLED:
-					return cancelled;
-				case BUFFERED:
-					return queue.size() / 2;
-				case TERMINATED:
-					return active == 0;
-				case ERROR:
-					return error;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == IntAttr.BUFFERED) return queue.size() / 2;
+			if (key == BooleanAttr.TERMINATED) return active == 0;
+			if (key == ThrowableAttr.ERROR) return error;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxJust.java
+++ b/src/main/java/reactor/core/publisher/FluxJust.java
@@ -135,13 +135,10 @@ final class FluxJust<T> extends Flux<T> implements Fuseable.ScalarCallable<T>, F
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch(key){
-				case TERMINATED:
-				case CANCELLED:
-					return terminado;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED || key == BooleanAttr.CANCELLED) return terminado;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 	}
 }

--- a/src/main/java/reactor/core/publisher/FluxMap.java
+++ b/src/main/java/reactor/core/publisher/FluxMap.java
@@ -131,14 +131,11 @@ final class FluxMap<T, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -248,14 +245,11 @@ final class FluxMap<T, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxMapFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxMapFuseable.java
@@ -139,14 +139,11 @@ final class FluxMapFuseable<T, R> extends FluxSource<T, R> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -226,14 +223,11 @@ final class FluxMapFuseable<T, R> extends FluxSource<T, R> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@SuppressWarnings("unchecked")

--- a/src/main/java/reactor/core/publisher/FluxMapSignal.java
+++ b/src/main/java/reactor/core/publisher/FluxMapSignal.java
@@ -233,20 +233,14 @@ final class FluxMapSignal<T, R> extends FluxSource<T, R> {
         }
 
 	    @Override
-	    public Object scan(Attr key) {
-		    switch (key) {
-			    case PARENT:
-				    return s;
-			    case TERMINATED:
-				    return done;
-			    case CANCELLED:
-			    	return getAsBoolean();
-			    case REQUESTED_FROM_DOWNSTREAM:
-			    	return requested;
-			    case BUFFERED:
-			    	return size();
-		    }
-		    return InnerOperator.super.scan(key);
+	    public Object scanUnsafe(Attr key) {
+		    if (key == ScannableAttr.PARENT) return s;
+		    if (key == BooleanAttr.TERMINATED) return done;
+		    if (key == BooleanAttr.CANCELLED) return getAsBoolean();
+		    if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+		    if (key == IntAttr.BUFFERED) return size();
+
+		    return InnerOperator.super.scanUnsafe(key);
 	    }
 
 	    @Override

--- a/src/main/java/reactor/core/publisher/FluxMaterialize.java
+++ b/src/main/java/reactor/core/publisher/FluxMaterialize.java
@@ -62,22 +62,15 @@ final class FluxMaterialize<T> extends FluxSource<T, Signal<T>> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return terminalSignal != null;
-				case ERROR:
-					return terminalSignal != null ? terminalSignal.getThrowable() : null;
-				case CANCELLED:
-					return getAsBoolean();
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case BUFFERED:
-					return size();
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return terminalSignal != null;
+			if (key == ThrowableAttr.ERROR) return terminalSignal != null ? terminalSignal.getThrowable() : null;
+			if (key == BooleanAttr.CANCELLED) return getAsBoolean();
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == IntAttr.BUFFERED) return size();
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxMergeSequential.java
+++ b/src/main/java/reactor/core/publisher/FluxMergeSequential.java
@@ -167,24 +167,16 @@ final class FluxMergeSequential<T, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case ERROR:
-					return error;
-				case TERMINATED:
-					return done && subscribers.isEmpty();
-				case DELAY_ERROR:
-					return errorMode != ErrorMode.IMMEDIATE;
-				case PREFETCH:
-					return maxConcurrency;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case BUFFERED:
-					return subscribers.size();
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == BooleanAttr.TERMINATED) return done && subscribers.isEmpty();
+			if (key == BooleanAttr.DELAY_ERROR) return errorMode != ErrorMode.IMMEDIATE;
+			if (key == IntAttr.PREFETCH) return maxConcurrency;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == IntAttr.BUFFERED) return subscribers.size();
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -511,21 +503,14 @@ final class FluxMergeSequential<T, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return subscription;
-				case ACTUAL:
-					return parent;
-				case TERMINATED:
-					return done && (queue == null || queue.isEmpty());
-				case CANCELLED:
-					return subscription == Operators.cancelledSubscription();
-				case BUFFERED:
-					return queue == null ? 0 : queue.size();
-				case PREFETCH:
-					return prefetch;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return subscription;
+			if (key == ScannableAttr.ACTUAL) return parent;
+			if (key == BooleanAttr.TERMINATED) return done && (queue == null || queue.isEmpty());
+			if (key == BooleanAttr.CANCELLED) return subscription == Operators.cancelledSubscription();
+			if (key == IntAttr.BUFFERED) return queue == null ? 0 : queue.size();
+			if (key == IntAttr.PREFETCH) return prefetch;
+
 			return null;
 		}
 

--- a/src/main/java/reactor/core/publisher/FluxOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/FluxOnAssembly.java
@@ -432,12 +432,10 @@ final class FluxOnAssembly<T> extends FluxSource<T, T> implements Fuseable, Asse
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxOnBackpressureBuffer.java
+++ b/src/main/java/reactor/core/publisher/FluxOnBackpressureBuffer.java
@@ -114,26 +114,17 @@ final class FluxOnBackpressureBuffer<O> extends FluxSource<O, O> implements Fuse
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case TERMINATED:
-					return done && queue.isEmpty();
-				case CANCELLED:
-					return cancelled;
-				case BUFFERED:
-					return queue.size();
-				case ERROR:
-					return error;
-				case PREFETCH:
-					return Integer.MAX_VALUE;
-				case DELAY_ERROR:
-					return delayError;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == BooleanAttr.TERMINATED) return done && queue.isEmpty();
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == IntAttr.BUFFERED) return queue.size();
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+			if (key == BooleanAttr.DELAY_ERROR) return delayError;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
+++ b/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
@@ -103,26 +103,17 @@ final class FluxOnBackpressureBufferStrategy<O> extends FluxSource<O, O> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case TERMINATED:
-					return done && isEmpty();
-				case CANCELLED:
-					return cancelled;
-				case BUFFERED:
-					return size();
-				case ERROR:
-					return error;
-				case PREFETCH:
-					return Integer.MAX_VALUE;
-				case DELAY_ERROR:
-					return delayError;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == BooleanAttr.TERMINATED) return done && isEmpty();
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == IntAttr.BUFFERED) return size();
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+			if (key == BooleanAttr.DELAY_ERROR) return delayError;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxOnBackpressureDrop.java
+++ b/src/main/java/reactor/core/publisher/FluxOnBackpressureDrop.java
@@ -159,18 +159,13 @@ final class FluxOnBackpressureDrop<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case TERMINATED:
-					return done;
-				case PREFETCH:
-					return Integer.MAX_VALUE;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 

--- a/src/main/java/reactor/core/publisher/FluxOnBackpressureLatest.java
+++ b/src/main/java/reactor/core/publisher/FluxOnBackpressureLatest.java
@@ -215,7 +215,7 @@ final class FluxOnBackpressureLatest<T> extends FluxSource<T, T> {
 			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
 			if (key == BooleanAttr.TERMINATED) return done;
 			if (key == BooleanAttr.CANCELLED) return cancelled;
-			if (key == IntAttr.BUFFERED) return value != null;
+			if (key == IntAttr.BUFFERED) return value != null ? 1 : 0;
 			if (key == ThrowableAttr.ERROR) return error;
 			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
 

--- a/src/main/java/reactor/core/publisher/FluxOnBackpressureLatest.java
+++ b/src/main/java/reactor/core/publisher/FluxOnBackpressureLatest.java
@@ -210,24 +210,16 @@ final class FluxOnBackpressureLatest<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case TERMINATED:
-					return done;
-				case CANCELLED:
-					return cancelled;
-				case BUFFERED:
-					return value != null;
-				case ERROR:
-					return error;
-				case PREFETCH:
-					return Integer.MAX_VALUE;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == IntAttr.BUFFERED) return value != null;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 	}

--- a/src/main/java/reactor/core/publisher/FluxPeek.java
+++ b/src/main/java/reactor/core/publisher/FluxPeek.java
@@ -98,14 +98,11 @@ final class FluxPeek<T> extends FluxSource<T, T> implements SignalPeek<T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
+++ b/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
@@ -100,14 +100,11 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 		volatile boolean done;
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		PeekFuseableSubscriber(Subscriber<? super T> actual,
@@ -346,14 +343,11 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -684,14 +678,11 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxPeekStateful.java
+++ b/src/main/java/reactor/core/publisher/FluxPeekStateful.java
@@ -103,14 +103,11 @@ final class FluxPeekStateful<T, S> extends FluxSource<T, T>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -140,15 +140,11 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key) {
-			case TERMINATED:
-				return isTerminated();
-			case ERROR:
-				return getError();
-			case CAPACITY:
-				return getBufferSize();
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == BooleanAttr.TERMINATED) return isTerminated();
+		if (key == ThrowableAttr.ERROR) return getError();
+		if (key == IntAttr.CAPACITY) return getBufferSize();
+
 		return null;
 	}
 

--- a/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -130,13 +130,10 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PREFETCH:
-				return getPrefetch();
-			case PARENT:
-				return source;
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+		if (key == ScannableAttr.PARENT) return source;
+
 		return null;
 	}
 
@@ -521,21 +518,14 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-				case PREFETCH:
-					return prefetch;
-				case ERROR:
-					return error;
-				case BUFFERED:
-					return queue != null ? queue.size() : 0;
-				case TERMINATED:
-					return isTerminated();
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == IntAttr.PREFETCH) return prefetch;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == IntAttr.BUFFERED) return queue != null ? queue.size() : 0;
+			if (key == BooleanAttr.TERMINATED) return isTerminated();
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+
 			return null;
 		}
 
@@ -590,14 +580,11 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case CANCELLED:
-					return isCancelled();
-				case REQUESTED_FROM_DOWNSTREAM:
-					return isCancelled() ? 0L : requested;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return isCancelled();
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return isCancelled() ? 0L : requested;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		//TODO factorize in Operators ?
@@ -663,14 +650,11 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return parent;
-				case TERMINATED:
-					return parent != null && parent.isTerminated();
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return parent;
+			if (key == BooleanAttr.TERMINATED) return parent != null && parent.isTerminated();
+
+			return super.scanUnsafe(key);
 		}
 	}
 }

--- a/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
+++ b/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
@@ -158,21 +158,14 @@ final class FluxPublishMulticast<T, R> extends FluxSource<T, R> implements Fusea
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case ERROR:
-					return error;
-				case CANCELLED:
-					return cancelled;
-				case TERMINATED:
-					return done;
-				case PREFETCH:
-					return prefetch;
-				case BUFFERED:
-					return queue != null ? queue.size() : 0;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == IntAttr.PREFETCH) return prefetch;
+			if (key == IntAttr.BUFFERED) return queue != null ? queue.size() : 0;
+
 			return null;
 		}
 
@@ -634,16 +627,12 @@ final class FluxPublishMulticast<T, R> extends FluxSource<T, R> implements Fusea
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case PARENT:
-					return parent;
-				case CANCELLED:
-					return once == 1;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == ScannableAttr.PARENT) return parent;
+			if (key == BooleanAttr.CANCELLED) return once == 1;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -694,12 +683,10 @@ final class FluxPublishMulticast<T, R> extends FluxSource<T, R> implements Fusea
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -792,12 +779,10 @@ final class FluxPublishMulticast<T, R> extends FluxSource<T, R> implements Fusea
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxPublishOn.java
+++ b/src/main/java/reactor/core/publisher/FluxPublishOn.java
@@ -515,26 +515,17 @@ final class FluxPublishOn<T> extends FluxSource<T, T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case PARENT:
-					return s;
-				case CANCELLED:
-					return cancelled;
-				case TERMINATED:
-					return done;
-				case BUFFERED:
-					return queue != null ? queue.size() : 0;
-				case ERROR:
-					return error;
-				case DELAY_ERROR:
-					return delayError;
-				case PREFETCH:
-					return prefetch;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM ) return requested;
+			if (key == ScannableAttr.PARENT ) return s;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == IntAttr.BUFFERED) return queue != null ? queue.size() : 0;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == BooleanAttr.DELAY_ERROR) return delayError;
+			if (key == IntAttr.PREFETCH) return prefetch;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -953,26 +944,17 @@ final class FluxPublishOn<T> extends FluxSource<T, T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case PARENT:
-					return s;
-				case CANCELLED:
-					return cancelled;
-				case TERMINATED:
-					return done;
-				case BUFFERED:
-					return queue != null ? queue.size() : 0;
-				case ERROR:
-					return error;
-				case DELAY_ERROR:
-					return delayError;
-				case PREFETCH:
-					return prefetch;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == IntAttr.BUFFERED) return queue != null ? queue.size() : 0;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == BooleanAttr.DELAY_ERROR) return delayError;
+			if (key == IntAttr.PREFETCH) return prefetch;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		void doComplete(Subscriber<?> a) {

--- a/src/main/java/reactor/core/publisher/FluxRange.java
+++ b/src/main/java/reactor/core/publisher/FluxRange.java
@@ -177,16 +177,12 @@ final class FluxRange extends Flux<Integer>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch(key){
-				case CANCELLED:
-					return cancelled;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case TERMINATED:
-					return isEmpty();
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == BooleanAttr.TERMINATED) return isEmpty();
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -330,16 +326,12 @@ final class FluxRange extends Flux<Integer>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch(key){
-				case CANCELLED:
-					return cancelled;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case TERMINATED:
-					return isEmpty();
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == BooleanAttr.TERMINATED) return isEmpty();
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxRefCount.java
+++ b/src/main/java/reactor/core/publisher/FluxRefCount.java
@@ -20,7 +20,6 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
 
-import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Disposable;
@@ -81,13 +80,10 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PREFETCH:
-				return getPrefetch();
-			case PARENT:
-				return source;
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+		if (key == ScannableAttr.PARENT) return source;
+
 		return null;
 	}
 
@@ -173,14 +169,12 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 			this.parent = parent;
 		}
 
-		@Override
-		public Object scan(Attr key) {
-			switch(key){
-				case PARENT:
-					return s;
+			@Override
+			public Object scanUnsafe(Attr key) {
+				if(key== ScannableAttr. PARENT) return s;
+
+				return InnerOperator.super.scanUnsafe(key);
 			}
-			return InnerOperator.super.scan(key);
-		}
 
 		@Override
 		public void onSubscribe(Subscription s) {

--- a/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
+++ b/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
@@ -59,13 +59,10 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PREFETCH:
-				return getPrefetch();
-			case PARENT:
-				return source;
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+		if (key == ScannableAttr.PARENT) return source;
+
 		return null;
 	}
 

--- a/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
+++ b/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
@@ -114,11 +114,10 @@ final class FluxRepeatWhen<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			if (key == Attr.CANCELLED) {
-				return cancelled;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override
@@ -209,13 +208,10 @@ final class FluxRepeatWhen<T> extends FluxSource<T, T> {
 		final DirectProcessor<Long> completionSignal = new DirectProcessor<>();
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return main.otherArbiter;
-				case ACTUAL:
-					return main;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return main.otherArbiter;
+			if (key == ScannableAttr.ACTUAL) return main;
+
 			return null;
 		}
 

--- a/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -1046,13 +1046,10 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 	}
 
 	@Override
-	public Object scan(Scannable.Attr key) {
-		switch (key){
-			case PREFETCH:
-				return getPrefetch();
-			case PARENT:
-				return source;
-		}
+	public Object scanUnsafe(Scannable.Attr key) {
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+		if (key == ScannableAttr.PARENT) return source;
+
 		return null;
 	}
 
@@ -1270,23 +1267,15 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-				case PREFETCH:
-					return Integer.MAX_VALUE;
-				case CAPACITY:
-					return buffer.capacity();
-				case ERROR:
-					return buffer.getError();
-				case BUFFERED:
-					return buffer.size();
-				case TERMINATED:
-					return isTerminated();
-				case CANCELLED:
-					return cancelled;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+			if (key == IntAttr.CAPACITY) return buffer.capacity();
+			if (key == ThrowableAttr.ERROR) return buffer.getError();
+			if (key == IntAttr.BUFFERED) return buffer.size();
+			if (key == BooleanAttr.TERMINATED) return isTerminated();
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+
 			return null;
 		}
 
@@ -1352,20 +1341,14 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return parent;
-				case TERMINATED:
-					return parent != null && parent.isTerminated();
-				case BUFFERED:
-					return size();
-				case CANCELLED:
-					return isCancelled();
-				case REQUESTED_FROM_DOWNSTREAM:
-					return isCancelled() ? 0L : requested;
-			}
-			return ReplaySubscription.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return parent;
+			if (key == BooleanAttr.TERMINATED) return parent != null && parent.isTerminated();
+			if (key == IntAttr.BUFFERED) return size();
+			if (key == BooleanAttr.CANCELLED) return isCancelled();
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return isCancelled() ? 0L : requested;
+
+			return ReplaySubscription.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxRetryWhen.java
+++ b/src/main/java/reactor/core/publisher/FluxRetryWhen.java
@@ -114,11 +114,10 @@ final class FluxRetryWhen<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			if (key == Attr.CANCELLED) {
-				return cancelled;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override
@@ -208,13 +207,10 @@ final class FluxRetryWhen<T> extends FluxSource<T, T> {
 		final DirectProcessor<Throwable> completionSignal = new DirectProcessor<>();
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return main.otherArbiter;
-				case ACTUAL:
-					return main;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return main.otherArbiter;
+			if (key == ScannableAttr.ACTUAL) return main;
+
 			return null;
 		}
 

--- a/src/main/java/reactor/core/publisher/FluxSample.java
+++ b/src/main/java/reactor/core/publisher/FluxSample.java
@@ -218,7 +218,7 @@ final class FluxSample<T, U> extends FluxSource<T, T> {
 			if (key == ScannableAttr.PARENT) return main.other;
 			if (key == ScannableAttr.ACTUAL) return main;
 			if (key == BooleanAttr.CANCELLED) return main.other == Operators.cancelledSubscription();
-			if (key == IntAttr.PREFETCH) return Long.MAX_VALUE;
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
 
 			return null;
 		}

--- a/src/main/java/reactor/core/publisher/FluxSample.java
+++ b/src/main/java/reactor/core/publisher/FluxSample.java
@@ -112,18 +112,13 @@ final class FluxSample<T, U> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case PARENT:
-					return main;
-				case CANCELLED:
-					return main == Operators.cancelledSubscription();
-				case BUFFERED:
-					return value != null ? 1 : 0;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == ScannableAttr.PARENT) return main;
+			if (key == BooleanAttr.CANCELLED) return main == Operators.cancelledSubscription();
+			if (key == IntAttr.BUFFERED) return value != null ? 1 : 0;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -219,17 +214,12 @@ final class FluxSample<T, U> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return main.other;
-				case ACTUAL:
-					return main;
-				case CANCELLED:
-					return main.other == Operators.cancelledSubscription();
-				case PREFETCH:
-					return Long.MAX_VALUE;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return main.other;
+			if (key == ScannableAttr.ACTUAL) return main;
+			if (key == BooleanAttr.CANCELLED) return main.other == Operators.cancelledSubscription();
+			if (key == IntAttr.PREFETCH) return Long.MAX_VALUE;
+
 			return null;
 		}
 

--- a/src/main/java/reactor/core/publisher/FluxSampleFirst.java
+++ b/src/main/java/reactor/core/publisher/FluxSampleFirst.java
@@ -121,18 +121,13 @@ final class FluxSampleFirst<T, U> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-				case PARENT:
-					return s;
-				case ERROR:
-					return error;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -249,12 +244,10 @@ final class FluxSampleFirst<T, U> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case ACTUAL:
-					return main;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.ACTUAL) return main;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxSampleTimeout.java
+++ b/src/main/java/reactor/core/publisher/FluxSampleTimeout.java
@@ -142,22 +142,15 @@ final class FluxSampleTimeout<T, U> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case CANCELLED:
-					return cancelled;
-				case PARENT:
-					return s;
-				case ERROR:
-					return error;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case BUFFERED:
-					return queue.size();
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == IntAttr.BUFFERED) return queue.size();
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -358,14 +351,11 @@ final class FluxSampleTimeout<T, U> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return once == 1;
-				case ACTUAL:
-					return main;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return once == 1;
+			if (key == ScannableAttr.ACTUAL) return main;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxScan.java
+++ b/src/main/java/reactor/core/publisher/FluxScan.java
@@ -123,16 +123,12 @@ final class FluxScan<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case BUFFERED:
-					return value != null ? 1 : 0;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == IntAttr.BUFFERED) return value != null ? 1 : 0;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxScanSeed.java
+++ b/src/main/java/reactor/core/publisher/FluxScanSeed.java
@@ -218,18 +218,13 @@ final class FluxScanSeed<T, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case BUFFERED:
-					return value != null ? 1 : 0;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == IntAttr.BUFFERED) return value != null ? 1 : 0;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxSkip.java
+++ b/src/main/java/reactor/core/publisher/FluxSkip.java
@@ -90,12 +90,10 @@ final class FluxSkip<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxSkipLast.java
+++ b/src/main/java/reactor/core/publisher/FluxSkipLast.java
@@ -92,16 +92,12 @@ final class FluxSkipLast<T> extends FluxSource<T, T> {
 
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-				case PREFETCH:
-					return n;
-				case BUFFERED:
-					return size();
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == IntAttr.PREFETCH) return n;
+			if (key == IntAttr.BUFFERED) return size();
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxSkipUntil.java
+++ b/src/main/java/reactor/core/publisher/FluxSkipUntil.java
@@ -150,14 +150,11 @@ final class FluxSkipUntil<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxSkipUntilOther.java
+++ b/src/main/java/reactor/core/publisher/FluxSkipUntilOther.java
@@ -64,15 +64,11 @@ final class FluxSkipUntilOther<T, U> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case CANCELLED:
-					return main.other == Operators.cancelledSubscription();
-				case PARENT:
-					return main.other;
-				case ACTUAL:
-					return main;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return main.other == Operators.cancelledSubscription();
+			if (key == ScannableAttr.PARENT) return main.other;
+			if (key == ScannableAttr.ACTUAL) return main;
+
 			return null;
 		}
 
@@ -150,14 +146,11 @@ final class FluxSkipUntilOther<T, U> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return main;
-				case CANCELLED:
-					return main == Operators.cancelledSubscription();
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return main;
+			if (key == BooleanAttr.CANCELLED) return main == Operators.cancelledSubscription();
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxSkipWhile.java
+++ b/src/main/java/reactor/core/publisher/FluxSkipWhile.java
@@ -151,14 +151,11 @@ final class FluxSkipWhile<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxSource.java
+++ b/src/main/java/reactor/core/publisher/FluxSource.java
@@ -79,13 +79,9 @@ public class FluxSource<I, O> extends Flux<O> implements Scannable {
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PREFETCH:
-				return getPrefetch();
-			case PARENT:
-				return source;
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+		if (key == ScannableAttr.PARENT) return source;
 		return null;
 	}
 

--- a/src/main/java/reactor/core/publisher/FluxSubscribeOn.java
+++ b/src/main/java/reactor/core/publisher/FluxSubscribeOn.java
@@ -187,16 +187,12 @@ final class FluxSubscribeOn<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxSubscribeOnCallable.java
+++ b/src/main/java/reactor/core/publisher/FluxSubscribeOnCallable.java
@@ -118,14 +118,11 @@ final class FluxSubscribeOnCallable<T> extends Flux<T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case CANCELLED:
-					return state == HAS_CANCELLED;
-				case BUFFERED:
-					return value != null ? 1 : 0;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return state == HAS_CANCELLED;
+			if (key == IntAttr.BUFFERED) return value != null ? 1 : 0;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxSubscribeOnValue.java
+++ b/src/main/java/reactor/core/publisher/FluxSubscribeOnValue.java
@@ -108,16 +108,12 @@ final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Scannable.Attr key) {
-			switch (key){
-				case CANCELLED:
-					return future == CANCELLED;
-				case TERMINATED:
-					return future == FINISHED;
-				case BUFFERED:
-					return value != null ? 1 : 0;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Scannable.Attr key) {
+			if (key == BooleanAttr.CANCELLED) return future == CANCELLED;
+			if (key == BooleanAttr.TERMINATED) return future == FINISHED;
+			if (key == IntAttr.BUFFERED) return value != null ? 1 : 0;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxSwitchMap.java
+++ b/src/main/java/reactor/core/publisher/FluxSwitchMap.java
@@ -165,24 +165,16 @@ final class FluxSwitchMap<T, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case CANCELLED:
-					return cancelled;
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case ERROR:
-					return error;
-				case PREFETCH:
-					return bufferSize;
-				case BUFFERED:
-					return queue.size();
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == IntAttr.PREFETCH) return bufferSize;
+			if (key == IntAttr.BUFFERED) return queue.size();
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -457,17 +449,12 @@ final class FluxSwitchMap<T, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-				case PARENT:
-					return s;
-				case ACTUAL:
-					return parent;
-				case PREFETCH:
-					return bufferSize;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == ScannableAttr.ACTUAL) return parent;
+			if (key == IntAttr.PREFETCH) return bufferSize;
+
 			return null;
 		}
 

--- a/src/main/java/reactor/core/publisher/FluxTake.java
+++ b/src/main/java/reactor/core/publisher/FluxTake.java
@@ -162,14 +162,11 @@ final class FluxTake<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -310,14 +307,11 @@ final class FluxTake<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -439,14 +433,11 @@ final class FluxTake<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return qs;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return qs;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxTakeLast.java
+++ b/src/main/java/reactor/core/publisher/FluxTakeLast.java
@@ -68,12 +68,10 @@ final class FluxTakeLast<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -188,18 +186,13 @@ final class FluxTakeLast<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case CANCELLED:
-					return cancelled;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case PARENT:
-					return s;
-				case BUFFERED:
-					return size();
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == IntAttr.BUFFERED) return size();
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxTakeUntil.java
+++ b/src/main/java/reactor/core/publisher/FluxTakeUntil.java
@@ -114,14 +114,11 @@ final class FluxTakeUntil<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxTakeUntilOther.java
+++ b/src/main/java/reactor/core/publisher/FluxTakeUntilOther.java
@@ -67,15 +67,11 @@ final class FluxTakeUntilOther<T, U> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case CANCELLED:
-					return main.other == Operators.cancelledSubscription();
-				case PARENT:
-					return main.other;
-				case ACTUAL:
-					return main;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return main.other == Operators.cancelledSubscription();
+			if (key == ScannableAttr.PARENT) return main.other;
+			if (key == ScannableAttr.ACTUAL) return main;
+
 			return null;
 		}
 
@@ -135,14 +131,11 @@ final class FluxTakeUntilOther<T, U> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return main;
-				case CANCELLED:
-					return main == Operators.cancelledSubscription();
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return main;
+			if (key == BooleanAttr.CANCELLED) return main == Operators.cancelledSubscription();
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxTakeWhile.java
+++ b/src/main/java/reactor/core/publisher/FluxTakeWhile.java
@@ -115,14 +115,11 @@ final class FluxTakeWhile<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxUsing.java
+++ b/src/main/java/reactor/core/publisher/FluxUsing.java
@@ -144,15 +144,11 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-				case CANCELLED:
-					return wip == 1;
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED || key == BooleanAttr.CANCELLED) return wip == 1;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -297,15 +293,12 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-				case CANCELLED:
-					return wip == 1;
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED || key == BooleanAttr.CANCELLED)
+				return wip == 1;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -458,15 +451,12 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-				case CANCELLED:
-					return wip == 1;
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED || key == BooleanAttr.CANCELLED)
+				return wip == 1;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxWindow.java
+++ b/src/main/java/reactor/core/publisher/FluxWindow.java
@@ -716,7 +716,7 @@ final class FluxWindow<T> extends FluxSource<T, Flux<T>> {
 		@Override
 		public Object scanUnsafe(Attr key) {
 			if (key == ScannableAttr.PARENT) return s;
-			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == BooleanAttr.CANCELLED) return cancelled == 1;
 			if (key == IntAttr.CAPACITY) return size;
 			if (key == BooleanAttr.TERMINATED) return done;
 			if (key == IntAttr.BUFFERED) return queue.size() + size();

--- a/src/main/java/reactor/core/publisher/FluxWindow.java
+++ b/src/main/java/reactor/core/publisher/FluxWindow.java
@@ -719,7 +719,12 @@ final class FluxWindow<T> extends FluxSource<T, Flux<T>> {
 			if (key == BooleanAttr.CANCELLED) return cancelled == 1;
 			if (key == IntAttr.CAPACITY) return size;
 			if (key == BooleanAttr.TERMINATED) return done;
-			if (key == IntAttr.BUFFERED) return queue.size() + size();
+			if (key == LongAttr.LARGE_BUFFERED) return (long) queue.size() + size();
+			if (key == IntAttr.BUFFERED) {
+				long realBuffered = (long) queue.size() + size();
+				if (realBuffered < Integer.MAX_VALUE) return (int) realBuffered;
+				return Integer.MIN_VALUE;
+			}
 			if (key == ThrowableAttr.ERROR) return error;
 			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
 

--- a/src/main/java/reactor/core/publisher/FluxWindow.java
+++ b/src/main/java/reactor/core/publisher/FluxWindow.java
@@ -244,18 +244,13 @@ final class FluxWindow<T> extends FluxSource<T, Flux<T>> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case CANCELLED:
-					return cancelled == 1;
-				case CAPACITY:
-					return size;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.CANCELLED) return cancelled == 1;
+			if (key == IntAttr.CAPACITY) return size;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -432,18 +427,13 @@ final class FluxWindow<T> extends FluxSource<T, Flux<T>> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case CANCELLED:
-					return cancelled == 1;
-				case CAPACITY:
-					return size;
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.CANCELLED) return cancelled == 1;
+			if (key == IntAttr.CAPACITY) return size;
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -724,24 +714,16 @@ final class FluxWindow<T> extends FluxSource<T, Flux<T>> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case CANCELLED:
-					return cancelled;
-				case CAPACITY:
-					return size;
-				case TERMINATED:
-					return done;
-				case BUFFERED:
-					return queue.size() + size();
-				case ERROR:
-					return error;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == IntAttr.CAPACITY) return size;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == IntAttr.BUFFERED) return queue.size() + size();
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
+++ b/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
@@ -141,24 +141,16 @@ final class FluxWindowBoundary<T, U> extends FluxSource<T, Flux<T>> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case ERROR:
-					return error;
-				case CANCELLED:
-					return cancelled == 1;
-				case TERMINATED:
-					return done;
-				case PREFETCH:
-					return Integer.MAX_VALUE;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case BUFFERED:
-					return queue.size();
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == BooleanAttr.CANCELLED) return cancelled == 1;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == IntAttr.BUFFERED) return queue.size();
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -388,11 +380,11 @@ final class FluxWindowBoundary<T, U> extends FluxSource<T, Flux<T>> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			if (key == Attr.ACTUAL) {
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.ACTUAL) {
 				return main;
 			}
-			return super.scan(key);
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
+++ b/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
@@ -274,24 +274,16 @@ final class FluxWindowPredicate<T> extends FluxSource<T, GroupedFlux<T, T>>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return s;
-				case CANCELLED:
-					return cancelled == 1;
-				case PREFETCH:
-					return prefetch;
-				case TERMINATED:
-					return done;
-				case BUFFERED:
-					return queue.size();
-				case ERROR:
-					return error;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.CANCELLED) return cancelled == 1;
+			if (key == IntAttr.PREFETCH) return prefetch;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == IntAttr.BUFFERED) return queue.size();
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -837,22 +829,15 @@ final class FluxWindowPredicate<T> extends FluxSource<T, GroupedFlux<T, T>>
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return parent;
-				case CANCELLED:
-					return cancelled;
-				case TERMINATED:
-					return done;
-				case BUFFERED:
-					return queue == null ? 0 : queue.size();
-				case ERROR:
-					return error;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return parent;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == IntAttr.BUFFERED) return queue == null ? 0 : queue.size();
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxWindowTimeOrSize.java
+++ b/src/main/java/reactor/core/publisher/FluxWindowTimeOrSize.java
@@ -312,23 +312,15 @@ final class FluxWindowTimeOrSize<T> extends FluxSource<T, Flux<T>> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return subscription;
-				case CANCELLED:
-//					return terminated == TERMINATED_WITH_CANCEL;
-					return cancelled == 1;
-				case TERMINATED:
-					return terminated == TERMINATED_WITH_ERROR || terminated == TERMINATED_WITH_SUCCESS;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case CAPACITY:
-					return batchSize;
-				case BUFFERED:
-					return batchSize - index;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return cancelled == 1;
+			if (key == ScannableAttr.PARENT) return subscription;
+			if (key == BooleanAttr.TERMINATED) return terminated == TERMINATED_WITH_ERROR || terminated == TERMINATED_WITH_SUCCESS;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == IntAttr.CAPACITY) return batchSize;
+			if (key == IntAttr.BUFFERED) return batchSize - index;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		/**

--- a/src/main/java/reactor/core/publisher/FluxWindowWhen.java
+++ b/src/main/java/reactor/core/publisher/FluxWindowWhen.java
@@ -160,12 +160,10 @@ final class FluxWindowWhen<T, U, V> extends FluxSource<T, Flux<T>> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch(key){
-				case TERMINATED:
-					return done;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/FluxWithLatestFrom.java
+++ b/src/main/java/reactor/core/publisher/FluxWithLatestFrom.java
@@ -118,14 +118,11 @@ final class FluxWithLatestFrom<T, U, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case CANCELLED:
-					return main == Operators.cancelledSubscription();
-				case PARENT:
-					return main;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return main == Operators.cancelledSubscription();
+			if (key == ScannableAttr.PARENT) return main;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -274,8 +271,8 @@ final class FluxWithLatestFrom<T, U, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			if (key == Attr.ACTUAL) {
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.ACTUAL) {
 				return main;
 			}
 			return null;

--- a/src/main/java/reactor/core/publisher/FluxZip.java
+++ b/src/main/java/reactor/core/publisher/FluxZip.java
@@ -391,14 +391,11 @@ final class FluxZip<T, R> extends Flux<R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case TERMINATED:
-					return wip == 0;
-				case BUFFERED:
-					return wip > 0 ? scalars.length : 0;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return wip == 0;
+			if (key == IntAttr.BUFFERED) return wip > 0 ? scalars.length : 0;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override
@@ -437,19 +434,13 @@ final class FluxZip<T, R> extends Flux<R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case ACTUAL:
-					return parent;
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-				case BUFFERED:
-					return parent.scalars[index] == null ? 0 : 1;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.ACTUAL) return parent;
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == IntAttr.BUFFERED) return parent.scalars[index] == null ? 0 : 1;
+
 			return null;
 		}
 
@@ -580,16 +571,12 @@ final class FluxZip<T, R> extends Flux<R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case ERROR:
-					return error;
-				case CANCELLED:
-					return cancelled;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		void error(Throwable e, int index) {
@@ -888,21 +875,14 @@ final class FluxZip<T, R> extends Flux<R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return  s;
-				case ACTUAL:
-					return parent;
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-				case BUFFERED:
-					return queue != null ? queue.size() : 0;
-				case TERMINATED:
-					return done && (queue == null || queue.isEmpty());
-				case PREFETCH:
-					return prefetch;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return  s;
+			if (key == ScannableAttr.ACTUAL) return parent;
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == IntAttr.BUFFERED) return queue != null ? queue.size() : 0;
+			if (key == BooleanAttr.TERMINATED) return done && (queue == null || queue.isEmpty());
+			if (key == IntAttr.PREFETCH) return prefetch;
+
 			return null;
 		}
 

--- a/src/main/java/reactor/core/publisher/FluxZipIterable.java
+++ b/src/main/java/reactor/core/publisher/FluxZipIterable.java
@@ -99,14 +99,11 @@ final class FluxZipIterable<T, U, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/InnerProducer.java
+++ b/src/main/java/reactor/core/publisher/InnerProducer.java
@@ -35,8 +35,8 @@ interface InnerProducer<O>
 	Subscriber<? super O> actual();
 
 	@Override
-	default Object scan(Attr key){
-		if(key == Attr.ACTUAL){
+	default Object scanUnsafe(Attr key){
+		if (key == ScannableAttr.ACTUAL) {
 			return actual();
 		}
 		return null;

--- a/src/main/java/reactor/core/publisher/LambdaMonoSubscriber.java
+++ b/src/main/java/reactor/core/publisher/LambdaMonoSubscriber.java
@@ -156,16 +156,11 @@ final class LambdaMonoSubscriber<T>
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return subscription;
-			case PREFETCH:
-				return Integer.MAX_VALUE;
-			case TERMINATED:
-			case CANCELLED:
-				return isDisposed();
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return subscription;
+		if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+		if (key == BooleanAttr.TERMINATED || key == BooleanAttr.CANCELLED) return isDisposed();
+
 		return null;
 	}
 

--- a/src/main/java/reactor/core/publisher/LambdaSubscriber.java
+++ b/src/main/java/reactor/core/publisher/LambdaSubscriber.java
@@ -140,16 +140,11 @@ final class LambdaSubscriber<T>
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return subscription;
-			case PREFETCH:
-				return Integer.MAX_VALUE;
-			case TERMINATED:
-			case CANCELLED:
-				return isDisposed();
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return subscription;
+		if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+		if (key == BooleanAttr.TERMINATED || key == BooleanAttr.CANCELLED) return isDisposed();
+
 		return null;
 	}
 

--- a/src/main/java/reactor/core/publisher/MonoAll.java
+++ b/src/main/java/reactor/core/publisher/MonoAll.java
@@ -59,14 +59,11 @@ final class MonoAll<T> extends MonoSource<T, Boolean> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return s;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoAny.java
+++ b/src/main/java/reactor/core/publisher/MonoAny.java
@@ -59,14 +59,11 @@ final class MonoAny<T> extends MonoSource<T, Boolean> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return s;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoCollect.java
+++ b/src/main/java/reactor/core/publisher/MonoCollect.java
@@ -81,14 +81,11 @@ final class MonoCollect<T, R> extends MonoSource<T, R> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return s;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoCollectList.java
+++ b/src/main/java/reactor/core/publisher/MonoCollectList.java
@@ -72,6 +72,7 @@ final class MonoCollectList<T, C extends Collection<? super T>> extends MonoSour
 		@Override
 		public Object scanUnsafe(Attr key) {
 			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return collection == null;
 
 			return super.scanUnsafe(key);
 		}

--- a/src/main/java/reactor/core/publisher/MonoCollectList.java
+++ b/src/main/java/reactor/core/publisher/MonoCollectList.java
@@ -70,12 +70,10 @@ final class MonoCollectList<T, C extends Collection<? super T>> extends MonoSour
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoCount.java
+++ b/src/main/java/reactor/core/publisher/MonoCount.java
@@ -48,12 +48,10 @@ final class MonoCount<T> extends MonoSource<T, Long> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoCreate.java
+++ b/src/main/java/reactor/core/publisher/MonoCreate.java
@@ -86,14 +86,11 @@ final class MonoCreate<T> extends Mono<T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return state == HAS_REQUEST_HAS_VALUE || state == NO_REQUEST_HAS_VALUE;
-				case CANCELLED:
-					return disposable == Flux.CANCELLED;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return state == HAS_REQUEST_HAS_VALUE || state == NO_REQUEST_HAS_VALUE;
+			if (key == BooleanAttr.CANCELLED) return disposable == Flux.CANCELLED;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
         @Override

--- a/src/main/java/reactor/core/publisher/MonoDelay.java
+++ b/src/main/java/reactor/core/publisher/MonoDelay.java
@@ -95,7 +95,6 @@ final class MonoDelay extends Mono<Long> {
 		public Object scanUnsafe(Attr key) {
 			if (key == BooleanAttr.TERMINATED) return cancel == FINISHED;
 			if (key == BooleanAttr.CANCELLED) return cancel == Flux.CANCELLED;
-			if (key == ScannableAttr.PARENT) return actual;
 
 			return InnerProducer.super.scanUnsafe(key);
 		}

--- a/src/main/java/reactor/core/publisher/MonoDelay.java
+++ b/src/main/java/reactor/core/publisher/MonoDelay.java
@@ -92,16 +92,12 @@ final class MonoDelay extends Mono<Long> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return cancel == FINISHED;
-				case CANCELLED:
-					return cancel == Flux.CANCELLED;
-				case PARENT:
-					return actual;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return cancel == FINISHED;
+			if (key == BooleanAttr.CANCELLED) return cancel == Flux.CANCELLED;
+			if (key == ScannableAttr.PARENT) return actual;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoDelayElement.java
+++ b/src/main/java/reactor/core/publisher/MonoDelayElement.java
@@ -73,14 +73,11 @@ final class MonoDelayElement<T> extends MonoSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return s;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoDelayUntil.java
+++ b/src/main/java/reactor/core/publisher/MonoDelayUntil.java
@@ -148,8 +148,7 @@ final class MonoDelayUntil<T> extends Mono<T> {
 
 		@Override
 		public Object scanUnsafe(Attr key) {
-			if (key == BooleanAttr.TERMINATED) return done;
-			if (key == ScannableAttr.PARENT) return actual;
+			if (key == BooleanAttr.TERMINATED) return done == n;
 			if (key == BooleanAttr.DELAY_ERROR) return delayError;
 
 			return super.scanUnsafe(key);

--- a/src/main/java/reactor/core/publisher/MonoDelayUntil.java
+++ b/src/main/java/reactor/core/publisher/MonoDelayUntil.java
@@ -147,16 +147,12 @@ final class MonoDelayUntil<T> extends Mono<T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return actual;
-				case DELAY_ERROR:
-					return delayError;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return actual;
+			if (key == BooleanAttr.DELAY_ERROR) return delayError;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override
@@ -260,19 +256,13 @@ final class MonoDelayUntil<T> extends Mono<T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-				case PARENT:
-					return s;
-				case ACTUAL:
-					return parent;
-				case ERROR:
-					return error;
-				case PREFETCH:
-					return Integer.MAX_VALUE;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == ScannableAttr.ACTUAL) return parent;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+
 			return null;
 		}
 

--- a/src/main/java/reactor/core/publisher/MonoElementAt.java
+++ b/src/main/java/reactor/core/publisher/MonoElementAt.java
@@ -75,14 +75,11 @@ final class MonoElementAt<T> extends MonoSource<T, T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return s;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoFilterWhen.java
+++ b/src/main/java/reactor/core/publisher/MonoFilterWhen.java
@@ -281,7 +281,7 @@ class MonoFilterWhen<T> extends MonoSource<T, T> {
 			if (key == BooleanAttr.CANCELLED) return sub == Operators.cancelledSubscription();
 			if (key == BooleanAttr.TERMINATED) return done;
 			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
-			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return done ? 0 : 1;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return done ? 0L : 1L;
 
 			return null;
 		}

--- a/src/main/java/reactor/core/publisher/MonoFilterWhen.java
+++ b/src/main/java/reactor/core/publisher/MonoFilterWhen.java
@@ -198,15 +198,14 @@ class MonoFilterWhen<T> extends MonoSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case PARENT:
-					return upstream;
-				case TERMINATED:
-					return asyncFilter != null ? asyncFilter.scan(Attr.TERMINATED) : super.scan(Attr.TERMINATED);
-				default: //CANCELLED, PREFETCH
-					return super.scan(key);
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return upstream;
+			if (key == BooleanAttr.TERMINATED) return asyncFilter != null
+					? asyncFilter.scanUnsafe(BooleanAttr.TERMINATED)
+					: super.scanUnsafe(BooleanAttr.TERMINATED);
+
+			//CANCELLED, PREFETCH
+			return super.scanUnsafe(key);
 		}
 
 		@Override
@@ -276,23 +275,15 @@ class MonoFilterWhen<T> extends MonoSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch(key) {
-				case PARENT:
-					return parent;
-				case ACTUAL:
-					return sub;
-				case CANCELLED:
-					return sub == Operators.cancelledSubscription();
-				case TERMINATED:
-					return done;
-				case PREFETCH:
-					return Integer.MAX_VALUE;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return done ? 0 : 1;
-				default:
-					return null;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return parent;
+			if (key == ScannableAttr.ACTUAL) return sub;
+			if (key == BooleanAttr.CANCELLED) return sub == Operators.cancelledSubscription();
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return done ? 0 : 1;
+
+			return null;
 		}
 	}
 }

--- a/src/main/java/reactor/core/publisher/MonoFlatMap.java
+++ b/src/main/java/reactor/core/publisher/MonoFlatMap.java
@@ -183,74 +183,74 @@ final class MonoFlatMap<T, R> extends MonoSource<T, R> implements Fuseable {
 		void secondComplete() {
 			actual.onComplete();
 		}
+	}
 
-		static final class ThenMapInner<R> implements InnerConsumer<R> {
+	static final class ThenMapInner<R> implements InnerConsumer<R> {
 
-			final ThenMapMain<?, R> parent;
+		final ThenMapMain<?, R> parent;
 
-			volatile Subscription s;
-			@SuppressWarnings("rawtypes")
-			static final AtomicReferenceFieldUpdater<ThenMapInner, Subscription> S =
-					AtomicReferenceFieldUpdater.newUpdater(ThenMapInner.class,
-							Subscription.class,
-							"s");
+		volatile Subscription s;
+		@SuppressWarnings("rawtypes")
+		static final AtomicReferenceFieldUpdater<ThenMapInner, Subscription> S =
+				AtomicReferenceFieldUpdater.newUpdater(ThenMapInner.class,
+						Subscription.class,
+						"s");
 
-			boolean done;
+		boolean done;
 
-			ThenMapInner(ThenMapMain<?, R> parent) {
-				this.parent = parent;
-			}
-
-			@Override
-			public Object scanUnsafe(Attr key) {
-				if (key == ScannableAttr.PARENT) return s;
-				if (key == ScannableAttr.ACTUAL) return parent;
-				if (key == BooleanAttr.TERMINATED) return done;
-				if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
-
-				return null;
-			}
-
-			@Override
-			public void onSubscribe(Subscription s) {
-				if (Operators.setOnce(S, this, s)) {
-					s.request(Long.MAX_VALUE);
-				}
-			}
-
-			@Override
-			public void onNext(R t) {
-				if (done) {
-					Operators.onNextDropped(t);
-					return;
-				}
-				done = true;
-				this.parent.complete(t);
-			}
-
-			@Override
-			public void onError(Throwable t) {
-				if (done) {
-					Operators.onErrorDropped(t);
-					return;
-				}
-				done = true;
-				this.parent.secondError(t);
-			}
-
-			@Override
-			public void onComplete() {
-				if (done) {
-					return;
-				}
-				done = true;
-				this.parent.secondComplete();
-			}
-
-			void cancel() {
-				Operators.terminate(S, this);
-			}
-
+		ThenMapInner(ThenMapMain<?, R> parent) {
+			this.parent = parent;
 		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == ScannableAttr.ACTUAL) return parent;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+
+			return null;
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.setOnce(S, this, s)) {
+				s.request(Long.MAX_VALUE);
+			}
+		}
+
+		@Override
+		public void onNext(R t) {
+			if (done) {
+				Operators.onNextDropped(t);
+				return;
+			}
+			done = true;
+			this.parent.complete(t);
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			if (done) {
+				Operators.onErrorDropped(t);
+				return;
+			}
+			done = true;
+			this.parent.secondError(t);
+		}
+
+		@Override
+		public void onComplete() {
+			if (done) {
+				return;
+			}
+			done = true;
+			this.parent.secondComplete();
+		}
+
+		void cancel() {
+			Operators.terminate(S, this);
+		}
+
 	}
 }

--- a/src/main/java/reactor/core/publisher/MonoFlatMap.java
+++ b/src/main/java/reactor/core/publisher/MonoFlatMap.java
@@ -204,7 +204,7 @@ final class MonoFlatMap<T, R> extends MonoSource<T, R> implements Fuseable {
 			@Override
 			public Object scanUnsafe(Attr key) {
 				if (key == ScannableAttr.PARENT) return s;
-				if (key == ScannableAttr.ACTUAL) 	return parent;
+				if (key == ScannableAttr.ACTUAL) return parent;
 				if (key == BooleanAttr.TERMINATED) return done;
 				if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
 

--- a/src/main/java/reactor/core/publisher/MonoFlatMap.java
+++ b/src/main/java/reactor/core/publisher/MonoFlatMap.java
@@ -87,16 +87,12 @@ final class MonoFlatMap<T, R> extends MonoSource<T, R> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-				case TERMINATED:
-					return done;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == BooleanAttr.TERMINATED) return done;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override
@@ -206,17 +202,12 @@ final class MonoFlatMap<T, R> extends MonoSource<T, R> implements Fuseable {
 			}
 
 			@Override
-			public Object scan(Attr key) {
-				switch (key){
-					case PARENT:
-						return s;
-					case ACTUAL:
-						return parent;
-					case TERMINATED:
-						return done;
-					case CANCELLED:
-						return s == Operators.cancelledSubscription();
-				}
+			public Object scanUnsafe(Attr key) {
+				if (key == ScannableAttr.PARENT) return s;
+				if (key == ScannableAttr.ACTUAL) 	return parent;
+				if (key == BooleanAttr.TERMINATED) return done;
+				if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+
 				return null;
 			}
 

--- a/src/main/java/reactor/core/publisher/MonoFlatMapMany.java
+++ b/src/main/java/reactor/core/publisher/MonoFlatMapMany.java
@@ -78,12 +78,10 @@ final class MonoFlatMapMany<T, R> extends Flux<R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return main;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return main;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -213,15 +211,11 @@ final class MonoFlatMapMany<T, R> extends Flux<R> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return parent.inner;
-				case ACTUAL:
-					return parent;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return parent.requested;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return parent.inner;
+			if (key == ScannableAttr.ACTUAL) return parent;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return parent.requested;
+
 			return null;
 		}
 

--- a/src/main/java/reactor/core/publisher/MonoHasElements.java
+++ b/src/main/java/reactor/core/publisher/MonoHasElements.java
@@ -19,6 +19,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Fuseable;
+import reactor.core.Scannable;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
@@ -47,12 +48,10 @@ final class MonoHasElements<T> extends MonoSource<T, Boolean> implements Fuseabl
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override
@@ -94,11 +93,11 @@ final class MonoHasElements<T> extends MonoSource<T, Boolean> implements Fuseabl
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			if (key == Attr.PARENT) {
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) {
 				return s;
 			}
-			return super.scan(key);
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoIgnoreEmpty.java
+++ b/src/main/java/reactor/core/publisher/MonoIgnoreEmpty.java
@@ -46,12 +46,10 @@ final class MonoIgnoreEmpty<T> extends MonoSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoNext.java
+++ b/src/main/java/reactor/core/publisher/MonoNext.java
@@ -109,14 +109,11 @@ final class MonoNext<T> extends MonoSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoPeekTerminal.java
+++ b/src/main/java/reactor/core/publisher/MonoPeekTerminal.java
@@ -117,14 +117,11 @@ final class MonoPeekTerminal<T> extends MonoSource<T, T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return s;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -82,7 +82,6 @@ public final class MonoProcessor<O> extends Mono<O>
 	volatile Throwable       error;
 	volatile int             state;
 	volatile int             wip;
-	volatile int             requested;
 	volatile int             connected;
 
 	MonoProcessor(Publisher<? extends O> source) {
@@ -406,7 +405,6 @@ public final class MonoProcessor<O> extends Mono<O>
 		if (key == ScannableAttr.ACTUAL) return processor;
 		if (key == ScannableAttr.PARENT) return subscription;
 		if (key == ThrowableAttr.ERROR) return error;
-		if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
 		if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
 		if (key == BooleanAttr.CANCELLED) return isCancelled();
 		if (key == BooleanAttr.TERMINATED) return isTerminated();

--- a/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -402,23 +402,14 @@ public final class MonoProcessor<O> extends Mono<O>
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case ACTUAL:
-				return processor;
-			case PARENT:
-				return subscription;
-			case ERROR:
-				return error;
-			case REQUESTED_FROM_DOWNSTREAM:
-				return requested;
-			case PREFETCH:
-				return Integer.MAX_VALUE;
-			case CANCELLED:
-				return isCancelled();
-			case TERMINATED:
-				return isTerminated();
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.ACTUAL) return processor;
+		if (key == ScannableAttr.PARENT) return subscription;
+		if (key == ThrowableAttr.ERROR) return error;
+		if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+		if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+		if (key == BooleanAttr.CANCELLED) return isCancelled();
+		if (key == BooleanAttr.TERMINATED) return isTerminated();
 		return null;
 	}
 

--- a/src/main/java/reactor/core/publisher/MonoPublishOn.java
+++ b/src/main/java/reactor/core/publisher/MonoPublishOn.java
@@ -70,16 +70,12 @@ final class MonoPublishOn<T> extends MonoSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case CANCELLED:
-					return future == Flux.CANCELLED;
-				case PARENT:
-					return s;
-				case ERROR:
-					return error;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return future == Flux.CANCELLED;
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == ThrowableAttr.ERROR) return error;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoReduce.java
+++ b/src/main/java/reactor/core/publisher/MonoReduce.java
@@ -61,14 +61,11 @@ final class MonoReduce<T> extends MonoSource<T, T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return s;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoReduceSeed.java
+++ b/src/main/java/reactor/core/publisher/MonoReduceSeed.java
@@ -80,14 +80,11 @@ final class MonoReduceSeed<T, R> extends MonoSource<T, R> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return s;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoSequenceEqual.java
+++ b/src/main/java/reactor/core/publisher/MonoSequenceEqual.java
@@ -98,12 +98,10 @@ final class MonoSequenceEqual<T> extends Mono<Boolean> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case CANCELLED:
-					return cancelled;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -298,23 +296,15 @@ final class MonoSequenceEqual<T> extends Mono<Boolean> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case ACTUAL:
-					return parent;
-				case ERROR:
-					return error;
-				case CANCELLED:
-					return subscription == Operators.cancelledSubscription();
-				case PARENT:
-					return subscription;
-				case PREFETCH:
-					return bufferSize;
-				case BUFFERED:
-					return queue.size();
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.ACTUAL) return parent;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == BooleanAttr.CANCELLED) return subscription == Operators.cancelledSubscription();
+			if (key == ScannableAttr.PARENT) return subscription;
+			if (key == IntAttr.PREFETCH) return bufferSize;
+			if (key == IntAttr.BUFFERED) return queue.size();
+
 			return null;
 		}
 

--- a/src/main/java/reactor/core/publisher/MonoSingle.java
+++ b/src/main/java/reactor/core/publisher/MonoSingle.java
@@ -68,14 +68,11 @@ final class MonoSingle<T> extends MonoSource<T, T> implements Fuseable {
 		boolean done;
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return s;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return super.scanUnsafe(key);
 		}
 
 		SingleSubscriber(Subscriber<? super T> actual,

--- a/src/main/java/reactor/core/publisher/MonoSource.java
+++ b/src/main/java/reactor/core/publisher/MonoSource.java
@@ -86,9 +86,8 @@ public class MonoSource<I, O> extends Mono<O> implements Scannable {
 	}
 
 	@Override
-	public Object scan(Scannable.Attr key) {
-		switch (key){
-			case PARENT:
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) {
 				return source;
 		}
 		return null;

--- a/src/main/java/reactor/core/publisher/MonoStreamCollector.java
+++ b/src/main/java/reactor/core/publisher/MonoStreamCollector.java
@@ -94,14 +94,11 @@ final class MonoStreamCollector<T, A, R> extends MonoSource<T, R> implements Fus
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return s;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return s;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoSubscribeOn.java
+++ b/src/main/java/reactor/core/publisher/MonoSubscribeOn.java
@@ -84,16 +84,12 @@ final class MonoSubscribeOn<T> extends MonoSource<T, T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-				case PARENT:
-					return s;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoTakeLastOne.java
+++ b/src/main/java/reactor/core/publisher/MonoTakeLastOne.java
@@ -74,12 +74,10 @@ final class MonoTakeLastOne<T> extends MonoSource<T, T> implements Fuseable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/MonoThenIgnore.java
+++ b/src/main/java/reactor/core/publisher/MonoThenIgnore.java
@@ -196,15 +196,11 @@ final class MonoThenIgnore<T> extends Mono<T> implements Fuseable {
         }
 
 	    @Override
-	    public Object scan(Attr key) {
-		    switch (key){
-			    case PARENT:
-				    return s;
-			    case ACTUAL:
-				    return parent;
-			    case CANCELLED:
-				    return s == Operators.cancelledSubscription();
-		    }
+	    public Object scanUnsafe(Attr key) {
+            if (key == ScannableAttr.PARENT) return s;
+            if (key == ScannableAttr.ACTUAL) return parent;
+            if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+
 		    return null;
 	    }
         
@@ -254,17 +250,12 @@ final class MonoThenIgnore<T> extends Mono<T> implements Fuseable {
         }
 
         @Override
-        public Object scan(Attr key) {
-            switch (key){
-                case PARENT:
-                    return s;
-                case ACTUAL:
-                    return parent;
-	            case TERMINATED:
-                    return done;
-	            case CANCELLED:
-	            	return s == Operators.cancelledSubscription();
-            }
+        public Object scanUnsafe(Attr key) {
+            if (key == ScannableAttr.PARENT) return s;
+            if (key == ScannableAttr.ACTUAL) return parent;
+            if (key == BooleanAttr.TERMINATED) return done;
+            if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+
             return null;
         }
 

--- a/src/main/java/reactor/core/publisher/MonoUntilOther.java
+++ b/src/main/java/reactor/core/publisher/MonoUntilOther.java
@@ -109,7 +109,7 @@ final class MonoUntilOther<T> extends Mono<T> {
 
 		@Override
 		public Object scanUnsafe(Attr key) {
-			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == BooleanAttr.TERMINATED) return done == n;
 			if (key == ScannableAttr.PARENT) return sourceSubscriber;
 			if (key == BooleanAttr.DELAY_ERROR) return delayError;
 
@@ -219,7 +219,7 @@ final class MonoUntilOther<T> extends Mono<T> {
 		}
 	}
 
-	static final class UntilOtherSource<T> implements Subscriber<T> {
+	static final class UntilOtherSource<T> implements InnerConsumer<T> {
 
 		final UntilOtherCoordinator<T> parent;
 
@@ -263,6 +263,15 @@ final class MonoUntilOther<T> extends Mono<T> {
 			if (value == null) {
 				parent.signal();
 			}
+		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == BooleanAttr.TERMINATED) return error != null || value != null;
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+
+			return null;
 		}
 
 		void cancel() {

--- a/src/main/java/reactor/core/publisher/MonoUntilOther.java
+++ b/src/main/java/reactor/core/publisher/MonoUntilOther.java
@@ -108,16 +108,12 @@ final class MonoUntilOther<T> extends Mono<T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case TERMINATED:
-					return done;
-				case PARENT:
-					return sourceSubscriber;
-				case DELAY_ERROR:
-					return delayError;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.PARENT) return sourceSubscriber;
+			if (key == BooleanAttr.DELAY_ERROR) return delayError;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override
@@ -294,17 +290,12 @@ final class MonoUntilOther<T> extends Mono<T> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-				case PARENT:
-					return s;
-				case ACTUAL:
-					return parent;
-				case ERROR:
-					return error;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == ScannableAttr.ACTUAL) return parent;
+			if (key == ThrowableAttr.ERROR) return error;
+
 			return null;
 		}
 

--- a/src/main/java/reactor/core/publisher/MonoWhen.java
+++ b/src/main/java/reactor/core/publisher/MonoWhen.java
@@ -155,7 +155,7 @@ final class MonoWhen<T, R> extends Mono<R> {
 
 		@Override
 		public Object scanUnsafe(Attr key) {
-			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == BooleanAttr.TERMINATED) return done == subscribers.length;
 			if (key == IntAttr.BUFFERED) return subscribers.length;
 			if (key == BooleanAttr.DELAY_ERROR) return delayError;
 

--- a/src/main/java/reactor/core/publisher/MonoWhen.java
+++ b/src/main/java/reactor/core/publisher/MonoWhen.java
@@ -154,16 +154,12 @@ final class MonoWhen<T, R> extends Mono<R> {
         }
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key) {
-				case TERMINATED:
-					return done;
-				case BUFFERED:
-					return subscribers.length;
-				case DELAY_ERROR:
-					return delayError;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == IntAttr.BUFFERED) return subscribers.length;
+			if (key == BooleanAttr.DELAY_ERROR) return delayError;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override
@@ -278,17 +274,12 @@ final class MonoWhen<T, R> extends Mono<R> {
         }
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-				case PARENT:
-					return s;
-				case ACTUAL:
-					return parent;
-				case ERROR:
-					return error;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == ScannableAttr.ACTUAL) return parent;
+			if (key == ThrowableAttr.ERROR) return error;
+
 			return null;
 		}
 

--- a/src/main/java/reactor/core/publisher/ParallelCollect.java
+++ b/src/main/java/reactor/core/publisher/ParallelCollect.java
@@ -48,13 +48,10 @@ final class ParallelCollect<T, C> extends ParallelFlux<C> implements Scannable, 
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return source;
-			case PREFETCH:
-				return getPrefetch();
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return source;
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+
 		return null;
 	}
 

--- a/src/main/java/reactor/core/publisher/ParallelConcatMap.java
+++ b/src/main/java/reactor/core/publisher/ParallelConcatMap.java
@@ -56,13 +56,10 @@ final class ParallelConcatMap<T, R> extends ParallelFlux<R> implements Scannable
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return source;
-			case PREFETCH:
-				return getPrefetch();
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return source;
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+
 		return null;
 	}
 

--- a/src/main/java/reactor/core/publisher/ParallelFilter.java
+++ b/src/main/java/reactor/core/publisher/ParallelFilter.java
@@ -37,13 +37,10 @@ final class ParallelFilter<T> extends ParallelFlux<T> implements Scannable{
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return source;
-			case PREFETCH:
-				return getPrefetch();
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return source;
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+
 		return null;
 	}
 

--- a/src/main/java/reactor/core/publisher/ParallelFlatMap.java
+++ b/src/main/java/reactor/core/publisher/ParallelFlatMap.java
@@ -61,13 +61,10 @@ final class ParallelFlatMap<T, R> extends ParallelFlux<R> implements Scannable{
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return source;
-			case PREFETCH:
-				return getPrefetch();
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return source;
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+
 		return null;
 	}
 

--- a/src/main/java/reactor/core/publisher/ParallelFluxHide.java
+++ b/src/main/java/reactor/core/publisher/ParallelFluxHide.java
@@ -44,13 +44,10 @@ final class ParallelFluxHide<T> extends ParallelFlux<T> implements Scannable{
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return source;
-			case PREFETCH:
-				return getPrefetch();
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return source;
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+
 		return null;
 	}
 

--- a/src/main/java/reactor/core/publisher/ParallelFluxOnAssembly.java
+++ b/src/main/java/reactor/core/publisher/ParallelFluxOnAssembly.java
@@ -113,13 +113,10 @@ final class ParallelFluxOnAssembly<T> extends ParallelFlux<T>
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return source;
-			case PREFETCH:
-				return getPrefetch();
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return source;
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+
 		return null;
 	}
 

--- a/src/main/java/reactor/core/publisher/ParallelGroup.java
+++ b/src/main/java/reactor/core/publisher/ParallelGroup.java
@@ -60,13 +60,10 @@ final class ParallelGroup<T> extends Flux<GroupedFlux<Integer, T>> implements
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return source;
-			case PREFETCH:
-				return getPrefetch();
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return source;
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+
 		return null;
 	}
 
@@ -116,16 +113,12 @@ final class ParallelGroup<T> extends Flux<GroupedFlux<Integer, T>> implements
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-			}
-			return InnerOperator.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+
+			return InnerOperator.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/ParallelLog.java
+++ b/src/main/java/reactor/core/publisher/ParallelLog.java
@@ -64,13 +64,10 @@ final class ParallelLog<T> extends ParallelFlux<T> implements Scannable {
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return source;
-			case PREFETCH:
-				return getPrefetch();
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return source;
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+
 		return null;
 	}
 }

--- a/src/main/java/reactor/core/publisher/ParallelMap.java
+++ b/src/main/java/reactor/core/publisher/ParallelMap.java
@@ -38,13 +38,10 @@ final class ParallelMap<T, R> extends ParallelFlux<R> implements Scannable {
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return source;
-			case PREFETCH:
-				return getPrefetch();
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return source;
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+
 		return null;
 	}
 

--- a/src/main/java/reactor/core/publisher/ParallelMergeReduce.java
+++ b/src/main/java/reactor/core/publisher/ParallelMergeReduce.java
@@ -46,11 +46,9 @@ final class ParallelMergeReduce<T> extends Mono<T> implements Scannable, Fuseabl
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return source;
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return source;
+
 		return null;
 	}
 
@@ -109,12 +107,10 @@ final class ParallelMergeReduce<T> extends Mono<T> implements Scannable, Fuseabl
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch(key){
-				case ERROR:
-					return error;
-			}
-			return super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ThrowableAttr.ERROR) return error;
+
+			return super.scanUnsafe(key);
 		}
 
 		SlotPair<T> addValue(T value) {
@@ -226,21 +222,14 @@ final class ParallelMergeReduce<T> extends Mono<T> implements Scannable, Fuseabl
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch(key){
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-				case PARENT:
-					return s;
-				case TERMINATED:
-					return done;
-				case ACTUAL:
-					return parent;
-				case BUFFERED:
-					return value != null ? 1 : 0;
-				case PREFETCH:
-					return Integer.MAX_VALUE;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == ScannableAttr.ACTUAL) return parent;
+			if (key == IntAttr.BUFFERED) return value != null ? 1 : 0;
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+
 			return null;
 		}
 

--- a/src/main/java/reactor/core/publisher/ParallelMergeSequential.java
+++ b/src/main/java/reactor/core/publisher/ParallelMergeSequential.java
@@ -49,13 +49,10 @@ final class ParallelMergeSequential<T> extends Flux<T> implements Scannable {
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return source;
-			case PREFETCH:
-				return getPrefetch();
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return source;
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+
 		return null;
 	}
 	
@@ -119,18 +116,13 @@ final class ParallelMergeSequential<T> extends Flux<T> implements Scannable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch(key){
-				case CANCELLED:
-					return cancelled;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case TERMINATED:
-					return done == 0;
-				case ERROR:
-					return error;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == BooleanAttr.TERMINATED) return done == 0;
+			if (key == ThrowableAttr.ERROR) return error;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -365,21 +357,14 @@ final class ParallelMergeSequential<T> extends Flux<T> implements Scannable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch(key){
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-				case PARENT:
-					return s;
-				case ACTUAL:
-					return parent;
-				case PREFETCH:
-					return prefetch;
-				case BUFFERED:
-					return queue != null ? queue.size() : 0;
-				case TERMINATED:
-					return done;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == ScannableAttr.ACTUAL) return parent;
+			if (key == IntAttr.PREFETCH) return prefetch;
+			if (key == IntAttr.BUFFERED) return queue != null ? queue.size() : 0;
+			if (key == BooleanAttr.TERMINATED) return done;
+
 			return null;
 		}
 		

--- a/src/main/java/reactor/core/publisher/ParallelMergeSort.java
+++ b/src/main/java/reactor/core/publisher/ParallelMergeSort.java
@@ -64,13 +64,10 @@ final class ParallelMergeSort<T> extends Flux<T> implements Scannable {
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return source;
-			case PREFETCH:
-				return getPrefetch();
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return source;
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+
 		return null;
 	}
 
@@ -139,18 +136,13 @@ final class ParallelMergeSort<T> extends Flux<T> implements Scannable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case ERROR:
-					return error;
-				case REQUESTED_FROM_DOWNSTREAM:
-					return requested;
-				case CANCELLED:
-					return cancelled;
-				case BUFFERED:
-					return subscribers.length - remaining;
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == IntAttr.BUFFERED) return subscribers.length - remaining;
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -335,17 +327,12 @@ final class ParallelMergeSort<T> extends Flux<T> implements Scannable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch(key){
-				case CANCELLED:
-					return s == Operators.cancelledSubscription();
-				case PARENT:
-					return s;
-				case ACTUAL:
-					return parent;
-				case PREFETCH:
-					return Integer.MAX_VALUE;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == ScannableAttr.ACTUAL) return parent;
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+
 			return null;
 		}
 

--- a/src/main/java/reactor/core/publisher/ParallelPeek.java
+++ b/src/main/java/reactor/core/publisher/ParallelPeek.java
@@ -129,13 +129,10 @@ final class ParallelPeek<T> extends ParallelFlux<T> implements SignalPeek<T>{
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return source;
-			case PREFETCH:
-				return getPrefetch();
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return source;
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+
 		return null;
 	}
 }

--- a/src/main/java/reactor/core/publisher/ParallelReduceSeed.java
+++ b/src/main/java/reactor/core/publisher/ParallelReduceSeed.java
@@ -49,13 +49,10 @@ final class ParallelReduceSeed<T, R> extends ParallelFlux<R> implements
 	}
 
 	@Override
-	public Object scan(Scannable.Attr key) {
-		switch (key){
-			case PARENT:
-				return source;
-			case PREFETCH:
-				return getPrefetch();
-		}
+	public Object scanUnsafe(Scannable.Attr key) {
+		if (key == ScannableAttr.PARENT) return source;
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+
 		return null;
 	}
 

--- a/src/main/java/reactor/core/publisher/ParallelRunOn.java
+++ b/src/main/java/reactor/core/publisher/ParallelRunOn.java
@@ -50,13 +50,10 @@ final class ParallelRunOn<T> extends ParallelFlux<T> implements Scannable, Fusea
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return source;
-			case PREFETCH:
-				return getPrefetch();
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return source;
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+
 		return null;
 	}
 	

--- a/src/main/java/reactor/core/publisher/ParallelSource.java
+++ b/src/main/java/reactor/core/publisher/ParallelSource.java
@@ -68,13 +68,10 @@ final class ParallelSource<T> extends ParallelFlux<T> implements Scannable {
 	}
 
 	@Override
-	public Object scan(Scannable.Attr key) {
-		switch (key){
-			case PARENT:
-				return source;
-			case PREFETCH:
-				return getPrefetch();
-		}
+	public Object scanUnsafe(Scannable.Attr key) {
+		if (key == ScannableAttr.PARENT) return source;
+		if (key == IntAttr.PREFETCH) return getPrefetch();
+
 		return null;
 	}
 	
@@ -143,21 +140,14 @@ final class ParallelSource<T> extends ParallelFlux<T> implements Scannable {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return s;
-				case PREFETCH:
-					return prefetch;
-				case TERMINATED:
-					return done;
-				case CANCELLED:
-					return cancelled;
-				case ERROR:
-					return error;
-				case BUFFERED:
-					return queue != null ? queue.size() : 0;
-			}
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == IntAttr.PREFETCH) return prefetch;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == IntAttr.BUFFERED) return queue != null ? queue.size() : 0;
+
 			return null;
 		}
 
@@ -495,12 +485,10 @@ final class ParallelSource<T> extends ParallelFlux<T> implements Scannable {
 			}
 
 			@Override
-			public Object scan(Attr key) {
-				switch (key){
-					case PARENT:
-						return parent;
-				}
-				return InnerProducer.super.scan(key);
+			public Object scanUnsafe(Attr key) {
+				if (key == ScannableAttr.PARENT) return parent;
+
+				return InnerProducer.super.scanUnsafe(key);
 			}
 
 			@Override

--- a/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -320,10 +320,17 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	}
 
 	@Override
+	public Throwable getError() {
+		return buffer.getError();
+	}
+
+	@Override
 	public Object scanUnsafe(Attr key) {
 		if (key == ScannableAttr.PARENT){
 			return subscription;
 		}
+		if (key == IntAttr.CAPACITY) return buffer.capacity();
+
 		return super.scanUnsafe(key);
 	}
 

--- a/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -320,11 +320,11 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		if(key == Attr.PARENT){
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT){
 			return subscription;
 		}
-		return super.scan(key);
+		return super.scanUnsafe(key);
 	}
 
 	@Override

--- a/src/main/java/reactor/core/publisher/SerializedSubscriber.java
+++ b/src/main/java/reactor/core/publisher/SerializedSubscriber.java
@@ -247,7 +247,7 @@ final class SerializedSubscriber<T> implements InnerOperator<T, T> {
 		return InnerOperator.super.scanUnsafe(key);
 	}
 
-	long producerCapacity() {
+	int producerCapacity() {
 		LinkedArrayNode<T> node = tail;
 		if(node != null){
 			return node.count;

--- a/src/main/java/reactor/core/publisher/SerializedSubscriber.java
+++ b/src/main/java/reactor/core/publisher/SerializedSubscriber.java
@@ -236,22 +236,15 @@ final class SerializedSubscriber<T> implements InnerOperator<T, T> {
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return s;
-			case ERROR:
-				return error;
-			case BUFFERED:
-				return producerCapacity();
-			case CAPACITY:
-				return LinkedArrayNode.DEFAULT_CAPACITY;
-			case CANCELLED:
-				return cancelled;
-			case TERMINATED:
-				return done;
-		}
-		return InnerOperator.super.scan(key);
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return s;
+		if (key == ThrowableAttr.ERROR) return error;
+		if (key == IntAttr.BUFFERED) return producerCapacity();
+		if (key == IntAttr.CAPACITY) return LinkedArrayNode.DEFAULT_CAPACITY;
+		if (key == BooleanAttr.CANCELLED) return cancelled;
+		if (key == BooleanAttr.TERMINATED) return done;
+
+		return InnerOperator.super.scanUnsafe(key);
 	}
 
 	long producerCapacity() {

--- a/src/main/java/reactor/core/publisher/SignalLogger.java
+++ b/src/main/java/reactor/core/publisher/SignalLogger.java
@@ -154,11 +154,9 @@ final class SignalLogger<IN> implements SignalPeek<IN> {
 	}
 
 	@Override
-	public Object scan(Attr key) {
-		switch (key){
-			case PARENT:
-				return source;
-		}
+	public Object scanUnsafe(Attr key) {
+		if (key == ScannableAttr.PARENT) return source;
+
 		return null;
 	}
 

--- a/src/main/java/reactor/core/publisher/TopicProcessor.java
+++ b/src/main/java/reactor/core/publisher/TopicProcessor.java
@@ -1163,8 +1163,17 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
 			if (key == BooleanAttr.TERMINATED) return processor.isTerminated();
 			if (key == BooleanAttr.CANCELLED) return !running.get();
-			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM ) return pendingRequest.getAsLong();
-			if (key == IntAttr.BUFFERED) return processor.ringBuffer.getCursor() - sequence.getAsLong();
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return pendingRequest.getAsLong();
+			if (key == LongAttr.LARGE_BUFFERED) {
+				return processor.ringBuffer.getCursor() - sequence.getAsLong();
+			}
+			if (key == IntAttr.BUFFERED) {
+				long realBuffered = processor.ringBuffer.getCursor() - sequence.getAsLong();
+				if (realBuffered <= Integer.MAX_VALUE) {
+					return (int) realBuffered;
+				}
+				return Integer.MIN_VALUE;
+			}
 
 			return InnerProducer.super.scanUnsafe(key);
 		}

--- a/src/main/java/reactor/core/publisher/TopicProcessor.java
+++ b/src/main/java/reactor/core/publisher/TopicProcessor.java
@@ -1163,7 +1163,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
 			if (key == BooleanAttr.TERMINATED) return processor.isTerminated();
 			if (key == BooleanAttr.CANCELLED) return !running.get();
-			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM )return pendingRequest.getAsLong();
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM ) return pendingRequest.getAsLong();
 			if (key == IntAttr.BUFFERED) return processor.ringBuffer.getCursor() - sequence.getAsLong();
 
 			return InnerProducer.super.scanUnsafe(key);

--- a/src/main/java/reactor/core/publisher/TopicProcessor.java
+++ b/src/main/java/reactor/core/publisher/TopicProcessor.java
@@ -1158,22 +1158,15 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return processor;
-				case PREFETCH:
-					return Integer.MAX_VALUE;
-				case TERMINATED:
-					return processor.isTerminated();
-				case CANCELLED:
-					return !running.get();
-				case REQUESTED_FROM_DOWNSTREAM:
-					return pendingRequest.getAsLong();
-				case BUFFERED:
-					return processor.ringBuffer.getCursor() - sequence.getAsLong();
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return processor;
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+			if (key == BooleanAttr.TERMINATED) return processor.isTerminated();
+			if (key == BooleanAttr.CANCELLED) return !running.get();
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM )return pendingRequest.getAsLong();
+			if (key == IntAttr.BUFFERED) return processor.ringBuffer.getCursor() - sequence.getAsLong();
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
+++ b/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
@@ -1194,20 +1194,14 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 		}
 
 		@Override
-		public Object scan(Attr key) {
-			switch (key){
-				case PARENT:
-					return processor;
-				case PREFETCH:
-					return Integer.MAX_VALUE;
-				case TERMINATED:
-					return processor.isTerminated();
-				case CANCELLED:
-					return !running.get();
-				case REQUESTED_FROM_DOWNSTREAM:
-					return pendingRequest.getAsLong();
-			}
-			return InnerProducer.super.scan(key);
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT ) return processor;
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
+			if (key == BooleanAttr.TERMINATED ) return processor.isTerminated();
+			if (key == BooleanAttr.CANCELLED) return !running.get();
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return pendingRequest.getAsLong();
+
+			return InnerProducer.super.scanUnsafe(key);
 		}
 
 		@Override

--- a/src/test/java/reactor/core/ScannableTest.java
+++ b/src/test/java/reactor/core/ScannableTest.java
@@ -28,18 +28,12 @@ public class ScannableTest {
 	static final Scannable.GenericAttr<String> CUSTOM_STRING = new Scannable.GenericAttr<>("global");
 
 	static final Scannable scannable = key -> {
-		if (key.equals(Scannable.IntAttr.BUFFERED)) {
-			return 1;
-		}
-		else if (key.equals(Scannable.BooleanAttr.TERMINATED)) {
-			return true;
-		}
-		else if (key.equals(Scannable.ScannableAttr.PARENT)) {
-			return null;
-		}
-		else if (key.equals(Scannable.ScannableAttr.ACTUAL)) {
+		if (key == Scannable.IntAttr.BUFFERED) return 1;
+		if (key == Scannable.BooleanAttr.TERMINATED) return true;
+		if (key == Scannable.ScannableAttr.PARENT) return null;
+		if (key == Scannable.ScannableAttr.ACTUAL)
 			return (Scannable) k -> (Scannable) k2 -> null;
-		}
+
 		return null;
 	};
 

--- a/src/test/java/reactor/core/ScannableTest.java
+++ b/src/test/java/reactor/core/ScannableTest.java
@@ -19,12 +19,13 @@ package reactor.core;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static reactor.core.Scannable.IntAttr.BUFFERED;
 
 /**
  * @author Stephane Maldini
  */
 public class ScannableTest {
+
+	static final Scannable.GenericAttr<String> CUSTOM_STRING = new Scannable.GenericAttr<>("global");
 
 	static final Scannable scannable = key -> {
 		if (key.equals(Scannable.IntAttr.BUFFERED)) {
@@ -68,8 +69,6 @@ public class ScannableTest {
 		assertThat(emptyScannable.scan(Scannable.BooleanAttr.DELAY_ERROR)).isFalse();
 		assertThat(emptyScannable.scan(Scannable.BooleanAttr.TERMINATED)).isNull();
 
-		assertThat(emptyScannable.scan(Scannable.StringAttr.NAME)).isNull();
-
 		assertThat(emptyScannable.scan(Scannable.ThrowableAttr.ERROR)).isNull();
 
 		assertThat(emptyScannable.scan(Scannable.ScannableAttr.ACTUAL)).isNull();
@@ -87,12 +86,17 @@ public class ScannableTest {
 		assertThat(Scannable.from(scannable).parents().count()).isEqualTo(0);
 		assertThat(Scannable.from(scannable).actuals().count()).isEqualTo(2);
 		assertThat(Scannable.from(scannable).scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
-		assertThat(Scannable.from(scannable).scanOrDefault(BUFFERED, 0)).isEqualTo(1);
+		assertThat(Scannable.from(scannable).scanOrDefault(Scannable.IntAttr.BUFFERED, 0)).isEqualTo(1);
 		assertThat(Scannable.from(scannable).scan(Scannable.ScannableAttr.ACTUAL)).isEqualTo(scannable.actuals().findFirst().get());
 	}
 
 	@Test
 	public void nullScan() {
 		assertThat(Scannable.from(null)).isNull();
+	}
+
+	@Test
+	public void globalDefaultTakesPrecedenceOverCallDefault() {
+		assertThat(scannable.scanOrDefault(CUSTOM_STRING, "bar")).isEqualTo("global");
 	}
 }

--- a/src/test/java/reactor/core/publisher/BlockingSingleSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/BlockingSingleSubscriberTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+import reactor.core.Scannable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BlockingSingleSubscriberTest {
+
+	BlockingSingleSubscriber test = new BlockingSingleSubscriber() {
+		@Override
+		public void onNext(Object o) { }
+
+		@Override
+		public void onError(Throwable t) {
+			value = null;
+			error = t;
+			countDown();
+		}
+	};
+
+	@Test
+	public void scanMain() {
+		Subscription s = Operators.emptySubscription();
+		test.onSubscribe(s);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).describedAs("PARENT").isSameAs(s);
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).describedAs("TERMINATED").isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).describedAs("CANCELLED").isFalse();
+		assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).describedAs("ERROR").isNull();
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).describedAs("PREFETCH").isEqualTo(Integer.MAX_VALUE);
+	}
+
+	@Test
+	public void scanMainTerminated() {
+		test.onComplete();
+
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+	}
+
+	@Test
+	public void scanMainError() {
+		test.onError(new IllegalStateException("boom"));
+
+		assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).hasMessage("boom");
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+	}
+
+	@Test
+	public void scanMainCancelled() {
+		test.dispose();
+
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+	}
+}

--- a/src/test/java/reactor/core/publisher/ConnectableFluxOnAssemblyTest.java
+++ b/src/test/java/reactor/core/publisher/ConnectableFluxOnAssemblyTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.Test;
+import reactor.core.Scannable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConnectableFluxOnAssemblyTest {
+
+	@Test
+	public void scanMain() throws Exception {
+		ConnectableFlux<String> source = Flux.just("foo").publish();
+		ConnectableFluxOnAssembly<String> test = new ConnectableFluxOnAssembly<>(source);
+
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(-1);
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(source);
+	}
+
+}

--- a/src/test/java/reactor/core/publisher/DelegateProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/DelegateProcessorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import reactor.core.Scannable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class DelegateProcessorTest {
+
+	@Test
+	public void scanReturnsDownStreamForParentElseDelegates() {
+		Publisher downstream = Mockito.mock(Publisher.class);
+
+		IllegalStateException boom = new IllegalStateException("boom");
+		InnerConsumer upstream = Mockito.mock(InnerConsumer.class);
+		when(upstream.scanUnsafe(Scannable.ThrowableAttr.ERROR))
+				.thenReturn(boom);
+		when(upstream.scanUnsafe(Scannable.BooleanAttr.DELAY_ERROR))
+				.thenReturn(true);
+
+		DelegateProcessor processor = new DelegateProcessor(
+				downstream, upstream);
+
+		assertThat(processor.scan(Scannable.ScannableAttr.PARENT)).isSameAs(downstream);
+
+		assertThat(processor.scan(Scannable.ThrowableAttr.ERROR)).isSameAs(boom);
+		assertThat(processor.scan(Scannable.BooleanAttr.DELAY_ERROR)).isTrue();
+	}
+}

--- a/src/test/java/reactor/core/publisher/DirectProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/DirectProcessorTest.java
@@ -17,9 +17,14 @@ package reactor.core.publisher;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.reactivestreams.Subscriber;
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class DirectProcessorTest {
 
@@ -244,6 +249,23 @@ public class DirectProcessorTest {
         ts.assertValues(1)
           .assertNotComplete()
           .assertNoError();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void scanInner() {
+        Subscriber<? super String> actual = mock(Subscriber.class);
+        DirectProcessor<String> parent = new DirectProcessor<>();
+
+        DirectProcessor.DirectInner<String> test =
+                new DirectProcessor.DirectInner<>(actual, parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+        test.cancel();
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
     }
 
 }

--- a/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -296,7 +296,7 @@ public class EmitterProcessorTest {
 		s.next(5);
 		s.next(6);
 		s.next(7);
-		assertThat(tp.scan(Scannable.Attr.BUFFERED)).isEqualTo(3);
+		assertThat(tp.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(3);
 		assertThat(tp.isTerminated()).isFalse();
 		s.complete();
 		assertThat(tp.isTerminated()).isFalse();
@@ -528,7 +528,7 @@ public class EmitterProcessorTest {
 		first.awaitAndAssertNextValues("1", "2", "3");
 		first.cancel();
 
-		assertThat(processor.scanOrDefault(Scannable.Attr.CANCELLED, false)).isTrue();
+		assertThat(processor.scanOrDefault(Scannable.BooleanAttr.CANCELLED, false)).isTrue();
 	}
 
 	@Test

--- a/src/test/java/reactor/core/publisher/EventLoopProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/EventLoopProcessorTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.concurrent.Executors;
+
+import org.junit.Test;
+import reactor.core.Scannable;
+import reactor.util.concurrent.WaitStrategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static reactor.core.Scannable.BooleanAttr.TERMINATED;
+import static reactor.core.Scannable.ScannableAttr.PARENT;
+import static reactor.core.Scannable.ThrowableAttr.ERROR;
+
+public class EventLoopProcessorTest {
+
+	@Test
+	public void scanMain() throws Exception {
+		EventLoopProcessor<String> test = new EventLoopProcessor<String>(128,
+				r -> new Thread(r),
+				Executors.newSingleThreadExecutor(),
+				true,
+				false,
+				() -> null,
+				WaitStrategy.sleeping()) {
+			@Override
+			public void run() {
+
+			}
+
+			@Override
+			public long getPending() {
+				return 456;
+			}
+
+			@Override
+			void doError(Throwable throwable) {
+				this.error = throwable;
+			}
+		};
+
+		assertThat(test.scan(PARENT)).isNull();
+		assertThat(test.scan(TERMINATED)).isFalse();
+
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(TERMINATED)).isTrue();
+		assertThat(test.scan(ERROR)).hasMessage("boom");
+
+		assertThat(test.scan(Scannable.IntAttr.CAPACITY)).isEqualTo(128);
+	}
+
+}

--- a/src/test/java/reactor/core/publisher/FluxAutoConnectFuseableTest.java
+++ b/src/test/java/reactor/core/publisher/FluxAutoConnectFuseableTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import reactor.core.Scannable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FluxAutoConnectFuseableTest {
+
+	@Test
+	public void scanMain() {
+		ConnectableFlux<String> source = Mockito.mock(ConnectableFlux.class);
+		Mockito.when(source.getPrefetch()).thenReturn(888);
+		FluxAutoConnectFuseable<String> test = new FluxAutoConnectFuseable<>(source, 123, d -> { });
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(source);
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(888);
+//		assertThat(test.scan(Scannable.IntAttr.CAPACITY)).isEqualTo(123);
+	}
+
+}

--- a/src/test/java/reactor/core/publisher/FluxAutoConnectTest.java
+++ b/src/test/java/reactor/core/publisher/FluxAutoConnectTest.java
@@ -19,8 +19,12 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 import reactor.core.Disposable;
+import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxAutoConnectTest {
 
@@ -73,5 +77,16 @@ public class FluxAutoConnectTest {
 		
 		cancel.get().dispose();
 		Assert.assertFalse("sp has subscribers?", e.downstreamCount() != 0);
+	}
+
+	@Test
+	public void scanMain() {
+		ConnectableFlux<String> source = Mockito.mock(ConnectableFlux.class);
+		Mockito.when(source.getPrefetch()).thenReturn(888);
+		FluxAutoConnect<String> test = new FluxAutoConnect<>(source, 123, d -> { });
+
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(888);
+//		assertThat(test.scan(Scannable.IntAttr.CAPACITY)).isEqualTo(123);
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(source);
 	}
 }

--- a/src/test/java/reactor/core/publisher/FluxElapsedTest.java
+++ b/src/test/java/reactor/core/publisher/FluxElapsedTest.java
@@ -17,7 +17,13 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.util.function.Tuple2;
 
@@ -36,4 +42,15 @@ public class FluxElapsedTest {
 		            .expectNextMatches(t -> t.getT1() == 2000 && t.getT2().equals("test"))
 		            .verifyComplete();
 	}
+
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Tuple2<Long, String>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxElapsed.ElapsedSubscriber<String> test = new FluxElapsed.ElapsedSubscriber<>(actual, Schedulers.single());
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxFilterFuseableTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFilterFuseableTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Fuseable;
+import reactor.core.Scannable;
+import reactor.test.publisher.FluxOperatorTest;
+
+public class FluxFilterFuseableTest extends FluxOperatorTest<String, String> {
+
+    @Test
+    public void scanSubscriber() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxFilterFuseable.FilterFuseableSubscriber<String> test = new FluxFilterFuseable.FilterFuseableSubscriber<>(actual, t -> true);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onError(new IllegalStateException("boom"));
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
+
+    @Test
+    public void scanConditionalSubscriber() {
+        Fuseable.ConditionalSubscriber<String> actual = Mockito.mock(Fuseable.ConditionalSubscriber.class);
+        FluxFilterFuseable.FilterFuseableConditionalSubscriber<String> test = new FluxFilterFuseable.FilterFuseableConditionalSubscriber<>(actual, t -> true);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onError(new IllegalStateException("boom"));
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
+}

--- a/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
@@ -420,6 +420,28 @@ public class FluxFilterWhenTest {
     }
 
     @Test
+    public void scanSmallBuffered() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxFilterWhen.FluxFilterWhenSubscriber<String> test = new FluxFilterWhen.FluxFilterWhenSubscriber<>(actual, t -> Mono.just(true), 789);
+
+        test.producerIndex = Integer.MAX_VALUE + 5L;
+        test.consumerIndex = Integer.MAX_VALUE + 2L;
+        assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(3);
+        assertThat(test.scan(Scannable.LongAttr.LARGE_BUFFERED)).isEqualTo(3L);
+    }
+
+    @Test
+    public void scanLargeBuffered() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxFilterWhen.FluxFilterWhenSubscriber<String> test = new FluxFilterWhen.FluxFilterWhenSubscriber<>(actual, t -> Mono.just(true), 789);
+
+        test.producerIndex = Integer.MAX_VALUE + 5L;
+        test.consumerIndex = 2L;
+        assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(Integer.MIN_VALUE);
+        assertThat(test.scan(Scannable.LongAttr.LARGE_BUFFERED)).isEqualTo(Integer.MAX_VALUE + 3L);
+    }
+
+    @Test
     public void scanInner() {
         Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxFilterWhen.FluxFilterWhenSubscriber<String> main = new FluxFilterWhen.FluxFilterWhenSubscriber<>(actual, t -> Mono.just(true), 789);

--- a/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
@@ -346,33 +346,33 @@ public class FluxFilterWhenTest {
 		            .thenRequest(2)
 		            .expectNext(2)
 		            .then(() -> {
-			            assertThat(scannable.get().scan(Scannable.Attr.PARENT)).isInstanceOf(FluxRange.RangeSubscription.class);
-			            assertThat(scannable.get().scan(Scannable.Attr.ACTUAL)).isInstanceOf(FluxPeek.PeekSubscriber.class);
-			            assertThat(scannable.get().scan(Scannable.Attr.PREFETCH)).isEqualTo(3);
-			            assertThat(scannable.get().scan(Scannable.Attr.CAPACITY)).isEqualTo(4);
-			            assertThat(scannable.get().scan(Scannable.Attr.ERROR)).isNull();
-			            assertThat(scannable.get().scan(Scannable.Attr.BUFFERED )).isEqualTo(1L);
-			            assertThat(scannable.get().scan(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(2L);
-			            assertThat(scannable.get().scan(Scannable.Attr.CANCELLED)).isEqualTo(false);
-			            assertThat(scannable.get().scan(Scannable.Attr.TERMINATED)).isEqualTo(false);
+			            assertThat(scannable.get().scan(Scannable.ScannableAttr.PARENT)).isInstanceOf(FluxRange.RangeSubscription.class);
+			            assertThat(scannable.get().scan(Scannable.ScannableAttr.ACTUAL)).isInstanceOf(FluxPeek.PeekSubscriber.class);
+			            assertThat(scannable.get().scan(Scannable.IntAttr.PREFETCH)).isEqualTo(3);
+			            assertThat(scannable.get().scan(Scannable.IntAttr.CAPACITY)).isEqualTo(4);
+			            assertThat(scannable.get().scan(Scannable.ThrowableAttr.ERROR)).isNull();
+			            assertThat(scannable.get().scan(Scannable.IntAttr.BUFFERED )).isEqualTo(1);
+			            assertThat(scannable.get().scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(2L);
+			            assertThat(scannable.get().scan(Scannable.BooleanAttr.CANCELLED)).isEqualTo(false);
+			            assertThat(scannable.get().scan(Scannable.BooleanAttr.TERMINATED)).isEqualTo(false);
 		            })
 	                .thenRequest(2)
 	                .expectNext(4)
 	                .then(() -> {
-		                assertThat(scannable.get().scan(Scannable.Attr.ERROR)).isNull();
-		                assertThat(scannable.get().scan(Scannable.Attr.BUFFERED )).isEqualTo(2L);
-		                assertThat(scannable.get().scan(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(4L);
-		                assertThat(scannable.get().scan(Scannable.Attr.CANCELLED)).isEqualTo(false);
-		                assertThat(scannable.get().scan(Scannable.Attr.TERMINATED)).isEqualTo(false);
+		                assertThat(scannable.get().scan(Scannable.ThrowableAttr.ERROR)).isNull();
+		                assertThat(scannable.get().scan(Scannable.IntAttr.BUFFERED )).isEqualTo(2);
+		                assertThat(scannable.get().scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(4L);
+		                assertThat(scannable.get().scan(Scannable.BooleanAttr.CANCELLED)).isEqualTo(false);
+		                assertThat(scannable.get().scan(Scannable.BooleanAttr.TERMINATED)).isEqualTo(false);
 	                })
 	                .thenRequest(20)
 	                .expectNext(6, 8, 10)
 	                .verifyComplete();
 
-		assertThat(scannable.get().scan(Scannable.Attr.BUFFERED)).isEqualTo(6L);
-		assertThat(scannable.get().scan(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(24L);
-		assertThat(scannable.get().scan(Scannable.Attr.CANCELLED)).isEqualTo(false);
-		assertThat(scannable.get().scan(Scannable.Attr.TERMINATED)).isEqualTo(true);
+		assertThat(scannable.get().scan(Scannable.IntAttr.BUFFERED)).isEqualTo(6);
+		assertThat(scannable.get().scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(24L);
+		assertThat(scannable.get().scan(Scannable.BooleanAttr.CANCELLED)).isEqualTo(false);
+		assertThat(scannable.get().scan(Scannable.BooleanAttr.TERMINATED)).isEqualTo(true);
 	}
 
 	//TODO introspect errors (but is difficult due to Expections.terminate)
@@ -390,11 +390,11 @@ public class FluxFilterWhenTest {
 		StepVerifier.create(flux, 0)
 		            .thenRequest(2)
 		            .expectNext(2)
-		            .then(() -> assertThat(scannable.get().scan(Scannable.Attr.CANCELLED)).isEqualTo(false))
+		            .then(() -> assertThat(scannable.get().scan(Scannable.BooleanAttr.CANCELLED)).isEqualTo(false))
 		            .thenCancel()
 		            .verify();
 
-		assertThat(scannable.get().scan(Scannable.Attr.CANCELLED)).isEqualTo(true);
+		assertThat(scannable.get().scan(Scannable.BooleanAttr.CANCELLED)).isEqualTo(true);
 	}
 
 }

--- a/src/test/java/reactor/core/publisher/FluxFirstEmittingTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFirstEmittingTest.java
@@ -15,10 +15,16 @@
  */
 package reactor.core.publisher;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
 
 import org.junit.Test;
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
 
 public class FluxFirstEmittingTest {
@@ -136,4 +142,33 @@ public class FluxFirstEmittingTest {
 		  .assertError(NullPointerException.class);
 	}
 
+    @Test
+    public void scanSubscriber() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxFirstEmitting.RaceCoordinator<String> parent = new FluxFirstEmitting.RaceCoordinator<>(1);
+        FluxFirstEmitting.FirstEmittingSubscriber<String> test = new FluxFirstEmitting.FirstEmittingSubscriber<>(actual, parent, 1);
+        Subscription sub = Operators.emptySubscription();
+        test.onSubscribe(sub);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(sub);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        parent.cancelled = true;
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
+
+    @Test
+    public void scanRaceCoordinator() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxFirstEmitting.RaceCoordinator<String> parent = new FluxFirstEmitting.RaceCoordinator<>(1);
+        FluxFirstEmitting.FirstEmittingSubscriber<String> test = new FluxFirstEmitting.FirstEmittingSubscriber<>(actual, parent, 1);
+        Subscription sub = Operators.emptySubscription();
+        test.onSubscribe(sub);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(sub);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        assertThat(parent.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        parent.cancelled = true;
+        assertThat(parent.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -1224,6 +1224,7 @@ public class FluxFlatMapTest {
         test.scalarQueue = new ConcurrentLinkedQueue<>();
         test.scalarQueue.add(1);
         assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
+        assertThat(test.scan(Scannable.LongAttr.LARGE_BUFFERED)).isEqualTo(1L);
         assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).isNull();
 
         assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
@@ -1235,6 +1236,23 @@ public class FluxFlatMapTest {
         assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
         test.cancel();
         assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
+
+    @Test
+   public void scanMainLargeBuffered() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxFlatMap.FlatMapMain<Integer, Integer> test = new FluxFlatMap.FlatMapMain<>(actual,
+                i -> Mono.just(i), true, 5, QueueSupplier.<Integer>unbounded(), 789,  QueueSupplier.<Integer>get(789));
+
+
+        test.scalarQueue = new ConcurrentLinkedQueue<>();
+        test.scalarQueue.add(1);
+        test.scalarQueue.add(2);
+        test.scalarQueue.add(3);
+        test.size = Integer.MAX_VALUE;
+
+        assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(Integer.MIN_VALUE);
+        assertThat(test.scan(Scannable.LongAttr.LARGE_BUFFERED)).isEqualTo(Integer.MAX_VALUE + 3L);
     }
 
     @Test

--- a/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -918,34 +918,34 @@ public class FluxFlatMapTest {
 	}
 
 	void assertBeforeOnSubscribeState(InnerOperator s) {
-		assertThat(s.scan(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(0L);
-		assertThat(s.scan(Scannable.Attr.PREFETCH)).isEqualTo(1);
-		assertThat(s.scan(Scannable.Attr.TERMINATED, Boolean.class)).isFalse();
-		assertThat(s.scanOrDefault(Scannable.Attr.CANCELLED, false)).isFalse();
+		assertThat(s.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(0L);
+		assertThat(s.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(1);
+		assertThat(s.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(s.scanOrDefault(Scannable.BooleanAttr.CANCELLED, false)).isFalse();
 	}
 
 	void assertAfterOnSubscribeState(InnerOperator s) {
-		assertThat(s.scan(Scannable.Attr.ERROR)).isNull();
-		assertThat(s.scan(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(1L);
-		assertThat(s.scan(Scannable.Attr.TERMINATED, Boolean.class)).isFalse();
-		assertThat(s.scanOrDefault(Scannable.Attr.CANCELLED, false)).isFalse();
+		assertThat(s.scan(Scannable.ThrowableAttr.ERROR)).isNull();
+		assertThat(s.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(1L);
+		assertThat(s.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(s.scanOrDefault(Scannable.BooleanAttr.CANCELLED, false)).isFalse();
 	}
 
 	void assertAfterOnNextInnerState(InnerConsumer s) {
-		assertThat(s.scan(Scannable.Attr.BUFFERED)).isEqualTo(1);
+		assertThat(s.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
 	}
 
 	void assertAfterOnNextInnerState2(InnerConsumer s) {
-		assertThat(s.scan(Scannable.Attr.BUFFERED)).isEqualTo(0);
+		assertThat(s.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(0);
 	}
 
 	void assertAfterOnCompleteInnerState(InnerConsumer s) {
-		assertThat(s.scan(Scannable.Attr.TERMINATED, Boolean.class)).isFalse();
+		assertThat(s.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
 	}
 
 	void assertAfterOnCompleteInnerState2(InnerConsumer s) {
-		assertThat(s.scan(Scannable.Attr.TERMINATED, Boolean.class)).isTrue();
-		assertThat(s.scan(Scannable.Attr.BUFFERED)).isEqualTo(0);
+		assertThat(s.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+		assertThat(s.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(0);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -954,9 +954,9 @@ public class FluxFlatMapTest {
 	}
 
 	void assertBeforeOnSubscribeInnerState(InnerConsumer s) {
-		assertThat(s.scan(Scannable.Attr.TERMINATED, Boolean.class)).isFalse();
-		assertThat(s.scan(Scannable.Attr.PREFETCH)).isEqualTo(32);
-		assertThat(s.scan(Scannable.Attr.BUFFERED)).isEqualTo(0);
+		assertThat(s.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(s.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(32);
+		assertThat(s.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(0);
 	}
 
 	@Test
@@ -967,7 +967,7 @@ public class FluxFlatMapTest {
 			assertAfterOnSubscribeState((FluxFlatMap.FlatMapMain) s);
 			s.onNext(1);
 			assertThat(((FluxFlatMap.FlatMapMain) s).actual()).isNotNull();
-			assertThat(((FluxFlatMap.FlatMapMain) s).scan(Scannable.Attr.CANCELLED, Boolean.class)).isTrue();
+			assertThat(((FluxFlatMap.FlatMapMain) s).scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
 			s.onComplete();
 		})
 		                        .flatMap(f -> Flux.from(s -> {
@@ -979,7 +979,7 @@ public class FluxFlatMapTest {
 			                        s.onNext(f);
 			                        assertAfterOnNextInnerState(((FluxFlatMap.FlatMapInner) s));
 			                        assertAfterOnCompleteInnerState(((FluxFlatMap.FlatMapInner) s));
-			                        assertThat(((FluxFlatMap.FlatMapInner)s).scan(Scannable.Attr.BUFFERED)).isEqualTo(1);
+			                        assertThat(((FluxFlatMap.FlatMapInner)s).scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
 			                        s.onComplete();
 			                        assertAfterOnCompleteInnerState(((FluxFlatMap.FlatMapInner) s));
 		                        }), 1), 1)
@@ -996,9 +996,9 @@ public class FluxFlatMapTest {
 			assertAfterOnSubscribeState((FluxFlatMap.FlatMapMain) s);
 			s.onNext(1);
 			assertThat(((FluxFlatMap.FlatMapMain) s).actual()).isNotNull();
-			assertThat(((FluxFlatMap.FlatMapMain) s).scan(Scannable.Attr.CANCELLED, Boolean.class)).isFalse();
+			assertThat(((FluxFlatMap.FlatMapMain) s).scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
 			s.onComplete();
-			assertThat(((FluxFlatMap.FlatMapMain) s).scan(Scannable.Attr.TERMINATED, Boolean.class)).isTrue();
+			assertThat(((FluxFlatMap.FlatMapMain) s).scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
 		})
 		                        .flatMap(f -> Flux.from(s -> {
 			                        assertBeforeOnSubscribeInnerState((FluxFlatMap.FlatMapInner) s);
@@ -1043,21 +1043,21 @@ public class FluxFlatMapTest {
 		            .expectNext(1)
 		            .then(() -> {
 						FluxFlatMap.FlatMapMain s = ref.get();
-			            assertThat(s.scan(Scannable.Attr.BUFFERED)).isEqualTo(0);
+			            assertThat(s.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(0);
 			            s.onNext(2);
 			            assertThat(s.actual()).isNotNull();
-			            assertThat(s.scan(Scannable.Attr.CANCELLED, Boolean.class)).isFalse();
-			            assertThat(s.scan(Scannable.Attr.BUFFERED)).isEqualTo(1);
-			            assertThat(s.scan(Scannable.Attr.TERMINATED, Boolean.class)).isFalse();
+			            assertThat(s.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+			            assertThat(s.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
+			            assertThat(s.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
 			            s.onComplete();
-			            assertThat(s.scan(Scannable.Attr.BUFFERED)).isEqualTo(1);
-			            assertThat(s.scan(Scannable.Attr.TERMINATED, Boolean.class)).isFalse();
+			            assertThat(s.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
+			            assertThat(s.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
 		            })
 		            .thenRequest(1)
 		            .then(() -> {
 			            FluxFlatMap.FlatMapMain s = ref.get();
-			            assertThat(s.scan(Scannable.Attr.TERMINATED, Boolean.class)).isTrue();
-			            assertThat(s.scan(Scannable.Attr.BUFFERED)).isEqualTo(0);
+			            assertThat(s.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+			            assertThat(s.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(0);
 		            })
 		            .expectNext(2)
 		            .verifyComplete();

--- a/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
@@ -16,6 +16,8 @@
 
 package reactor.core.publisher;
 
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -25,7 +27,14 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
 import reactor.core.Fuseable;
+import reactor.core.Scannable;
+import reactor.core.Scannable.IntAttr;
+import reactor.core.Scannable.LongAttr;
+import reactor.core.Scannable.ScannableAttr;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
@@ -327,4 +336,41 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
 				.verifyComplete();
 	}
 
+    @Test
+    public void scanOperator() {
+        Flux<Integer> source = Flux.range(1, 10);
+        FluxFlattenIterable<Integer, Integer> test = new FluxFlattenIterable<>(source, i -> new ArrayList<>(i), 35, QueueSupplier.one());
+
+        assertThat(test.scan(ScannableAttr.PARENT)).isSameAs(source);
+        assertThat(test.scan(IntAttr.PREFETCH)).isEqualTo(35);
+    }
+
+    @Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxFlattenIterable.FlattenIterableSubscriber<Integer, Integer> test =
+                new FluxFlattenIterable.FlattenIterableSubscriber<>(actual, i -> new ArrayList<>(i), 123, QueueSupplier.<Integer>one());
+        Subscription s = Operators.emptySubscription();
+        test.onSubscribe(s);
+
+        assertThat(test.scan(ScannableAttr.PARENT)).isSameAs(s);
+        assertThat(test.scan(ScannableAttr.ACTUAL)).isSameAs(actual);
+        assertThat(test.scan(IntAttr.PREFETCH)).isEqualTo(123);
+        test.requested = 35;
+        assertThat(test.scan(LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(35);
+        test.queue.add(5);
+        assertThat(test.scan(IntAttr.BUFFERED)).isEqualTo(1);
+
+        assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).isNull();
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.error = new IllegalStateException("boom");
+        assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).hasMessage("boom");
+        test.onComplete();
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancel();
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxHideTest.java
+++ b/src/test/java/reactor/core/publisher/FluxHideTest.java
@@ -19,9 +19,10 @@ import org.junit.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Fuseable;
+import reactor.core.Scannable;
 import reactor.test.publisher.TestPublisher;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxHideTest {
 
@@ -115,4 +116,26 @@ public class FluxHideTest {
 
 		sfs.clear(); //NOOP
 	}
+
+	@Test
+    public void scanSubscriber() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxHide.HideSubscriber<String> test = new FluxHide.HideSubscriber<>(actual);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+    }
+
+	@Test
+    public void scanSuppressFuseableSubscriber() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxHide.SuppressFuseableSubscriber<String> test = new FluxHide.SuppressFuseableSubscriber<>(actual);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxIntervalTest.java
+++ b/src/test/java/reactor/core/publisher/FluxIntervalTest.java
@@ -24,10 +24,14 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
 import reactor.core.scheduler.Schedulers;
+import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxIntervalTest {
 
@@ -137,4 +141,15 @@ public class FluxIntervalTest {
 		            .thenCancel()
 		            .verify();
 	}
+
+	@Test
+    public void scanIntervalRunnable() {
+        Subscriber<Long> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxInterval.IntervalRunnable test = new FluxInterval.IntervalRunnable(actual, Schedulers.single().createWorker());
+
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancel();
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxMapTest.java
+++ b/src/test/java/reactor/core/publisher/FluxMapTest.java
@@ -21,9 +21,16 @@ import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
 import reactor.core.Fuseable;
+import reactor.core.Scannable;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxMapTest extends FluxOperatorTest<String, String> {
 
@@ -287,4 +294,66 @@ public class FluxMapTest extends FluxOperatorTest<String, String> {
 		  .assertNoError()
 		  .assertComplete();
 	}
+
+    @Test
+    public void scanSubscriber() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxMap.MapSubscriber<Integer, String> test = new FluxMap.MapSubscriber<>(actual, i -> String.valueOf(i));
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onError(new IllegalStateException("boom"));
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
+
+    @Test
+    public void scanConditionalSubscriber() {
+        Fuseable.ConditionalSubscriber<String> actual = Mockito.mock(Fuseable.ConditionalSubscriber.class);
+        FluxMap.MapConditionalSubscriber<Integer, String> test = new FluxMap.MapConditionalSubscriber<>(actual, i -> String.valueOf(i));
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onError(new IllegalStateException("boom"));
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
+
+    @Test
+    public void scanFuseableSubscriber() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxMapFuseable.MapFuseableSubscriber<Integer, String> test =
+        		new FluxMapFuseable.MapFuseableSubscriber<>(actual, i -> String.valueOf(i));
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onError(new IllegalStateException("boom"));
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
+
+    @Test
+    public void scanFuseableConditionalSubscriber() {
+        Fuseable.ConditionalSubscriber<String> actual = Mockito.mock(Fuseable.ConditionalSubscriber.class);
+        FluxMapFuseable.MapFuseableConditionalSubscriber<Integer, String> test =
+        		new FluxMapFuseable.MapFuseableConditionalSubscriber<>(actual, i -> String.valueOf(i));
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onError(new IllegalStateException("boom"));
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
+++ b/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
@@ -21,6 +21,10 @@ import java.io.StringWriter;
 import java.util.Objects;
 
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.core.publisher.FluxOnAssembly.AssemblySnapshotException;
 import reactor.test.StepVerifier;
 
@@ -258,4 +262,16 @@ public class FluxOnAssemblyTest {
 		String parallelFluxOnAssemblyStr = Flux.range(1, 10).parallel(2).checkpoint("onAssemblyDescription").toString();
 		assertTrue("Description not included: " + parallelFluxOnAssemblyStr, parallelFluxOnAssemblyStr.contains(expectedDescription));
 	}
+
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxOnAssembly.OnAssemblySubscriber<Integer> test =
+        		new FluxOnAssembly.OnAssemblySubscriber<>(actual, new AssemblySnapshotException(), Flux.just(1));
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferTest.java
+++ b/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferTest.java
@@ -20,8 +20,12 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 
@@ -142,4 +146,32 @@ public class FluxOnBackpressureBufferTest
 		            .expectNext(8, 9, 10, 11, 12, 13, 14, 15)
 		            .verifyComplete();
 	}
+
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxOnBackpressureBuffer.BackpressureBufferSubscriber<Integer> test =
+        		new FluxOnBackpressureBuffer.BackpressureBufferSubscriber<>(actual,
+        				123, false, true, t -> {});
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.BooleanAttr.DELAY_ERROR)).isTrue();
+        test.requested = 35;
+        assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(35);
+        assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+        assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(0); // RS: TODO non-zero size
+
+        assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).isNull();
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onError(new IllegalStateException("boom"));
+        assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).isSameAs(test.error);
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancel();
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/FluxProcessorTest.java
@@ -25,10 +25,10 @@ import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.Assert;
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
+import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxProcessorTest {
@@ -250,4 +250,15 @@ public class FluxProcessorTest {
 		}
 	}
 
+	@Test
+	public void scanProcessor() {
+		FluxProcessor<String, String> test = DirectProcessor.<String>create().serialize();
+
+		assertThat(test.scan(Scannable.IntAttr.CAPACITY)).isEqualTo(16);
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).isNull();
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).hasMessage("boom");
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+	}
 }

--- a/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
+++ b/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
@@ -21,6 +21,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 import reactor.core.Disposable;
+import reactor.core.Scannable;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
@@ -203,4 +205,14 @@ public class FluxRefCountGraceTest {
 		publisher.complete();
 		assertThat(termination.get()).isEqualTo(SignalType.ON_COMPLETE);
 	}
+
+	@Test
+	public void scanMain() {
+		ConnectableFlux<Integer> parent = Flux.just(10).publish();
+		FluxRefCountGrace<Integer> test = new FluxRefCountGrace<Integer>(parent, 17, Duration.ofSeconds(1), Schedulers.single());
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(256);
+	}
+
 }

--- a/src/test/java/reactor/core/publisher/FluxRefCountTest.java
+++ b/src/test/java/reactor/core/publisher/FluxRefCountTest.java
@@ -233,8 +233,7 @@ public class FluxRefCountTest {
 	public void scanInner() {
 		Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, sub -> sub.request(100));
 		FluxRefCount<Integer> main = new FluxRefCount<Integer>(Flux.just(10).publish(), 17);
-		FluxRefCount.RefCountMonitor.RefCountInner<Integer> test =
-				new FluxRefCount.RefCountMonitor.RefCountInner<Integer>(actual, new FluxRefCount.RefCountMonitor<>(1, main));
+		FluxRefCount.RefCountInner<Integer> test = new FluxRefCount.RefCountInner<Integer>(actual, new FluxRefCount.RefCountMonitor<>(1, main));
 		Subscription sub = Operators.emptySubscription();
 		test.onSubscribe(sub);
 

--- a/src/test/java/reactor/core/publisher/FluxReplayTest.java
+++ b/src/test/java/reactor/core/publisher/FluxReplayTest.java
@@ -20,11 +20,17 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
 import reactor.core.Disposable;
 import reactor.core.Fuseable;
+import reactor.core.Scannable;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.scheduler.VirtualTimeScheduler;
@@ -83,7 +89,7 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 		vts = null;
 		VirtualTimeScheduler.reset();
 	}
-	
+
 	@Test
 	public void cacheFlux() {
 
@@ -277,4 +283,61 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 		boolean cancelled = ((FluxReplay.ReplaySubscriber) connected).cancelled;
 		assertThat(cancelled).isTrue();
 	}
+
+	@Test
+    public void scanMain() {
+        Flux<Integer> parent = Flux.just(1);
+        FluxReplay<Integer> test = new FluxReplay<>(parent, 25, 1000, Schedulers.single());
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(25);
+    }
+
+	@Test
+    public void scanInner() {
+		Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxReplay<Integer> main = new FluxReplay<>(Flux.just(1), 2, 1000, Schedulers.single());
+        FluxReplay.ReplayInner<Integer> test = new FluxReplay.ReplayInner<>(actual);
+        FluxReplay.ReplaySubscriber<Integer> parent = new FluxReplay.ReplaySubscriber<>(new FluxReplay.UnboundedReplayBuffer<>(10), main);
+        parent.trySubscribe(test);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(0); // RS: TODO non-zero size
+        test.request(35);
+        Assertions.assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(35);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.parent.terminate();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancel();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
+
+	@Test
+    public void scanSubscriber() {
+		FluxReplay<Integer> parent = new FluxReplay<>(Flux.just(1), 2, 1000, Schedulers.single());
+        FluxReplay.ReplaySubscriber<Integer> test = new FluxReplay.ReplaySubscriber<>(new FluxReplay.UnboundedReplayBuffer<>(10), parent);
+        Subscription sub = Operators.emptySubscription();
+        test.onSubscribe(sub);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(sub);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.CAPACITY)).isEqualTo(Integer.MAX_VALUE);
+        test.buffer.add(1);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        Assertions.assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).isNull();
+        test.onError(new IllegalStateException("boom"));
+        Assertions.assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).hasMessage("boom");
+        test.terminate();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancelled = true;
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
+++ b/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
@@ -19,7 +19,12 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
@@ -195,4 +200,34 @@ public class FluxRetryWhenTest {
 		            .expectComplete()
 		            .verify();
 	}
+
+	@Test
+    public void scanMainSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxRetryWhen.RetryWhenMainSubscriber<Integer> test =
+        		new FluxRetryWhen.RetryWhenMainSubscriber<>(actual, null, Flux.empty());
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        test.requested = 35;
+        Assertions.assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(35L);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancel();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
+
+	@Test
+    public void scanOtherSubscriber() {
+		Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxRetryWhen.RetryWhenMainSubscriber<Integer> main =
+        		new FluxRetryWhen.RetryWhenMainSubscriber<>(actual, null, Flux.empty());
+        FluxRetryWhen.RetryWhenOtherSubscriber test = new FluxRetryWhen.RetryWhenOtherSubscriber();
+        test.main = main;
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(main.otherArbiter);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(main);
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxScanSeedTest.java
+++ b/src/test/java/reactor/core/publisher/FluxScanSeedTest.java
@@ -19,11 +19,14 @@ package reactor.core.publisher;
 import java.util.Arrays;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxScanSeedTest extends FluxOperatorTest<String, String> {
 
@@ -148,4 +151,24 @@ public class FluxScanSeedTest extends FluxOperatorTest<String, String> {
 		  .assertNotComplete()
 		  .assertError(NullPointerException.class);
 	}
+
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxScanSeed.ScanSeedSubscriber<Integer, Integer> test = new FluxScanSeed.ScanSeedSubscriber<>(actual,
+        		(i, j) -> i + j, 0);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        test.requested = 35;
+        Assertions.assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(35);
+        test.value = 5;
+        Assertions.assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onComplete();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxSkipLastTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSkipLastTest.java
@@ -19,11 +19,14 @@ package reactor.core.publisher;
 import java.util.Arrays;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxSkipLastTest extends FluxOperatorTest<String, String> {
 	@Override
@@ -173,4 +176,17 @@ public class FluxSkipLastTest extends FluxOperatorTest<String, String> {
 		  .assertComplete();
 	}
 
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxSkipLast.SkipLastSubscriber<Integer> test = new FluxSkipLast.SkipLastSubscriber<>(actual, 7);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(7);
+        test.offer(1);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxSkipTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSkipTest.java
@@ -19,7 +19,12 @@ package reactor.core.publisher;
 import java.util.Arrays;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
@@ -124,4 +129,15 @@ public class FluxSkipTest extends FluxOperatorTest<String, String> {
 		            .expectNext("test", "test2", "test3")
 		            .verifyComplete();
 	}
+
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxSkip.SkipSubscriber<Integer> test = new FluxSkip.SkipSubscriber<>(actual, 7);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxSkipUntilTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSkipUntilTest.java
@@ -18,11 +18,14 @@ package reactor.core.publisher;
 import java.util.Arrays;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxSkipUntilTest extends FluxOperatorTest<String, String> {
 
@@ -64,4 +67,19 @@ public class FluxSkipUntilTest extends FluxOperatorTest<String, String> {
 		            .expectNext(5, 6, 7, 8, 9, 10)
 		            .verifyComplete();
 	}
+
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxSkipUntil.SkipUntilSubscriber<Integer> test = new FluxSkipUntil.SkipUntilSubscriber<>(actual, i -> true);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onComplete();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxSkipWhileTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSkipWhileTest.java
@@ -19,12 +19,15 @@ package reactor.core.publisher;
 import java.util.Arrays;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxSkipWhileTest extends FluxOperatorTest<String, String> {
 
@@ -196,4 +199,18 @@ public class FluxSkipWhileTest extends FluxOperatorTest<String, String> {
 		            .verifyComplete();
 	}
 
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxSkipWhile.SkipWhileSubscriber<Integer> test = new FluxSkipWhile.SkipWhileSubscriber<>(actual, i -> true);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onComplete();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxSourceTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSourceTest.java
@@ -16,8 +16,10 @@
 package reactor.core.publisher;
 
 import org.junit.Test;
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class FluxSourceTest {
@@ -68,4 +70,14 @@ public class FluxSourceTest {
 		StepVerifier.create(Mono.empty().flux())
 		            .verifyComplete();
 	}
+
+	@Test
+	public void scanMain() {
+		Flux<Integer> parent = Flux.range(1,  10);
+		FluxSource<Integer, Integer> test = new FluxSource<>(parent);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(-1);
+	}
+
 }

--- a/src/test/java/reactor/core/publisher/FluxTakeTest.java
+++ b/src/test/java/reactor/core/publisher/FluxTakeTest.java
@@ -420,15 +420,15 @@ public class FluxTakeTest {
 
 	@SuppressWarnings("unchecked")
 	void assertTrackableBeforeOnSubscribe(InnerOperator t){
-		assertThat(t.scan(Scannable.Attr.TERMINATED, Boolean.class)).isFalse();
+		assertThat(t.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
 	}
 
 	void assertTrackableAfterOnSubscribe(InnerOperator t){
-		assertThat(t.scan(Scannable.Attr.TERMINATED, Boolean.class)).isFalse();
+		assertThat(t.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
 	}
 
 	void assertTrackableAfterOnComplete(InnerOperator t){
-		assertThat(t.scan(Scannable.Attr.TERMINATED, Boolean.class)).isTrue();
+		assertThat(t.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
 	}
 
 	@Test

--- a/src/test/java/reactor/core/publisher/FluxTakeUntilPredicateTest.java
+++ b/src/test/java/reactor/core/publisher/FluxTakeUntilPredicateTest.java
@@ -15,7 +15,12 @@
  */
 package reactor.core.publisher;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
 
 public class FluxTakeUntilPredicateTest {
@@ -155,4 +160,19 @@ public class FluxTakeUntilPredicateTest {
 
 	}
 
+	@Test
+    public void scanPredicateSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxTakeUntil.TakeUntilPredicateSubscriber<Integer> test =
+        		new FluxTakeUntil.TakeUntilPredicateSubscriber<>(actual, i -> true);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onComplete();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxTakeWhileTest.java
+++ b/src/test/java/reactor/core/publisher/FluxTakeWhileTest.java
@@ -16,7 +16,12 @@
 
 package reactor.core.publisher;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
@@ -166,4 +171,20 @@ public class FluxTakeWhileTest {
 		            .expectNext("test")
 		            .verifyComplete();
 	}
+
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxTakeWhile.TakeWhileSubscriber<Integer> test =
+        		new FluxTakeWhile.TakeWhileSubscriber<>(actual, i -> true);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onComplete();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -18,8 +18,8 @@ package reactor.core.publisher;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -27,14 +27,16 @@ import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.util.concurrent.QueueSupplier;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuple3;
-import reactor.util.function.Tuple4;
 import reactor.util.function.Tuple7;
 import reactor.util.function.Tuples;
 
@@ -1271,4 +1273,84 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 		            .expectNext(28)
 		            .verifyComplete();
 	}
+
+	@Test
+    public void scanCoordinator() {
+		Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+		FluxZip.ZipCoordinator<Integer, Integer> test = new FluxZip.ZipCoordinator<Integer, Integer>(actual,
+				i -> 5, 123, QueueSupplier.unbounded(), 345);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        test.requested = 35;
+        Assertions.assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(35);
+
+        Assertions.assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).isNull();
+        test.error = new IllegalStateException("boom");
+        Assertions.assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).hasMessage("boom");
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancel();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
+
+	@Test
+    public void scanInner() {
+		Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+		FluxZip.ZipCoordinator<Integer, Integer> main = new FluxZip.ZipCoordinator<Integer, Integer>(actual,
+				i -> 5, 123, QueueSupplier.unbounded(), 345);
+		FluxZip.ZipInner<Integer> test = new FluxZip.ZipInner<>(main, 234, 1, QueueSupplier.unbounded());
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(main);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(234);
+        test.queue = new ConcurrentLinkedQueue<>();
+        test.queue.offer(67);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.queue.clear();
+        test.onComplete();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancel();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
+
+
+	@Test
+    public void scanSingleCoordinator() {
+		Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+		FluxZip.ZipSingleCoordinator<Integer, Integer> test =
+				new FluxZip.ZipSingleCoordinator<Integer, Integer>(actual, new Object[1], 1, i -> 5);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+        test.wip = 1;
+        Assertions.assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.wip = 0;
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancel();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
+
+	@Test
+    public void scanSingleSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxZip.ZipSingleCoordinator<Integer, Integer> main =
+				new FluxZip.ZipSingleCoordinator<Integer, Integer>(actual, new Object[1], 1, i -> 5);
+        FluxZip.ZipSingleSubscriber<Integer> test = new FluxZip.ZipSingleSubscriber<>(main, 0);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(main);
+        test.onNext(7);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -1096,9 +1096,9 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 			                        assertInnerSubscriberBefore(ref.get());
 		                        }), 0)
 		            .then(() -> assertThat(ref.get()
-		                                      .scan(Scannable.Attr.BUFFERED)).isEqualTo(3))
+		                                      .scan(Scannable.IntAttr.BUFFERED)).isEqualTo(3))
 		            .then(() -> assertThat(ref.get()
-		                                      .scan(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE))
+		                                      .scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE))
 		            .then(() -> assertThat(ref.get()
 		                                      .inners()).hasSize(3))
 		            .thenCancel()
@@ -1113,9 +1113,9 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 		                                                               .findFirst()
 		                                                               .get();
 
-		assertThat(s.scan(Scannable.Attr.TERMINATED, Boolean.class)).isFalse();
-		assertThat(s.scan(Scannable.Attr.BUFFERED)).isEqualTo(0);
-		assertThat(s.scan(Scannable.Attr.CANCELLED, Boolean.class)).isFalse();
+		assertThat(s.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(s.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(0);
+		assertThat(s.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
 	}
 
 	@SuppressWarnings("unchecked")
@@ -1124,9 +1124,9 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 		                                                               .findFirst()
 		                                                               .get();
 
-		assertThat(s.scan(Scannable.Attr.TERMINATED, Boolean.class)).isTrue();
-		assertThat(s.scan(Scannable.Attr.BUFFERED)).isEqualTo(1);
-		assertThat(s.scan(Scannable.Attr.CANCELLED, Boolean.class)).isTrue();
+		assertThat(s.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+		assertThat(s.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
+		assertThat(s.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
 
 		Hooks.onNextDropped(v -> {
 		});
@@ -1158,9 +1158,9 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 		            .then(() -> assertThat(ref.get()
 		                                      .inners().count()).isEqualTo(3))
 		            .then(() -> assertThat(ref.get()
-		                                      .scan(Scannable.Attr.ERROR)).isNull())
+		                                      .scan(Scannable.ThrowableAttr.ERROR)).isNull())
 		            .then(() -> assertThat(ref.get()
-		                                      .scan(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(0L))
+		                                      .scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(0L))
 		            .thenCancel()
 		            .verify();
 
@@ -1180,9 +1180,9 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 					ref.get()
 					   .cancel();
 					assertThat(ref.get()
-					              .scan(Scannable.Attr.CANCELLED, Boolean.class)).isTrue();
+					              .scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
 					assertThat(ref.get()
-					              .scanOrDefault(Scannable.Attr.TERMINATED, false));
+					              .scanOrDefault(Scannable.BooleanAttr.TERMINATED, false));
 					return Flux.just(3);
 				}),
 				Flux.just(3)
@@ -1195,9 +1195,9 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 		            .then(() -> assertThat(ref.get()
 		                                      .inners()).hasSize(3))
 		            .then(() -> assertThat(ref.get()
-		                                      .scan(Scannable.Attr.ERROR)).isNull())
+		                                      .scan(Scannable.ThrowableAttr.ERROR)).isNull())
 		            .then(() -> assertThat(ref.get()
-		                                      .scan(Scannable.Attr
+		                                      .scan(Scannable.LongAttr
 				                                      .REQUESTED_FROM_DOWNSTREAM)).isEqualTo(0L))
 		            .thenCancel()
 		            .verify();
@@ -1211,10 +1211,10 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 		                                         .iterator()
 		                                         .next();
 
-		assertThat(s.scan(Scannable.Attr.TERMINATED, Boolean.class)).isFalse();
-		assertThat(s.scan(Scannable.Attr.PREFETCH)).isEqualTo(123);
-		assertThat(s.scan(Scannable.Attr.BUFFERED)).isEqualTo(0);
-		assertThat(s.scan(Scannable.Attr.CANCELLED, Boolean.class)).isFalse();
+		assertThat(s.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(s.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(123);
+		assertThat(s.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(0);
+		assertThat(s.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
 	}
 
 	@SuppressWarnings("unchecked")
@@ -1223,10 +1223,10 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 		                                         .iterator()
 		                                         .next();
 
-		assertThat(s.scan(Scannable.Attr.TERMINATED, Boolean.class)).isFalse();
-		assertThat(s.scan(Scannable.Attr.PREFETCH)).isEqualTo(123);
+		assertThat(s.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(s.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(123);
 		assertThat(c.inners()).hasSize(3);
-		assertThat(s.scan(Scannable.Attr.CANCELLED, Boolean.class)).isTrue();
+		assertThat(s.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
 	}
 
 	@Test

--- a/src/test/java/reactor/core/publisher/InnerProducerTest.java
+++ b/src/test/java/reactor/core/publisher/InnerProducerTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import reactor.core.Scannable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InnerProducerTest {
+
+	@Test
+	public void scanDefaultMethod() {
+		Subscriber<String> actual = new LambdaSubscriber<>(null, null, null, null);
+		InnerProducer<String> test = new InnerProducer<String>() {
+			@Override
+			public Subscriber<? super String> actual() {
+				return actual;
+			}
+
+			@Override
+			public void request(long n) { }
+
+			@Override
+			public void cancel() { }
+		};
+
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+	}
+}

--- a/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
@@ -261,6 +261,24 @@ public class LambdaMonoSubscriberTest {
 		Assertions.assertThat(cancelCount.get()).isEqualTo(1);
 	}
 
+	@Test
+	public void scan() {
+		LambdaMonoSubscriber<String> test = new LambdaMonoSubscriber<>(null, null, null, null);
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		Assertions.assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+
+		Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+		test.dispose();
+
+		Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+		Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
+
 	private static class TestSubscription implements Subscription {
 
 		volatile boolean isCancelled = false;
@@ -276,5 +294,4 @@ public class LambdaMonoSubscriberTest {
 			this.isCancelled = true;
 		}
 	}
-
 }

--- a/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
@@ -189,12 +189,12 @@ public class LambdaMonoSubscriberTest {
 		assertTrue(MonoSource.wrap(s -> {
 			assertTrue(s instanceof LambdaMonoSubscriber);
 			LambdaMonoSubscriber<?> bfs = (LambdaMonoSubscriber<?>)s;
-			assertTrue(bfs.scan(Scannable.Attr.PREFETCH, Integer.class) == Integer.MAX_VALUE);
-			assertFalse(bfs.scan(Scannable.Attr.TERMINATED, Boolean.class));
+			assertTrue(bfs.scan(Scannable.IntAttr.PREFETCH) == Integer.MAX_VALUE);
+			assertFalse(bfs.scan(Scannable.BooleanAttr.TERMINATED));
 			bfs.onSubscribe(Operators.emptySubscription());
 			bfs.onSubscribe(Operators.emptySubscription()); // noop
 			s.onComplete();
-			assertTrue(bfs.scan(Scannable.Attr.TERMINATED, Boolean.class));
+			assertTrue(bfs.scan(Scannable.BooleanAttr.TERMINATED));
 			bfs.dispose();
 			bfs.dispose();
 		}).subscribe(s -> {}, null, () -> {}).isDisposed());
@@ -214,7 +214,7 @@ public class LambdaMonoSubscriberTest {
 				s.onComplete();
 				s.onError(new Exception("test2"));
 				s.onNext("test2");
-				assertTrue(bfs.scan(Scannable.Attr.TERMINATED, Boolean.class));
+				assertTrue(bfs.scan(Scannable.BooleanAttr.TERMINATED));
 				bfs.dispose();
 			})
 			          .subscribe(s -> {

--- a/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
+++ b/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
@@ -329,7 +329,7 @@ public class MonoDelayElementTest {
 					MonoDelayElement.DelayElementSubscriber delayedSubscriber =
 							(MonoDelayElement.DelayElementSubscriber) s;
 
-					upstream.set(delayedSubscriber.scan(Scannable.Attr.PARENT));
+					upstream.set(delayedSubscriber.scan(Scannable.ScannableAttr.PARENT));
 				}))
 		            .expectSubscription()
 		            .expectNoEvent(Duration.ofSeconds(2))

--- a/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
+++ b/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
@@ -314,4 +314,51 @@ public class MonoFilterWhenTest {
 		assertThat(terminated).isTrue();
 	}
 
+	@Test
+	public void scanSubscriber() {
+		Subscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoFilterWhen.MonoFilterWhenSubscriber<String> test = new MonoFilterWhen.MonoFilterWhenSubscriber<>(
+				actual, s -> Mono.just(false));
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+		//TERMINATED IS COVERED BY TEST ABOVE
+
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
+
+	@Test
+	public void scanFilterWhenInner() {
+		Subscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoFilterWhen.MonoFilterWhenSubscriber<String> main = new MonoFilterWhen.MonoFilterWhenSubscriber<>(
+				actual, s -> Mono.just(false));
+		MonoFilterWhen.FilterWhenInner test = new MonoFilterWhen.FilterWhenInner(main, true);
+
+		Subscription innerSubscription = Operators.emptySubscription();
+		test.onSubscribe(innerSubscription);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(main);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(innerSubscription);
+
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+		assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(1L);
+
+
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+		assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(0L);
+
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
+
 }

--- a/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
+++ b/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
@@ -305,12 +305,12 @@ public class MonoFilterWhenTest {
 
 		assertThat(subscriber.get()).isNotNull()
 	                                .isInstanceOf(Scannable.class);
-		Boolean terminated = ((Scannable) subscriber.get()).scan(Scannable.Attr.TERMINATED, Boolean.class);
+		Boolean terminated = ((Scannable) subscriber.get()).scan(Scannable.BooleanAttr.TERMINATED);
 		assertThat(terminated).isFalse();
 
 		filter.emit(Boolean.TRUE);
 
-		terminated = ((Scannable) subscriber.get()).scan(Scannable.Attr.TERMINATED, Boolean.class);
+		terminated = ((Scannable) subscriber.get()).scan(Scannable.BooleanAttr.TERMINATED);
 		assertThat(terminated).isTrue();
 	}
 

--- a/src/test/java/reactor/core/publisher/MonoFlatMapTest.java
+++ b/src/test/java/reactor/core/publisher/MonoFlatMapTest.java
@@ -1,33 +1,80 @@
 package reactor.core.publisher;
 
 import org.junit.Test;
-
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Scannable;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class MonoFlatMapTest {
 
-    @Test
-    public void normalHidden() {
-        AssertSubscriber<Integer> ts = AssertSubscriber.create();
-        
-        Mono.just(1).hide().flatMap(v -> Mono.just(2).hide()).subscribe(ts);
-        
-        ts.assertValues(2)
-        .assertComplete()
-        .assertNoError();
-    }
+	@Test
+	public void normalHidden() {
+		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-    @Test
-    public void cancel() {
-        TestPublisher<String> cancelTester = TestPublisher.create();
+		Mono.just(1).hide().flatMap(v -> Mono.just(2).hide()).subscribe(ts);
 
-        MonoProcessor<Integer> processor = cancelTester.mono()
-                                                       .flatMap(s -> Mono.just(s.length()))
-                                                       .toProcessor();
-        processor.subscribe();
-        processor.cancel();
+		ts.assertValues(2)
+		.assertComplete()
+		.assertNoError();
+	}
 
-        cancelTester.assertCancelled();
-    }
+	@Test
+	public void cancel() {
+		TestPublisher<String> cancelTester = TestPublisher.create();
+
+		MonoProcessor<Integer> processor = cancelTester.mono()
+													   .flatMap(s -> Mono.just(s.length()))
+													   .toProcessor();
+		processor.subscribe();
+		processor.cancel();
+
+		cancelTester.assertCancelled();
+	}
+
+	@Test
+	public void scanMain() {
+		Subscriber<Integer> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoFlatMap.ThenMapMain<String, Integer> test = new MonoFlatMap.ThenMapMain<>(
+				actual, s -> Mono.just(s.length()));
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
+
+	@Test
+	public void scanInner() {
+		Subscriber<Integer> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoFlatMap.ThenMapMain<String, Integer> main = new MonoFlatMap.ThenMapMain<>(actual, s -> Mono.just(s.length()));
+		MonoFlatMap.ThenMapInner<Integer> test = new MonoFlatMap.ThenMapInner<>(main);
+		Subscription innerSubscription = Operators.emptySubscription();
+		test.onSubscribe(innerSubscription);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(innerSubscription);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(main);
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
 }

--- a/src/test/java/reactor/core/publisher/MonoHasElementsTest.java
+++ b/src/test/java/reactor/core/publisher/MonoHasElementsTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
@@ -190,4 +191,95 @@ public class MonoHasElementsTest {
 
 		assertThat(cancelled.get()).isTrue();
 	}
+
+	@Test
+	public void scanHasElements() {
+		Subscriber<? super Boolean> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoHasElements.HasElementsSubscriber<String> test = new MonoHasElements.HasElementsSubscriber<>(actual);
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+		test.onComplete();
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+	}
+
+	@Test
+	public void scanHasElementsNoTerminatedOnError() {
+		Subscriber<? super Boolean> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoHasElements.HasElementsSubscriber<String> test = new MonoHasElements.HasElementsSubscriber<>(actual);
+
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+	}
+
+	@Test
+	public void scanHasElementsCancelled() {
+		Subscriber<? super Boolean> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoHasElements.HasElementsSubscriber<String> test = new MonoHasElements.HasElementsSubscriber<>(actual);
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
+
+	@Test
+	public void scanHasElement() {
+		Subscriber<? super Boolean> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoHasElements.HasElementSubscriber<String> test = new MonoHasElements.HasElementSubscriber<>(actual);
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+		test.onComplete();
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+	}
+
+	@Test
+	public void scanHasElementNoTerminatedOnError() {
+		Subscriber<? super Boolean> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoHasElements.HasElementSubscriber<String> test = new MonoHasElements.HasElementSubscriber<>(actual);
+
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+	}
+
+	@Test
+	public void scanHasElementCancelled() {
+		Subscriber<? super Boolean> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoHasElements.HasElementSubscriber<String> test = new MonoHasElements.HasElementSubscriber<>(actual);
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
+
 }

--- a/src/test/java/reactor/core/publisher/MonoHasElementsTest.java
+++ b/src/test/java/reactor/core/publisher/MonoHasElementsTest.java
@@ -141,7 +141,7 @@ public class MonoHasElementsTest {
 				    });
 
 		assertThat(sub.get()).isInstanceOf(MonoHasElements.HasElementSubscriber.class);
-		assertThat(Scannable.from(sub.get()).scan(Scannable.Attr.PARENT).getClass()).isEqualTo(FluxHide.HideSubscriber.class);
+		assertThat(Scannable.from(sub.get()).scan(Scannable.ScannableAttr.PARENT).getClass()).isEqualTo(FluxHide.HideSubscriber.class);
 	}
 
 	@Test

--- a/src/test/java/reactor/core/publisher/MonoIgnoreEmptyTest.java
+++ b/src/test/java/reactor/core/publisher/MonoIgnoreEmptyTest.java
@@ -17,7 +17,12 @@
 package reactor.core.publisher;
 
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoIgnoreEmptyTest {
 
@@ -33,6 +38,17 @@ public class MonoIgnoreEmptyTest {
 		StepVerifier.create(Flux.just(1)
 		                        .then())
 		            .expectComplete();
+	}
+
+	@Test
+	public void scanSubscriber() {
+		Subscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoIgnoreEmpty.IgnoreElementsSubscriber<String> test = new MonoIgnoreEmpty.IgnoreElementsSubscriber<>(actual);
+		Subscription sub = Operators.emptySubscription();
+		test.onSubscribe(sub);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(sub);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
 	}
 
 }

--- a/src/test/java/reactor/core/publisher/MonoPeekTerminalTest.java
+++ b/src/test/java/reactor/core/publisher/MonoPeekTerminalTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Scannable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MonoPeekTerminalTest {
+
+	@Test
+	public void scanSubscriber() {
+		Subscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoPeekTerminal<String> main = new MonoPeekTerminal<>(Mono.just("foo"), null, null, null);
+		MonoPeekTerminal.MonoTerminalPeekSubscriber<String> test = new MonoPeekTerminal.MonoTerminalPeekSubscriber<>(
+				actual, main);
+		Subscription sub = Operators.emptySubscription();
+		test.onSubscribe(sub);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(sub);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+	}
+
+}

--- a/src/test/java/reactor/core/publisher/MonoReduceSeedTest.java
+++ b/src/test/java/reactor/core/publisher/MonoReduceSeedTest.java
@@ -21,8 +21,13 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Scannable;
 import reactor.test.publisher.ReduceOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoReduceSeedTest extends ReduceOperatorTest<String, String> {
 
@@ -148,6 +153,29 @@ public class MonoReduceSeedTest extends ReduceOperatorTest<String, String> {
 		ts.assertNoValues()
 		  .assertNotComplete()
 		  .assertError(NullPointerException.class);
+	}
+
+
+	@Test
+	public void scanSubscriber() {
+		Subscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoReduceSeed.ReduceSeedSubscriber<Integer, String> test = new MonoReduceSeed.ReduceSeedSubscriber<>(
+				actual, (s, i) -> s + i, "foo");
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
 	}
 
 }

--- a/src/test/java/reactor/core/publisher/MonoSourceTest.java
+++ b/src/test/java/reactor/core/publisher/MonoSourceTest.java
@@ -16,8 +16,10 @@
 package reactor.core.publisher;
 
 import org.junit.Test;
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class MonoSourceTest {
@@ -85,5 +87,13 @@ public class MonoSourceTest {
 	public void onAssemblyDescription() {
 		String monoOnAssemblyStr = Mono.just(1).checkpoint("onAssemblyDescription").toString();
 		assertTrue("Description not included: " + monoOnAssemblyStr, monoOnAssemblyStr.contains("\"description\" : \"onAssemblyDescription\""));
+	}
+
+	@Test
+	public void scanSubscriber() {
+		Flux<String> source = Flux.just("foo");
+		MonoSource<String, Integer> test = new MonoSource<>(source);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(source);
 	}
 }

--- a/src/test/java/reactor/core/publisher/MonoStreamCollectorTest.java
+++ b/src/test/java/reactor/core/publisher/MonoStreamCollectorTest.java
@@ -19,39 +19,72 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoStreamCollectorTest {
 
-    @Test
-    public void collectToList() {
-        Mono<List<Integer>> source = Flux.range(1, 5).collect(Collectors.toList());
+	@Test
+	public void collectToList() {
+		Mono<List<Integer>> source = Flux.range(1, 5).collect(Collectors.toList());
 
-        for (int i = 0; i < 5; i++) {
-            AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
-            source.subscribe(ts);
-    
-            ts.assertValues(Arrays.asList(1, 2, 3, 4, 5))
-            .assertNoError()
-            .assertComplete();
-        }
-    }
+		for (int i = 0; i < 5; i++) {
+			AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
+			source.subscribe(ts);
 
-    @Test
-    public void collectToSet() {
-        Mono<Set<Integer>> source = Flux.just(1).repeat(5).collect(Collectors.toSet());
+			ts.assertValues(Arrays.asList(1, 2, 3, 4, 5))
+			.assertNoError()
+			.assertComplete();
+		}
+	}
 
-        for (int i = 0; i < 5; i++) {
-            AssertSubscriber<Set<Integer>> ts = AssertSubscriber.create();
-            source.subscribe(ts);
-    
-            ts.assertValues(Collections.singleton(1))
-            .assertNoError()
-            .assertComplete();
-        }
-    }
+	@Test
+	public void collectToSet() {
+		Mono<Set<Integer>> source = Flux.just(1).repeat(5).collect(Collectors.toSet());
+
+		for (int i = 0; i < 5; i++) {
+			AssertSubscriber<Set<Integer>> ts = AssertSubscriber.create();
+			source.subscribe(ts);
+
+			ts.assertValues(Collections.singleton(1))
+			.assertNoError()
+			.assertComplete();
+		}
+	}
+
+	@Test
+	public void scanStreamCollectorSubscriber() {
+		Subscriber<List<String>> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		Collector<String, Integer, List<String>> collector = (Collector<String, Integer, List<String>>) Collectors.<String>toList();
+		MonoStreamCollector.StreamCollectorSubscriber<String, Integer, List<String>> test = new MonoStreamCollector.StreamCollectorSubscriber<>(
+				actual,
+				1,
+				collector.accumulator(),
+				collector.finisher());
+		Subscription parent = Operators.emptySubscription();
+
+		test.onSubscribe(parent);
+
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
 
 }

--- a/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
@@ -59,6 +59,7 @@ public class SerializedSubscriberTest {
 		test.tail.count = Integer.MAX_VALUE;
 
 		assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(Integer.MAX_VALUE);
+		assertThat(test.scan(Scannable.LongAttr.LARGE_BUFFERED)).isNull();
 	}
 
 }

--- a/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+import reactor.core.Scannable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SerializedSubscriberTest {
+
+	@Test
+	public void scanSerializedSubscriber() {
+		LambdaSubscriber<String> actual = new LambdaSubscriber<>(null, e -> { }, null, null);
+		SerializedSubscriber<String> test = new SerializedSubscriber<>(actual);
+		Subscription subscription = Operators.emptySubscription();
+		test.onSubscribe(subscription);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(subscription);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+		assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isZero();
+		assertThat(test.scan(Scannable.IntAttr.CAPACITY)).isEqualTo(SerializedSubscriber.LinkedArrayNode.DEFAULT_CAPACITY);
+
+		assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).isNull();
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).hasMessage("boom");
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
+
+	@Test
+	public void scanSerializedSubscriberMaxBuffered() {
+		LambdaSubscriber<String> actual = new LambdaSubscriber<>(null, e -> { }, null, null);
+		SerializedSubscriber<String> test = new SerializedSubscriber<>(actual);
+
+		test.tail = new SerializedSubscriber.LinkedArrayNode<>("");
+		test.tail.count = Integer.MAX_VALUE;
+
+		assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(Integer.MAX_VALUE);
+	}
+
+}

--- a/src/test/java/reactor/core/publisher/SignalLoggerTests.java
+++ b/src/test/java/reactor/core/publisher/SignalLoggerTests.java
@@ -19,10 +19,12 @@ package reactor.core.publisher;
 import java.util.Collection;
 import java.util.logging.Level;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.Fuseable;
 import reactor.core.Fuseable.SynchronousSubscription;
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.util.Logger;
 import reactor.util.Loggers;
@@ -98,6 +100,14 @@ public class SignalLoggerTests {
 		};
 
 		assertThat(sl.subscriptionAsString(s), is("SignalLoggerTests$1"));
+	}
+
+	@Test
+	public void scanSignalLogger() {
+		Mono<String> source = Mono.empty();
+		SignalLogger<String> sl = new SignalLogger<>(source, null, null, false);
+
+		Assertions.assertThat(sl.scan(Scannable.ScannableAttr.PARENT)).isSameAs(source);
 	}
 
 	//=========================================================

--- a/src/test/java/reactor/core/publisher/TopicProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/TopicProcessorTest.java
@@ -710,7 +710,34 @@ public class TopicProcessorTest {
 		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
 	}
 
-	//TODO BUFFERED
+
+	@Test
+	public void scanInnerBufferedSmallHasIntRealValue() {
+		TopicProcessor<String> main = TopicProcessor.create("name", 16);
+		RingBuffer.Sequence sequence = RingBuffer.newSequence(123);
+		Subscriber<String> sub = new LambdaSubscriber<>(null, e -> {}, null, null);
+		TopicProcessor.TopicInner<String> test = new TopicProcessor.TopicInner<>(main, sequence, sub);
+
+		main.ringBuffer.getSequencer().cursor.set(Integer.MAX_VALUE + 5L);
+		test.sequence.set(6L);
+
+		assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(Integer.MAX_VALUE - 1);
+		assertThat(test.scan(Scannable.LongAttr.LARGE_BUFFERED)).isEqualTo(Integer.MAX_VALUE - 1L);
+	}
+
+	@Test
+	public void scanInnerBufferedLargeHasIntMinValue() {
+		TopicProcessor<String> main = TopicProcessor.create("name", 16);
+		RingBuffer.Sequence sequence = RingBuffer.newSequence(123);
+		Subscriber<String> sub = new LambdaSubscriber<>(null, e -> {}, null, null);
+		TopicProcessor.TopicInner<String> test = new TopicProcessor.TopicInner<>(main, sequence, sub);
+
+		main.ringBuffer.getSequencer().cursor.set(Integer.MAX_VALUE + 5L);
+		test.sequence.set(2L);
+
+		assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(Integer.MIN_VALUE);
+		assertThat(test.scan(Scannable.LongAttr.LARGE_BUFFERED)).isEqualTo(Integer.MAX_VALUE + 3L);
+	}
 
 	private void assertProcessor(TopicProcessor<Integer> processor,
 			boolean shared,

--- a/src/test/java/reactor/test/publisher/BaseOperatorTest.java
+++ b/src/test/java/reactor/test/publisher/BaseOperatorTest.java
@@ -601,13 +601,10 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 					            catch (Exception e) {
 					            }
 					            if (Scannable.from(qs)
-					                         .scan(Scannable.Attr.ERROR) != null) {
+					                         .scan(Scannable.ThrowableAttr.ERROR) != null) {
 						            if (scenario.producerError != null) {
-							            assertThat(Scannable.from(qs)
-							                                .scan(Scannable.Attr.ERROR,
-									                                Throwable.class)).hasMessage(
-									            scenario.producerError
-									                    .getMessage());
+							            assertThat(Scannable.from(qs).scan(Scannable.ThrowableAttr.ERROR))
+									            .hasMessage(scenario.producerError.getMessage());
 						            }
 						            if (up.actual() != qs || scenario.prefetch() == -1) {
 							            qs.size(); //touch undeterministic
@@ -656,12 +653,10 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 						                            assertThat(qs.size()).isEqualTo(up.size());
 					                            }
 					                            if (Scannable.from(qs)
-					                                         .scan(Scannable.Attr.ERROR) != null) {
+					                                         .scan(Scannable.ThrowableAttr.ERROR) != null) {
 						                            if (scenario.producerError != null) {
-							                            assertThat(Scannable.from(qs)
-							                                                .scan(Scannable.Attr.ERROR,
-									                                                Throwable.class)).hasMessage(
-									                            scenario.producerError.getMessage());
+							                            assertThat(Scannable.from(qs).scan(Scannable.ThrowableAttr.ERROR))
+									                            .hasMessage(scenario.producerError.getMessage());
 						                            }
 						                            if (up.actual() != qs || scenario.prefetch() == -1) {
 							                            qs.size(); //touch undeterministic
@@ -939,16 +934,16 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 	final void touchInner(Object t){
 		if(t == null) return;
 		Scannable o = Scannable.from(t);
-		o.scan(Scannable.Attr.ACTUAL);
-		o.scan(Scannable.Attr.BUFFERED);
-		o.scan(Scannable.Attr.CANCELLED);
-		o.scan(Scannable.Attr.CAPACITY);
-		o.scan(Scannable.Attr.DELAY_ERROR);
-		o.scan(Scannable.Attr.ERROR);
-		o.scan(Scannable.Attr.PREFETCH);
-		o.scan(Scannable.Attr.PARENT);
-		o.scan(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM);
-		o.scan(Scannable.Attr.TERMINATED);
+		o.scan(Scannable.ScannableAttr.ACTUAL);
+		o.scan(Scannable.IntAttr.BUFFERED);
+		o.scan(Scannable.BooleanAttr.CANCELLED);
+		o.scan(Scannable.IntAttr.CAPACITY);
+		o.scan(Scannable.BooleanAttr.DELAY_ERROR);
+		o.scan(Scannable.ThrowableAttr.ERROR);
+		o.scan(Scannable.IntAttr.PREFETCH);
+		o.scan(Scannable.ScannableAttr.PARENT);
+		o.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM);
+		o.scan(Scannable.BooleanAttr.TERMINATED);
 		o.inners();
 	}
 
@@ -997,9 +992,8 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 		                                                  .ifPresent(t -> {
 			                                                  ref.set(t);
 			                                                 if (scenario.prefetch() != -1) {
-				                                                  assertThat(t.scan(
-						                                                  Scannable.Attr.PREFETCH)).isEqualTo(
-						                                                  scenario.prefetch());
+				                                                  assertThat(t.scan(Scannable.IntAttr.PREFETCH))
+						                                                  .isEqualTo(scenario.prefetch());
 			                                                  }
 		                                                  }));
 
@@ -1015,8 +1009,8 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 		return Flux.from(f)
 		           .doOnSubscribe(parent -> {
 			           Scannable t = Scannable.from(parent);
-			           assertThat(t.scan(Scannable.Attr.ERROR)).isNull();
-			           assertThat(t.scanOrDefault(Scannable.Attr.TERMINATED, false)).isFalse();
+			           assertThat(t.scan(Scannable.ThrowableAttr.ERROR)).isNull();
+			           assertThat(t.scanOrDefault(Scannable.BooleanAttr.TERMINATED, false)).isFalse();
 
 			           //noop path
 			           if (parent instanceof Subscriber) {
@@ -1030,7 +1024,7 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 			           if (ref.get() != null) {
 				           Scannable t = ref.get();
 				           if (scenario.shouldAssertPostTerminateState()) {
-					           assertThat(t.scanOrDefault(Scannable.Attr.TERMINATED, true)).isTrue();
+					           assertThat(t.scanOrDefault(Scannable.BooleanAttr.TERMINATED, true)).isTrue();
 				           }
 				           touchTreeState(ref.get());
 			           }
@@ -1041,11 +1035,11 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 	final PO fluxState(OperatorScenario<I, PI, O, PO> scenario, boolean conditional) {
 		Flux<I> source = Flux.from(s -> {
 			Scannable t = Scannable.from(s);
-			assertThat(t.scan(Scannable.Attr.ERROR)).isNull();
-			assertThat(t.scanOrDefault(Scannable.Attr.TERMINATED, false)).isFalse();
+			assertThat(t.scan(Scannable.ThrowableAttr.ERROR)).isNull();
+			assertThat(t.scanOrDefault(Scannable.BooleanAttr.TERMINATED, false)).isFalse();
 
 				if (scenario.prefetch() != -1) {
-					assertThat(t.scan(Scannable.Attr.PREFETCH)).isEqualTo(scenario.prefetch());
+					assertThat(t.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(scenario.prefetch());
 				}
 
 			touchTreeState(s);
@@ -1056,7 +1050,7 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 			s.onComplete();
 			touchTreeState(s);
 			if (scenario.shouldAssertPostTerminateState()) {
-				assertThat(t.scanOrDefault(Scannable.Attr.TERMINATED, true)).isTrue();
+				assertThat(t.scanOrDefault(Scannable.BooleanAttr.TERMINATED, true)).isTrue();
 			}
 		});
 


### PR DESCRIPTION
See #504. Concept of the change is in `Scannable`, the rest is manual refactoring from `switch` on a single `enum` to `if (key == xxx)` lines using several enums.

For easier implementation for now the `scanUnsafe` method is the single one to be implemented by components but it does not ensure type safety :(

Categorizing attributes in type-specific enums allows to let each enum define a meaningful default value that is exploited by `scan`. Also, this removes the need for `scan` to ask for a `Class` (or a `defaultValue`).

This is still being explored, and I'm open to even better suggestions to make all of this type-safe, but the goal was to limit the amount of manual refactoring in all 162 Scannables (which was already quite large).

I'm also wondering if the global default should be applied at all for `scanOrDefault` (current resolution order: component specific value from `scanUnsafe`, global default if null, provided default if still null...).