### PR TITLE
fix #620 Add more scannable mappings to several operators

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -328,6 +328,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 		if (key == ScannableAttr.PARENT) return s;
 		if (key == IntAttr.BUFFERED) return getPending();
 		if (key == BooleanAttr.CANCELLED) return isCancelled();
+		if (key == IntAttr.PREFETCH) return getPrefetch();
 
 		return super.scanUnsafe(key);
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxAutoConnect.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxAutoConnect.java
@@ -73,6 +73,7 @@ final class FluxAutoConnect<T> extends Flux<T>
 	public Object scanUnsafe(Attr key) {
 		if (key == IntAttr.PREFETCH) return getPrefetch();
 		if (key == ScannableAttr.PARENT) return source;
+		if (key == IntAttr.CAPACITY) return remaining;
 
 		return null;
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxAutoConnectFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxAutoConnectFuseable.java
@@ -74,6 +74,7 @@ final class FluxAutoConnectFuseable<T> extends Flux<T>
 	public Object scanUnsafe(Attr key) {
 		if (key == IntAttr.PREFETCH) return getPrefetch();
 		if (key == ScannableAttr.PARENT) return source;
+		if (key == IntAttr.CAPACITY) return remaining;
 
 		return null;
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBuffer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBuffer.java
@@ -191,10 +191,11 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxOperator<
 		public Object scanUnsafe(Attr key) {
 			if (key == ScannableAttr.PARENT) return s;
 			if (key == BooleanAttr.TERMINATED) return done;
-			if (key == IntAttr.CAPACITY) {
+			if (key == IntAttr.BUFFERED) {
 				C b = buffer;
 				return b != null ? b.size() : 0;
 			}
+			if (key == IntAttr.CAPACITY) return size;
 			if (key == IntAttr.PREFETCH) return size;
 
 			return InnerOperator.super.scanUnsafe(key);
@@ -344,7 +345,8 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxOperator<
 		public Object scanUnsafe(Attr key) {
 			if (key == ScannableAttr.PARENT) return s;
 			if (key == BooleanAttr.TERMINATED) return done;
-			if (key == IntAttr.CAPACITY) {
+			if (key == IntAttr.CAPACITY) return size;
+			if (key == IntAttr.BUFFERED) {
 				C b = buffer;
 				return b != null ? b.size() : 0;
 			}
@@ -528,6 +530,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxOperator<
 			if (key == BooleanAttr.TERMINATED) return done;
 			if (key == BooleanAttr.CANCELLED) return cancelled;
 			if (key == IntAttr.CAPACITY) return size() * size;
+			if (key == IntAttr.BUFFERED) return stream().mapToInt(Collection::size).sum();
 			if (key == IntAttr.PREFETCH) return Integer.MAX_VALUE;
 			if (key == LongAttr.REQUESTED_FROM_DOWNSTREAM) return requested;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxAutoConnectFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxAutoConnectFuseableTest.java
@@ -33,7 +33,7 @@ public class FluxAutoConnectFuseableTest {
 
 		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(source);
 		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(888);
-//		assertThat(test.scan(Scannable.IntAttr.CAPACITY)).isEqualTo(123);
+		assertThat(test.scan(Scannable.IntAttr.CAPACITY)).isEqualTo(123);
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxAutoConnectTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxAutoConnectTest.java
@@ -87,7 +87,7 @@ public class FluxAutoConnectTest {
 		FluxAutoConnect<String> test = new FluxAutoConnect<>(source, 123, d -> { });
 
 		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(888);
-//		assertThat(test.scan(Scannable.IntAttr.CAPACITY)).isEqualTo(123);
+		assertThat(test.scan(Scannable.IntAttr.CAPACITY)).isEqualTo(123);
 		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(source);
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
@@ -318,7 +318,8 @@ public class MonoFilterWhenTest {
 	@Test
 	public void scanSubscriber() {
 		Subscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
-		MonoFilterWhen.MonoFilterWhenSubscriber<String> test = new MonoFilterWhen.MonoFilterWhenSubscriber<>(
+		MonoFilterWhen.MonoFilterWhenMain<String>
+				test = new MonoFilterWhen.MonoFilterWhenMain<>(
 				actual, s -> Mono.just(false), Context.empty());
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
@@ -338,15 +339,16 @@ public class MonoFilterWhenTest {
 	@Test
 	public void scanFilterWhenInner() {
 		Subscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
-		MonoFilterWhen.MonoFilterWhenSubscriber<String> main = new MonoFilterWhen.MonoFilterWhenSubscriber<>(
+		MonoFilterWhen.MonoFilterWhenMain<String>
+				main = new MonoFilterWhen.MonoFilterWhenMain<>(
 				actual, s -> Mono.just(false), Context.empty());
 		MonoFilterWhen.FilterWhenInner test = new MonoFilterWhen.FilterWhenInner(main, true);
 
 		Subscription innerSubscription = Operators.emptySubscription();
 		test.onSubscribe(innerSubscription);
 
-		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(main);
-		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(innerSubscription);
+		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(main);
+		assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(innerSubscription);
 
 		assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
 		assertThat(test.scan(Scannable.LongAttr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(1L);


### PR DESCRIPTION
 - `EmitterProcessor`: add PREFETCH
 - `FluxAutoConnect` variants: CAPACITY represent remaining needed
 subscriptions before auto-connecting
 - `FluxBuffer` (aka exact buffer, overlapping buffer and dropping
 buffer variants): CAPACITY now represents the buffer maxSizes, while
 added BUFFERED gives the current total number of elements in the
 buffer(s)
 - `ConcatMapImmediate`: TERMINATED returns true if an error has been
 emitted downstream
 - `Mono#FilterWhenInner`: main is now ACTUAL, innerSubscription is now
 PARENT