### PR TITLE
scheduler based on fork join pool

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/ForkJoinPoolScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ForkJoinPoolScheduler.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.scheduler;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
+
+import reactor.core.Disposable;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+final class ForkJoinPoolScheduler implements Scheduler {
+
+	private final ForkJoinPool             pool;
+	private final ScheduledExecutorService scheduler;
+	/**
+	 * Construct a new instance
+	 *
+	 * @param parallelism Parallelism. Number of fork-join pool threads. See {@link
+	 * ForkJoinPool}
+	 * @param workerThreadFactory Thread factory for fork-join worker threads
+	 * @param threadFactory Thread factory to use for constructing the single threaded
+	 * {@link ScheduledExecutorService} used for time-based scheduling.
+	 */
+	ForkJoinPoolScheduler(int parallelism,
+			ForkJoinPool.ForkJoinWorkerThreadFactory workerThreadFactory,
+			ThreadFactory threadFactory) {
+		pool = new ForkJoinPool(parallelism,
+				workerThreadFactory,
+				this::uncaughtException,
+				true);
+		scheduler = new ScheduledThreadPoolExecutor(1, threadFactory);
+	}
+
+	@Override
+	public Scheduler.Worker createWorker() {
+		return new Worker(pool, scheduler);
+	}
+
+	@Override
+	public void dispose() {
+		Schedulers.executorServiceShutdown(pool, FORK_JOIN_POOL);
+		Schedulers.executorServiceShutdown(scheduler, FORK_JOIN_POOL_TIMER);
+	}
+
+	@Override
+	public boolean isDisposed() {
+		return pool.isShutdown();
+	}
+
+	@Override
+	public Disposable schedule(Runnable runnable) {
+		try {
+			return new DisposableForkJoinTask(pool.submit(runnable));
+		}
+		catch (RejectedExecutionException ignored) {
+			return REJECTED;
+		}
+	}
+
+	@Override
+	public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
+		if (delay == 0) {
+			return schedule(task);
+		}
+		PendingTask pendingTask = new PendingTask(task, NO_PARENT);
+		ScheduledFuture<?> future =
+				scheduler.schedule(new ExecuteTask(pendingTask, pool), delay, unit);
+		return new DisposableFuture(future, pendingTask);
+	}
+
+	@Override
+	public Disposable schedulePeriodically(Runnable task,
+			long initialDelay,
+			long period,
+			TimeUnit unit) {
+		PendingTask pendingTask = new PendingTask(task, NO_PARENT);
+		ScheduledFuture<?> future =
+				scheduler.scheduleAtFixedRate(new ExecuteTask(pendingTask, pool),
+						initialDelay,
+						period,
+						unit);
+		return new DisposableFuture(future, pendingTask);
+	}
+
+	private void uncaughtException(Thread t, Throwable e) {
+		log.error("Scheduler worker in group " + t.getThreadGroup()
+		                                          .getName() + " failed with an uncaught exception",
+				e);
+	}
+
+	private static class DisposableForkJoinTask implements Disposable {
+
+		private final ForkJoinTask<?> task;
+
+		DisposableForkJoinTask(ForkJoinTask<?> task) {
+			this.task = task;
+		}
+
+		@Override
+		public void dispose() {
+			task.cancel(false);
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return task.isDone();
+		}
+	}
+
+	private static class ExecuteTask implements Runnable {
+
+		private final Runnable task;
+		private final Executor executor;
+
+		ExecuteTask(Runnable task, Executor executor) {
+			this.task = task;
+			this.executor = executor;
+		}
+
+		@Override
+		public void run() {
+			executor.execute(task);
+		}
+	}
+
+	private static class PendingTask implements Runnable, Disposable {
+
+		private final    Runnable        task;
+		private final    BooleanSupplier isParentDisposed;
+		private volatile boolean         disposed;
+
+		PendingTask(Runnable task, BooleanSupplier disposed) {
+			this.task = task;
+			isParentDisposed = disposed;
+		}
+
+		@Override
+		public void dispose() {
+			disposed = true;
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return disposed || isParentDisposed.getAsBoolean();
+		}
+
+		@Override
+		public void run() {
+			if (!isDisposed()) {
+				task.run();
+			}
+		}
+	}
+
+	static final class DisposableFuture implements Disposable {
+
+		final Future<?>   f;
+		final PendingTask task;
+
+		DisposableFuture(Future<?> f, PendingTask task) {
+			this.f = f;
+			this.task = task;
+		}
+
+		@Override
+		public void dispose() {
+			task.dispose();
+			f.cancel(false);
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return (f.isCancelled() || f.isDone()) && task.isDisposed();
+		}
+	}
+
+	private static class Worker implements Scheduler.Worker {
+
+		private final Executor                 executor;
+		private final ScheduledExecutorService scheduler;
+		private final Object          lock  = new Object();
+		private final Queue<Runnable> tasks = new ArrayDeque<>();
+		private volatile boolean shutdown;
+		private boolean executing = false;
+
+		public Worker(Executor executor, ScheduledExecutorService scheduler) {
+			this.executor = executor;
+			this.scheduler = scheduler;
+		}
+
+		@Override
+		public void dispose() {
+			if (shutdown) {
+				return;
+			}
+
+			shutdown = true;
+
+			synchronized (lock) {
+				tasks.clear();
+			}
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return shutdown;
+		}
+
+		@Override
+		public Disposable schedule(Runnable task) {
+			if (shutdown) {
+				return REJECTED;
+			}
+
+			DisposableWorkerTask workerTask =
+					new DisposableWorkerTask(task, this::isDisposed);
+
+			try {
+				execute(workerTask);
+			}
+			catch (RejectedExecutionException ignored) {
+				// dispose the task since it made it into the queue
+				workerTask.dispose();
+				return REJECTED;
+			}
+
+			return workerTask;
+		}
+
+		@Override
+		public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
+			if (delay == 0) {
+				return schedule(task);
+			}
+
+			if (shutdown) {
+				return REJECTED;
+			}
+
+			PendingTask pendingTask = new PendingTask(task, this::isDisposed);
+			ScheduledFuture<?> future;
+			try {
+				future = scheduler.schedule(new ExecuteTask(pendingTask, this::execute),
+						delay,
+						unit);
+			}
+			catch (RejectedExecutionException ignored) {
+				return REJECTED;
+			}
+			return new DisposableFuture(future, pendingTask);
+		}
+
+		@Override
+		public Disposable schedulePeriodically(Runnable task,
+				long initialDelay,
+				long period,
+				TimeUnit unit) {
+			if (shutdown) {
+				return REJECTED;
+			}
+
+			PendingTask pendingTask = new PendingTask(task, this::isDisposed);
+			ScheduledFuture<?> future;
+			try {
+				future = scheduler.scheduleAtFixedRate(new ExecuteTask(pendingTask,
+						this::execute), initialDelay, period, unit);
+			}
+			catch (RejectedExecutionException ignored) {
+				return REJECTED;
+			}
+			return new DisposableFuture(future, pendingTask);
+		}
+
+		private void execute(Runnable command) {
+			synchronized (lock) {
+				tasks.add(command);
+
+				if (!executing) {
+					executor.execute(this::execute);
+					executing = true;
+				}
+			}
+		}
+
+		private void execute() {
+			while (true) {
+				Runnable task;
+				synchronized (lock) {
+					task = tasks.poll();
+					if (task == null) {
+						executing = false;
+						return;
+					}
+				}
+
+				try {
+					task.run();
+				}
+				catch (Throwable ex) {
+					Schedulers.handleError(ex);
+				}
+			}
+		}
+	}
+
+	private static class DisposableWorkerTask implements Disposable, Runnable {
+
+		private final    Runnable        task;
+		private final    BooleanSupplier isParentDisposed;
+		private volatile boolean         disposed;
+
+		private DisposableWorkerTask(Runnable task, BooleanSupplier disposed) {
+			this.task = task;
+			isParentDisposed = disposed;
+		}
+
+		@Override
+		public void dispose() {
+			disposed = true;
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return disposed || isParentDisposed.getAsBoolean();
+		}
+
+		@Override
+		public void run() {
+			if (isDisposed()) {
+				return;
+			}
+
+			task.run();
+		}
+	}
+
+	static final         AtomicLong      COUNTER                     = new AtomicLong();
+	static final         String          FORK_JOIN_POOL              = "forkJoinPool";
+	static final         String          FORK_JOIN_POOL_TIMER_SUFFIX = "-timer";
+	static final         String          FORK_JOIN_POOL_TIMER        =
+			FORK_JOIN_POOL + FORK_JOIN_POOL_TIMER_SUFFIX;
+	private static final Logger          log                         =
+			Loggers.getLogger(Schedulers.class);
+	private static final BooleanSupplier NO_PARENT                   = () -> false;
+}

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -19,6 +19,8 @@ package reactor.core.scheduler;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -284,6 +286,57 @@ public abstract class Schedulers {
 	}
 
 	/**
+	 * {@link Scheduler} that hosts a fixed pool of single-threaded ExecutorService-based
+	 * workers and is suited for parallel work.
+	 *
+	 * @param name Thread prefix
+	 *
+	 * @return a new {@link Scheduler} that hosts a fixed pool of single-threaded
+	 * ExecutorService-based workers and is suited for parallel work
+	 */
+	public static Scheduler newForkJoinPool(String name) {
+		return newForkJoinPool(name, Runtime.getRuntime().availableProcessors());
+	}
+
+	/**
+	 * {@link Scheduler} that utilizes a {@link java.util.concurrent.ForkJoinPool} for
+	 * workers and is suited for parallel work. Since the ForkJoinPool does not support
+	 * periodic or delayed scheduling, a single ScheduledExecutorService is used to
+	 * enqueue any tasks that are delayed or periodic
+	 *
+	 * @param name Thread prefix
+	 * @param parallelism Number of worker threads
+	 *
+	 * @return a new {@link Scheduler} that utilizes a ForkJoinPool
+	 */
+	public static Scheduler newForkJoinPool(String name, int parallelism) {
+		return newForkJoinPool(parallelism,
+				new SchedulerForkJoinWorkerThreadFactory(name,
+						ForkJoinPoolScheduler.COUNTER),
+				new SchedulerThreadFactory(name + ForkJoinPoolScheduler.FORK_JOIN_POOL_TIMER_SUFFIX,
+						true,
+						ForkJoinPoolScheduler.COUNTER));
+	}
+
+	/**
+	 * {@link Scheduler} that utilizes a {@link java.util.concurrent.ForkJoinPool} for
+	 * workers and is suited for parallel work. Since the ForkJoinPool does not support
+	 * periodic or delayed scheduling, a single ScheduledExecutorService is used to
+	 * enqueue any tasks that are delayed or periodic
+	 *
+	 * @param parallelism Number of worker threads
+	 * @param workerThreadFactory factory for ForkJoinPool thrads
+	 * @param threadFactory  factory for single scheduler thread
+	 *
+	 * @return a new {@link Scheduler} that utilizes a ForkJoinPool
+	 */
+	public static Scheduler newForkJoinPool(int parallelism,
+			ForkJoinPool.ForkJoinWorkerThreadFactory workerThreadFactory,
+			ThreadFactory threadFactory) {
+		return factory.newForkJoinPool(parallelism, workerThreadFactory, threadFactory);
+	}
+
+	/**
 	 * {@link Scheduler} that hosts a single-threaded ExecutorService-based worker and is
 	 * suited for parallel work.
 	 *
@@ -514,6 +567,20 @@ public abstract class Schedulers {
 		default Scheduler newSingle(ThreadFactory threadFactory) {
 			return new SingleScheduler(threadFactory);
 		}
+
+		/**
+		 * {@link Scheduler} that utilizes a {@link java.util.concurrent.ForkJoinPool} for
+		 * workers and is suited for parallel work. Since the ForkJoinPool does not support
+		 * periodic or delayed scheduling, a single ScheduledExecutorService is used to
+		 * enqueue any tasks that are delayed or periodic
+		 *
+		 * @return a new {@link Scheduler} that utilizes a ForkJoinPool
+		 */
+		default Scheduler newForkJoinPool(int parallelism,
+				ForkJoinPool.ForkJoinWorkerThreadFactory workerThreadFactory,
+				ThreadFactory threadFactory) {
+			return new ForkJoinPoolScheduler(parallelism, workerThreadFactory, threadFactory);
+		}
 	}
 
 	// Internals
@@ -601,6 +668,32 @@ public abstract class Schedulers {
 		@Override
 		public String get() {
 			return name;
+		}
+	}
+
+	static final class SchedulerForkJoinWorkerThread extends ForkJoinWorkerThread {
+
+		SchedulerForkJoinWorkerThread(String name, ForkJoinPool pool) {
+			super(pool);
+			setName(name);
+		}
+	}
+
+	static final class SchedulerForkJoinWorkerThreadFactory
+			implements ForkJoinPool.ForkJoinWorkerThreadFactory {
+
+		final String     name;
+		final AtomicLong COUNTER;
+
+		SchedulerForkJoinWorkerThreadFactory(String name, AtomicLong COUNTER) {
+			this.name = name;
+			this.COUNTER = COUNTER;
+		}
+
+		@Override
+		public ForkJoinWorkerThread newThread(ForkJoinPool pool) {
+			return new SchedulerForkJoinWorkerThread(name + "-" + COUNTER.incrementAndGet(),
+					pool);
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/ForkJoinPoolSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ForkJoinPoolSchedulerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.scheduler;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Assert;
+import org.junit.Test;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ForkJoinPoolSchedulerTest extends AbstractSchedulerTest {
+
+	@Override
+	protected Scheduler scheduler() {
+		return Schedulers.forkJoinPool();
+	}
+
+	@Override
+	protected boolean shouldCheckInterrupted() {
+		return true;
+	}
+
+	@Test
+	public void scheduledDoesntReject() {
+		Scheduler s = scheduler();
+
+		assertThat(s.schedule(() -> {}, 100, TimeUnit.MILLISECONDS))
+				.describedAs("direct delayed scheduling")
+				.isNotInstanceOf(RejectedDisposable.class);
+		assertThat(s.schedulePeriodically(() -> {}, 100, 100, TimeUnit.MILLISECONDS))
+				.describedAs("direct periodic scheduling")
+				.isNotInstanceOf(RejectedDisposable.class);
+
+		Scheduler.Worker w = s.createWorker();
+		assertThat(w.schedule(() -> {}, 100, TimeUnit.MILLISECONDS))
+				.describedAs("worker delayed scheduling")
+				.isNotInstanceOf(RejectedDisposable.class);
+		assertThat(w.schedulePeriodically(() -> {}, 100, 100, TimeUnit.MILLISECONDS))
+				.describedAs("worker periodic scheduling")
+				.isNotInstanceOf(RejectedDisposable.class);
+	}
+
+	@Test
+	public void smokeTestDelay() {
+		for (int i = 0; i < 20; i++) {
+			Scheduler s = Schedulers.newForkJoinPool("test");
+			AtomicLong start = new AtomicLong();
+			AtomicLong end = new AtomicLong();
+
+			try {
+				StepVerifier.create(Mono
+						.delay(Duration.ofMillis(100), s)
+						.log()
+						.doOnSubscribe(sub -> start.set(System.nanoTime()))
+						.doOnTerminate((v, e) -> end.set(System.nanoTime()))
+				)
+				            .expectSubscription()
+				            .expectNext(0L)
+				            .verifyComplete();
+
+				long endValue = end.longValue();
+				long startValue = start.longValue();
+				long measuredDelay = endValue - startValue;
+				long measuredDelayMs = TimeUnit.NANOSECONDS.toMillis(measuredDelay);
+				assertThat(measuredDelayMs)
+						.as("iteration %s, measured delay %s nanos, start at %s nanos, end at %s nanos", i, measuredDelay, startValue, endValue)
+						.isGreaterThanOrEqualTo(100L)
+						.isLessThan(200L);
+			}
+			finally {
+				s.dispose();
+			}
+		}
+	}
+
+	@Test
+	public void smokeTestInterval() {
+		Scheduler s = scheduler();
+
+		try {
+			StepVerifier.create(Flux.interval(Duration.ofMillis(100), Duration.ofMillis(200), s))
+			            .expectSubscription()
+			            .expectNoEvent(Duration.ofMillis(100))
+			            .expectNext(0L)
+			            .expectNoEvent(Duration.ofMillis(200))
+			            .expectNext(1L)
+			            .expectNoEvent(Duration.ofMillis(200))
+			            .expectNext(2L)
+			            .thenCancel();
+		}
+		finally {
+			s.dispose();
+		}
+	}
+
+	@Test(timeout=500)
+	public void scheduleThenDisposeOfScheduler() throws Exception {
+		Scheduler s = Schedulers.newForkJoinPool("test",1 );
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		s.schedule(latch::countDown, 50, TimeUnit.MILLISECONDS);
+
+		assertThat(s.isDisposed()).isFalse();
+		s.dispose();
+		assertThat(s.isDisposed()).isTrue();
+		assertThat(latch.await(100, TimeUnit.MILLISECONDS)).isFalse();
+	}
+
+	@Test(timeout=500)
+	public void scheduleThenDisposeOfWorker() throws Exception {
+		Scheduler s = scheduler();
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		Scheduler.Worker worker = s.createWorker();
+
+		worker.schedule(latch::countDown, 50, TimeUnit.MILLISECONDS);
+
+		assertThat(worker.isDisposed()).isFalse();
+		worker.dispose();
+		assertThat(worker.isDisposed()).isTrue();
+		assertThat(latch.await(100, TimeUnit.MILLISECONDS)).isFalse();
+	}
+
+}


### PR DESCRIPTION
this is a Scheduler implementation that uses a ForkJoinPool and a
ScheduledExecutorService for scheduling.

it differs from the Parallel scheduler in that Workers are not pre-bound
to a specific thread in the pool. each Worker maintains its own queue of
tasks and when it has tasks to execute it will grab a thread from the
pool to use to execute it.

since the ForkJoinPool does not support time-based scheduling, a
single-threaded ScheduledExecutorService is used to enqueue tasks in the
main FJ pool as necessary.

standard ThreadFactory is only used for the single SES thread.

a custom FJP thread factory is used to rename FJP threads