### PR TITLE
fix #696 Tuple values must now be non-null

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxElapsed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxElapsed.java
@@ -17,6 +17,7 @@
 package reactor.core.publisher;
 
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -25,7 +26,6 @@ import reactor.core.scheduler.Scheduler;
 import reactor.util.context.Context;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
-import javax.annotation.Nullable;
 
 /**
  * @author Stephane Maldini
@@ -41,7 +41,7 @@ final class FluxElapsed<T> extends FluxOperator<T, Tuple2<Long, T>> implements F
 
 	@Override
 	public void subscribe(Subscriber<? super Tuple2<Long, T>> s, Context ctx) {
-		source.subscribe(new ElapsedSubscriber<T>(s, scheduler), ctx);
+		source.subscribe(new ElapsedSubscriber<>(s, scheduler), ctx);
 	}
 
 	static final class ElapsedSubscriber<T>

--- a/reactor-core/src/main/java/reactor/util/function/Tuple2.java
+++ b/reactor-core/src/main/java/reactor/util/function/Tuple2.java
@@ -21,29 +21,29 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-
+import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * A tuple that holds two values
+ * A tuple that holds two non-null values.
  *
- * @param <T1> The type of the first value held by this tuple
- * @param <T2> The type of the second value held by this tuple
+ * @param <T1> The type of the first non-null value held by this tuple
+ * @param <T2> The type of the second non-null value held by this tuple
  * @author Jon Brisbin
  * @author Stephane Maldini
  */
 @SuppressWarnings("rawtypes")
 public class Tuple2<T1, T2> implements Iterable<Object>, Serializable {
 
-	/** */
-    private static final long serialVersionUID = 4839927936743208499L;
+	private static final long serialVersionUID = -3518082018884860684L;
 
-	final T1 t1;
-	final T2 t2;
+	@Nonnull final T1 t1;
+	@Nonnull final T2 t2;
 
-	Tuple2(@Nullable T1 t1, @Nullable T2 t2) {
-		this.t1 = t1;
-		this.t2 = t2;
+	Tuple2(T1 t1, T2 t2) {
+		this.t1 = Objects.requireNonNull(t1, "t1");
+		this.t2 = Objects.requireNonNull(t2, "t2");
 	}
 
 	/**
@@ -51,7 +51,6 @@ public class Tuple2<T1, T2> implements Iterable<Object>, Serializable {
 	 *
 	 * @return The first object
 	 */
-	@Nullable
 	public T1 getT1() {
 		return t1;
 	}
@@ -61,7 +60,6 @@ public class Tuple2<T1, T2> implements Iterable<Object>, Serializable {
 	 *
 	 * @return The second object
 	 */
-	@Nullable
 	public T2 getT2() {
 		return t2;
 	}
@@ -71,7 +69,7 @@ public class Tuple2<T1, T2> implements Iterable<Object>, Serializable {
 	 * Get the object at the given index.
 	 *
 	 * @param index The index of the object to retrieve. Starts at 0.
-	 * @return The object. Might be {@literal null}.
+	 * @return The object or {@literal null} if out of bounds.
 	 */
 	@Nullable
 	public Object get(int index) {
@@ -119,16 +117,15 @@ public class Tuple2<T1, T2> implements Iterable<Object>, Serializable {
 
 		Tuple2<?, ?> tuple2 = (Tuple2<?, ?>) o;
 
-		return (t1 != null ? t1.equals(tuple2.t1) : tuple2.t1 == null) &&
-				(t2 != null ? t2.equals(tuple2.t2) : tuple2.t2 == null);
+		return t1.equals(tuple2.t1) && t2.equals(tuple2.t2);
 
 	}
 
 	@Override
 	public int hashCode() {
 		int result = size();
-		result = 31 * result + (t1 != null ? t1.hashCode() : 0);
-		result = 31 * result + (t2 != null ? t2.hashCode() : 0);
+		result = 31 * result + t1.hashCode();
+		result = 31 * result + t2.hashCode();
 		return result;
 	}
 
@@ -142,26 +139,12 @@ public class Tuple2<T1, T2> implements Iterable<Object>, Serializable {
 	}
 
 	/**
-	 * String representation that can be adjusted for higher-cardinality Tuples in order
-	 * to show all values hold. Default to the t1 and t2 values separated by a comma.
-	 */
-	protected StringBuilder innerToString() {
-		StringBuilder sb = new StringBuilder();
-		if (t1 != null) sb.append(t1);
-		sb.append(',');
-		if (t2 != null) sb.append(t2);
-		return sb;
-	}
-
-	/**
 	 * A Tuple String representation is the comma separated list of values, enclosed
-	 * in square brackets. Note that intermediate {@literal null} values are represented
-	 * as the empty String, like {@code [value1,,value3]} for a Tuple3 or {@code [,value2]}
-	 * for a Tuple2.
+	 * in square brackets.
 	 * @return the Tuple String representation
 	 */
 	@Override
 	public final String toString() {
-		return innerToString().insert(0, '[').append(']').toString();
+		return Tuples.tupleToString(toArray()).insert(0, '[').append(']').toString();
 	}
 }

--- a/reactor-core/src/main/java/reactor/util/function/Tuple2.java
+++ b/reactor-core/src/main/java/reactor/util/function/Tuple2.java
@@ -145,6 +145,6 @@ public class Tuple2<T1, T2> implements Iterable<Object>, Serializable {
 	 */
 	@Override
 	public final String toString() {
-		return Tuples.tupleToString(toArray()).insert(0, '[').append(']').toString();
+		return Tuples.tupleStringRepresentation(toArray()).insert(0, '[').append(']').toString();
 	}
 }

--- a/reactor-core/src/main/java/reactor/util/function/Tuple3.java
+++ b/reactor-core/src/main/java/reactor/util/function/Tuple3.java
@@ -16,26 +16,28 @@
 
 package reactor.util.function;
 
+import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * A tuple that holds three values
+ * A tuple that holds three non-null values.
  *
- * @param <T1> The type of the first value held by this tuple
- * @param <T2> The type of the second value held by this tuple
- * @param <T3> The type of the third value held by this tuple
+ * @param <T1> The type of the first non-null value held by this tuple
+ * @param <T2> The type of the second non-null value held by this tuple
+ * @param <T3> The type of the third non-null value held by this tuple
  * @author Jon Brisbin
  * @author Stephane Maldini
  */
 public class Tuple3<T1, T2, T3> extends Tuple2<T1, T2> {
 
-	private static final long serialVersionUID = 6315773492205460562L;
+	private static final long serialVersionUID = -4430274211524723033L;
 
-	final T3 t3;
+	@Nonnull final T3 t3;
 
-	Tuple3(@Nullable T1 t1, @Nullable T2 t2, @Nullable T3 t3) {
+	Tuple3(T1 t1, T2 t2, T3 t3) {
 		super(t1, t2);
-		this.t3 = t3;
+		this.t3 = Objects.requireNonNull(t3, "t3");
 	}
 
 	/**
@@ -43,7 +45,6 @@ public class Tuple3<T1, T2, T3> extends Tuple2<T1, T2> {
 	 *
 	 * @return The third object
 	 */
-	@Nullable
 	public T3 getT3() {
 		return t3;
 	}
@@ -77,7 +78,7 @@ public class Tuple3<T1, T2, T3> extends Tuple2<T1, T2> {
 		@SuppressWarnings("rawtypes")
         Tuple3 tuple3 = (Tuple3) o;
 
-		return t3 != null ? t3.equals(tuple3.t3) : tuple3.t3 == null;
+		return t3.equals(tuple3.t3);
 	}
 
 	@Override
@@ -88,14 +89,7 @@ public class Tuple3<T1, T2, T3> extends Tuple2<T1, T2> {
 	@Override
 	public int hashCode() {
 		int result = super.hashCode();
-		result = 31 * result + (t3 != null ? t3.hashCode() : 0);
+		result = 31 * result + t3.hashCode();
 		return result;
-	}
-
-	@Override
-	public StringBuilder innerToString() {
-		StringBuilder sb = super.innerToString().append(',');
-		if (t3 != null) sb.append(t3);
-		return sb;
 	}
 }

--- a/reactor-core/src/main/java/reactor/util/function/Tuple4.java
+++ b/reactor-core/src/main/java/reactor/util/function/Tuple4.java
@@ -16,27 +16,29 @@
 
 package reactor.util.function;
 
+import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * A tuple that holds four values
+ * A tuple that holds four non-null values
  *
- * @param <T1> The type of the first value held by this tuple
- * @param <T2> The type of the second value held by this tuple
- * @param <T3> The type of the third value held by this tuple
- * @param <T4> The type of the fourth value held by this tuple
+ * @param <T1> The type of the first non-null value held by this tuple
+ * @param <T2> The type of the second non-null value held by this tuple
+ * @param <T3> The type of the third non-null value held by this tuple
+ * @param <T4> The type of the fourth non-null value held by this tuple
  * @author Jon Brisbin
  * @author Stephane Maldini
  */
 public class Tuple4<T1, T2, T3, T4> extends Tuple3<T1, T2, T3> {
 
-	private static final long serialVersionUID = 8075447176142642390L;
+	private static final long serialVersionUID = -4898704078143033129L;
 
-	final T4 t4;
+	@Nonnull final T4 t4;
 
-	Tuple4(@Nullable T1 t1, @Nullable T2 t2, @Nullable T3 t3, @Nullable T4 t4) {
+	Tuple4(T1 t1, T2 t2, T3 t3, T4 t4) {
 		super( t1, t2, t3);
-		this.t4 = t4;
+		this.t4 = Objects.requireNonNull(t4, "t4");
 	}
 
 	/**
@@ -44,7 +46,6 @@ public class Tuple4<T1, T2, T3, T4> extends Tuple3<T1, T2, T3> {
 	 *
 	 * @return The fourth object
 	 */
-	@Nullable
 	public T4 getT4() {
 		return t4;
 	}
@@ -80,26 +81,19 @@ public class Tuple4<T1, T2, T3, T4> extends Tuple3<T1, T2, T3> {
 		@SuppressWarnings("rawtypes")
         Tuple4 tuple4 = (Tuple4) o;
 
-		return t4 != null ? t4.equals(tuple4.t4) : tuple4.t4 == null;
+		return t4.equals(tuple4.t4);
 
 	}
 
 	@Override
 	public int hashCode() {
 		int result = super.hashCode();
-		result = 31 * result + (t4 != null ? t4.hashCode() : 0);
+		result = 31 * result + t4.hashCode();
 		return result;
 	}
 
 	@Override
 	public int size() {
 		return 4;
-	}
-
-	@Override
-	public StringBuilder innerToString() {
-		StringBuilder sb = super.innerToString().append(',');
-		if (t4 != null) sb.append(t4);
-		return sb;
 	}
 }

--- a/reactor-core/src/main/java/reactor/util/function/Tuple5.java
+++ b/reactor-core/src/main/java/reactor/util/function/Tuple5.java
@@ -16,28 +16,30 @@
 
 package reactor.util.function;
 
+import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * A tuple that holds five values
+ * A tuple that holds five non-null values
  *
- * @param <T1> The type of the first value held by this tuple
- * @param <T2> The type of the second value held by this tuple
- * @param <T3> The type of the third value held by this tuple
- * @param <T4> The type of the fourth value held by this tuple
- * @param <T5> The type of the fifth value held by this tuple
+ * @param <T1> The type of the first non-null value held by this tuple
+ * @param <T2> The type of the second non-null value held by this tuple
+ * @param <T3> The type of the third non-null value held by this tuple
+ * @param <T4> The type of the fourth non-null value held by this tuple
+ * @param <T5> The type of the fifth non-null value held by this tuple
  * @author Jon Brisbin
  * @author Stephane Maldini
  */
 public class Tuple5<T1, T2, T3, T4, T5> extends Tuple4<T1, T2, T3, T4> {
 
-	private static final long serialVersionUID = -5866370282498275773L;
+	private static final long serialVersionUID = 3541548454198133275L;
 
-	final T5 t5;
+	@Nonnull final T5 t5;
 
-	Tuple5(@Nullable T1 t1, @Nullable T2 t2, @Nullable T3 t3, @Nullable T4 t4, @Nullable T5 t5) {
+	Tuple5(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) {
 		super(t1, t2, t3, t4);
-		this.t5 = t5;
+		this.t5 = Objects.requireNonNull(t5, "t5");
 	}
 
 	/**
@@ -45,7 +47,6 @@ public class Tuple5<T1, T2, T3, T4, T5> extends Tuple4<T1, T2, T3, T4> {
 	 *
 	 * @return The fifth object
 	 */
-	@Nullable
 	public T5 getT5() {
 		return t5;
 	}
@@ -83,26 +84,19 @@ public class Tuple5<T1, T2, T3, T4, T5> extends Tuple4<T1, T2, T3, T4> {
 		@SuppressWarnings("rawtypes")
         Tuple5 tuple5 = (Tuple5) o;
 
-		return t5 != null ? t5.equals(tuple5.t5) : tuple5.t5 == null;
+		return t5.equals(tuple5.t5);
 
 	}
 
 	@Override
 	public int hashCode() {
 		int result = super.hashCode();
-		result = 31 * result + (t5 != null ? t5.hashCode() : 0);
+		result = 31 * result + t5.hashCode();
 		return result;
 	}
 
 	@Override
 	public int size() {
 		return 5;
-	}
-
-	@Override
-	public StringBuilder innerToString() {
-		StringBuilder sb = super.innerToString().append(',');
-		if (t5 != null) sb.append(t5);
-		return sb;
 	}
 }

--- a/reactor-core/src/main/java/reactor/util/function/Tuple6.java
+++ b/reactor-core/src/main/java/reactor/util/function/Tuple6.java
@@ -16,6 +16,8 @@
 
 package reactor.util.function;
 
+import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -32,14 +34,13 @@ import javax.annotation.Nullable;
  */
 public class Tuple6<T1, T2, T3, T4, T5, T6> extends Tuple5<T1, T2, T3, T4, T5> {
 
-	private static final long serialVersionUID = -4214053259792235250L;
+	private static final long serialVersionUID = 770306356087176830L;
 
-	final T6 t6;
+	@Nonnull final T6 t6;
 
-	Tuple6(@Nullable T1 t1, @Nullable T2 t2, @Nullable T3 t3, @Nullable T4 t4,
-			@Nullable T5 t5, @Nullable T6 t6) {
+	Tuple6(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) {
 		super(t1, t2, t3, t4, t5);
-		this.t6 = t6;
+		this.t6 = Objects.requireNonNull(t6, "t6");
 	}
 
 	/**
@@ -47,7 +48,6 @@ public class Tuple6<T1, T2, T3, T4, T5, T6> extends Tuple5<T1, T2, T3, T4, T5> {
 	 *
 	 * @return The sixth object
 	 */
-	@Nullable
 	public T6 getT6() {
 		return t6;
 	}
@@ -87,26 +87,19 @@ public class Tuple6<T1, T2, T3, T4, T5, T6> extends Tuple5<T1, T2, T3, T4, T5> {
 		@SuppressWarnings("rawtypes")
         Tuple6 tuple6 = (Tuple6) o;
 
-		return t6 != null ? t6.equals(tuple6.t6) : tuple6.t6 == null;
+		return t6.equals(tuple6.t6);
 
 	}
 
 	@Override
 	public int hashCode() {
 		int result = super.hashCode();
-		result = 31 * result + (t6 != null ? t6.hashCode() : 0);
+		result = 31 * result + t6.hashCode();
 		return result;
 	}
 
 	@Override
 	public int size() {
 		return 6;
-	}
-
-	@Override
-	public StringBuilder innerToString() {
-		StringBuilder sb = super.innerToString().append(',');
-		if (t6 != null) sb.append(t6);
-		return sb;
 	}
 }

--- a/reactor-core/src/main/java/reactor/util/function/Tuple7.java
+++ b/reactor-core/src/main/java/reactor/util/function/Tuple7.java
@@ -16,31 +16,32 @@
 
 package reactor.util.function;
 
+import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * A tuple that holds seven values
+ * A tuple that holds seven non-null values
  *
- * @param <T1> The type of the first value held by this tuple
- * @param <T2> The type of the second value held by this tuple
- * @param <T3> The type of the third value held by this tuple
- * @param <T4> The type of the fourth value held by this tuple
- * @param <T5> The type of the fifth value held by this tuple
- * @param <T6> The type of the sixth value held by this tuple
- * @param <T7> The type of the seventh value held by this tuple
+ * @param <T1> The type of the first non-null value held by this tuple
+ * @param <T2> The type of the second non-null value held by this tuple
+ * @param <T3> The type of the third non-null value held by this tuple
+ * @param <T4> The type of the fourth non-null value held by this tuple
+ * @param <T5> The type of the fifth non-null value held by this tuple
+ * @param <T6> The type of the sixth non-null value held by this tuple
+ * @param <T7> The type of the seventh non-null value held by this tuple
  * @author Jon Brisbin
  * @author Stephane Maldini
  */
 public class Tuple7<T1, T2, T3, T4, T5, T6, T7> extends Tuple6<T1, T2, T3, T4, T5, T6> {
 
-	private static final long serialVersionUID = 8273600047065201704L;
+	private static final long serialVersionUID = -8002391247456579281L;
 
-	final T7 t7;
+	@Nonnull final T7 t7;
 
-	Tuple7(@Nullable T1 t1, @Nullable T2 t2, @Nullable T3 t3, @Nullable T4 t4,
-			@Nullable T5 t5, @Nullable T6 t6, @Nullable T7 t7) {
+	Tuple7(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) {
 		super( t1, t2, t3, t4, t5, t6);
-		this.t7 = t7;
+		this.t7 = Objects.requireNonNull(t7, "t7");
 	}
 
 	/**
@@ -48,7 +49,6 @@ public class Tuple7<T1, T2, T3, T4, T5, T6, T7> extends Tuple6<T1, T2, T3, T4, T
 	 *
 	 * @return The seventh object
 	 */
-	@Nullable
 	public T7 getT7() {
 		return t7;
 	}
@@ -90,26 +90,19 @@ public class Tuple7<T1, T2, T3, T4, T5, T6, T7> extends Tuple6<T1, T2, T3, T4, T
 		@SuppressWarnings("rawtypes")
         Tuple7 tuple7 = (Tuple7) o;
 
-		return t7 != null ? t7.equals(tuple7.t7) : tuple7.t7 == null;
+		return t7.equals(tuple7.t7);
 
 	}
 
 	@Override
 	public int hashCode() {
 		int result = super.hashCode();
-		result = 31 * result + (t7 != null ? t7.hashCode() : 0);
+		result = 31 * result + t7.hashCode();
 		return result;
 	}
 
 	@Override
 	public int size() {
 		return 7;
-	}
-
-	@Override
-	public StringBuilder innerToString() {
-		StringBuilder sb = super.innerToString().append(',');
-		if (t7 != null) sb.append(t7);
-		return sb;
 	}
 }

--- a/reactor-core/src/main/java/reactor/util/function/Tuple8.java
+++ b/reactor-core/src/main/java/reactor/util/function/Tuple8.java
@@ -16,6 +16,8 @@
 
 package reactor.util.function;
 
+import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -35,14 +37,13 @@ import javax.annotation.Nullable;
 public class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> extends
                                                     Tuple7<T1, T2, T3, T4, T5, T6, T7> {
 
-	private static final long serialVersionUID = 3070436338779769189L;
+	private static final long serialVersionUID = -8746796646535446242L;
 
-	final T8 t8;
+	@Nonnull final T8 t8;
 
-	Tuple8(@Nullable T1 t1, @Nullable T2 t2, @Nullable T3 t3, @Nullable T4 t4,
-			@Nullable T5 t5, @Nullable T6 t6, @Nullable T7 t7, @Nullable T8 t8) {
+	Tuple8(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) {
 		super(t1, t2, t3, t4, t5, t6, t7);
-		this.t8 = t8;
+		this.t8 = Objects.requireNonNull(t8, "t8");
 	}
 
 	/**
@@ -50,7 +51,6 @@ public class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> extends
 	 *
 	 * @return The eighth object
 	 */
-	@Nullable
 	public T8 getT8() {
 		return t8;
 	}
@@ -94,26 +94,19 @@ public class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> extends
 		@SuppressWarnings("rawtypes")
         Tuple8 tuple8 = (Tuple8) o;
 
-		return t8 != null ? t8.equals(tuple8.t8) : tuple8.t8 == null;
+		return t8.equals(tuple8.t8);
 
 	}
 
 	@Override
 	public int hashCode() {
 		int result = super.hashCode();
-		result = 31 * result + (t8 != null ? t8.hashCode() : 0);
+		result = 31 * result + t8.hashCode();
 		return result;
 	}
 
 	@Override
 	public int size() {
 		return 8;
-	}
-
-	@Override
-	public StringBuilder innerToString() {
-		StringBuilder sb = super.innerToString().append(',');
-		if (t8 != null) sb.append(t8);
-		return sb;
 	}
 }

--- a/reactor-core/src/main/java/reactor/util/function/Tuples.java
+++ b/reactor-core/src/main/java/reactor/util/function/Tuples.java
@@ -19,8 +19,6 @@ package reactor.util.function;
 import java.util.Collection;
 import java.util.function.Function;
 
-import javax.annotation.Nullable;
-
 /**
  * A {@literal Tuples} is an immutable {@link Collection} of objects, each of which can be of an arbitrary type.
  *
@@ -40,13 +38,11 @@ public abstract class Tuples implements Function {
 	 */
 	public static Tuple2 fromArray(Object[] list) {
 		//noinspection ConstantConditions
-		if (list == null || list.length == 0) {
-			throw new IllegalArgumentException("null or empty array, need between 1 and 8 values");
+		if (list == null || list.length < 2) {
+			throw new IllegalArgumentException("null or too small array, need between 2 and 8 values");
 		}
 
 		switch (list.length){
-			case 1:
-				return of(list[0], null);
 			case 2:
 				return of(list[0], list[1]);
 			case 3:
@@ -62,69 +58,62 @@ public abstract class Tuples implements Function {
 			case 8:
 				return of(list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7]);
 		}
-		throw new IllegalArgumentException("too many arguments ("+ list.length + "), need between 1 and 8 values");
+		throw new IllegalArgumentException("too many arguments ("+ list.length + "), need between 2 and 8 values");
 	}
 
 	/**
 	 * Create a {@link Tuple2} with the given objects.
 	 *
-	 * @param t1   The first value in the tuple.
-	 * @param t2   The second value in the tuple.
+	 * @param t1   The first value in the tuple. Not null.
+	 * @param t2   The second value in the tuple. Not null.
 	 * @param <T1> The type of the first value.
 	 * @param <T2> The type of the second value.
 	 * @return The new {@link Tuple2}.
 	 */
-	public static <T1, T2> Tuple2<T1, T2> of(@Nullable T1 t1, @Nullable T2 t2) {
+	public static <T1, T2> Tuple2<T1, T2> of(T1 t1, T2 t2) {
 		return new Tuple2<>(t1, t2);
 	}
 
 	/**
 	 * Create a {@link Tuple3} with the given objects.
 	 *
-	 * @param t1   The first value in the tuple.
-	 * @param t2   The second value in the tuple.
-	 * @param t3   The third value in the tuple.
+	 * @param t1   The first value in the tuple. Not null.
+	 * @param t2   The second value in the tuple. Not null.
+	 * @param t3   The third value in the tuple. Not null.
 	 * @param <T1> The type of the first value.
 	 * @param <T2> The type of the second value.
 	 * @param <T3> The type of the third value.
 	 * @return The new {@link Tuple3}.
 	 */
-	public static <T1, T2, T3> Tuple3<T1, T2, T3> of(
-			@Nullable T1 t1,
-			@Nullable T2 t2,
-			@Nullable T3 t3) {
+	public static <T1, T2, T3> Tuple3<T1, T2, T3> of(T1 t1, T2 t2, T3 t3) {
 		return new Tuple3<>(t1, t2, t3);
 	}
 
 	/**
 	 * Create a {@link Tuple4} with the given objects.
 	 *
-	 * @param t1   The first value in the tuple.
-	 * @param t2   The second value in the tuple.
-	 * @param t3   The third value in the tuple.
-	 * @param t4   The fourth value in the tuple.
+	 * @param t1   The first value in the tuple. Not null.
+	 * @param t2   The second value in the tuple. Not null.
+	 * @param t3   The third value in the tuple. Not null.
+	 * @param t4   The fourth value in the tuple. Not null.
 	 * @param <T1> The type of the first value.
 	 * @param <T2> The type of the second value.
 	 * @param <T3> The type of the third value.
 	 * @param <T4> The type of the fourth value.
 	 * @return The new {@link Tuple4}.
 	 */
-	public static <T1, T2, T3, T4> Tuple4<T1, T2, T3, T4> of(
-			@Nullable T1 t1,
-			@Nullable T2 t2,
-			@Nullable T3 t3,
-			@Nullable T4 t4) {
+	public static <T1, T2, T3, T4> Tuple4<T1, T2, T3, T4> of(T1 t1, T2 t2, T3 t3, T4 t4) {
 		return new Tuple4<>(t1, t2, t3, t4);
 	}
 
 	/**
 	 * Create a {@link Tuple5} with the given objects.
 	 *
-	 * @param t1   The first value in the tuple.
-	 * @param t2   The second value in the tuple.
-	 * @param t3   The third value in the tuple.
-	 * @param t4   The fourth value in the tuple.
-	 * @param t5   The fifth value in the tuple.
+	 * @param t1   The first value in the tuple. Not null.
+	 * @param t2   The second value in the tuple. Not null.
+	 * @param t3   The third value in the tuple. Not null.
+	 * @param t4   The fourth value in the tuple. Not null.
+	 * @param t5   The fifth value in the tuple. Not null.
 	 * @param <T1> The type of the first value.
 	 * @param <T2> The type of the second value.
 	 * @param <T3> The type of the third value.
@@ -133,23 +122,23 @@ public abstract class Tuples implements Function {
 	 * @return The new {@link Tuple5}.
 	 */
 	public static <T1, T2, T3, T4, T5> Tuple5<T1, T2, T3, T4, T5> of(
-			@Nullable T1 t1,
-			@Nullable T2 t2,
-			@Nullable T3 t3,
-			@Nullable T4 t4,
-			@Nullable T5 t5) {
+			T1 t1,
+			T2 t2,
+			T3 t3,
+			T4 t4,
+			T5 t5) {
 		return new Tuple5<>(t1, t2, t3, t4, t5);
 	}
 
 	/**
 	 * Create a {@link Tuple6} with the given objects.
 	 *
-	 * @param t1   The first value in the tuple.
-	 * @param t2   The second value in the tuple.
-	 * @param t3   The third value in the tuple.
-	 * @param t4   The fourth value in the tuple.
-	 * @param t5   The fifth value in the tuple.
-	 * @param t6   The sixth value in the tuple.
+	 * @param t1   The first value in the tuple. Not null.
+	 * @param t2   The second value in the tuple. Not null.
+	 * @param t3   The third value in the tuple. Not null.
+	 * @param t4   The fourth value in the tuple. Not null.
+	 * @param t5   The fifth value in the tuple. Not null.
+	 * @param t6   The sixth value in the tuple. Not null.
 	 * @param <T1> The type of the first value.
 	 * @param <T2> The type of the second value.
 	 * @param <T3> The type of the third value.
@@ -159,25 +148,25 @@ public abstract class Tuples implements Function {
 	 * @return The new {@link Tuple6}.
 	 */
 	public static <T1, T2, T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> of(
-			@Nullable T1 t1,
-			@Nullable T2 t2,
-			@Nullable T3 t3,
-			@Nullable T4 t4,
-			@Nullable T5 t5,
-			@Nullable T6 t6) {
+			T1 t1,
+			T2 t2,
+			T3 t3,
+			T4 t4,
+			T5 t5,
+			T6 t6) {
 		return new Tuple6<>(t1, t2, t3, t4, t5, t6);
 	}
 
 	/**
 	 * Create a {@link Tuple7} with the given objects.
 	 *
-	 * @param t1   The first value in the tuple.
-	 * @param t2   The second value in the tuple.
-	 * @param t3   The third value in the tuple.
-	 * @param t4   The fourth value in the tuple.
-	 * @param t5   The fifth value in the tuple.
-	 * @param t6   The sixth value in the tuple.
-	 * @param t7   The seventh value in the tuple.
+	 * @param t1   The first value in the tuple. Not null.
+	 * @param t2   The second value in the tuple. Not null.
+	 * @param t3   The third value in the tuple. Not null.
+	 * @param t4   The fourth value in the tuple. Not null.
+	 * @param t5   The fifth value in the tuple. Not null.
+	 * @param t6   The sixth value in the tuple. Not null.
+	 * @param t7   The seventh value in the tuple. Not null.
 	 * @param <T1> The type of the first value.
 	 * @param <T2> The type of the second value.
 	 * @param <T3> The type of the third value.
@@ -188,27 +177,27 @@ public abstract class Tuples implements Function {
 	 * @return The new {@link Tuple7}.
 	 */
 	public static <T1, T2, T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> of(
-			@Nullable T1 t1,
-			@Nullable T2 t2,
-			@Nullable T3 t3,
-			@Nullable T4 t4,
-			@Nullable T5 t5,
-			@Nullable T6 t6,
-			@Nullable T7 t7) {
+			T1 t1,
+			T2 t2,
+			T3 t3,
+			T4 t4,
+			T5 t5,
+			T6 t6,
+			T7 t7) {
 		return new Tuple7<>(t1, t2, t3, t4, t5, t6, t7);
 	}
 
 	/**
 	 * Create a {@link Tuple8} with the given objects.
 	 *
-	 * @param t1   The first value in the tuple.
-	 * @param t2   The second value in the tuple.
-	 * @param t3   The third value in the tuple.
-	 * @param t4   The fourth value in the tuple.
-	 * @param t5   The fifth value in the tuple.
-	 * @param t6   The sixth value in the tuple.
-	 * @param t7   The seventh value in the tuple.
-	 * @param t8   The eighth value in the tuple.
+	 * @param t1   The first value in the tuple. Not Null.
+	 * @param t2   The second value in the tuple.Not Null.
+	 * @param t3   The third value in the tuple. Not Null.
+	 * @param t4   The fourth value in the tuple. Not Null.
+	 * @param t5   The fifth value in the tuple. Not Null.
+	 * @param t6   The sixth value in the tuple. Not Null.
+	 * @param t7   The seventh value in the tuple. Not Null.
+	 * @param t8   The eighth value in the tuple. Not Null.
 	 * @param <T1> The type of the first value.
 	 * @param <T2> The type of the second value.
 	 * @param <T3> The type of the third value.
@@ -220,14 +209,14 @@ public abstract class Tuples implements Function {
 	 * @return The new {@link Tuple8}.
 	 */
 	public static <T1, T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> of(
-			@Nullable T1 t1,
-			@Nullable T2 t2,
-			@Nullable T3 t3,
-			@Nullable T4 t4,
-			@Nullable T5 t5,
-			@Nullable T6 t6,
-			@Nullable T7 t7,
-			@Nullable T8 t8) {
+			T1 t1,
+			T2 t2,
+			T3 t3,
+			T4 t4,
+			T5 t5,
+			T6 t6,
+			T7 t7,
+			T8 t8) {
 		return new Tuple8<>(t1, t2, t3, t4, t5, t6, t7, t8);
 	}
 
@@ -476,6 +465,28 @@ public abstract class Tuples implements Function {
 		return fromArray((Object[])o);
 	}
 
+	/**
+	 * Builds a string representation suitable of the values suitable for a Tuple of any
+	 * size by accepting an array of elements. This outputs the String representation of
+	 * each object, comma separated. It manages nulls as well by putting an empty string
+	 * and the comma.
+	 *
+	 * @param values the values of the tuple to represent
+	 * @return the String representation of the values in the Tuple.
+	 */
+	static StringBuilder tupleToString(Object... values) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < values.length; i++) {
+			Object t = values[i];
+			if (i != 0) {
+				sb.append(',');
+			}
+			if (t != null) {
+				sb.append(t);
+			}
+		}
+		return sb;
+	}
 
 
 	static final Tuples   empty            = new Tuples(){};

--- a/reactor-core/src/main/java/reactor/util/function/Tuples.java
+++ b/reactor-core/src/main/java/reactor/util/function/Tuples.java
@@ -466,15 +466,16 @@ public abstract class Tuples implements Function {
 	}
 
 	/**
-	 * Builds a string representation suitable of the values suitable for a Tuple of any
-	 * size by accepting an array of elements. This outputs the String representation of
-	 * each object, comma separated. It manages nulls as well by putting an empty string
-	 * and the comma.
+	 * Prepare a string representation of the values suitable for a Tuple of any
+	 * size by accepting an array of elements. This builds a {@link StringBuilder}
+	 * containing the String representation of each object, comma separated. It manages
+	 * nulls as well by putting an empty string and the comma.
 	 *
 	 * @param values the values of the tuple to represent
-	 * @return the String representation of the values in the Tuple.
+	 * @return a {@link StringBuilder} initialized with the string representation of the
+	 * values in the Tuple.
 	 */
-	static StringBuilder tupleToString(Object... values) {
+	static StringBuilder tupleStringRepresentation(Object... values) {
 		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < values.length; i++) {
 			Object t = values[i];

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxElapsedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxElapsedTest.java
@@ -21,7 +21,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-
 import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;

--- a/reactor-core/src/test/java/reactor/util/function/Tuple2Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple2Test.java
@@ -85,4 +85,14 @@ public class Tuple2Test {
 		        .isNotEqualTo(otherFull);
 	}
 
+	@Test
+	public void sanityTestHashcode() {
+		Tuple2<Integer, Integer> same = new Tuple2<>(1, 2);
+		Tuple2<Integer, Integer> different = new Tuple2<>(2, 1);
+
+		assertThat(full.hashCode())
+				.isEqualTo(same.hashCode())
+				.isNotEqualTo(different.hashCode());
+	}
+
 }

--- a/reactor-core/src/test/java/reactor/util/function/Tuple2Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple2Test.java
@@ -19,25 +19,24 @@ package reactor.util.function;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class Tuple2Test {
 
-	private Tuple2<Integer, Integer> empty = new Tuple2<>(null, null);
 	private Tuple2<Integer, Integer> full = new Tuple2<>(1, 2);
 
 	@Test
-	public void sparseToString() {
-		assertThat(new Tuple2<Integer, Integer>(null, 2))
-				.hasToString("[,2]");
-
-		assertThat(new Tuple2<Integer, Integer>(1, null))
-				.hasToString("[1,]");
+	public void nullT1Rejected() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> new Tuple2<>(null, 2))
+				.withMessage("t1");
 	}
 
 	@Test
-	public void nullsCountedInSize() {
-		assertThat(empty.size()).isEqualTo(2);
-		assertThat(empty).hasSize(2);
+	public void nullT2Rejected() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> new Tuple2<>(1, null))
+				.withMessage("t2");
 	}
 
 	@Test
@@ -60,18 +59,6 @@ public class Tuple2Test {
 	}
 
 	@Test
-	public void sparseIsNotSameLeftAndRight() {
-		Tuple2<Integer, Integer> sparseLeft = new Tuple2<>(null, 1);
-		Tuple2<Integer, Integer> sparseRight = new Tuple2<>(1, null);
-
-		assertThat(sparseLeft.hashCode())
-				.isNotEqualTo(sparseRight.hashCode());
-
-		assertThat(sparseLeft)
-				.isNotEqualTo(sparseRight);
-	}
-
-	@Test
 	public void equalityOfSameReference() {
 		assertThat(full).isEqualTo(full);
 	}
@@ -83,33 +70,19 @@ public class Tuple2Test {
 	}
 
 	@Test
-	public void equalsCombinations() {
-		Tuple2<Integer, Integer> otherEmpty = new Tuple2<>(null, null);
-		Tuple2<Integer, Integer> sparseLeft = new Tuple2<>(null, 2);
-		Tuple2<Integer, Integer> sparseRight = new Tuple2<>(1, null);
+	public void equals() {
 		Tuple2<Integer, Integer> otherFull = new Tuple2<>(1, 2);
 
-		assertThat(empty)
-				.isEqualTo(otherEmpty)
-				.isNotEqualTo(sparseLeft)
-				.isNotEqualTo(sparseRight)
-	            .isNotEqualTo(otherFull);
+		assertThat(full)
+		        .isEqualTo(otherFull);
+	}
 
-		assertThat(sparseLeft)
-				.isNotEqualTo(otherEmpty)
-				.isNotEqualTo(sparseRight)
-		        .isNotEqualTo(otherFull);
-
-		assertThat(sparseRight)
-				.isNotEqualTo(otherEmpty)
-				.isNotEqualTo(sparseLeft)
-		        .isNotEqualTo(otherFull);
+	@Test
+	public void invertedContentNotEquals() {
+		Tuple2<Integer, Integer> otherFull = new Tuple2<>(2, 1);
 
 		assertThat(full)
-				.isNotEqualTo(otherEmpty)
-				.isNotEqualTo(sparseLeft)
-				.isNotEqualTo(sparseRight)
-		        .isEqualTo(otherFull);
+		        .isNotEqualTo(otherFull);
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/util/function/Tuple3Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple3Test.java
@@ -68,4 +68,14 @@ public class Tuple3Test {
 				.isNotEqualTo(new Tuple3<>(1, 2, 10))
 	            .isEqualTo(new Tuple3<>(1, 2, 3));
 	}
+
+	@Test
+	public void sanityTestHashcode() {
+		Tuple3<Integer, Integer, Integer> same = new Tuple3<>(1, 2, 3);
+		Tuple3<Integer, Integer, Integer> different = new Tuple3<>(1, 2, 1);
+
+		assertThat(full.hashCode())
+				.isEqualTo(same.hashCode())
+				.isNotEqualTo(different.hashCode());
+	}
 }

--- a/reactor-core/src/test/java/reactor/util/function/Tuple3Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple3Test.java
@@ -19,28 +19,17 @@ package reactor.util.function;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class Tuple3Test {
 
-	private Tuple3<Integer, Integer, Integer> empty = new Tuple3<>(null, null, null);
 	private Tuple3<Integer, Integer, Integer> full = new Tuple3<>(1, 2, 3);
 
 	@Test
-	public void sparseToString() {
-		assertThat(new Tuple3<>(null, 2, 3))
-				.hasToString("[,2,3]");
-
-		assertThat(new Tuple3<>(1, null, 3))
-				.hasToString("[1,,3]");
-
-		assertThat(new Tuple3<>(1, 2, null))
-				.hasToString("[1,2,]");
-	}
-
-	@Test
-	public void nullsCountedInSize() {
-		assertThat(empty.size()).isEqualTo(3);
-		assertThat(empty).hasSize(3);
+	public void nullT3Rejected() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> new Tuple3<>(1, 2, null))
+				.withMessage("t3");
 	}
 
 	@Test
@@ -63,21 +52,6 @@ public class Tuple3Test {
 	}
 
 	@Test
-	public void sparseIsNotSameAsSmaller() {
-		Tuple3<Integer, Integer, Integer> sparseLeft = new Tuple3<>(null, 1, 2);
-		Tuple3<Integer, Integer, Integer> sparseRight = new Tuple3<>(1, 2, null);
-		Tuple2<Integer, Integer> smaller = new Tuple2<>(1, 2);
-
-		assertThat(sparseLeft.hashCode())
-				.isNotEqualTo(sparseRight.hashCode())
-				.isNotEqualTo(smaller.hashCode());
-
-		assertThat(sparseLeft)
-				.isNotEqualTo(sparseRight)
-				.isNotEqualTo(smaller);
-	}
-
-	@Test
 	public void equalityOfSameReference() {
 		assertThat(full).isEqualTo(full);
 	}
@@ -90,12 +64,7 @@ public class Tuple3Test {
 
 	@Test
 	public void t3Combinations() {
-		assertThat(new Tuple3<>(1, 2, null))
-				.isEqualTo(new Tuple3<>(1, 2, null))
-	            .isNotEqualTo(new Tuple3<>(1, 2, 10));
-
 		assertThat(new Tuple3<>(1, 2, 3))
-				.isNotEqualTo(new Tuple3<>(1, 2, null))
 				.isNotEqualTo(new Tuple3<>(1, 2, 10))
 	            .isEqualTo(new Tuple3<>(1, 2, 3));
 	}

--- a/reactor-core/src/test/java/reactor/util/function/Tuple4Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple4Test.java
@@ -19,28 +19,17 @@ package reactor.util.function;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class Tuple4Test {
 
-	private Tuple4<Integer, Integer, Integer, Integer> empty = new Tuple4<>(null, null, null, null);
 	private Tuple4<Integer, Integer, Integer, Integer> full = new Tuple4<>(1, 2, 3, 4);
 
 	@Test
-	public void sparseToString() {
-		assertThat(new Tuple4<>(null, 2, 3, 4))
-				.hasToString("[,2,3,4]");
-
-		assertThat(new Tuple4<>(1, null, 3, 4))
-				.hasToString("[1,,3,4]");
-
-		assertThat(new Tuple4<>(1, 2, 3,null))
-				.hasToString("[1,2,3,]");
-	}
-
-	@Test
-	public void nullsCountedInSize() {
-		assertThat(empty.size()).isEqualTo(4);
-		assertThat(empty).hasSize(4);
+	public void nullT4Rejected() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> new Tuple4<>(1, 2, 3, null))
+				.withMessage("t4");
 	}
 
 	@Test
@@ -63,21 +52,6 @@ public class Tuple4Test {
 	}
 
 	@Test
-	public void sparseIsNotSameAsSmaller() {
-		Tuple4<Integer, Integer, Integer, Integer> sparseLeft = new Tuple4<>(null, 1, 2, 3);
-		Tuple4<Integer, Integer, Integer, Integer> sparseRight = new Tuple4<>(1, 2, 3, null);
-		Tuple3<Integer, Integer, Integer> smaller = new Tuple3<>(1, 2, 3);
-
-		assertThat(sparseLeft.hashCode())
-				.isNotEqualTo(sparseRight.hashCode())
-				.isNotEqualTo(smaller.hashCode());
-
-		assertThat(sparseLeft)
-				.isNotEqualTo(sparseRight)
-				.isNotEqualTo(smaller);
-	}
-
-	@Test
 	public void equalityOfSameReference() {
 		assertThat(full).isEqualTo(full);
 	}
@@ -90,12 +64,7 @@ public class Tuple4Test {
 
 	@Test
 	public void t4Combinations() {
-		assertThat(new Tuple4<>(1, 2, 3, null))
-				.isEqualTo(new Tuple4<>(1, 2, 3, null))
-				.isNotEqualTo(new Tuple4<>(1, 2, 3, 10));
-
 		assertThat(new Tuple4<>(1, 2, 3, 4))
-				.isNotEqualTo(new Tuple4<>(1, 2, 3, null))
 				.isNotEqualTo(new Tuple4<>(1, 2, 3, 10))
 				.isEqualTo(new Tuple4<>(1, 2, 3, 4));
 	}

--- a/reactor-core/src/test/java/reactor/util/function/Tuple4Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple4Test.java
@@ -68,4 +68,14 @@ public class Tuple4Test {
 				.isNotEqualTo(new Tuple4<>(1, 2, 3, 10))
 				.isEqualTo(new Tuple4<>(1, 2, 3, 4));
 	}
+
+	@Test
+	public void sanityTestHashcode() {
+		Tuple4<Integer, Integer, Integer, Integer> same = new Tuple4<>(1, 2, 3, 4);
+		Tuple4<Integer, Integer, Integer, Integer> different = new Tuple4<>(1, 2, 3, 1);
+
+		assertThat(full.hashCode())
+				.isEqualTo(same.hashCode())
+				.isNotEqualTo(different.hashCode());
+	}
 }

--- a/reactor-core/src/test/java/reactor/util/function/Tuple5Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple5Test.java
@@ -19,28 +19,17 @@ package reactor.util.function;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class Tuple5Test {
 
-	private Tuple5<Integer, Integer, Integer, Integer, Integer> empty = new Tuple5<>(null, null, null, null, null);
 	private Tuple5<Integer, Integer, Integer, Integer, Integer> full = new Tuple5<>(1, 2, 3, 4, 5);
 
 	@Test
-	public void sparseToString() {
-		assertThat(new Tuple5<>(null, 2, 3, 4, 5))
-				.hasToString("[,2,3,4,5]");
-
-		assertThat(new Tuple5<>(1, null, null, 4, 5))
-				.hasToString("[1,,,4,5]");
-
-		assertThat(new Tuple5<>(1, 2, 3, 4, null))
-				.hasToString("[1,2,3,4,]");
-	}
-
-	@Test
-	public void nullsCountedInSize() {
-		assertThat(empty.size()).isEqualTo(5);
-		assertThat(empty).hasSize(5);
+	public void nullT5Rejected() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> new Tuple5<>(1, 2, 3, 4, null))
+				.withMessage("t5");
 	}
 
 	@Test
@@ -63,21 +52,6 @@ public class Tuple5Test {
 	}
 
 	@Test
-	public void sparseIsNotSameAsSmaller() {
-		Tuple5<Integer, Integer, Integer, Integer, Integer> sparseLeft = new Tuple5<>(null, 1, 2, 3, 4);
-		Tuple5<Integer, Integer, Integer, Integer, Integer> sparseRight = new Tuple5<>(1, 2, 3, 4, null);
-		Tuple4<Integer, Integer, Integer, Integer> smaller = new Tuple4<>(1, 2, 3, 4);
-
-		assertThat(sparseLeft.hashCode())
-				.isNotEqualTo(sparseRight.hashCode())
-				.isNotEqualTo(smaller.hashCode());
-
-		assertThat(sparseLeft)
-				.isNotEqualTo(sparseRight)
-				.isNotEqualTo(smaller);
-	}
-
-	@Test
 	public void equalityOfSameReference() {
 		assertThat(full).isEqualTo(full);
 	}
@@ -90,12 +64,7 @@ public class Tuple5Test {
 
 	@Test
 	public void t5Combinations() {
-		assertThat(new Tuple5<>(1, 2, 3, 4, null))
-				.isEqualTo(new Tuple5<>(1, 2, 3, 4, null))
-				.isNotEqualTo(new Tuple5<>(1, 2, 3, 4, 10));
-
 		assertThat(new Tuple5<>(1, 2, 3, 4, 5))
-				.isNotEqualTo(new Tuple5<>(1, 2, 3, 4, null))
 				.isNotEqualTo(new Tuple5<>(1, 2, 3, 4, 10))
 				.isEqualTo(new Tuple5<>(1, 2, 3, 4, 5));
 	}

--- a/reactor-core/src/test/java/reactor/util/function/Tuple5Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple5Test.java
@@ -68,4 +68,14 @@ public class Tuple5Test {
 				.isNotEqualTo(new Tuple5<>(1, 2, 3, 4, 10))
 				.isEqualTo(new Tuple5<>(1, 2, 3, 4, 5));
 	}
+
+	@Test
+	public void sanityTestHashcode() {
+		Tuple5<Integer, Integer, Integer, Integer, Integer> same = new Tuple5<>(1, 2, 3, 4, 5);
+		Tuple5<Integer, Integer, Integer, Integer, Integer> different = new Tuple5<>(1, 2, 3, 4, 1);
+
+		assertThat(full.hashCode())
+				.isEqualTo(same.hashCode())
+				.isNotEqualTo(different.hashCode());
+	}
 }

--- a/reactor-core/src/test/java/reactor/util/function/Tuple6Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple6Test.java
@@ -70,4 +70,14 @@ public class Tuple6Test {
 				.isNotEqualTo(new Tuple6<>(1, 2, 3, 4, 5, 10))
 				.isEqualTo(new Tuple6<>(1, 2, 3, 4, 5, 6));
 	}
+
+	@Test
+	public void sanityTestHashcode() {
+		Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> same = new Tuple6<>(1, 2, 3, 4, 5, 6);
+		Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> different = new Tuple6<>(1, 2, 3, 4, 5, 1);
+
+		assertThat(full.hashCode())
+				.isEqualTo(same.hashCode())
+				.isNotEqualTo(different.hashCode());
+	}
 }

--- a/reactor-core/src/test/java/reactor/util/function/Tuple6Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple6Test.java
@@ -19,30 +19,18 @@ package reactor.util.function;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class Tuple6Test {
 
-	private Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> empty =
-			new Tuple6<>(null, null, null, null, null, null);
 	private Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> full =
 			new Tuple6<>(1, 2, 3, 4, 5, 6);
 
 	@Test
-	public void sparseToString() {
-		assertThat(new Tuple6<>(null, 2, 3, 4, 5, 6))
-				.hasToString("[,2,3,4,5,6]");
-
-		assertThat(new Tuple6<>(1, null, 3, 4, null, 6))
-				.hasToString("[1,,3,4,,6]");
-
-		assertThat(new Tuple6<>(1, 2, 3, 4, 5, null))
-				.hasToString("[1,2,3,4,5,]");
-	}
-
-	@Test
-	public void nullsCountedInSize() {
-		assertThat(empty.size()).isEqualTo(6);
-		assertThat(empty).hasSize(6);
+	public void nullT6Rejected() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> new Tuple6<>(1, 2, 3, 4, 5, null))
+				.withMessage("t6");
 	}
 
 	@Test
@@ -66,21 +54,6 @@ public class Tuple6Test {
 	}
 
 	@Test
-	public void sparseIsNotSameAsSmaller() {
-		Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> sparseLeft = new Tuple6<>(null, 1, 2, 3, 4, 5);
-		Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> sparseRight = new Tuple6<>(1, 2, 3, 4, 5, null);
-		Tuple5<Integer, Integer, Integer, Integer, Integer> smaller = new Tuple5<>(1, 2, 3, 4, 5);
-
-		assertThat(sparseLeft.hashCode())
-				.isNotEqualTo(sparseRight.hashCode())
-				.isNotEqualTo(smaller.hashCode());
-
-		assertThat(sparseLeft)
-				.isNotEqualTo(sparseRight)
-				.isNotEqualTo(smaller);
-	}
-
-	@Test
 	public void equalityOfSameReference() {
 		assertThat(full).isEqualTo(full);
 	}
@@ -93,12 +66,7 @@ public class Tuple6Test {
 
 	@Test
 	public void t6Combinations() {
-		assertThat(new Tuple6<>(1, 2, 3, 4, 5, null))
-				.isEqualTo(new Tuple6<>(1, 2, 3, 4, 5, null))
-				.isNotEqualTo(new Tuple6<>(1, 2, 3, 4, 5, 10));
-
 		assertThat(new Tuple6<>(1, 2, 3, 4, 5, 6))
-				.isNotEqualTo(new Tuple6<>(1, 2, 3, 4, 5, null))
 				.isNotEqualTo(new Tuple6<>(1, 2, 3, 4, 5, 10))
 				.isEqualTo(new Tuple6<>(1, 2, 3, 4, 5, 6));
 	}

--- a/reactor-core/src/test/java/reactor/util/function/Tuple7Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple7Test.java
@@ -19,30 +19,18 @@ package reactor.util.function;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class Tuple7Test {
 
-	private Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> empty =
-			new Tuple7<>(null, null, null, null, null, null, null);
 	private Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> full =
 			new Tuple7<>(1, 2, 3, 4, 5, 6, 7);
 
 	@Test
-	public void sparseToString() {
-		assertThat(new Tuple7<>(null, 2, 3, 4, 5, 6, 7))
-				.hasToString("[,2,3,4,5,6,7]");
-
-		assertThat(new Tuple7<>(1, 2, 3, 4, null, null, 7))
-				.hasToString("[1,2,3,4,,,7]");
-
-		assertThat(new Tuple7<>(1, 2, 3, 4, 5, 6, null))
-				.hasToString("[1,2,3,4,5,6,]");
-	}
-
-	@Test
-	public void nullsCountedInSize() {
-		assertThat(empty.size()).isEqualTo(7);
-		assertThat(empty).hasSize(7);
+	public void nullT7Rejected() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> new Tuple7<>(1, 2, 3, 4, 5, 6, null))
+				.withMessage("t7");
 	}
 
 	@Test
@@ -65,21 +53,6 @@ public class Tuple7Test {
 	}
 
 	@Test
-	public void sparseIsNotSameAsSmaller() {
-		Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> sparseLeft = new Tuple7<>(null, 1, 2, 3, 4, 5, 6);
-		Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> sparseRight = new Tuple7<>(1, 2, 3, 4, 5, 6, null);
-		Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> smaller = new Tuple6<>(1, 2, 3, 4, 5, 6);
-
-		assertThat(sparseLeft.hashCode())
-				.isNotEqualTo(sparseRight.hashCode())
-				.isNotEqualTo(smaller.hashCode());
-
-		assertThat(sparseLeft)
-				.isNotEqualTo(sparseRight)
-				.isNotEqualTo(smaller);
-	}
-
-	@Test
 	public void equalityOfSameReference() {
 		assertThat(full).isEqualTo(full);
 	}
@@ -92,12 +65,7 @@ public class Tuple7Test {
 
 	@Test
 	public void t7Combinations() {
-		assertThat(new Tuple7<>(1, 2, 3, 4, 5, 6, null))
-				.isEqualTo(new Tuple7<>(1, 2, 3, 4, 5, 6, null))
-				.isNotEqualTo(new Tuple7<>(1, 2, 3, 4, 5, 6, 10));
-
 		assertThat(new Tuple7<>(1, 2, 3, 4, 5, 6, 7))
-				.isNotEqualTo(new Tuple7<>(1, 2, 3, 4, 5, 6, null))
 				.isNotEqualTo(new Tuple7<>(1, 2, 3, 4, 5, 6, 10))
 				.isEqualTo(new Tuple7<>(1, 2, 3, 4, 5, 6, 7));
 	}

--- a/reactor-core/src/test/java/reactor/util/function/Tuple7Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple7Test.java
@@ -69,4 +69,14 @@ public class Tuple7Test {
 				.isNotEqualTo(new Tuple7<>(1, 2, 3, 4, 5, 6, 10))
 				.isEqualTo(new Tuple7<>(1, 2, 3, 4, 5, 6, 7));
 	}
+
+	@Test
+	public void sanityTestHashcode() {
+		Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> same = new Tuple7<>(1, 2, 3, 4, 5, 6, 7);
+		Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> different = new Tuple7<>(1, 2, 3, 4, 5, 6,1);
+
+		assertThat(full.hashCode())
+				.isEqualTo(same.hashCode())
+				.isNotEqualTo(different.hashCode());
+	}
 }

--- a/reactor-core/src/test/java/reactor/util/function/Tuple8Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple8Test.java
@@ -69,4 +69,16 @@ public class Tuple8Test {
 				.isNotEqualTo(new Tuple8<>(1, 2, 3, 4, 5, 6, 7, 10))
 				.isEqualTo(new Tuple8<>(1, 2, 3, 4, 5, 6, 7, 8));
 	}
+
+	@Test
+	public void sanityTestHashcode() {
+		Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>
+				same = new Tuple8<>(1, 2, 3, 4, 5, 6, 7, 8);
+		Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>
+				different = new Tuple8<>(1, 2, 3, 4, 5, 6, 7, 1);
+
+		assertThat(full.hashCode())
+				.isEqualTo(same.hashCode())
+				.isNotEqualTo(different.hashCode());
+	}
 }

--- a/reactor-core/src/test/java/reactor/util/function/Tuple8Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple8Test.java
@@ -19,30 +19,18 @@ package reactor.util.function;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class Tuple8Test {
 
-	private Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> empty =
-			new Tuple8<>(null, null, null, null, null, null, null, null);
 	private Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> full =
 			new Tuple8<>(1, 2, 3, 4, 5, 6, 7, 8);
 
 	@Test
-	public void sparseToString() {
-		assertThat(new Tuple8<>(null, 2, 3, 4, 5, 6, 7, 8))
-				.hasToString("[,2,3,4,5,6,7,8]");
-
-		assertThat(new Tuple8<>(1, 2, 3, 4, 5, null, null, 8))
-				.hasToString("[1,2,3,4,5,,,8]");
-
-		assertThat(new Tuple8<>(1, 2, 3, 4, 5, 6, 7, null))
-				.hasToString("[1,2,3,4,5,6,7,]");
-	}
-
-	@Test
-	public void nullsCountedInSize() {
-		assertThat(empty.size()).isEqualTo(8);
-		assertThat(empty).hasSize(8);
+	public void nullT8Rejected() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> new Tuple8<>(1, 2, 3, 4, 5, 6, 7, null))
+				.withMessage("t8");
 	}
 
 	@Test
@@ -65,21 +53,6 @@ public class Tuple8Test {
 	}
 
 	@Test
-	public void sparseIsNotSameAsSmaller() {
-		Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> sparseLeft = new Tuple8<>(null, 1, 2, 3, 4, 5, 6, 7);
-		Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> sparseRight = new Tuple8<>(1, 2, 3, 4, 5, 6, 7, null);
-		Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> smaller = new Tuple7<>(1, 2, 3, 4, 5, 6, 7);
-
-		assertThat(sparseLeft.hashCode())
-				.isNotEqualTo(sparseRight.hashCode())
-	            .isNotEqualTo(smaller.hashCode());
-
-		assertThat(sparseLeft)
-				.isNotEqualTo(sparseRight)
-	            .isNotEqualTo(smaller);
-	}
-
-	@Test
 	public void equalityOfSameReference() {
 		assertThat(full).isEqualTo(full);
 	}
@@ -92,12 +65,7 @@ public class Tuple8Test {
 
 	@Test
 	public void t8Combinations() {
-		assertThat(new Tuple8<>(1, 2, 3, 4, 5, 6, 7, null))
-				.isEqualTo(new Tuple8<>(1, 2, 3, 4, 5, 6, 7, null))
-				.isNotEqualTo(new Tuple8<>(1, 2, 3, 4, 5, 6, 7, 10));
-
 		assertThat(new Tuple8<>(1, 2, 3, 4, 5, 6, 7, 8))
-				.isNotEqualTo(new Tuple8<>(1, 2, 3, 4, 5, 6, 7, null))
 				.isNotEqualTo(new Tuple8<>(1, 2, 3, 4, 5, 6, 7, 10))
 				.isEqualTo(new Tuple8<>(1, 2, 3, 4, 5, 6, 7, 8));
 	}

--- a/reactor-core/src/test/java/reactor/util/function/TupleTests.java
+++ b/reactor-core/src/test/java/reactor/util/function/TupleTests.java
@@ -71,26 +71,21 @@ public class TupleTests {
 	public void fromArrayRejects0() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
 		          .isThrownBy(() -> Tuples.fromArray(new Object[0]))
-		          .withMessageStartingWith("null or empty array, need between 1 and 8 values");
+		          .withMessageStartingWith("null or too small array, need between 2 and 8 values");
+	}
+
+	@Test
+	public void fromArrayRejects1() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+		          .isThrownBy(() -> Tuples.fromArray(new Object[1]))
+		          .withMessageStartingWith("null or too small array, need between 2 and 8 values");
 	}
 
 	@Test
 	public void fromArrayRejectsNull() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
 		          .isThrownBy(() -> Tuples.fromArray(null))
-		          .withMessageStartingWith("null or empty array, need between 1 and 8 values");
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void tuple2CreatedFromArray1() {
-		Integer[] source = new Integer[] { 1 };
-		Tuple2 expected = Tuples.of(1, null);
-		Tuple2 actual = Tuples.fromArray(source);
-
-		assertThat(actual)
-		          .isExactlyInstanceOf(Tuple2.class)
-		          .isEqualTo(expected);
+		          .withMessageStartingWith("null or too small array, need between 2 and 8 values");
 	}
 
 	@Test
@@ -183,7 +178,7 @@ public class TupleTests {
 
 		assertThatExceptionOfType(IllegalArgumentException.class)
 		          .isThrownBy(() -> Tuples.fromArray(source))
-		          .withMessage("too many arguments (9), need between 1 and 8 values");
+		          .withMessage("too many arguments (9), need between 2 and 8 values");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/function/TupleTests.java
+++ b/reactor-core/src/test/java/reactor/util/function/TupleTests.java
@@ -407,4 +407,18 @@ public class TupleTests {
 		assertThat(result).isEqualTo(36);
 	}
 
+	@Test
+	public void tupleStringRepresentationFull() {
+		assertThat(Tuples.tupleStringRepresentation(1, 2, 3, 4, 5)
+		                 .toString())
+				.isEqualTo("1,2,3,4,5");
+	}
+
+	@Test
+	public void tupleStringRepresentationSparse() {
+		assertThat(Tuples.tupleStringRepresentation(null, 2, null, 4, 5, null)
+		                 .toString())
+				.isEqualTo(",2,,4,5,");
+	}
+
 }

--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -1731,9 +1731,9 @@ final class DefaultStepVerifierBuilder<T>
 			//noinspection ConstantConditions
 			satisfies(() -> clazz != null, () -> "Require non-null clazz");
 			hasOneOperatorErrorWithError();
-			return satisfies(() -> clazz.isInstance(operatorErrors.peek().getT1()),
+			return satisfies(() -> clazz.isInstance(operatorErrors.peek().getT1().get()),
 					() -> String.format("Expected operator error to be of type %s, was %s.",
-							clazz.getCanonicalName(), operatorErrors.peek().getT1().getClass().getCanonicalName()));
+							clazz.getCanonicalName(), operatorErrors.peek().getT1().get().getClass().getCanonicalName()));
 		}
 
 		@Override

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -19,6 +19,7 @@ package reactor.test;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -1044,14 +1045,14 @@ public interface StepVerifier {
 		 * Assert that the tested publisher has triggered the {@link Hooks#onOperatorError(BiFunction) onOperatorError} hook
 		 * once or more, and assert the errors and optionally associated data as a collection.
 		 */
-		Assertions hasOperatorErrorsSatisfying(Consumer<Collection<Tuple2<Throwable, ?>>> errorsConsumer);
+		Assertions hasOperatorErrorsSatisfying(Consumer<Collection<Tuple2<Optional<Throwable>, Optional<?>>>> errorsConsumer);
 
 		/**
 		 * Assert that the tested publisher has triggered the {@link Hooks#onOperatorError(BiFunction) onOperatorError} hook
 		 * once or more, and check that the collection of errors and their optionally
 		 * associated data matches a predicate.
 		 */
-		Assertions hasOperatorErrorsMatching(Predicate<Collection<Tuple2<Throwable, ?>>> errorsConsumer);
+		Assertions hasOperatorErrorsMatching(Predicate<Collection<Tuple2<Optional<Throwable>, Optional<?>>>> errorsConsumer);
 
 		/**
 		 * Assert that the whole verification took strictly less than the provided

--- a/reactor-test/src/test/java/reactor/test/StepVerifierAssertionsTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierAssertionsTests.java
@@ -366,8 +366,8 @@ public class StepVerifierAssertionsTests {
 			fail("expected an AssertionError");
 		}
 		catch (AssertionError ae) {
-			assertThat(ae).hasMessage("Expected operator error matching the given predicate," +
-					" did not match: <[java.lang.IllegalStateException: boom1,]>.");
+			assertThat(ae).hasMessage("Expected operator error matching the given predicate, " +
+					"did not match: <[Optional[java.lang.IllegalStateException: boom1],Optional.empty]>.");
 		}
 	}
 
@@ -412,9 +412,9 @@ public class StepVerifierAssertionsTests {
 			fail("expected an AssertionError");
 		}
 		catch (AssertionError ae) {
-			assertThat(ae).hasMessageEndingWith("Expected size:<3> but was:<2> in:\n" +
-					"<[[java.lang.IllegalStateException: boom2,],\n" +
-					"    [java.lang.IllegalStateException: boom3,]]>");
+			assertThat(ae).hasMessageStartingWith("\nExpected size:<3> but was:<2> in:\n")
+			              .hasMessageContaining("boom2")
+			              .hasMessageContaining("boom3");
 		}
 	}
 
@@ -436,9 +436,10 @@ public class StepVerifierAssertionsTests {
 			fail("expected an AssertionError");
 		}
 		catch (AssertionError ae) {
-			assertThat(ae).hasMessage("Expected collection of operator errors matching the" +
-					" given predicate, did not match: <[[java.lang.IllegalStateException: boom2,]," +
-					" [java.lang.IllegalStateException: boom3,]]>.");
+			assertThat(ae).hasMessageStartingWith("Expected collection of operator errors matching the" +
+					" given predicate, did not match: <[[")
+			              .hasMessageContaining("boom2")
+			              .hasMessageContaining("boom3");
 		}
 	}
 


### PR DESCRIPTION
Tuples are primarily meant as a companion util class for reactor-related
usage, so it is legitimate for them to have the same level of non-null
strictness as enforced by the Reactive Streams specification.

This will have the benefit of preventing compiler and tools warnings
when dereferencing the Tuple values, especially in operators that build
a Tuple for you like elapsed, timestamp, zip, when... All these being
guaranteed to fill the Tuples with non-null values anyway, as they take
them from their onNext values.