### PR TITLE
fix a number of warnings and tune nullable / non-null annotations

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Fuseable.java
+++ b/reactor-core/src/main/java/reactor/core/Fuseable.java
@@ -60,7 +60,7 @@ public interface Fuseable {
 	interface ConditionalSubscriber<T> extends Subscriber<T> {
 		/**
 		 * Try consuming the value and return true if successful.
-		 * @param t the value to consume
+		 * @param t the value to consume, not null
 		 * @return true if consumed, false if dropped and a new value can be immediately sent
 		 */
 		boolean tryOnNext(T t);

--- a/reactor-core/src/main/java/reactor/core/Scannable.java
+++ b/reactor-core/src/main/java/reactor/core/Scannable.java
@@ -49,7 +49,7 @@ public interface Scannable {
 
 			@Override
 			public boolean hasNext() {
-				return c != null;
+				return c != null && c.isScanAvailable();
 			}
 
 			@Override

--- a/reactor-core/src/main/java/reactor/core/Scannable.java
+++ b/reactor-core/src/main/java/reactor/core/Scannable.java
@@ -20,10 +20,7 @@ import java.util.Iterator;
 import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
 import javax.annotation.Nullable;
-
-import com.sun.istack.internal.localization.NullLocalizable;
 
 /**
  * A Scannable component exposes state in a non strictly memory consistent way and

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3829,9 +3829,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Transform the elements emitted by this {@link Flux} asynchronously into Publishers,
+	 * Transform the signals emitted by this {@link Flux} asynchronously into Publishers,
 	 * then flatten these inner publishers into a single {@link Flux} through merging,
-	 * which allow them to interleave.
+	 * which allow them to interleave. Note that at least one of the signal mappers must
+	 * be provided, and all provided mappers must produce a publisher.
 	 * <p>
 	 * There are three dimensions to this operator that can be compared with
 	 * {@link #flatMapSequential(Function) flatMapSequential} and {@link #concatMap(Function) concatMap}:
@@ -3848,16 +3849,20 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.0.M2/src/docs/marble/flatmaps.png" alt="">
 	 * <p>
-	 * @param mapperOnNext the {@link Function} to call on next data and returning a sequence to merge
-	 * @param mapperOnError the {@link Function} to call on error signal and returning a sequence to merge
-	 * @param mapperOnComplete the {@link Function} to call on complete signal and returning a sequence to merge
+	 * @param mapperOnNext the {@link Function} to call on next data and returning a sequence to merge.
+	 * Use {@literal null} to ignore (provided at least one other mapper is specified).
+	 * @param mapperOnError the {@link Function} to call on error signal and returning a sequence to merge.
+	 * Use {@literal null} to ignore (provided at least one other mapper is specified).
+	 * @param mapperOnComplete the {@link Function} to call on complete signal and returning a sequence to merge.
+	 * Use {@literal null} to ignore (provided at least one other mapper is specified).
 	 * @param <R> the output {@link Publisher} type target
 	 *
 	 * @return a new {@link Flux}
 	 */
-	public final <R> Flux<R> flatMap(Function<? super T, ? extends Publisher<? extends R>> mapperOnNext,
-			Function<? super Throwable, ? extends Publisher<? extends R>> mapperOnError,
-			Supplier<? extends Publisher<? extends R>> mapperOnComplete) {
+	public final <R> Flux<R> flatMap(
+			@Nullable Function<? super T, ? extends Publisher<? extends R>> mapperOnNext,
+			@Nullable Function<? super Throwable, ? extends Publisher<? extends R>> mapperOnError,
+			@Nullable Supplier<? extends Publisher<? extends R>> mapperOnComplete) {
 		return onAssembly(new FluxFlatMap<>(
 				new FluxMapSignal<>(this, mapperOnNext, mapperOnError, mapperOnComplete),
 				identityFunction(),

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
@@ -763,7 +763,7 @@ final class FluxConcatMap<T, R> extends FluxSource<T, R> {
 		long produced;
 
 		ConcatMapInner(FluxConcatMapSupport<?, R> parent) {
-			super(Operators.nullSubscriber());
+			super(Operators.emptySubscriber());
 			this.parent = parent;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
@@ -28,6 +28,7 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
+
 import javax.annotation.Nullable;
 
 /**
@@ -118,7 +119,7 @@ final class FluxConcatMap<T, R> extends FluxSource<T, R> {
 	}
 
 	static final class ConcatMapImmediate<T, R>
-			implements InnerOperator<T, R>, FluxConcatMapSupport<R> {
+			implements FluxConcatMapSupport<T, R> {
 
 		final Subscriber<? super R> actual;
 
@@ -184,7 +185,7 @@ final class FluxConcatMap<T, R> extends FluxSource<T, R> {
 			if (key == IntAttr.BUFFERED) return queue != null ? queue.size() : 0;
 			if (key == ThrowableAttr.ERROR) return error;
 
-			return InnerOperator.super.scanUnsafe(key);
+			return FluxConcatMapSupport.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -447,7 +448,7 @@ final class FluxConcatMap<T, R> extends FluxSource<T, R> {
 	}
 
 	static final class ConcatMapDelayed<T, R>
-			implements InnerOperator<T, R>, FluxConcatMapSupport<R> {
+			implements FluxConcatMapSupport<T, R> {
 
 		final Subscriber<? super R> actual;
 
@@ -518,7 +519,7 @@ final class FluxConcatMap<T, R> extends FluxSource<T, R> {
 			if (key == ThrowableAttr.ERROR) return error;
 			if (key == BooleanAttr.DELAY_ERROR) return true;
 
-			return InnerOperator.super.scanUnsafe(key);
+			return FluxConcatMapSupport.super.scanUnsafe(key);
 		}
 
 		@Override
@@ -741,7 +742,11 @@ final class FluxConcatMap<T, R> extends FluxSource<T, R> {
 		}
 	}
 
-	interface FluxConcatMapSupport<T> {
+	/**
+	 * @param <I> input type consumed by the InnerOperator
+	 * @param <T> output type, as forwarded by the inner this helper supports
+	 */
+	interface FluxConcatMapSupport<I, T> extends InnerOperator<I, T> {
 
 		void innerNext(T value);
 
@@ -753,13 +758,21 @@ final class FluxConcatMap<T, R> extends FluxSource<T, R> {
 	static final class ConcatMapInner<R>
 			extends Operators.MultiSubscriptionSubscriber<R, R> {
 
-		final FluxConcatMapSupport<R> parent;
+		final FluxConcatMapSupport<?, R> parent;
 
 		long produced;
 
-		ConcatMapInner(FluxConcatMapSupport<R> parent) {
-			super(null); //TODO investigate null
+		ConcatMapInner(FluxConcatMapSupport<?, R> parent) {
+			super(Operators.nullSubscriber());
 			this.parent = parent;
+		}
+
+		@Nullable
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == ScannableAttr.ACTUAL) return parent;
+
+			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDistinct.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDistinct.java
@@ -264,7 +264,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 		}
 
 		@Override
-		public boolean tryOnNext(@Nullable T t) {
+		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t);
 				return true;
@@ -384,7 +384,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 		}
 
 		@Override
-		public boolean tryOnNext(@Nullable T t) {
+		public boolean tryOnNext(T t) {
 
 			if (sourceMode == Fuseable.ASYNC) {
 				actual.onNext(null);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
@@ -193,7 +193,7 @@ final class FluxDistinctUntilChanged<T, K> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public boolean tryOnNext(@Nullable T t) {
+		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t);
 				return true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDoFinally.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDoFinally.java
@@ -225,7 +225,7 @@ final class FluxDoFinally<T> extends FluxSource<T, T> {
 
 		@Override
 		@SuppressWarnings("unchecked")
-		public boolean tryOnNext(@Nullable T t) {
+		public boolean tryOnNext(T t) {
 			return ((ConditionalSubscriber<? super T>)actual).tryOnNext(t);
 		}
 	}
@@ -240,7 +240,7 @@ final class FluxDoFinally<T> extends FluxSource<T, T> {
 
 		@Override
 		@SuppressWarnings("unchecked")
-		public boolean tryOnNext(@Nullable T t) {
+		public boolean tryOnNext(T t) {
 			return ((ConditionalSubscriber<? super T>)actual).tryOnNext(t);
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilter.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilter.java
@@ -102,7 +102,7 @@ final class FluxFilter<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public boolean tryOnNext(@Nullable T t) {
+		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t);
 				return false;
@@ -218,7 +218,7 @@ final class FluxFilter<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		public boolean tryOnNext(@Nullable T t) {
+		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t);
 				return false;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
@@ -110,7 +110,7 @@ final class FluxFilterFuseable<T> extends FluxSource<T, T> implements Fuseable {
 		}
 
 		@Override
-		public boolean tryOnNext(@Nullable T t) {
+		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t);
 				return false;
@@ -291,7 +291,7 @@ final class FluxFilterFuseable<T> extends FluxSource<T, T> implements Fuseable {
 		}
 
 		@Override
-		public boolean tryOnNext(@Nullable T t) {
+		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t);
 				return false;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGroupBy.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGroupBy.java
@@ -262,6 +262,9 @@ final class FluxGroupBy<T, K, V> extends FluxSource<T, GroupedFlux<K, V>>
 
 		void signalAsyncError() {
 			Throwable e = Exceptions.terminate(ERROR, this); //TODO investigate if e == null
+			if (e == null) {
+				e = new IllegalStateException("FluxGroupBy.signalAsyncError called without error set");
+			}
 			groupCount = 0;
 			for (UnicastGroupedFlux<K, V> g : groupMap.values()) {
 				g.onError(e);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
@@ -111,7 +111,7 @@ final class FluxHandle<T, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public boolean tryOnNext(@Nullable T t) {
+		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t);
 				return false;
@@ -268,7 +268,7 @@ final class FluxHandle<T, R> extends FluxSource<T, R> {
 		}
 
 		@Override
-		public boolean tryOnNext(@Nullable T t) {
+		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t);
 				return false;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
@@ -88,7 +88,7 @@ final class FluxHandleFuseable<T, R> extends FluxSource<T, R> implements Fuseabl
 		}
 
 		@Override
-		public boolean tryOnNext(@Nullable T t) {
+		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t);
 				return true;
@@ -392,7 +392,7 @@ final class FluxHandleFuseable<T, R> extends FluxSource<T, R> implements Fuseabl
 		}
 
 		@Override
-		public boolean tryOnNext(@Nullable T t) {
+		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t);
 				return true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
@@ -210,7 +210,8 @@ final class FluxOnBackpressureBufferStrategy<O> extends FluxSource<O, O> {
 
 			for (; ; ) {
 				Subscriber<? super T> a = actual;
-				if (a != null) { //TODO investigate null (can actual be null?)
+				//noinspection ConstantConditions
+				if (a != null) {
 					innerDrain(a);
 					return;
 				}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
@@ -738,7 +738,7 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 		}
 
 		@Override
-		public boolean tryOnNext(@Nullable T t) {
+		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t);
 				return false;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
@@ -394,7 +394,15 @@ final class FluxSwitchMap<T, R> extends FluxSource<T, R> {
 		}
 
 		void innerNext(SwitchMapInner<R> inner, R value) {
-			queueBiAtomic.test(inner, value); //TODO investigate null
+			if (queueBiAtomic != null) {
+				//the queue is a "BiQueue" from Reactor, test(A, B) actually does double insertion
+				queueBiAtomic.test(inner, value);
+			}
+			else {
+				//the queue is a regular queue, a bit more overhead to do double insertion
+				queue.offer(inner);
+				queue.offer(value);
+			}
 			drain();
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -680,37 +680,37 @@ public abstract class Operators {
 	 * @return a placeholder subscriber
 	 */
 	@SuppressWarnings("unchecked")
-	public static <T> Subscriber<T> nullSubscriber() {
-		return (Subscriber<T>) NULL_SUBSCRIBER;
+	public static <T> Subscriber<T> emptySubscriber() {
+		return (Subscriber<T>) EMPTY_SUBSCRIBER;
 	}
 
 	Operators() {
 	}
 
 
-	static final Subscriber<?> NULL_SUBSCRIBER = new Subscriber<Object>() {
+	static final Subscriber<?> EMPTY_SUBSCRIBER = new Subscriber<Object>() {
 		@Override
 		public void onSubscribe(Subscription s) {
 			Throwable e = new IllegalStateException("onSubscribe should not be used");
-			log.error("Unexpected call to Operators.nullSubscriber()", e);
+			log.error("Unexpected call to Operators.emptySubscriber()", e);
 		}
 
 		@Override
 		public void onNext(Object o) {
 			Throwable e = new IllegalStateException("onNext should not be used, got " + o);
-			log.error("Unexpected call to Operators.nullSubscriber()", e);
+			log.error("Unexpected call to Operators.emptySubscriber()", e);
 		}
 
 		@Override
 		public void onError(Throwable t) {
 			Throwable e = new IllegalStateException("onError should not be used", t);
-			log.error("Unexpected call to Operators.nullSubscriber()", e);
+			log.error("Unexpected call to Operators.emptySubscriber()", e);
 		}
 
 		@Override
 		public void onComplete() {
 			Throwable e = new IllegalStateException("onComplete should not be used");
-			log.error("Unexpected call to Operators.nullSubscriber()", e);
+			log.error("Unexpected call to Operators.emptySubscriber()", e);
 		}
 	};
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -672,8 +672,47 @@ public abstract class Operators {
 		return false;
 	}
 
+	/**
+	 * A {@link Subscriber} that is expected to be used as a placeholder and
+	 * never actually be called. All methods log an error.
+	 *
+	 * @param <T> the type of data (ignored)
+	 * @return a placeholder subscriber
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> Subscriber<T> nullSubscriber() {
+		return (Subscriber<T>) NULL_SUBSCRIBER;
+	}
+
 	Operators() {
 	}
+
+
+	static final Subscriber<?> NULL_SUBSCRIBER = new Subscriber<Object>() {
+		@Override
+		public void onSubscribe(Subscription s) {
+			Throwable e = new IllegalStateException("onSubscribe should not be used");
+			log.error("Unexpected call to Operators.nullSubscriber()", e);
+		}
+
+		@Override
+		public void onNext(Object o) {
+			Throwable e = new IllegalStateException("onNext should not be used, got " + o);
+			log.error("Unexpected call to Operators.nullSubscriber()", e);
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			Throwable e = new IllegalStateException("onError should not be used", t);
+			log.error("Unexpected call to Operators.nullSubscriber()", e);
+		}
+
+		@Override
+		public void onComplete() {
+			Throwable e = new IllegalStateException("onComplete should not be used");
+			log.error("Unexpected call to Operators.nullSubscriber()", e);
+		}
+	};
 
 	//
 	enum CancelledSubscription implements Subscription, Scannable {

--- a/reactor-core/src/main/java/reactor/core/publisher/SignalLogger.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SignalLogger.java
@@ -192,7 +192,7 @@ final class SignalLogger<IN> implements SignalPeek<IN> {
 		return null;
 	}
 
-	String subscriptionAsString(@Nullable Subscription s) {
+	static String subscriptionAsString(@Nullable Subscription s) {
 		if (s == null) {
 			return "null subscription";
 		}

--- a/reactor-core/src/test/java/reactor/core/CoreTest.java
+++ b/reactor-core/src/test/java/reactor/core/CoreTest.java
@@ -17,6 +17,8 @@ package reactor.core;
 
 import java.util.Collections;
 
+import javax.annotation.Nullable;
+
 import org.junit.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -71,6 +73,7 @@ public class CoreTest {
 		}
 
 		@Override
+		@Nullable
 		public Integer poll() {
 			return null;
 		}

--- a/reactor-core/src/test/java/reactor/core/ScannableTest.java
+++ b/reactor-core/src/test/java/reactor/core/ScannableTest.java
@@ -86,7 +86,9 @@ public class ScannableTest {
 
 	@Test
 	public void nullScan() {
-		assertThat(Scannable.from(null)).isNull();
+		assertThat(Scannable.from(null))
+				.isNotNull()
+				.isSameAs(Scannable.Attr.NULL_SCAN);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/DisposablesTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/DisposablesTest.java
@@ -77,7 +77,7 @@ public class DisposablesTest {
 		Hooks.onErrorDropped(e -> assertThat(e).isInstanceOf(NullPointerException.class)
 		                                       .hasMessage("next is null"));
 		try {
-			assertThat(Disposables.validate(null, null));
+			assertThat(Disposables.validate(null, null)).isFalse();
 		} finally {
 			Hooks.resetOnErrorDropped();
 		}

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -25,6 +25,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 
+import javax.annotation.Nullable;
+
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -602,6 +604,7 @@ public class EmitterProcessorTest {
 					.assertComplete();
 		}
 
+		@Nullable
 		public Throwable getLastException() {
 			return lastException;
 		}
@@ -674,7 +677,9 @@ public class EmitterProcessorTest {
 		assertProcessor(processor, bufferSize, autoCancel);
 	}
 
-	public void assertProcessor(EmitterProcessor<Integer> processor, Integer bufferSize, Boolean autoCancel) {
+	public void assertProcessor(EmitterProcessor<Integer> processor,
+			@Nullable Integer bufferSize,
+			@Nullable Boolean autoCancel) {
 		int expectedBufferSize = bufferSize != null ? bufferSize : QueueSupplier.SMALL_BUFFER_SIZE;
 		boolean expectedAutoCancel = autoCancel != null ? autoCancel : true;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Subscriber;
@@ -384,6 +386,7 @@ public class FluxDistinctTest extends FluxOperatorTest<String, String> {
 		}
 
 		@Override
+		@Nullable
 		public Iterator<T> iterator() {
 			return null;
 		}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMaterializeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMaterializeTest.java
@@ -144,12 +144,9 @@ public class FluxMaterializeTest
 	public void materialize() {
 		StepVerifier.create(Flux.just("Three", "Two", "One")
 		                        .materialize())
-		            .expectNextMatches(s -> s.isOnNext() && s.get()
-		                                                     .equals("Three"))
-		            .expectNextMatches(s -> s.isOnNext() && s.get()
-		                                                     .equals("Two"))
-		            .expectNextMatches(s -> s.isOnNext() && s.get()
-		                                                     .equals("One"))
+		            .expectNextMatches(s -> s.isOnNext() && "Three".equals(s.get()))
+		            .expectNextMatches(s -> s.isOnNext() && "Two".equals(s.get()))
+		            .expectNextMatches(s -> s.isOnNext() && "One".equals(s.get()))
 		            .expectNextMatches(Signal::isOnComplete)
 		            .verifyComplete();
 	}
@@ -159,13 +156,10 @@ public class FluxMaterializeTest
 		StepVerifier.create(Flux.just("Three", "Two")
 		                        .concatWith(Flux.error(new RuntimeException("test")))
 		                        .materialize())
-		            .expectNextMatches(s -> s.isOnNext() && s.get()
-		                                                     .equals("Three"))
-		            .expectNextMatches(s -> s.isOnNext() && s.get()
-		                                                     .equals("Two"))
-		            .expectNextMatches(s -> s.isOnError() && s.getThrowable()
-		                                                      .getMessage()
-		                                                      .equals("test"))
+		            .expectNextMatches(s -> s.isOnNext() && "Three".equals(s.get()))
+		            .expectNextMatches(s -> s.isOnNext() && "Two".equals(s.get()))
+		            .expectNextMatches(s -> s.isOnError() && s.getThrowable() != null
+				            && "test".equals(s.getThrowable().getMessage()))
 		            .verifyComplete();
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
@@ -33,6 +33,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.annotation.Nullable;
+
 import org.assertj.core.api.Assertions;
 import org.hamcrest.CoreMatchers;
 import org.junit.AfterClass;
@@ -1315,6 +1317,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		}
 
 		@Override
+		@Nullable
 		public Worker createWorker() {
 			return null;
 		}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSkipUntilOtherTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSkipUntilOtherTest.java
@@ -262,6 +262,7 @@ public class FluxSkipUntilOtherTest extends FluxOperatorTest<String, String> {
 
         Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
         SerializedSubscriber<?> serialized = (SerializedSubscriber<?>) test.scan(Scannable.ScannableAttr.ACTUAL);
+        Assertions.assertThat(serialized).isNotNull();
         Assertions.assertThat(serialized.actual()).isSameAs(actual);
 
         Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
@@ -16,6 +16,8 @@
 
 package reactor.core.publisher;
 
+import java.util.concurrent.ConcurrentLinkedQueue;
+
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
@@ -24,6 +26,7 @@ import org.reactivestreams.Subscription;
 
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
+import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.concurrent.QueueSupplier;
 
@@ -137,6 +140,18 @@ public class FluxSwitchMapTest {
 		ts.assertValues(10, 20, 300, 400)
 		  .assertNoError()
 		  .assertComplete();
+	}
+
+	@Test
+	public void switchRegularQueue() {
+		Flux<String> source = Flux.just("a", "bb", "ccc");
+		FluxSwitchMap<String, Integer> test = new FluxSwitchMap<>(
+				source, s -> Flux.range(1, s.length()),
+				ConcurrentLinkedQueue::new, 128);
+
+		StepVerifier.create(test)
+		            .expectNext(1, 1, 2, 1, 2, 3)
+		            .verifyComplete();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeUntilOtherTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeUntilOtherTest.java
@@ -201,6 +201,7 @@ public class FluxTakeUntilOtherTest {
         Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
         @SuppressWarnings("unchecked")
 		SerializedSubscriber<Integer> serialized = (SerializedSubscriber<Integer>) test.scan(Scannable.ScannableAttr.ACTUAL);
+        Assertions.assertThat(serialized).isNotNull();
         Assertions.assertThat(serialized.actual()).isSameAs(actual);
 
         Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
@@ -382,8 +382,8 @@ public class FluxWindowPredicateTest extends
 
 	private <T> Predicate<? super Signal<T>> signalErrorMessage(String expectedMessage) {
 		return signal -> signal.isOnError()
-				&& signal.getThrowable().getMessage() != null
-				&& signal.getThrowable().getMessage().equals(expectedMessage);
+				&& signal.getThrowable() != null
+				&& expectedMessage.equals(signal.getThrowable().getMessage());
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoThenIgnoreTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoThenIgnoreTest.java
@@ -86,7 +86,7 @@ public class MonoThenIgnoreTest {
 	@Test
 	public void scanThenAcceptInner() {
 		Subscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
-		MonoThenIgnore.ThenIgnoreMain<String> main = new MonoThenIgnore.ThenIgnoreMain<>(actual, new Publisher[0], null);
+		MonoThenIgnore.ThenIgnoreMain<String> main = new MonoThenIgnore.ThenIgnoreMain<>(actual, new Publisher[0], Mono.just("foo"));
 
 		MonoThenIgnore.ThenAcceptInner<String> test = new MonoThenIgnore.ThenAcceptInner<>(main);
 		Subscription parent = Operators.emptySubscription();
@@ -107,7 +107,7 @@ public class MonoThenIgnoreTest {
 	@Test
 	public void scanThenIgnoreInner() {
 		Subscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
-		MonoThenIgnore.ThenIgnoreMain<String> main = new MonoThenIgnore.ThenIgnoreMain<>(actual, new Publisher[0], null);
+		MonoThenIgnore.ThenIgnoreMain<String> main = new MonoThenIgnore.ThenIgnoreMain<>(actual, new Publisher[0], Mono.just("foo"));
 
 		MonoThenIgnore.ThenIgnoreInner test = new MonoThenIgnore.ThenIgnoreInner(main);
 		Subscription parent = Operators.emptySubscription();

--- a/reactor-core/src/test/java/reactor/core/publisher/SignalLoggerTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SignalLoggerTests.java
@@ -60,37 +60,32 @@ public class SignalLoggerTests {
 
 	@Test
 	public void nullSubscriptionAsString() {
-		SignalLogger sl = new SignalLogger<>(Mono.empty(), null, null, false);
-
-		assertThat(sl.subscriptionAsString(null), is("null subscription"));
+		assertThat(SignalLogger.subscriptionAsString(null), is("null subscription"));
 	}
 
 	@Test
 	public void normalSubscriptionAsString() {
-		SignalLogger sl = new SignalLogger<>(Mono.empty(), null, null, false);
 		Subscription s = new FluxPeek.PeekSubscriber<>(null, null);
 
-		assertThat(sl.subscriptionAsString(s), is("FluxPeek.PeekSubscriber"));
+		assertThat(SignalLogger.subscriptionAsString(s), is("FluxPeek.PeekSubscriber"));
 	}
 
 	@Test
 	public void synchronousSubscriptionAsString() {
-		SignalLogger sl = new SignalLogger<>(Mono.empty(), null, null, false);
 		SynchronousSubscription<Object> s = new FluxArray.ArraySubscription<>(null, null);
 
-		assertThat(sl.subscriptionAsString(s), is("[Synchronous Fuseable] FluxArray.ArraySubscription"));
+		assertThat(SignalLogger.subscriptionAsString(s), is("[Synchronous Fuseable] FluxArray.ArraySubscription"));
 	}
+
 	@Test
 	public void queueSubscriptionAsString() {
-		SignalLogger sl = new SignalLogger<>(Mono.empty(), null, null, false);
 		Fuseable.QueueSubscription<Object> s = Operators.EmptySubscription.INSTANCE;
 
-		assertThat(sl.subscriptionAsString(s), is("[Fuseable] Operators.EmptySubscription"));
+		assertThat(SignalLogger.subscriptionAsString(s), is("[Fuseable] Operators.EmptySubscription"));
 	}
 
 	@Test
 	public void anonymousSubscriptionAsString() {
-		SignalLogger sl = new SignalLogger<>(Mono.empty(), null, null, false);
 		Subscription s = new Subscription() {
 			@Override
 			public void request(long n) {}
@@ -99,13 +94,13 @@ public class SignalLoggerTests {
 			public void cancel() {}
 		};
 
-		assertThat(sl.subscriptionAsString(s), is("SignalLoggerTests$1"));
+		assertThat(SignalLogger.subscriptionAsString(s), is("SignalLoggerTests$1"));
 	}
 
 	@Test
 	public void scanSignalLogger() {
 		Mono<String> source = Mono.empty();
-		SignalLogger<String> sl = new SignalLogger<>(source, null, null, false);
+		SignalLogger<String> sl = new SignalLogger<>(source, null, Level.INFO, false);
 
 		Assertions.assertThat(sl.scan(Scannable.ScannableAttr.PARENT)).isSameAs(source);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/TopicProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/TopicProcessorTest.java
@@ -21,6 +21,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nullable;
+
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
 import org.junit.Test;
@@ -741,12 +743,12 @@ public class TopicProcessorTest {
 
 	private void assertProcessor(TopicProcessor<Integer> processor,
 			boolean shared,
-			String name,
-			Integer bufferSize,
-			WaitStrategy waitStrategy,
-			Boolean autoCancel,
-			ExecutorService executor,
-			ExecutorService requestTaskExecutor) {
+			@Nullable String name,
+			@Nullable Integer bufferSize,
+			@Nullable WaitStrategy waitStrategy,
+			@Nullable Boolean autoCancel,
+			@Nullable ExecutorService executor,
+			@Nullable ExecutorService requestTaskExecutor) {
 
 		String expectedName = name != null ? name : TopicProcessor.class.getSimpleName();
 		int expectedBufferSize = bufferSize != null ? bufferSize : QueueSupplier.SMALL_BUFFER_SIZE;

--- a/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
@@ -19,6 +19,8 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Consumer;
 
+import javax.annotation.Nullable;
+
 import org.junit.Test;
 
 import reactor.core.Disposable;
@@ -79,7 +81,10 @@ public class UnicastProcessorTest {
 		assertProcessor(processor, queue, onOverflow, onTerminate);
 	}
 
-	public void assertProcessor(UnicastProcessor<Integer> processor, Queue<Integer> queue, Consumer<? super Integer> onOverflow, Disposable onTerminate) {
+	public void assertProcessor(UnicastProcessor<Integer> processor,
+			@Nullable Queue<Integer> queue,
+			@Nullable Consumer<? super Integer> onOverflow,
+			@Nullable Disposable onTerminate) {
 		Queue<Integer> expectedQueue = queue != null ? queue : QueueSupplier.<Integer>unbounded().get();
 		Disposable expectedOnTerminate = onTerminate != null ? onTerminate : UnicastProcessor.Builder.NOOP_DISPOSABLE;
 		assertEquals(expectedQueue.getClass(), processor.queue.getClass());

--- a/reactor-core/src/test/java/reactor/core/publisher/WorkQueueProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/WorkQueueProcessorTest.java
@@ -30,6 +30,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
 import org.hamcrest.CoreMatchers;
@@ -1335,12 +1337,12 @@ public class WorkQueueProcessorTest {
 
 	private void assertProcessor(WorkQueueProcessor<Integer> processor,
 			boolean shared,
-			String name,
-			Integer bufferSize,
-			WaitStrategy waitStrategy,
-			Boolean autoCancel,
-			ExecutorService executor,
-			ExecutorService requestTaskExecutor) {
+			@Nullable String name,
+			@Nullable Integer bufferSize,
+			@Nullable WaitStrategy waitStrategy,
+			@Nullable Boolean autoCancel,
+			@Nullable ExecutorService executor,
+			@Nullable ExecutorService requestTaskExecutor) {
 
 		String expectedName = name != null ? name : WorkQueueProcessor.class.getSimpleName();
 		int expectedBufferSize = bufferSize != null ? bufferSize : QueueSupplier.SMALL_BUFFER_SIZE;

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/CombinationTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/CombinationTests.java
@@ -22,6 +22,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
+import javax.annotation.Nullable;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -262,7 +264,7 @@ public class CombinationTests {
 		}
 
 		@Override
-		public int compareTo(SensorData other) {
+		public int compareTo(@Nullable SensorData other) {
 			if (null == other) {
 				return 1;
 			}

--- a/reactor-core/src/test/java/reactor/test/publisher/BaseOperatorTest.java
+++ b/reactor-core/src/test/java/reactor/test/publisher/BaseOperatorTest.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
+import javax.annotation.Nullable;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -931,7 +933,7 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 		};
 	}
 
-	final void touchInner(Object t){
+	final void touchInner(@Nullable Object t){
 		if(t == null) return;
 		Scannable o = Scannable.from(t);
 		o.scan(Scannable.ScannableAttr.ACTUAL);
@@ -948,7 +950,7 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 	}
 
 	@SuppressWarnings("unchecked")
-	final void touchTreeState(Object parent){
+	final void touchTreeState(@Nullable Object parent){
 		if (parent == null) {
 			return;
 		}

--- a/reactor-core/src/test/java/reactor/test/publisher/FluxEmptySyncFuseable.java
+++ b/reactor-core/src/test/java/reactor/test/publisher/FluxEmptySyncFuseable.java
@@ -15,6 +15,8 @@
  */
 package reactor.test.publisher;
 
+import javax.annotation.Nullable;
+
 import org.reactivestreams.Subscriber;
 import reactor.core.Fuseable;
 import reactor.core.publisher.Flux;
@@ -28,6 +30,7 @@ final class FluxEmptySyncFuseable<T> extends Flux<T> implements Fuseable {
 	public void subscribe(Subscriber<? super T> s) {
 		s.onSubscribe(new SynchronousSubscription<T>() {
 			@Override
+			@Nullable
 			public T poll() {
 				return null;
 			}

--- a/reactor-core/src/test/java/reactor/test/publisher/FluxFuseableExceptionOnPoll.java
+++ b/reactor-core/src/test/java/reactor/test/publisher/FluxFuseableExceptionOnPoll.java
@@ -15,6 +15,8 @@
  */
 package reactor.test.publisher;
 
+import javax.annotation.Nullable;
+
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Fuseable;
@@ -106,6 +108,7 @@ final class FluxFuseableExceptionOnPoll<T> extends FluxSource<T, T>
 		}
 
 		@Override
+		@Nullable
 		public T poll() {
 			T t = qs.poll();
 			if (t != null) {

--- a/reactor-core/src/test/java/reactor/test/publisher/MonoOperatorTest.java
+++ b/reactor-core/src/test/java/reactor/test/publisher/MonoOperatorTest.java
@@ -22,6 +22,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 
+import javax.annotation.Nullable;
+
 import org.reactivestreams.Subscription;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -51,7 +53,7 @@ public abstract class MonoOperatorTest<I, O>
 			return new Scenario<>(scenario, new Exception("scenario:"));
 		}
 
-		Scenario(Function<Mono<I>, ? extends Mono<O>> scenario, Exception stack) {
+		Scenario(@Nullable Function<Mono<I>, ? extends Mono<O>> scenario, @Nullable Exception stack) {
 			super(scenario, stack);
 		}
 
@@ -178,7 +180,7 @@ public abstract class MonoOperatorTest<I, O>
 		}
 
 		@Override
-		public Scenario<I, O> applyAllOptions(OperatorScenario<I, Mono<I>, O, Mono<O>> source) {
+		public Scenario<I, O> applyAllOptions(@Nullable OperatorScenario<I, Mono<I>, O, Mono<O>> source) {
 			super.applyAllOptions(source);
 			return this;
 		}

--- a/reactor-core/src/test/java/reactor/test/publisher/OperatorScenario.java
+++ b/reactor-core/src/test/java/reactor/test/publisher/OperatorScenario.java
@@ -21,6 +21,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 
+import javax.annotation.Nullable;
+
 import org.reactivestreams.Publisher;
 import reactor.test.StepVerifier;
 
@@ -51,12 +53,12 @@ public class OperatorScenario<I, PI extends Publisher<? extends I>, O, PO extend
 	String                         description    = null;
 	Consumer<StepVerifier.Step<O>> verifier       = null;
 
-	OperatorScenario(Function<PI, ? extends PO> body, Exception stack) {
+	OperatorScenario(@Nullable Function<PI, ? extends PO> body, @Nullable Exception stack) {
 		this.body = body;
 		this.stack = stack;
 	}
 
-	public OperatorScenario<I, PI, O, PO> applyAllOptions(OperatorScenario<I, PI, O, PO> source) {
+	public OperatorScenario<I, PI, O, PO> applyAllOptions(@Nullable OperatorScenario<I, PI, O, PO> source) {
 		if (source == null) {
 			return this;
 		}
@@ -203,6 +205,7 @@ public class OperatorScenario<I, PI extends Publisher<? extends I>, O, PO extend
 		return this;
 	}
 
+	@Nullable
 	final Consumer<StepVerifier.Step<O>> verifier() {
 		return verifier;
 	}
@@ -266,10 +269,12 @@ public class OperatorScenario<I, PI extends Publisher<? extends I>, O, PO extend
 		return step;
 	}
 
+	@Nullable
 	final Function<PI, ? extends PO> body() {
 		return body;
 	}
 
+	@Nullable
 	final String description() {
 		return description;
 	}

--- a/reactor-core/src/test/java/reactor/test/publisher/ParallelOperatorTest.java
+++ b/reactor-core/src/test/java/reactor/test/publisher/ParallelOperatorTest.java
@@ -21,6 +21,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 
+import javax.annotation.Nullable;
+
 import org.reactivestreams.Subscription;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -50,7 +52,7 @@ public abstract class ParallelOperatorTest<I, O>
 			return new Scenario<>(scenario, new Exception("scenario:"));
 		}
 
-		Scenario(Function<ParallelFlux<I>, ? extends ParallelFlux<O>> scenario, Exception stack) {
+		Scenario(@Nullable Function<ParallelFlux<I>, ? extends ParallelFlux<O>> scenario, @Nullable Exception stack) {
 			super(scenario, stack);
 		}
 


### PR DESCRIPTION
Actual changes:
 - `SignalLogger` method to stringify a `Subscription` is now static
 - `Scannable.from` never returns `null` (but still distinguish the case with a `NULL_SCAN`)
 - removed leftover `@Nullable` from various `tryOnNext`
 - added an `Operators.nullSubscriber()` method to use where a Subscriber is required but irrelevant (cf `FluxConcatMap`)
 - made `FluxConcatMapSupport` extend `InnerOperator` so it can be returned as ACTUAL in scanUnsafe
 - `FluxGroupBy#signalAsyncError` should never be called without setting `error` first. This is tested and an `IllegalStateException` is thrown to groups and main if that is not the case.
 - `FluxSwitchMap` used to wrongly assume the `queue` was always capable of offering 2 elements (no null check on `queueBiAtomic`. This now falls back to offering twice to a regular queue (added test)
 - `FluxZip` throws if source array is empty. In array mode, the sparse scalars array is always created (avoiding a potential null if no source is callable).

a few tests have been a bit tuned to eliminate some test-only null warnings.