### PR TITLE
Fix #650 Ignore empty multivalue expectations

### DIFF
--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -378,24 +378,26 @@ final class DefaultStepVerifierBuilder<T>
 	public DefaultStepVerifierBuilder<T> expectNextSequence(
 			Iterable<? extends T> iterable) {
 		Objects.requireNonNull(iterable, "iterable");
-		if (iterable instanceof Collection) {
-			checkPotentialHang(((Collection) iterable).size(), "expectNextSequence");
+		if (iterable.iterator().hasNext()) {
+			if (iterable instanceof Collection) {
+				checkPotentialHang(((Collection) iterable).size(), "expectNextSequence");
+			} else {
+				//best effort
+				checkPotentialHang(-1, "expectNextSequence");
+			}
+			this.script.add(new SignalSequenceEvent<>(iterable, "expectNextSequence"));
 		}
-		else {
-			//best effort
-			checkPotentialHang(-1, "expectNextSequence");
-		}
-		this.script.add(new SignalSequenceEvent<>(iterable, "expectNextSequence"));
-
 		return this;
 	}
 
 	@Override
 	public DefaultStepVerifierBuilder<T> expectNextCount(long count) {
 		checkPositive(count);
-		String desc = "expectNextCount(" + count + ")";
-		checkPotentialHang(count, desc);
-		this.script.add(new SignalCountEvent<>(count, desc));
+		if (count != 0) {
+			String desc = "expectNextCount(" + count + ")";
+			checkPotentialHang(count, desc);
+			this.script.add(new SignalCountEvent<>(count, desc));
+		}
 		return this;
 	}
 

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -34,6 +34,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.scheduler.VirtualTimeScheduler;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.*;
 import static reactor.test.publisher.TestPublisher.Violation.REQUEST_OVERFLOW;
 
@@ -222,6 +223,15 @@ public class StepVerifierTests {
 		            .expectNextCount(400_000)
 		            .expectComplete()
 		            .verify();
+	}
+
+	@Test
+	public void expectNextCountZeroBeforeExpectNext() {
+		StepVerifier.create(Flux.just("foo", "bar"))
+				.expectNextCount(0)
+				.expectNext("foo", "bar")
+				.expectComplete()
+				.verify();
 	}
 
 	@Test
@@ -1414,6 +1424,15 @@ public class StepVerifierTests {
 	                .expectNextSequence(Arrays.asList(1, 2, 3))
 	                .verifyComplete())
 	            .withMessage("expectation \"expectComplete\" failed (expected: onComplete(); actual: onNext(4))");
+	}
+
+	@Test
+	public void expectNextSequenceEmptyListBeforeExpectNext() {
+		StepVerifier.create(Flux.just("foo", "bar"))
+				.expectNextSequence(emptyList())
+				.expectNext("foo", "bar")
+				.expectComplete()
+				.verify();
 	}
 
 	@Test


### PR DESCRIPTION
Added logic to handle empty multivalue expectations in DefaultStepVerifierBuilder, 
ignoring effectively empty multivalue expectations such as count of 0 and empty iterable.