### PR TITLE
Add support for scalar error

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Fuseable.java
+++ b/reactor-core/src/main/java/reactor/core/Fuseable.java
@@ -196,14 +196,11 @@ public interface Fuseable {
 	}
 
 	/**
-	 * Marker interface indicating that the target can return a value or null
-	 * immediately and thus a viable target for assembly-time optimizations.
+	 * Marker interface indicating that the target can return a value or null,
+	 * otherwise fail immediately and thus a viable target for assembly-time
+	 * optimizations.
 	 *
 	 * @param <T> the value type returned
 	 */
-	interface ScalarCallable<T> extends Callable<T> {
-        @Override
-        @Nullable
-        T call();
-	}
+	interface ScalarCallable<T> extends Callable<T> { }
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxEmpty.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxEmpty.java
@@ -55,7 +55,7 @@ extends Flux<Object>
 
 	@Override
 	@Nullable
-	public Object call() {
+	public Object call() throws Exception {
 		return null; /* Scalar optimizations on empty */
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxJust.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxJust.java
@@ -59,7 +59,7 @@ final class FluxJust<T> extends Flux<T> implements Fuseable.ScalarCallable<T>, F
 	}
 
 	@Override
-	public T call() {
+	public T call() throws Exception {
 		return value;
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoEmpty.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoEmpty.java
@@ -58,7 +58,7 @@ extends Mono<Object>
 
 	@Override
 	@Nullable
-	public Object call() {
+	public Object call() throws Exception {
 		return null; /* Scalar optimizations on empty */
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoError.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoError.java
@@ -20,6 +20,8 @@ import java.util.Objects;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
+import reactor.core.Fuseable;
+
 
 /**
  * Emits a constant or generated Throwable instance to Subscribers.
@@ -27,7 +29,7 @@ import reactor.core.Exceptions;
  * @param <T> the value type
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
-final class MonoError<T> extends Mono<T> {
+final class MonoError<T> extends Mono<T> implements Fuseable.ScalarCallable{
 
 	final Throwable error;
 
@@ -48,5 +50,13 @@ final class MonoError<T> extends Mono<T> {
 	@Override
 	public void subscribe(CoreSubscriber<? super T> s) {
 		Operators.error(s, Operators.onOperatorError(error));
+	}
+
+	@Override
+	public Object call() throws Exception {
+		if(error instanceof Exception){
+			throw ((Exception)error);
+		}
+		throw Exceptions.propagate(error);
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoJust.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoJust.java
@@ -35,7 +35,7 @@ extends Mono<T>
 	}
 
 	@Override
-	public T call() {
+	public T call() throws Exception {
 		return value;
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxErrorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxErrorTest.java
@@ -31,11 +31,17 @@ public class FluxErrorTest {
 		            .verifyErrorMessage("test");
 	}
 
+	@Test
+	public void normalOnRequest() {
+		StepVerifier.create(Flux.error(new Exception("test"), true))
+		            .verifyErrorMessage("test");
+	}
+
     @Test
     public void scanSubscription() {
 	    @SuppressWarnings("unchecked") CoreSubscriber<String> subscriber = Mockito.mock(CoreSubscriber.class);
-        FluxError.ErrorSubscription test =
-                new FluxError.ErrorSubscription(subscriber, new IllegalStateException("boom"));
+        FluxErrorOnRequest.ErrorSubscription test =
+                new FluxErrorOnRequest.ErrorSubscription(subscriber, new IllegalStateException("boom"));
 
         assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).isFalse();
         assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
@@ -49,8 +55,8 @@ public class FluxErrorTest {
     public void scanSubscriptionCancelled() {
 	    @SuppressWarnings("unchecked")
 	    CoreSubscriber<String> subscriber = Mockito.mock(CoreSubscriber.class);
-        FluxError.ErrorSubscription test =
-                new FluxError.ErrorSubscription(subscriber, new IllegalStateException("boom"));
+	    FluxErrorOnRequest.ErrorSubscription test =
+                new FluxErrorOnRequest.ErrorSubscription(subscriber, new IllegalStateException("boom"));
 
         assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
         test.cancel();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -486,7 +486,7 @@ public class FluxFlatMapTest {
 	@Test
 	public void failPublisherDelay() {
 		StepVerifier.create(Flux.just(1, 2, 3)
-		                        .flatMapDelayError(d -> Flux.error(new Exception("test")),
+		                        .flatMapDelayError(d -> Flux.error(new Exception("test")).hide(),
 				                        1,
 				                        1))
 		            .verifyErrorMessage("Multiple exceptions");

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeTest.java
@@ -112,7 +112,7 @@ public class FluxMergeTest {
 		IllegalStateException boom = new IllegalStateException("boom");
 
 		StepVerifier.create(Flux.mergeDelayError(32,
-				Flux.error(boom),
+				Flux.error(boom).hide(),
 				Flux.range(1, 4)
 		))
 		            .expectNext(1, 2, 3, 4)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekStatefulTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekStatefulTest.java
@@ -97,7 +97,7 @@ public class FluxPeekStatefulTest {
 		LongAdder seedCount = new LongAdder();
 		LongAdder state = new LongAdder();
 
-		new FluxPeekStateful<>(new FluxError<Integer>(new RuntimeException("forced " + "failure"),	false),
+		new FluxPeekStateful<>(new FluxError<Integer>(new RuntimeException("forced " + "failure")),
 				() -> {
 					seedCount.increment();
 					return state;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
@@ -306,7 +306,7 @@ public class FluxPeekTest extends FluxOperatorTest<String, String> {
 		AtomicBoolean onAfterComplete = new AtomicBoolean();
 		AtomicBoolean onCancel = new AtomicBoolean();
 
-		new FluxPeek<>(new FluxError<>(new RuntimeException("forced failure"), false),
+		new FluxPeek<>(new FluxError<>(new RuntimeException("forced failure")),
 				onSubscribe::set,
 				onNext::set,
 				onError::set,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
@@ -43,6 +43,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Subscription;
+
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
@@ -277,18 +278,17 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void error() {
-		AssertSubscriber<Integer> ts = AssertSubscriber.create();
+		StepVerifier.create(Flux.error(new RuntimeException("forced failure"))
+		                        .publishOn(Schedulers.fromExecutorService(exec)))
+		            .verifyErrorMessage("forced failure");
+	}
 
-		Flux.<Integer>error(new RuntimeException("forced failure")).publishOn(Schedulers.fromExecutorService(
-				exec))
-		                                                           .subscribe(ts);
-
-		ts.await(Duration.ofSeconds(5));
-
-		ts.assertNoValues()
-		  .assertError(RuntimeException.class)
-		  .assertErrorMessage("forced failure")
-		  .assertNotComplete();
+	@Test
+	public void errorHide() {
+		StepVerifier.create(Flux.error(new RuntimeException("forced failure"))
+		                        .hide()
+		                        .publishOn(Schedulers.fromExecutorService(exec)))
+		            .verifyErrorMessage("forced failure");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSourceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSourceTest.java
@@ -47,7 +47,24 @@ public class FluxSourceTest {
 		Flux<Integer> m = Flux.from(Mono.just(1));
 		assertTrue(m instanceof FluxJust);
 		StepVerifier.create(m)
-		            .expectNext(1);
+		            .expectNext(1)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void error() {
+		Flux<Integer> m = Flux.from(Mono.error(new Exception("test")));
+		assertTrue(m instanceof FluxError);
+		StepVerifier.create(m)
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void errorPropagate() {
+		Flux<Integer> m = Flux.from(Mono.error(new Error("test")));
+		assertTrue(m instanceof FluxError);
+		StepVerifier.create(m)
+		            .verifyErrorMessage("test");
 	}
 
 
@@ -79,7 +96,14 @@ public class FluxSourceTest {
 	}
 
 	@Test
-	public void fluxEmpty() {
+	public void fluxError() {
+		StepVerifier.create(Mono.error(new Exception("test")).flux())
+		            .verifyErrorMessage("test");
+	}
+
+
+	@Test
+	public void fluxmpty() {
 		StepVerifier.create(Mono.empty().flux())
 		            .verifyComplete();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnCallableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnCallableTest.java
@@ -31,6 +31,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class FluxSubscribeOnCallableTest {
 
 	@Test
+	public void error() {
+		StepVerifier.create(Flux.error(new RuntimeException("forced failure"))
+		                        .subscribeOn(Schedulers.single()))
+		            .verifyErrorMessage("forced failure");
+	}
+
+	@Test
+	public void errorHide() {
+		StepVerifier.create(Flux.error(new RuntimeException("forced failure"))
+		                        .hide()
+		                        .subscribeOn(Schedulers.single()))
+		            .verifyErrorMessage("forced failure");
+	}
+
+	@Test
 	public void callableReturnsNull() {
 		StepVerifier.create(Mono.empty()
 		                        .flux()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -57,6 +57,9 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 					.prefetch(3),
 
 				scenario(f -> f.zipWith(Flux.<String>error(exception()),
+						(a, b) -> a)).shouldHitDropErrorHookAfterTerminate(false),
+
+				scenario(f -> f.zipWith(Flux.<String>error(exception()).hide(),
 						(a, b) -> a)));
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
@@ -92,6 +92,21 @@ public class MonoCollectListTest {
 	}
 
 	@Test
+	public void collectListError() {
+		StepVerifier.create(Flux.error(new Exception("test"))
+		                        .collectList())
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void collectListErrorHide() {
+		StepVerifier.create(Flux.error(new Exception("test"))
+		                        .hide()
+		                        .collectList())
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
 	public void scanBufferAllSubscriber() {
 		CoreSubscriber<List<String>> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
 		MonoCollectList.MonoBufferAllSubscriber<String, List<String>> test = new MonoCollectList.MonoBufferAllSubscriber<String, List<String>>(

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDefaultIfEmptyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDefaultIfEmptyTest.java
@@ -17,6 +17,7 @@
 package reactor.core.publisher;
 
 import org.junit.Test;
+import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 public class MonoDefaultIfEmptyTest {
@@ -29,6 +30,21 @@ public class MonoDefaultIfEmptyTest {
 	@Test(expected = NullPointerException.class)
 	public void valueNull() {
 		Mono.never().defaultIfEmpty(null);
+	}
+
+	@Test
+	public void error() {
+		StepVerifier.create(Mono.error(new RuntimeException("forced failure"))
+		                        .defaultIfEmpty("blah"))
+		            .verifyErrorMessage("forced failure");
+	}
+
+	@Test
+	public void errorHide() {
+		StepVerifier.create(Mono.error(new RuntimeException("forced failure"))
+		                        .hide()
+		                        .defaultIfEmpty("blah"))
+		            .verifyErrorMessage("forced failure");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoJustTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoJustTest.java
@@ -34,7 +34,12 @@ public class MonoJustTest {
 
     @Test
     public void valueSame() {
-        Assert.assertSame(1, new MonoJust<>(1).call());
+	    try {
+		    Assert.assertSame(1, new MonoJust<>(1).call());
+	    }
+	    catch (Exception e) {
+		    e.printStackTrace();
+	    }
     }
 
     @Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPublishOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPublishOnTest.java
@@ -33,6 +33,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -371,4 +372,20 @@ public class MonoPublishOnTest {
 		Assertions.assertThat(test.scan(Scannable.ThrowableAttr.ERROR)).hasMessage("boom");
 	}
 
+
+
+	@Test
+	public void error() {
+		StepVerifier.create(Mono.error(new RuntimeException("forced failure"))
+		                        .publishOn(Schedulers.single()))
+		            .verifyErrorMessage("forced failure");
+	}
+
+	@Test
+	public void errorHide() {
+		StepVerifier.create(Mono.error(new RuntimeException("forced failure"))
+		                        .hide()
+		                        .publishOn(Schedulers.single()))
+		            .verifyErrorMessage("forced failure");
+	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSingleTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSingleTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
@@ -78,6 +79,36 @@ public class MonoSingleTest {
 		ts.assertNoValues()
 		  .assertError(NoSuchElementException.class)
 		  .assertNotComplete();
+	}
+
+	@Test
+	public void error() {
+		StepVerifier.create(Flux.error(new RuntimeException("forced failure"))
+		                        .single())
+		            .verifyErrorMessage("forced failure");
+	}
+
+	@Test
+	public void errorHide() {
+		StepVerifier.create(Flux.error(new RuntimeException("forced failure"))
+		                        .hide()
+		                        .single())
+		            .verifyErrorMessage("forced failure");
+	}
+
+	@Test
+	public void errorDefault() {
+		StepVerifier.create(Flux.error(new RuntimeException("forced failure"))
+		                        .single("bla"))
+		            .verifyErrorMessage("forced failure");
+	}
+
+	@Test
+	public void errorHideDefault() {
+		StepVerifier.create(Flux.error(new RuntimeException("forced failure"))
+		                        .hide()
+		                        .single("bla"))
+		            .verifyErrorMessage("forced failure");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSourceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSourceTest.java
@@ -45,6 +45,22 @@ public class MonoSourceTest {
 	}
 
 	@Test
+	public void error() {
+		Mono<Integer> m = Mono.from(Flux.error(new Exception("test")));
+		assertTrue(m instanceof MonoError);
+		StepVerifier.create(m)
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void errorPropagate() {
+		Mono<Integer> m = Mono.from(Flux.error(new Error("test")));
+		assertTrue(m instanceof MonoError);
+		StepVerifier.create(m)
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
 	public void justNext() {
 		StepVerifier.create(Mono.from(Flux.just(1, 2, 3)))
 	                .expectNext(1)

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSubscribeOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSubscribeOnTest.java
@@ -26,6 +26,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -185,5 +186,20 @@ public class MonoSubscribeOnTest {
 		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isFalse();
 		test.cancel();
 		assertThat(test.scan(Scannable.BooleanAttr.CANCELLED)).isTrue();
+	}
+
+	@Test
+	public void error() {
+		StepVerifier.create(Mono.error(new RuntimeException("forced failure"))
+		                        .subscribeOn(Schedulers.single()))
+		            .verifyErrorMessage("forced failure");
+	}
+
+	@Test
+	public void errorHide() {
+		StepVerifier.create(Mono.error(new RuntimeException("forced failure"))
+		                        .hide()
+		                        .subscribeOn(Schedulers.single()))
+		            .verifyErrorMessage("forced failure");
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTakeLastOneTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTakeLastOneTest.java
@@ -48,6 +48,29 @@ public class MonoTakeLastOneTest {
 	}
 
 	@Test
+	public void errorHide() {
+		StepVerifier.create(Flux.error(new Exception("test"))
+		                        .hide()
+		                        .last())
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void errorDefault() {
+		StepVerifier.create(Flux.error(new Exception("test"))
+		                        .last("blah"))
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void errorHideDefault() {
+		StepVerifier.create(Flux.error(new Exception("test"))
+		                        .hide()
+		                        .last("blah"))
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
 	public void normal() {
 		StepVerifier.create(Flux.range(1, 100)
 		                        .last())

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
@@ -692,7 +692,7 @@ public class ParallelFluxTest {
 		ParallelFlux<Integer> pf = ParallelFlux.from(Flux.range(1, 4), 2)
 		                                       .concatMapDelayError(i -> {
 		                                       	if (i == 1)
-		                                       		return Mono.error(new IllegalStateException("boom"));
+		                                       		return Mono.<Integer>error(new IllegalStateException("boom")).hide();
 		                                       	return Flux.just(i, 100 * i);
 		                                       });
 
@@ -706,7 +706,7 @@ public class ParallelFluxTest {
 		ParallelFlux<Integer> pf = ParallelFlux.from(Flux.range(1, 4), 2)
 		                                       .concatMapDelayError(i -> {
 			                                       if (i == 1)
-				                                       return Mono.error(new IllegalStateException("boom"));
+				                                       return Mono.<Integer>error(new IllegalStateException("boom")).hide();
 			                                       return Flux.just(i, 100 * i);
 		                                       }, 4);
 
@@ -735,7 +735,7 @@ public class ParallelFluxTest {
 		ParallelFlux<Integer> pf = ParallelFlux.from(Flux.range(1, 4), 2)
 		                                       .flatMap(i -> {
 			                                       if (i == 1)
-				                                       return Mono.error(new IllegalStateException("boom"));
+				                                       return Mono.<Integer>error(new IllegalStateException("boom")).hide();
 			                                       return Flux.just(i, 100 * i);
 		                                       }, true);
 
@@ -749,7 +749,7 @@ public class ParallelFluxTest {
 		ParallelFlux<Integer> pf = ParallelFlux.from(Flux.range(1, 4), 2)
 		                                       .flatMap(i -> {
 			                                       if (i == 1)
-				                                       return Mono.error(new IllegalStateException("boom"));
+				                                       return Mono.<Integer>error(new IllegalStateException("boom")).hide();
 			                                       return Flux.just(i, 100 * i);
 		                                       }, true, 2);
 


### PR DESCRIPTION
This is a shortcut for flows that over use Flux/Mono.error as valid constant error routes. This might change some assumption in particular in delayError as the updated test shows, in effect since the error is now synchronously available, some delayError tests have been updated to hide the optimization.