### PR TITLE
apply #664 fix to conditional fused case too, increase test coverage

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
@@ -560,7 +560,22 @@ final class FluxPeekFuseable<T> extends FluxSource<T, T>
 		@Nullable
 		public T poll() {
 			boolean d = done;
-			T v = s.poll();
+			T v;
+			try {
+				v = s.poll();
+			}
+			catch (Throwable e) {
+				if (parent.onErrorCall() != null) {
+					try {
+						parent.onErrorCall()
+						      .accept(e);
+					}
+					catch (Throwable errorCallbackError) {
+						throw Exceptions.propagate(Operators.onOperatorError(s, errorCallbackError, e));
+					}
+				}
+				throw Exceptions.propagate(Operators.onOperatorError(s, e));
+			}
 			if (v != null && parent.onNextCall() != null) {
 				try {
 					//noinspection ConstantConditions


### PR DESCRIPTION
The fix for #664 was only applied to the PeekFuseableSubscriber in
6a621d8, overlooking the PeekFuseableConditionalSubscriber.

This commit applies the fix to the conditional case.

Additionally, it increases the test coverage to cover this conditional
case but also the parts of poll() that apply the doOnComplete and
doAfterTerminate callbacks.