### PR TITLE
Fix #609 - scanWith will emit in lockstep w/prior

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxScanSeed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxScanSeed.java
@@ -72,10 +72,10 @@ final class FluxScanSeed<T, R> extends FluxSource<T, R> {
 	static final class ScanSeedCoordinator<T, R>
 			extends Operators.MultiSubscriptionSubscriber<R, R> {
 
-		final         Supplier<R>                 initialSupplier;
-		private final Publisher<? extends T>      source;
-		private final BiFunction<R, ? super T, R> accumulator;
-		volatile      int                         wip;
+		final    Supplier<R>                 initialSupplier;
+		final    Publisher<? extends T>      source;
+		final    BiFunction<R, ? super T, R> accumulator;
+		volatile int                         wip;
 		long produced;
 		private ScanSeedSubscriber<T, R> seedSubscriber;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxScanSeedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxScanSeedTest.java
@@ -172,8 +172,6 @@ public class FluxScanSeedTest extends FluxOperatorTest<String, String> {
 
         Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
         Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
-        test.value = 5;
-        Assertions.assertThat(test.scan(Scannable.IntAttr.BUFFERED)).isEqualTo(1);
 
         Assertions.assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
         test.onComplete();


### PR DESCRIPTION
Modify FluxScanSeed so that the seed is sent
immediately, which allows the accumulator to
run in lockstep with the upstream stage.

This fixes a problem where the accumulated value
lagged the upstream by one.

Emitting the seed in `request` was the easiest solution as it minimized state keeping. I checked the code for precedence in doing this, and the initial stages (ie, `just`), acted like this.

I had to add `skip(1)` for the `scenarios_errorFromUpstreamFailure` tests to pass. (I tried a variation that emitted the seed after calling `request` from upstream but that was additional state-keeping and didn't fix the tests. after reading those tests i don't think they can be fixed w/o modifying the tests to say "it is okay to expect one value, because this operator is also kinda a source")