### PR TITLE
fix #612 Have UnicastProcessor return a bufferSize estimated from queue

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -30,6 +30,7 @@ import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 /**
  * A Processor implementation that takes a custom queue and allows
@@ -148,6 +149,11 @@ public final class UnicastProcessor<T>
 		this.queue = Objects.requireNonNull(queue, "queue");
 		this.onOverflow = Objects.requireNonNull(onOverflow, "onOverflow");
 		this.onTerminate = Objects.requireNonNull(onTerminate, "onTerminate");
+	}
+
+	@Override
+	public int getBufferSize() {
+		return Queues.capacity(this.queue);
 	}
 
 	void doTerminate() {

--- a/reactor-core/src/main/java/reactor/util/concurrent/Queues.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/Queues.java
@@ -18,6 +18,7 @@ package reactor.util.concurrent;
 
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * Utility methods around {@link Queue Queues} and pre-defined {@link QueueSupplier suppliers}.
@@ -37,14 +38,17 @@ public class Queues {
 	 * @return the capacity of the queue, if discoverable with confidence, or {@link #CAPACITY_UNSURE} negative constant.
 	 */
 	public static final int capacity(Queue q) {
-		if (q instanceof BlockingQueue) {
-			return ((BlockingQueue) q).remainingCapacity();
-		}
-		else if (q instanceof SpscLinkedArrayQueue) {
+		if (q instanceof SpscLinkedArrayQueue) {
 			return Integer.MAX_VALUE;
 		}
 		else if (q instanceof SpscArrayQueue) {
 			return ((SpscArrayQueue) q).length();
+		}
+		else if (q instanceof BlockingQueue) {
+			return ((BlockingQueue) q).remainingCapacity();
+		}
+		else if (q instanceof ConcurrentLinkedQueue) {
+			return Integer.MAX_VALUE;
 		}
 		else {
 			return CAPACITY_UNSURE;

--- a/reactor-core/src/main/java/reactor/util/concurrent/Queues.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/Queues.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.concurrent;
+
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * Utility methods around {@link Queue Queues} and pre-defined {@link QueueSupplier suppliers}.
+ */
+public class Queues {
+
+	public static final int CAPACITY_UNSURE = Integer.MIN_VALUE;
+
+	/**
+	 * Return the capacity of a given {@link Queue} in a best effort fashion. Queues that
+	 * are known to be unbounded will return {@code Integer.MAX_VALUE} and queues that
+	 * have a known bounded capacity will return that capacity. For other {@link Queue}
+	 * implementations not recognized by this method or not providing this kind of
+	 * information, {@link #CAPACITY_UNSURE} ({@code Integer.MIN_VALUE}) is returned.
+	 *
+	 * @param q the {@link Queue} to try to get a capacity for
+	 * @return the capacity of the queue, if discoverable with confidence, or {@link #CAPACITY_UNSURE} negative constant.
+	 */
+	public static final int capacity(Queue q) {
+		if (q instanceof BlockingQueue) {
+			return ((BlockingQueue) q).remainingCapacity();
+		}
+		else if (q instanceof SpscLinkedArrayQueue) {
+			return Integer.MAX_VALUE;
+		}
+		else if (q instanceof SpscArrayQueue) {
+			return ((SpscArrayQueue) q).length();
+		}
+		else {
+			return CAPACITY_UNSURE;
+		}
+	}
+
+}

--- a/reactor-core/src/main/java/reactor/util/concurrent/package-info.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/package-info.java
@@ -15,7 +15,8 @@
  */
 
 /**
- * Queue {@link reactor.util.concurrent.QueueSupplier suppliers} and busy spin utils
+ * Queue {@link reactor.util.concurrent.QueueSupplier suppliers} and
+ * {@link reactor.util.concurrent.Queues utilities}, busy spin utils
  * {@link reactor.util.concurrent.WaitStrategy}.
  * Used for operational serialization (serializing threads) or buffering (asynchronous boundary).
  *

--- a/reactor-core/src/test/java/reactor/util/concurrent/QueuesTest.java
+++ b/reactor-core/src/test/java/reactor/util/concurrent/QueuesTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.concurrent;
+
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QueuesTest {
+
+	@Test
+	public void capacityReactorUnboundedQueue() {
+		Queue q = QueueSupplier.unbounded(2).get();
+
+		assertThat(Queues.capacity(q)).isEqualTo(Integer.MAX_VALUE);
+	}
+
+	@Test
+	public void capacityReactorBoundedQueue() {
+		//the bounded queue floors at 8 and rounds to the next power of 2
+
+		assertThat(Queues.capacity(QueueSupplier.get(2).get()))
+				.isEqualTo(8);
+
+		assertThat(Queues.capacity(QueueSupplier.get(8).get()))
+				.isEqualTo(8);
+
+		assertThat(Queues.capacity(QueueSupplier.get(9).get()))
+				.isEqualTo(16);
+	}
+
+	@Test
+	public void capacityBoundedBlockingQueue() {
+		Queue q = new LinkedBlockingQueue<>(10);
+
+		assertThat(Queues.capacity(q)).isEqualTo(10);
+	}
+
+	@Test
+	public void capacityUnboundedBlockingQueue() {
+		Queue q = new LinkedBlockingQueue<>();
+
+		assertThat(Queues.capacity(q)).isEqualTo(Integer.MAX_VALUE);
+
+	}
+
+	@Test
+	public void capacityOtherQueue() {
+		Queue q = new PriorityQueue<>(10);
+
+		assertThat(Queues.capacity(q))
+				.isEqualTo(Integer.MIN_VALUE)
+				.isEqualTo(Queues.CAPACITY_UNSURE);
+	}
+
+}

--- a/reactor-core/src/test/java/reactor/util/concurrent/QueuesTest.java
+++ b/reactor-core/src/test/java/reactor/util/concurrent/QueuesTest.java
@@ -18,6 +18,7 @@ package reactor.util.concurrent;
 
 import java.util.PriorityQueue;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.junit.Test;
@@ -59,7 +60,13 @@ public class QueuesTest {
 		Queue q = new LinkedBlockingQueue<>();
 
 		assertThat(Queues.capacity(q)).isEqualTo(Integer.MAX_VALUE);
+	}
 
+	@Test
+	public void capacityUnboundedConcurrentLinkedQueue() {
+		Queue q = new ConcurrentLinkedQueue<>();
+
+		assertThat(Queues.capacity(q)).isEqualTo(Integer.MAX_VALUE);
 	}
 
 	@Test


### PR DESCRIPTION
cc @osi 
@smaldini I put in 2 commits: one introduces the `Queues` class with the `capacityEstimate` method and the other modifies the `UnicastProcessor`. A follow-up issue (#733)  has been opened if we want to put all methods from `QueueSupplier` to `Queues`, except the instance method (hence the class being kept).