### PR TITLE
fix #628 Replace Processor.Builder.create() with Processor.builder()

### DIFF
--- a/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -53,21 +53,16 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 
 	/**
 	 * {@link EmitterProcessor} builder that can be used to create new
-	 * processors.
+	 * processors. Instantiate it through the {@link EmitterProcessor#builder()} static
+	 * method:
+	 * <p>
+	 * {@code EmitterProcessor<String> processor = EmitterProcessor.<String>builder().build()}
 	 *
 	 * @param <T> Type of dispatched signal
 	 */
 	public final static class Builder<T> {
 		boolean autoCancel;
 		int bufferSize;
-
-		/**
-		 * Creates a new {@link EmitterProcessor} builder with default properties.
-		 * @return new EmitterProcessor builder
-		 */
-		public static <T> Builder<T> create()  {
-			return new Builder<T>();
-		}
 
 		Builder() {
 			this.autoCancel = true;
@@ -109,6 +104,14 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	}
 
 	/**
+	 * Create a new {@link EmitterProcessor} {@link Builder} with default properties.
+	 * @return new EmitterProcessor builder
+	 */
+	public static <E> Builder<E> builder()  {
+		return new Builder<>();
+	}
+
+	/**
 	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE}
 	 * backlog size, blockingWait Strategy and auto-cancel.
 	 *
@@ -117,7 +120,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	 * @return a fresh processor
 	 */
 	public static <E> EmitterProcessor<E> create() {
-		return Builder.<E>create().build();
+		return EmitterProcessor.<E>builder().build();
 	}
 
 	/**
@@ -128,11 +131,11 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	 * @param autoCancel automatically cancel
 	 *
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> EmitterProcessor<E> create(boolean autoCancel) {
-		return Builder.<E>create().autoCancel(autoCancel).build();
+		return EmitterProcessor.<E>builder().autoCancel(autoCancel).build();
 	}
 
 	/**
@@ -143,11 +146,11 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	 * @param bufferSize the internal buffer size to hold signals
 	 *
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> EmitterProcessor<E> create(int bufferSize) {
-		return Builder.<E>create().bufferSize(bufferSize).build();
+		return EmitterProcessor.<E>builder().bufferSize(bufferSize).build();
 	}
 
 	/**
@@ -159,11 +162,11 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	 * @param autoCancel automatically cancel
 	 *
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> EmitterProcessor<E> create(int bufferSize, boolean autoCancel) {
-		return Builder.<E>create().bufferSize(bufferSize).autoCancel(autoCancel).build();
+		return EmitterProcessor.<E>builder().bufferSize(bufferSize).autoCancel(autoCancel).build();
 	}
 
 	final int prefetch;

--- a/src/main/java/reactor/core/publisher/TopicProcessor.java
+++ b/src/main/java/reactor/core/publisher/TopicProcessor.java
@@ -69,7 +69,10 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 
 	/**
 	 * {@link TopicProcessor} builder that can be used to create new
-	 * processors.
+	 * processors. Instantiate it through the {@link TopicProcessor#builder()} static
+	 * method:
+	 * <p>
+	 * {@code TopicProcessor<String> processor = TopicProcessor.<String>builder().build()}
 	 *
 	 * @param <T> Type of dispatched signal
 	 */
@@ -83,14 +86,6 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 		boolean share;
 		boolean autoCancel;
 		Supplier<T> signalSupplier;
-
-		/**
-		 * Creates a new {@link TopicProcessor} builder with default properties.
-		 * @return new TopicProcessor builder
-		 */
-		public static <T> Builder<T> create()  {
-			return new Builder<T>();
-		}
 
 		Builder() {
 			this.bufferSize = QueueSupplier.SMALL_BUFFER_SIZE;
@@ -220,6 +215,14 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
+	 * Create a new {@link TopicProcessor} {@link Builder} with default properties.
+	 * @return new TopicProcessor builder
+	 */
+	public static <E> Builder<E> builder()  {
+		return new Builder<>();
+	}
+
+	/**
 	 * Create a new TopicProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and auto-cancel. <p> A new Cached ThreadExecutorPool will be
 	 * implicitly created.
@@ -227,7 +230,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * @return a fresh processor
 	 */
 	public static <E> TopicProcessor<E> create() {
-		return Builder.<E>create().build();
+		return TopicProcessor.<E>builder().build();
 	}
 
 	/**
@@ -236,11 +239,11 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * @param name processor thread logical name
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> create(String name) {
-		return Builder.<E>create().name(name).build();
+		return TopicProcessor.<E>builder().name(name).build();
 	}
 
 
@@ -252,11 +255,11 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> create(boolean autoCancel) {
-		return Builder.<E>create().autoCancel(autoCancel).build();
+		return TopicProcessor.<E>builder().autoCancel(autoCancel).build();
 	}
 
 	/**
@@ -267,11 +270,11 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * @param service A provided ExecutorService to manage threading infrastructure
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> create(ExecutorService service) {
-		return Builder.<E>create().executor(service).build();
+		return TopicProcessor.<E>builder().executor(service).build();
 	}
 
 	/**
@@ -284,12 +287,12 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> create(ExecutorService service,
 	                                                boolean autoCancel) {
-		return Builder.<E>create().executor(service).autoCancel(autoCancel).build();
+		return TopicProcessor.<E>builder().executor(service).autoCancel(autoCancel).build();
 	}
 
 	/**
@@ -302,11 +305,11 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * @param bufferSize A Backlog Size to mitigate slow subscribers
 	 * @param <E> Type of processed signals
 	 * @return the fresh TopicProcessor instance
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> create(String name, int bufferSize) {
-		return Builder.<E>create().name(name).bufferSize(bufferSize).build();
+		return TopicProcessor.<E>builder().name(name).bufferSize(bufferSize).build();
 	}
 
 	/**
@@ -320,12 +323,12 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> create(String name, int bufferSize,
 	                                                boolean autoCancel) {
-		return Builder.<E>create().name(name).bufferSize(bufferSize).autoCancel(autoCancel).build();
+		return TopicProcessor.<E>builder().name(name).bufferSize(bufferSize).autoCancel(autoCancel).build();
 	}
 
 	/**
@@ -336,12 +339,12 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * @param bufferSize A Backlog Size to mitigate slow subscribers
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> create(ExecutorService service,
 	                                                int bufferSize) {
-		return Builder.<E>create().executor(service).bufferSize(bufferSize).build();
+		return TopicProcessor.<E>builder().executor(service).bufferSize(bufferSize).build();
 	}
 
 	/**
@@ -354,12 +357,12 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> create(ExecutorService service,
 	                                                int bufferSize, boolean autoCancel) {
-		return Builder.<E>create().executor(service).bufferSize(bufferSize).autoCancel(autoCancel).build();
+		return TopicProcessor.<E>builder().executor(service).bufferSize(bufferSize).autoCancel(autoCancel).build();
 	}
 
 	/**
@@ -373,12 +376,12 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * blocking wait strategy.
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> create(String name, int bufferSize,
 	                                                WaitStrategy strategy) {
-		return Builder.<E>create().name(name).bufferSize(bufferSize).waitStrategy(strategy).build();
+		return TopicProcessor.<E>builder().name(name).bufferSize(bufferSize).waitStrategy(strategy).build();
 	}
 
 	/**
@@ -395,13 +398,13 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * buffer
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> create(String name, int bufferSize,
 	                                                WaitStrategy strategy,
 	                                                Supplier<E> signalSupplier) {
-		return Builder.<E>create()
+		return TopicProcessor.<E>builder()
 				.name(name)
 				.bufferSize(bufferSize)
 				.waitStrategy(strategy)
@@ -422,13 +425,13 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> create(String name, int bufferSize,
 	                                                WaitStrategy strategy,
 	                                                boolean autoCancel) {
-		return Builder.<E>create()
+		return TopicProcessor.<E>builder()
 				.name(name)
 				.bufferSize(bufferSize)
 				.waitStrategy(strategy)
@@ -446,13 +449,13 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * blocking wait strategy.
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> create(ExecutorService service,
 	                                                int bufferSize,
 	                                                WaitStrategy strategy) {
-		return Builder.<E>create()
+		return TopicProcessor.<E>builder()
 				.executor(service)
 				.bufferSize(bufferSize)
 				.waitStrategy(strategy)
@@ -471,13 +474,13 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> create(ExecutorService service,
 	                                                int bufferSize, WaitStrategy strategy,
 	                                                boolean autoCancel) {
-		return Builder.<E>create()
+		return TopicProcessor.<E>builder()
 				.executor(service)
 				.bufferSize(bufferSize)
 				.waitStrategy(strategy)
@@ -501,13 +504,13 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> create(ExecutorService service, ExecutorService requestTaskExecutor,
 	                                                int bufferSize, WaitStrategy strategy,
 	                                                boolean autoCancel) {
-		return Builder.<E>create()
+		return TopicProcessor.<E>builder()
 				.executor(service)
 				.requestTaskExecutor(requestTaskExecutor)
 				.bufferSize(bufferSize)
@@ -525,11 +528,11 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> share(boolean autoCancel) {
-		return Builder.<E>create().share(true).autoCancel(autoCancel).build();
+		return TopicProcessor.<E>builder().share(true).autoCancel(autoCancel).build();
 	}
 
 	/**
@@ -541,11 +544,11 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * @param service A provided ExecutorService to manage threading infrastructure
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> share(ExecutorService service) {
-		return Builder.<E>create().share(true).executor(service).build();
+		return TopicProcessor.<E>builder().share(true).executor(service).build();
 	}
 
 	/**
@@ -559,12 +562,12 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> share(ExecutorService service,
 	                                               boolean autoCancel) {
-		return Builder.<E>create().share(true).executor(service).autoCancel(autoCancel).build();
+		return TopicProcessor.<E>builder().share(true).executor(service).autoCancel(autoCancel).build();
 	}
 
 	/**
@@ -578,11 +581,11 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * @param bufferSize A Backlog Size to mitigate slow subscribers
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> share(String name, int bufferSize) {
-		return Builder.<E>create().share(true).name(name).bufferSize(bufferSize).build();
+		return TopicProcessor.<E>builder().share(true).name(name).bufferSize(bufferSize).build();
 	}
 
 	/**
@@ -598,12 +601,12 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> share(String name, int bufferSize,
 	                                               boolean autoCancel) {
-		return Builder.<E>create().share(true)
+		return TopicProcessor.<E>builder().share(true)
 				.name(name)
 				.bufferSize(bufferSize)
 				.autoCancel(autoCancel)
@@ -620,12 +623,12 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * @param bufferSize A Backlog Size to mitigate slow subscribers
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> share(ExecutorService service,
 	                                               int bufferSize) {
-		return Builder.<E>create().share(true)
+		return TopicProcessor.<E>builder().share(true)
 				.executor(service)
 				.bufferSize(bufferSize)
 				.build();
@@ -643,12 +646,12 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> share(ExecutorService service,
 	                                               int bufferSize, boolean autoCancel) {
-		return Builder.<E>create().share(true)
+		return TopicProcessor.<E>builder().share(true)
 				.executor(service)
 				.bufferSize(bufferSize)
 				.autoCancel(autoCancel)
@@ -668,12 +671,12 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * blocking wait strategy.
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> share(String name, int bufferSize,
 	                                               WaitStrategy strategy) {
-		return Builder.<E>create().share(true)
+		return TopicProcessor.<E>builder().share(true)
 				.name(name)
 				.bufferSize(bufferSize)
 				.waitStrategy(strategy)
@@ -693,12 +696,12 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * buffer
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> share(String name, int bufferSize,
 	                                               Supplier<E> signalSupplier) {
-		return Builder.<E>create().share(true)
+		return TopicProcessor.<E>builder().share(true)
 				.name(name)
 				.bufferSize(bufferSize)
 				.signalSupplier(signalSupplier)
@@ -720,13 +723,13 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * @param <E> Type of processed signals
 	 * @param signalSupplier the supplier of signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> share(String name, int bufferSize,
 			WaitStrategy waitStrategy,
 			Supplier<E> signalSupplier) {
-		return Builder.<E>create().share(true)
+		return TopicProcessor.<E>builder().share(true)
 				.name(name)
 				.bufferSize(bufferSize)
 				.waitStrategy(waitStrategy)
@@ -749,13 +752,13 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> share(String name, int bufferSize,
 	                                               WaitStrategy strategy,
 	                                               boolean autoCancel) {
-		return Builder.<E>create().share(true)
+		return TopicProcessor.<E>builder().share(true)
 				.name(name)
 				.bufferSize(bufferSize)
 				.waitStrategy(strategy)
@@ -775,13 +778,13 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * blocking wait strategy.
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> share(ExecutorService service,
 	                                               int bufferSize,
 	                                               WaitStrategy strategy) {
-		return Builder.<E>create().share(true)
+		return TopicProcessor.<E>builder().share(true)
 				.executor(service)
 				.bufferSize(bufferSize)
 				.waitStrategy(strategy)
@@ -802,13 +805,13 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> share(ExecutorService service,
 	                                               int bufferSize, WaitStrategy strategy,
 	                                               boolean autoCancel) {
-		return Builder.<E>create().share(true)
+		return TopicProcessor.<E>builder().share(true)
 				.executor(service)
 				.bufferSize(bufferSize)
 				.waitStrategy(strategy)
@@ -833,14 +836,14 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> TopicProcessor<E> share(ExecutorService service,
 			ExecutorService requestTaskExecutor,
 			int bufferSize, WaitStrategy strategy,
 			boolean autoCancel) {
-		return Builder.<E>create().share(true)
+		return TopicProcessor.<E>builder().share(true)
 				.executor(service)
 				.requestTaskExecutor(requestTaskExecutor)
 				.bufferSize(bufferSize)

--- a/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -44,7 +44,10 @@ public final class UnicastProcessor<T>
 
 	/**
 	 * {@link UnicastProcessor} builder that can be used to create new
-	 * processors.
+	 * processors. Instantiate it through the {@link UnicastProcessor#builder()} static
+	 * method:
+	 * <p>
+	 * {@code UnicastProcessor<String> processor = UnicastProcessor.<String>builder().build()}
 	 *
 	 * @param <T> Type of dispatched signal
 	 */
@@ -55,14 +58,6 @@ public final class UnicastProcessor<T>
 		Queue<T> queue;
 		Disposable onTerminate;
 		Consumer<? super T> onOverflow;
-
-		/**
-		 * Creates a new {@link UnicastProcessor} builder with default properties.
-		 * @return new UnicastProcessor builder
-		 */
-		public static <T> Builder<T> create()  {
-			return new Builder<T>();
-		}
 
 		Builder() {
 			this.onTerminate = NOOP_DISPOSABLE;
@@ -112,14 +107,22 @@ public final class UnicastProcessor<T>
 	}
 
 	/**
+	 * Create a new {@link UnicastProcessor} {@link Builder} with default properties.
+	 * @return new UnicastProcessor builder
+	 */
+	public static <E> Builder<E> builder()  {
+		return new Builder<>();
+	}
+
+	/**
 	 * Create a unicast {@link FluxProcessor} that will buffer on a given queue in an
 	 * unbounded fashion.
 	 *
-	 * @param <T> the relayed type
+	 * @param <E> the relayed type
 	 * @return a unicast {@link FluxProcessor}
 	 */
-	public static <T> UnicastProcessor<T> create() {
-		return Builder.<T>create().build();
+	public static <E> UnicastProcessor<E> create() {
+		return UnicastProcessor.<E>builder().build();
 	}
 
 	/**
@@ -127,13 +130,13 @@ public final class UnicastProcessor<T>
 	 * unbounded fashion.
 	 *
 	 * @param queue the buffering queue
-	 * @param <T> the relayed type
+	 * @param <E> the relayed type
 	 * @return a unicast {@link FluxProcessor}
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
-	public static <T> UnicastProcessor<T> create(Queue<T> queue) {
-		return Builder.<T>create().queue(queue).build();
+	public static <E> UnicastProcessor<E> create(Queue<E> queue) {
+		return UnicastProcessor.<E>builder().queue(queue).build();
 	}
 
 	/**
@@ -142,13 +145,13 @@ public final class UnicastProcessor<T>
 	 *
 	 * @param queue the buffering queue
 	 * @param endcallback called on any terminal signal
-	 * @param <T> the relayed type
+	 * @param <E> the relayed type
 	 * @return a unicast {@link FluxProcessor}
 	 * @deprecated use {@link Builder#build()}
 	 */
 	@Deprecated
-	public static <T> UnicastProcessor<T> create(Queue<T> queue, Disposable endcallback) {
-		return Builder.<T>create().queue(queue).onTerminate(endcallback).build();
+	public static <E> UnicastProcessor<E> create(Queue<E> queue, Disposable endcallback) {
+		return UnicastProcessor.<E>builder().queue(queue).onTerminate(endcallback).build();
 	}
 
 	/**
@@ -159,16 +162,16 @@ public final class UnicastProcessor<T>
 	 * @param endcallback called on any terminal signal
 	 * @param onOverflow called when queue.offer return false and unicastProcessor is
 	 * about to emit onError.
-	 * @param <T> the relayed type
+	 * @param <E> the relayed type
 	 *
 	 * @return a unicast {@link FluxProcessor}
 	 * @deprecated use {@link Builder#build()}
 	 */
 	@Deprecated
-	public static <T> UnicastProcessor<T> create(Queue<T> queue,
-			Consumer<? super T> onOverflow,
+	public static <E> UnicastProcessor<E> create(Queue<E> queue,
+			Consumer<? super E> onOverflow,
 			Disposable endcallback) {
-		return Builder.<T>create().queue(queue).onOverflow(onOverflow).onTerminate(endcallback).build();
+		return UnicastProcessor.<E>builder().queue(queue).onOverflow(onOverflow).onTerminate(endcallback).build();
 	}
 
 	final Queue<T>            queue;

--- a/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
+++ b/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
@@ -66,7 +66,10 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 
 	/**
 	 * {@link WorkQueueProcessor} builder that can be used to create new
-	 * processors.
+	 * processors. Instantiate it through the {@link WorkQueueProcessor#builder()} static
+	 * method:
+	 * <p>
+	 * {@code WorkQueueProcessor<String> processor = WorkQueueProcessor.<String>builder().build()}
 	 *
 	 * @param <T> Type of dispatched signal
 	 */
@@ -79,14 +82,6 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 		WaitStrategy waitStrategy;
 		boolean share;
 		boolean autoCancel;
-
-		/**
-		 * Creates a new {@link WorkQueueProcessor} builder with default properties.
-		 * @return new WorkQueueProcessor builder
-		 */
-		public static <T> Builder<T> create()  {
-			return new Builder<T>();
-		}
 
 		Builder() {
 			this.bufferSize = QueueSupplier.SMALL_BUFFER_SIZE;
@@ -205,6 +200,14 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	}
 
 	/**
+	 * Create a new {@link WorkQueueProcessor} {@link Builder} with default properties.
+	 * @return new WorkQueueProcessor builder
+	 */
+	public final static <T> Builder<T> builder() {
+		return new Builder<>();
+	}
+
+	/**
 	 * Create a new WorkQueueProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and auto-cancel. <p> A new Cached ThreadExecutorPool will be
 	 * implicitly created.
@@ -212,7 +215,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * @return a fresh processor
 	 */
 	public static <E> WorkQueueProcessor<E> create() {
-		return Builder.<E>create().build();
+		return WorkQueueProcessor.<E>builder().build();
 	}
 
 	/**
@@ -223,11 +226,11 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> create(boolean autoCancel) {
-		return Builder.<E>create().autoCancel(autoCancel).build();
+		return WorkQueueProcessor.<E>builder().autoCancel(autoCancel).build();
 	}
 
 	/**
@@ -238,11 +241,11 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * @param service A provided ExecutorService to manage threading infrastructure
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> create(ExecutorService service) {
-		return Builder.<E>create().executor(service).build();
+		return WorkQueueProcessor.<E>builder().executor(service).build();
 	}
 
 	/**
@@ -255,31 +258,31 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> create(ExecutorService service,
 			boolean autoCancel) {
-		return Builder.<E>create().executor(service).autoCancel(autoCancel).build();
+		return WorkQueueProcessor.<E>builder().executor(service).autoCancel(autoCancel).build();
 	}
 
 	/**
-	 * Create a new TopicProcessor using the default buffer size 32, blockingWait
+	 * Create a new WorkQueueProcessor using the default buffer size 32, blockingWait
 	 * Strategy and auto-cancel. <p> A new Cached ThreadExecutorPool will be implicitly
 	 * created and will use the passed name to qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> create(String name) {
-		return Builder.<E>create().name(name).build();
+		return WorkQueueProcessor.<E>builder().name(name).build();
 	}
 
 	/**
-	 * Create a new TopicProcessor using the passed buffer size, blockingWait
+	 * Create a new WorkQueueProcessor using the passed buffer size, blockingWait
 	 * Strategy and auto-cancel. <p> A new Cached ThreadExecutorPool will be implicitly
 	 * created and will use the passed name to qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
@@ -287,15 +290,15 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * @param bufferSize A Backlog Size to mitigate slow subscribers
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> create(String name, int bufferSize) {
-		return Builder.<E>create().name(name).bufferSize(bufferSize).build();
+		return WorkQueueProcessor.<E>builder().name(name).bufferSize(bufferSize).build();
 	}
 
 	/**
-	 * Create a new TopicProcessor using the passed buffer size, blockingWait
+	 * Create a new WorkQueueProcessor using the passed buffer size, blockingWait
 	 * Strategy and the passed auto-cancel setting. <p> A new Cached ThreadExecutorPool
 	 * will be implicitly created and will use the passed name to qualify the created
 	 * threads.
@@ -306,28 +309,28 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> create(String name, int bufferSize,
 			boolean autoCancel) {
-		return Builder.<E>create().name(name).bufferSize(bufferSize).autoCancel(autoCancel).build();
+		return WorkQueueProcessor.<E>builder().name(name).bufferSize(bufferSize).autoCancel(autoCancel).build();
 	}
 
 	/**
-	 * Create a new TopicProcessor using the passed buffer size, blockingWait
+	 * Create a new WorkQueueProcessor using the passed buffer size, blockingWait
 	 * Strategy and auto-cancel. <p> The passed {@link ExecutorService}
 	 * will execute as many event-loop consuming the ringbuffer as subscribers.
 	 * @param service A provided ExecutorService to manage threading infrastructure
 	 * @param bufferSize A Backlog Size to mitigate slow subscribers
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> create(ExecutorService service,
 			int bufferSize) {
-		return Builder.<E>create().executor(service).bufferSize(bufferSize).build();
+		return WorkQueueProcessor.<E>builder().executor(service).bufferSize(bufferSize).build();
 	}
 
 	/**
@@ -340,12 +343,12 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> create(ExecutorService service,
 			int bufferSize, boolean autoCancel) {
-		return Builder.<E>create().executor(service).bufferSize(bufferSize).autoCancel(autoCancel).build();
+		return WorkQueueProcessor.<E>builder().executor(service).bufferSize(bufferSize).autoCancel(autoCancel).build();
 	}
 
 	/**
@@ -359,12 +362,12 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * smart blocking wait strategy.
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> create(String name, int bufferSize,
 			WaitStrategy strategy) {
-		return Builder.<E>create().name(name).bufferSize(bufferSize).waitStrategy(strategy).build();
+		return WorkQueueProcessor.<E>builder().name(name).bufferSize(bufferSize).waitStrategy(strategy).build();
 	}
 
 	/**
@@ -380,12 +383,12 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> create(String name, int bufferSize,
 			WaitStrategy strategy, boolean autoCancel) {
-		return Builder.<E>create()
+		return WorkQueueProcessor.<E>builder()
 				.name(name)
 				.bufferSize(bufferSize)
 				.waitStrategy(strategy)
@@ -404,12 +407,12 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * smart blocking wait strategy.
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> create(ExecutorService executor,
 			int bufferSize, WaitStrategy strategy) {
-		return Builder.<E>create()
+		return WorkQueueProcessor.<E>builder()
 				.executor(executor)
 				.bufferSize(bufferSize)
 				.waitStrategy(strategy)
@@ -428,12 +431,12 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> create(ExecutorService executor,
 			int bufferSize, WaitStrategy strategy, boolean autoCancel) {
-		return Builder.<E>create()
+		return WorkQueueProcessor.<E>builder()
 				.executor(executor)
 				.bufferSize(bufferSize)
 				.waitStrategy(strategy)
@@ -457,13 +460,13 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> create(ExecutorService executor,
 			ExecutorService requestTaskExecutor,
 			int bufferSize, WaitStrategy strategy, boolean autoCancel) {
-		return Builder.<E>create()
+		return WorkQueueProcessor.<E>builder()
 				.executor(executor)
 				.requestTaskExecutor(requestTaskExecutor)
 				.bufferSize(bufferSize)
@@ -481,11 +484,11 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> share(boolean autoCancel) {
-		return Builder.<E>create().share(true).autoCancel(autoCancel).build();
+		return WorkQueueProcessor.<E>builder().share(true).autoCancel(autoCancel).build();
 	}
 
 	/**
@@ -496,11 +499,11 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * @param service A provided ExecutorService to manage threading infrastructure
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> share(ExecutorService service) {
-		return Builder.<E>create().share(true).executor(service).build();
+		return WorkQueueProcessor.<E>builder().share(true).executor(service).build();
 	}
 
 	/**
@@ -514,16 +517,16 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> share(ExecutorService service,
 			boolean autoCancel) {
-		return Builder.<E>create().share(true).executor(service).autoCancel(autoCancel).build();
+		return WorkQueueProcessor.<E>builder().share(true).executor(service).autoCancel(autoCancel).build();
 	}
 
 	/**
-	 * Create a new TopicProcessor using the passed buffer size, blockingWait
+	 * Create a new WorkQueueProcessor using the passed buffer size, blockingWait
 	 * Strategy and auto-cancel. <p> A Shared Processor authorizes concurrent onNext calls
 	 * and is suited for multi-threaded publisher that will fan-in data. <p> A new Cached
 	 * ThreadExecutorPool will be implicitly created and will use the passed name to
@@ -533,15 +536,15 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * @param bufferSize A Backlog Size to mitigate slow subscribers
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> share(String name, int bufferSize) {
-		return Builder.<E>create().share(true).name(name).bufferSize(bufferSize).build();
+		return WorkQueueProcessor.<E>builder().share(true).name(name).bufferSize(bufferSize).build();
 	}
 
 	/**
-	 * Create a new TopicProcessor using the passed buffer size, blockingWait
+	 * Create a new WorkQueueProcessor using the passed buffer size, blockingWait
 	 * Strategy and the passed auto-cancel setting. <p> A Shared Processor authorizes
 	 * concurrent onNext calls and is suited for multi-threaded publisher that will fan-in
 	 * data. <p> A new Cached ThreadExecutorPool will be implicitly created and will use
@@ -553,16 +556,16 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> share(String name, int bufferSize,
 			boolean autoCancel) {
-		return Builder.<E>create().share(true).name(name).bufferSize(bufferSize).autoCancel(autoCancel).build();
+		return WorkQueueProcessor.<E>builder().share(true).name(name).bufferSize(bufferSize).autoCancel(autoCancel).build();
 	}
 
 	/**
-	 * Create a new TopicProcessor using the passed buffer size, blockingWait
+	 * Create a new WorkQueueProcessor using the passed buffer size, blockingWait
 	 * Strategy and auto-cancel. <p> A Shared Processor authorizes concurrent onNext calls
 	 * and is suited for multi-threaded publisher that will fan-in data. <p> The passed
 	 * {@link ExecutorService} will execute as many event-loop
@@ -571,12 +574,12 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * @param bufferSize A Backlog Size to mitigate slow subscribers
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> share(ExecutorService service,
 			int bufferSize) {
-		return Builder.<E>create().share(true).executor(service).bufferSize(bufferSize).build();
+		return WorkQueueProcessor.<E>builder().share(true).executor(service).bufferSize(bufferSize).build();
 	}
 
 	/**
@@ -591,12 +594,12 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> share(ExecutorService service,
 			int bufferSize, boolean autoCancel) {
-		return Builder.<E>create().share(true).executor(service).bufferSize(bufferSize).autoCancel(autoCancel).build();
+		return WorkQueueProcessor.<E>builder().share(true).executor(service).bufferSize(bufferSize).autoCancel(autoCancel).build();
 	}
 
 	/**
@@ -612,12 +615,12 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * smart blocking wait strategy.
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> share(String name, int bufferSize,
 			WaitStrategy strategy) {
-		return Builder.<E>create().share(true).name(name).bufferSize(bufferSize).waitStrategy(strategy).build();
+		return WorkQueueProcessor.<E>builder().share(true).name(name).bufferSize(bufferSize).waitStrategy(strategy).build();
 	}
 
 	/**
@@ -635,12 +638,12 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> share(String name, int bufferSize,
 			WaitStrategy strategy, boolean autoCancel) {
-		return Builder.<E>create().share(true)
+		return WorkQueueProcessor.<E>builder().share(true)
 				.name(name)
 				.bufferSize(bufferSize)
 				.waitStrategy(strategy)
@@ -660,12 +663,12 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * smart blocking wait strategy.
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> share(ExecutorService executor,
 			int bufferSize, WaitStrategy strategy) {
-		return Builder.<E>create().share(true)
+		return WorkQueueProcessor.<E>builder().share(true)
 				.executor(executor)
 				.bufferSize(bufferSize)
 				.waitStrategy(strategy)
@@ -686,12 +689,12 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> share(ExecutorService executor,
 			int bufferSize, WaitStrategy strategy, boolean autoCancel) {
-		return Builder.<E>create().share(true)
+		return WorkQueueProcessor.<E>builder().share(true)
 				.executor(executor)
 				.bufferSize(bufferSize)
 				.waitStrategy(strategy)
@@ -716,13 +719,13 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * subscribers ?
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use {@link Builder#build()}
+	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
 	@Deprecated
 	public static <E> WorkQueueProcessor<E> share(ExecutorService executor,
 			ExecutorService requestTaskExecutor,
 			int bufferSize, WaitStrategy strategy, boolean autoCancel) {
-		return Builder.<E>create().share(true)
+		return WorkQueueProcessor.<E>builder().share(true)
 				.executor(executor)
 				.requestTaskExecutor(requestTaskExecutor)
 				.bufferSize(bufferSize)

--- a/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -54,7 +54,7 @@ public class EmitterProcessorTest {
 		final int elements = 10;
 		CountDownLatch latch = new CountDownLatch(elements + 1);
 
-		Processor<Integer, Integer> processor = EmitterProcessor.Builder.<Integer>create().bufferSize(16).build();
+		Processor<Integer, Integer> processor = EmitterProcessor.<Integer>builder().bufferSize(16).build();
 
 		List<Integer> list = new ArrayList<>();
 
@@ -116,7 +116,7 @@ public class EmitterProcessorTest {
 		final int elements = 10000;
 		CountDownLatch latch = new CountDownLatch(elements);
 
-		Processor<Integer, Integer> processor = EmitterProcessor.Builder.<Integer>create().bufferSize(1024).build();
+		Processor<Integer, Integer> processor = EmitterProcessor.<Integer>builder().bufferSize(1024).build();
 
 		EmitterProcessor<Integer> stream = EmitterProcessor.create();
 		FluxSink<Integer> session = stream.sink();
@@ -233,7 +233,7 @@ public class EmitterProcessorTest {
 
 	@Test
 	public void normalAtomicRingBufferBackpressured() {
-		EmitterProcessor<Integer> tp = EmitterProcessor.Builder.<Integer>create().bufferSize(100).build();
+		EmitterProcessor<Integer> tp = EmitterProcessor.<Integer>builder().bufferSize(100).build();
 		StepVerifier.create(tp, 0L)
 		            .then(() -> {
 			            Assert.assertTrue("No subscribers?", tp.hasDownstreams());
@@ -318,7 +318,7 @@ public class EmitterProcessorTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void failNullBufferSize() {
-		EmitterProcessor.Builder.<Integer>create().bufferSize(0);
+		EmitterProcessor.<Integer>builder().bufferSize(0);
 	}
 
 	@Test(expected = NullPointerException.class)
@@ -369,7 +369,7 @@ public class EmitterProcessorTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void failNegativeBufferSize() {
-		EmitterProcessor.Builder.<Integer>create().bufferSize(-1);
+		EmitterProcessor.<Integer>builder().bufferSize(-1);
 	}
 
 	static final List<String> DATA     = new ArrayList<>();
@@ -506,7 +506,7 @@ public class EmitterProcessorTest {
 
 	@Test
 	public void testHanging() {
-		FluxProcessor<String, String> processor = EmitterProcessor.Builder.<String>create().bufferSize(2).build();
+		FluxProcessor<String, String> processor = EmitterProcessor.<String>builder().bufferSize(2).build();
 
 		AssertSubscriber<String> first = AssertSubscriber.create(0);
 		processor.log("after-1").subscribe(first);
@@ -534,7 +534,7 @@ public class EmitterProcessorTest {
 
 	@Test
 	public void testNPE() {
-		FluxProcessor<String, String> processor = EmitterProcessor.Builder.<String>create().bufferSize(8).build();
+		FluxProcessor<String, String> processor = EmitterProcessor.<String>builder().bufferSize(8).build();
 		AssertSubscriber<String> first = AssertSubscriber.create(1);
 		processor.log().take(1).subscribe(first);
 
@@ -614,7 +614,7 @@ public class EmitterProcessorTest {
 		int N_THREADS = 3;
 		int N_ITEMS = 8;
 
-		FluxProcessor<String, String> processor = EmitterProcessor.Builder.<String>create().bufferSize(4).build();
+		FluxProcessor<String, String> processor = EmitterProcessor.<String>builder().bufferSize(4).build();
 		List<String> data = new ArrayList<>();
 		for (int i = 1; i <= N_ITEMS; i++) {
 			data.add(String.valueOf(i));

--- a/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
+++ b/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
@@ -567,7 +567,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void asyncFusionMapToNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		UnicastProcessor<Integer> up = UnicastProcessor.Builder.<Integer>create().queue(QueueSupplier.<Integer>get(2).get()).build();
+		UnicastProcessor<Integer> up = UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(2).get()).build();
 		up.onNext(1);
 		up.onNext(2);
 		up.onComplete();
@@ -586,7 +586,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.Builder.<Integer>create().queue(QueueSupplier.<Integer>get(2).get()).build();
+				UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(2).get()).build();
 		up.onNext(1);
 		up.onNext(2);
 		up.onComplete();

--- a/src/test/java/reactor/core/publisher/FluxFilterTest.java
+++ b/src/test/java/reactor/core/publisher/FluxFilterTest.java
@@ -180,7 +180,7 @@ public class FluxFilterTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.Builder.<Integer>create().queue(new ConcurrentLinkedQueue<>()).build();
+				UnicastProcessor.<Integer>builder().queue(new ConcurrentLinkedQueue<>()).build();
 
 		up.filter(v -> (v & 1) == 0)
 		  .subscribe(ts);
@@ -200,7 +200,7 @@ public class FluxFilterTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Object> ts = AssertSubscriber.create(1);
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.Builder.<Integer>create().queue(new ConcurrentLinkedQueue<>()).build();
+				UnicastProcessor.<Integer>builder().queue(new ConcurrentLinkedQueue<>()).build();
 
 		Flux.just(1)
 		    .hide()
@@ -226,7 +226,7 @@ public class FluxFilterTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Object> ts = AssertSubscriber.create(1);
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.Builder.<Integer>create().queue(new ConcurrentLinkedQueue<>()).build();
+				UnicastProcessor.<Integer>builder().queue(new ConcurrentLinkedQueue<>()).build();
 
 		Flux.just(1)
 		    .hide()

--- a/src/test/java/reactor/core/publisher/FluxMapTest.java
+++ b/src/test/java/reactor/core/publisher/FluxMapTest.java
@@ -145,7 +145,7 @@ public class FluxMapTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.Builder.<Integer>create().queue(new ConcurrentLinkedQueue<>()).build();
+				UnicastProcessor.<Integer>builder().queue(new ConcurrentLinkedQueue<>()).build();
 
 		up.map(v -> v + 1)
 		  .subscribe(ts);
@@ -165,7 +165,7 @@ public class FluxMapTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Object> ts = AssertSubscriber.create(1);
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.Builder.<Integer>create().queue(new ConcurrentLinkedQueue<>()).build();
+				UnicastProcessor.<Integer>builder().queue(new ConcurrentLinkedQueue<>()).build();
 
 		Flux.just(1)
 		    .hide()

--- a/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
+++ b/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
@@ -489,7 +489,7 @@ public class FluxPeekFuseableTest {
 	public void asyncFusionAvailable() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		UnicastProcessor.Builder.<Integer>create().queue(QueueSupplier.<Integer>get(2).get()).build()
+		UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(2).get()).build()
 		                .doOnNext(v -> {
 		                })
 		                .subscribe(ts);

--- a/src/test/java/reactor/core/publisher/FluxPeekTest.java
+++ b/src/test/java/reactor/core/publisher/FluxPeekTest.java
@@ -736,7 +736,7 @@ public class FluxPeekTest extends FluxOperatorTest<String, String> {
 	public void asyncFusionAvailable() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		UnicastProcessor.Builder.<Integer>create().queue(QueueSupplier.<Integer>get(2).get()).build()
+		UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(2).get()).build()
 		                .doOnNext(v -> {
 		                })
 		                .subscribe(ts);

--- a/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
+++ b/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
@@ -147,7 +147,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.Builder.<Integer>create().queue(QueueSupplier.<Integer>get(16).get()).build();
+				UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(16).get()).build();
 
 		up.publish(o -> zip((Object[] a) -> (Integer) a[0] + (Integer) a[1], o, o.skip(1)))
 		  .subscribe(ts);

--- a/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
+++ b/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
@@ -240,7 +240,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.Builder.<Integer>create().queue(new ConcurrentLinkedQueue<>()).build();
+				UnicastProcessor.<Integer>builder().queue(new ConcurrentLinkedQueue<>()).build();
 
 		for (int i = 0; i < 1_000_000; i++) {
 			up.onNext(i);
@@ -260,7 +260,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void normalAsyncFusedBackpressured() throws Exception {
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.Builder.<Integer>create().queue(QueueSupplier.<Integer>unbounded(1024).get()).build();
+				UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>unbounded(1024).get()).build();
 
 		for (int i = 0; i < 1_000_000; i++) {
 			up.onNext(0);
@@ -692,7 +692,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	public void mappedAsyncSourceWithNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.Builder.<Integer>create().queue(QueueSupplier.<Integer>get(2).get()).build();
+				UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(2).get()).build();
 		up.onNext(1);
 		up.onNext(2);
 		up.onComplete();
@@ -712,7 +712,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	public void mappedAsyncSourceWithNullPostFilter() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.Builder.<Integer>create().queue(QueueSupplier.<Integer>get(2).get()).build();
+				UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(2).get()).build();
 		up.onNext(1);
 		up.onNext(2);
 		up.onComplete();
@@ -794,7 +794,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void threadBoundaryPreventsInvalidFusionMap() {
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.Builder.<Integer>create().queue(QueueSupplier.<Integer>get(2).get()).build();
+				UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(2).get()).build();
 
 		AssertSubscriber<String> ts = AssertSubscriber.create();
 
@@ -817,7 +817,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void threadBoundaryPreventsInvalidFusionFilter() {
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.Builder.<Integer>create().queue(QueueSupplier.<Integer>get(2).get()).build();
+				UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(2).get()).build();
 
 		String s = Thread.currentThread()
 		                 .getName();

--- a/src/test/java/reactor/core/publisher/FluxPublishTest.java
+++ b/src/test/java/reactor/core/publisher/FluxPublishTest.java
@@ -157,7 +157,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts1 = AssertSubscriber.create();
 		AssertSubscriber<Integer> ts2 = AssertSubscriber.create();
 
-		UnicastProcessor<Integer> up = UnicastProcessor.Builder.<Integer>create().queue(QueueSupplier.<Integer>get(8).get()).build();
+		UnicastProcessor<Integer> up = UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(8).get()).build();
 		up.onNext(1);
 		up.onNext(2);
 		up.onNext(3);
@@ -196,7 +196,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts1 = AssertSubscriber.create(0);
 		AssertSubscriber<Integer> ts2 = AssertSubscriber.create(0);
 
-		UnicastProcessor<Integer> up = UnicastProcessor.Builder.<Integer>create().queue(QueueSupplier.<Integer>get(8).get()).build();
+		UnicastProcessor<Integer> up = UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(8).get()).build();
 		up.onNext(1);
 		up.onNext(2);
 		up.onNext(3);

--- a/src/test/java/reactor/core/publisher/TopicProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/TopicProcessorTest.java
@@ -45,7 +45,7 @@ public class TopicProcessorTest {
 
 	@Test
 	public void testShutdownSuccessfullAfterAllDataIsRequested() throws InterruptedException {
-		TopicProcessor<String> processor = TopicProcessor.Builder.<String>create().name("processor").bufferSize(4).build();
+		TopicProcessor<String> processor = TopicProcessor.<String>builder().name("processor").bufferSize(4).build();
 		Publisher<String>
 				publisher = Flux.fromArray(new String[] { "1", "2", "3", "4", "5" });
 		publisher.subscribe(processor);
@@ -68,7 +68,7 @@ public class TopicProcessorTest {
 
 	@Test
 	public void testForceShutdownWhileWaitingForRequest() throws InterruptedException {
-		TopicProcessor<String> processor = TopicProcessor.Builder.<String>create().name("processor").bufferSize(4).build();
+		TopicProcessor<String> processor = TopicProcessor.<String>builder().name("processor").bufferSize(4).build();
 		Publisher<String> publisher = Flux.fromArray(new String[] { "1", "2", "3", "4", "5" });
 		publisher.subscribe(processor);
 
@@ -86,7 +86,7 @@ public class TopicProcessorTest {
 
 	@Test
 	public void testForceShutdownWhileWaitingForInitialRequest() throws InterruptedException {
-		TopicProcessor<String> processor = TopicProcessor.Builder.<String>create().name("processor").bufferSize(4).build();
+		TopicProcessor<String> processor = TopicProcessor.<String>builder().name("processor").bufferSize(4).build();
 		Publisher<String> publisher = new CappedPublisher(2);
 		publisher.subscribe(processor);
 
@@ -140,7 +140,7 @@ public class TopicProcessorTest {
 
 	@Test
 	public void testForceShutdownWhileWaitingForMoreData() throws InterruptedException {
-		TopicProcessor<String> processor = TopicProcessor.Builder.<String>create().name("processor").bufferSize(4).build();
+		TopicProcessor<String> processor = TopicProcessor.<String>builder().name("processor").bufferSize(4).build();
 		Publisher<String> publisher = new CappedPublisher(2);
 		publisher.subscribe(processor);
 
@@ -158,7 +158,7 @@ public class TopicProcessorTest {
 
 	@Test
 	public void testForceShutdownAfterShutdown() throws InterruptedException {
-		TopicProcessor<String> processor = TopicProcessor.Builder.<String>create().name("processor").bufferSize(4).build();
+		TopicProcessor<String> processor = TopicProcessor.<String>builder().name("processor").bufferSize(4).build();
 		Publisher<String> publisher = Flux.fromArray(new String[] { "1", "2", "3", "4", "5" });
 		publisher.subscribe(processor);
 
@@ -181,7 +181,7 @@ public class TopicProcessorTest {
 	@Test
 	public void testShutdown() {
 		for (int i = 0; i < 1000; i++) {
-			TopicProcessor<?> dispatcher = TopicProcessor.Builder.<String>create().name("rb-test-dispose").bufferSize(16).build();
+			TopicProcessor<?> dispatcher = TopicProcessor.<String>builder().name("rb-test-dispose").bufferSize(16).build();
 			dispatcher.awaitAndShutdown();
 		}
 	}
@@ -190,7 +190,7 @@ public class TopicProcessorTest {
 
 	@Test
 	public void drainTest() throws Exception {
-		final TopicProcessor<Integer> sink = TopicProcessor.Builder.<Integer>create().name("topic").build();
+		final TopicProcessor<Integer> sink = TopicProcessor.<Integer>builder().name("topic").build();
 		sink.onNext(1);
 		sink.onNext(2);
 		sink.onNext(3);
@@ -233,7 +233,7 @@ public class TopicProcessorTest {
 	public void chainedTopicProcessor() throws Exception{
 		ExecutorService es = Executors.newFixedThreadPool(2);
 		try {
-			TopicProcessor<String> bc = TopicProcessor.Builder.<String>create().executor(es).bufferSize(16).build();
+			TopicProcessor<String> bc = TopicProcessor.<String>builder().executor(es).bufferSize(16).build();
 
 			int elems = 100;
 			CountDownLatch latch = new CountDownLatch(elems);
@@ -254,7 +254,7 @@ public class TopicProcessorTest {
 	public void testTopicProcessorGetters() {
 
 		final int TEST_BUFFER_SIZE = 16;
-		TopicProcessor<Object> processor = TopicProcessor.Builder.create().name("testProcessor").bufferSize(TEST_BUFFER_SIZE).build();
+		TopicProcessor<Object> processor = TopicProcessor.builder().name("testProcessor").bufferSize(TEST_BUFFER_SIZE).build();
 
 		assertEquals(TEST_BUFFER_SIZE, processor.getAvailableCapacity());
 
@@ -264,23 +264,23 @@ public class TopicProcessorTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void failNullBufferSize() {
-		TopicProcessor.Builder.create().name("test").bufferSize(0);
+		TopicProcessor.builder().name("test").bufferSize(0);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void failNonPowerOfTwo() {
-		TopicProcessor.Builder.create().name("test").bufferSize(3);
+		TopicProcessor.builder().name("test").bufferSize(3);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void failNegativeBufferSize() {
-		TopicProcessor.Builder.create().name("test").bufferSize(-1);
+		TopicProcessor.builder().name("test").bufferSize(-1);
 	}
 
 	//see https://github.com/reactor/reactor-core/issues/445
 	@Test(timeout = 5_000)
 	public void testBufferSize1Shared() throws Exception {
-		TopicProcessor<String> broadcast = TopicProcessor.Builder.<String>create()
+		TopicProcessor<String> broadcast = TopicProcessor.<String>builder()
 				.name("share-name")
 				.bufferSize(1)
 				.autoCancel(true)
@@ -309,7 +309,7 @@ public class TopicProcessorTest {
 	//see https://github.com/reactor/reactor-core/issues/445
 	@Test(timeout = 5_000)
 	public void testBufferSize1Created() throws Exception {
-		TopicProcessor<String> broadcast = TopicProcessor.Builder.<String>create().name("share-name").bufferSize(1).autoCancel(true).build();
+		TopicProcessor<String> broadcast = TopicProcessor.<String>builder().name("share-name").bufferSize(1).autoCancel(true).build();
 
 		int simultaneousSubscribers = 3000;
 		CountDownLatch latch = new CountDownLatch(simultaneousSubscribers);
@@ -336,7 +336,7 @@ public class TopicProcessorTest {
 		String mainName = "topicProcessorRequestTask";
 		String expectedName = mainName + "[request-task]";
 
-		TopicProcessor<Object> processor = TopicProcessor.Builder.create().name(mainName).bufferSize(8).build();
+		TopicProcessor<Object> processor = TopicProcessor.builder().name(mainName).bufferSize(8).build();
 
 		processor.requestTask(Operators.cancelledSubscription());
 
@@ -360,7 +360,7 @@ public class TopicProcessorTest {
 		String expectedName = "topicProcessorRequestTaskCreate";
 		//NOTE: the below single executor should not be used usually as requestTask assumes it immediately gets executed
 		ExecutorService customTaskExecutor = Executors.newSingleThreadExecutor(r -> new Thread(r, expectedName));
-		TopicProcessor<Object> processor = TopicProcessor.Builder.create()
+		TopicProcessor<Object> processor = TopicProcessor.builder()
 				.executor(Executors.newCachedThreadPool())
 				.requestTaskExecutor(customTaskExecutor)
 				.bufferSize(8)
@@ -391,7 +391,7 @@ public class TopicProcessorTest {
 		//NOTE: the below single executor should not be used usually as requestTask assumes it immediately gets executed
 		ExecutorService customTaskExecutor = Executors.newSingleThreadExecutor(r -> new Thread(r, expectedName));
 
-		TopicProcessor<Object> processor = TopicProcessor.Builder.create().share(true)
+		TopicProcessor<Object> processor = TopicProcessor.builder().share(true)
 				.executor(Executors.newCachedThreadPool())
 				.requestTaskExecutor(customTaskExecutor)
 				.bufferSize(8)

--- a/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
@@ -32,7 +32,7 @@ public class UnicastProcessorTest {
     @Test
     public void secondSubscriberRejectedProperly() {
 
-        UnicastProcessor<Integer> up = UnicastProcessor.Builder.<Integer>create().queue(new ConcurrentLinkedQueue<>()).build();
+        UnicastProcessor<Integer> up = UnicastProcessor.<Integer>builder().queue(new ConcurrentLinkedQueue<>()).build();
 
         up.subscribe();
 

--- a/src/test/java/reactor/core/publisher/WorkQueueProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/WorkQueueProcessorTest.java
@@ -92,7 +92,7 @@ public class WorkQueueProcessorTest {
 	@Test
 	public void fixedThreadPoolWorkQueueRejectsSubscribers() {
 		ExecutorService executorService = Executors.newFixedThreadPool(2);
-		WorkQueueProcessor<String> bc = WorkQueueProcessor.Builder.<String>create().executor(executorService).bufferSize(16).build();
+		WorkQueueProcessor<String> bc = WorkQueueProcessor.<String>builder().executor(executorService).bufferSize(16).build();
 		CountDownLatch latch = new CountDownLatch(3);
 		TestWorkQueueSubscriber spec1 = new TestWorkQueueSubscriber(latch, "spec1");
 		TestWorkQueueSubscriber spec2 = new TestWorkQueueSubscriber(latch, "spec2");
@@ -124,7 +124,7 @@ public class WorkQueueProcessorTest {
 	@Test
 	public void forkJoinPoolWorkQueueRejectsSubscribers() {
 		ExecutorService executorService = Executors.newWorkStealingPool(2);
-		WorkQueueProcessor<String> bc = WorkQueueProcessor.Builder.<String>create().executor(executorService).bufferSize(16).build();
+		WorkQueueProcessor<String> bc = WorkQueueProcessor.<String>builder().executor(executorService).bufferSize(16).build();
 		CountDownLatch latch = new CountDownLatch(2);
 		TestWorkQueueSubscriber spec1 = new TestWorkQueueSubscriber(latch, "spec1");
 		TestWorkQueueSubscriber spec2 = new TestWorkQueueSubscriber(latch, "spec2");
@@ -153,7 +153,7 @@ public class WorkQueueProcessorTest {
 
 	@Test
 	public void highRate() throws Exception {
-		WorkQueueProcessor<String> queueProcessor = WorkQueueProcessor.Builder.<String>create()
+		WorkQueueProcessor<String> queueProcessor = WorkQueueProcessor.<String>builder()
 				.share(true)
 				.name("Processor")
 				.bufferSize(256)
@@ -234,7 +234,7 @@ public class WorkQueueProcessorTest {
 
 	@Test(timeout = 15000L)
 	public void disposeSubscribeNoThreadLeak() throws Exception {
-		WorkQueueProcessor<String> wq = WorkQueueProcessor.Builder.<String>create().autoCancel(false).build();
+		WorkQueueProcessor<String> wq = WorkQueueProcessor.<String>builder().autoCancel(false).build();
 
 		Disposable d = wq.subscribe();
 		d.dispose();
@@ -250,7 +250,7 @@ public class WorkQueueProcessorTest {
 	@Test
 	public void retryErrorPropagatedFromWorkQueueSubscriberCold() throws Exception {
 		AtomicInteger errors = new AtomicInteger(3);
-		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.Builder.<Integer>create().autoCancel(false).build();
+		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.<Integer>builder().autoCancel(false).build();
 		AtomicInteger onNextSignals = new AtomicInteger();
 		wq.onNext(1);
 		wq.onNext(2);
@@ -278,7 +278,7 @@ public class WorkQueueProcessorTest {
 	@Test
 	public void retryErrorPropagatedFromWorkQueueSubscriberHot() throws Exception {
 		AtomicInteger errors = new AtomicInteger(3);
-		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.Builder.<Integer>create().autoCancel(false).build();
+		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.<Integer>builder().autoCancel(false).build();
 		AtomicInteger onNextSignals = new AtomicInteger();
 
 		StepVerifier.create(wq.doOnNext(e -> onNextSignals.incrementAndGet()).<Integer>handle(
@@ -308,7 +308,7 @@ public class WorkQueueProcessorTest {
 	@Test
 	public void retryErrorPropagatedFromWorkQueueSubscriberHotPoisonSignal()
 			throws Exception {
-		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.Builder.<Integer>create().autoCancel(false).build();
+		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.<Integer>builder().autoCancel(false).build();
 		AtomicInteger onNextSignals = new AtomicInteger();
 
 		StepVerifier.create(wq.doOnNext(e -> onNextSignals.incrementAndGet()).<Integer>handle(
@@ -338,7 +338,7 @@ public class WorkQueueProcessorTest {
 	@Test
 	public void retryErrorPropagatedFromWorkQueueSubscriberHotPoisonSignal2()
 			throws Exception {
-		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.Builder.<Integer>create().autoCancel(false).build();
+		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.<Integer>builder().autoCancel(false).build();
 		AtomicInteger onNextSignals = new AtomicInteger();
 
 		StepVerifier.create(wq.log()
@@ -368,7 +368,7 @@ public class WorkQueueProcessorTest {
 
 	@Test()
 	public void retryNoThreadLeak() throws Exception {
-		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.Builder.<Integer>create().autoCancel(false).build();
+		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.<Integer>builder().autoCancel(false).build();
 
 		wq.handle((integer, sink) -> sink.error(new RuntimeException()))
 		  .retry(10)
@@ -384,8 +384,8 @@ public class WorkQueueProcessorTest {
 
 	@Test
 	public void simpleTest() throws Exception {
-		final TopicProcessor<Integer> sink = TopicProcessor.Builder.<Integer>create().name("topic").build();
-		final WorkQueueProcessor<Integer> processor = WorkQueueProcessor.Builder.<Integer>create().name("queue").build();
+		final TopicProcessor<Integer> sink = TopicProcessor.<Integer>builder().name("topic").build();
+		final WorkQueueProcessor<Integer> processor = WorkQueueProcessor.<Integer>builder().name("queue").build();
 
 		int elems = 10000;
 		CountDownLatch latch = new CountDownLatch(elems);
@@ -427,7 +427,7 @@ public class WorkQueueProcessorTest {
 	@Test
 	public void singleThreadWorkQueueDoesntRejectsSubscribers() {
 		ExecutorService executorService = Executors.newSingleThreadExecutor();
-		WorkQueueProcessor<String> bc = WorkQueueProcessor.Builder.<String>create().executor(executorService).bufferSize(2).build();
+		WorkQueueProcessor<String> bc = WorkQueueProcessor.<String>builder().executor(executorService).bufferSize(2).build();
 		CountDownLatch latch = new CountDownLatch(1);
 		TestWorkQueueSubscriber spec1 = new TestWorkQueueSubscriber(latch, "spec1");
 		TestWorkQueueSubscriber spec2 = new TestWorkQueueSubscriber(latch, "spec2");
@@ -453,7 +453,7 @@ public class WorkQueueProcessorTest {
 	@Test(timeout = 400)
 	public void singleThreadWorkQueueSucceedsWithOneSubscriber() {
 		ExecutorService executorService = Executors.newSingleThreadExecutor();
-		WorkQueueProcessor<String> bc = WorkQueueProcessor.Builder.<String>create().executor(executorService).bufferSize(2).build();
+		WorkQueueProcessor<String> bc = WorkQueueProcessor.<String>builder().executor(executorService).bufferSize(2).build();
 		CountDownLatch latch = new CountDownLatch(1);
 		TestWorkQueueSubscriber spec1 = new TestWorkQueueSubscriber(latch, "spec1");
 
@@ -559,7 +559,7 @@ public class WorkQueueProcessorTest {
 	public void chainedWorkQueueProcessor() throws Exception{
 		ExecutorService es = Executors.newFixedThreadPool(2);
 		try {
-			WorkQueueProcessor<String> bc = WorkQueueProcessor.Builder.<String>create().executor(es).bufferSize(16).build();
+			WorkQueueProcessor<String> bc = WorkQueueProcessor.<String>builder().executor(es).bufferSize(16).build();
 
 			int elems = 18;
 			CountDownLatch latch = new CountDownLatch(elems);
@@ -580,7 +580,7 @@ public class WorkQueueProcessorTest {
 	public void testWorkQueueProcessorGetters() {
 
 		final int TEST_BUFFER_SIZE = 16;
-		WorkQueueProcessor<Object> processor = WorkQueueProcessor.Builder.create().name("testProcessor").bufferSize(TEST_BUFFER_SIZE).build();
+		WorkQueueProcessor<Object> processor = WorkQueueProcessor.builder().name("testProcessor").bufferSize(TEST_BUFFER_SIZE).build();
 
 		assertEquals(TEST_BUFFER_SIZE, processor.getAvailableCapacity());
 
@@ -593,17 +593,17 @@ public class WorkQueueProcessorTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void failNonPowerOfTwo() {
-		WorkQueueProcessor.Builder.create().name("test").bufferSize(3);
+		WorkQueueProcessor.builder().name("test").bufferSize(3);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void failNullBufferSize() {
-		WorkQueueProcessor.Builder.create().name("test").bufferSize(0);
+		WorkQueueProcessor.builder().name("test").bufferSize(0);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void failNegativeBufferSize() {
-		WorkQueueProcessor.Builder.create().name("test").bufferSize(-1);
+		WorkQueueProcessor.builder().name("test").bufferSize(-1);
 	}
 
 
@@ -611,7 +611,7 @@ public class WorkQueueProcessorTest {
 	public void retryErrorPropagatedFromWorkQueueSubscriberHotPublishOn()
 			throws Exception {
 		AtomicInteger errors = new AtomicInteger(3);
-		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.Builder.<Integer>create().autoCancel(false).build();
+		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.<Integer>builder().autoCancel(false).build();
 		AtomicInteger onNextSignals = new AtomicInteger();
 
 		StepVerifier.create(wq.log()
@@ -651,7 +651,7 @@ public class WorkQueueProcessorTest {
 	public void retryErrorPropagatedFromWorkQueueSubscriberHotPublishOnPrefetch1()
 			throws Exception {
 		AtomicInteger errors = new AtomicInteger(3);
-		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.Builder.<Integer>create().autoCancel(false).build();
+		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.<Integer>builder().autoCancel(false).build();
 		AtomicInteger onNextSignals = new AtomicInteger();
 
 		StepVerifier.create(wq.publishOn(Schedulers.parallel(), 1)
@@ -690,7 +690,7 @@ public class WorkQueueProcessorTest {
 	@Test
 	public void retryErrorPropagatedFromWorkQueueSubscriberHotPoisonSignalPublishOn()
 			throws Exception {
-		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.Builder.<Integer>create().autoCancel(false).build();
+		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.<Integer>builder().autoCancel(false).build();
 		AtomicInteger onNextSignals = new AtomicInteger();
 
 		StepVerifier.create(wq.publishOn(Schedulers.parallel())
@@ -726,7 +726,7 @@ public class WorkQueueProcessorTest {
 	@Test
 	public void retryErrorPropagatedFromWorkQueueSubscriberHotPoisonSignalParallel()
 			throws Exception {
-		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.Builder.<Integer>create().autoCancel(false).build();
+		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.<Integer>builder().autoCancel(false).build();
 		AtomicInteger onNextSignals = new AtomicInteger();
 
 		Function<Flux<Integer>, Flux<Integer>> function =
@@ -774,7 +774,7 @@ public class WorkQueueProcessorTest {
 	@Test
 	public void retryErrorPropagatedFromWorkQueueSubscriberHotPoisonSignalPublishOnPrefetch1()
 			throws Exception {
-		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.Builder.<Integer>create().autoCancel(false).build();
+		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.<Integer>builder().autoCancel(false).build();
 		AtomicInteger onNextSignals = new AtomicInteger();
 
 		StepVerifier.create(wq.publishOn(Schedulers.parallel(), 1)
@@ -810,7 +810,7 @@ public class WorkQueueProcessorTest {
 	@Test
 	public void retryErrorPropagatedFromWorkQueueSubscriberHotPoisonSignalFlatMap()
 			throws Exception {
-		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.Builder.<Integer>create().autoCancel(false).build();
+		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.<Integer>builder().autoCancel(false).build();
 		AtomicInteger onNextSignals = new AtomicInteger();
 
 		StepVerifier.create(wq.publish()
@@ -852,7 +852,7 @@ public class WorkQueueProcessorTest {
 	@Test
 	public void retryErrorPropagatedFromWorkQueueSubscriberHotPoisonSignalFlatMapPrefetch1()
 			throws Exception {
-		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.Builder.<Integer>create().autoCancel(false).build();
+		WorkQueueProcessor<Integer> wq = WorkQueueProcessor.<Integer>builder().autoCancel(false).build();
 		AtomicInteger onNextSignals = new AtomicInteger();
 
 		StepVerifier.create(wq.flatMap(i -> Mono.just(i)
@@ -890,7 +890,7 @@ public class WorkQueueProcessorTest {
 	//see https://github.com/reactor/reactor-core/issues/445
 	@Test(timeout = 5_000)
 	public void testBufferSize1Shared() throws Exception {
-		WorkQueueProcessor<String> broadcast = WorkQueueProcessor.Builder.<String>create()
+		WorkQueueProcessor<String> broadcast = WorkQueueProcessor.<String>builder()
 				.share(true)
 				.name("share-name")
 				.bufferSize(1)
@@ -919,7 +919,7 @@ public class WorkQueueProcessorTest {
 	//see https://github.com/reactor/reactor-core/issues/445
 	@Test(timeout = 5_000)
 	public void testBufferSize1Created() throws Exception {
-		WorkQueueProcessor<String> broadcast = WorkQueueProcessor.Builder.<String>create()
+		WorkQueueProcessor<String> broadcast = WorkQueueProcessor.<String>builder()
 				.share(true).name("share-name")
 				.bufferSize(1)
 				.autoCancel(true)
@@ -950,7 +950,7 @@ public class WorkQueueProcessorTest {
 		String mainName = "workQueueProcessorRequestTask";
 		String expectedName = mainName + "[request-task]";
 
-		WorkQueueProcessor<Object> processor = WorkQueueProcessor.Builder.create().name(mainName).bufferSize(8).build();
+		WorkQueueProcessor<Object> processor = WorkQueueProcessor.builder().name(mainName).bufferSize(8).build();
 
 		processor.requestTask(Operators.cancelledSubscription());
 
@@ -973,7 +973,7 @@ public class WorkQueueProcessorTest {
 		String expectedName = "workQueueProcessorRequestTaskCreate";
 		//NOTE: the below single executor should not be used usually as requestTask assumes it immediately gets executed
 		ExecutorService customTaskExecutor = Executors.newSingleThreadExecutor(r -> new Thread(r, expectedName));
-		WorkQueueProcessor<Object> processor = WorkQueueProcessor.Builder.create()
+		WorkQueueProcessor<Object> processor = WorkQueueProcessor.builder()
 				.executor(Executors.newCachedThreadPool())
 				.requestTaskExecutor(customTaskExecutor)
 				.bufferSize(8)
@@ -1008,7 +1008,7 @@ public class WorkQueueProcessorTest {
 		String expectedName = "workQueueProcessorRequestTaskShare";
 		//NOTE: the below single executor should not be used usually as requestTask assumes it immediately gets executed
 		ExecutorService customTaskExecutor = Executors.newSingleThreadExecutor(r -> new Thread(r, expectedName));
-		WorkQueueProcessor<Object> processor = WorkQueueProcessor.Builder.create()
+		WorkQueueProcessor<Object> processor = WorkQueueProcessor.builder()
 				.executor(Executors.newCachedThreadPool())
 				.requestTaskExecutor(customTaskExecutor)
 				.bufferSize(8)

--- a/src/test/java/reactor/core/publisher/scenarios/BurstyWorkQueueProcessorTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/BurstyWorkQueueProcessorTests.java
@@ -61,7 +61,7 @@ public class BurstyWorkQueueProcessorTests {
 	@Test
 	@Ignore
 	public void test() throws Exception {
-		processor = WorkQueueProcessor.Builder.create().name("test-processor").bufferSize(RINGBUFFER_SIZE).build();
+		processor = WorkQueueProcessor.builder().name("test-processor").bufferSize(RINGBUFFER_SIZE).build();
 
 		Flux
 				.create((emitter) -> burstyProducer(emitter, PRODUCED_MESSAGES_COUNT, BURST_SIZE))

--- a/src/test/java/reactor/core/publisher/scenarios/CombinationTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/CombinationTests.java
@@ -84,7 +84,7 @@ public class CombinationTests {
 	public Flux<SensorData> sensorOdd() {
 		if (sensorOdd == null) {
 			// this is the stream we publish odd-numbered events to
-			this.sensorOdd = TopicProcessor.Builder.<SensorData>create().name("odd").build();
+			this.sensorOdd = TopicProcessor.<SensorData>builder().name("odd").build();
 
 			// add substream to "master" list
 			//allSensors().add(sensorOdd.reduce(this::computeMin).timeout(1000));
@@ -96,7 +96,7 @@ public class CombinationTests {
 	public Flux<SensorData> sensorEven() {
 		if (sensorEven == null) {
 			// this is the stream we publish even-numbered events to
-			this.sensorEven = TopicProcessor.Builder.<SensorData>create().name("even").build();
+			this.sensorEven = TopicProcessor.<SensorData>builder().name("even").build();
 
 			// add substream to "master" list
 			//allSensors().add(sensorEven.reduce(this::computeMin).timeout(1000));

--- a/src/test/java/reactor/core/publisher/scenarios/ConsistentProcessorTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/ConsistentProcessorTests.java
@@ -136,8 +136,8 @@ public class ConsistentProcessorTests {
 	}
 
 	private void setupPipeline() {
-		processor = TopicProcessor.Builder.<String>create().autoCancel(false).build();
-		workProcessor = WorkQueueProcessor.Builder.<String>create().autoCancel(false).build();
+		processor = TopicProcessor.<String>builder().autoCancel(false).build();
+		workProcessor = WorkQueueProcessor.<String>builder().autoCancel(false).build();
 		processor.subscribe(workProcessor);
 	}
 

--- a/src/test/java/reactor/core/publisher/scenarios/FizzBuzzTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/FizzBuzzTests.java
@@ -78,7 +78,7 @@ public class FizzBuzzTests extends AbstractReactorTest {
 
 		//this line causes an java.lang.ArrayIndexOutOfBoundsException unless there is a break point in ZipAction
 		// .createSubscriber()
-		TopicProcessor<String> ring = TopicProcessor.Builder.<String>create().name("test").bufferSize(1024).build();
+		TopicProcessor<String> ring = TopicProcessor.<String>builder().name("test").bufferSize(1024).build();
 
 //        EmitterProcessor<String> ring = EmitterProcessor.create();
 

--- a/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -906,7 +906,7 @@ public class FluxTests extends AbstractReactorTest {
 		}).log("points")
 		  .buffer(2)
 		  .map(pairs -> new Point(pairs.get(0), pairs.get(1)))
-		  .subscribeWith(TopicProcessor.Builder.<Point>create().name("tee").bufferSize(32).build());
+		  .subscribeWith(TopicProcessor.<Point>builder().name("tee").bufferSize(32).build());
 
 		Flux<InnerSample> innerSamples = points.log("inner-1")
 		                                          .filter(Point::isInner)
@@ -1311,14 +1311,14 @@ public class FluxTests extends AbstractReactorTest {
 		final Flux<Integer> forkStream2 = Flux.just(1, 2, 3)
 		                                            .log("begin-persistence");
 
-		final TopicProcessor<Integer> computationEmitterProcessor = TopicProcessor.Builder.<Integer>create()
+		final TopicProcessor<Integer> computationEmitterProcessor = TopicProcessor.<Integer>builder()
 				.name("computation")
 				.bufferSize(BACKLOG)
 				.build();
 		final Flux<String> computationStream = computationEmitterProcessor
 		                                                 .map(i -> Integer.toString(i));
 
-		final TopicProcessor<Integer> persistenceEmitterProcessor = TopicProcessor.Builder.<Integer>create()
+		final TopicProcessor<Integer> persistenceEmitterProcessor = TopicProcessor.<Integer>builder()
 				.name("persistence")
 				.bufferSize(BACKLOG)
 				.build();
@@ -1363,7 +1363,7 @@ public class FluxTests extends AbstractReactorTest {
 
 		final EmitterProcessor<Integer> forkEmitterProcessor = EmitterProcessor.create();
 
-		final EmitterProcessor<Integer> computationEmitterProcessor = EmitterProcessor.Builder.<Integer>create().autoCancel(false).build();
+		final EmitterProcessor<Integer> computationEmitterProcessor = EmitterProcessor.<Integer>builder().autoCancel(false).build();
 
 		Scheduler computation = Schedulers.newSingle("computation");
 		Scheduler persistence = Schedulers.newSingle("persistence");
@@ -1381,7 +1381,7 @@ public class FluxTests extends AbstractReactorTest {
 				                      .doOnNext(ls -> println("Computed: ", ls))
 				                      .log("computation");
 
-		final EmitterProcessor<Integer> persistenceEmitterProcessor = EmitterProcessor.Builder.<Integer>create().autoCancel(false).build();
+		final EmitterProcessor<Integer> persistenceEmitterProcessor = EmitterProcessor.<Integer>builder().autoCancel(false).build();
 
 		final Flux<List<String>> persistenceStream =
 				persistenceEmitterProcessor.publishOn(persistence)

--- a/src/test/java/reactor/core/publisher/tck/EmitterProcessorVerification.java
+++ b/src/test/java/reactor/core/publisher/tck/EmitterProcessorVerification.java
@@ -29,7 +29,7 @@ public class EmitterProcessorVerification extends AbstractProcessorVerification 
 
 	@Override
 	public Processor<Long, Long> createProcessor(int bufferSize) {
-		return EmitterProcessor.Builder.<Long>create().bufferSize(bufferSize).build();
+		return EmitterProcessor.<Long>builder().bufferSize(bufferSize).build();
 	}
 
 	@Override

--- a/src/test/java/reactor/core/publisher/tck/FluxWithProcessorVerification.java
+++ b/src/test/java/reactor/core/publisher/tck/FluxWithProcessorVerification.java
@@ -43,7 +43,7 @@ public class FluxWithProcessorVerification extends AbstractFluxVerification {
 		Flux<String> otherStream = Flux.just("test", "test2", "test3");
 		System.out.println("Providing new downstream");
 		FluxProcessor<Integer, Integer> p =
-				WorkQueueProcessor.Builder.<Integer>create().name("fluxion-raw-fork").bufferSize(bufferSize).build();
+				WorkQueueProcessor.<Integer>builder().name("fluxion-raw-fork").bufferSize(bufferSize).build();
 
 		cumulated.set(0);
 		cumulatedJoin.set(0);
@@ -63,7 +63,7 @@ public class FluxWithProcessorVerification extends AbstractFluxVerification {
 						                          combinator))
 				                          .doOnNext(this::monitorThreadUse))
 				 .doOnNext(array -> cumulatedJoin.getAndIncrement())
-				 .subscribeWith(TopicProcessor.Builder.<Integer>create().name("fluxion-raw-join").bufferSize(bufferSize).build())
+				 .subscribeWith(TopicProcessor.<Integer>builder().name("fluxion-raw-join").bufferSize(bufferSize).build())
 				 .doOnError(Throwable::printStackTrace)
 				 .awaitOnSubscribe());
 	}

--- a/src/test/java/reactor/core/publisher/tck/TopicProcessorVerification.java
+++ b/src/test/java/reactor/core/publisher/tck/TopicProcessorVerification.java
@@ -27,7 +27,7 @@ public class TopicProcessorVerification extends AbstractProcessorVerification {
 
 	@Override
 	public Processor<Long, Long> createProcessor(int bufferSize) {
-		return TopicProcessor.Builder.<Long>create().name("rb-async").bufferSize(bufferSize).build();
+		return TopicProcessor.<Long>builder().name("rb-async").bufferSize(bufferSize).build();
 	}
 
 	@Override

--- a/src/test/java/reactor/core/publisher/tck/WorkQueueProcessorVerification.java
+++ b/src/test/java/reactor/core/publisher/tck/WorkQueueProcessorVerification.java
@@ -28,7 +28,7 @@ public class WorkQueueProcessorVerification extends AbstractProcessorVerificatio
 	@Override
 	public Processor<Long, Long> createProcessor(int bufferSize) {
 		System.out.println("new processor");
-		return  WorkQueueProcessor.Builder.<Long>create().name("rb-work").bufferSize(bufferSize).build();
+		return  WorkQueueProcessor.<Long>builder().name("rb-work").bufferSize(bufferSize).build();
 	}
 
 	@Override


### PR DESCRIPTION
Replace the `Processor.Builder.<T>create()` approach with a slightly shorter `Processor.<T>builder()` approach.