### PR TITLE
improve Mono and Flux javadoc wording on contextMap/contextGet

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3126,7 +3126,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	/**
 	 * Enrich a potentially empty upstream {@link Context}, producing a new {@link Context}
 	 * that is propagated downstream. If the returned {@link Context} is empty, the
-	 * propagation will be halted. The method is potentially invoked twice.
+	 * propagation will be halted.
 	 * <p>
 	 * Lifecycle for {@link Context} propagation is as such :
 	 * <ol>

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3124,29 +3124,37 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Propagate a new {@link Context} given an eventual older parent {@link Context}.
-	 * If the returned {@link Context} is empty, the propagation will be halted.
+	 * Enrich a potentially empty upstream {@link Context}, producing a new {@link Context}
+	 * that is propagated downstream. If the returned {@link Context} is empty, the
+	 * propagation will be halted. The method is potentially invoked twice.
 	 * <p>
-	 *     Lifecycle for {@link Context} propagation is as such :
-	 *     <ol>
-	 *     <li> During right-to-left subscribe(Subscriber) phase, contextMap will
-	 *     read the target {@link Subscriber} context if any and cache it.</li>
-	 *     <li> Before left-to-right onSubscribe(Subscription), {@link Context}
-	 *     might be propagated from parent. If this happens, the given
-	 *     {@link Function} will be invoked with this new {@link Context}
+	 * Lifecycle for {@link Context} propagation is as such :
+	 * <ol>
+	 *     <li>
+	 *         During right-to-left {@code subscribe(Subscriber)} phase, contextMap will
+	 *         read the target {@link Subscriber} context if any and cache it.
 	 *     </li>
-	 *     <li> If no context was propagated before left-to-right onSubscribe
-	 *     (Subscription) phase, contextMap will
-	 *     call the given {@link Function} during onSubscribe(Subscription) with the
-	 *     cached
-	 *     {@link Context} or default to an empty one.</li>
-	 *     <li>contextMap will propagate the resulting {@link Context} if non
-	 *     empty and != from cached context before the downstream actual {@code
-	 *     Subscriber#onSubscribe(Subscription)}</li>
-	 *     </ol>
+	 *     <li>
+	 *         Before left-to-right {@code onSubscribe(Subscription)}, {@link Context}
+	 *         might be propagated from parent. If this happens, the given
+	 *         {@link Function} will be invoked with this new {@link Context}.
+	 *     </li>
+	 *     <li>
+	 *         If no context was propagated before left-to-right {@code onSubscribe(Subscription)}
+	 *         phase, contextMap will call the given {@link Function} during {@code onSubscribe(Subscription)}
+	 *         with the cached {@link Context} or default to an empty one.
+	 *     </li>
+	 *     <li>
+	 *         contextMap will then propagate the resulting {@link Context} if non empty
+	 *         and different from the cached context, before the downstream actual
+	 *         {@code Subscriber#onSubscribe(Subscription)} is invoked.
+	 *     </li>
+	 * </ol>
+	 * <p>
+	 * Note this all happens once per-subscription, not on each onNext.
 	 *
 	 * @param doOnContext the function taking a previous {@link Context} state
-	 *  and returning a candidate new one to propagate (if != and not empty).
+	 *  and returning a new one, propagated if not empty and different from the original.
 	 *
 	 * @return a contextualized {@link Flux}
 	 * @see Context
@@ -3157,13 +3165,15 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Evaluate {@link Context} information for each received element and allow for
-	 * transforming the produced sequence.
+	 * When receiving an element, inspect the current {@link Context} information and
+	 * allow to map to a new value depending on source value and context. Note that the
+	 * {@link Context} is immutable, so any attempt at modifying it as a side effect will
+	 * be ignored by this operator.
 	 *
-	 * @param doOnContext the bifunction evaluating each item with the current
-	 * {@link Context}
+	 * @param doOnContext a {@link BiFunction} receiving the current {@link Context} and
+	 * the currently emitted element, allowing to perform a map operation
 	 *
-	 * @return a {@link Flux} injecting {@link Context} in the produced sequence
+	 * @return a {@link Flux} potentially transformed using information from the {@link Context}
 	 * @see Context
 	 * @see #contextMap
 	 */

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1437,29 +1437,37 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Propagate a new {@link Context} given an eventual older parent {@link Context}.
-	 * If the returned {@link Context} is empty, the propagation will be halted.
+	 * Enrich a potentially empty upstream {@link Context}, producing a new {@link Context}
+	 * that is propagated downstream. If the returned {@link Context} is empty, the
+	 * propagation will be halted. The method is potentially invoked twice.
 	 * <p>
-	 *     Lifecycle for {@link Context} propagation is as such :
-	 *     <ul>
-	 *     <li> #1 During right-to-left subscribe(Subscriber) phase, contextMap will
-	 *     read the target {@link Subscriber} context if any and cache it.</li>
-	 *     <li> #2-A Before left-to-right onSubscribe(Subscription), {@link Context}
-	 *     might be propagated from parent. If this happens, the given
-	 *     {@link Function} will be invoked with this new {@link Context}
+	 * Lifecycle for {@link Context} propagation is as such :
+	 * <ol>
+	 *     <li>
+	 *         During right-to-left {@code subscribe(Subscriber)} phase, contextMap will
+	 *         read the target {@link Subscriber} context if any and cache it.
 	 *     </li>
-	 *     <li> #2-B If no context was propagated before left-to-right onSubscribe
-	 *     (Subscription) phase, contextMap will
-	 *     call the given {@link Function} during onSubscribe(Subscription) with the
-	 *     cached
-	 *     {@link Context} or default to an empty one.</li>
-	 *     <li>contextMap will first propagate the resulting {@link Context} if non
-	 *     empty and != from cached context before the downstream actual {@code
-	 *     Subscriber#onSubscribe(Subscription)}</li>
-	 *     </ul>
+	 *     <li>
+	 *         Before left-to-right {@code onSubscribe(Subscription)}, {@link Context}
+	 *         might be propagated from parent. If this happens, the given
+	 *         {@link Function} will be invoked with this new {@link Context}.
+	 *     </li>
+	 *     <li>
+	 *         If no context was propagated before left-to-right {@code onSubscribe(Subscription)}
+	 *         phase, contextMap will call the given {@link Function} during {@code onSubscribe(Subscription)}
+	 *         with the cached {@link Context} or default to an empty one.
+	 *     </li>
+	 *     <li>
+	 *         contextMap will then propagate the resulting {@link Context} if non empty
+	 *         and different from the cached context, before the downstream actual
+	 *         {@code Subscriber#onSubscribe(Subscription)} is invoked.
+	 *     </li>
+	 * </ol>
+	 * <p>
+	 * Note this all happens once per-subscription, not on each onNext.
 	 *
 	 * @param doOnContext the function taking a previous {@link Context} state
-	 *  and returning a candidate new one to propagate (if != and not empty).
+	 *  and returning a new one, propagated if not empty and different from the original.
 	 *
 	 * @return a contextualized {@link Mono}
 	 * @see Context
@@ -1469,13 +1477,15 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Evaluate {@link Context} information for each received element and allow for
-	 * transforming the produced sequence.
+	 * When receiving the element, inspect the current {@link Context} information and
+	 * allow to map to a new value depending on source value and context. Note that the
+	 * {@link Context} is immutable, so any attempt at modifying it as a side effect will
+	 * be ignored by this operator.
 	 *
-	 * @param doOnContext the bifunction evaluating each item with the current
-	 * {@link Context}
+	 * @param doOnContext a {@link BiFunction} receiving the current {@link Context} and
+	 * the emitted element, allowing to perform a map operation
 	 *
-	 * @return a {@link Mono} injecting {@link Context} in the produced sequence
+	 * @return a {@link Mono} potentially transformed using information from the {@link Context}
 	 * @see Context
 	 * @see #contextMap
 	 */

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1439,7 +1439,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	/**
 	 * Enrich a potentially empty upstream {@link Context}, producing a new {@link Context}
 	 * that is propagated downstream. If the returned {@link Context} is empty, the
-	 * propagation will be halted. The method is potentially invoked twice.
+	 * propagation will be halted.
 	 * <p>
 	 * Lifecycle for {@link Context} propagation is as such :
 	 * <ol>


### PR DESCRIPTION
The javadoc for both methods was a bit unclear. Still have a doubt @smaldini: is the `contextMap` function still potentially invoked twice?