### PR TITLE
Use BiPredicate for DistinctUntilChanged

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
@@ -16,6 +16,7 @@
 package reactor.core.publisher;
 
 import java.util.Objects;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 
 import org.reactivestreams.Subscriber;
@@ -32,11 +33,15 @@ import javax.annotation.Nullable;
  */
 final class FluxDistinctUntilChanged<T, K> extends FluxSource<T, T> {
 
-	final Function<? super T, K> keyExtractor;
+	final Function<? super T, K>            keyExtractor;
+	final BiPredicate<? super K, ? super K> keyComparator;
 
-	FluxDistinctUntilChanged(Flux<? extends T> source, Function<? super T, K> keyExtractor) {
+	FluxDistinctUntilChanged(Flux<? extends T> source,
+			Function<? super T, K> keyExtractor,
+			BiPredicate<? super K, ? super K> keyComparator) {
 		super(source);
 		this.keyExtractor = Objects.requireNonNull(keyExtractor, "keyExtractor");
+		this.keyComparator = Objects.requireNonNull(keyComparator, "keyComparator");
 	}
 
 	@Override
@@ -44,10 +49,10 @@ final class FluxDistinctUntilChanged<T, K> extends FluxSource<T, T> {
 	public void subscribe(Subscriber<? super T> s) {
 		if (s instanceof ConditionalSubscriber) {
 			source.subscribe(new DistinctUntilChangedConditionalSubscriber<>((ConditionalSubscriber<? super T>) s,
-					keyExtractor));
+					keyExtractor, keyComparator));
 		}
 		else {
-			source.subscribe(new DistinctUntilChangedSubscriber<>(s, keyExtractor));
+			source.subscribe(new DistinctUntilChangedSubscriber<>(s, keyExtractor, keyComparator));
 		}
 	}
 
@@ -56,6 +61,7 @@ final class FluxDistinctUntilChanged<T, K> extends FluxSource<T, T> {
 		final Subscriber<? super T> actual;
 
 		final Function<? super T, K> keyExtractor;
+		final BiPredicate<? super K, ? super K> keyComparator;
 
 		Subscription s;
 
@@ -64,9 +70,11 @@ final class FluxDistinctUntilChanged<T, K> extends FluxSource<T, T> {
 		K lastKey;
 
 		DistinctUntilChangedSubscriber(Subscriber<? super T> actual,
-													   Function<? super T, K> keyExtractor) {
+				Function<? super T, K> keyExtractor,
+				BiPredicate<? super K, ? super K> keyComparator) {
 			this.actual = actual;
 			this.keyExtractor = keyExtractor;
+			this.keyComparator = keyComparator;
 		}
 
 		@Override
@@ -103,8 +111,7 @@ final class FluxDistinctUntilChanged<T, K> extends FluxSource<T, T> {
 				return true;
 			}
 
-			if (Objects.equals(lastKey, k)) {
-				lastKey = k;
+			if (null != lastKey && keyComparator.test(lastKey, k)) {
 				return false;
 			}
 			lastKey = k;
@@ -163,6 +170,7 @@ final class FluxDistinctUntilChanged<T, K> extends FluxSource<T, T> {
 		final ConditionalSubscriber<? super T> actual;
 
 		final Function<? super T, K> keyExtractor;
+		final BiPredicate<? super K, ? super K> keyComparator;
 
 		Subscription s;
 
@@ -171,9 +179,11 @@ final class FluxDistinctUntilChanged<T, K> extends FluxSource<T, T> {
 		K lastKey;
 
 		DistinctUntilChangedConditionalSubscriber(ConditionalSubscriber<? super T> actual,
-				Function<? super T, K> keyExtractor) {
+				Function<? super T, K> keyExtractor,
+				BiPredicate<? super K, ? super K> keyComparator) {
 			this.actual = actual;
 			this.keyExtractor = keyExtractor;
+			this.keyComparator = keyComparator;
 		}
 
 		@Override
@@ -210,8 +220,7 @@ final class FluxDistinctUntilChanged<T, K> extends FluxSource<T, T> {
 				return true;
 			}
 
-			if (Objects.equals(lastKey, k)) {
-				lastKey = k;
+			if (null != lastKey && keyComparator.test(lastKey, k)) {
 				return false;
 			}
 			lastKey = k;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
@@ -200,6 +200,22 @@ public class FluxDistinctUntilChangedTest extends FluxOperatorTest<String, Strin
 	}
 
 	@Test
+	public void keyComparatorThrows() {
+		AssertSubscriber<Integer> ts = AssertSubscriber.create();
+
+		Flux.range(1, 10)
+		    .distinctUntilChanged(Function.identity(), (v1,v2) -> {
+			    throw new RuntimeException("forced failure");
+		    })
+		    .subscribe(ts);
+
+		ts.assertValues(1)
+		  .assertNotComplete()
+		  .assertError(RuntimeException.class)
+		  .assertErrorMessage("forced failure");
+	}
+
+	@Test
 	public void allDistinctConditional() {
 		DirectProcessor<Integer> dp = new DirectProcessor<>();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
@@ -17,9 +17,10 @@
 package reactor.core.publisher;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.Objects;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
 
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -55,12 +56,17 @@ public class FluxDistinctUntilChangedTest extends FluxOperatorTest<String, Strin
 
 	@Test(expected = NullPointerException.class)
 	public void sourceNull() {
-		new FluxDistinctUntilChanged<>(null, v -> v);
+		new FluxDistinctUntilChanged<>(null, v -> v, (k1, k2) -> true);
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void keyExtractorNull() {
 		Flux.never().distinctUntilChanged(null);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void predicateNull() {
+		Flux.never().distinctUntilChanged(v -> v, null);
 	}
 
 	@Test
@@ -163,6 +169,19 @@ public class FluxDistinctUntilChangedTest extends FluxOperatorTest<String, Strin
 		  .assertComplete()
 		  .assertNoError();
 	}
+	
+	@Test
+	public void withKeyComparator() {
+		AssertSubscriber<Integer> ts = AssertSubscriber.create();
+
+		Flux.range(1, 10)
+		    .distinctUntilChanged(Function.identity(), (a,b) -> b - a < 4)
+		    .subscribe(ts);
+
+		ts.assertValues(1, 5, 9)
+		  .assertComplete()
+		  .assertNoError();
+	}
 
 	@Test
 	public void keySelectorThrows() {
@@ -200,7 +219,7 @@ public class FluxDistinctUntilChangedTest extends FluxOperatorTest<String, Strin
 	public void scanSubscriber() {
 		Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		FluxDistinctUntilChanged.DistinctUntilChangedSubscriber<String, Integer> test = new FluxDistinctUntilChanged.DistinctUntilChangedSubscriber<>(
-			actual, String::hashCode);
+			actual, String::hashCode, Objects::equals);
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 
@@ -216,7 +235,7 @@ public class FluxDistinctUntilChangedTest extends FluxOperatorTest<String, Strin
 	public void scanConditionalSubscriber() {
 		Fuseable.ConditionalSubscriber<String> actual = Mockito.mock(Fuseable.ConditionalSubscriber.class);
 		FluxDistinctUntilChanged.DistinctUntilChangedConditionalSubscriber<String, Integer> test = new FluxDistinctUntilChanged.DistinctUntilChangedConditionalSubscriber<>(
-				actual, String::hashCode);
+				actual, String::hashCode, Objects::equals);
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 


### PR DESCRIPTION
Addressing #608, extend the functionality of distinct-until-changed to
accept a BiPredicate<T,T> to determine if the event is "different" from
the last event. The prior key-based system is still supported as an
overlay.