### PR TITLE
Fix reactor-test javadoc and make external links stand out

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,31 +124,6 @@ configure(subprojects) { p ->
 	targetCompatibility = 1.8
   }
 
-  javadoc {
-	dependsOn jar
-	group = "Reactor Core Javadoc"
-	description = "Generates aggregated Javadoc API documentation."
-	title = "Reactor Core $version"
-
-	options.addStringOption('charSet', 'UTF-8')
-
-	options.memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PROTECTED
-	options.author = true
-	options.header = "$p.name"
-	options.overview = "$rootDir/src/api/overview.html"
-	options.stylesheetFile = file("$rootDir/src/api/stylesheet.css")
-	options.links(rootProject.ext.javadocLinks)
-	options.tags = [ "apiNote:a:API Note:", "implSpec:a:Implementation Requirements:",
-					 "implNote:a:Implementation Note:" ]
-
-	maxMemory = "1024m"
-	destinationDir = new File(p.buildDir, "docs/javadoc")
-	source p.sourceSets.main.allJava
-	doFirst {
-	  classpath = files(p.sourceSets.main.compileClasspath)
-	}
-  }
-
   if (JavaVersion.current().isJava8Compatible()) {
 	compileTestJava.options.compilerArgs += "-parameters"
 	p.tasks.withType(Javadoc) {
@@ -232,6 +207,31 @@ project('reactor-core') {
 			"org.mockito:mockito-core:$mockitoVersion"
   }
 
+  javadoc {
+	dependsOn jar
+	group = "Reactor Core Javadoc"
+	description = "Generates aggregated Javadoc API documentation."
+	title = "Reactor Core $version"
+
+	options.addStringOption('charSet', 'UTF-8')
+
+	options.memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PROTECTED
+	options.author = true
+	options.header = "$project.name"
+	options.overview = "$rootDir/src/api/overview.html"
+	options.stylesheetFile = file("$rootDir/src/api/stylesheet.css")
+	options.links(rootProject.ext.javadocLinks )
+	options.tags = [ "apiNote:a:API Note:", "implSpec:a:Implementation Requirements:",
+					 "implNote:a:Implementation Note:" ]
+
+	maxMemory = "1024m"
+	destinationDir = new File(project.buildDir, "docs/javadoc")
+	source project.sourceSets.main.allJava
+	doFirst {
+	  classpath = files(project.sourceSets.main.compileClasspath)
+	}
+  }
+
   task loops(type: Test) {
 	exclude '**/*'
 	include '**/*Loop.*'
@@ -281,6 +281,31 @@ project('reactor-test') {
 	testCompile "org.hamcrest:hamcrest-library:1.3",
 			"org.assertj:assertj-core:$assertJVersion",
 			"org.mockito:mockito-core:$mockitoVersion"
+  }
+
+  javadoc {
+	dependsOn jar
+	group = "Reactor Test Javadoc"
+	description = "Generates aggregated Javadoc API documentation."
+	title = "Reactor Test $version"
+
+	options.addStringOption('charSet', 'UTF-8')
+
+	options.memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PROTECTED
+	options.author = true
+	options.header = "$project.name"
+	options.stylesheetFile = file("$rootDir/src/api/stylesheet.css")
+	options.links(rootProject.ext.javadocLinks
+			.plus("http://projectreactor.io/docs/core/release/api/") as String[])
+	options.tags = [ "apiNote:a:API Note:", "implSpec:a:Implementation Requirements:",
+					 "implNote:a:Implementation Note:" ]
+
+	maxMemory = "1024m"
+	destinationDir = new File(project.buildDir, "docs/javadoc")
+	source project.sourceSets.main.allJava
+	doFirst {
+	  classpath = files(project.sourceSets.main.compileClasspath)
+	}
   }
 }
 

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -807,7 +807,7 @@ public interface StepVerifier {
 		/**
 		 * Expect the source {@link Publisher} to NOT run with Reactor Fusion flow
 		 * optimization. It will check if publisher is {@link Fuseable} or
-		 * subscription is a {@link Fuseable.QueueSubscription}.
+		 * subscription is a {@link reactor.core.Fuseable.QueueSubscription}.
 		 *
 		 * @return this builder
 		 *

--- a/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
+++ b/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
@@ -44,7 +44,7 @@ public class VirtualTimeScheduler implements Scheduler {
 	/**
 	 * Create a new {@link VirtualTimeScheduler} without enabling it. Call
 	 * {@link #getOrSet(VirtualTimeScheduler)} to enable it on
-	 * {@link Schedulers.Factory} factories.
+	 * {@link reactor.core.scheduler.Schedulers.Factory} factories.
 	 *
 	 * @return a new {@link VirtualTimeScheduler} intended for timed-only
 	 * {@link Schedulers} factories.
@@ -54,7 +54,7 @@ public class VirtualTimeScheduler implements Scheduler {
 	}
 
 	/**
-	 * Assign a single newly created {@link VirtualTimeScheduler} to all {@link Schedulers.Factory}
+	 * Assign a single newly created {@link VirtualTimeScheduler} to all {@link reactor.core.scheduler.Schedulers.Factory}
 	 * factories. While the method is thread safe, its usually advised to execute such
 	 * wide-impact BEFORE all tested code runs (setup etc). The created scheduler is returned.
 	 *
@@ -66,7 +66,7 @@ public class VirtualTimeScheduler implements Scheduler {
 
 	/**
 	 * Assign an externally created {@link VirtualTimeScheduler} to the relevant
-	 * {@link Schedulers.Factory} factories, depending on how it was created (see
+	 * {@link reactor.core.scheduler.Schedulers.Factory} factories, depending on how it was created (see
 	 * {@link #create()} and {@link #create()}). Note that the returned scheduler
 	 * should always be captured and used going forward, as the provided scheduler can be
 	 * superseded by a matching scheduler that has already been enabled.
@@ -83,7 +83,7 @@ public class VirtualTimeScheduler implements Scheduler {
 
 	/**
 	 * Assign an externally created {@link VirtualTimeScheduler} to the relevant
-	 * {@link Schedulers.Factory} factories, depending on how it was created (see
+	 * {@link reactor.core.scheduler.Schedulers.Factory} factories, depending on how it was created (see
 	 * {@link #create()} and {@link #create()}). Contrary to
 	 * {@link #getOrSet(VirtualTimeScheduler)}, the provided scheduler is always used, even
 	 * if a matching scheduler is currently enabled.

--- a/src/api/stylesheet.css
+++ b/src/api/stylesheet.css
@@ -34,6 +34,10 @@ a:active {
     text-decoration:none;
     color:#6db33f;
 }
+a[href^="http"] {
+    color: #16906a;
+}
+
 a[name] {
     color:#353833;
 }

--- a/src/docs/asciidoc/reactiveProgramming.adoc
+++ b/src/docs/asciidoc/reactiveProgramming.adoc
@@ -297,10 +297,10 @@ assertThat(results).containsExactly( // <8>
 <4> Second we'll get the associated stat
 <5> We are actually interested in asynchronously combining these 2 values
 <6> Furthermore, we'd like to aggregate the values into a `List` as they become available.
-<8> In production, we'd continue working with the `Flux` asynchronously by further combining
+<7> In production, we'd continue working with the `Flux` asynchronously by further combining
 it or subscribing to it. Since we're in a test, we'll block waiting for the processing to finish
 instead, directly returning the aggregated list of values.
-<9> We are now ready to assert the result.
+<8> We are now ready to assert the result.
 
 These caveats of Callback and Future seem familiar: aren't they what Reactive Programming directly tries to
 address with the `Publisher`-`Subscriber` pair?


### PR DESCRIPTION
2 parts to this PR:
 1. fix the generation of `reactor-test` javadocs inside reactor-core repo (would previously display it as pertaining to "Reactor Core")
 2. style external links in reactor-core and reactor-test javadocs in a slightly different shade of green