### PR TITLE
fix #616 Keep one significant factory method for Processors with Builder

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -54,95 +54,32 @@ import static reactor.core.publisher.FluxPublish.PublishSubscriber.TERMINATED;
 public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 
 	/**
-	 * {@link EmitterProcessor} builder that can be used to create new
-	 * processors. Instantiate it through the {@link EmitterProcessor#builder()} static
-	 * method:
-	 * <p>
-	 * {@code EmitterProcessor<String> processor = EmitterProcessor.<String>builder().build()}
-	 *
-	 * @param <T> Type of dispatched signal
-	 */
-	public final static class Builder<T> {
-		boolean autoCancel;
-		int bufferSize;
-
-		Builder() {
-			this.autoCancel = true;
-			this.bufferSize = QueueSupplier.SMALL_BUFFER_SIZE;
-		}
-
-		/**
-		 * Configures buffer size for this builder. Default value is {@link QueueSupplier#SMALL_BUFFER_SIZE}.
-		 * @param bufferSize the internal buffer size to hold signals
-		 * @return builder with provided buffer size
-		 */
-		public Builder<T> bufferSize(int bufferSize) {
-			if (bufferSize < 1){
-				throw new IllegalArgumentException("bufferSize must be strictly positive, " +
-						"was: "+bufferSize);
-			}
-			this.bufferSize = bufferSize;
-			return this;
-		}
-
-		/**
-		 * Configures auto-cancel for this builder. Default value is true.
-		 * @param autoCancel automatically cancel
-		 * @return builder with provided auto-cancel
-		 */
-		public Builder<T> autoCancel(boolean autoCancel) {
-			this.autoCancel = autoCancel;
-			return this;
-		}
-
-		/**
-		 * Creates a new {@link EmitterProcessor} using the properties
-		 * of this builder.
-		 * @return a fresh processor
-		 */
-		public EmitterProcessor<T> build() {
-			return new EmitterProcessor<>(autoCancel, bufferSize);
-		}
-	}
-
-	/**
-	 * Create a new {@link EmitterProcessor} {@link Builder} with default properties.
-	 * @return new EmitterProcessor builder
-	 */
-	public static <E> Builder<E> builder()  {
-		return new Builder<>();
-	}
-
-	/**
 	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE}
-	 * backlog size, blockingWait Strategy and auto-cancel.
+	 * backlog size and auto-cancel.
 	 *
 	 * @param <E> Type of processed signals
 	 *
 	 * @return a fresh processor
 	 */
 	public static <E> EmitterProcessor<E> create() {
-		return EmitterProcessor.<E>builder().build();
+		return create(QueueSupplier.SMALL_BUFFER_SIZE, true);
 	}
 
 	/**
 	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE}
-	 * backlog size, blockingWait Strategy and the provided auto-cancel.
+	 * backlog size and the provided auto-cancel.
 	 *
 	 * @param <E> Type of processed signals
 	 * @param autoCancel automatically cancel
 	 *
 	 * @return a fresh processor
-	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
-	@Deprecated
 	public static <E> EmitterProcessor<E> create(boolean autoCancel) {
-		return EmitterProcessor.<E>builder().autoCancel(autoCancel).build();
+		return create(QueueSupplier.SMALL_BUFFER_SIZE, autoCancel);
 	}
 
 	/**
-	 * Create a new {@link EmitterProcessor} using the provided backlog size, a
-	 * blockingWait Strategy and auto-cancel.
+	 * Create a new {@link EmitterProcessor} using the provided backlog size, with auto-cancel.
 	 *
 	 * @param <E> Type of processed signals
 	 * @param bufferSize the internal buffer size to hold signals
@@ -150,23 +87,20 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	 * @return a fresh processor
 	 */
 	public static <E> EmitterProcessor<E> create(int bufferSize) {
-		return new EmitterProcessor(true, bufferSize);
+		return create(bufferSize, true);
 	}
 
 	/**
-	 * Create a new {@link EmitterProcessor} using the provided backlog size and auto-cancellation,
-	 * and a blockingWait Strategy.
+	 * Create a new {@link EmitterProcessor} using the provided backlog size and auto-cancellation.
 	 *
 	 * @param <E> Type of processed signals
 	 * @param bufferSize the internal buffer size to hold signals
 	 * @param autoCancel automatically cancel
 	 *
 	 * @return a fresh processor
-	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
-	@Deprecated
 	public static <E> EmitterProcessor<E> create(int bufferSize, boolean autoCancel) {
-		return EmitterProcessor.<E>builder().bufferSize(bufferSize).autoCancel(autoCancel).build();
+		return new EmitterProcessor<>(autoCancel, bufferSize);
 	}
 
 	final int prefetch;

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -35,7 +35,7 @@ import static reactor.core.publisher.FluxPublish.PublishSubscriber.EMPTY;
 import static reactor.core.publisher.FluxPublish.PublishSubscriber.TERMINATED;
 
 /**
- * * An implementation of a RingBuffer backed message-passing Processor implementing
+ * An implementation of a RingBuffer backed message-passing Processor implementing
  * publish-subscribe with synchronous (thread-stealing and happen-before interactions)
  * drain loops.
  * <p>
@@ -127,7 +127,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 
 	/**
 	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE}
-	 * backlog size, blockingWait Strategy and auto-cancel.
+	 * backlog size, blockingWait Strategy and the provided auto-cancel.
 	 *
 	 * @param <E> Type of processed signals
 	 * @param autoCancel automatically cancel
@@ -141,23 +141,21 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	}
 
 	/**
-	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE}
-	 * backlog size, blockingWait Strategy and auto-cancel.
+	 * Create a new {@link EmitterProcessor} using the provided backlog size, a
+	 * blockingWait Strategy and auto-cancel.
 	 *
 	 * @param <E> Type of processed signals
 	 * @param bufferSize the internal buffer size to hold signals
 	 *
 	 * @return a fresh processor
-	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
-	@Deprecated
 	public static <E> EmitterProcessor<E> create(int bufferSize) {
-		return EmitterProcessor.<E>builder().bufferSize(bufferSize).build();
+		return new EmitterProcessor(true, bufferSize);
 	}
 
 	/**
-	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE}
-	 * backlog size, blockingWait Strategy and auto-cancel.
+	 * Create a new {@link EmitterProcessor} using the provided backlog size and auto-cancellation,
+	 * and a blockingWait Strategy.
 	 *
 	 * @param <E> Type of processed signals
 	 * @param bufferSize the internal buffer size to hold signals

--- a/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
@@ -237,7 +237,10 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 
 	/**
 	 * Create a new {@link TopicProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size, blockingWait
-	 * Strategy and auto-cancel. <p> A new Cached ThreadExecutorPool will be implicitly created.
+	 * Strategy and auto-cancel.
+	 * <p>
+	 * A new Cached ThreadExecutorPool will be implicitly
+	 * created and will use the passed name to qualify the created threads.
 	 * @param name processor thread logical name
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
@@ -298,18 +301,15 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
-	 * Create a new TopicProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
-	 * blockingWait Strategy and the passed auto-cancel setting. <p> A new Cached
-	 * ThreadExecutorPool will be implicitly created and will use the passed name to
+	 * Create a new TopicProcessor using the provided backlog size, with a blockingWait Strategy
+	 * and auto-cancellation. <p> A new Cached ThreadExecutorPool will be implicitly created and will use the passed name to
 	 * qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
 	 * @param bufferSize A Backlog Size to mitigate slow subscribers
 	 * @param <E> Type of processed signals
 	 * @return the fresh TopicProcessor instance
-	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
-	@Deprecated
 	public static <E> TopicProcessor<E> create(String name, int bufferSize) {
 		return TopicProcessor.<E>builder().name(name).bufferSize(bufferSize).build();
 	}
@@ -334,7 +334,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
-	 * Create a new TopicProcessor using passed backlog size, blockingWait Strategy
+	 * Create a new TopicProcessor using passed backlog size, a blockingWait Strategy
 	 * and will auto-cancel. <p> The passed {@link ExecutorService}
 	 * will execute as many event-loop consuming the ringbuffer as subscribers.
 	 * @param service A provided ExecutorService to manage threading infrastructure
@@ -350,7 +350,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
-	 * Create a new TopicProcessor using passed backlog size, blockingWait Strategy
+	 * Create a new TopicProcessor using passed backlog size, a blockingWait Strategy
 	 * and the auto-cancel argument. <p> The passed {@link ExecutorService}
 	 * will execute as many event-loop consuming the ringbuffer as subscribers.
 	 * @param service A provided ExecutorService to manage threading infrastructure
@@ -522,7 +522,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
-	 * Create a new TopicProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
+	 * Create a new shared TopicProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and the passed auto-cancel setting. <p> A Shared Processor
 	 * authorizes concurrent onNext calls and is suited for multi-threaded publisher that
 	 * will fan-in data. <p> A new Cached ThreadExecutorPool will be implicitly created.
@@ -538,7 +538,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
-	 * Create a new TopicProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
+	 * Create a new shared TopicProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and auto-cancel. <p> A Shared Processor authorizes concurrent
 	 * onNext calls and is suited for multi-threaded publisher that will fan-in data. <p>
 	 * The passed {@link ExecutorService} will execute as many
@@ -554,7 +554,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
-	 * Create a new TopicProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
+	 * Create a new shared TopicProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and the passed auto-cancel setting. <p> A Shared Processor
 	 * authorizes concurrent onNext calls and is suited for multi-threaded publisher that
 	 * will fan-in data. <p> The passed {@link ExecutorService} will
@@ -573,25 +573,26 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
-	 * Create a new TopicProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
-	 * blockingWait Strategy and the passed auto-cancel setting. <p> A Shared Processor
-	 * authorizes concurrent onNext calls and is suited for multi-threaded publisher that
-	 * will fan-in data. <p> A new Cached ThreadExecutorPool will be implicitly created
-	 * and will use the passed name to qualify the created threads.
+	 * Create a new shared TopicProcessor using the passed backlog size, with a blockingWait
+	 * Strategy and auto-cancellation.
+	 * <p>
+	 * A Shared Processor authorizes concurrent onNext calls and is suited for multi-threaded
+	 * publisher that will fan-in data.
+	 * <p>
+	 * A new Cached ThreadExecutorPool will be implicitly created and will use the passed
+	 * name to qualify the created threads.
 	 * @param name Use a new Cached ExecutorService and assign this name to the created
 	 * threads
 	 * @param bufferSize A Backlog Size to mitigate slow subscribers
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
-	@Deprecated
 	public static <E> TopicProcessor<E> share(String name, int bufferSize) {
 		return TopicProcessor.<E>builder().share(true).name(name).bufferSize(bufferSize).build();
 	}
 
 	/**
-	 * Create a new TopicProcessor using the blockingWait Strategy, passed backlog
+	 * Create a new shared TopicProcessor using the blockingWait Strategy, passed backlog
 	 * size, and auto-cancel settings. <p> A Shared Processor authorizes concurrent onNext
 	 * calls and is suited for multi-threaded publisher that will fan-in data. <p> The
 	 * passed {@link ExecutorService} will execute as many event-loop
@@ -616,7 +617,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
-	 * Create a new TopicProcessor using passed backlog size, blockingWait Strategy
+	 * Create a new shared TopicProcessor using passed backlog size, blockingWait Strategy
 	 * and will auto-cancel. <p> A Shared Processor authorizes concurrent onNext calls and
 	 * is suited for multi-threaded publisher that will fan-in data. <p> The passed {@link
 	 * ExecutorService} will execute as many event-loop consuming the
@@ -637,7 +638,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
-	 * Create a new TopicProcessor using passed backlog size, blockingWait Strategy
+	 * Create a new shared TopicProcessor using passed backlog size, blockingWait Strategy
 	 * and the auto-cancel argument. <p> A Shared Processor authorizes concurrent onNext
 	 * calls and is suited for multi-threaded publisher that will fan-in data. <p> The
 	 * passed {@link ExecutorService} will execute as many event-loop
@@ -661,7 +662,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
-	 * Create a new TopicProcessor using passed backlog size, wait strategy and will
+	 * Create a new shared TopicProcessor using passed backlog size, wait strategy and will
 	 * auto-cancel. <p> A Shared Processor authorizes concurrent onNext calls and is
 	 * suited for multi-threaded publisher that will fan-in data. <p> A new Cached
 	 * ThreadExecutorPool will be implicitly created and will use the passed name to
@@ -686,7 +687,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
-	 * Create a new TopicProcessor using passed backlog size, wait strategy and
+	 * Create a new shared TopicProcessor using passed backlog size, wait strategy and
 	 * signal supplier. The created processor will auto-cancel and is shared. <p> A Shared
 	 * Processor authorizes concurrent onNext calls and is suited for multi-threaded
 	 * publisher that will fan-in data. <p> A new Cached ThreadExecutorPool will be
@@ -711,7 +712,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
-	 * Create a new TopicProcessor using passed backlog size, wait strategy and
+	 * Create a new shared TopicProcessor using passed backlog size, wait strategy and
 	 * signal supplier. The created processor will auto-cancel and is shared. <p> A Shared
 	 * Processor authorizes concurrent onNext calls and is suited for multi-threaded
 	 * publisher that will fan-in data. <p> A new Cached ThreadExecutorPool will be
@@ -740,7 +741,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
-	 * Create a new TopicProcessor using passed backlog size, wait strategy and
+	 * Create a new shared TopicProcessor using passed backlog size, wait strategy and
 	 * auto-cancel settings. <p> A Shared Processor authorizes concurrent onNext calls and
 	 * is suited for multi-threaded publisher that will fan-in data. <p> A new Cached
 	 * ThreadExecutorPool will be implicitly created and will use the passed name to
@@ -769,7 +770,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
-	 * Create a new TopicProcessor using passed backlog size, wait strategy and will
+	 * Create a new shared TopicProcessor using passed backlog size, wait strategy and will
 	 * auto-cancel. <p> A Shared Processor authorizes concurrent onNext calls and is
 	 * suited for multi-threaded publisher that will fan-in data. <p> The passed {@link
 	 * ExecutorService} will execute as many event-loop consuming the
@@ -794,7 +795,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
-	 * Create a new TopicProcessor using passed backlog size, wait strategy and
+	 * Create a new shared TopicProcessor using passed backlog size, wait strategy and
 	 * auto-cancel settings. <p> A Shared Processor authorizes concurrent onNext calls and
 	 * is suited for multi-threaded publisher that will fan-in data. <p> The passed {@link
 	 * ExecutorService} will execute as many event-loop consuming the
@@ -822,7 +823,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
-	 * Create a new TopicProcessor using passed backlog size, wait strategy and
+	 * Create a new shared TopicProcessor using passed backlog size, wait strategy and
 	 * auto-cancel settings. <p> A Shared Processor authorizes concurrent onNext calls and
 	 * is suited for multi-threaded publisher that will fan-in data. <p> The passed {@link
 	 * ExecutorService} will execute as many event-loop consuming the

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -117,7 +117,7 @@ public final class UnicastProcessor<T>
 	}
 
 	/**
-	 * Create a unicast {@link FluxProcessor} that will buffer on a given queue in an
+	 * Create a new {@link UnicastProcessor} that will buffer on an internal queue in an
 	 * unbounded fashion.
 	 *
 	 * @param <E> the relayed type
@@ -128,7 +128,7 @@ public final class UnicastProcessor<T>
 	}
 
 	/**
-	 * Create a unicast {@link FluxProcessor} that will buffer on a given queue in an
+	 * Create a new {@link UnicastProcessor} that will buffer on a provided queue in an
 	 * unbounded fashion.
 	 *
 	 * @param queue the buffering queue
@@ -142,22 +142,20 @@ public final class UnicastProcessor<T>
 	}
 
 	/**
-	 * Create a unicast {@link FluxProcessor} that will buffer on a given queue in an
+	 * Create a new {@link UnicastProcessor} that will buffer on a provided queue in an
 	 * unbounded fashion.
 	 *
 	 * @param queue the buffering queue
 	 * @param endcallback called on any terminal signal
 	 * @param <E> the relayed type
 	 * @return a unicast {@link FluxProcessor}
-	 * @deprecated use {@link Builder#build()}
 	 */
-	@Deprecated
 	public static <E> UnicastProcessor<E> create(Queue<E> queue, Disposable endcallback) {
-		return UnicastProcessor.<E>builder().queue(queue).onTerminate(endcallback).build();
+		return new UnicastProcessor(queue, endcallback);
 	}
 
 	/**
-	 * Create a unicast {@link FluxProcessor} that will buffer on a given queue in an
+	 * Create a new {@link UnicastProcessor} that will buffer on a provided queue in an
 	 * unbounded fashion.
 	 *
 	 * @param queue the buffering queue

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -45,78 +45,6 @@ public final class UnicastProcessor<T>
 		implements Fuseable.QueueSubscription<T>, Fuseable, InnerOperator<T, T> {
 
 	/**
-	 * {@link UnicastProcessor} builder that can be used to create new
-	 * processors. Instantiate it through the {@link UnicastProcessor#builder()} static
-	 * method:
-	 * <p>
-	 * {@code UnicastProcessor<String> processor = UnicastProcessor.<String>builder().build()}
-	 *
-	 * @param <T> Type of dispatched signal
-	 */
-	public final static class Builder<T> {
-
-		static final Disposable NOOP_DISPOSABLE = () -> {};
-
-		Queue<T> queue;
-		Disposable onTerminate;
-		Consumer<? super T> onOverflow;
-
-		Builder() {
-			this.onTerminate = NOOP_DISPOSABLE;
-			this.onOverflow = t -> {};
-		}
-
-		/**
-		 * Configures queue for this builder. Unbounded queue is used by default.
-		 * If the provided <code>queue</code> is null, default unbounded queue is used.
-		 * @param queue the buffering queue
-		 * @return builder with provided queue
-		 */
-		public Builder<T> queue(@Nullable Queue<T> queue) {
-			this.queue = queue;
-			return this;
-		}
-
-		/**
-		 * Configures onTerminate callback for this builder.
-		 * @param onTerminate called on any terminal signal
-		 * @return builder with provided onTerminate callback
-		 */
-		public Builder<T> onTerminate(Disposable onTerminate) {
-			this.onTerminate = onTerminate;
-			return this;
-		}
-
-		/**
-		 * Configures onOverflow callback for this builder.
-		 * @param onOverflow called when queue.offer return false and unicastProcessor is about to emit onError.
-		 * @return builder with provided onOverflow callback
-		 */
-		public Builder<T> onOverflow(Consumer<? super T> onOverflow) {
-			this.onOverflow = onOverflow;
-			return this;
-		}
-
-		/**
-		 * Creates a new {@link UnicastProcessor} using the properties
-		 * of this builder.
-		 * @return a fresh processor
-		 */
-		public UnicastProcessor<T>  build() {
-			Queue<T> queue = this.queue != null ? this.queue : QueueSupplier.<T>unbounded().get();
-			return new UnicastProcessor<T>(queue, onOverflow, onTerminate);
-		}
-	}
-
-	/**
-	 * Create a new {@link UnicastProcessor} {@link Builder} with default properties.
-	 * @return new UnicastProcessor builder
-	 */
-	public static <E> Builder<E> builder()  {
-		return new Builder<>();
-	}
-
-	/**
 	 * Create a new {@link UnicastProcessor} that will buffer on an internal queue in an
 	 * unbounded fashion.
 	 *
@@ -124,7 +52,7 @@ public final class UnicastProcessor<T>
 	 * @return a unicast {@link FluxProcessor}
 	 */
 	public static <E> UnicastProcessor<E> create() {
-		return UnicastProcessor.<E>builder().build();
+		return new UnicastProcessor<>(QueueSupplier.<E>unbounded().get());
 	}
 
 	/**
@@ -134,11 +62,9 @@ public final class UnicastProcessor<T>
 	 * @param queue the buffering queue
 	 * @param <E> the relayed type
 	 * @return a unicast {@link FluxProcessor}
-	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
-	@Deprecated
 	public static <E> UnicastProcessor<E> create(Queue<E> queue) {
-		return UnicastProcessor.<E>builder().queue(queue).build();
+		return new UnicastProcessor<>(queue);
 	}
 
 	/**
@@ -151,7 +77,7 @@ public final class UnicastProcessor<T>
 	 * @return a unicast {@link FluxProcessor}
 	 */
 	public static <E> UnicastProcessor<E> create(Queue<E> queue, Disposable endcallback) {
-		return new UnicastProcessor(queue, endcallback);
+		return new UnicastProcessor<>(queue, endcallback);
 	}
 
 	/**
@@ -165,13 +91,11 @@ public final class UnicastProcessor<T>
 	 * @param <E> the relayed type
 	 *
 	 * @return a unicast {@link FluxProcessor}
-	 * @deprecated use {@link Builder#build()}
 	 */
-	@Deprecated
 	public static <E> UnicastProcessor<E> create(Queue<E> queue,
 			Consumer<? super E> onOverflow,
 			Disposable endcallback) {
-		return UnicastProcessor.<E>builder().queue(queue).onOverflow(onOverflow).onTerminate(endcallback).build();
+		return new UnicastProcessor<>(queue, onOverflow, endcallback);
 	}
 
 	final Queue<T>            queue;

--- a/reactor-core/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
@@ -292,9 +292,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * @param bufferSize A Backlog Size to mitigate slow subscribers
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
-	@Deprecated
 	public static <E> WorkQueueProcessor<E> create(String name, int bufferSize) {
 		return WorkQueueProcessor.<E>builder().name(name).bufferSize(bufferSize).build();
 	}
@@ -478,7 +476,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	}
 
 	/**
-	 * Create a new WorkQueueProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
+	 * Create a new shared WorkQueueProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and the passed auto-cancel setting. <p> A Shared Processor
 	 * authorizes concurrent onNext calls and is suited for multi-threaded publisher that
 	 * will fan-in data. <p> A new Cached ThreadExecutorPool will be implicitly created.
@@ -494,7 +492,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	}
 
 	/**
-	 * Create a new WorkQueueProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
+	 * Create a new shared WorkQueueProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and auto-cancel. The passed {@link
 	 * ExecutorService} will execute as many event-loop consuming the
 	 * ringbuffer as subscribers.
@@ -509,7 +507,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	}
 
 	/**
-	 * Create a new WorkQueueProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
+	 * Create a new shared WorkQueueProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and the passed auto-cancel setting. <p> A Shared Processor
 	 * authorizes concurrent onNext calls and is suited for multi-threaded publisher that
 	 * will fan-in data. <p> The passed {@link ExecutorService} will
@@ -528,7 +526,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	}
 
 	/**
-	 * Create a new WorkQueueProcessor using the passed buffer size, blockingWait
+	 * Create a new shared WorkQueueProcessor using the passed buffer size, blockingWait
 	 * Strategy and auto-cancel. <p> A Shared Processor authorizes concurrent onNext calls
 	 * and is suited for multi-threaded publisher that will fan-in data. <p> A new Cached
 	 * ThreadExecutorPool will be implicitly created and will use the passed name to
@@ -538,15 +536,13 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * @param bufferSize A Backlog Size to mitigate slow subscribers
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
-	 * @deprecated use the Builder ({@link #builder()} and its {@link Builder#build()} method)
 	 */
-	@Deprecated
 	public static <E> WorkQueueProcessor<E> share(String name, int bufferSize) {
 		return WorkQueueProcessor.<E>builder().share(true).name(name).bufferSize(bufferSize).build();
 	}
 
 	/**
-	 * Create a new WorkQueueProcessor using the passed buffer size, blockingWait
+	 * Create a new shared WorkQueueProcessor using the passed buffer size, blockingWait
 	 * Strategy and the passed auto-cancel setting. <p> A Shared Processor authorizes
 	 * concurrent onNext calls and is suited for multi-threaded publisher that will fan-in
 	 * data. <p> A new Cached ThreadExecutorPool will be implicitly created and will use
@@ -567,7 +563,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	}
 
 	/**
-	 * Create a new WorkQueueProcessor using the passed buffer size, blockingWait
+	 * Create a new shared WorkQueueProcessor using the passed buffer size, blockingWait
 	 * Strategy and auto-cancel. <p> A Shared Processor authorizes concurrent onNext calls
 	 * and is suited for multi-threaded publisher that will fan-in data. <p> The passed
 	 * {@link ExecutorService} will execute as many event-loop
@@ -585,7 +581,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	}
 
 	/**
-	 * Create a new WorkQueueProcessor using the passed buffer size, blockingWait
+	 * Create a new shared WorkQueueProcessor using the passed buffer size, blockingWait
 	 * Strategy and auto-cancel. <p> A Shared Processor authorizes concurrent onNext calls
 	 * and is suited for multi-threaded publisher that will fan-in data. <p> The passed
 	 * {@link ExecutorService} will execute as many event-loop
@@ -605,7 +601,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	}
 
 	/**
-	 * Create a new WorkQueueProcessor using the passed buffer size, blockingWait
+	 * Create a new shared WorkQueueProcessor using the passed buffer size, blockingWait
 	 * Strategy and auto-cancel. <p> A Shared Processor authorizes concurrent onNext calls
 	 * and is suited for multi-threaded publisher that will fan-in data. <p> A new Cached
 	 * ThreadExecutorPool will be implicitly created and will use the passed name to
@@ -626,7 +622,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	}
 
 	/**
-	 * Create a new WorkQueueProcessor using the passed buffer size, blockingWait
+	 * Create a new shared WorkQueueProcessor using the passed buffer size, blockingWait
 	 * Strategy and auto-cancel settings. <p> A Shared Processor authorizes concurrent
 	 * onNext calls and is suited for multi-threaded publisher that will fan-in data. <p>
 	 * A new Cached ThreadExecutorPool will be implicitly created and will use the passed
@@ -654,7 +650,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	}
 
 	/**
-	 * Create a new WorkQueueProcessor using the passed buffer size and blockingWait
+	 * Create a new shared WorkQueueProcessor using the passed buffer size and blockingWait
 	 * Strategy settings but will auto-cancel. <p> A Shared Processor authorizes
 	 * concurrent onNext calls and is suited for multi-threaded publisher that will fan-in
 	 * data. <p> The passed {@link ExecutorService} will execute as
@@ -678,7 +674,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	}
 
 	/**
-	 * Create a new WorkQueueProcessor using the passed buffer size, wait strategy
+	 * Create a new shared WorkQueueProcessor using the passed buffer size, wait strategy
 	 * and auto-cancel settings. <p> A Shared Processor authorizes concurrent onNext calls
 	 * and is suited for multi-threaded publisher that will fan-in data. <p> The passed
 	 * {@link ExecutorService} will execute as many event-loop
@@ -705,7 +701,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	}
 
 	/**
-	 * Create a new WorkQueueProcessor using the passed buffer size, wait strategy
+	 * Create a new shared WorkQueueProcessor using the passed buffer size, wait strategy
 	 * and auto-cancel settings. <p> A Shared Processor authorizes concurrent onNext calls
 	 * and is suited for multi-threaded publisher that will fan-in data. <p> The passed
 	 * {@link ExecutorService} will execute as many event-loop

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -652,7 +652,6 @@ public class EmitterProcessorTest {
 	}
 
 	@Test
-	@Deprecated
 	public void createOverrideBufferSize() {
 		int bufferSize = 1024;
 		EmitterProcessor<Integer> processor = EmitterProcessor.create(bufferSize);
@@ -660,7 +659,6 @@ public class EmitterProcessorTest {
 	}
 
 	@Test
-	@Deprecated
 	public void createOverrideAutoCancel() {
 		boolean autoCancel = false;
 		EmitterProcessor<Integer> processor = EmitterProcessor.create(autoCancel);
@@ -668,7 +666,6 @@ public class EmitterProcessorTest {
 	}
 
 	@Test
-	@Deprecated
 	public void createOverrideAll() {
 		int bufferSize = 1024;
 		boolean autoCancel = false;

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
-
 import javax.annotation.Nullable;
 
 import org.junit.Assert;
@@ -56,7 +55,7 @@ public class EmitterProcessorTest {
 		final int elements = 10;
 		CountDownLatch latch = new CountDownLatch(elements + 1);
 
-		Processor<Integer, Integer> processor = EmitterProcessor.<Integer>builder().bufferSize(16).build();
+		Processor<Integer, Integer> processor = EmitterProcessor.create(16);
 
 		List<Integer> list = new ArrayList<>();
 
@@ -118,7 +117,7 @@ public class EmitterProcessorTest {
 		final int elements = 10000;
 		CountDownLatch latch = new CountDownLatch(elements);
 
-		Processor<Integer, Integer> processor = EmitterProcessor.<Integer>builder().bufferSize(1024).build();
+		Processor<Integer, Integer> processor = EmitterProcessor.create(1024);
 
 		EmitterProcessor<Integer> stream = EmitterProcessor.create();
 		FluxSink<Integer> session = stream.sink();
@@ -235,7 +234,7 @@ public class EmitterProcessorTest {
 
 	@Test
 	public void normalAtomicRingBufferBackpressured() {
-		EmitterProcessor<Integer> tp = EmitterProcessor.<Integer>builder().bufferSize(100).build();
+		EmitterProcessor<Integer> tp = EmitterProcessor.create(100);
 		StepVerifier.create(tp, 0L)
 		            .then(() -> {
 			            Assert.assertTrue("No subscribers?", tp.hasDownstreams());
@@ -320,7 +319,7 @@ public class EmitterProcessorTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void failNullBufferSize() {
-		EmitterProcessor.<Integer>builder().bufferSize(0);
+		EmitterProcessor.create(0);
 	}
 
 	@Test(expected = NullPointerException.class)
@@ -371,7 +370,7 @@ public class EmitterProcessorTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void failNegativeBufferSize() {
-		EmitterProcessor.<Integer>builder().bufferSize(-1);
+		EmitterProcessor.create(-1);
 	}
 
 	static final List<String> DATA     = new ArrayList<>();
@@ -508,7 +507,7 @@ public class EmitterProcessorTest {
 
 	@Test
 	public void testHanging() {
-		FluxProcessor<String, String> processor = EmitterProcessor.<String>builder().bufferSize(2).build();
+		FluxProcessor<String, String> processor = EmitterProcessor.create(2);
 
 		AssertSubscriber<String> first = AssertSubscriber.create(0);
 		processor.log("after-1").subscribe(first);
@@ -536,7 +535,7 @@ public class EmitterProcessorTest {
 
 	@Test
 	public void testNPE() {
-		FluxProcessor<String, String> processor = EmitterProcessor.<String>builder().bufferSize(8).build();
+		FluxProcessor<String, String> processor = EmitterProcessor.create(8);
 		AssertSubscriber<String> first = AssertSubscriber.create(1);
 		processor.log().take(1).subscribe(first);
 
@@ -617,7 +616,7 @@ public class EmitterProcessorTest {
 		int N_THREADS = 3;
 		int N_ITEMS = 8;
 
-		FluxProcessor<String, String> processor = EmitterProcessor.<String>builder().bufferSize(4).build();
+		FluxProcessor<String, String> processor = EmitterProcessor.create(4);
 		List<String> data = new ArrayList<>();
 		for (int i = 1; i <= N_ITEMS; i++) {
 			data.add(String.valueOf(i));

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
@@ -568,7 +568,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void asyncFusionMapToNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		UnicastProcessor<Integer> up = UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(2).get()).build();
+		UnicastProcessor<Integer> up = UnicastProcessor.create(QueueSupplier.<Integer>get(2).get());
 		up.onNext(1);
 		up.onNext(2);
 		up.onComplete();
@@ -587,7 +587,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(2).get()).build();
+				UnicastProcessor.create(QueueSupplier.<Integer>get(2).get());
 		up.onNext(1);
 		up.onNext(2);
 		up.onComplete();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFilterTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFilterTest.java
@@ -180,7 +180,7 @@ public class FluxFilterTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.<Integer>builder().queue(new ConcurrentLinkedQueue<>()).build();
+				UnicastProcessor.create(new ConcurrentLinkedQueue<>());
 
 		up.filter(v -> (v & 1) == 0)
 		  .subscribe(ts);
@@ -200,7 +200,7 @@ public class FluxFilterTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Object> ts = AssertSubscriber.create(1);
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.<Integer>builder().queue(new ConcurrentLinkedQueue<>()).build();
+				UnicastProcessor.create(new ConcurrentLinkedQueue<>());
 
 		Flux.just(1)
 		    .hide()
@@ -226,7 +226,7 @@ public class FluxFilterTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Object> ts = AssertSubscriber.create(1);
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.<Integer>builder().queue(new ConcurrentLinkedQueue<>()).build();
+				UnicastProcessor.create(new ConcurrentLinkedQueue<>());
 
 		Flux.just(1)
 		    .hide()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMapTest.java
@@ -145,7 +145,7 @@ public class FluxMapTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.<Integer>builder().queue(new ConcurrentLinkedQueue<>()).build();
+				UnicastProcessor.create(new ConcurrentLinkedQueue<>());
 
 		up.map(v -> v + 1)
 		  .subscribe(ts);
@@ -165,7 +165,7 @@ public class FluxMapTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Object> ts = AssertSubscriber.create(1);
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.<Integer>builder().queue(new ConcurrentLinkedQueue<>()).build();
+				UnicastProcessor.create(new ConcurrentLinkedQueue<>());
 
 		Flux.just(1)
 		    .hide()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
@@ -490,7 +490,7 @@ public class FluxPeekFuseableTest {
 	public void asyncFusionAvailable() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(2).get()).build()
+		UnicastProcessor.create(QueueSupplier.<Integer>get(2).get())
 		                .doOnNext(v -> {
 		                })
 		                .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
@@ -736,7 +736,7 @@ public class FluxPeekTest extends FluxOperatorTest<String, String> {
 	public void asyncFusionAvailable() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(2).get()).build()
+		UnicastProcessor.create(QueueSupplier.<Integer>get(2).get())
 		                .doOnNext(v -> {
 		                })
 		                .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
@@ -148,7 +148,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(16).get()).build();
+				UnicastProcessor.create(QueueSupplier.<Integer>get(16).get());
 
 		up.publish(o -> zip((Object[] a) -> (Integer) a[0] + (Integer) a[1], o, o.skip(1)))
 		  .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
@@ -241,7 +241,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.<Integer>builder().queue(new ConcurrentLinkedQueue<>()).build();
+				UnicastProcessor.create(new ConcurrentLinkedQueue<>());
 
 		for (int i = 0; i < 1_000_000; i++) {
 			up.onNext(i);
@@ -261,7 +261,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void normalAsyncFusedBackpressured() throws Exception {
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>unbounded(1024).get()).build();
+				UnicastProcessor.create(QueueSupplier.<Integer>unbounded(1024).get());
 
 		for (int i = 0; i < 1_000_000; i++) {
 			up.onNext(0);
@@ -693,7 +693,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	public void mappedAsyncSourceWithNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(2).get()).build();
+				UnicastProcessor.create(QueueSupplier.<Integer>get(2).get());
 		up.onNext(1);
 		up.onNext(2);
 		up.onComplete();
@@ -713,7 +713,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	public void mappedAsyncSourceWithNullPostFilter() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(2).get()).build();
+				UnicastProcessor.create(QueueSupplier.<Integer>get(2).get());
 		up.onNext(1);
 		up.onNext(2);
 		up.onComplete();
@@ -795,7 +795,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void threadBoundaryPreventsInvalidFusionMap() {
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(2).get()).build();
+				UnicastProcessor.create(QueueSupplier.<Integer>get(2).get());
 
 		AssertSubscriber<String> ts = AssertSubscriber.create();
 
@@ -818,7 +818,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void threadBoundaryPreventsInvalidFusionFilter() {
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(2).get()).build();
+				UnicastProcessor.create(QueueSupplier.<Integer>get(2).get());
 
 		String s = Thread.currentThread()
 		                 .getName();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
@@ -157,7 +157,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts1 = AssertSubscriber.create();
 		AssertSubscriber<Integer> ts2 = AssertSubscriber.create();
 
-		UnicastProcessor<Integer> up = UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(8).get()).build();
+		UnicastProcessor<Integer> up = UnicastProcessor.create(QueueSupplier.<Integer>get(8).get());
 		up.onNext(1);
 		up.onNext(2);
 		up.onNext(3);
@@ -196,7 +196,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts1 = AssertSubscriber.create(0);
 		AssertSubscriber<Integer> ts2 = AssertSubscriber.create(0);
 
-		UnicastProcessor<Integer> up = UnicastProcessor.<Integer>builder().queue(QueueSupplier.<Integer>get(8).get()).build();
+		UnicastProcessor<Integer> up = UnicastProcessor.create(QueueSupplier.<Integer>get(8).get());
 		up.onNext(1);
 		up.onNext(2);
 		up.onNext(3);

--- a/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
@@ -37,7 +37,7 @@ public class UnicastProcessorTest {
     @Test
     public void secondSubscriberRejectedProperly() {
 
-        UnicastProcessor<Integer> up = UnicastProcessor.<Integer>builder().queue(new ConcurrentLinkedQueue<>()).build();
+        UnicastProcessor<Integer> up = UnicastProcessor.create(new ConcurrentLinkedQueue<>());
 
         up.subscribe();
 
@@ -111,7 +111,7 @@ public class UnicastProcessorTest {
 			@Nullable Consumer<? super Integer> onOverflow,
 			@Nullable Disposable onTerminate) {
 		Queue<Integer> expectedQueue = queue != null ? queue : QueueSupplier.<Integer>unbounded().get();
-		Disposable expectedOnTerminate = onTerminate != null ? onTerminate : UnicastProcessor.Builder.NOOP_DISPOSABLE;
+		Disposable expectedOnTerminate = onTerminate != null ? onTerminate : null;
 		assertEquals(expectedQueue.getClass(), processor.queue.getClass());
 		assertEquals(expectedOnTerminate, processor.onTerminate);
 		if (onOverflow != null)

--- a/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
@@ -80,7 +80,6 @@ public class UnicastProcessorTest {
 	}
 
 	@Test
-	@Deprecated
 	public void createOverrideQueue() {
 		Queue<Integer> queue = QueueSupplier.<Integer>get(10).get();
 		UnicastProcessor<Integer> processor = UnicastProcessor.create(queue);
@@ -88,7 +87,6 @@ public class UnicastProcessorTest {
 	}
 
 	@Test
-	@Deprecated
 	public void createOverrideQueueOnTerminate() {
 		Disposable onTerminate = () -> {};
 		Queue<Integer> queue = QueueSupplier.<Integer>get(10).get();
@@ -97,7 +95,6 @@ public class UnicastProcessorTest {
 	}
 
 	@Test
-	@Deprecated
 	public void createOverrideAll() {
 		Disposable onTerminate = () -> {};
 		Consumer<? super Integer> onOverflow = t -> {};

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -1363,7 +1363,7 @@ public class FluxTests extends AbstractReactorTest {
 
 		final EmitterProcessor<Integer> forkEmitterProcessor = EmitterProcessor.create();
 
-		final EmitterProcessor<Integer> computationEmitterProcessor = EmitterProcessor.<Integer>builder().autoCancel(false).build();
+		final EmitterProcessor<Integer> computationEmitterProcessor = EmitterProcessor.create(false);
 
 		Scheduler computation = Schedulers.newSingle("computation");
 		Scheduler persistence = Schedulers.newSingle("persistence");
@@ -1381,7 +1381,7 @@ public class FluxTests extends AbstractReactorTest {
 				                      .doOnNext(ls -> println("Computed: ", ls))
 				                      .log("computation");
 
-		final EmitterProcessor<Integer> persistenceEmitterProcessor = EmitterProcessor.<Integer>builder().autoCancel(false).build();
+		final EmitterProcessor<Integer> persistenceEmitterProcessor = EmitterProcessor.create(false);
 
 		final Flux<List<String>> persistenceStream =
 				persistenceEmitterProcessor.publishOn(persistence)

--- a/reactor-core/src/test/java/reactor/core/publisher/tck/EmitterProcessorVerification.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/tck/EmitterProcessorVerification.java
@@ -29,7 +29,7 @@ public class EmitterProcessorVerification extends AbstractProcessorVerification 
 
 	@Override
 	public Processor<Long, Long> createProcessor(int bufferSize) {
-		return EmitterProcessor.<Long>builder().bufferSize(bufferSize).build();
+		return EmitterProcessor.create(bufferSize);
 	}
 
 	@Override


### PR DESCRIPTION
This commit removes the recent deprecation on a few factory methods for
Processors that now have a Builder, keeping most significant and short
constructions from the boilerplate of using a builder.

WorkQueueProcessor and TopicProcessor keep the create/share with name
and bufferSize, UnicastProcessor keeps the queue+terminationCallback
variant and EmitterProcessor keeps the bufferSize variant.