### PR TITLE
fix #657 Remove redundant cancelled field in repeatWhen/retryWhen 

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
@@ -52,7 +52,6 @@ final class FluxRepeatWhen<T> extends FluxSource<T, T> {
 
 	@Override
 	public void subscribe(Subscriber<? super T> s) {
-
 		RepeatWhenOtherSubscriber other = new RepeatWhenOtherSubscriber();
 		Subscriber<Long> signaller = Operators.serialize(other.completionSignal);
 
@@ -108,14 +107,6 @@ final class FluxRepeatWhen<T> extends FluxSource<T, T> {
 			this.signaller = signaller;
 			this.source = source;
 			this.otherArbiter = new Operators.DeferredSubscription();
-		}
-
-		@Override
-		@Nullable
-		public Object scanUnsafe(Attr key) {
-			if (key == BooleanAttr.CANCELLED) return cancelled;
-
-			return super.scanUnsafe(key);
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
@@ -99,8 +99,6 @@ final class FluxRepeatWhen<T> extends FluxSource<T, T> {
 				AtomicIntegerFieldUpdater.newUpdater(RepeatWhenMainSubscriber.class,
 						"wip");
 
-		volatile boolean cancelled;
-
 		long produced;
 
 		RepeatWhenMainSubscriber(Subscriber<? super T> actual,
@@ -127,14 +125,10 @@ final class FluxRepeatWhen<T> extends FluxSource<T, T> {
 
 		@Override
 		public void cancel() {
-			if (cancelled) {
-				return;
+			if (!cancelled) {
+				cancelWhen();
+				super.cancel();
 			}
-			cancelled = true;
-
-			cancelWhen();
-
-			super.cancel();
 		}
 
 		@Override
@@ -186,14 +180,12 @@ final class FluxRepeatWhen<T> extends FluxSource<T, T> {
 		}
 
 		void whenError(Throwable e) {
-			cancelled = true;
 			super.cancel();
 
 			actual.onError(e);
 		}
 
 		void whenComplete() {
-			cancelled = true;
 			super.cancel();
 
 			actual.onComplete();

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
@@ -117,7 +117,7 @@ final class FluxRepeatWhen<T> extends FluxSource<T, T> {
 		@Override
 		public void cancel() {
 			if (!cancelled) {
-				cancelWhen();
+				otherArbiter.cancel();
 				super.cancel();
 			}
 		}
@@ -146,10 +146,6 @@ final class FluxRepeatWhen<T> extends FluxSource<T, T> {
 
 			otherArbiter.request(1);
 			signaller.onNext(p);
-		}
-
-		void cancelWhen() {
-			otherArbiter.cancel();
 		}
 
 		void setWhen(Subscription w) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRetryWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRetryWhen.java
@@ -111,14 +111,6 @@ final class FluxRetryWhen<T> extends FluxSource<T, T> {
 		}
 
 		@Override
-		@Nullable
-		public Object scanUnsafe(Attr key) {
-			if (key == BooleanAttr.CANCELLED) return cancelled;
-
-			return super.scanUnsafe(key);
-		}
-
-		@Override
 		public Stream<? extends Scannable> inners() {
 			return Stream.of(Scannable.from(signaller), otherArbiter);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRetryWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRetryWhen.java
@@ -118,14 +118,10 @@ final class FluxRetryWhen<T> extends FluxSource<T, T> {
 		@Override
 		public void cancel() {
 			if (!cancelled) {
-				cancelWhen();
+				otherArbiter.cancel();
 				super.cancel();
 			}
 
-		}
-
-		void cancelWhen() {
-			otherArbiter.cancel();
 		}
 
 		public void setWhen(Subscription w) {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatWhenTest.java
@@ -17,6 +17,7 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.assertj.core.api.Assertions;
@@ -27,6 +28,8 @@ import org.reactivestreams.Subscription;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxRepeatWhenTest {
 
@@ -47,6 +50,98 @@ public class FluxRepeatWhenTest {
 		ts.assertValues(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
 		  .assertComplete()
 		  .assertNoError();
+	}
+
+	@Test
+	public void cancelsOther() {
+		AtomicBoolean cancelled = new AtomicBoolean();
+		Flux<Integer> when = Flux.range(1, 10)
+		                         .doOnCancel(() -> cancelled.set(true));
+
+		StepVerifier.create(Flux.just(1).repeatWhen(other -> when))
+		            .thenCancel()
+		            .verify();
+
+		assertThat(cancelled.get()).isTrue();
+	}
+
+	@Test
+	public void directOtherErrorPreventsSubscribe() {
+		AtomicBoolean sourceSubscribed = new AtomicBoolean();
+		AtomicBoolean sourceCancelled = new AtomicBoolean();
+		Flux<Integer> source = Flux.just(1)
+		                           .doOnSubscribe(sub -> sourceSubscribed.set(true))
+		                           .doOnCancel(() -> sourceCancelled.set(true));
+
+		Flux<Integer> repeat = source.repeatWhen(other -> Mono.error(new IllegalStateException("boom")));
+
+		StepVerifier.create(repeat)
+		            .expectSubscription()
+		            .verifyErrorMessage("boom");
+
+		assertThat(sourceSubscribed.get()).isFalse();
+		assertThat(sourceCancelled.get()).isFalse();
+	}
+
+	@Test
+	public void lateOtherErrorCancelsSource() {
+		AtomicBoolean sourceSubscribed = new AtomicBoolean();
+		AtomicBoolean sourceCancelled = new AtomicBoolean();
+		AtomicInteger count = new AtomicInteger();
+		Flux<Integer> source = Flux.just(1)
+		                           .doOnSubscribe(sub -> sourceSubscribed.set(true))
+		                           .doOnCancel(() -> sourceCancelled.set(true));
+
+
+		Flux<Integer> repeat = source.repeatWhen(other -> other.flatMap(l ->
+				count.getAndIncrement() == 0 ? Mono.just(l) : Mono.<Long>error(new IllegalStateException("boom"))));
+
+		StepVerifier.create(repeat)
+		            .expectSubscription()
+		            .expectNext(1)
+		            .expectNext(1)
+		            .verifyErrorMessage("boom");
+
+		assertThat(sourceSubscribed.get()).isTrue();
+		assertThat(sourceCancelled.get()).isTrue();
+	}
+
+	@Test
+	public void directOtherEmptyPreventsSubscribe() {
+		AtomicBoolean sourceSubscribed = new AtomicBoolean();
+		AtomicBoolean sourceCancelled = new AtomicBoolean();
+		Flux<Integer> source = Flux.just(1)
+		                           .doOnSubscribe(sub -> sourceSubscribed.set(true))
+		                           .doOnCancel(() -> sourceCancelled.set(true));
+
+		Flux<Integer> repeat = source.repeatWhen(other -> Flux.empty());
+
+		StepVerifier.create(repeat)
+		            .expectSubscription()
+		            .verifyComplete();
+
+		assertThat(sourceSubscribed.get()).isFalse();
+		assertThat(sourceCancelled.get()).isFalse();
+	}
+
+	@Test
+	public void lateOtherEmptyCancelsSource() {
+		AtomicBoolean sourceSubscribed = new AtomicBoolean();
+		AtomicBoolean sourceCancelled = new AtomicBoolean();
+		Flux<Integer> source = Flux.just(1)
+		                           .doOnSubscribe(sub -> sourceSubscribed.set(true))
+		                           .doOnCancel(() -> sourceCancelled.set(true));
+
+		Flux<Integer> repeat = source.repeatWhen(other -> other.take(1));
+
+		StepVerifier.create(repeat)
+		            .expectSubscription()
+		            .expectNext(1) //original
+		            .expectNext(1) //repeat
+		            .verifyComplete(); //repeat terminated
+
+		assertThat(sourceSubscribed.get()).isTrue();
+		assertThat(sourceCancelled.get()).isTrue();
 	}
 
 	@Test
@@ -259,14 +354,14 @@ public class FluxRepeatWhenTest {
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
 
-        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
-        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
         test.requested = 35;
-        Assertions.assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(35L);
+        assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(35L);
 
-        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
         test.cancel();
-        Assertions.assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+        assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
     }
 
 	@Test
@@ -277,7 +372,7 @@ public class FluxRepeatWhenTest {
         FluxRepeatWhen.RepeatWhenOtherSubscriber test = new FluxRepeatWhen.RepeatWhenOtherSubscriber();
         test.main = main;
 
-        Assertions.assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(main.otherArbiter);
-        Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(main);
+        assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(main.otherArbiter);
+        assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(main);
     }
 }


### PR DESCRIPTION
The implementation wasn't reusing the `cancelled` from its super class,
shadowing it instead.

This commit removes the redundant field and reworks the methods that
were setting it to true before calling `super.cancel()` (since
otherwise such a call would be short-circuited, as it starts by checking
`cancelled` is false).