### PR TITLE
fix #670 Add expect|verifyErrorSatisfies StepVerifier error expectations

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeTest.java
@@ -116,7 +116,6 @@ public class FluxMergeTest {
 				Flux.range(1, 4)
 		))
 		            .expectNext(1, 2, 3, 4)
-		            .consumeErrorWith(e -> assertThat(e).isEqualTo(boom))
-		            .verify();
+		            .verifyErrorSatisfies(e -> assertThat(e).isEqualTo(boom));
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
@@ -676,7 +676,7 @@ public class FluxPeekFuseableTest {
 
 		StepVerifier.create(f)
 		            .then(f::connect)
-		            .consumeErrorWith(e -> {
+		            .verifyErrorSatisfies(e -> {
 					            assertThat(e)
 					                      .isInstanceOf(IllegalStateException.class)
 					                      .hasMessage("fromOnError2")
@@ -686,8 +686,7 @@ public class FluxPeekFuseableTest {
 					                      .hasCauseInstanceOf(IllegalArgumentException.class);
 					            assertThat(e.getCause().getCause())
 					                      .hasMessage("fromOnNext");
-				            })
-		            .verify();
+				            });
 	}
 
 	@Test
@@ -746,7 +745,7 @@ public class FluxPeekFuseableTest {
 
 		StepVerifier.create(f)
 		            .then(f::connect)
-		            .consumeErrorWith(e -> {
+		            .verifyErrorSatisfies(e -> {
 					            assertThat(e)
 					                      .isInstanceOf(IllegalStateException.class)
 					                      .hasMessage("fromOnError2")
@@ -756,8 +755,7 @@ public class FluxPeekFuseableTest {
 					                      .hasCauseInstanceOf(IllegalArgumentException.class);
 					            assertThat(e.getCause().getCause())
 					                      .hasMessage("fromOnNext");
-				            })
-		            .verify();
+				            });
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
@@ -74,8 +74,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 
 	void assertRejected(StepVerifier.Step<String> step) {
 		try {
-			step.consumeErrorWith(e -> Assert.assertTrue(Exceptions.unwrap(e) instanceof RejectedExecutionException))
-			    .verify();
+			step.verifyErrorSatisfies(e -> Assert.assertTrue(Exceptions.unwrap(e) instanceof RejectedExecutionException));
 		}
 		catch (Exception e) {
 			assertTrue(Exceptions.unwrap(e) instanceof RejectedExecutionException);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxUsingTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxUsingTest.java
@@ -305,10 +305,9 @@ public class FluxUsingTest extends FluxOperatorTest<String, String> {
 				false);
 
 		StepVerifier.create(test)
-		            .consumeErrorWith(e -> assertThat(e)
+		            .verifyErrorSatisfies(e -> assertThat(e)
 				            .hasMessage("resourceCleanup")
-				            .is(suppressingFactory))
-		            .verify();
+				            .is(suppressingFactory));
 
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoWhenTest.java
@@ -320,8 +320,7 @@ public class MonoWhenTest {
 		            .then(() -> assertThat(mp.isError()).isTrue())
 		            .then(() -> assertThat(mp.isSuccess()).isFalse())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
-		            .consumeErrorWith(e -> assertThat(e).hasMessage("test1"))
-		            .verify();
+		            .verifyErrorSatisfies(e -> assertThat(e).hasMessage("test1"));
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/test/publisher/BaseOperatorTest.java
+++ b/reactor-core/src/test/java/reactor/test/publisher/BaseOperatorTest.java
@@ -169,13 +169,13 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 			String m = scenario.producerError.getMessage();
 			Consumer<StepVerifier.Step<O>> errorVerifier = step -> {
 				try {
-					step.consumeErrorWith(e -> {
+					step.verifyErrorSatisfies(e -> {
 						if (e instanceof NullPointerException || e instanceof IllegalStateException || e.getMessage()
 						                                                                                .equals(m)) {
 							return;
 						}
 						throw Exceptions.propagate(e);
-					}).verify();
+					});
 //						step.expectErrorMessage(m)
 //						.verifyThenAssertThat()
 //						.hasOperatorErrorWithMessage(m);

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -378,6 +378,19 @@ public interface StepVerifier {
 		StepVerifier expectErrorMatches(Predicate<Throwable> predicate);
 
 		/**
+		 * Expect an error and assert it via assertion(s) provided as a {@link Consumer}.
+		 * Any {@link AssertionError} thrown by the consumer has its message propagated
+		 * through a new StepVerifier-specific AssertionError.
+		 *
+		 * @param assertionConsumer the consumer that applies assertion(s) on the next received error
+		 *
+		 * @return the built verification scenario, ready to be verified
+		 *
+		 * @see Subscriber#onError(Throwable)
+		 */
+		StepVerifier expectErrorSatisfies(Consumer<Throwable> assertionConsumer);
+
+		/**
 		 * Expect the completion signal.
 		 *
 		 * @return the built verification scenario, ready to be verified
@@ -465,6 +478,27 @@ public interface StepVerifier {
 		 * @see Subscriber#onError(Throwable)
 		 */
 		Duration verifyErrorMatches(Predicate<Throwable> predicate);
+
+		/**
+		 * Trigger the {@link #verify() verification}, expecting an error as terminal event
+		 * which gets asserted via assertion(s) provided as a {@link Consumer}.
+		 * Any {@link AssertionError} thrown by the consumer has its message propagated
+		 * through a new StepVerifier-specific AssertionError.
+		 * <p>
+		 * This is a convenience method that calls {@link #verify()} in addition to the
+		 * expectation. Explicitly use the expect method and verification method
+		 * separately if you need something more specific (like activating logging or
+		 * changing the default timeout).
+		 *
+		 * @param assertionConsumer the consumer that applies assertion(s) on the next received error
+		 *
+		 * @return the actual {@link Duration} the verification took.
+		 *
+		 * @see #expectErrorSatisfies(Consumer)
+		 * @see #verify()
+		 * @see Subscriber#onError(Throwable)
+		 */
+		Duration verifyErrorSatisfies(Consumer<Throwable> assertionConsumer);
 
 		/**
 		 * Trigger the {@link #verify() verification}, expecting a completion signal

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -401,8 +401,7 @@ public class StepVerifierTests {
 				            }
 			            })
 			            .verify())
-	            .withMessage("expectation \"consumeErrorWith\" failed (assertion failed on " +
-			            "exception <java.lang.IllegalArgumentException>: IllegalArgumentException)");
+	            .withMessage("IllegalArgumentException");
 	}
 
 	@Test

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -362,6 +362,31 @@ public class StepVerifierTests {
 	}
 
 	@Test
+	public void errorSatisfies() {
+		Flux<String> flux = Flux.just("foo")
+		                        .concatWith(Mono.error(new IllegalArgumentException()));
+
+		StepVerifier.create(flux)
+		            .expectNext("foo")
+		            .expectErrorSatisfies(t -> assertThat(t).isInstanceOf(IllegalArgumentException.class))
+		            .verify();
+	}
+
+	@Test
+	public void errorSatisfiesInvalid() {
+		Flux<String> flux = Flux.just("foo")
+		                        .concatWith(Mono.error(new IllegalArgumentException()));
+
+		assertThatExceptionOfType(AssertionError.class)
+				.isThrownBy(() -> StepVerifier.create(flux)
+		            .expectNext("foo")
+		            .expectErrorSatisfies(t -> assertThat(t).hasMessage("foo"))
+		            .verify())
+	            .withMessage("expectation \"expectErrorSatisfies\" failed (assertion failed on exception <java.lang.IllegalArgumentException>: " +
+			            "\nExpecting message:\n <\"foo\">\nbut was:\n <null>)");
+	}
+
+	@Test
 	public void consumeErrorWith() {
 		Flux<String> flux = Flux.just("foo")
 		                        .concatWith(Mono.error(new IllegalArgumentException()));
@@ -376,7 +401,8 @@ public class StepVerifierTests {
 				            }
 			            })
 			            .verify())
-	            .withMessage("IllegalArgumentException");
+	            .withMessage("expectation \"consumeErrorWith\" failed (assertion failed on " +
+			            "exception <java.lang.IllegalArgumentException>: IllegalArgumentException)");
 	}
 
 	@Test
@@ -1321,7 +1347,7 @@ public class StepVerifierTests {
 	}
 
 	@Test
-	public void verifyErrorPredicateTriggersVerificationFail() {
+	public void verifyErrorPredicateTriggersVerificationFailBadSignal() {
 		assertThatExceptionOfType(AssertionError.class)
 				.isThrownBy(() -> StepVerifier.create(Flux.empty())
 				                              .verifyErrorMatches(e -> e instanceof IllegalArgumentException))
@@ -1329,9 +1355,40 @@ public class StepVerifierTests {
 	}
 
 	@Test
+	public void verifyErrorPredicateTriggersVerificationFailNoMatch() {
+		assertThatExceptionOfType(AssertionError.class)
+				.isThrownBy(() -> StepVerifier.create(Flux.error(new IllegalArgumentException("boom")))
+				                              .verifyErrorMatches(e -> e.getMessage() == null))
+		        .withMessage("expectation \"expectErrorMatches\" failed (predicate failed on exception: java.lang.IllegalArgumentException: boom)");
+	}
+
+	@Test
 	public void verifyErrorPredicateTriggersVerificationSuccess() {
 		StepVerifier.create(Flux.error(new IllegalArgumentException("boom")))
 		            .verifyErrorMatches(e -> e instanceof IllegalArgumentException);
+	}
+
+	@Test
+	public void verifyErrorAssertionTriggersVerificationFailBadSignal() {
+		assertThatExceptionOfType(AssertionError.class)
+				.isThrownBy(() -> StepVerifier.create(Flux.empty())
+				                              .verifyErrorSatisfies(e -> assertThat(e).isNotNull()))
+		        .withMessage("expectation \"verifyErrorSatisfies\" failed (expected: onError(); actual: onComplete())");
+	}
+
+	@Test
+	public void verifyErrorAssertionTriggersVerificationFailNoMatch() {
+		assertThatExceptionOfType(AssertionError.class)
+				.isThrownBy(() -> StepVerifier.create(Flux.error(new IllegalArgumentException("boom")))
+				                              .verifyErrorSatisfies(e -> assertThat(e).hasMessage("foo")))
+		        .withMessage("expectation \"verifyErrorSatisfies\" failed (assertion failed on exception <java.lang.IllegalArgumentException: boom>: "
+				        + "\nExpecting message:\n <\"foo\">\nbut was:\n <\"boom\">)");
+	}
+
+	@Test
+	public void verifyErrorAssertionTriggersVerificationSuccess() {
+		StepVerifier.create(Flux.error(new IllegalArgumentException("boom")))
+		            .verifyErrorSatisfies(e -> assertThat(e).hasMessage("boom"));
 	}
 
 	@Test


### PR DESCRIPTION
This commit adds two convenience methods: expectErrorSatisfies and
verifyErrorSatisfies, taking a Consumer that is expected to apply
assertions to the error.

This is similar to consumeErrorWith, but more discoverable (due to
naming alignment) and with the slight difference that the consumer's
assertion error message is wrapped inside a StepVerifier-specific
AssertionError.