### PR TITLE
Test coverage of `scanUnsafe`

### DIFF
--- a/src/main/java/reactor/core/Scannable.java
+++ b/src/main/java/reactor/core/Scannable.java
@@ -161,7 +161,12 @@ public interface Scannable {
 		/**
 		 * A {@link Integer} attribute implemented by components with a backlog
 		 * capacity. It will expose current queue size or similar related to
-		 * user-provided held data.
+		 * user-provided held data. Note that some operators and processors CAN keep
+		 * a backlog larger than {@code Integer.MAX_VALUE}, in which case
+		 * the {@link LongAttr#LARGE_BUFFERED LongAttr} {@literal LARGE_BUFFERED}
+		 * should be used instead. Such operators will attempt to serve a BUFFERED
+		 * query but will return {@link Integer#MIN_VALUE} when actual buffer size is
+		 * oversized for int.
 		 */
 		BUFFERED(0);
 
@@ -181,6 +186,19 @@ public interface Scannable {
 	 * {@link Scannable} attributes associated with a {@link Long} value.
 	 */
 	enum LongAttr implements Attr<Long> {
+
+		/**
+		 * Similar to {@link IntAttr#BUFFERED}, but reserved for operators that can hold
+		 * a backlog of items that can grow beyond {@literal Integer.MAX_VALUE}. These
+		 * operators will also answer to a {@link IntAttr#BUFFERED} query up to the point
+		 * where their buffer is actually too large, at which point they'll return
+		 * {@literal Integer.MIN_VALUE}, which serves as a signal that this attribute
+		 * should be used instead. Defaults to {@literal null}.
+		 * <p>
+		 * {@code Flux.flatMap}, {@code Flux.filterWhen}, {@link reactor.core.publisher.TopicProcessor},
+		 * and {@code Flux.window} (with overlap) are known to use this attribute.
+		 */
+		LARGE_BUFFERED(null),
 
 		/**
 		 * A {@link Long} attribute exposing the current pending demand of a downstream

--- a/src/main/java/reactor/core/publisher/BlockingIterable.java
+++ b/src/main/java/reactor/core/publisher/BlockingIterable.java
@@ -64,7 +64,7 @@ final class BlockingIterable<T> implements Iterable<T>, Scannable {
 
 	@Override
 	public Object scanUnsafe(Attr key) {
-		if (key == IntAttr.PREFETCH) return batchSize;
+		if (key == IntAttr.PREFETCH) return (int) Math.min(Integer.MAX_VALUE, batchSize); //FIXME should batchSize be forced to int?
 		if (key == ScannableAttr.PARENT) return source;
 
 		return null;
@@ -259,8 +259,8 @@ final class BlockingIterable<T> implements Iterable<T>, Scannable {
 		public Object scanUnsafe(Attr key) {
 			if (key == BooleanAttr.TERMINATED) return done;
 			if (key == ScannableAttr.PARENT) return  s;
-			if (key == BooleanAttr.CANCELLED) 			    	return s == Operators.cancelledSubscription();
-			if (key == IntAttr.PREFETCH) return batchSize;
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+			if (key == IntAttr.PREFETCH) return (int) Math.min(Integer.MAX_VALUE, batchSize); //FIXME should batchSize be typed int?
 			if (key == ThrowableAttr.ERROR) return error;
 
 			return null;

--- a/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -384,6 +384,11 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	}
 
 	@Override
+	public int getPrefetch() {
+		return prefetch;
+	}
+
+	@Override
 	public Object scanUnsafe(Attr key) {
 		if (key == ScannableAttr.PARENT) return s;
 		if (key == IntAttr.BUFFERED) return getPending();

--- a/src/main/java/reactor/core/publisher/FluxBuffer.java
+++ b/src/main/java/reactor/core/publisher/FluxBuffer.java
@@ -190,7 +190,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxSource<T,
 			if (key == BooleanAttr.TERMINATED) return done;
 			if (key == IntAttr.CAPACITY) {
 				C b = buffer;
-				return b != null ? b.size() : 0L;
+				return b != null ? b.size() : 0;
 			}
 			if (key == IntAttr.PREFETCH) return size;
 
@@ -341,7 +341,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxSource<T,
 			if (key == BooleanAttr.TERMINATED) return done;
 			if (key == IntAttr.CAPACITY) {
 				C b = buffer;
-				return b != null ? b.size() : 0L;
+				return b != null ? b.size() : 0;
 			}
 			if (key == IntAttr.PREFETCH) return size;
 

--- a/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
+++ b/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
@@ -298,7 +298,7 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 			if (key == BooleanAttr.CANCELLED) return getAsBoolean();
 			if (key == IntAttr.CAPACITY) {
 				C b = buffer;
-				return b != null ? b.size() : 0L;
+				return b != null ? b.size() : 0;
 			}
 			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
 

--- a/src/main/java/reactor/core/publisher/FluxCreate.java
+++ b/src/main/java/reactor/core/publisher/FluxCreate.java
@@ -269,7 +269,7 @@ final class FluxCreate<T> extends Flux<T> {
 			if (key == ThrowableAttr.ERROR) return error;
 			if (key == BooleanAttr.TERMINATED) return done;
 
-			return null;
+			return sink.scanUnsafe(key);
 		}
 	}
 

--- a/src/main/java/reactor/core/publisher/FluxDelaySubscription.java
+++ b/src/main/java/reactor/core/publisher/FluxDelaySubscription.java
@@ -61,8 +61,7 @@ final class FluxDelaySubscription<T, U> extends FluxSource<T, T> {
 
 		boolean done;
 
-		DelaySubscriptionOtherSubscriber(Subscriber<? super T> actual, Publisher<?
-				extends T> source) {
+		DelaySubscriptionOtherSubscriber(Subscriber<? super T> actual, Publisher<? extends T> source) {
 			this.actual = actual;
 			this.source = source;
 
@@ -71,6 +70,7 @@ final class FluxDelaySubscription<T, U> extends FluxSource<T, T> {
 		@Override
 		public Object scanUnsafe(Attr key) {
 			if (key == ScannableAttr.PARENT) return s;
+			if (key == ScannableAttr.ACTUAL) return actual;
 			if (key == BooleanAttr.TERMINATED) return done;
 
 			return super.scanUnsafe(key);
@@ -132,48 +132,46 @@ final class FluxDelaySubscription<T, U> extends FluxSource<T, T> {
 		void subscribeSource() {
 			source.subscribe(new DelaySubscriptionMainSubscriber<>(actual, this));
 		}
+	}
 
-		static final class DelaySubscriptionMainSubscriber<T>
-				implements InnerConsumer<T> {
+	static final class DelaySubscriptionMainSubscriber<T>
+			implements InnerConsumer<T> {
 
-			final Subscriber<? super T> actual;
+		final Subscriber<? super T> actual;
 
-			final DelaySubscriptionOtherSubscriber<?, ?> arbiter;
+		final DelaySubscriptionOtherSubscriber<?, ?> arbiter;
 
-			DelaySubscriptionMainSubscriber(Subscriber<? super T> actual,
-					DelaySubscriptionOtherSubscriber<?, ?> arbiter) {
-				this.actual = actual;
-				this.arbiter = arbiter;
-			}
+		DelaySubscriptionMainSubscriber(Subscriber<? super T> actual,
+				DelaySubscriptionOtherSubscriber<?, ?> arbiter) {
+			this.actual = actual;
+			this.arbiter = arbiter;
+		}
 
-			@Override
-			public Object scanUnsafe(Attr key) {
-				if (key == ScannableAttr.ACTUAL) return actual;
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.ACTUAL) return actual;
 
-				return null;
-			}
+			return null;
+		}
 
-			@Override
-			public void onSubscribe(Subscription s) {
-				arbiter.set(s);
-			}
+		@Override
+		public void onSubscribe(Subscription s) {
+			arbiter.set(s);
+		}
 
-			@Override
-			public void onNext(T t) {
-				actual.onNext(t);
-			}
+		@Override
+		public void onNext(T t) {
+			actual.onNext(t);
+		}
 
-			@Override
-			public void onError(Throwable t) {
-				actual.onError(t);
-			}
+		@Override
+		public void onError(Throwable t) {
+			actual.onError(t);
+		}
 
-			@Override
-			public void onComplete() {
-				actual.onComplete();
-			}
-
-
+		@Override
+		public void onComplete() {
+			actual.onComplete();
 		}
 	}
 }

--- a/src/main/java/reactor/core/publisher/FluxFilterWhen.java
+++ b/src/main/java/reactor/core/publisher/FluxFilterWhen.java
@@ -437,7 +437,7 @@ class FluxFilterWhen<T> extends FluxSource<T, T> {
 			if (key == BooleanAttr.CANCELLED) return sub == Operators.cancelledSubscription();
 			if (key == BooleanAttr.TERMINATED) return done;
 			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
-			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return done ? 0 : 1;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return done ? 0L : 1L;
 
 			return null;
 		}

--- a/src/main/java/reactor/core/publisher/FluxFilterWhen.java
+++ b/src/main/java/reactor/core/publisher/FluxFilterWhen.java
@@ -360,7 +360,12 @@ class FluxFilterWhen<T> extends FluxSource<T, T> {
 				return error;
 			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
 			if (key == IntAttr.CAPACITY) return toFilter.length();
-			if (key == IntAttr.BUFFERED) return (int) (producerIndex - consumerIndex);
+			if (key == LongAttr.LARGE_BUFFERED) return producerIndex - consumerIndex;
+			if (key == IntAttr.BUFFERED) {
+				long realBuffered = producerIndex - consumerIndex;
+				if (realBuffered <= Integer.MAX_VALUE) return (int) realBuffered;
+				return Integer.MIN_VALUE;
+			}
 			if (key == IntAttr.PREFETCH) return bufferSize;
 
 			return InnerOperator.super.scanUnsafe(key);

--- a/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -263,7 +263,12 @@ final class FluxFlatMap<T, R> extends FluxSource<T, R> {
 			if (key == BooleanAttr.DELAY_ERROR) return delayError;
 			if (key == IntAttr.PREFETCH) return maxConcurrency;
 			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
-			if (key == IntAttr.BUFFERED) return (scalarQueue != null ? scalarQueue.size() : 0) + size;
+			if (key == LongAttr.LARGE_BUFFERED) return (scalarQueue != null ? (long) scalarQueue.size() : 0L) + size;
+			if (key == IntAttr.BUFFERED) {
+				long realBuffered = (scalarQueue != null ? (long) scalarQueue.size() : 0L) + size;
+				if (realBuffered <= Integer.MAX_VALUE) return (int) realBuffered;
+				return Integer.MIN_VALUE;
+			}
 
 			return InnerOperator.super.scanUnsafe(key);
 		}

--- a/src/main/java/reactor/core/publisher/FluxOnBackpressureLatest.java
+++ b/src/main/java/reactor/core/publisher/FluxOnBackpressureLatest.java
@@ -215,7 +215,7 @@ final class FluxOnBackpressureLatest<T> extends FluxSource<T, T> {
 			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
 			if (key == BooleanAttr.TERMINATED) return done;
 			if (key == BooleanAttr.CANCELLED) return cancelled;
-			if (key == IntAttr.BUFFERED) return value != null;
+			if (key == IntAttr.BUFFERED) return value != null ? 1 : 0;
 			if (key == ThrowableAttr.ERROR) return error;
 			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
 

--- a/src/main/java/reactor/core/publisher/FluxSample.java
+++ b/src/main/java/reactor/core/publisher/FluxSample.java
@@ -218,7 +218,7 @@ final class FluxSample<T, U> extends FluxSource<T, T> {
 			if (key == ScannableAttr.PARENT) return main.other;
 			if (key == ScannableAttr.ACTUAL) return main;
 			if (key == BooleanAttr.CANCELLED) return main.other == Operators.cancelledSubscription();
-			if (key == IntAttr.PREFETCH) return Long.MAX_VALUE;
+			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
 
 			return null;
 		}

--- a/src/main/java/reactor/core/publisher/FluxWindow.java
+++ b/src/main/java/reactor/core/publisher/FluxWindow.java
@@ -716,7 +716,7 @@ final class FluxWindow<T> extends FluxSource<T, Flux<T>> {
 		@Override
 		public Object scanUnsafe(Attr key) {
 			if (key == ScannableAttr.PARENT) return s;
-			if (key == BooleanAttr.CANCELLED) return cancelled;
+			if (key == BooleanAttr.CANCELLED) return cancelled == 1;
 			if (key == IntAttr.CAPACITY) return size;
 			if (key == BooleanAttr.TERMINATED) return done;
 			if (key == IntAttr.BUFFERED) return queue.size() + size();

--- a/src/main/java/reactor/core/publisher/FluxWindow.java
+++ b/src/main/java/reactor/core/publisher/FluxWindow.java
@@ -719,7 +719,12 @@ final class FluxWindow<T> extends FluxSource<T, Flux<T>> {
 			if (key == BooleanAttr.CANCELLED) return cancelled == 1;
 			if (key == IntAttr.CAPACITY) return size;
 			if (key == BooleanAttr.TERMINATED) return done;
-			if (key == IntAttr.BUFFERED) return queue.size() + size();
+			if (key == LongAttr.LARGE_BUFFERED) return (long) queue.size() + size();
+			if (key == IntAttr.BUFFERED) {
+				long realBuffered = (long) queue.size() + size();
+				if (realBuffered < Integer.MAX_VALUE) return (int) realBuffered;
+				return Integer.MIN_VALUE;
+			}
 			if (key == ThrowableAttr.ERROR) return error;
 			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
 

--- a/src/main/java/reactor/core/publisher/MonoCollectList.java
+++ b/src/main/java/reactor/core/publisher/MonoCollectList.java
@@ -72,6 +72,7 @@ final class MonoCollectList<T, C extends Collection<? super T>> extends MonoSour
 		@Override
 		public Object scanUnsafe(Attr key) {
 			if (key == ScannableAttr.PARENT) return s;
+			if (key == BooleanAttr.TERMINATED) return collection == null;
 
 			return super.scanUnsafe(key);
 		}

--- a/src/main/java/reactor/core/publisher/MonoDelay.java
+++ b/src/main/java/reactor/core/publisher/MonoDelay.java
@@ -95,7 +95,6 @@ final class MonoDelay extends Mono<Long> {
 		public Object scanUnsafe(Attr key) {
 			if (key == BooleanAttr.TERMINATED) return cancel == FINISHED;
 			if (key == BooleanAttr.CANCELLED) return cancel == Flux.CANCELLED;
-			if (key == ScannableAttr.PARENT) return actual;
 
 			return InnerProducer.super.scanUnsafe(key);
 		}

--- a/src/main/java/reactor/core/publisher/MonoDelayUntil.java
+++ b/src/main/java/reactor/core/publisher/MonoDelayUntil.java
@@ -148,8 +148,7 @@ final class MonoDelayUntil<T> extends Mono<T> {
 
 		@Override
 		public Object scanUnsafe(Attr key) {
-			if (key == BooleanAttr.TERMINATED) return done;
-			if (key == ScannableAttr.PARENT) return actual;
+			if (key == BooleanAttr.TERMINATED) return done == n;
 			if (key == BooleanAttr.DELAY_ERROR) return delayError;
 
 			return super.scanUnsafe(key);

--- a/src/main/java/reactor/core/publisher/MonoFilterWhen.java
+++ b/src/main/java/reactor/core/publisher/MonoFilterWhen.java
@@ -281,7 +281,7 @@ class MonoFilterWhen<T> extends MonoSource<T, T> {
 			if (key == BooleanAttr.CANCELLED) return sub == Operators.cancelledSubscription();
 			if (key == BooleanAttr.TERMINATED) return done;
 			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
-			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return done ? 0 : 1;
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return done ? 0L : 1L;
 
 			return null;
 		}

--- a/src/main/java/reactor/core/publisher/MonoFlatMap.java
+++ b/src/main/java/reactor/core/publisher/MonoFlatMap.java
@@ -183,74 +183,74 @@ final class MonoFlatMap<T, R> extends MonoSource<T, R> implements Fuseable {
 		void secondComplete() {
 			actual.onComplete();
 		}
+	}
 
-		static final class ThenMapInner<R> implements InnerConsumer<R> {
+	static final class ThenMapInner<R> implements InnerConsumer<R> {
 
-			final ThenMapMain<?, R> parent;
+		final ThenMapMain<?, R> parent;
 
-			volatile Subscription s;
-			@SuppressWarnings("rawtypes")
-			static final AtomicReferenceFieldUpdater<ThenMapInner, Subscription> S =
-					AtomicReferenceFieldUpdater.newUpdater(ThenMapInner.class,
-							Subscription.class,
-							"s");
+		volatile Subscription s;
+		@SuppressWarnings("rawtypes")
+		static final AtomicReferenceFieldUpdater<ThenMapInner, Subscription> S =
+				AtomicReferenceFieldUpdater.newUpdater(ThenMapInner.class,
+						Subscription.class,
+						"s");
 
-			boolean done;
+		boolean done;
 
-			ThenMapInner(ThenMapMain<?, R> parent) {
-				this.parent = parent;
-			}
-
-			@Override
-			public Object scanUnsafe(Attr key) {
-				if (key == ScannableAttr.PARENT) return s;
-				if (key == ScannableAttr.ACTUAL) return parent;
-				if (key == BooleanAttr.TERMINATED) return done;
-				if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
-
-				return null;
-			}
-
-			@Override
-			public void onSubscribe(Subscription s) {
-				if (Operators.setOnce(S, this, s)) {
-					s.request(Long.MAX_VALUE);
-				}
-			}
-
-			@Override
-			public void onNext(R t) {
-				if (done) {
-					Operators.onNextDropped(t);
-					return;
-				}
-				done = true;
-				this.parent.complete(t);
-			}
-
-			@Override
-			public void onError(Throwable t) {
-				if (done) {
-					Operators.onErrorDropped(t);
-					return;
-				}
-				done = true;
-				this.parent.secondError(t);
-			}
-
-			@Override
-			public void onComplete() {
-				if (done) {
-					return;
-				}
-				done = true;
-				this.parent.secondComplete();
-			}
-
-			void cancel() {
-				Operators.terminate(S, this);
-			}
-
+		ThenMapInner(ThenMapMain<?, R> parent) {
+			this.parent = parent;
 		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.PARENT) return s;
+			if (key == ScannableAttr.ACTUAL) return parent;
+			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+
+			return null;
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.setOnce(S, this, s)) {
+				s.request(Long.MAX_VALUE);
+			}
+		}
+
+		@Override
+		public void onNext(R t) {
+			if (done) {
+				Operators.onNextDropped(t);
+				return;
+			}
+			done = true;
+			this.parent.complete(t);
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			if (done) {
+				Operators.onErrorDropped(t);
+				return;
+			}
+			done = true;
+			this.parent.secondError(t);
+		}
+
+		@Override
+		public void onComplete() {
+			if (done) {
+				return;
+			}
+			done = true;
+			this.parent.secondComplete();
+		}
+
+		void cancel() {
+			Operators.terminate(S, this);
+		}
+
 	}
 }

--- a/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -82,7 +82,6 @@ public final class MonoProcessor<O> extends Mono<O>
 	volatile Throwable       error;
 	volatile int             state;
 	volatile int             wip;
-	volatile int             requested;
 	volatile int             connected;
 
 	MonoProcessor(Publisher<? extends O> source) {
@@ -406,7 +405,6 @@ public final class MonoProcessor<O> extends Mono<O>
 		if (key == ScannableAttr.ACTUAL) return processor;
 		if (key == ScannableAttr.PARENT) return subscription;
 		if (key == ThrowableAttr.ERROR) return error;
-		if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
 		if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
 		if (key == BooleanAttr.CANCELLED) return isCancelled();
 		if (key == BooleanAttr.TERMINATED) return isTerminated();

--- a/src/main/java/reactor/core/publisher/MonoUntilOther.java
+++ b/src/main/java/reactor/core/publisher/MonoUntilOther.java
@@ -109,7 +109,7 @@ final class MonoUntilOther<T> extends Mono<T> {
 
 		@Override
 		public Object scanUnsafe(Attr key) {
-			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == BooleanAttr.TERMINATED) return done == n;
 			if (key == ScannableAttr.PARENT) return sourceSubscriber;
 			if (key == BooleanAttr.DELAY_ERROR) return delayError;
 
@@ -219,7 +219,7 @@ final class MonoUntilOther<T> extends Mono<T> {
 		}
 	}
 
-	static final class UntilOtherSource<T> implements Subscriber<T> {
+	static final class UntilOtherSource<T> implements InnerConsumer<T> {
 
 		final UntilOtherCoordinator<T> parent;
 
@@ -263,6 +263,15 @@ final class MonoUntilOther<T> extends Mono<T> {
 			if (value == null) {
 				parent.signal();
 			}
+		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == ThrowableAttr.ERROR) return error;
+			if (key == BooleanAttr.TERMINATED) return error != null || value != null;
+			if (key == BooleanAttr.CANCELLED) return s == Operators.cancelledSubscription();
+
+			return null;
 		}
 
 		void cancel() {

--- a/src/main/java/reactor/core/publisher/MonoWhen.java
+++ b/src/main/java/reactor/core/publisher/MonoWhen.java
@@ -155,7 +155,7 @@ final class MonoWhen<T, R> extends Mono<R> {
 
 		@Override
 		public Object scanUnsafe(Attr key) {
-			if (key == BooleanAttr.TERMINATED) return done;
+			if (key == BooleanAttr.TERMINATED) return done == subscribers.length;
 			if (key == IntAttr.BUFFERED) return subscribers.length;
 			if (key == BooleanAttr.DELAY_ERROR) return delayError;
 

--- a/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -320,10 +320,17 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	}
 
 	@Override
+	public Throwable getError() {
+		return buffer.getError();
+	}
+
+	@Override
 	public Object scanUnsafe(Attr key) {
 		if (key == ScannableAttr.PARENT){
 			return subscription;
 		}
+		if (key == IntAttr.CAPACITY) return buffer.capacity();
+
 		return super.scanUnsafe(key);
 	}
 

--- a/src/main/java/reactor/core/publisher/SerializedSubscriber.java
+++ b/src/main/java/reactor/core/publisher/SerializedSubscriber.java
@@ -247,7 +247,7 @@ final class SerializedSubscriber<T> implements InnerOperator<T, T> {
 		return InnerOperator.super.scanUnsafe(key);
 	}
 
-	long producerCapacity() {
+	int producerCapacity() {
 		LinkedArrayNode<T> node = tail;
 		if(node != null){
 			return node.count;

--- a/src/main/java/reactor/core/publisher/TopicProcessor.java
+++ b/src/main/java/reactor/core/publisher/TopicProcessor.java
@@ -1163,8 +1163,17 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
 			if (key == BooleanAttr.TERMINATED) return processor.isTerminated();
 			if (key == BooleanAttr.CANCELLED) return !running.get();
-			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM ) return pendingRequest.getAsLong();
-			if (key == IntAttr.BUFFERED) return processor.ringBuffer.getCursor() - sequence.getAsLong();
+			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return pendingRequest.getAsLong();
+			if (key == LongAttr.LARGE_BUFFERED) {
+				return processor.ringBuffer.getCursor() - sequence.getAsLong();
+			}
+			if (key == IntAttr.BUFFERED) {
+				long realBuffered = processor.ringBuffer.getCursor() - sequence.getAsLong();
+				if (realBuffered <= Integer.MAX_VALUE) {
+					return (int) realBuffered;
+				}
+				return Integer.MIN_VALUE;
+			}
 
 			return InnerProducer.super.scanUnsafe(key);
 		}

--- a/src/test/java/reactor/core/publisher/BlockingSingleSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/BlockingSingleSubscriberTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+import reactor.core.Scannable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BlockingSingleSubscriberTest {
+
+	BlockingSingleSubscriber test = new BlockingSingleSubscriber() {
+		@Override
+		public void onNext(Object o) { }
+
+		@Override
+		public void onError(Throwable t) {
+			value = null;
+			error = t;
+			countDown();
+		}
+	};
+
+	@Test
+	public void scanMain() {
+		Subscription s = Operators.emptySubscription();
+		test.onSubscribe(s);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).describedAs("PARENT").isSameAs(s);
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).describedAs("TERMINATED").isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).describedAs("CANCELLED").isFalse();
+		assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).describedAs("ERROR").isNull();
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).describedAs("PREFETCH").isEqualTo(Integer.MAX_VALUE);
+	}
+
+	@Test
+	public void scanMainTerminated() {
+		test.onComplete();
+
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+	}
+
+	@Test
+	public void scanMainError() {
+		test.onError(new IllegalStateException("boom"));
+
+		assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).hasMessage("boom");
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+	}
+
+	@Test
+	public void scanMainCancelled() {
+		test.dispose();
+
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+	}
+}

--- a/src/test/java/reactor/core/publisher/ConnectableFluxOnAssemblyTest.java
+++ b/src/test/java/reactor/core/publisher/ConnectableFluxOnAssemblyTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.Test;
+import reactor.core.Scannable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConnectableFluxOnAssemblyTest {
+
+	@Test
+	public void scanMain() throws Exception {
+		ConnectableFlux<String> source = Flux.just("foo").publish();
+		ConnectableFluxOnAssembly<String> test = new ConnectableFluxOnAssembly<>(source);
+
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(-1);
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(source);
+	}
+
+}

--- a/src/test/java/reactor/core/publisher/DelegateProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/DelegateProcessorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import reactor.core.Scannable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class DelegateProcessorTest {
+
+	@Test
+	public void scanReturnsDownStreamForParentElseDelegates() {
+		Publisher downstream = Mockito.mock(Publisher.class);
+
+		IllegalStateException boom = new IllegalStateException("boom");
+		InnerConsumer upstream = Mockito.mock(InnerConsumer.class);
+		when(upstream.scanUnsafe(Scannable.ThrowableAttr.ERROR))
+				.thenReturn(boom);
+		when(upstream.scanUnsafe(Scannable.BooleanAttr.DELAY_ERROR))
+				.thenReturn(true);
+
+		DelegateProcessor processor = new DelegateProcessor(
+				downstream, upstream);
+
+		assertThat(processor.scan(Scannable.ScannableAttr.PARENT)).isSameAs(downstream);
+
+		assertThat(processor.scan(Scannable.ThrowableAttr.ERROR)).isSameAs(boom);
+		assertThat(processor.scan(Scannable.BooleanAttr.DELAY_ERROR)).isTrue();
+	}
+}

--- a/src/test/java/reactor/core/publisher/DirectProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/DirectProcessorTest.java
@@ -17,9 +17,14 @@ package reactor.core.publisher;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.reactivestreams.Subscriber;
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class DirectProcessorTest {
 
@@ -244,6 +249,23 @@ public class DirectProcessorTest {
         ts.assertValues(1)
           .assertNotComplete()
           .assertNoError();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void scanInner() {
+        Subscriber<? super String> actual = mock(Subscriber.class);
+        DirectProcessor<String> parent = new DirectProcessor<>();
+
+        DirectProcessor.DirectInner<String> test =
+                new DirectProcessor.DirectInner<>(actual, parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+        test.cancel();
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
     }
 
 }

--- a/src/test/java/reactor/core/publisher/EventLoopProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/EventLoopProcessorTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.concurrent.Executors;
+
+import org.junit.Test;
+import reactor.core.Scannable;
+import reactor.util.concurrent.WaitStrategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static reactor.core.Scannable.BooleanAttr.TERMINATED;
+import static reactor.core.Scannable.ScannableAttr.PARENT;
+import static reactor.core.Scannable.ThrowableAttr.ERROR;
+
+public class EventLoopProcessorTest {
+
+	@Test
+	public void scanMain() throws Exception {
+		EventLoopProcessor<String> test = new EventLoopProcessor<String>(128,
+				r -> new Thread(r),
+				Executors.newSingleThreadExecutor(),
+				true,
+				false,
+				() -> null,
+				WaitStrategy.sleeping()) {
+			@Override
+			public void run() {
+
+			}
+
+			@Override
+			public long getPending() {
+				return 456;
+			}
+
+			@Override
+			void doError(Throwable throwable) {
+				this.error = throwable;
+			}
+		};
+
+		assertThat(test.scan(PARENT)).isNull();
+		assertThat(test.scan(TERMINATED)).isFalse();
+
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(TERMINATED)).isTrue();
+		assertThat(test.scan(ERROR)).hasMessage("boom");
+
+		assertThat(test.scan(Scannable.IntAttr.CAPACITY)).isEqualTo(128);
+	}
+
+}

--- a/src/test/java/reactor/core/publisher/FluxAutoConnectFuseableTest.java
+++ b/src/test/java/reactor/core/publisher/FluxAutoConnectFuseableTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import reactor.core.Scannable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FluxAutoConnectFuseableTest {
+
+	@Test
+	public void scanMain() {
+		ConnectableFlux<String> source = Mockito.mock(ConnectableFlux.class);
+		Mockito.when(source.getPrefetch()).thenReturn(888);
+		FluxAutoConnectFuseable<String> test = new FluxAutoConnectFuseable<>(source, 123, d -> { });
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(source);
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(888);
+//		assertThat(test.scan(Scannable.IntAttr.CAPACITY)).isEqualTo(123);
+	}
+
+}

--- a/src/test/java/reactor/core/publisher/FluxAutoConnectTest.java
+++ b/src/test/java/reactor/core/publisher/FluxAutoConnectTest.java
@@ -19,8 +19,12 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 import reactor.core.Disposable;
+import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxAutoConnectTest {
 
@@ -73,5 +77,16 @@ public class FluxAutoConnectTest {
 		
 		cancel.get().dispose();
 		Assert.assertFalse("sp has subscribers?", e.downstreamCount() != 0);
+	}
+
+	@Test
+	public void scanMain() {
+		ConnectableFlux<String> source = Mockito.mock(ConnectableFlux.class);
+		Mockito.when(source.getPrefetch()).thenReturn(888);
+		FluxAutoConnect<String> test = new FluxAutoConnect<>(source, 123, d -> { });
+
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(888);
+//		assertThat(test.scan(Scannable.IntAttr.CAPACITY)).isEqualTo(123);
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(source);
 	}
 }

--- a/src/test/java/reactor/core/publisher/FluxElapsedTest.java
+++ b/src/test/java/reactor/core/publisher/FluxElapsedTest.java
@@ -17,7 +17,13 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.util.function.Tuple2;
 
@@ -36,4 +42,15 @@ public class FluxElapsedTest {
 		            .expectNextMatches(t -> t.getT1() == 2000 && t.getT2().equals("test"))
 		            .verifyComplete();
 	}
+
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Tuple2<Long, String>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxElapsed.ElapsedSubscriber<String> test = new FluxElapsed.ElapsedSubscriber<>(actual, Schedulers.single());
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxFilterFuseableTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFilterFuseableTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Fuseable;
+import reactor.core.Scannable;
+import reactor.test.publisher.FluxOperatorTest;
+
+public class FluxFilterFuseableTest extends FluxOperatorTest<String, String> {
+
+    @Test
+    public void scanSubscriber() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxFilterFuseable.FilterFuseableSubscriber<String> test = new FluxFilterFuseable.FilterFuseableSubscriber<>(actual, t -> true);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onError(new IllegalStateException("boom"));
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
+
+    @Test
+    public void scanConditionalSubscriber() {
+        Fuseable.ConditionalSubscriber<String> actual = Mockito.mock(Fuseable.ConditionalSubscriber.class);
+        FluxFilterFuseable.FilterFuseableConditionalSubscriber<String> test = new FluxFilterFuseable.FilterFuseableConditionalSubscriber<>(actual, t -> true);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onError(new IllegalStateException("boom"));
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
+}

--- a/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
@@ -420,6 +420,28 @@ public class FluxFilterWhenTest {
     }
 
     @Test
+    public void scanSmallBuffered() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxFilterWhen.FluxFilterWhenSubscriber<String> test = new FluxFilterWhen.FluxFilterWhenSubscriber<>(actual, t -> Mono.just(true), 789);
+
+        test.producerIndex = Integer.MAX_VALUE + 5L;
+        test.consumerIndex = Integer.MAX_VALUE + 2L;
+        assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(3);
+        assertThat(test.scan(Scannable.LongAttr.LARGE_BUFFERED)).isEqualTo(3L);
+    }
+
+    @Test
+    public void scanLargeBuffered() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxFilterWhen.FluxFilterWhenSubscriber<String> test = new FluxFilterWhen.FluxFilterWhenSubscriber<>(actual, t -> Mono.just(true), 789);
+
+        test.producerIndex = Integer.MAX_VALUE + 5L;
+        test.consumerIndex = 2L;
+        assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(Integer.MIN_VALUE);
+        assertThat(test.scan(Scannable.LongAttr.LARGE_BUFFERED)).isEqualTo(Integer.MAX_VALUE + 3L);
+    }
+
+    @Test
     public void scanInner() {
         Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxFilterWhen.FluxFilterWhenSubscriber<String> main = new FluxFilterWhen.FluxFilterWhenSubscriber<>(actual, t -> Mono.just(true), 789);

--- a/src/test/java/reactor/core/publisher/FluxFirstEmittingTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFirstEmittingTest.java
@@ -15,10 +15,16 @@
  */
 package reactor.core.publisher;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
 
 import org.junit.Test;
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
 
 public class FluxFirstEmittingTest {
@@ -136,4 +142,33 @@ public class FluxFirstEmittingTest {
 		  .assertError(NullPointerException.class);
 	}
 
+    @Test
+    public void scanSubscriber() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxFirstEmitting.RaceCoordinator<String> parent = new FluxFirstEmitting.RaceCoordinator<>(1);
+        FluxFirstEmitting.FirstEmittingSubscriber<String> test = new FluxFirstEmitting.FirstEmittingSubscriber<>(actual, parent, 1);
+        Subscription sub = Operators.emptySubscription();
+        test.onSubscribe(sub);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(sub);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        parent.cancelled = true;
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
+
+    @Test
+    public void scanRaceCoordinator() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxFirstEmitting.RaceCoordinator<String> parent = new FluxFirstEmitting.RaceCoordinator<>(1);
+        FluxFirstEmitting.FirstEmittingSubscriber<String> test = new FluxFirstEmitting.FirstEmittingSubscriber<>(actual, parent, 1);
+        Subscription sub = Operators.emptySubscription();
+        test.onSubscribe(sub);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(sub);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        assertThat(parent.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        parent.cancelled = true;
+        assertThat(parent.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -1224,6 +1224,7 @@ public class FluxFlatMapTest {
         test.scalarQueue = new ConcurrentLinkedQueue<>();
         test.scalarQueue.add(1);
         assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
+        assertThat(test.scan(Scannable.LongAttr.LARGE_BUFFERED)).isEqualTo(1L);
         assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).isNull();
 
         assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
@@ -1235,6 +1236,23 @@ public class FluxFlatMapTest {
         assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
         test.cancel();
         assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
+
+    @Test
+   public void scanMainLargeBuffered() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxFlatMap.FlatMapMain<Integer, Integer> test = new FluxFlatMap.FlatMapMain<>(actual,
+                i -> Mono.just(i), true, 5, QueueSupplier.<Integer>unbounded(), 789,  QueueSupplier.<Integer>get(789));
+
+
+        test.scalarQueue = new ConcurrentLinkedQueue<>();
+        test.scalarQueue.add(1);
+        test.scalarQueue.add(2);
+        test.scalarQueue.add(3);
+        test.size = Integer.MAX_VALUE;
+
+        assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(Integer.MIN_VALUE);
+        assertThat(test.scan(Scannable.LongAttr.LARGE_BUFFERED)).isEqualTo(Integer.MAX_VALUE + 3L);
     }
 
     @Test

--- a/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
@@ -16,6 +16,8 @@
 
 package reactor.core.publisher;
 
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -25,7 +27,14 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
 import reactor.core.Fuseable;
+import reactor.core.Scannable;
+import reactor.core.Scannable.IntAttr;
+import reactor.core.Scannable.LongAttr;
+import reactor.core.Scannable.ScannableAttr;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
@@ -327,4 +336,41 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
 				.verifyComplete();
 	}
 
+    @Test
+    public void scanOperator() {
+        Flux<Integer> source = Flux.range(1, 10);
+        FluxFlattenIterable<Integer, Integer> test = new FluxFlattenIterable<>(source, i -> new ArrayList<>(i), 35, QueueSupplier.one());
+
+        assertThat(test.scan(ScannableAttr.PARENT)).isSameAs(source);
+        assertThat(test.scan(IntAttr.PREFETCH)).isEqualTo(35);
+    }
+
+    @Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxFlattenIterable.FlattenIterableSubscriber<Integer, Integer> test =
+                new FluxFlattenIterable.FlattenIterableSubscriber<>(actual, i -> new ArrayList<>(i), 123, QueueSupplier.<Integer>one());
+        Subscription s = Operators.emptySubscription();
+        test.onSubscribe(s);
+
+        assertThat(test.scan(ScannableAttr.PARENT)).isSameAs(s);
+        assertThat(test.scan(ScannableAttr.ACTUAL)).isSameAs(actual);
+        assertThat(test.scan(IntAttr.PREFETCH)).isEqualTo(123);
+        test.requested = 35;
+        assertThat(test.scan(LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(35);
+        test.queue.add(5);
+        assertThat(test.scan(IntAttr.BUFFERED)).isEqualTo(1);
+
+        assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).isNull();
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.error = new IllegalStateException("boom");
+        assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).hasMessage("boom");
+        test.onComplete();
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancel();
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxHideTest.java
+++ b/src/test/java/reactor/core/publisher/FluxHideTest.java
@@ -19,9 +19,10 @@ import org.junit.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Fuseable;
+import reactor.core.Scannable;
 import reactor.test.publisher.TestPublisher;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxHideTest {
 
@@ -115,4 +116,26 @@ public class FluxHideTest {
 
 		sfs.clear(); //NOOP
 	}
+
+	@Test
+    public void scanSubscriber() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxHide.HideSubscriber<String> test = new FluxHide.HideSubscriber<>(actual);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+    }
+
+	@Test
+    public void scanSuppressFuseableSubscriber() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxHide.SuppressFuseableSubscriber<String> test = new FluxHide.SuppressFuseableSubscriber<>(actual);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxIntervalTest.java
+++ b/src/test/java/reactor/core/publisher/FluxIntervalTest.java
@@ -24,10 +24,14 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
 import reactor.core.scheduler.Schedulers;
+import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxIntervalTest {
 
@@ -137,4 +141,15 @@ public class FluxIntervalTest {
 		            .thenCancel()
 		            .verify();
 	}
+
+	@Test
+    public void scanIntervalRunnable() {
+        Subscriber<Long> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxInterval.IntervalRunnable test = new FluxInterval.IntervalRunnable(actual, Schedulers.single().createWorker());
+
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancel();
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxMapTest.java
+++ b/src/test/java/reactor/core/publisher/FluxMapTest.java
@@ -21,9 +21,16 @@ import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
 import reactor.core.Fuseable;
+import reactor.core.Scannable;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxMapTest extends FluxOperatorTest<String, String> {
 
@@ -287,4 +294,66 @@ public class FluxMapTest extends FluxOperatorTest<String, String> {
 		  .assertNoError()
 		  .assertComplete();
 	}
+
+    @Test
+    public void scanSubscriber() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxMap.MapSubscriber<Integer, String> test = new FluxMap.MapSubscriber<>(actual, i -> String.valueOf(i));
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onError(new IllegalStateException("boom"));
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
+
+    @Test
+    public void scanConditionalSubscriber() {
+        Fuseable.ConditionalSubscriber<String> actual = Mockito.mock(Fuseable.ConditionalSubscriber.class);
+        FluxMap.MapConditionalSubscriber<Integer, String> test = new FluxMap.MapConditionalSubscriber<>(actual, i -> String.valueOf(i));
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onError(new IllegalStateException("boom"));
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
+
+    @Test
+    public void scanFuseableSubscriber() {
+        Subscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxMapFuseable.MapFuseableSubscriber<Integer, String> test =
+        		new FluxMapFuseable.MapFuseableSubscriber<>(actual, i -> String.valueOf(i));
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onError(new IllegalStateException("boom"));
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
+
+    @Test
+    public void scanFuseableConditionalSubscriber() {
+        Fuseable.ConditionalSubscriber<String> actual = Mockito.mock(Fuseable.ConditionalSubscriber.class);
+        FluxMapFuseable.MapFuseableConditionalSubscriber<Integer, String> test =
+        		new FluxMapFuseable.MapFuseableConditionalSubscriber<>(actual, i -> String.valueOf(i));
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onError(new IllegalStateException("boom"));
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
+++ b/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
@@ -21,6 +21,10 @@ import java.io.StringWriter;
 import java.util.Objects;
 
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.core.publisher.FluxOnAssembly.AssemblySnapshotException;
 import reactor.test.StepVerifier;
 
@@ -258,4 +262,16 @@ public class FluxOnAssemblyTest {
 		String parallelFluxOnAssemblyStr = Flux.range(1, 10).parallel(2).checkpoint("onAssemblyDescription").toString();
 		assertTrue("Description not included: " + parallelFluxOnAssemblyStr, parallelFluxOnAssemblyStr.contains(expectedDescription));
 	}
+
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxOnAssembly.OnAssemblySubscriber<Integer> test =
+        		new FluxOnAssembly.OnAssemblySubscriber<>(actual, new AssemblySnapshotException(), Flux.just(1));
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferTest.java
+++ b/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferTest.java
@@ -20,8 +20,12 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 
@@ -142,4 +146,32 @@ public class FluxOnBackpressureBufferTest
 		            .expectNext(8, 9, 10, 11, 12, 13, 14, 15)
 		            .verifyComplete();
 	}
+
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxOnBackpressureBuffer.BackpressureBufferSubscriber<Integer> test =
+        		new FluxOnBackpressureBuffer.BackpressureBufferSubscriber<>(actual,
+        				123, false, true, t -> {});
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.BooleanAttr.DELAY_ERROR)).isTrue();
+        test.requested = 35;
+        assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(35);
+        assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+        assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(0); // RS: TODO non-zero size
+
+        assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).isNull();
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onError(new IllegalStateException("boom"));
+        assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).isSameAs(test.error);
+        assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancel();
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/FluxProcessorTest.java
@@ -25,10 +25,10 @@ import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.Assert;
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
+import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxProcessorTest {
@@ -250,4 +250,15 @@ public class FluxProcessorTest {
 		}
 	}
 
+	@Test
+	public void scanProcessor() {
+		FluxProcessor<String, String> test = DirectProcessor.<String>create().serialize();
+
+		assertThat(test.scan(Scannable.IntAttr.CAPACITY)).isEqualTo(16);
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).isNull();
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).hasMessage("boom");
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+	}
 }

--- a/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
+++ b/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
@@ -19,17 +19,15 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
 import org.junit.Test;
 import reactor.core.Disposable;
+import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxRefCountGraceTest {
 
@@ -86,7 +84,7 @@ public class FluxRefCountGraceTest {
 		p.subscribe().dispose();
 		p.subscribe().dispose();
 		p.subscribe().dispose();
-		
+
 		AssertSubscriber<Integer> ts1 = AssertSubscriber.create();
 		p.subscribe(ts1);
 
@@ -196,4 +194,14 @@ public class FluxRefCountGraceTest {
 		publisher.complete();
 		assertThat(termination.get()).isEqualTo(SignalType.ON_COMPLETE);
 	}
+
+	@Test
+	public void scanMain() {
+		ConnectableFlux<Integer> parent = Flux.just(10).publish();
+		FluxRefCountGrace<Integer> test = new FluxRefCountGrace<Integer>(parent, 17, Duration.ofSeconds(1), Schedulers.single());
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(256);
+	}
+
 }

--- a/src/test/java/reactor/core/publisher/FluxReplayTest.java
+++ b/src/test/java/reactor/core/publisher/FluxReplayTest.java
@@ -20,11 +20,17 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
 import reactor.core.Disposable;
 import reactor.core.Fuseable;
+import reactor.core.Scannable;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.scheduler.VirtualTimeScheduler;
@@ -83,7 +89,7 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 		vts = null;
 		VirtualTimeScheduler.reset();
 	}
-	
+
 	@Test
 	public void cacheFlux() {
 
@@ -277,4 +283,61 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 		boolean cancelled = ((FluxReplay.ReplaySubscriber) connected).cancelled;
 		assertThat(cancelled).isTrue();
 	}
+
+	@Test
+    public void scanMain() {
+        Flux<Integer> parent = Flux.just(1);
+        FluxReplay<Integer> test = new FluxReplay<>(parent, 25, 1000, Schedulers.single());
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(25);
+    }
+
+	@Test
+    public void scanInner() {
+		Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxReplay<Integer> main = new FluxReplay<>(Flux.just(1), 2, 1000, Schedulers.single());
+        FluxReplay.ReplayInner<Integer> test = new FluxReplay.ReplayInner<>(actual);
+        FluxReplay.ReplaySubscriber<Integer> parent = new FluxReplay.ReplaySubscriber<>(new FluxReplay.UnboundedReplayBuffer<>(10), main);
+        parent.trySubscribe(test);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(0); // RS: TODO non-zero size
+        test.request(35);
+        Assertions.assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(35);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.parent.terminate();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancel();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
+
+	@Test
+    public void scanSubscriber() {
+		FluxReplay<Integer> parent = new FluxReplay<>(Flux.just(1), 2, 1000, Schedulers.single());
+        FluxReplay.ReplaySubscriber<Integer> test = new FluxReplay.ReplaySubscriber<>(new FluxReplay.UnboundedReplayBuffer<>(10), parent);
+        Subscription sub = Operators.emptySubscription();
+        test.onSubscribe(sub);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(sub);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.CAPACITY)).isEqualTo(Integer.MAX_VALUE);
+        test.buffer.add(1);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        Assertions.assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).isNull();
+        test.onError(new IllegalStateException("boom"));
+        Assertions.assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).hasMessage("boom");
+        test.terminate();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancelled = true;
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
+++ b/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
@@ -19,7 +19,12 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
@@ -195,4 +200,34 @@ public class FluxRetryWhenTest {
 		            .expectComplete()
 		            .verify();
 	}
+
+	@Test
+    public void scanMainSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxRetryWhen.RetryWhenMainSubscriber<Integer> test =
+        		new FluxRetryWhen.RetryWhenMainSubscriber<>(actual, null, Flux.empty());
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        test.requested = 35;
+        Assertions.assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(35L);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancel();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
+
+	@Test
+    public void scanOtherSubscriber() {
+		Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxRetryWhen.RetryWhenMainSubscriber<Integer> main =
+        		new FluxRetryWhen.RetryWhenMainSubscriber<>(actual, null, Flux.empty());
+        FluxRetryWhen.RetryWhenOtherSubscriber test = new FluxRetryWhen.RetryWhenOtherSubscriber();
+        test.main = main;
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(main.otherArbiter);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(main);
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxScanSeedTest.java
+++ b/src/test/java/reactor/core/publisher/FluxScanSeedTest.java
@@ -19,11 +19,14 @@ package reactor.core.publisher;
 import java.util.Arrays;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxScanSeedTest extends FluxOperatorTest<String, String> {
 
@@ -148,4 +151,24 @@ public class FluxScanSeedTest extends FluxOperatorTest<String, String> {
 		  .assertNotComplete()
 		  .assertError(NullPointerException.class);
 	}
+
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxScanSeed.ScanSeedSubscriber<Integer, Integer> test = new FluxScanSeed.ScanSeedSubscriber<>(actual,
+        		(i, j) -> i + j, 0);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        test.requested = 35;
+        Assertions.assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(35);
+        test.value = 5;
+        Assertions.assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onComplete();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxSkipLastTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSkipLastTest.java
@@ -19,11 +19,14 @@ package reactor.core.publisher;
 import java.util.Arrays;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxSkipLastTest extends FluxOperatorTest<String, String> {
 	@Override
@@ -173,4 +176,17 @@ public class FluxSkipLastTest extends FluxOperatorTest<String, String> {
 		  .assertComplete();
 	}
 
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxSkipLast.SkipLastSubscriber<Integer> test = new FluxSkipLast.SkipLastSubscriber<>(actual, 7);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(7);
+        test.offer(1);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxSkipTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSkipTest.java
@@ -19,7 +19,12 @@ package reactor.core.publisher;
 import java.util.Arrays;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
@@ -124,4 +129,15 @@ public class FluxSkipTest extends FluxOperatorTest<String, String> {
 		            .expectNext("test", "test2", "test3")
 		            .verifyComplete();
 	}
+
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxSkip.SkipSubscriber<Integer> test = new FluxSkip.SkipSubscriber<>(actual, 7);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxSkipUntilTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSkipUntilTest.java
@@ -18,11 +18,14 @@ package reactor.core.publisher;
 import java.util.Arrays;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxSkipUntilTest extends FluxOperatorTest<String, String> {
 
@@ -64,4 +67,19 @@ public class FluxSkipUntilTest extends FluxOperatorTest<String, String> {
 		            .expectNext(5, 6, 7, 8, 9, 10)
 		            .verifyComplete();
 	}
+
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxSkipUntil.SkipUntilSubscriber<Integer> test = new FluxSkipUntil.SkipUntilSubscriber<>(actual, i -> true);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onComplete();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxSkipWhileTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSkipWhileTest.java
@@ -19,12 +19,15 @@ package reactor.core.publisher;
 import java.util.Arrays;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxSkipWhileTest extends FluxOperatorTest<String, String> {
 
@@ -196,4 +199,18 @@ public class FluxSkipWhileTest extends FluxOperatorTest<String, String> {
 		            .verifyComplete();
 	}
 
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxSkipWhile.SkipWhileSubscriber<Integer> test = new FluxSkipWhile.SkipWhileSubscriber<>(actual, i -> true);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onComplete();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxSourceTest.java
+++ b/src/test/java/reactor/core/publisher/FluxSourceTest.java
@@ -16,8 +16,10 @@
 package reactor.core.publisher;
 
 import org.junit.Test;
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class FluxSourceTest {
@@ -68,4 +70,14 @@ public class FluxSourceTest {
 		StepVerifier.create(Mono.empty().flux())
 		            .verifyComplete();
 	}
+
+	@Test
+	public void scanMain() {
+		Flux<Integer> parent = Flux.range(1,  10);
+		FluxSource<Integer, Integer> test = new FluxSource<>(parent);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(-1);
+	}
+
 }

--- a/src/test/java/reactor/core/publisher/FluxTakeUntilPredicateTest.java
+++ b/src/test/java/reactor/core/publisher/FluxTakeUntilPredicateTest.java
@@ -15,7 +15,12 @@
  */
 package reactor.core.publisher;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
 
 public class FluxTakeUntilPredicateTest {
@@ -155,4 +160,19 @@ public class FluxTakeUntilPredicateTest {
 
 	}
 
+	@Test
+    public void scanPredicateSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxTakeUntil.TakeUntilPredicateSubscriber<Integer> test =
+        		new FluxTakeUntil.TakeUntilPredicateSubscriber<>(actual, i -> true);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onComplete();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxTakeWhileTest.java
+++ b/src/test/java/reactor/core/publisher/FluxTakeWhileTest.java
@@ -16,7 +16,12 @@
 
 package reactor.core.publisher;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
@@ -166,4 +171,20 @@ public class FluxTakeWhileTest {
 		            .expectNext("test")
 		            .verifyComplete();
 	}
+
+	@Test
+    public void scanSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxTakeWhile.TakeWhileSubscriber<Integer> test =
+        		new FluxTakeWhile.TakeWhileSubscriber<>(actual, i -> true);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.onComplete();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -18,8 +18,8 @@ package reactor.core.publisher;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -27,14 +27,16 @@ import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.util.concurrent.QueueSupplier;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuple3;
-import reactor.util.function.Tuple4;
 import reactor.util.function.Tuple7;
 import reactor.util.function.Tuples;
 
@@ -1271,4 +1273,84 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 		            .expectNext(28)
 		            .verifyComplete();
 	}
+
+	@Test
+    public void scanCoordinator() {
+		Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+		FluxZip.ZipCoordinator<Integer, Integer> test = new FluxZip.ZipCoordinator<Integer, Integer>(actual,
+				i -> 5, 123, QueueSupplier.unbounded(), 345);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        test.requested = 35;
+        Assertions.assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(35);
+
+        Assertions.assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).isNull();
+        test.error = new IllegalStateException("boom");
+        Assertions.assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).hasMessage("boom");
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancel();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
+
+	@Test
+    public void scanInner() {
+		Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+		FluxZip.ZipCoordinator<Integer, Integer> main = new FluxZip.ZipCoordinator<Integer, Integer>(actual,
+				i -> 5, 123, QueueSupplier.unbounded(), 345);
+		FluxZip.ZipInner<Integer> test = new FluxZip.ZipInner<>(main, 234, 1, QueueSupplier.unbounded());
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(main);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(234);
+        test.queue = new ConcurrentLinkedQueue<>();
+        test.queue.offer(67);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.queue.clear();
+        test.onComplete();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancel();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
+
+
+	@Test
+    public void scanSingleCoordinator() {
+		Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+		FluxZip.ZipSingleCoordinator<Integer, Integer> test =
+				new FluxZip.ZipSingleCoordinator<Integer, Integer>(actual, new Object[1], 1, i -> 5);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+        test.wip = 1;
+        Assertions.assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+        test.wip = 0;
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        test.cancel();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
+
+	@Test
+    public void scanSingleSubscriber() {
+        Subscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+        FluxZip.ZipSingleCoordinator<Integer, Integer> main =
+				new FluxZip.ZipSingleCoordinator<Integer, Integer>(actual, new Object[1], 1, i -> 5);
+        FluxZip.ZipSingleSubscriber<Integer> test = new FluxZip.ZipSingleSubscriber<>(main, 0);
+        Subscription parent = Operators.emptySubscription();
+        test.onSubscribe(parent);
+
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(main);
+        test.onNext(7);
+        Assertions.assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+    }
 }

--- a/src/test/java/reactor/core/publisher/InnerProducerTest.java
+++ b/src/test/java/reactor/core/publisher/InnerProducerTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import reactor.core.Scannable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InnerProducerTest {
+
+	@Test
+	public void scanDefaultMethod() {
+		Subscriber<String> actual = new LambdaSubscriber<>(null, null, null, null);
+		InnerProducer<String> test = new InnerProducer<String>() {
+			@Override
+			public Subscriber<? super String> actual() {
+				return actual;
+			}
+
+			@Override
+			public void request(long n) { }
+
+			@Override
+			public void cancel() { }
+		};
+
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+	}
+}

--- a/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
@@ -261,6 +261,24 @@ public class LambdaMonoSubscriberTest {
 		Assertions.assertThat(cancelCount.get()).isEqualTo(1);
 	}
 
+	@Test
+	public void scan() {
+		LambdaMonoSubscriber<String> test = new LambdaMonoSubscriber<>(null, null, null, null);
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		Assertions.assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+
+		Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+		test.dispose();
+
+		Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+		Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
+
 	private static class TestSubscription implements Subscription {
 
 		volatile boolean isCancelled = false;
@@ -276,5 +294,4 @@ public class LambdaMonoSubscriberTest {
 			this.isCancelled = true;
 		}
 	}
-
 }

--- a/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
+++ b/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
@@ -314,4 +314,51 @@ public class MonoFilterWhenTest {
 		assertThat(terminated).isTrue();
 	}
 
+	@Test
+	public void scanSubscriber() {
+		Subscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoFilterWhen.MonoFilterWhenSubscriber<String> test = new MonoFilterWhen.MonoFilterWhenSubscriber<>(
+				actual, s -> Mono.just(false));
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+		//TERMINATED IS COVERED BY TEST ABOVE
+
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
+
+	@Test
+	public void scanFilterWhenInner() {
+		Subscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoFilterWhen.MonoFilterWhenSubscriber<String> main = new MonoFilterWhen.MonoFilterWhenSubscriber<>(
+				actual, s -> Mono.just(false));
+		MonoFilterWhen.FilterWhenInner test = new MonoFilterWhen.FilterWhenInner(main, true);
+
+		Subscription innerSubscription = Operators.emptySubscription();
+		test.onSubscribe(innerSubscription);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(main);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(innerSubscription);
+
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+		assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(1L);
+
+
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+		assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(0L);
+
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
+
 }

--- a/src/test/java/reactor/core/publisher/MonoFlatMapTest.java
+++ b/src/test/java/reactor/core/publisher/MonoFlatMapTest.java
@@ -1,33 +1,80 @@
 package reactor.core.publisher;
 
 import org.junit.Test;
-
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Scannable;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class MonoFlatMapTest {
 
-    @Test
-    public void normalHidden() {
-        AssertSubscriber<Integer> ts = AssertSubscriber.create();
-        
-        Mono.just(1).hide().flatMap(v -> Mono.just(2).hide()).subscribe(ts);
-        
-        ts.assertValues(2)
-        .assertComplete()
-        .assertNoError();
-    }
+	@Test
+	public void normalHidden() {
+		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-    @Test
-    public void cancel() {
-        TestPublisher<String> cancelTester = TestPublisher.create();
+		Mono.just(1).hide().flatMap(v -> Mono.just(2).hide()).subscribe(ts);
 
-        MonoProcessor<Integer> processor = cancelTester.mono()
-                                                       .flatMap(s -> Mono.just(s.length()))
-                                                       .toProcessor();
-        processor.subscribe();
-        processor.cancel();
+		ts.assertValues(2)
+		.assertComplete()
+		.assertNoError();
+	}
 
-        cancelTester.assertCancelled();
-    }
+	@Test
+	public void cancel() {
+		TestPublisher<String> cancelTester = TestPublisher.create();
+
+		MonoProcessor<Integer> processor = cancelTester.mono()
+													   .flatMap(s -> Mono.just(s.length()))
+													   .toProcessor();
+		processor.subscribe();
+		processor.cancel();
+
+		cancelTester.assertCancelled();
+	}
+
+	@Test
+	public void scanMain() {
+		Subscriber<Integer> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoFlatMap.ThenMapMain<String, Integer> test = new MonoFlatMap.ThenMapMain<>(
+				actual, s -> Mono.just(s.length()));
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
+
+	@Test
+	public void scanInner() {
+		Subscriber<Integer> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoFlatMap.ThenMapMain<String, Integer> main = new MonoFlatMap.ThenMapMain<>(actual, s -> Mono.just(s.length()));
+		MonoFlatMap.ThenMapInner<Integer> test = new MonoFlatMap.ThenMapInner<>(main);
+		Subscription innerSubscription = Operators.emptySubscription();
+		test.onSubscribe(innerSubscription);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(innerSubscription);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(main);
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
 }

--- a/src/test/java/reactor/core/publisher/MonoHasElementsTest.java
+++ b/src/test/java/reactor/core/publisher/MonoHasElementsTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
@@ -190,4 +191,95 @@ public class MonoHasElementsTest {
 
 		assertThat(cancelled.get()).isTrue();
 	}
+
+	@Test
+	public void scanHasElements() {
+		Subscriber<? super Boolean> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoHasElements.HasElementsSubscriber<String> test = new MonoHasElements.HasElementsSubscriber<>(actual);
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+		test.onComplete();
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+	}
+
+	@Test
+	public void scanHasElementsNoTerminatedOnError() {
+		Subscriber<? super Boolean> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoHasElements.HasElementsSubscriber<String> test = new MonoHasElements.HasElementsSubscriber<>(actual);
+
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+	}
+
+	@Test
+	public void scanHasElementsCancelled() {
+		Subscriber<? super Boolean> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoHasElements.HasElementsSubscriber<String> test = new MonoHasElements.HasElementsSubscriber<>(actual);
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
+
+	@Test
+	public void scanHasElement() {
+		Subscriber<? super Boolean> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoHasElements.HasElementSubscriber<String> test = new MonoHasElements.HasElementSubscriber<>(actual);
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+		test.onComplete();
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+	}
+
+	@Test
+	public void scanHasElementNoTerminatedOnError() {
+		Subscriber<? super Boolean> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoHasElements.HasElementSubscriber<String> test = new MonoHasElements.HasElementSubscriber<>(actual);
+
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+	}
+
+	@Test
+	public void scanHasElementCancelled() {
+		Subscriber<? super Boolean> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoHasElements.HasElementSubscriber<String> test = new MonoHasElements.HasElementSubscriber<>(actual);
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
+
 }

--- a/src/test/java/reactor/core/publisher/MonoIgnoreEmptyTest.java
+++ b/src/test/java/reactor/core/publisher/MonoIgnoreEmptyTest.java
@@ -17,7 +17,12 @@
 package reactor.core.publisher;
 
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoIgnoreEmptyTest {
 
@@ -33,6 +38,17 @@ public class MonoIgnoreEmptyTest {
 		StepVerifier.create(Flux.just(1)
 		                        .then())
 		            .expectComplete();
+	}
+
+	@Test
+	public void scanSubscriber() {
+		Subscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoIgnoreEmpty.IgnoreElementsSubscriber<String> test = new MonoIgnoreEmpty.IgnoreElementsSubscriber<>(actual);
+		Subscription sub = Operators.emptySubscription();
+		test.onSubscribe(sub);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(sub);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
 	}
 
 }

--- a/src/test/java/reactor/core/publisher/MonoPeekTerminalTest.java
+++ b/src/test/java/reactor/core/publisher/MonoPeekTerminalTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Scannable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MonoPeekTerminalTest {
+
+	@Test
+	public void scanSubscriber() {
+		Subscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoPeekTerminal<String> main = new MonoPeekTerminal<>(Mono.just("foo"), null, null, null);
+		MonoPeekTerminal.MonoTerminalPeekSubscriber<String> test = new MonoPeekTerminal.MonoTerminalPeekSubscriber<>(
+				actual, main);
+		Subscription sub = Operators.emptySubscription();
+		test.onSubscribe(sub);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(sub);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+	}
+
+}

--- a/src/test/java/reactor/core/publisher/MonoReduceSeedTest.java
+++ b/src/test/java/reactor/core/publisher/MonoReduceSeedTest.java
@@ -21,8 +21,13 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Scannable;
 import reactor.test.publisher.ReduceOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoReduceSeedTest extends ReduceOperatorTest<String, String> {
 
@@ -148,6 +153,29 @@ public class MonoReduceSeedTest extends ReduceOperatorTest<String, String> {
 		ts.assertNoValues()
 		  .assertNotComplete()
 		  .assertError(NullPointerException.class);
+	}
+
+
+	@Test
+	public void scanSubscriber() {
+		Subscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		MonoReduceSeed.ReduceSeedSubscriber<Integer, String> test = new MonoReduceSeed.ReduceSeedSubscriber<>(
+				actual, (s, i) -> s + i, "foo");
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
 	}
 
 }

--- a/src/test/java/reactor/core/publisher/MonoSourceTest.java
+++ b/src/test/java/reactor/core/publisher/MonoSourceTest.java
@@ -16,8 +16,10 @@
 package reactor.core.publisher;
 
 import org.junit.Test;
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class MonoSourceTest {
@@ -85,5 +87,13 @@ public class MonoSourceTest {
 	public void onAssemblyDescription() {
 		String monoOnAssemblyStr = Mono.just(1).checkpoint("onAssemblyDescription").toString();
 		assertTrue("Description not included: " + monoOnAssemblyStr, monoOnAssemblyStr.contains("\"description\" : \"onAssemblyDescription\""));
+	}
+
+	@Test
+	public void scanSubscriber() {
+		Flux<String> source = Flux.just("foo");
+		MonoSource<String, Integer> test = new MonoSource<>(source);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(source);
 	}
 }

--- a/src/test/java/reactor/core/publisher/MonoStreamCollectorTest.java
+++ b/src/test/java/reactor/core/publisher/MonoStreamCollectorTest.java
@@ -19,39 +19,72 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoStreamCollectorTest {
 
-    @Test
-    public void collectToList() {
-        Mono<List<Integer>> source = Flux.range(1, 5).collect(Collectors.toList());
+	@Test
+	public void collectToList() {
+		Mono<List<Integer>> source = Flux.range(1, 5).collect(Collectors.toList());
 
-        for (int i = 0; i < 5; i++) {
-            AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
-            source.subscribe(ts);
-    
-            ts.assertValues(Arrays.asList(1, 2, 3, 4, 5))
-            .assertNoError()
-            .assertComplete();
-        }
-    }
+		for (int i = 0; i < 5; i++) {
+			AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
+			source.subscribe(ts);
 
-    @Test
-    public void collectToSet() {
-        Mono<Set<Integer>> source = Flux.just(1).repeat(5).collect(Collectors.toSet());
+			ts.assertValues(Arrays.asList(1, 2, 3, 4, 5))
+			.assertNoError()
+			.assertComplete();
+		}
+	}
 
-        for (int i = 0; i < 5; i++) {
-            AssertSubscriber<Set<Integer>> ts = AssertSubscriber.create();
-            source.subscribe(ts);
-    
-            ts.assertValues(Collections.singleton(1))
-            .assertNoError()
-            .assertComplete();
-        }
-    }
+	@Test
+	public void collectToSet() {
+		Mono<Set<Integer>> source = Flux.just(1).repeat(5).collect(Collectors.toSet());
+
+		for (int i = 0; i < 5; i++) {
+			AssertSubscriber<Set<Integer>> ts = AssertSubscriber.create();
+			source.subscribe(ts);
+
+			ts.assertValues(Collections.singleton(1))
+			.assertNoError()
+			.assertComplete();
+		}
+	}
+
+	@Test
+	public void scanStreamCollectorSubscriber() {
+		Subscriber<List<String>> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+		Collector<String, Integer, List<String>> collector = (Collector<String, Integer, List<String>>) Collectors.<String>toList();
+		MonoStreamCollector.StreamCollectorSubscriber<String, Integer, List<String>> test = new MonoStreamCollector.StreamCollectorSubscriber<>(
+				actual,
+				1,
+				collector.accumulator(),
+				collector.finisher());
+		Subscription parent = Operators.emptySubscription();
+
+		test.onSubscribe(parent);
+
+		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
 
 }

--- a/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
@@ -59,6 +59,7 @@ public class SerializedSubscriberTest {
 		test.tail.count = Integer.MAX_VALUE;
 
 		assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(Integer.MAX_VALUE);
+		assertThat(test.scan(Scannable.LongAttr.LARGE_BUFFERED)).isNull();
 	}
 
 }

--- a/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
+++ b/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+import reactor.core.Scannable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SerializedSubscriberTest {
+
+	@Test
+	public void scanSerializedSubscriber() {
+		LambdaSubscriber<String> actual = new LambdaSubscriber<>(null, e -> { }, null, null);
+		SerializedSubscriber<String> test = new SerializedSubscriber<>(actual);
+		Subscription subscription = Operators.emptySubscription();
+		test.onSubscribe(subscription);
+
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(subscription);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+
+		assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isZero();
+		assertThat(test.scan(Scannable.IntAttr.CAPACITY)).isEqualTo(SerializedSubscriber.LinkedArrayNode.DEFAULT_CAPACITY);
+
+		assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).isNull();
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).hasMessage("boom");
+		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+
+		test.cancel();
+		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
+
+	@Test
+	public void scanSerializedSubscriberMaxBuffered() {
+		LambdaSubscriber<String> actual = new LambdaSubscriber<>(null, e -> { }, null, null);
+		SerializedSubscriber<String> test = new SerializedSubscriber<>(actual);
+
+		test.tail = new SerializedSubscriber.LinkedArrayNode<>("");
+		test.tail.count = Integer.MAX_VALUE;
+
+		assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(Integer.MAX_VALUE);
+	}
+
+}

--- a/src/test/java/reactor/core/publisher/SignalLoggerTests.java
+++ b/src/test/java/reactor/core/publisher/SignalLoggerTests.java
@@ -19,10 +19,12 @@ package reactor.core.publisher;
 import java.util.Collection;
 import java.util.logging.Level;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.Fuseable;
 import reactor.core.Fuseable.SynchronousSubscription;
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.util.Logger;
 import reactor.util.Loggers;
@@ -98,6 +100,14 @@ public class SignalLoggerTests {
 		};
 
 		assertThat(sl.subscriptionAsString(s), is("SignalLoggerTests$1"));
+	}
+
+	@Test
+	public void scanSignalLogger() {
+		Mono<String> source = Mono.empty();
+		SignalLogger<String> sl = new SignalLogger<>(source, null, null, false);
+
+		Assertions.assertThat(sl.scan(Scannable.ScannableAttr.PARENT)).isSameAs(source);
 	}
 
 	//=========================================================

--- a/src/test/java/reactor/core/publisher/TopicProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/TopicProcessorTest.java
@@ -710,7 +710,34 @@ public class TopicProcessorTest {
 		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
 	}
 
-	//TODO BUFFERED
+
+	@Test
+	public void scanInnerBufferedSmallHasIntRealValue() {
+		TopicProcessor<String> main = TopicProcessor.create("name", 16);
+		RingBuffer.Sequence sequence = RingBuffer.newSequence(123);
+		Subscriber<String> sub = new LambdaSubscriber<>(null, e -> {}, null, null);
+		TopicProcessor.TopicInner<String> test = new TopicProcessor.TopicInner<>(main, sequence, sub);
+
+		main.ringBuffer.getSequencer().cursor.set(Integer.MAX_VALUE + 5L);
+		test.sequence.set(6L);
+
+		assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(Integer.MAX_VALUE - 1);
+		assertThat(test.scan(Scannable.LongAttr.LARGE_BUFFERED)).isEqualTo(Integer.MAX_VALUE - 1L);
+	}
+
+	@Test
+	public void scanInnerBufferedLargeHasIntMinValue() {
+		TopicProcessor<String> main = TopicProcessor.create("name", 16);
+		RingBuffer.Sequence sequence = RingBuffer.newSequence(123);
+		Subscriber<String> sub = new LambdaSubscriber<>(null, e -> {}, null, null);
+		TopicProcessor.TopicInner<String> test = new TopicProcessor.TopicInner<>(main, sequence, sub);
+
+		main.ringBuffer.getSequencer().cursor.set(Integer.MAX_VALUE + 5L);
+		test.sequence.set(2L);
+
+		assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(Integer.MIN_VALUE);
+		assertThat(test.scan(Scannable.LongAttr.LARGE_BUFFERED)).isEqualTo(Integer.MAX_VALUE + 3L);
+	}
 
 	private void assertProcessor(TopicProcessor<Integer> processor,
 			boolean shared,


### PR DESCRIPTION
Attempting to cover all usages of `scanUnsafe` from PR #606 before
merging it. (see below comment for tracking of covered and uncovered
operators so far).

<details>
 <summary>Click for details about the typical test and the list of covered operators</summary>

**Test Model**
replace the `Scannable` line with the operator instance, edit and remove assertions
depending on attributes actually covered by its `scanUnsafe`.

```
  @Test
  public void scanMain() {
    Subscriber<T> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
    Scannable test = key -> null;
    Subscription parent = Operators.emptySubscription();
    test.onSubscribe(parent);

    assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(0);
    assertThat(test.scan(Scannable.IntAttr.CAPACITY)).isEqualTo(0);
    assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(0);

    assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(0L);

    assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
    assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);

    assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
    assertThat(test.scan(Scannable.BooleanAttr.DELAY_ERROR)).isFalse();

    assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).isNull();

    assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
    test.onError(new IllegalStateException("boom"));
    assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isTrue();
  }
```

**DONE**
```
BlockingIterable
BlockingIterable.SubscriberIterator
BlockingSingleSubscriber
ConnectableFluxOnAssembly
DirectProcessor.DirectInner
EmitterProcessor
EventLoopProcessor
FluxArray.ArrayConditionalSubscription
FluxArray.ArraySubscription
FluxAutoConnect
FluxAutoConnectFuseable
FluxAwaitOnSubscribe.PostOnSubscribeSubscriber
FluxBuffer.BufferExactSubscriber
FluxBuffer.BufferOverlappingSubscriber
FluxBuffer.BufferSkipSubscriber
FluxBufferBoundary.BufferBoundaryMain
FluxBufferBoundary.BufferBoundaryOther
FluxBufferTimeOrSize
FluxBufferPredicate.BufferPredicateSubscriber
FluxBufferWhen.BufferStartEndEnder
FluxBufferWhen.BufferStartEndMainSubscriber
FluxBufferWhen.BufferStartEndStarter
FluxCancelOn.CancelSubscriber
FluxCombineLatest.CombineLatestCoordinator
FluxCombineLatest.CombineLatestInner
FluxConcatArray.ConcatArrayDelayErrorSubscriber
FluxConcatMap.ConcatMapDelayed
FluxConcatMap.ConcatMapImmediate
FluxCreate.BaseSink
FluxCreate.BufferAsyncSink
FluxCreate.LatestAsyncSink
FluxCreate.SerializedSink
FluxDefaultIfEmpty.DefaultIfEmptySubscriber
FluxDelaySubscription.DelaySubscriptionOtherSubscriber
FluxDelaySubscription.DelaySubscriptionMainSubscriber
FluxDematerialize.DematerializeSubscriber
FluxDetach.DetachSubscriber
FluxDistinct.DistinctConditionalSubscriber
FluxDistinct.DistinctFuseableSubscriber
FluxDistinct.DistinctSubscriber
FluxDistinctUntilChanged.DistinctUntilChangedConditionalSubscriber
FluxDistinctUntilChanged.DistinctUntilChangedSubscriber
FluxDoFinally.DoFinallySubscriber
FluxElapsed.ElapsedSubscriber
FluxError.ErrorSubscription
FluxFilter.FilterConditionalSubscriber
FluxFilter.FilterSubscriber
FluxFilterFuseable.FilterFuseableConditionalSubscriber
FluxFilterFuseable.FilterFuseableSubscriber
FluxFilterWhen.FilterWhenInner
FluxFilterWhen.FluxFilterWhenSubscriber
FluxFirstEmitting.FirstEmittingSubscriber
FluxFirstEmitting.RaceCoordinator
FluxFlatMap.FlatMapInner
FluxFlatMap.FlatMapMain
FluxFlattenIterable.FlattenIterableSubscriber
FluxGenerate.GenerateSubscription
FluxGroupBy.GroupByMain
FluxGroupBy.UnicastGroupedFlux
FluxGroupJoin.GroupJoinSubscription
FluxGroupJoin.LeftRightEndSubscriber
FluxGroupJoin.LeftRightSubscriber
FluxHandle.HandleConditionalSubscriber
FluxHandle.HandleSubscriber
FluxHandleFuseable.HandleFuseableConditionalSubscriber
FluxHandleFuseable.HandleFuseableSubscriber
FluxHide.HideSubscriber
FluxHide.SuppressFuseableSubscriber
FluxInterval.IntervalRunnable
FluxIterable.IterableSubscription
FluxIterable.IterableSubscriptionConditional
FluxJoin.JoinSubscription
FluxJust.WeakScalarSubscription
FluxMap.MapConditionalSubscriber
FluxMap.MapSubscriber
FluxMapFuseable.MapFuseableConditionalSubscriber
FluxMapFuseable.MapFuseableSubscriber
FluxMapSignal.FluxMapSignalSubscriber
FluxMaterialize.MaterializeSubscriber
FluxMergeSequential.MergeSequentialInner
FluxMergeSequential.MergeSequentialMain
FluxOnAssembly.OnAssemblySubscriber
FluxOnBackpressureBuffer.BackpressureBufferSubscriber
FluxOnBackpressureBufferStrategy.BackpressureBufferDropOldestSubscriber
FluxOnBackpressureDrop.DropSubscriber
FluxOnBackpressureLatest.LatestSubscriber
FluxPeek.PeekSubscriber
FluxPeekFuseable.PeekConditionalSubscriber
FluxPeekFuseable.PeekFuseableConditionalSubscriber
FluxPeekFuseable.PeekFuseableSubscriber
FluxPeekStateful.PeekStatefulSubscriber
FluxProcessor
FluxPublish
FluxPublish.PublishInner
FluxPublish.PublishSubscriber
FluxPublish.PubSubInner
FluxPublishMulticast.CancelFuseableMulticaster
FluxPublishMulticast.CancelMulticaster
FluxPublishMulticast.FluxPublishMulticaster
FluxPublishMulticast.PublishMulticastInner
FluxPublishOn.PublishOnConditionalSubscriber
FluxPublishOn.PublishOnSubscriber
FluxRange.RangeSubscription
FluxRange.RangeSubscriptionConditional
FluxRefCount
FluxRefCount.RefCountMonitor.RefCountInner
FluxRefCountGrace
FluxRepeatWhen.RepeatWhenMainSubscriber
FluxRepeatWhen.RepeatWhenOtherSubscriber
FluxReplay
FluxReplay.ReplayInner
FluxReplay.ReplaySubscriber
FluxRetryWhen.RetryWhenMainSubscriber
FluxRetryWhen.RetryWhenOtherSubscriber
FluxSample.SampleMainSubscriber
FluxSample.SampleOther
FluxSampleFirst.SampleFirstMain
FluxSampleFirst.SampleFirstOther
FluxSampleTimeout.SampleTimeoutMain
FluxSampleTimeout.SampleTimeoutOther
FluxScan.ScanSubscriber
FluxScanSeed.ScanSeedSubscriber
FluxSkip.SkipSubscriber
FluxSkipLast.SkipLastSubscriber
FluxSkipUntil.SkipUntilSubscriber
FluxSkipUntilOther.SkipUntilMainSubscriber
FluxSkipUntilOther.SkipUntilOtherSubscriber
FluxSkipWhile.SkipWhileSubscriber
FluxSource
FluxSubscribeOn.SubscribeOnSubscriber
FluxSubscribeOnCallable.CallableSubscribeOnSubscription
FluxSubscribeOnValue.ScheduledScalar
FluxSwitchMap.SwitchMapInner
FluxSwitchMap.SwitchMapMain
FluxTake.TakeConditionalSubscriber
FluxTake.TakeFuseableSubscriber
FluxTake.TakeSubscriber
FluxTakeLast.TakeLastManySubscriber
FluxTakeLast.TakeLastZeroSubscriber
FluxTakeUntil.TakeUntilPredicateSubscriber
FluxTakeUntilOther.TakeUntilMainSubscriber
FluxTakeUntilOther.TakeUntilOtherSubscriber
FluxTakeWhile.TakeWhileSubscriber
FluxUsing.UsingConditionalSubscriber
FluxUsing.UsingFuseableSubscriber
FluxUsing.UsingSubscriber
FluxWindow.WindowExactSubscriber
FluxWindow.WindowOverlapSubscriber
FluxWindow.WindowSkipSubscriber
FluxWindowBoundary.WindowBoundaryMain
FluxWindowBoundary.WindowBoundaryOther
FluxWindowPredicate.WindowGroupedFlux
FluxWindowPredicate.WindowPredicateMain
FluxWindowTimeOrSize.WindowTimeoutSubscriber
FluxWindowWhen.WindowStartEndMainSubscriber
FluxWithLatestFrom.WithLatestFromOtherSubscriber
FluxWithLatestFrom.WithLatestFromSubscriber
FluxZip.ZipCoordinator
FluxZip.ZipInner
FluxZip.ZipSingleCoordinator
FluxZip.ZipSingleSubscriber
FluxZipIterable.ZipSubscriber
Operators.CancelledSubscription
Operators.DeferredSubscription
Operators.EmptySubscription
Operators.MonoSubscriber
Operators.MultiSubscriptionSubscriber
Operators.ScalarSubscription
InnerProducer
LambdaMonoSubscriber
LambdaSubscriber
MonoAll.AllSubscriber
MonoAny.AnySubscriber
MonoCollect.CollectSubscriber
MonoCollectList.MonoBufferAllSubscriber
MonoCount.CountSubscriber
MonoCreate.DefaultMonoSink
MonoDelay.MonoDelayRunnable
MonoDelayElement.DelayElementSubscriber
MonoDelayUntil
MonoElementAt.ElementAtSubscriber
MonoFilterWhen.FilterWhenInner
MonoFilterWhen.MonoFilterWhenSubscriber
MonoFlatMap.ThenMapMain
MonoFlatMap.ThenMapMain.ThenMapInner
MonoFlatMapMany.FlatMapInner
MonoFlatMapMany.FlatMapMain
MonoHasElements.HasElementsSubscriber
MonoHasElements.HasElementSubscriber
MonoIgnoreEmpty.IgnoreElementsSubscriber
MonoNext.NextSubscriber
MonoPeekTerminal.MonoTerminalPeekSubscriber
MonoProcessor
MonoPublishOn.PublishOnSubscriber
MonoReduce.ReduceSubscriber
MonoReduceSeed.ReduceSeedSubscriber
MonoSequenceEqual.EqualCoordinator
MonoSequenceEqual.EqualSubscriber
MonoSingle.SingleSubscriber
MonoSource
MonoStreamCollector.StreamCollectorSubscriber
MonoSubscribeOn.SubscribeOnSubscriber
MonoTakeLastOne.TakeLastOneSubscriber
MonoThenIgnore.ThenAcceptInner
MonoThenIgnore.ThenIgnoreInner
MonoUntilOther.UntilOtherCoordinator
MonoUntilOther.UntilOtherTrigger
MonoWhen.WhenCoordinator
MonoWhen.WhenInner
DelegateProcessor
ReplayProcessor
SerializedSubscriber
SignalLogger
TopicProcessor.TopicInner
WorkQueueProcessor.WorkQueueInner
```
</details>
 

**TODO**
Parallel Operators: Opened issue #634 to later cover.