### PR TITLE
follow-up #722 MonoProcessor block consider negative timeout unbounded

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import java.util.function.Function;
 import java.util.function.LongSupplier;
 import javax.annotation.Nullable;
 
@@ -34,8 +33,6 @@ import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.util.concurrent.WaitStrategy;
-
-import static reactor.util.concurrent.WaitStrategy.NOOP_SPIN_OBSERVER;
 
 /**
  * A {@code MonoProcessor} is a {@link Mono} extension that implements stateful semantics. Multi-subscribe is allowed.
@@ -121,10 +118,16 @@ public final class MonoProcessor<O> extends Mono<O>
 		cancel();
 	}
 
+	/**
+	 * Block the calling thread indefinitely, waiting for the completion of this {@code MonoProcessor}. If the
+	 * {@link MonoProcessor} is completed with an error a RuntimeException that wraps the error is thrown.
+	 *
+	 * @return the value of this {@code MonoProcessor}
+	 */
 	@Override
 	@Nullable
 	public O block() {
-		return block(Duration.ofSeconds(-1));
+		return block(WaitStrategy.NOOP_SPIN_OBSERVER);
 	}
 
 	/**
@@ -139,25 +142,23 @@ public final class MonoProcessor<O> extends Mono<O>
 	@Override
 	@Nullable
 	public O block(Duration timeout) {
+		long delay = System.nanoTime() + timeout.toNanos();
+		Runnable spinObserver = () -> {
+			if (delay < System.nanoTime()) {
+				WaitStrategy.alert();
+			}
+		};
+		return block(spinObserver);
+	}
+
+	@Nullable
+	private O block(Runnable spinObserver) {
 		try {
 			if (!isPending()) {
 				return peek();
 			}
 			else if(subscription == null) {
 				getOrStart();
-			}
-
-			Runnable spinObserver;
-			if (timeout.isNegative()) {
-				spinObserver = NOOP_SPIN_OBSERVER;
-			}
-			else {
-				long delay = System.nanoTime() + timeout.toNanos();
-				spinObserver = () -> {
-					if (delay < System.nanoTime()) {
-						WaitStrategy.alert();
-					}
-				};
 			}
 
 			try {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -152,7 +152,7 @@ public final class MonoProcessor<O> extends Mono<O>
 	}
 
 	@Nullable
-	private O block(Runnable spinObserver) {
+	O block(Runnable spinObserver) {
 		try {
 			if (!isPending()) {
 				return peek();

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -124,7 +124,7 @@ public final class MonoProcessor<O> extends Mono<O>
 	@Override
 	@Nullable
 	public O block() {
-		return block(Duration.ZERO);
+		return block(Duration.ofSeconds(-1));
 	}
 
 	/**
@@ -148,13 +148,13 @@ public final class MonoProcessor<O> extends Mono<O>
 			}
 
 			Runnable spinObserver;
-			if (timeout.isZero()) {
+			if (timeout.isNegative()) {
 				spinObserver = NOOP_SPIN_OBSERVER;
 			}
 			else {
 				long delay = System.nanoTime() + timeout.toNanos();
 				spinObserver = () -> {
-					if (!timeout.isZero() && delay < System.nanoTime()) {
+					if (delay < System.nanoTime()) {
 						WaitStrategy.alert();
 					}
 				};

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
@@ -575,7 +575,7 @@ public class MonoProcessorTest {
 	}
 
 	@Test
-	public void monoProcessorBlock() {
+	public void monoProcessorBlockIsUnbounded() {
 		long start = System.nanoTime();
 
 		String result = Mono.just("foo")
@@ -586,6 +586,35 @@ public class MonoProcessorTest {
 		assertThat(result).isEqualTo("foo");
 		assertThat(Duration.ofNanos(System.nanoTime() - start))
 				.isGreaterThanOrEqualTo(Duration.ofMillis(500));
+	}
+
+	@Test
+	public void monoProcessorBlockNegativeIsUnbounded() {
+		long start = System.nanoTime();
+
+		String result = Mono.just("foo")
+		                    .delayElement(Duration.ofMillis(500))
+		                    .toProcessor()
+		                    .block(Duration.ofSeconds(-1));
+
+		assertThat(result).isEqualTo("foo");
+		assertThat(Duration.ofNanos(System.nanoTime() - start))
+				.isGreaterThanOrEqualTo(Duration.ofMillis(500));
+	}
+
+	@Test
+	public void monoProcessorBlockZeroIsImmediateTimeout() {
+		long start = System.nanoTime();
+
+		assertThatExceptionOfType(IllegalStateException.class)
+				.isThrownBy(() -> Mono.just("foo")
+				                      .delayElement(Duration.ofMillis(500))
+				                      .toProcessor()
+				                      .block(Duration.ZERO))
+		        .withMessage("Timeout on Mono blocking read");
+
+		assertThat(Duration.ofNanos(System.nanoTime() - start))
+				.isLessThan(Duration.ofMillis(500));
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
@@ -589,17 +589,18 @@ public class MonoProcessorTest {
 	}
 
 	@Test
-	public void monoProcessorBlockNegativeIsUnbounded() {
+	public void monoProcessorBlockNegativeIsImmediateTimeout() {
 		long start = System.nanoTime();
 
-		String result = Mono.just("foo")
-		                    .delayElement(Duration.ofMillis(500))
-		                    .toProcessor()
-		                    .block(Duration.ofSeconds(-1));
+		assertThatExceptionOfType(IllegalStateException.class)
+				.isThrownBy(() -> Mono.just("foo")
+				                      .delayElement(Duration.ofMillis(500))
+				                      .toProcessor()
+				                      .block(Duration.ofSeconds(-1)))
+				.withMessage("Timeout on Mono blocking read");
 
-		assertThat(result).isEqualTo("foo");
 		assertThat(Duration.ofNanos(System.nanoTime() - start))
-				.isGreaterThanOrEqualTo(Duration.ofMillis(500));
+				.isLessThan(Duration.ofMillis(500));
 	}
 
 	@Test


### PR DESCRIPTION
This commit follows-up on d8c7bf0 to change the semantic of the block
timeout: a Duration.ZERO will effectively immediately timeout, while a
NEGATIVE duration will be considered as "no timeout" and let block
indefinitely. `block()` variant thus uses a `Duration.ofSeconds(-1)`.