### PR TITLE
Add delayUntil API to Flux

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3211,7 +3211,115 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a delayed {@link Flux}
 	 */
 	public final Flux<T> delayElements(Duration delay, Scheduler timer) {
-		return concatMap(t ->  Mono.delay(delay, timer).map(i -> t));
+		return delayUntilOther(Mono.delay(delay, timer));
+	}
+
+	/**
+	 * Subscribe to this {@link Flux} and generate a {@link Publisher} from each of this
+	 * Flux elements, each acting as a trigger for relaying said element.
+	 * <p>
+	 * That is to say, the resulting {@link Flux} delays each of its emission until the
+	 * associated trigger Publisher terminates.
+	 * <p>
+	 * In case of an error either in the source or in a trigger, that error is propagated
+	 * immediately downstream.
+	 * Note that unlike with the {@link Mono#delayUntil(Function) Mono variant} there is
+	 * no fusion of subsequent calls.
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/master/src/docs/marble/delayUntil.png" alt="">
+	 *
+	 * @param triggerProvider a {@link Function} that maps each element into a
+	 * {@link Publisher} whose termination will trigger relaying the value.
+	 *
+	 * @return this Flux, but with elements delayed until their derived publisher terminates.
+	 */
+	//TODO update the marble URL to a tag pre-release
+	public final Flux<T> delayUntil(Function<? super T, ? extends Publisher<?>> triggerProvider) {
+		return concatMap(v -> Mono.just(v)
+		                          .delayUntil(triggerProvider));
+	}
+
+	/**
+	 * Subscribe to this {@link Flux} and generate a {@link Publisher} from each of this
+	 * Flux elements, each acting as a trigger for relaying said element.
+	 * <p>
+	 * That is to say, the resulting {@link Flux} delays each of its emission until the
+	 * associated trigger Publisher terminates.
+	 * <p>
+	 * In case of an error in a trigger, the element associated with the failed
+	 * trigger is dropped but subsequent elements are still propagated and delayed. Any
+	 * error in the source is propagated immediately downstream.
+	 * Note that unlike with the {@link Mono#delayUntil(Function) Mono variant} there is
+	 * no fusion of subsequent calls.
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/master/src/docs/marble/delayUntil.png" alt="">
+	 *
+	 * @param triggerProvider a {@link Function} that maps each element into a
+	 * {@link Publisher} whose termination will trigger relaying the value.
+	 *
+	 * @return this Flux, but with elements delayed until their derived publisher terminates.
+	 */
+	//TODO update the marble URL to a tag pre-release
+	public final Flux<T> delayUntilDelayError(Function<? super T, ? extends Publisher<?>> triggerProvider) {
+		return concatMapDelayError(v -> Mono.just(v)
+		                                    //no need for delayError variant since no macro fusion of triggers
+		                                    .delayUntil(triggerProvider),
+				true, QueueSupplier.XS_BUFFER_SIZE);
+	}
+
+	/**
+	 * Subscribe to this {@link Flux} and subscribe to a common {@link Publisher} whenever
+	 * an element is emitted, which acts as a trigger for relaying said element.
+	 * <p>
+	 * That is to say, the resulting {@link Flux} delays each of its emission until the
+	 * associated trigger Publisher terminates. Be careful with hot publishers as their
+	 * state will be shared between subscriptions, probably only delaying the first
+	 * emission as a result.
+	 * <p>
+	 * In case of an error either in the source or in a trigger, that error is propagated
+	 * immediately downstream.
+	 * Note that unlike with the {@link Mono#delayUntilOther(Publisher) Mono variant} there is
+	 * no fusion of subsequent calls.
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/master/src/docs/marble/delayUntilOther.png" alt="">
+	 *
+	 * @param triggerPublisher a {@link Publisher} whose termination will trigger relaying the value.
+	 *
+	 * @return this Flux, but with elements delayed until the trigger publisher terminates.
+	 */
+	//TODO update the marble URL to a tag pre-release
+	public final Flux<T> delayUntilOther(Publisher<?> triggerPublisher) {
+		return concatMap(v -> Mono.just(v)
+		                          .delayUntilOther(triggerPublisher));
+	}
+
+	/**
+	 * Subscribe to this {@link Flux} and subscribe to a common {@link Publisher} whenever
+	 * an element is emitted, which acts as a trigger for relaying said element.
+	 * <p>
+	 * That is to say, the resulting {@link Flux} delays each of its emission until the
+	 * associated trigger Publisher terminates. Be careful with hot publishers as their
+	 * state will be shared between subscriptions, probably only delaying the first
+	 * emission as a result.
+	 * <p>
+	 * In case of an error in a trigger, the element associated with the failed
+	 * trigger is dropped but subsequent elements are still propagated and delayed. Any
+	 * error in the source is propagated immediately downstream.
+	 * Note that unlike with the {@link Mono#delayUntilOtherDelayError(Publisher) Mono variant} there is
+	 * no fusion of subsequent calls.
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/master/src/docs/marble/delayUntilOther.png" alt="">
+	 *
+	 * @param triggerPublisher a {@link Publisher} whose termination will trigger relaying the value.
+	 *
+	 * @return this Flux, but with elements delayed until the trigger publisher terminates.
+	 */
+	//TODO update the marble URL to a tag pre-release
+	public final Flux<T> delayUntilOtherDelayError(Publisher<?> triggerPublisher) {
+		return concatMapDelayError(v -> Mono.just(v)
+		                                    //no need for delayError variant since no macro fusion of triggers
+		                                    .delayUntilOther(triggerPublisher),
+				true, QueueSupplier.XS_BUFFER_SIZE);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1567,9 +1567,9 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/master/src/docs/marble/delayUntilOther.png" alt="">
 	 *
-	 * @param anyPublisher the publisher which first emission or termination will trigger
-	 * the emission of this Mono's value.
-	 * @return this Mono, but delayed until the given publisher first emits or terminates.
+	 * @param anyPublisher the publisher which termination will trigger the emission of
+	 * this Mono's value.
+	 * @return this Mono, but delayed until the given publisher terminates.
 	 */
 	//TODO update the marble URL to a tag pre-release
 	public Mono<T> delayUntilOtherDelayError(Publisher<?> anyPublisher) {
@@ -1598,9 +1598,9 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/master/src/docs/marble/delayUntil.png" alt="">
 	 *
 	 * @param triggerProvider a {@link Function} that maps this Mono's value into a
-	 * {@link Publisher} whose first emission or termination will trigger the relaying the value.
+	 * {@link Publisher} whose termination will trigger relaying the value.
 	 *
-	 * @return this Mono, but delayed until the derived publisher first emits or terminates.
+	 * @return this Mono, but delayed until the derived publisher terminates.
 	 */
 	//TODO update the marble URL to a tag pre-release
 	public Mono<T> delayUntil(Function<? super T, ? extends Publisher<?>> triggerProvider) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.util.context.Context;
 
@@ -208,9 +209,7 @@ final class MonoDelayUntil<T> extends Mono<T> {
 						compositeError.addSuppressed(e);
 					} else
 					if (error != null) {
-						compositeError = new Throwable("Multiple errors");
-						compositeError.addSuppressed(error);
-						compositeError.addSuppressed(e);
+						compositeError = Exceptions.multiple(error, e);
 					} else {
 						error = e;
 					}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
@@ -32,9 +32,9 @@ import reactor.util.context.Context;
 
 /**
  * Waits for a Mono source to terminate or produce a value, in which case the value is
- * mapped to a Publisher used as a delay: its first production or termination will trigger
- * the actual emission of the value downstream. If the Mono source didn't produce a value,
- * terminate with the same signal (empty completion or error).
+ * mapped to a Publisher used as a delay: its termination will trigger the actual emission
+ * of the value downstream. If the Mono source didn't produce a value, terminate with the
+ * same signal (empty completion or error).
  *
  * @param <T> the value type
  *

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoUntilOther.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoUntilOther.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.util.context.Context;
 import javax.annotation.Nullable;
@@ -182,9 +183,7 @@ final class MonoUntilOther<T> extends Mono<T> {
 						compositeError.addSuppressed(e);
 					} else
 					if (error != null) {
-						compositeError = new Throwable("Multiple errors");
-						compositeError.addSuppressed(error);
-						compositeError.addSuppressed(e);
+						compositeError = Exceptions.multiple(error, e);
 					} else {
 						error = e;
 					}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoWhen.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.util.context.Context;
 import javax.annotation.Nullable;
@@ -214,9 +215,7 @@ final class MonoWhen<T, R> extends Mono<R> {
                             compositeError.addSuppressed(e);
                         } else
                         if (error != null) {
-                            compositeError = new Throwable("Multiple errors");
-                            compositeError.addSuppressed(error);
-                            compositeError.addSuppressed(e);
+	                        compositeError = Exceptions.multiple(error, e);
                         } else {
                             error = e;
                         }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDelayUntilTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDelayUntilTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
+import reactor.core.Disposable;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FluxDelayUntilTest {
+
+	@Test
+	public void testFluxEmptyAndPublisherVoid() {
+		Publisher<Void> voidPublisher = Mono.fromRunnable(() -> { });
+		StepVerifier.create(Flux.<String>empty().delayUntil(a -> voidPublisher))
+		            .verifyComplete();
+	}
+
+	@Test
+	public void testFlux1AndPublisherVoid() {
+		Publisher<Void> voidPublisher = Mono.fromRunnable(() -> { });
+
+		StepVerifier.create(Flux.just("foo").delayUntil(a -> voidPublisher))
+		            .expectNext("foo")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void testFlux2AndPublisherVoid() {
+		Publisher<Void> voidPublisher = Mono.fromRunnable(() -> { });
+
+		StepVerifier.create(Flux.just("foo", "bar").delayUntil(a -> voidPublisher))
+		            .expectNext("foo", "bar")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void testFlux2DoesntReorderViaDelays() {
+		StepVerifier.withVirtualTime(() ->
+				Flux.just(100, 200, 300)
+				    .delayUntil(v -> Mono.delay(Duration.ofMillis(400 - v)))
+		)
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofMillis(300))
+		            .expectNext(100)
+		            .expectNoEvent(Duration.ofMillis(200))
+		            .expectNext(200)
+		            .expectNoEvent(Duration.ofMillis(100))
+		            .expectNext(300)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void triggerSequenceWithDelays() {
+		StepVerifier.withVirtualTime(() -> Flux.just("foo", "bar")
+		                                       .delayUntil(a -> Flux.just(1, 2, 3).hide().delayElements(Duration.ofMillis(500))))
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofMillis(1400))
+		            .thenAwait(Duration.ofMillis(100))
+		            .expectNext("foo")
+		            .expectNoEvent(Duration.ofMillis(1500))
+		            .expectNext("bar")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void triggerSequenceHasMultipleValuesNotCancelled() {
+		AtomicBoolean triggerCancelled = new AtomicBoolean();
+		StepVerifier.create(Flux.just("foo")
+		                        .delayUntil(
+				                        a -> Flux.just(1, 2, 3).hide()
+				                                 .doOnCancel(() -> triggerCancelled.set(true))))
+		            .expectNext("foo")
+		            .verifyComplete();
+		assertThat(triggerCancelled.get()).isFalse();
+	}
+
+	@Test
+	public void triggerSequenceHasSingleValueNotCancelled() {
+		AtomicBoolean triggerCancelled = new AtomicBoolean();
+		StepVerifier.create(Flux.just("foo")
+		                        .delayUntil(
+				                        a -> Mono.just(1)
+				                                 .doOnCancel(() -> triggerCancelled.set(true))))
+		            .expectNext("foo")
+		            .verifyComplete();
+		assertThat(triggerCancelled.get()).isFalse();
+	}
+
+	@Test
+	public void triggerSequenceDoneFirst() {
+		StepVerifier.withVirtualTime(() -> Mono.delay(Duration.ofSeconds(2))
+		                                       .flatMapMany(Flux::just)
+		                                       .delayUntil(a -> Mono.just("foo")))
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofSeconds(2))
+		            .expectNext(0L)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void sourceHasError() {
+		StepVerifier.create(Flux.<String>error(new IllegalStateException("boom"))
+				.delayUntil(a -> Mono.just("foo")))
+		            .verifyErrorMessage("boom");
+	}
+
+	@Test
+	public void triggerHasError() {
+		StepVerifier.create(Flux.just("foo")
+		                        .delayUntil(a -> Mono.<String>error(new IllegalStateException("boom"))))
+		            .verifyErrorMessage("boom");
+	}
+
+	@Test
+	public void sourceAndTriggerHaveErrorsNotDelayed() {
+		StepVerifier.create(Flux.<String>error(new IllegalStateException("boom1"))
+				.delayUntil(a -> Mono.<Integer>error(new IllegalStateException("boom2"))))
+		            .verifyErrorMessage("boom1");
+	}
+
+
+	@Test
+	public void sourceAndTriggerHaveErrorsDelayedShortCircuits() {
+		IllegalStateException boom1 = new IllegalStateException("boom1");
+		IllegalStateException boom2 = new IllegalStateException("boom2");
+		StepVerifier.create(Flux.error(boom1)
+		                        .delayUntilDelayError(a -> Mono.<Integer>error(boom2)))
+		            .verifyErrorMessage("boom1");
+	}
+
+	@Test
+	public void triggersWithErrorsDelayed() {
+		IllegalStateException boom1 = new IllegalStateException("boom1");
+		IllegalStateException boom2 = new IllegalStateException("boom2");
+		StepVerifier.create(
+				Flux.just(1, 2, 3)
+				    .delayUntilDelayError(i -> i == 1 ? Mono.error(boom1) : i == 2 ? Mono.error(boom2) : Mono.empty())
+		)
+		            .expectNext(3)
+		            .consumeErrorWith(e -> assertThat(e)
+						            .hasMessage("Multiple exceptions")
+				                    .hasSuppressedException(boom1)
+				                    .hasSuppressedException(boom2))
+		            .verify();
+	}
+
+	@Test
+	public void testAPIDelayUntil() {
+		StepVerifier.withVirtualTime(() -> Flux.just("foo")
+		                                       .delayUntil(a -> Mono.delay(Duration.ofSeconds(2))))
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofSeconds(2))
+		            .expectNext("foo")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void testAPIDelayUntilErrorsImmediately() {
+		IllegalArgumentException boom = new IllegalArgumentException("boom");
+		StepVerifier.create(Flux.error(boom)
+		                        .delayUntil(a -> Mono.delay(Duration.ofSeconds(2))))
+		            .expectErrorMessage("boom")
+		            .verify(Duration.ofMillis(200)); //at least, less than 2s
+	}
+
+	@Test
+	public void testAPIDelayUntilDelayErrorNoError() {
+		StepVerifier.withVirtualTime(() -> Flux.just("foo", "bar")
+		                                       .delayUntilDelayError(a -> Mono.delay(Duration.ofSeconds(2))))
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofSeconds(2))
+		            .expectNext("foo")
+		            .expectNoEvent(Duration.ofSeconds(2))
+		            .expectNext("bar")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void testAPIDelayUntilDelayErrorWaitsOtherTriggers() {
+		IllegalArgumentException boom = new IllegalArgumentException("boom");
+
+		StepVerifier.withVirtualTime(() -> Mono.just("ok")
+		                                       .delayUntilDelayError(a -> Mono.error(boom))
+		                                       .delayUntilDelayError(a -> Mono.delay(Duration.ofSeconds(2))))
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofSeconds(2))
+		            .verifyErrorMessage("boom");
+	}
+
+	@Test
+	public void testAPIchainingCumulatesDelaysAfterValueGenerated() {
+		AtomicInteger generator1Used = new AtomicInteger();
+		AtomicInteger generator2Used = new AtomicInteger();
+
+		Function<String, Mono<Long>> generator1 = a -> {
+			generator1Used.incrementAndGet();
+			return Mono.delay(Duration.ofMillis(400));
+		};
+		Function<Object, Mono<Long>> generator2 = a -> {
+			generator2Used.incrementAndGet();
+			return Mono.delay(Duration.ofMillis(800));
+		};
+
+		StepVerifier.withVirtualTime(() -> Flux.just("foo")
+		                                       .delayElements(Duration.ofSeconds(3))
+		                                       .delayUntil(generator1)
+		                                       .delayUntil(generator2))
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofMillis(2900))
+		            .then(() -> assertThat(generator1Used.get()).isZero())
+		            .then(() -> assertThat(generator2Used.get()).isZero())
+		            .expectNoEvent(Duration.ofMillis(100))
+		            .then(() -> assertThat(generator1Used.get()).isEqualTo(1))
+		            .then(() -> assertThat(generator2Used.get()).isEqualTo(0))
+		            .expectNoEvent(Duration.ofMillis(400))
+		            .then(() -> assertThat(generator2Used.get()).isEqualTo(1))
+		            .expectNoEvent(Duration.ofMillis(800))
+		            .expectNext("foo")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void immediateCancel() {
+		AtomicReference<String> value = new AtomicReference<>();
+		AtomicReference<Throwable> error = new AtomicReference<>();
+
+		Disposable s = Flux.just("foo", "bar")
+		                   .delayUntil(v -> Mono.just(1))
+		                   .subscribe(value::set, error::set, () -> {}, Subscription::cancel);
+
+		assertThat(value.get()).isNull();
+		assertThat(error.get()).isNull(); //would be a NPE if trigger array wasn't pre-initialized
+	}
+
+	@Test
+	public void isAlias() {
+		assertThat(Flux.range(1, 10).delayUntil(a -> Mono.empty()))
+				.isInstanceOf(FluxConcatMap.class);
+
+		assertThat(Flux.range(1, 10).delayUntilDelayError(a -> Mono.empty()))
+				.isInstanceOf(FluxConcatMap.class);
+	}
+
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDelayUntilTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDelayUntilTest.java
@@ -137,7 +137,7 @@ public class MonoDelayUntilTest {
 				Mono.just("ok"), a -> Mono.<Integer>error(boom1))
 				.delayUntilDelayError(a -> Mono.error(boom2))
 		)
-		            .verifyErrorMatches(e -> e.getMessage().equals("Multiple errors") &&
+		            .verifyErrorMatches(e -> e.getMessage().equals("Multiple exceptions") &&
 				            e.getSuppressed()[0] == boom1 &&
 				            e.getSuppressed()[1] == boom2);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoWhenTest.java
@@ -420,7 +420,7 @@ public class MonoWhenTest {
 		StepVerifier.create(Mono.whenDelayError(
 				Arrays.asList(Mono.just("foo"), Mono.<String>error(boom1), Mono.<String>error(boom2)),
 				Tuples.fn3()))
-		            .verifyErrorMatches(e -> e.getMessage().equals("Multiple errors") &&
+		            .verifyErrorMatches(e -> e.getMessage().equals("Multiple exceptions") &&
 				            e.getSuppressed()[0] == boom1 &&
 				            e.getSuppressed()[1] == boom2);
 	}
@@ -447,7 +447,7 @@ public class MonoWhenTest {
 				Mono.<Void>error(boom2));
 
 		StepVerifier.create(Mono.whenDelayError(voidPublishers))
-		            .verifyErrorMatches(e -> e.getMessage().equals("Multiple errors") &&
+		            .verifyErrorMatches(e -> e.getMessage().equals("Multiple exceptions") &&
 				            e.getSuppressed()[0] == boom1 &&
 				            e.getSuppressed()[1] == boom2);
 	}


### PR DESCRIPTION
See #631. @smaldini 2 meaningful commits in this PR:

 - Use standard composite exception in Mono delayUntil/delayUntilOther/when
 - Add delayUntil API to Flux