### PR TITLE
fix #638 Add toProcessor variant that also connects inline

### DIFF
--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -3200,8 +3200,9 @@ public abstract class Mono<T> implements Publisher<T> {
 
 	/**
 	 * Wrap this {@link Mono} into a {@link MonoProcessor} (turning it hot and allowing to block,
-	 * cancel, as well as many other operations). The {@link MonoProcessor} should then
-	 * be {@link #subscribe() subscribed to} in order to request unbounded amount.
+	 * cancel, as well as many other operations). Note that the {@link MonoProcessor} is
+	 * {@link MonoProcessor#connect() connected to} (which is equivalent to calling subscribe
+	 * on it).
 	 *
 	 * <p>
 	 * <img width="500" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.0.M1/src/docs/marble/unbounded1.png" alt="">
@@ -3210,18 +3211,6 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @return a {@link MonoProcessor} to use to either retrieve value or cancel the underlying {@link Subscription}
 	 */
 	public final MonoProcessor<T> toProcessor() {
-		if (this instanceof MonoProcessor) {
-			return (MonoProcessor<T>)this;
-		}
-		else {
-			return new MonoProcessor<>(this);
-		}
-	}
-
-	public final MonoProcessor<T> toProcessor(boolean connect) {
-		if (!connect)
-			return toProcessor();
-
 		MonoProcessor<T> result;
 		if (this instanceof MonoProcessor) {
 			result = (MonoProcessor<T>)this;
@@ -3231,10 +3220,6 @@ public abstract class Mono<T> implements Publisher<T> {
 		}
 		result.connect();
 		return result;
-	}
-
-	public final MonoProcessor<T> toConnectedProcessor() {
-		return toProcessor(true);
 	}
 
 	/**

--- a/src/main/java/reactor/core/publisher/Mono.java
+++ b/src/main/java/reactor/core/publisher/Mono.java
@@ -3218,6 +3218,25 @@ public abstract class Mono<T> implements Publisher<T> {
 		}
 	}
 
+	public final MonoProcessor<T> toProcessor(boolean connect) {
+		if (!connect)
+			return toProcessor();
+
+		MonoProcessor<T> result;
+		if (this instanceof MonoProcessor) {
+			result = (MonoProcessor<T>)this;
+		}
+		else {
+			result = new MonoProcessor<>(this);
+		}
+		result.connect();
+		return result;
+	}
+
+	public final MonoProcessor<T> toConnectedProcessor() {
+		return toProcessor(true);
+	}
+
 	/**
 	 * Transform this {@link Mono} in order to generate a target {@link Mono}. Unlike {@link #compose(Function)}, the
 	 * provided function is executed as part of assembly.

--- a/src/test/java/reactor/core/publisher/MonoProcessorTest.java
+++ b/src/test/java/reactor/core/publisher/MonoProcessorTest.java
@@ -437,23 +437,9 @@ public class MonoProcessorTest {
 	}
 
 	@Test
-	public void monoToProcessorDoesntConnect() {
-		MonoProcessor<String> monoProcessor = Mono.just("foo").toProcessor();
-
-		assertThat(monoProcessor.connected).isZero();
-	}
-
-	@Test
-	public void monoToProcessorAndSubscribeDoesConnect() {
-		MonoProcessor<String> monoProcessor = Mono.just("foo").toProcessor();
-
-		assertThat(monoProcessor.subscribe()).isSameAs(monoProcessor);
-		assertThat(monoProcessor.connected).isEqualTo(1);
-	}
-
-	@Test
 	public void monoToProcessorReusesInstance() {
-		MonoProcessor<String> monoProcessor = Mono.just("foo").toProcessor();
+		MonoProcessor<String> monoProcessor = Mono.just("foo")
+		                                          .toProcessor();
 
 		assertThat(monoProcessor)
 				.isSameAs(monoProcessor.toProcessor())
@@ -461,39 +447,17 @@ public class MonoProcessorTest {
 	}
 
 	@Test
-	public void monoToProcessorConnect() {
+	public void monoToProcessorConnects() {
 		MonoProcessor<String> connectedProcessor = Mono.just("foo")
-		                                          .toProcessor(true);
+		                                          .toProcessor();
 
 		assertThat(connectedProcessor.connected).isEqualTo(1);
 	}
 
 	@Test
-	public void monoToProcessorConnectReusesInstance() {
-		MonoProcessor<String> connectedProcessor = Mono.just("foo")
-		                                          .toProcessor(true);
-
-		assertThat(connectedProcessor)
-				.isSameAs(connectedProcessor.toProcessor(true))
-				.isSameAs(connectedProcessor.toProcessor())
-				.isSameAs(connectedProcessor.subscribe());
-	}
-
-	@Test
 	public void monoToProcessorChain() {
 		StepVerifier.withVirtualTime(() -> Mono.just("foo")
-		                                       .toProcessor(true)
-		                                       .delayElement(Duration.ofMillis(500)))
-		            .expectSubscription()
-		            .expectNoEvent(Duration.ofMillis(500))
-		            .expectNext("foo")
-		            .verifyComplete();
-	}
-
-	@Test
-	public void monoToProcessorChain2() {
-		StepVerifier.withVirtualTime(() -> Mono.just("foo")
-		                                       .toConnectedProcessor()
+		                                       .toProcessor()
 		                                       .delayElement(Duration.ofMillis(500)))
 		            .expectSubscription()
 		            .expectNoEvent(Duration.ofMillis(500))
@@ -507,7 +471,7 @@ public class MonoProcessorTest {
 		Mono<String> coldToHot = Mono.just("foo")
 		                             .doOnSubscribe(sub -> subscriptionCount.incrementAndGet())
 		                             .cache()
-		                             .toConnectedProcessor() //this actually subscribes
+		                             .toProcessor() //this actually subscribes
 		                             .filter(s -> s.length() < 4);
 
 		assertThat(subscriptionCount.get()).isEqualTo(1);


### PR DESCRIPTION
@osi @smaldini I put the two possible variants of #638 in there:
boolean parameter or `toConnectedProcessor` dedicated name. I tend to
prefer the second alternative. wdyt?