### PR TITLE
fix #661 Macro-fusion of flux then and mono then use incompatible T[]

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -3007,7 +3007,7 @@ public abstract class Mono<T> implements Publisher<T> {
             MonoThenIgnore<T> a = (MonoThenIgnore<T>) this;
             return a.shift(other);
 		}
-		return onAssembly(new MonoThenIgnore<>(new Mono[] { this }, other));
+		return onAssembly(new MonoThenIgnore<>(new Publisher[] { this }, other));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoThenIgnore.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoThenIgnore.java
@@ -65,7 +65,7 @@ final class MonoThenIgnore<T> extends Mono<T> implements Fuseable {
         Objects.requireNonNull(newLast, "newLast");
         Publisher<?>[] a = ignore;
         int n = a.length;
-        Mono<?>[] b = new Mono[n + 1];
+        Publisher<?>[] b = new Publisher[n + 1];
         System.arraycopy(a, 0, b, 0, n);
         b[n] = last;
         

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoThenIgnoreTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoThenIgnoreTest.java
@@ -120,4 +120,24 @@ public class MonoThenIgnoreTest {
 		test.cancel();
 		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
 	}
+
+	//see https://github.com/reactor/reactor-core/issues/661
+	@Test
+	public void fluxThenMonoAndShift() {
+		StepVerifier.create(Flux.just("Good Morning", "Hello")
+		                        .then(Mono.just("Good Afternoon"))
+		                        .then(Mono.just("Bye")))
+		            .expectNext("Bye")
+		            .verifyComplete();
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/661
+	@Test
+	public void monoThenMonoAndShift() {
+		StepVerifier.create(Mono.just("Good Morning")
+		                        .then(Mono.just("Good Afternoon"))
+		                        .then(Mono.just("Bye")))
+		            .expectNext("Bye")
+		            .verifyComplete();
+	}
 }


### PR DESCRIPTION
This commit fixes a bug around macro-fusion of `then(Mono<T>)` when
mixing a Flux suppressed source and a Mono suppressed source (see #547).

This is due to the Flux's usage of `then` resulting in a Publisher array
of sources whereas the Mono usage still results in a Mono array. When
attempting the two, the type difference causes an ArrayStoreException.