### PR TITLE
733 OPTION 1: Queues replaces QueueSupplier, which gets deprecations

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -29,7 +29,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static reactor.core.publisher.FluxPublish.PublishSubscriber.EMPTY;
 import static reactor.core.publisher.FluxPublish.PublishSubscriber.TERMINATED;
@@ -54,7 +54,7 @@ import static reactor.core.publisher.FluxPublish.PublishSubscriber.TERMINATED;
 public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 
 	/**
-	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE}
+	 * Create a new {@link EmitterProcessor} using {@link Queues#SMALL_BUFFER_SIZE}
 	 * backlog size and auto-cancel.
 	 *
 	 * @param <E> Type of processed signals
@@ -62,11 +62,11 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	 * @return a fresh processor
 	 */
 	public static <E> EmitterProcessor<E> create() {
-		return create(QueueSupplier.SMALL_BUFFER_SIZE, true);
+		return create(Queues.SMALL_BUFFER_SIZE, true);
 	}
 
 	/**
-	 * Create a new {@link EmitterProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE}
+	 * Create a new {@link EmitterProcessor} using {@link Queues#SMALL_BUFFER_SIZE}
 	 * backlog size and the provided auto-cancel.
 	 *
 	 * @param <E> Type of processed signals
@@ -75,7 +75,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	 * @return a fresh processor
 	 */
 	public static <E> EmitterProcessor<E> create(boolean autoCancel) {
-		return create(QueueSupplier.SMALL_BUFFER_SIZE, autoCancel);
+		return create(Queues.SMALL_BUFFER_SIZE, autoCancel);
 	}
 
 	/**
@@ -220,7 +220,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 				}
 			}
 
-			queue = QueueSupplier.<T>get(prefetch).get();
+			queue = Queues.<T>get(prefetch).get();
 
 			s.request(prefetch);
 		}
@@ -245,7 +245,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 
 		if (q == null) {
 			if (Operators.setOnce(S, this, Operators.emptySubscription())) {
-				q = QueueSupplier.<T>get(prefetch).get();
+				q = Queues.<T>get(prefetch).get();
 				queue = q;
 			}
 			else {

--- a/reactor-core/src/main/java/reactor/core/publisher/EventLoopProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EventLoopProcessor.java
@@ -29,14 +29,13 @@ import java.util.function.Consumer;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
-import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 import reactor.util.concurrent.WaitStrategy;
-import javax.annotation.Nullable;
 
 /**
  * A base processor used by executor backed processors to take care of their ExecutorService
@@ -211,7 +210,7 @@ abstract class EventLoopProcessor<IN> extends FluxProcessor<IN, IN>
 			Supplier<Slot<IN>> factory,
 			WaitStrategy strategy) {
 
-		if (!QueueSupplier.isPowerOfTwo(bufferSize)) {
+		if (!Queues.isPowerOfTwo(bufferSize)) {
 			throw new IllegalArgumentException("bufferSize must be a power of 2 : " + bufferSize);
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -59,7 +59,7 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Scheduler.Worker;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.Logger;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuple3;
@@ -123,7 +123,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	@SafeVarargs
 	public static <T, V> Flux<V> combineLatest(Function<Object[], V> combinator, Publisher<? extends T>... sources) {
-		return combineLatest(combinator, QueueSupplier.XS_BUFFER_SIZE, sources);
+		return combineLatest(combinator, Queues.XS_BUFFER_SIZE, sources);
 	}
 
 	/**
@@ -160,7 +160,7 @@ public abstract class Flux<T> implements Publisher<T> {
 		}
 
 		return onAssembly(new FluxCombineLatest<>(sources,
-				combinator, QueueSupplier.get(prefetch), prefetch));
+				combinator, Queues.get(prefetch), prefetch));
 	}
 
 	/**
@@ -326,7 +326,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public static <T, V> Flux<V> combineLatest(Iterable<? extends Publisher<? extends T>> sources,
 			Function<Object[], V> combinator) {
-		return combineLatest(sources, QueueSupplier.XS_BUFFER_SIZE, combinator);
+		return combineLatest(sources, Queues.XS_BUFFER_SIZE, combinator);
 	}
 
 	/**
@@ -351,7 +351,7 @@ public abstract class Flux<T> implements Publisher<T> {
 
 		return onAssembly(new FluxCombineLatest<T, V>(sources,
 				combinator,
-				QueueSupplier.get(prefetch), prefetch));
+				Queues.get(prefetch), prefetch));
 	}
 
 	/**
@@ -391,7 +391,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a new {@link Flux} concatenating all inner sources sequences
 	 */
 	public static <T> Flux<T> concat(Publisher<? extends Publisher<? extends T>> sources) {
-		return concat(sources, QueueSupplier.XS_BUFFER_SIZE);
+		return concat(sources, Queues.XS_BUFFER_SIZE);
 	}
 
 	/**
@@ -414,7 +414,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	public static <T> Flux<T> concat(Publisher<? extends Publisher<? extends T>> sources, int prefetch) {
 		return onAssembly(new FluxConcatMap<>(from(sources),
 				identityFunction(),
-				QueueSupplier.get(prefetch), prefetch,
+				Queues.get(prefetch), prefetch,
 				FluxConcatMap.ErrorMode.IMMEDIATE));
 	}
 
@@ -456,7 +456,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a new {@link Flux} concatenating all inner sources sequences, delaying errors
 	 */
 	public static <T> Flux<T> concatDelayError(Publisher<? extends Publisher<? extends T>> sources) {
-		return concatDelayError(sources, QueueSupplier.XS_BUFFER_SIZE);
+		return concatDelayError(sources, Queues.XS_BUFFER_SIZE);
 	}
 
 	/**
@@ -479,7 +479,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	public static <T> Flux<T> concatDelayError(Publisher<? extends Publisher<? extends T>> sources, int prefetch) {
 		return onAssembly(new FluxConcatMap<>(from(sources),
 				identityFunction(),
-				QueueSupplier.get(prefetch), prefetch,
+				Queues.get(prefetch), prefetch,
 				FluxConcatMap.ErrorMode.END));
 	}
 
@@ -509,7 +509,7 @@ public abstract class Flux<T> implements Publisher<T> {
 			T>> sources, boolean delayUntilEnd, int prefetch) {
 		return onAssembly(new FluxConcatMap<>(from(sources),
 				identityFunction(),
-				QueueSupplier.get(prefetch), prefetch,
+				Queues.get(prefetch), prefetch,
 				delayUntilEnd ? FluxConcatMap.ErrorMode.END : FluxConcatMap.ErrorMode.BOUNDARY));
 	}
 
@@ -1054,8 +1054,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public static <T> Flux<T> merge(Publisher<? extends Publisher<? extends T>> source) {
 		return merge(source,
-				QueueSupplier.SMALL_BUFFER_SIZE,
-				QueueSupplier.XS_BUFFER_SIZE);
+				Queues.SMALL_BUFFER_SIZE,
+				Queues.XS_BUFFER_SIZE);
 	}
 
 	/**
@@ -1078,7 +1078,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a merged {@link Flux}
 	 */
 	public static <T> Flux<T> merge(Publisher<? extends Publisher<? extends T>> source, int concurrency) {
-		return merge(source, concurrency, QueueSupplier.XS_BUFFER_SIZE);
+		return merge(source, concurrency, Queues.XS_BUFFER_SIZE);
 	}
 
 	/**
@@ -1107,9 +1107,9 @@ public abstract class Flux<T> implements Publisher<T> {
 				identityFunction(),
 				false,
 				concurrency,
-				QueueSupplier.get(concurrency),
+				Queues.get(concurrency),
 				prefetch,
-				QueueSupplier.get(prefetch)));
+				Queues.get(prefetch)));
 	}
 
 	/**
@@ -1153,7 +1153,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	@SafeVarargs
 	public static <I> Flux<I> merge(Publisher<? extends I>... sources) {
-		return merge(QueueSupplier.XS_BUFFER_SIZE, sources);
+		return merge(Queues.XS_BUFFER_SIZE, sources);
 	}
 
 	/**
@@ -1217,8 +1217,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a merged {@link Flux}, subscribing early but keeping the original ordering
 	 */
 	public static <T> Flux<T> mergeSequential(Publisher<? extends Publisher<? extends T>> sources) {
-		return mergeSequential(sources, false, QueueSupplier.SMALL_BUFFER_SIZE,
-				QueueSupplier.XS_BUFFER_SIZE);
+		return mergeSequential(sources, false, Queues.SMALL_BUFFER_SIZE,
+				Queues.XS_BUFFER_SIZE);
 	}
 
 	/**
@@ -1276,7 +1276,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	@SafeVarargs
 	public static <I> Flux<I> mergeSequential(Publisher<? extends I>... sources) {
-		return mergeSequential(QueueSupplier.XS_BUFFER_SIZE, false, sources);
+		return mergeSequential(Queues.XS_BUFFER_SIZE, false, sources);
 	}
 
 	/**
@@ -1330,8 +1330,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a merged {@link Flux}, subscribing early but keeping the original ordering
 	 */
 	public static <I> Flux<I> mergeSequential(Iterable<? extends Publisher<? extends I>> sources) {
-		return mergeSequential(sources, false, QueueSupplier.SMALL_BUFFER_SIZE,
-				QueueSupplier.XS_BUFFER_SIZE);
+		return mergeSequential(sources, false, Queues.SMALL_BUFFER_SIZE,
+				Queues.XS_BUFFER_SIZE);
 	}
 
 	/**
@@ -1428,7 +1428,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a {@link FluxProcessor} accepting publishers and producing T
 	 */
 	public static <T> Flux<T> switchOnNext(Publisher<? extends Publisher<? extends T>> mergedPublishers) {
-		return switchOnNext(mergedPublishers, QueueSupplier.XS_BUFFER_SIZE);
+		return switchOnNext(mergedPublishers, Queues.XS_BUFFER_SIZE);
 	}
 
 	/**
@@ -1451,7 +1451,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	public static <T> Flux<T> switchOnNext(Publisher<? extends Publisher<? extends T>> mergedPublishers, int prefetch) {
 		return onAssembly(new FluxSwitchMap<>(from(mergedPublishers),
 				identityFunction(),
-				QueueSupplier.unbounded(prefetch), prefetch));
+				Queues.unbounded(prefetch), prefetch));
 	}
 
 	/**
@@ -1533,8 +1533,8 @@ public abstract class Flux<T> implements Publisher<T> {
 		return onAssembly(new FluxZip<T1, O>(source1,
 				source2,
 				combinator,
-				QueueSupplier.xs(),
-				QueueSupplier.XS_BUFFER_SIZE));
+				Queues.xs(),
+				Queues.XS_BUFFER_SIZE));
 	}
 
 	/**
@@ -1694,7 +1694,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	public static <O> Flux<O> zip(Iterable<? extends Publisher<?>> sources,
 			final Function<? super Object[], ? extends O> combinator) {
 
-		return zip(sources, QueueSupplier.XS_BUFFER_SIZE, combinator);
+		return zip(sources, Queues.XS_BUFFER_SIZE, combinator);
 	}
 
 	/**
@@ -1724,7 +1724,7 @@ public abstract class Flux<T> implements Publisher<T> {
 
 		return onAssembly(new FluxZip<Object, O>(sources,
 				combinator,
-				QueueSupplier.get(prefetch),
+				Queues.get(prefetch),
 				prefetch));
 	}
 
@@ -1749,7 +1749,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	@SafeVarargs
 	public static <I, O> Flux<O> zip(
 			final Function<? super Object[], ? extends O> combinator, Publisher<? extends I>... sources) {
-		return zip(combinator, QueueSupplier.XS_BUFFER_SIZE, sources);
+		return zip(combinator, Queues.XS_BUFFER_SIZE, sources);
 	}
 
 	/**
@@ -1791,7 +1791,7 @@ public abstract class Flux<T> implements Publisher<T> {
 
 		return onAssembly(new FluxZip<>(sources,
 				combinator,
-				QueueSupplier.get(prefetch),
+				Queues.get(prefetch),
 				prefetch));
 	}
 
@@ -2418,7 +2418,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	public final <U, V, C extends Collection<? super T>> Flux<C> bufferWhen(Publisher<U> bucketOpening,
 			Function<? super U, ? extends Publisher<V>> closeSelector, Supplier<C> bufferSupplier) {
 		return onAssembly(new FluxBufferWhen<>(this, bucketOpening, closeSelector,
-				bufferSupplier, QueueSupplier.unbounded(QueueSupplier.XS_BUFFER_SIZE)));
+				bufferSupplier, Queues.unbounded(Queues.XS_BUFFER_SIZE)));
 	}
 
 	/**
@@ -2905,7 +2905,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public final <V> Flux<V> concatMap(Function<? super T, ? extends Publisher<? extends V>>
 			mapper) {
-		return concatMap(mapper, QueueSupplier.XS_BUFFER_SIZE);
+		return concatMap(mapper, Queues.XS_BUFFER_SIZE);
 	}
 
 	/**
@@ -2940,7 +2940,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public final <V> Flux<V> concatMap(Function<? super T, ? extends Publisher<? extends V>>
 			mapper, int prefetch) {
-		return onAssembly(new FluxConcatMap<>(this, mapper, QueueSupplier.get(prefetch), prefetch,
+		return onAssembly(new FluxConcatMap<>(this, mapper, Queues.get(prefetch), prefetch,
 				FluxConcatMap.ErrorMode.IMMEDIATE));
 	}
 
@@ -2975,7 +2975,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 */
 	public final <V> Flux<V> concatMapDelayError(Function<? super T, Publisher<? extends V>> mapper) {
-		return concatMapDelayError(mapper, QueueSupplier.XS_BUFFER_SIZE);
+		return concatMapDelayError(mapper, Queues.XS_BUFFER_SIZE);
 	}
 
 	/**
@@ -3012,7 +3012,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public final <V> Flux<V> concatMapDelayError(Function<? super T, ? extends Publisher<?
 			extends V>> mapper, int prefetch) {
-		return onAssembly(new FluxConcatMap<>(this, mapper, QueueSupplier.get(prefetch), prefetch,
+		return onAssembly(new FluxConcatMap<>(this, mapper, Queues.get(prefetch), prefetch,
 				FluxConcatMap.ErrorMode.BOUNDARY));
 	}
 
@@ -3053,7 +3053,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public final <V> Flux<V> concatMapDelayError(Function<? super T, ? extends Publisher<?
 			extends V>> mapper, boolean delayUntilEnd, int prefetch) {
-		return onAssembly(new FluxConcatMap<>(this, mapper, QueueSupplier.get(prefetch), prefetch,
+		return onAssembly(new FluxConcatMap<>(this, mapper, Queues.get(prefetch), prefetch,
 				delayUntilEnd ? FluxConcatMap.ErrorMode.END : FluxConcatMap.ErrorMode
 						.BOUNDARY));
 	}
@@ -3076,7 +3076,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a concatenation of the values from the Iterables obtained from each element in this {@link Flux}
 	 */
 	public final <R> Flux<R> concatMapIterable(Function<? super T, ? extends Iterable<? extends R>> mapper) {
-		return concatMapIterable(mapper, QueueSupplier.XS_BUFFER_SIZE);
+		return concatMapIterable(mapper, Queues.XS_BUFFER_SIZE);
 	}
 
 	/**
@@ -3100,7 +3100,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	public final <R> Flux<R> concatMapIterable(Function<? super T, ? extends Iterable<? extends R>> mapper,
 			int prefetch) {
 		return onAssembly(new FluxFlattenIterable<>(this, mapper, prefetch,
-				QueueSupplier.get(prefetch)));
+				Queues.get(prefetch)));
 	}
 
 	/**
@@ -3280,7 +3280,7 @@ public abstract class Flux<T> implements Publisher<T> {
 		return concatMapDelayError(v -> Mono.just(v)
 		                                    //no need for delayError variant since no macro fusion of triggers
 		                                    .delayUntil(triggerProvider),
-				true, QueueSupplier.XS_BUFFER_SIZE);
+				true, Queues.XS_BUFFER_SIZE);
 	}
 
 	/**
@@ -3335,7 +3335,7 @@ public abstract class Flux<T> implements Publisher<T> {
 		return concatMapDelayError(v -> Mono.just(v)
 		                                    //no need for delayError variant since no macro fusion of triggers
 		                                    .delayUntilOther(triggerPublisher),
-				true, QueueSupplier.XS_BUFFER_SIZE);
+				true, Queues.XS_BUFFER_SIZE);
 	}
 
 	/**
@@ -3835,7 +3835,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a filtered {@link Flux}
 	 */
 	public final Flux<T> filterWhen(Function<? super T, ? extends Publisher<Boolean>> asyncPredicate) {
-		return filterWhen(asyncPredicate, QueueSupplier.SMALL_BUFFER_SIZE);
+		return filterWhen(asyncPredicate, Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -3911,8 +3911,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a new {@link Flux}
 	 */
 	public final <R> Flux<R> flatMap(Function<? super T, ? extends Publisher<? extends R>> mapper) {
-		return flatMap(mapper, QueueSupplier.SMALL_BUFFER_SIZE, QueueSupplier
-				.XS_BUFFER_SIZE);
+		return flatMap(mapper, Queues.SMALL_BUFFER_SIZE, Queues.XS_BUFFER_SIZE);
 	}
 
 	/**
@@ -3944,7 +3943,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public final <V> Flux<V> flatMap(Function<? super T, ? extends Publisher<? extends V>> mapper, int
 			concurrency) {
-		return flatMap(mapper, concurrency, QueueSupplier.XS_BUFFER_SIZE);
+		return flatMap(mapper, concurrency, Queues.XS_BUFFER_SIZE);
 	}
 
 	/**
@@ -4054,9 +4053,9 @@ public abstract class Flux<T> implements Publisher<T> {
 		return onAssembly(new FluxFlatMap<>(
 				new FluxMapSignal<>(this, mapperOnNext, mapperOnError, mapperOnComplete),
 				identityFunction(),
-				false, QueueSupplier.XS_BUFFER_SIZE,
-				QueueSupplier.xs(), QueueSupplier.XS_BUFFER_SIZE,
-				QueueSupplier.xs()
+				false, Queues.XS_BUFFER_SIZE,
+				Queues.xs(), Queues.XS_BUFFER_SIZE,
+				Queues.xs()
 		));
 	}
 
@@ -4078,7 +4077,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a concatenation of the values from the Iterables obtained from each element in this {@link Flux}
 	 */
 	public final <R> Flux<R> flatMapIterable(Function<? super T, ? extends Iterable<? extends R>> mapper) {
-		return flatMapIterable(mapper, QueueSupplier.SMALL_BUFFER_SIZE);
+		return flatMapIterable(mapper, Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -4102,7 +4101,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public final <R> Flux<R> flatMapIterable(Function<? super T, ? extends Iterable<? extends R>> mapper, int prefetch) {
 		return onAssembly(new FluxFlattenIterable<>(this, mapper, prefetch,
-				QueueSupplier.get(prefetch)));
+				Queues.get(prefetch)));
 	}
 
 	/**
@@ -4139,7 +4138,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public final <R> Flux<R> flatMapSequential(Function<? super T, ? extends
 			Publisher<? extends R>> mapper) {
-		return flatMapSequential(mapper, QueueSupplier.SMALL_BUFFER_SIZE);
+		return flatMapSequential(mapper, Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -4180,7 +4179,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public final <R> Flux<R> flatMapSequential(Function<? super T, ? extends
 			Publisher<? extends R>> mapper, int maxConcurrency) {
-		return flatMapSequential(mapper, maxConcurrency, QueueSupplier.XS_BUFFER_SIZE);
+		return flatMapSequential(mapper, maxConcurrency, Queues.XS_BUFFER_SIZE);
 	}
 
 	/**
@@ -4349,7 +4348,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public final <K, V> Flux<GroupedFlux<K, V>> groupBy(Function<? super T, ? extends K> keyMapper,
 			Function<? super T, ? extends V> valueMapper) {
-		return groupBy(keyMapper, valueMapper, QueueSupplier.SMALL_BUFFER_SIZE);
+		return groupBy(keyMapper, valueMapper, Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -4379,8 +4378,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	public final <K, V> Flux<GroupedFlux<K, V>> groupBy(Function<? super T, ? extends K> keyMapper,
 			Function<? super T, ? extends V> valueMapper, int prefetch) {
 		return onAssembly(new FluxGroupBy<>(this, keyMapper, valueMapper,
-				QueueSupplier.unbounded(prefetch),
-				QueueSupplier.unbounded(prefetch), prefetch));
+				Queues.unbounded(prefetch),
+				Queues.unbounded(prefetch), prefetch));
 	}
 
 	/**
@@ -4422,8 +4421,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	) {
 		return onAssembly(new FluxGroupJoin<T, TRight, TLeftEnd, TRightEnd, R>(
 				this, other, leftEnd, rightEnd, resultSelector,
-				QueueSupplier.unbounded(QueueSupplier.XS_BUFFER_SIZE),
-				QueueSupplier.unbounded(QueueSupplier.XS_BUFFER_SIZE)));
+				Queues.unbounded(Queues.XS_BUFFER_SIZE),
+				Queues.unbounded(Queues.XS_BUFFER_SIZE)));
 	}
 
 	/**
@@ -4538,8 +4537,7 @@ public abstract class Flux<T> implements Publisher<T> {
 			BiFunction<? super T, ? super TRight, ? extends R> resultSelector
 	) {
 		return onAssembly(new FluxJoin<T, TRight, TLeftEnd, TRightEnd, R>(
-				this, other, leftEnd, rightEnd, resultSelector, QueueSupplier
-				.unbounded(QueueSupplier.XS_BUFFER_SIZE)));
+				this, other, leftEnd, rightEnd, resultSelector, Queues.unbounded(Queues.XS_BUFFER_SIZE)));
 	}
 
 	/**
@@ -4762,7 +4760,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	public final Flux<T> mergeWith(Publisher<? extends T> other) {
 		if (this instanceof FluxMerge) {
 			FluxMerge<T> fluxMerge = (FluxMerge<T>) this;
-			return fluxMerge.mergeAdditionalSource(other, QueueSupplier::get);
+			return fluxMerge.mergeAdditionalSource(other, Queues::get);
 		}
 		return merge(this, other);
 	}
@@ -4813,8 +4811,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 */
 	public final Flux<T> onBackpressureBuffer() {
-		return onAssembly(new FluxOnBackpressureBuffer<>(this, QueueSupplier
-				.SMALL_BUFFER_SIZE, true, null));
+		return onAssembly(new FluxOnBackpressureBuffer<>(this,
+				Queues.SMALL_BUFFER_SIZE, true, null));
 	}
 
 	/**
@@ -5206,7 +5204,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a new {@link ParallelFlux} instance
 	 */
 	public final ParallelFlux<T> parallel(int parallelism) {
-		return parallel(parallelism, QueueSupplier.SMALL_BUFFER_SIZE);
+		return parallel(parallelism, Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -5228,13 +5226,13 @@ public abstract class Flux<T> implements Publisher<T> {
 		return ParallelFlux.from(this,
 				parallelism,
 				prefetch,
-				QueueSupplier.get(prefetch));
+				Queues.get(prefetch));
 	}
 
 	/**
 	 * Prepare a {@link ConnectableFlux} which shares this {@link Flux} sequence and
 	 * dispatches values to subscribers in a backpressure-aware manner. Prefetch will
-	 * default to {@link QueueSupplier#SMALL_BUFFER_SIZE}. This will effectively turn
+	 * default to {@link Queues#SMALL_BUFFER_SIZE}. This will effectively turn
 	 * any type of sequence into a hot sequence.
 	 * <p>
 	 * Backpressure will be coordinated on {@link Subscription#request} and if any
@@ -5246,7 +5244,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a new {@link ConnectableFlux}
 	 */
 	public final ConnectableFlux<T> publish() {
-		return publish(QueueSupplier.SMALL_BUFFER_SIZE);
+		return publish(Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -5265,8 +5263,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a new {@link ConnectableFlux}
 	 */
 	public final ConnectableFlux<T> publish(int prefetch) {
-		return onAssembly(new FluxPublish<>(this, prefetch, QueueSupplier
-				.get(prefetch)));
+		return onAssembly(new FluxPublish<>(this, prefetch, Queues.get(prefetch)));
 	}
 
 	/**
@@ -5281,7 +5278,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public final <R> Flux<R> publish(Function<? super Flux<T>, ? extends Publisher<?
 			extends R>> transform) {
-		return publish(transform, QueueSupplier.SMALL_BUFFER_SIZE);
+		return publish(transform, Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -5297,8 +5294,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public final <R> Flux<R> publish(Function<? super Flux<T>, ? extends Publisher<?
 			extends R>> transform, int prefetch) {
-		return onAssembly(new FluxPublishMulticast<>(this, transform, prefetch, QueueSupplier
-				.get(prefetch)));
+		return onAssembly(new FluxPublishMulticast<>(this, transform, prefetch,
+				Queues.get(prefetch)));
 	}
 
 	/**
@@ -5334,7 +5331,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a {@link Flux} producing asynchronously on a given {@link Scheduler}
 	 */
 	public final Flux<T> publishOn(Scheduler scheduler) {
-		return publishOn(scheduler, QueueSupplier.SMALL_BUFFER_SIZE);
+		return publishOn(scheduler, Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -5397,7 +5394,7 @@ public abstract class Flux<T> implements Publisher<T> {
 			return onAssembly(new FluxSubscribeOnCallable<>(c, scheduler));
 		}
 
-		return onAssembly(new FluxPublishOn<>(this, scheduler, delayError, prefetch, QueueSupplier.get(prefetch)));
+		return onAssembly(new FluxPublishOn<>(this, scheduler, delayError, prefetch, Queues.get(prefetch)));
 	}
 
 	/**
@@ -5816,7 +5813,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * defined by a companion {@link Publisher}
 	 */
 	public final <U> Flux<T> sampleTimeout(Function<? super T, ? extends Publisher<U>> throttlerFactory) {
-		return sampleTimeout(throttlerFactory, QueueSupplier.XS_BUFFER_SIZE);
+		return sampleTimeout(throttlerFactory, Queues.XS_BUFFER_SIZE);
 	}
 
 	/**
@@ -5841,7 +5838,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	public final <U> Flux<T> sampleTimeout(Function<? super T, ? extends Publisher<U>>
 			throttlerFactory, int maxConcurrency) {
 		return onAssembly(new FluxSampleTimeout<>(this, throttlerFactory,
-				QueueSupplier.get(maxConcurrency)));
+				Queues.get(maxConcurrency)));
 	}
 
 	/**
@@ -5941,7 +5938,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public final Flux<T> share() {
 		return onAssembly(new FluxRefCount<>(
-				new FluxPublish<>(this, QueueSupplier.SMALL_BUFFER_SIZE, QueueSupplier.small()), 1)
+				new FluxPublish<>(this, Queues.SMALL_BUFFER_SIZE, Queues.small()), 1)
 		);
 	}
 
@@ -6474,7 +6471,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 */
 	public final <V> Flux<V> switchMap(Function<? super T, Publisher<? extends V>> fn) {
-		return switchMap(fn, QueueSupplier.XS_BUFFER_SIZE);
+		return switchMap(fn, Queues.XS_BUFFER_SIZE);
 	}
 
 	/**
@@ -6494,7 +6491,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * for each source onNext
 	 */
 	public final <V> Flux<V> switchMap(Function<? super T, Publisher<? extends V>> fn, int prefetch) {
-		return onAssembly(new FluxSwitchMap<>(this, fn, QueueSupplier.unbounded(prefetch), prefetch));
+		return onAssembly(new FluxSwitchMap<>(this, fn, Queues.unbounded(prefetch), prefetch));
 	}
 
 	/**
@@ -6891,7 +6888,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a blocking {@link Iterable}
 	 */
 	public final Iterable<T> toIterable() {
-		return toIterable(QueueSupplier.SMALL_BUFFER_SIZE);
+		return toIterable(Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -6928,7 +6925,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	public final Iterable<T> toIterable(long batchSize, @Nullable Supplier<Queue<T>> queueProvider) {
 		final Supplier<Queue<T>> provider;
 		if(queueProvider == null){
-			provider = QueueSupplier.get((int)Math.min(Integer.MAX_VALUE, batchSize));
+			provider = Queues.get((int)Math.min(Integer.MAX_VALUE, batchSize));
 		}
 		else{
 			provider = queueProvider;
@@ -6946,7 +6943,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a {@link Stream} of unknown size with onClose attached to {@link Subscription#cancel()}
 	 */
 	public final Stream<T> toStream() {
-		return toStream(QueueSupplier.SMALL_BUFFER_SIZE);
+		return toStream(Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -6962,7 +6959,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public final Stream<T> toStream(int batchSize) {
 		final Supplier<Queue<T>> provider;
-		provider = QueueSupplier.get(batchSize);
+		provider = Queues.get(batchSize);
 		return new BlockingIterable<>(this, batchSize, provider).stream();
 	}
 
@@ -7002,7 +6999,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a {@link Flux} of {@link Flux} windows based on element count
 	 */
 	public final Flux<Flux<T>> window(int maxSize) {
-		return onAssembly(new FluxWindow<>(this, maxSize, QueueSupplier.get(maxSize)));
+		return onAssembly(new FluxWindow<>(this, maxSize, Queues.get(maxSize)));
 	}
 
 	/**
@@ -7031,8 +7028,8 @@ public abstract class Flux<T> implements Publisher<T> {
 		return onAssembly(new FluxWindow<>(this,
 				maxSize,
 				skip,
-				QueueSupplier.unbounded(QueueSupplier.XS_BUFFER_SIZE),
-				QueueSupplier.unbounded(QueueSupplier.XS_BUFFER_SIZE)));
+				Queues.unbounded(Queues.XS_BUFFER_SIZE),
+				Queues.unbounded(Queues.XS_BUFFER_SIZE)));
 	}
 
 	/**
@@ -7049,8 +7046,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	public final Flux<Flux<T>> window(Publisher<?> boundary) {
 		return onAssembly(new FluxWindowBoundary<>(this,
 				boundary,
-				QueueSupplier.unbounded(QueueSupplier.XS_BUFFER_SIZE),
-				QueueSupplier.unbounded(QueueSupplier.XS_BUFFER_SIZE)));
+				Queues.unbounded(Queues.XS_BUFFER_SIZE),
+				Queues.unbounded(Queues.XS_BUFFER_SIZE)));
 	}
 
 	/**
@@ -7229,7 +7226,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	//TODO bump marbles URL to upcoming release tag
 	public final Flux<GroupedFlux<T, T>> windowUntil(Predicate<T> boundaryTrigger, boolean cutBefore) {
-		return windowUntil(boundaryTrigger, cutBefore, QueueSupplier.SMALL_BUFFER_SIZE);
+		return windowUntil(boundaryTrigger, cutBefore, Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -7258,8 +7255,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	//TODO bump marbles URL to upcoming release tag
 	public final Flux<GroupedFlux<T, T>> windowUntil(Predicate<T> boundaryTrigger, boolean cutBefore, int prefetch) {
 		return onAssembly(new FluxWindowPredicate<>(this,
-				QueueSupplier.unbounded(prefetch),
-				QueueSupplier.unbounded(prefetch),
+				Queues.unbounded(prefetch),
+				Queues.unbounded(prefetch),
 				prefetch,
 				boundaryTrigger,
 				cutBefore ? FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE : FluxBufferPredicate.Mode.UNTIL));
@@ -7282,7 +7279,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	//TODO bump marbles URL to upcoming release tag
 	public final Flux<GroupedFlux<T, T>> windowWhile(Predicate<T> inclusionPredicate) {
-		return windowWhile(inclusionPredicate, QueueSupplier.SMALL_BUFFER_SIZE);
+		return windowWhile(inclusionPredicate, Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -7304,8 +7301,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	//TODO bump marbles URL to upcoming release tag
 	public final Flux<GroupedFlux<T, T>> windowWhile(Predicate<T> inclusionPredicate, int prefetch) {
 		return onAssembly(new FluxWindowPredicate<>(this,
-				QueueSupplier.unbounded(prefetch),
-				QueueSupplier.unbounded(prefetch),
+				Queues.unbounded(prefetch),
+				Queues.unbounded(prefetch),
 				prefetch,
 				inclusionPredicate,
 				FluxBufferPredicate.Mode.WHILE));
@@ -7343,8 +7340,8 @@ public abstract class Flux<T> implements Publisher<T> {
 		return onAssembly(new FluxWindowWhen<>(this,
 				bucketOpening,
 				closeSelector,
-				QueueSupplier.unbounded(QueueSupplier.XS_BUFFER_SIZE),
-				QueueSupplier.unbounded(QueueSupplier.XS_BUFFER_SIZE)));
+				Queues.unbounded(Queues.XS_BUFFER_SIZE),
+				Queues.unbounded(Queues.XS_BUFFER_SIZE)));
 	}
 
 	/**
@@ -7565,9 +7562,9 @@ public abstract class Flux<T> implements Publisher<T> {
 				mapper,
 				delayError,
 				concurrency,
-				QueueSupplier.get(concurrency),
+				Queues.get(concurrency),
 				prefetch,
-				QueueSupplier.get(prefetch)
+				Queues.get(prefetch)
 		));
 	}
 
@@ -7671,9 +7668,9 @@ public abstract class Flux<T> implements Publisher<T> {
 		return onAssembly(new FluxMerge<>(sources,
 				delayError,
 				sources.length,
-				QueueSupplier.get(sources.length),
+				Queues.get(sources.length),
 				prefetch,
-				QueueSupplier.get(prefetch)));
+				Queues.get(prefetch)));
 	}
 
 	@SafeVarargs

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
@@ -33,7 +33,7 @@ import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.core.publisher.FluxSink.OverflowStrategy;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 /**
  * Provides a multi-valued sink API for a callback that is called for
@@ -77,7 +77,7 @@ final class FluxCreate<T> extends Flux<T> {
 				return new LatestAsyncSink<>(t);
 			}
 			default: {
-				return new BufferAsyncSink<>(t, QueueSupplier.SMALL_BUFFER_SIZE);
+				return new BufferAsyncSink<>(t, Queues.SMALL_BUFFER_SIZE);
 			}
 		}
 	}
@@ -121,7 +121,7 @@ final class FluxCreate<T> extends Flux<T> {
 
 		SerializedSink(BaseSink<T> sink) {
 			this.sink = sink;
-			this.queue = QueueSupplier.<T>unbounded(16).get();
+			this.queue = Queues.<T>unbounded(16).get();
 		}
 
 		@Override
@@ -608,7 +608,7 @@ final class FluxCreate<T> extends Flux<T> {
 
 		 BufferAsyncSink(CoreSubscriber<? super T> actual, int capacityHint) {
 			super(actual);
-			this.queue = QueueSupplier.<T>unbounded(capacityHint).get();
+			this.queue = Queues.<T>unbounded(capacityHint).get();
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilterWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilterWhen.java
@@ -32,7 +32,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
 
 /**
@@ -110,7 +110,7 @@ class FluxFilterWhen<T> extends FluxOperator<T, T> {
 				Function<? super T, ? extends Publisher<Boolean>> asyncPredicate,
 				int bufferSize) {
 			this.actual = actual;
-			this.toFilter = new AtomicReferenceArray<>(QueueSupplier.ceilingNextPowerOfTwo(bufferSize));
+			this.toFilter = new AtomicReferenceArray<>(Queues.ceilingNextPowerOfTwo(bufferSize));
 			this.asyncPredicate = asyncPredicate;
 			this.bufferSize = bufferSize;
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMergeSequential.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMergeSequential.java
@@ -35,7 +35,7 @@ import reactor.core.Fuseable;
 import reactor.core.Fuseable.QueueSubscription;
 import reactor.core.Scannable;
 import reactor.core.publisher.FluxConcatMap.ErrorMode;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
 
 /**
@@ -62,7 +62,7 @@ final class FluxMergeSequential<T, R> extends FluxOperator<T, R> {
 			Function<? super T, ? extends Publisher<? extends R>> mapper,
 			int maxConcurrency, int prefetch, ErrorMode errorMode) {
 		this(source, mapper, maxConcurrency, prefetch, errorMode,
-				QueueSupplier.get(Math.max(prefetch, maxConcurrency)));
+				Queues.get(Math.max(prefetch, maxConcurrency)));
 	}
 
 	//for testing purpose
@@ -547,7 +547,7 @@ final class FluxMergeSequential<T, R> extends FluxOperator<T, R> {
 					}
 				}
 
-				queue = QueueSupplier.<R>get(prefetch).get();
+				queue = Queues.<R>get(prefetch).get();
 				s.request(prefetch == Integer.MAX_VALUE ? Long.MAX_VALUE : prefetch);
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBuffer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBuffer.java
@@ -27,7 +27,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 /**
  * @author Stephane Maldini
@@ -106,10 +106,10 @@ final class FluxOnBackpressureBuffer<O> extends FluxOperator<O, O> implements Fu
 			Queue<T> q;
 
 			if (unbounded) {
-				q = QueueSupplier.<T>unbounded(bufferSize).get();
+				q = Queues.<T>unbounded(bufferSize).get();
 			}
 			else {
-				q = QueueSupplier.<T>get(bufferSize).get();
+				q = Queues.<T>get(bufferSize).get();
 			}
 
 			this.queue = q;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -35,7 +35,7 @@ import reactor.core.Disposable;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 /**
  * @param <T>
@@ -1002,7 +1002,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 			return new ReplaySubscriber<>(new SizeBoundReplayBuffer<>(history),
 					this);
 		}
-		return new ReplaySubscriber<>(new UnboundedReplayBuffer<>(QueueSupplier.SMALL_BUFFER_SIZE),
+		return new ReplaySubscriber<>(new UnboundedReplayBuffer<>(Queues.SMALL_BUFFER_SIZE),
 					this);
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -47,7 +47,7 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Scheduler.Worker;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.Logger;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuple3;
@@ -541,7 +541,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @return a Mono that emits a Boolean value that indicates whether the two sequences are the same
 	 */
 	public static <T> Mono<Boolean> sequenceEqual(Publisher<? extends T> source1, Publisher<? extends T> source2) {
-		return sequenceEqual(source1, source2, equalsBiPredicate(), QueueSupplier.SMALL_BUFFER_SIZE);
+		return sequenceEqual(source1, source2, equalsBiPredicate(), Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -562,7 +562,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 */
 	public static <T> Mono<Boolean> sequenceEqual(Publisher<? extends T> source1, Publisher<? extends T> source2,
 			BiPredicate<? super T, ? super T> isEqual) {
-		return sequenceEqual(source1, source2, isEqual, QueueSupplier.SMALL_BUFFER_SIZE);
+		return sequenceEqual(source1, source2, isEqual, Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -1128,7 +1128,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 */
 	@SafeVarargs
 	public static <T, V> Mono<V> zip(Function<? super Object[], ? extends V> combinator, Mono<? extends T>... monos) {
-		return fromDirect(new FluxZip<>(monos, combinator, QueueSupplier.one(), 1));
+		return fromDirect(new FluxZip<>(monos, combinator, Queues.one(), 1));
 	}
 
 	/**
@@ -1150,7 +1150,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 */
 	public static <T, V> Mono<V> zip(final Iterable<?extends Mono<? extends T>> monos,
 			final Function<? super Object[], ? extends V> combinator) {
-		return fromDirect(new FluxZip<>(monos, combinator, QueueSupplier.<T>one(), 1));
+		return fromDirect(new FluxZip<>(monos, combinator, Queues.<T>one(), 1));
 	}
 
 //	 ==============================================================================================================
@@ -2115,7 +2115,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 */
 	public final <R> Flux<R> flatMapIterable(Function<? super T, ? extends Iterable<? extends R>> mapper) {
 		return Flux.onAssembly(new MonoFlattenIterable<>(this, mapper, Integer
-				.MAX_VALUE, QueueSupplier.one()));
+				.MAX_VALUE, Queues.one()));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPublishMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPublishMulticast.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 /**
  * Shares a sequence for the duration of a function that may transform it and
@@ -48,7 +48,7 @@ final class MonoPublishMulticast<T, R> extends MonoOperator<T, R> implements Fus
 
 		FluxPublishMulticast.FluxPublishMulticaster<T, R> multicast =
 				new FluxPublishMulticast.FluxPublishMulticaster<>(Integer.MAX_VALUE,
-						QueueSupplier.one(), s.currentContext());
+						Queues.one(), s.currentContext());
 
 		Mono<? extends R> out;
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSequenceEqual.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSequenceEqual.java
@@ -28,7 +28,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
 
 import static reactor.core.publisher.Operators.cancelledSubscription;
@@ -294,7 +294,7 @@ final class MonoSequenceEqual<T> extends Mono<Boolean> {
 		EqualSubscriber(EqualCoordinator<T> parent, int bufferSize) {
 			this.parent = parent;
 			this.bufferSize = bufferSize;
-			this.queue = QueueSupplier.<T>get(bufferSize).get();
+			this.queue = Queues.<T>get(bufferSize).get();
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -39,7 +39,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.publisher.FluxConcatMap.ErrorMode;
 import reactor.core.scheduler.Scheduler;
 import reactor.util.Logger;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 /**
  * A ParallelFlux publishes to an array of Subscribers, in parallel 'rails' (or
@@ -73,8 +73,8 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	public static <T> ParallelFlux<T> from(Publisher<? extends T> source) {
 		return from(source,
 				Runtime.getRuntime()
-				       .availableProcessors(), QueueSupplier.SMALL_BUFFER_SIZE,
-				QueueSupplier.small());
+				       .availableProcessors(), Queues.SMALL_BUFFER_SIZE,
+				Queues.small());
 	}
 
 	/**
@@ -90,8 +90,8 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	public static <T> ParallelFlux<T> from(Publisher<? extends T> source,
 			int parallelism) {
 		return from(source,
-				parallelism, QueueSupplier.SMALL_BUFFER_SIZE,
-				QueueSupplier.small());
+				parallelism, Queues.SMALL_BUFFER_SIZE,
+				Queues.small());
 	}
 
 	/**
@@ -524,7 +524,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	public final <R> ParallelFlux<R> flatMap(Function<? super T, ? extends Publisher<? extends R>> mapper) {
 		return flatMap(mapper,
 				false,
-				Integer.MAX_VALUE, QueueSupplier.SMALL_BUFFER_SIZE);
+				Integer.MAX_VALUE, Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -543,7 +543,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 			boolean delayError) {
 		return flatMap(mapper,
 				delayError,
-				Integer.MAX_VALUE, QueueSupplier.SMALL_BUFFER_SIZE);
+				Integer.MAX_VALUE, Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -566,7 +566,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 			int maxConcurrency) {
 		return flatMap(mapper,
 				delayError,
-				maxConcurrency, QueueSupplier.SMALL_BUFFER_SIZE);
+				maxConcurrency, Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -592,8 +592,8 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 				mapper,
 				delayError,
 				maxConcurrency,
-				QueueSupplier.get(maxConcurrency),
-				prefetch, QueueSupplier.get(prefetch)));
+				Queues.get(maxConcurrency),
+				prefetch, Queues.get(prefetch)));
 	}
 
 	/**
@@ -785,7 +785,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	 * and default prefetch amount.
 	 * <p>
 	 * This operator uses the default prefetch size returned by {@code
-	 * QueueSupplier.SMALL_BUFFER_SIZE}.
+	 * Queues.SMALL_BUFFER_SIZE}.
 	 * <p>
 	 * The operator will call {@code Scheduler.createWorker()} as many times as this
 	 * ParallelFlux's parallelism level is.
@@ -802,7 +802,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	 * @return the new {@link ParallelFlux} instance
 	 */
 	public final ParallelFlux<T> runOn(Scheduler scheduler) {
-		return runOn(scheduler, QueueSupplier.SMALL_BUFFER_SIZE);
+		return runOn(scheduler, Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -810,7 +810,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	 * work-stealing and a given prefetch amount.
 	 * <p>
 	 * This operator uses the default prefetch size returned by {@code
-	 * QueueSupplier.SMALL_BUFFER_SIZE}.
+	 * Queues.SMALL_BUFFER_SIZE}.
 	 * <p>
 	 * The operator will call {@code Scheduler.createWorker()} as many times as this
 	 * ParallelFlux's parallelism level is.
@@ -832,7 +832,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 		return onAssembly(new ParallelRunOn<>(this,
 				scheduler,
 				prefetch,
-				QueueSupplier.get(prefetch)));
+				Queues.get(prefetch)));
 	}
 
 	/**
@@ -841,14 +841,14 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	 * for the rails.
 	 * <p>
 	 * This operator uses the default prefetch size returned by {@code
-	 * QueueSupplier.SMALL_BUFFER_SIZE}.
+	 * Queues.SMALL_BUFFER_SIZE}.
 	 *
 	 * @return the new Flux instance
 	 *
 	 * @see ParallelFlux#sequential(int)
 	 */
 	public final Flux<T> sequential() {
-		return sequential(QueueSupplier.SMALL_BUFFER_SIZE);
+		return sequential(Queues.SMALL_BUFFER_SIZE);
 	}
 
 	/**
@@ -863,7 +863,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	public final Flux<T> sequential(int prefetch) {
 		return Flux.onAssembly(new ParallelMergeSequential<>(this,
 				prefetch,
-				QueueSupplier.get(prefetch)));
+				Queues.get(prefetch)));
 	}
 
 	/**
@@ -1071,7 +1071,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 			ErrorMode errorMode) {
 		return onAssembly(new ParallelConcatMap<>(this,
 				mapper,
-				QueueSupplier.get(prefetch),
+				Queues.get(prefetch),
 				prefetch,
 				errorMode));
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -32,7 +32,7 @@ import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static reactor.core.publisher.FluxReplay.ReplaySubscriber.EMPTY;
 import static reactor.core.publisher.FluxReplay.ReplaySubscriber.TERMINATED;
@@ -91,7 +91,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	}
 
 	/**
-	 * Create a new {@link ReplayProcessor} using {@link QueueSupplier#SMALL_BUFFER_SIZE}
+	 * Create a new {@link ReplayProcessor} using {@link Queues#SMALL_BUFFER_SIZE}
 	 * backlog size, blockingWait Strategy and auto-cancel.
 	 *
 	 * @param <E> Type of processed signals
@@ -99,7 +99,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * @return a fresh processor
 	 */
 	public static <E> ReplayProcessor<E> create() {
-		return create(QueueSupplier.SMALL_BUFFER_SIZE, true);
+		return create(Queues.SMALL_BUFFER_SIZE, true);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/RingBuffer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/RingBuffer.java
@@ -19,17 +19,15 @@ package reactor.core.publisher;
 import java.lang.reflect.Field;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
-
-import reactor.util.concurrent.QueueSupplier;
-import reactor.util.concurrent.WaitStrategy;
 import javax.annotation.Nullable;
+
+import reactor.util.concurrent.Queues;
+import reactor.util.concurrent.WaitStrategy;
 import sun.misc.Unsafe;
 
 import static java.util.Arrays.copyOf;
@@ -162,7 +160,7 @@ abstract class RingBuffer<E> implements LongSupplier {
 			@Nullable Runnable spinObserver) {
 		SingleProducerSequencer sequencer = new SingleProducerSequencer(bufferSize, waitStrategy, spinObserver);
 
-		if (hasUnsafe() && QueueSupplier.isPowerOfTwo(bufferSize)) {
+		if (hasUnsafe() && Queues.isPowerOfTwo(bufferSize)) {
 			return new UnsafeRingBuffer<>(factory, sequencer);
 		}
 		else {

--- a/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
@@ -29,7 +29,7 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 import reactor.util.concurrent.WaitStrategy;
 
 /**
@@ -89,7 +89,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 		Supplier<T> signalSupplier;
 
 		Builder() {
-			this.bufferSize = QueueSupplier.SMALL_BUFFER_SIZE;
+			this.bufferSize = Queues.SMALL_BUFFER_SIZE;
 			this.autoCancel = true;
 			this.share = false;
 		}
@@ -109,12 +109,12 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 		}
 
 		/**
-		 * Configures buffer size for this builder. Default value is {@link QueueSupplier#SMALL_BUFFER_SIZE}.
+		 * Configures buffer size for this builder. Default value is {@link Queues#SMALL_BUFFER_SIZE}.
 		 * @param bufferSize the internal buffer size to hold signals, must be a power of 2.
 		 * @return builder with provided buffer size
 		 */
 		public Builder<T> bufferSize(int bufferSize) {
-			if (!QueueSupplier.isPowerOfTwo(bufferSize)) {
+			if (!Queues.isPowerOfTwo(bufferSize)) {
 				throw new IllegalArgumentException("bufferSize must be a power of 2 : " + bufferSize);
 			}
 
@@ -224,7 +224,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	/**
-	 * Create a new TopicProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
+	 * Create a new TopicProcessor using {@link Queues#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and auto-cancel. <p> A new Cached ThreadExecutorPool will be
 	 * implicitly created.
 	 * @param <E> Type of processed signals

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -30,6 +30,7 @@ import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 /**
  * A Processor implementation that takes a custom queue and allows
@@ -148,6 +149,11 @@ public final class UnicastProcessor<T>
 		this.queue = Objects.requireNonNull(queue, "queue");
 		this.onOverflow = Objects.requireNonNull(onOverflow, "onOverflow");
 		this.onTerminate = Objects.requireNonNull(onTerminate, "onTerminate");
+	}
+
+	@Override
+	public int getBufferSize() {
+		return Queues.capacity(this.queue);
 	}
 
 	void doTerminate() {

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -29,7 +29,6 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
-import reactor.util.concurrent.QueueSupplier;
 import reactor.util.concurrent.Queues;
 
 /**
@@ -53,7 +52,7 @@ public final class UnicastProcessor<T>
 	 * @return a unicast {@link FluxProcessor}
 	 */
 	public static <E> UnicastProcessor<E> create() {
-		return new UnicastProcessor<>(QueueSupplier.<E>unbounded().get());
+		return new UnicastProcessor<>(Queues.<E>unbounded().get());
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
@@ -35,7 +35,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.util.Logger;
 import reactor.util.Loggers;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 import reactor.util.concurrent.WaitStrategy;
 
 /**
@@ -85,7 +85,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 		boolean autoCancel;
 
 		Builder() {
-			this.bufferSize = QueueSupplier.SMALL_BUFFER_SIZE;
+			this.bufferSize = Queues.SMALL_BUFFER_SIZE;
 			this.autoCancel = true;
 			this.share = false;
 		}
@@ -105,12 +105,12 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 		}
 
 		/**
-		 * Configures buffer size for this builder. Default value is {@link QueueSupplier#SMALL_BUFFER_SIZE}.
+		 * Configures buffer size for this builder. Default value is {@link Queues#SMALL_BUFFER_SIZE}.
 		 * @param bufferSize the internal buffer size to hold signals, must be a power of 2
 		 * @return builder with provided buffer size
 		 */
 		public Builder<T> bufferSize(int bufferSize) {
-			if (!QueueSupplier.isPowerOfTwo(bufferSize)) {
+			if (!Queues.isPowerOfTwo(bufferSize)) {
 				throw new IllegalArgumentException("bufferSize must be a power of 2 : " + bufferSize);
 			}
 
@@ -209,7 +209,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	}
 
 	/**
-	 * Create a new WorkQueueProcessor using {@link QueueSupplier#SMALL_BUFFER_SIZE} backlog size,
+	 * Create a new WorkQueueProcessor using {@link Queues#SMALL_BUFFER_SIZE} backlog size,
 	 * blockingWait Strategy and auto-cancel. <p> A new Cached ThreadExecutorPool will be
 	 * implicitly created.
 	 * @param <E> Type of processed signals

--- a/reactor-core/src/main/java/reactor/util/concurrent/OpenHashSet.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/OpenHashSet.java
@@ -45,7 +45,7 @@ public final class OpenHashSet<T> {
     @SuppressWarnings("unchecked")
     public OpenHashSet(int capacity, float loadFactor) {
         this.loadFactor = loadFactor;
-        int c = QueueSupplier.ceilingNextPowerOfTwo(capacity);
+        int c = Queues.ceilingNextPowerOfTwo(capacity);
         this.mask = c - 1;
         this.maxSize = (int)(loadFactor * c);
         this.keys = (T[])new Object[c];

--- a/reactor-core/src/main/java/reactor/util/concurrent/QueueSupplier.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/QueueSupplier.java
@@ -28,7 +28,10 @@ import javax.annotation.Nullable;
  * Provide a 1-producer/1-consumer ready queue adapted for a given capacity.
  *
  * @param <T> the queue element type
+ * @deprecated will be removed in 3.1.0.RELEASE, static methods replaced by {@link Queues}
+ * and instances to be replaced by plain {@link Supplier}.
  */
+@Deprecated
 public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 
 	/**
@@ -142,7 +145,7 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	}
 
 
-
+    //TODO move instance code below to Queues#get
 	final long    batchSize;
 
 	QueueSupplier(long batchSize) {
@@ -162,6 +165,8 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 			return new SpscArrayQueue<>((int)batchSize);
 		}
 	}
+
+	//TODO move all code below to Queues before removing class
 
 	static final class OneQueue<T> extends AtomicReference<T> implements Queue<T> {
         @Override

--- a/reactor-core/src/main/java/reactor/util/concurrent/QueueSupplier.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/QueueSupplier.java
@@ -34,13 +34,18 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	/**
 	 * An allocation friendly default of available slots in a given container, e.g. slow publishers and or fast/few
 	 * subscribers
+	 *
+	 * @deprecated use the same constant in {@link Queues}
 	 */
+	@Deprecated
 	public static final int XS_BUFFER_SIZE    = Math.max(8,
 			Integer.parseInt(System.getProperty("reactor.bufferSize.x", "32")));
 	/**
 	 * A small default of available slots in a given container, compromise between intensive pipelines, small
 	 * subscribers numbers and memory use.
+	 * @deprecated use the same constant in {@link Queues}
 	 */
+	@Deprecated
 	public static final int SMALL_BUFFER_SIZE = Math.max(16,
 			Integer.parseInt(System.getProperty("reactor.bufferSize.small", "256")));
 
@@ -51,7 +56,9 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	 * @param x Value to round up
 	 *
 	 * @return The next power of 2 from x inclusive
+	 * @deprecated use the same method in {@link Queues}
 	 */
+	@Deprecated
 	public static int ceilingNextPowerOfTwo(final int x) {
 		return 1 << (32 - Integer.numberOfLeadingZeros(x - 1));
 	}
@@ -61,8 +68,9 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	 * @param batchSize the bounded or unbounded (int.max) queue size
 	 * @param <T> the reified {@link Queue} generic type
 	 * @return an unbounded or bounded {@link Queue} {@link Supplier}
+	 * @deprecated use the same method in {@link Queues}
 	 */
-	@SuppressWarnings("unchecked")
+	@Deprecated
 	public static <T> Supplier<Queue<T>> get(int batchSize) {
 		if (batchSize == Integer.MAX_VALUE) {
 			return SMALL_UNBOUNDED;
@@ -83,7 +91,9 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	 * @param x the int to test
 	 *
 	 * @return true if x is a power of 2
+	 * @deprecated use the same method in {@link Queues}
 	 */
+	@Deprecated
 	public static boolean isPowerOfTwo(final int x) {
 		return Integer.bitCount(x) == 1;
 	}
@@ -92,8 +102,9 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	 *
 	 * @param <T> the reified {@link Queue} generic type
 	 * @return a bounded {@link Queue} {@link Supplier}
+	 * @deprecated use the same method in {@link Queues}
 	 */
-	@SuppressWarnings("unchecked")
+	@Deprecated
 	public static <T> Supplier<Queue<T>> one() {
 		return ONE_SUPPLIER;
 	}
@@ -102,8 +113,9 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	 * @param <T> the reified {@link Queue} generic type
 	 *
 	 * @return a bounded {@link Queue} {@link Supplier}
+	 * @deprecated use the same method in {@link Queues}
 	 */
-	@SuppressWarnings("unchecked")
+	@Deprecated
 	public static <T> Supplier<Queue<T>> small() {
 		return SMALL_SUPPLIER;
 	}
@@ -112,8 +124,9 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	 *
 	 * @param <T> the reified {@link Queue} generic type
 	 * @return an unbounded {@link Queue} {@link Supplier}
+	 * @deprecated use the same method in {@link Queues}
 	 */
-	@SuppressWarnings("unchecked")
+	@Deprecated
 	public static <T> Supplier<Queue<T>> unbounded() {
 		return SMALL_UNBOUNDED;
 	}
@@ -124,8 +137,9 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	 * @param linkSize the link size
 	 * @param <T> the reified {@link Queue} generic type
 	 * @return an unbounded {@link Queue} {@link Supplier}
+	 * @deprecated use the same method in {@link Queues}
 	 */
-	@SuppressWarnings("unchecked")
+	@Deprecated
 	public static <T> Supplier<Queue<T>> unbounded(int linkSize) {
 		if (linkSize == XS_BUFFER_SIZE) {
 			return XS_UNBOUNDED;
@@ -140,11 +154,15 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	 *
 	 * @param <T> the reified {@link Queue} generic type
 	 * @return a bounded {@link Queue} {@link Supplier}
+	 * @deprecated use the same method in {@link Queues}
 	 */
-	@SuppressWarnings("unchecked")
+	@Deprecated
 	public static <T> Supplier<Queue<T>> xs() {
 		return XS_SUPPLIER;
 	}
+
+
+
 	final long    batchSize;
 
 	QueueSupplier(long batchSize) {
@@ -155,7 +173,7 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	public Queue<T> get() {
 
 		if(batchSize > 10_000_000){
-			return new SpscLinkedArrayQueue<>(SMALL_BUFFER_SIZE);
+			return new SpscLinkedArrayQueue<>(Queues.SMALL_BUFFER_SIZE);
 		}
 		else if (batchSize == 1) {
 			return new OneQueue<>();
@@ -307,15 +325,17 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 			queue.remove();
 		}
 	}
+
+
     @SuppressWarnings("rawtypes")
     static final Supplier ONE_SUPPLIER   = OneQueue::new;
 	@SuppressWarnings("rawtypes")
-    static final Supplier XS_SUPPLIER    = () -> new SpscArrayQueue<>(XS_BUFFER_SIZE);
+    static final Supplier XS_SUPPLIER    = () -> new SpscArrayQueue<>(Queues.XS_BUFFER_SIZE);
 	@SuppressWarnings("rawtypes")
-    static final Supplier SMALL_SUPPLIER = () -> new SpscArrayQueue<>(SMALL_BUFFER_SIZE);
+    static final Supplier SMALL_SUPPLIER = () -> new SpscArrayQueue<>(Queues.SMALL_BUFFER_SIZE);
 	@SuppressWarnings("rawtypes")
 	static final Supplier SMALL_UNBOUNDED =
-			() -> new SpscLinkedArrayQueue<>(SMALL_BUFFER_SIZE);
+			() -> new SpscLinkedArrayQueue<>(Queues.SMALL_BUFFER_SIZE);
 	@SuppressWarnings("rawtypes")
-	static final Supplier XS_UNBOUNDED = () -> new SpscLinkedArrayQueue<>(XS_BUFFER_SIZE);
+	static final Supplier XS_UNBOUNDED = () -> new SpscLinkedArrayQueue<>(Queues.XS_BUFFER_SIZE);
 }

--- a/reactor-core/src/main/java/reactor/util/concurrent/QueueSupplier.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/QueueSupplier.java
@@ -38,16 +38,14 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	 * @deprecated use the same constant in {@link Queues}
 	 */
 	@Deprecated
-	public static final int XS_BUFFER_SIZE    = Math.max(8,
-			Integer.parseInt(System.getProperty("reactor.bufferSize.x", "32")));
+	public static final int XS_BUFFER_SIZE    = Queues.XS_BUFFER_SIZE;
 	/**
 	 * A small default of available slots in a given container, compromise between intensive pipelines, small
 	 * subscribers numbers and memory use.
 	 * @deprecated use the same constant in {@link Queues}
 	 */
 	@Deprecated
-	public static final int SMALL_BUFFER_SIZE = Math.max(16,
-			Integer.parseInt(System.getProperty("reactor.bufferSize.small", "256")));
+	public static final int SMALL_BUFFER_SIZE =  Queues.SMALL_BUFFER_SIZE;
 
 	/**
 	 * Calculate the next power of 2, greater than or equal to x.<p> From Hacker's Delight, Chapter 3, Harry S. Warren
@@ -60,7 +58,7 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	 */
 	@Deprecated
 	public static int ceilingNextPowerOfTwo(final int x) {
-		return 1 << (32 - Integer.numberOfLeadingZeros(x - 1));
+		return Queues.ceilingNextPowerOfTwo(x);
 	}
 
 	/**
@@ -72,19 +70,7 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	 */
 	@Deprecated
 	public static <T> Supplier<Queue<T>> get(int batchSize) {
-		if (batchSize == Integer.MAX_VALUE) {
-			return SMALL_UNBOUNDED;
-		}
-		if (batchSize == XS_BUFFER_SIZE) {
-			return XS_SUPPLIER;
-		}
-		if (batchSize == SMALL_BUFFER_SIZE) {
-			return SMALL_SUPPLIER;
-		}
-		if (batchSize == 1) {
-			return ONE_SUPPLIER;
-		}
-		return new QueueSupplier<>(Math.max(8, batchSize));
+		return Queues.get(batchSize);
 	}
 
 	/**
@@ -95,7 +81,7 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	 */
 	@Deprecated
 	public static boolean isPowerOfTwo(final int x) {
-		return Integer.bitCount(x) == 1;
+		return Queues.isPowerOfTwo(x);
 	}
 
 	/**
@@ -106,7 +92,7 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	 */
 	@Deprecated
 	public static <T> Supplier<Queue<T>> one() {
-		return ONE_SUPPLIER;
+		return Queues.one();
 	}
 
 	/**
@@ -117,7 +103,7 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	 */
 	@Deprecated
 	public static <T> Supplier<Queue<T>> small() {
-		return SMALL_SUPPLIER;
+		return Queues.small();
 	}
 
 	/**
@@ -128,7 +114,7 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	 */
 	@Deprecated
 	public static <T> Supplier<Queue<T>> unbounded() {
-		return SMALL_UNBOUNDED;
+		return Queues.unbounded();
 	}
 
 	/**
@@ -141,13 +127,7 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	 */
 	@Deprecated
 	public static <T> Supplier<Queue<T>> unbounded(int linkSize) {
-		if (linkSize == XS_BUFFER_SIZE) {
-			return XS_UNBOUNDED;
-		}
-		else if (linkSize == Integer.MAX_VALUE || linkSize == SMALL_BUFFER_SIZE) {
-			return unbounded();
-		}
-		return  () -> new SpscLinkedArrayQueue<>(linkSize);
+		return Queues.unbounded(linkSize);
 	}
 
 	/**
@@ -158,7 +138,7 @@ public final class QueueSupplier<T> implements Supplier<Queue<T>> {
 	 */
 	@Deprecated
 	public static <T> Supplier<Queue<T>> xs() {
-		return XS_SUPPLIER;
+		return Queues.xs();
 	}
 
 

--- a/reactor-core/src/main/java/reactor/util/concurrent/Queues.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/Queues.java
@@ -21,7 +21,8 @@ import java.util.concurrent.BlockingQueue;
 import java.util.function.Supplier;
 
 /**
- * Utility methods around {@link Queue Queues} and pre-defined {@link QueueSupplier suppliers}.
+ * Utility methods around {@link Queue Queues} and pre-defined {@link Queue}
+ * {@link Supplier suppliers}.
  */
 public class Queues {
 

--- a/reactor-core/src/main/java/reactor/util/concurrent/Queues.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/Queues.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.concurrent;
+
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * Utility methods around {@link Queue Queues} and pre-defined {@link QueueSupplier suppliers}.
+ */
+public class Queues {
+
+	public static final int CAPACITY_UNSURE = Integer.MIN_VALUE;
+
+	/**
+	 * Return the capacity of a given {@link Queue} in a best effort fashion. Queues that
+	 * are known to be unbounded will return {@code Integer.MAX_VALUE} and queues that
+	 * have a known bounded capacity will return that capacity. For other {@link Queue}
+	 * implementations not recognized by this method or not providing this kind of
+	 * information, {@link #CAPACITY_UNSURE} ({@code Integer.MIN_VALUE}) is returned.
+	 *
+	 * @param q the {@link Queue} to try to get a capacity for
+	 * @return the capacity of the queue, if discoverable with confidence, or {@link #CAPACITY_UNSURE} negative constant.
+	 */
+	public static final int capacity(Queue q) {
+		if (q instanceof BlockingQueue) {
+			return ((BlockingQueue) q).remainingCapacity();
+		}
+		else if (q instanceof SpscLinkedArrayQueue) {
+			return Integer.MAX_VALUE;
+		}
+		else if (q instanceof SpscArrayQueue) {
+			return ((SpscArrayQueue) q).length();
+		}
+		else {
+			return CAPACITY_UNSURE;
+		}
+	}
+
+}

--- a/reactor-core/src/main/java/reactor/util/concurrent/Queues.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/Queues.java
@@ -18,6 +18,7 @@ package reactor.util.concurrent;
 
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
+import java.util.function.Supplier;
 
 /**
  * Utility methods around {@link Queue Queues} and pre-defined {@link QueueSupplier suppliers}.
@@ -25,6 +26,122 @@ import java.util.concurrent.BlockingQueue;
 public class Queues {
 
 	public static final int CAPACITY_UNSURE = Integer.MIN_VALUE;
+
+	/**
+	 * An allocation friendly default of available slots in a given container, e.g. slow publishers and or fast/few
+	 * subscribers
+	 */
+	public static final int XS_BUFFER_SIZE    = Math.max(8,
+			Integer.parseInt(System.getProperty("reactor.bufferSize.x", "32")));
+	/**
+	 * A small default of available slots in a given container, compromise between intensive pipelines, small
+	 * subscribers numbers and memory use.
+	 */
+	public static final int SMALL_BUFFER_SIZE = Math.max(16,
+			Integer.parseInt(System.getProperty("reactor.bufferSize.small", "256")));
+
+	/**
+	 * Calculate the next power of 2, greater than or equal to x.<p> From Hacker's Delight, Chapter 3, Harry S. Warren
+	 * Jr.
+	 *
+	 * @param x Value to round up
+	 *
+	 * @return The next power of 2 from x inclusive
+	 */
+	public static int ceilingNextPowerOfTwo(final int x) {
+		return 1 << (32 - Integer.numberOfLeadingZeros(x - 1));
+	}
+
+	/**
+	 *
+	 * @param batchSize the bounded or unbounded (int.max) queue size
+	 * @param <T> the reified {@link Queue} generic type
+	 * @return an unbounded or bounded {@link Queue} {@link Supplier}
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> Supplier<Queue<T>> get(int batchSize) {
+		if (batchSize == Integer.MAX_VALUE) {
+			return QueueSupplier.SMALL_UNBOUNDED;
+		}
+		if (batchSize == XS_BUFFER_SIZE) {
+			return QueueSupplier.XS_SUPPLIER;
+		}
+		if (batchSize == SMALL_BUFFER_SIZE) {
+			return QueueSupplier.SMALL_SUPPLIER;
+		}
+		if (batchSize == 1) {
+			return QueueSupplier.ONE_SUPPLIER;
+		}
+		return new QueueSupplier<>(Math.max(8, batchSize));
+	}
+
+	/**
+	 * @param x the int to test
+	 *
+	 * @return true if x is a power of 2
+	 */
+	public static boolean isPowerOfTwo(final int x) {
+		return Integer.bitCount(x) == 1;
+	}
+
+	/**
+	 *
+	 * @param <T> the reified {@link Queue} generic type
+	 * @return a bounded {@link Queue} {@link Supplier}
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> Supplier<Queue<T>> one() {
+		return QueueSupplier.ONE_SUPPLIER;
+	}
+
+	/**
+	 * @param <T> the reified {@link Queue} generic type
+	 *
+	 * @return a bounded {@link Queue} {@link Supplier}
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> Supplier<Queue<T>> small() {
+		return QueueSupplier.SMALL_SUPPLIER;
+	}
+
+	/**
+	 *
+	 * @param <T> the reified {@link Queue} generic type
+	 * @return an unbounded {@link Queue} {@link Supplier}
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> Supplier<Queue<T>> unbounded() {
+		return QueueSupplier.SMALL_UNBOUNDED;
+	}
+
+	/**
+	 * Returns an unbounded, linked-array-based Queue. Integer.max sized link will
+	 * return the default {@link #SMALL_BUFFER_SIZE} size.
+	 * @param linkSize the link size
+	 * @param <T> the reified {@link Queue} generic type
+	 * @return an unbounded {@link Queue} {@link Supplier}
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> Supplier<Queue<T>> unbounded(int linkSize) {
+		if (linkSize == XS_BUFFER_SIZE) {
+			return QueueSupplier.XS_UNBOUNDED;
+		}
+		else if (linkSize == Integer.MAX_VALUE || linkSize == SMALL_BUFFER_SIZE) {
+			return unbounded();
+		}
+		return  () -> new SpscLinkedArrayQueue<>(linkSize);
+	}
+
+	/**
+	 *
+	 * @param <T> the reified {@link Queue} generic type
+	 * @return a bounded {@link Queue} {@link Supplier}
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> Supplier<Queue<T>> xs() {
+		return QueueSupplier.XS_SUPPLIER;
+	}
+
 
 	/**
 	 * Return the capacity of a given {@link Queue} in a best effort fashion. Queues that

--- a/reactor-core/src/main/java/reactor/util/concurrent/SpscArrayQueue.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/SpscArrayQueue.java
@@ -19,8 +19,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.concurrent.atomic.*;
-
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import javax.annotation.Nullable;
 
 /**
@@ -40,7 +40,7 @@ final class SpscArrayQueue<T> extends SpscArrayQueueP3<T> implements Queue<T> {
 	private static final long serialVersionUID = 494623116936946976L;
 
 	SpscArrayQueue(int capacity) {
-		super(QueueSupplier.ceilingNextPowerOfTwo(capacity));
+		super(Queues.ceilingNextPowerOfTwo(capacity));
 	}
 	
 	@Override

--- a/reactor-core/src/main/java/reactor/util/concurrent/SpscLinkedArrayQueue.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/SpscLinkedArrayQueue.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.BiPredicate;
-
 import javax.annotation.Nullable;
 
 /**
@@ -61,7 +60,7 @@ final class SpscLinkedArrayQueue<T> extends AbstractQueue<T>
 	static final Object NEXT = new Object();
 
 	SpscLinkedArrayQueue(int linkSize) {
-		int c = QueueSupplier.ceilingNextPowerOfTwo(Math.max(8, linkSize));
+		int c = Queues.ceilingNextPowerOfTwo(Math.max(8, linkSize));
 		this.producerArray = this.consumerArray = new AtomicReferenceArray<>(c + 1);
 		this.mask = c - 1;
 	}

--- a/reactor-core/src/main/java/reactor/util/concurrent/package-info.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/package-info.java
@@ -15,7 +15,8 @@
  */
 
 /**
- * Queue {@link reactor.util.concurrent.QueueSupplier suppliers} and busy spin utils
+ * Queue {@link reactor.util.concurrent.QueueSupplier suppliers} and
+ * {@link reactor.util.concurrent.Queues utilities}, busy spin utils
  * {@link reactor.util.concurrent.WaitStrategy}.
  * Used for operational serialization (serializing threads) or buffering (asynchronous boundary).
  *

--- a/reactor-core/src/test/java/reactor/core/publisher/BlockingIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BlockingIterableTest.java
@@ -30,7 +30,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.Scannable;
 import reactor.core.Scannable.IntAttr;
 import reactor.core.Scannable.ScannableAttr;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
@@ -132,7 +132,7 @@ public class BlockingIterableTest {
 	@Test
 	public void scanOperator() {
 		Flux<Integer> source = Flux.range(1, 10);
-		BlockingIterable<Integer> test = new BlockingIterable<>(source, 35, QueueSupplier.one());
+		BlockingIterable<Integer> test = new BlockingIterable<>(source, 35, Queues.one());
 
 		assertThat(test.scanUnsafe(ScannableAttr.PARENT)).describedAs("PARENT").isSameAs(source);
 
@@ -146,7 +146,7 @@ public class BlockingIterableTest {
 		Flux<Integer> source = Flux.range(1, 10);
 		BlockingIterable<Integer> test = new BlockingIterable<>(source,
 				Integer.MAX_VALUE + 30L,
-				QueueSupplier.one());
+				Queues.one());
 
 		assertThat(test.scan(IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE); //FIXME
 	}
@@ -154,7 +154,7 @@ public class BlockingIterableTest {
 	@Test
 	public void scanSubscriber() {
 		BlockingIterable.SubscriberIterator<String> subscriberIterator =
-				new BlockingIterable.SubscriberIterator<>(QueueSupplier.<String>one().get(), 123);
+				new BlockingIterable.SubscriberIterator<>(Queues.<String>one().get(), 123);
 		Subscription s = Operators.emptySubscription();
 		subscriberIterator.onSubscribe(s);
 
@@ -169,7 +169,7 @@ public class BlockingIterableTest {
 	@Test
 	public void scanSubscriberLargePrefetchIsLimitedToIntMax() {
 		BlockingIterable.SubscriberIterator<String> subscriberIterator =
-				new BlockingIterable.SubscriberIterator<>(QueueSupplier.<String>one().get(),
+				new BlockingIterable.SubscriberIterator<>(Queues.<String>one().get(),
 						Integer.MAX_VALUE + 30L);
 
 		assertThat(subscriberIterator.scan(IntAttr.PREFETCH)).isEqualTo(Integer.MAX_VALUE); //FIXME
@@ -178,7 +178,7 @@ public class BlockingIterableTest {
 	@Test
 	public void scanSubscriberTerminated() {
 		BlockingIterable.SubscriberIterator<String> test =
-				new BlockingIterable.SubscriberIterator<>(QueueSupplier.<String>one().get(), 123);
+				new BlockingIterable.SubscriberIterator<>(Queues.<String>one().get(), 123);
 
 		assertThat(test.scan(Scannable.BooleanAttr.TERMINATED)).describedAs("before TERMINATED").isFalse();
 
@@ -189,7 +189,7 @@ public class BlockingIterableTest {
 
 	@Test
 	public void scanSubscriberError() {
-		BlockingIterable.SubscriberIterator<String> test = new BlockingIterable.SubscriberIterator<>(QueueSupplier.<String>one().get(),
+		BlockingIterable.SubscriberIterator<String> test = new BlockingIterable.SubscriberIterator<>(Queues.<String>one().get(),
 				123);
 		IllegalStateException error = new IllegalStateException("boom");
 
@@ -205,7 +205,7 @@ public class BlockingIterableTest {
 
 	@Test
 	public void scanSubscriberCancelled() {
-		BlockingIterable.SubscriberIterator<String> test = new BlockingIterable.SubscriberIterator<>(QueueSupplier.<String>one().get(),
+		BlockingIterable.SubscriberIterator<String> test = new BlockingIterable.SubscriberIterator<>(Queues.<String>one().get(),
 				123);
 
 		//simulate cancellation by offering two elements

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -39,7 +39,7 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -264,7 +264,7 @@ public class EmitterProcessorTest {
 	public void state(){
 		EmitterProcessor<Integer> tp = EmitterProcessor.create();
 		assertThat(tp.getPending()).isEqualTo(0);
-		assertThat(tp.getBufferSize()).isEqualTo(QueueSupplier.SMALL_BUFFER_SIZE);
+		assertThat(tp.getBufferSize()).isEqualTo(Queues.SMALL_BUFFER_SIZE);
 		assertThat(tp.isCancelled()).isFalse();
 		assertThat(tp.inners()).isEmpty();
 
@@ -721,7 +721,7 @@ public class EmitterProcessorTest {
 	public void assertProcessor(EmitterProcessor<Integer> processor,
 			@Nullable Integer bufferSize,
 			@Nullable Boolean autoCancel) {
-		int expectedBufferSize = bufferSize != null ? bufferSize : QueueSupplier.SMALL_BUFFER_SIZE;
+		int expectedBufferSize = bufferSize != null ? bufferSize : Queues.SMALL_BUFFER_SIZE;
 		boolean expectedAutoCancel = autoCancel != null ? autoCancel : true;
 
 		assertEquals(expectedBufferSize, processor.prefetch);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
@@ -29,7 +29,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -237,7 +237,7 @@ public class FluxBufferWhenTest {
 		CoreSubscriber<List<String>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 
 		FluxBufferWhen.BufferStartEndMainSubscriber<String, Integer, Long, List<String>> test = new FluxBufferWhen.BufferStartEndMainSubscriber<>(
-				actual, ArrayList::new, QueueSupplier.<List<String>>one().get(), u -> Mono.just(1L));
+				actual, ArrayList::new, Queues.<List<String>>one().get(), u -> Mono.just(1L));
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 		test.request(100L);
@@ -259,7 +259,7 @@ public class FluxBufferWhenTest {
 		CoreSubscriber<List<String>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 
 		FluxBufferWhen.BufferStartEndMainSubscriber<String, Integer, Long, List<String>> test = new FluxBufferWhen.BufferStartEndMainSubscriber<>(
-				actual, ArrayList::new, QueueSupplier.<List<String>>one().get(), u -> Mono.just(1L));
+				actual, ArrayList::new, Queues.<List<String>>one().get(), u -> Mono.just(1L));
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 		test.cancel();
@@ -271,7 +271,7 @@ public class FluxBufferWhenTest {
 	public void scanStartEndEnder() {
 		//noinspection ConstantConditions
 		FluxBufferWhen.BufferStartEndMainSubscriber<String, Integer, Long, List<String>> main = new FluxBufferWhen.BufferStartEndMainSubscriber<>(
-				null, ArrayList::new, QueueSupplier.<List<String>>one().get(), u -> Mono.just(1L));
+				null, ArrayList::new, Queues.<List<String>>one().get(), u -> Mono.just(1L));
 
 		FluxBufferWhen.BufferStartEndEnder test = new FluxBufferWhen.BufferStartEndEnder<>(main, Arrays.asList("foo", "bar"), 1);
 
@@ -297,7 +297,7 @@ public class FluxBufferWhenTest {
 	public void scanStartEndStarter() {
 		//noinspection ConstantConditions
 		FluxBufferWhen.BufferStartEndMainSubscriber<String, Integer, Long, List<String>> main = new FluxBufferWhen.BufferStartEndMainSubscriber<>(
-				null, ArrayList::new, QueueSupplier.<List<String>>one().get(), u -> Mono.just(1L));
+				null, ArrayList::new, Queues.<List<String>>one().get(), u -> Mono.just(1L));
 
 		FluxBufferWhen.BufferStartEndStarter test = new FluxBufferWhen.BufferStartEndStarter<>(main);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCombineLatestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCombineLatestTest.java
@@ -30,7 +30,7 @@ import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,7 +39,7 @@ public class FluxCombineLatestTest extends FluxOperatorTest<String, String> {
 	@Override
 	protected Scenario<String, String> defaultScenarioOptions(Scenario<String, String> defaultOptions) {
 		return defaultOptions.fusionMode(Fuseable.ASYNC)
-		                     .prefetch(QueueSupplier.XS_BUFFER_SIZE);
+		                     .prefetch(Queues.XS_BUFFER_SIZE);
 	}
 
 	@Override
@@ -261,7 +261,7 @@ public class FluxCombineLatestTest extends FluxOperatorTest<String, String> {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 
 		FluxCombineLatest.CombineLatestCoordinator<String, Integer> test = new FluxCombineLatest.CombineLatestCoordinator<>(
-				actual, arr -> { throw new IllegalStateException("boomArray");}, 123, QueueSupplier.<FluxCombineLatest.SourceAndArray>one().get(), 456);
+				actual, arr -> { throw new IllegalStateException("boomArray");}, 123, Queues.<FluxCombineLatest.SourceAndArray>one().get(), 456);
 		test.request(2L);
 		test.error = new IllegalStateException("boom"); //most straightforward way to push it as otherwise it is drained
 
@@ -281,7 +281,7 @@ public class FluxCombineLatestTest extends FluxOperatorTest<String, String> {
 	public void scanInner() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		FluxCombineLatest.CombineLatestCoordinator<String, Integer> main = new FluxCombineLatest.CombineLatestCoordinator<>(
-				actual, arr -> arr.length, 123, QueueSupplier.<FluxCombineLatest.SourceAndArray>one().get(), 456);
+				actual, arr -> arr.length, 123, Queues.<FluxCombineLatest.SourceAndArray>one().get(), 456);
 
 		FluxCombineLatest.CombineLatestInner<String> test = new FluxCombineLatest.CombineLatestInner<>(main, 1, 789);
 		Subscription parent = Operators.emptySubscription();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
@@ -31,7 +31,7 @@ import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,7 +41,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	protected Scenario<String, String> defaultScenarioOptions(Scenario<String, String> defaultOptions) {
 		return defaultOptions.shouldHitDropNextHookAfterTerminate(false)
 		                     .shouldHitDropErrorHookAfterTerminate(false)
-		                     .prefetch(QueueSupplier.XS_BUFFER_SIZE);
+		                     .prefetch(Queues.XS_BUFFER_SIZE);
 	}
 
 	@Override
@@ -568,7 +568,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void asyncFusionMapToNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		UnicastProcessor<Integer> up = UnicastProcessor.create(QueueSupplier.<Integer>get(2).get());
+		UnicastProcessor<Integer> up = UnicastProcessor.create(Queues.<Integer>get(2).get());
 		up.onNext(1);
 		up.onNext(2);
 		up.onComplete();
@@ -587,7 +587,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.create(QueueSupplier.<Integer>get(2).get());
+				UnicastProcessor.create(Queues.<Integer>get(2).get());
 		up.onNext(1);
 		up.onNext(2);
 		up.onComplete();
@@ -778,7 +778,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void scanConcatMapDelayed() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		FluxConcatMap.ConcatMapDelayed<String, Integer> test = new FluxConcatMap.ConcatMapDelayed<>(
-				actual, s -> Mono.just(s.length()), QueueSupplier.one(), 123, true);
+				actual, s -> Mono.just(s.length()), Queues.one(), 123, true);
 
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
@@ -806,7 +806,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void scanConcatMapImmediate() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		FluxConcatMap.ConcatMapImmediate<String, Integer> test = new FluxConcatMap.ConcatMapImmediate<>(
-				actual, s -> Mono.just(s.length()), QueueSupplier.one(), 123);
+				actual, s -> Mono.just(s.length()), Queues.one(), 123);
 
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
@@ -832,7 +832,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void scanConcatMapImmediateError() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		FluxConcatMap.ConcatMapImmediate<String, Integer> test = new FluxConcatMap.ConcatMapImmediate<>(
-				actual, s -> Mono.just(s.length()), QueueSupplier.one(), 123);
+				actual, s -> Mono.just(s.length()), Queues.one(), 123);
 
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -34,7 +34,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -443,7 +443,7 @@ public class FluxFlatMapTest {
 	public void defaultPrefetch() {
 		assertThat(Flux.just(1, 2, 3)
 		               .flatMap(Flux::just)
-		               .getPrefetch()).isEqualTo(QueueSupplier.XS_BUFFER_SIZE);
+		               .getPrefetch()).isEqualTo(Queues.XS_BUFFER_SIZE);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -1210,7 +1210,7 @@ public class FluxFlatMapTest {
     public void scanMain() {
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxFlatMap.FlatMapMain<Integer, Integer> test = new FluxFlatMap.FlatMapMain<>(actual,
-                i -> Mono.just(i), true, 5, QueueSupplier.<Integer>unbounded(), 789,  QueueSupplier.<Integer>get(789));
+                i -> Mono.just(i), true, 5, Queues.<Integer>unbounded(), 789,  Queues.<Integer>get(789));
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
 
@@ -1242,7 +1242,7 @@ public class FluxFlatMapTest {
    public void scanMainLargeBuffered() {
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxFlatMap.FlatMapMain<Integer, Integer> test = new FluxFlatMap.FlatMapMain<>(actual,
-                i -> Mono.just(i), true, 5, QueueSupplier.<Integer>unbounded(), 789,  QueueSupplier.<Integer>get(789));
+                i -> Mono.just(i), true, 5, Queues.<Integer>unbounded(), 789,  Queues.<Integer>get(789));
 
 
         test.scalarQueue = new ConcurrentLinkedQueue<>();
@@ -1259,7 +1259,7 @@ public class FluxFlatMapTest {
     public void scanInner() {
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxFlatMap.FlatMapMain<Integer, Integer> main = new FluxFlatMap.FlatMapMain<>(actual,
-                i -> Mono.just(i), true, 5, QueueSupplier.<Integer>unbounded(), 789,  QueueSupplier.<Integer>get(789));
+                i -> Mono.just(i), true, 5, Queues.<Integer>unbounded(), 789,  Queues.<Integer>get(789));
         FluxFlatMap.FlatMapInner<Integer> inner = new FluxFlatMap.FlatMapInner<>(main, 123);
         Subscription parent = Operators.emptySubscription();
         inner.onSubscribe(parent);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
@@ -35,7 +35,7 @@ import reactor.core.Scannable.ScannableAttr;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
@@ -45,7 +45,7 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
 	protected Scenario<String, String> defaultScenarioOptions(Scenario<String, String> defaultOptions) {
 		return defaultOptions.fusionMode(Fuseable.SYNC)
 		                     .fusionModeThreadBarrier(Fuseable.ANY)
-		                     .prefetch(QueueSupplier.SMALL_BUFFER_SIZE)
+		                     .prefetch(Queues.SMALL_BUFFER_SIZE)
 		                     .shouldHitDropNextHookAfterTerminate(false);
 	}
 
@@ -338,7 +338,7 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
     @Test
     public void scanOperator() {
         Flux<Integer> source = Flux.range(1, 10);
-        FluxFlattenIterable<Integer, Integer> test = new FluxFlattenIterable<>(source, i -> new ArrayList<>(i), 35, QueueSupplier.one());
+        FluxFlattenIterable<Integer, Integer> test = new FluxFlattenIterable<>(source, i -> new ArrayList<>(i), 35, Queues.one());
 
         assertThat(test.scan(ScannableAttr.PARENT)).isSameAs(source);
         assertThat(test.scan(IntAttr.PREFETCH)).isEqualTo(35);
@@ -348,7 +348,7 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
     public void scanSubscriber() {
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxFlattenIterable.FlattenIterableSubscriber<Integer, Integer> test =
-                new FluxFlattenIterable.FlattenIterableSubscriber<>(actual, i -> new ArrayList<>(i), 123, QueueSupplier.<Integer>one());
+                new FluxFlattenIterable.FlattenIterableSubscriber<>(actual, i -> new ArrayList<>(i), 123, Queues.<Integer>one());
         Subscription s = Operators.emptySubscription();
         test.onSubscribe(s);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
@@ -32,7 +32,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -43,7 +43,7 @@ public class FluxGroupByTest extends
 	protected Scenario<String, GroupedFlux<Integer, String>> defaultScenarioOptions(Scenario<String, GroupedFlux<Integer, String>> defaultOptions) {
 		return defaultOptions.fusionMode(Fuseable.ASYNC)
 		                     .fusionModeThreadBarrier(Fuseable.ANY)
-		                     .prefetch(QueueSupplier.SMALL_BUFFER_SIZE)
+		                     .prefetch(Queues.SMALL_BUFFER_SIZE)
 		                     .shouldAssertPostTerminateState(false);
 	}
 
@@ -839,7 +839,7 @@ public class FluxGroupByTest extends
 	public void scanMain() {
 		CoreSubscriber<GroupedFlux<Integer, String>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		FluxGroupBy.GroupByMain<Integer, Integer, String> test = new FluxGroupBy.GroupByMain<>(actual,
-				QueueSupplier.<GroupedFlux<Integer, String>>one().get(), QueueSupplier.one(), 123, i -> i % 5, i -> String.valueOf(i));
+				Queues.<GroupedFlux<Integer, String>>one().get(), Queues.one(), 123, i -> i % 5, i -> String.valueOf(i));
 		Subscription sub = Operators.emptySubscription();
         test.onSubscribe(sub);
 
@@ -859,9 +859,9 @@ public class FluxGroupByTest extends
 	public void scanUnicastGroupedFlux() {
 		CoreSubscriber<GroupedFlux<Integer, String>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		FluxGroupBy.GroupByMain<Integer, Integer, String> main = new FluxGroupBy.GroupByMain<>(actual,
-				QueueSupplier.<GroupedFlux<Integer, String>>one().get(), QueueSupplier.one(), 123, i -> i % 5, i -> String.valueOf(i));
+				Queues.<GroupedFlux<Integer, String>>one().get(), Queues.one(), 123, i -> i % 5, i -> String.valueOf(i));
 		FluxGroupBy.UnicastGroupedFlux<Integer, String> test = new FluxGroupBy.UnicastGroupedFlux<Integer, String>(1,
-				QueueSupplier.<String>one().get(), main, 123);
+				Queues.<String>one().get(), main, 123);
 		CoreSubscriber<String> sub = new LambdaSubscriber<>(null, e -> {}, null, null);
         test.subscribe(sub);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxGroupJoinTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxGroupJoinTest.java
@@ -25,7 +25,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -282,8 +282,8 @@ public class FluxGroupJoinTest {
 						s -> Mono.just(s),
 						s -> Mono.just(s),
 						(l, r) -> l,
-						QueueSupplier.unbounded().get(),
-						QueueSupplier.one());
+						Queues.unbounded().get(),
+						Queues.one());
 
 		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
 		test.request(123);
@@ -313,8 +313,8 @@ public class FluxGroupJoinTest {
 						s -> Mono.just(s),
 						s -> Mono.just(s),
 						(l, r) -> l,
-						QueueSupplier.unbounded().get(),
-						QueueSupplier.one());
+						Queues.unbounded().get(),
+						Queues.one());
 		FluxGroupJoin.LeftRightSubscriber test = new FluxGroupJoin.LeftRightSubscriber(parent, true);
 		Subscription sub = Operators.emptySubscription();
 		test.onSubscribe(sub);
@@ -335,8 +335,8 @@ public class FluxGroupJoinTest {
 						s -> Mono.just(s),
 						s -> Mono.just(s),
 						(l, r) -> l,
-						QueueSupplier.unbounded().get(),
-						QueueSupplier.one());
+						Queues.unbounded().get(),
+						Queues.one());
 		FluxGroupJoin.LeftRightEndSubscriber test = new FluxGroupJoin.LeftRightEndSubscriber(parent, false, 1);
 		Subscription sub = Operators.emptySubscription();
 		test.onSubscribe(sub);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxJoinTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxJoinTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -262,7 +262,7 @@ public class FluxJoinTest {
 						s -> Mono.just(s),
 						s -> Mono.just(s),
 						(l, r) -> l,
-						QueueSupplier.unbounded().get());
+						Queues.unbounded().get());
 
 		assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
 		test.request(123);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
@@ -41,7 +41,7 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -194,10 +194,10 @@ public class FluxMergeSequentialTest {
 	@Test
 	public void longEager() {
 
-		Flux.range(1, 2 * QueueSupplier.SMALL_BUFFER_SIZE)
+		Flux.range(1, 2 * Queues.SMALL_BUFFER_SIZE)
 		        .flatMapSequential(v -> Flux.just(1))
 		        .subscribeWith(AssertSubscriber.create())
-		        .assertValueCount(2 * QueueSupplier.SMALL_BUFFER_SIZE)
+		        .assertValueCount(2 * Queues.SMALL_BUFFER_SIZE)
 		        .assertNoError()
 		        .assertComplete();
 	}
@@ -420,12 +420,12 @@ public class FluxMergeSequentialTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidCapacityHint() {
-		Flux.just(1).flatMapSequential(toJust, 0, QueueSupplier.SMALL_BUFFER_SIZE);
+		Flux.just(1).flatMapSequential(toJust, 0, Queues.SMALL_BUFFER_SIZE);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidMaxConcurrent() {
-		Flux.just(1).flatMapSequential(toJust, QueueSupplier.SMALL_BUFFER_SIZE, 0);
+		Flux.just(1).flatMapSequential(toJust, Queues.SMALL_BUFFER_SIZE, 0);
 	}
 
 	@Test
@@ -487,7 +487,7 @@ public class FluxMergeSequentialTest {
 		AssertSubscriber<Object> ts = AssertSubscriber.create(0);
 
 		Flux.just(1).hide()
-		    .flatMapSequential(t -> Flux.range(1, QueueSupplier.SMALL_BUFFER_SIZE * 2)
+		    .flatMapSequential(t -> Flux.range(1, Queues.SMALL_BUFFER_SIZE * 2)
 		                                .doOnNext(t1 -> count.getAndIncrement())
 		                                .hide())
 		    .subscribe(ts);
@@ -495,14 +495,14 @@ public class FluxMergeSequentialTest {
 		ts.assertNoError();
 		ts.assertNoValues();
 		ts.assertNotComplete();
-		Assert.assertEquals(QueueSupplier.XS_BUFFER_SIZE, count.get());
+		Assert.assertEquals(Queues.XS_BUFFER_SIZE, count.get());
 	}
 
 	@Test
 	public void testMaxConcurrent5() {
 		final List<Long> requests = new ArrayList<>();
 		Flux.range(1, 100).doOnRequest(requests::add)
-		    .flatMapSequential(toJust, 5, QueueSupplier.SMALL_BUFFER_SIZE)
+		    .flatMapSequential(toJust, 5, Queues.SMALL_BUFFER_SIZE)
 		    .subscribe(ts);
 
 		ts.assertNoError();
@@ -684,7 +684,7 @@ public class FluxMergeSequentialTest {
 		int prefetch = 32;
 		int maxConcurrency = 256;
 		Supplier<Queue<FluxMergeSequential.MergeSequentialInner<Integer>>> badQueueSupplier =
-				QueueSupplier.get(Math.min(prefetch, maxConcurrency));
+				Queues.get(Math.min(prefetch, maxConcurrency));
 
 		FluxMergeSequential<Integer, Integer> fluxMergeSequential =
 				new FluxMergeSequential<>(Flux.range(0, 500),
@@ -717,7 +717,7 @@ public class FluxMergeSequentialTest {
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxMergeSequential.MergeSequentialMain<Integer, Integer> test =
         		new FluxMergeSequential.MergeSequentialMain<Integer, Integer>(actual, i -> Mono.just(i),
-        				5, 123, ErrorMode.BOUNDARY, QueueSupplier.unbounded());
+        				5, 123, ErrorMode.BOUNDARY, Queues.unbounded());
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
 
@@ -742,7 +742,7 @@ public class FluxMergeSequentialTest {
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxMergeSequential.MergeSequentialMain<Integer, Integer> main =
         		new FluxMergeSequential.MergeSequentialMain<Integer, Integer>(actual, i -> Mono.just(i),
-        				5, 123, ErrorMode.IMMEDIATE, QueueSupplier.unbounded());
+        				5, 123, ErrorMode.IMMEDIATE, Queues.unbounded());
         FluxMergeSequential.MergeSequentialInner<Integer> inner =
         		new FluxMergeSequential.MergeSequentialInner<>(main, 123);
         Subscription parent = Operators.emptySubscription();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
@@ -35,7 +35,7 @@ import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -488,7 +488,7 @@ public class FluxPeekFuseableTest {
 	public void asyncFusionAvailable() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		UnicastProcessor.create(QueueSupplier.<Integer>get(2).get())
+		UnicastProcessor.create(Queues.<Integer>get(2).get())
 		                .doOnNext(v -> {
 		                })
 		                .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
@@ -35,7 +35,7 @@ import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static java.lang.Thread.sleep;
 import static org.hamcrest.CoreMatchers.*;
@@ -736,7 +736,7 @@ public class FluxPeekTest extends FluxOperatorTest<String, String> {
 	public void asyncFusionAvailable() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		UnicastProcessor.create(QueueSupplier.<Integer>get(2).get())
+		UnicastProcessor.create(Queues.<Integer>get(2).get())
 		                .doOnNext(v -> {
 		                })
 		                .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
@@ -28,7 +28,7 @@ import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
@@ -41,7 +41,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
 
 	@Override
 	protected Scenario<String, String> defaultScenarioOptions(Scenario<String, String> defaultOptions) {
-		return defaultOptions.prefetch(QueueSupplier.SMALL_BUFFER_SIZE)
+		return defaultOptions.prefetch(Queues.SMALL_BUFFER_SIZE)
 		                     .fusionModeThreadBarrier(Fuseable.ANY);
 	}
 
@@ -149,7 +149,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.create(QueueSupplier.<Integer>get(16).get());
+				UnicastProcessor.create(Queues.<Integer>get(16).get());
 
 		up.publish(o -> zip((Object[] a) -> (Integer) a[0] + (Integer) a[1], o, o.skip(1)))
 		  .subscribe(ts);
@@ -279,7 +279,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
 	@Test
     public void scanMulticaster() {
         FluxPublishMulticast.FluxPublishMulticaster<Integer, Integer> test =
-        		new FluxPublishMulticast.FluxPublishMulticaster<>(123, QueueSupplier.<Integer>unbounded(), Context.empty());
+        		new FluxPublishMulticast.FluxPublishMulticaster<>(123, Queues.<Integer>unbounded(), Context.empty());
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
 
@@ -305,7 +305,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
     public void scanMulticastInner() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		FluxPublishMulticast.FluxPublishMulticaster<Integer, Integer> parent =
-        		new FluxPublishMulticast.FluxPublishMulticaster<>(123, QueueSupplier.<Integer>unbounded(), Context.empty());
+        		new FluxPublishMulticast.FluxPublishMulticaster<>(123, Queues.<Integer>unbounded(), Context.empty());
         FluxPublishMulticast.PublishMulticastInner<Integer> test =
         		new FluxPublishMulticast.PublishMulticastInner<>(parent, actual);
 
@@ -323,7 +323,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
     public void scanCancelMulticaster() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		FluxPublishMulticast.FluxPublishMulticaster<Integer, Integer> parent =
-        		new FluxPublishMulticast.FluxPublishMulticaster<>(123, QueueSupplier.<Integer>unbounded(), Context.empty());
+        		new FluxPublishMulticast.FluxPublishMulticaster<>(123, Queues.<Integer>unbounded(), Context.empty());
         FluxPublishMulticast.CancelMulticaster<Integer> test =
         		new FluxPublishMulticast.CancelMulticaster<>(actual, parent);
         Subscription sub = Operators.emptySubscription();
@@ -337,7 +337,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
     public void scanCancelFuseableMulticaster() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		FluxPublishMulticast.FluxPublishMulticaster<Integer, Integer> parent =
-        		new FluxPublishMulticast.FluxPublishMulticaster<>(123, QueueSupplier.<Integer>unbounded(), Context.empty());
+        		new FluxPublishMulticast.FluxPublishMulticaster<>(123, Queues.<Integer>unbounded(), Context.empty());
         FluxPublishMulticast.CancelFuseableMulticaster<Integer> test =
         		new FluxPublishMulticast.CancelFuseableMulticaster<>(actual, parent);
         Subscription sub = Operators.emptySubscription();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
@@ -54,7 +54,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.hamcrest.CoreMatchers.*;
@@ -68,7 +68,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 
 	@Override
 	protected Scenario<String, String> defaultScenarioOptions(Scenario<String, String> defaultOptions) {
-		return defaultOptions.prefetch(QueueSupplier.SMALL_BUFFER_SIZE)
+		return defaultOptions.prefetch(Queues.SMALL_BUFFER_SIZE)
 		                     .fusionModeThreadBarrier(Fuseable.ASYNC)
 		                     .fusionMode(Fuseable.ASYNC);
 	}
@@ -260,7 +260,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void normalAsyncFusedBackpressured() throws Exception {
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.create(QueueSupplier.<Integer>unbounded(1024).get());
+				UnicastProcessor.create(Queues.<Integer>unbounded(1024).get());
 
 		for (int i = 0; i < 1_000_000; i++) {
 			up.onNext(0);
@@ -494,7 +494,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 
 		int s = clq.size();
 		Assert.assertTrue("More requests?" + clq, s == 1 || s == 2 || s == 3);
-		Assert.assertEquals((Long) (long) QueueSupplier.SMALL_BUFFER_SIZE, clq.poll());
+		Assert.assertEquals((Long) (long) Queues.SMALL_BUFFER_SIZE, clq.poll());
 	}
 
 	@Test
@@ -691,7 +691,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	public void mappedAsyncSourceWithNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.create(QueueSupplier.<Integer>get(2).get());
+				UnicastProcessor.create(Queues.<Integer>get(2).get());
 		up.onNext(1);
 		up.onNext(2);
 		up.onComplete();
@@ -711,7 +711,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	public void mappedAsyncSourceWithNullPostFilter() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.create(QueueSupplier.<Integer>get(2).get());
+				UnicastProcessor.create(Queues.<Integer>get(2).get());
 		up.onNext(1);
 		up.onNext(2);
 		up.onComplete();
@@ -793,7 +793,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void threadBoundaryPreventsInvalidFusionMap() {
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.create(QueueSupplier.<Integer>get(2).get());
+				UnicastProcessor.create(Queues.<Integer>get(2).get());
 
 		AssertSubscriber<String> ts = AssertSubscriber.create();
 
@@ -816,7 +816,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void threadBoundaryPreventsInvalidFusionFilter() {
 		UnicastProcessor<Integer> up =
-				UnicastProcessor.create(QueueSupplier.<Integer>get(2).get());
+				UnicastProcessor.create(Queues.<Integer>get(2).get());
 
 		String s = Thread.currentThread()
 		                 .getName();
@@ -1254,7 +1254,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
     public void scanSubscriber() {
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxPublishOn.PublishOnSubscriber<Integer> test = new FluxPublishOn.PublishOnSubscriber<>(actual,
-        		Schedulers.single(), Schedulers.single().createWorker(), true, 123, QueueSupplier.unbounded());
+        		Schedulers.single(), Schedulers.single().createWorker(), true, 123, Queues.unbounded());
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
 
@@ -1283,7 +1283,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		Fuseable.ConditionalSubscriber<Integer> actual = Mockito.mock(Fuseable.ConditionalSubscriber.class);
         FluxPublishOn.PublishOnConditionalSubscriber<Integer> test =
         		new FluxPublishOn.PublishOnConditionalSubscriber<>(actual, Schedulers.single(),
-        				Schedulers.single().createWorker(), true, 123, QueueSupplier.unbounded());
+        				Schedulers.single().createWorker(), true, 123, Queues.unbounded());
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
@@ -29,7 +29,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,7 +37,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 
 	@Override
 	protected Scenario<String, String> defaultScenarioOptions(Scenario<String, String> defaultOptions) {
-		return defaultOptions.prefetch(QueueSupplier.SMALL_BUFFER_SIZE);
+		return defaultOptions.prefetch(Queues.SMALL_BUFFER_SIZE);
 	}
 
 	@Override
@@ -157,7 +157,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts1 = AssertSubscriber.create();
 		AssertSubscriber<Integer> ts2 = AssertSubscriber.create();
 
-		UnicastProcessor<Integer> up = UnicastProcessor.create(QueueSupplier.<Integer>get(8).get());
+		UnicastProcessor<Integer> up = UnicastProcessor.create(Queues.<Integer>get(8).get());
 		up.onNext(1);
 		up.onNext(2);
 		up.onNext(3);
@@ -196,7 +196,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts1 = AssertSubscriber.create(0);
 		AssertSubscriber<Integer> ts2 = AssertSubscriber.create(0);
 
-		UnicastProcessor<Integer> up = UnicastProcessor.create(QueueSupplier.<Integer>get(8).get());
+		UnicastProcessor<Integer> up = UnicastProcessor.create(Queues.<Integer>get(8).get());
 		up.onNext(1);
 		up.onNext(2);
 		up.onNext(3);
@@ -478,7 +478,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 	@Test
     public void scanMain() {
         Flux<Integer> parent = Flux.just(1);
-        FluxPublish<Integer> test = new FluxPublish<>(parent, 123, QueueSupplier.<Integer>unbounded());
+        FluxPublish<Integer> test = new FluxPublish<>(parent, 123, Queues.<Integer>unbounded());
 
         assertThat(test.scan(Scannable.ScannableAttr.PARENT)).isSameAs(parent);
         assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(123);
@@ -486,7 +486,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 
 	@Test
     public void scanSubscriber() {
-        FluxPublish<Integer> main = new FluxPublish<>(Flux.just(1), 123, QueueSupplier.<Integer>unbounded());
+        FluxPublish<Integer> main = new FluxPublish<>(Flux.just(1), 123, Queues.<Integer>unbounded());
         FluxPublish.PublishSubscriber<Integer> test = new FluxPublish.PublishSubscriber<>(789, main);
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
@@ -511,7 +511,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 
 	@Test
     public void scanInner() {
-		FluxPublish<Integer> main = new FluxPublish<>(Flux.just(1), 123, QueueSupplier.<Integer>unbounded());
+		FluxPublish<Integer> main = new FluxPublish<>(Flux.just(1), 123, Queues.<Integer>unbounded());
         FluxPublish.PublishSubscriber<Integer> parent = new FluxPublish.PublishSubscriber<>(789, main);
         Subscription sub = Operators.emptySubscription();
         parent.onSubscribe(sub);
@@ -534,7 +534,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 
 	@Test
     public void scanPubSubInner() {
-		FluxPublish<Integer> main = new FluxPublish<>(Flux.just(1), 123, QueueSupplier.<Integer>unbounded());
+		FluxPublish<Integer> main = new FluxPublish<>(Flux.just(1), 123, Queues.<Integer>unbounded());
         FluxPublish.PublishSubscriber<Integer> parent = new FluxPublish.PublishSubscriber<>(789, main);
         Subscription sub = Operators.emptySubscription();
         parent.onSubscribe(sub);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTimeoutTest.java
@@ -27,7 +27,7 @@ import reactor.core.Scannable;
 import reactor.core.publisher.FluxSampleTimeout.SampleTimeoutOther;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 public class FluxSampleTimeoutTest {
 
@@ -165,7 +165,7 @@ public class FluxSampleTimeoutTest {
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxSampleTimeout.SampleTimeoutMain<Integer, Integer> test =
         		new FluxSampleTimeout.SampleTimeoutMain<>(actual, i -> Flux.just(i),
-        				QueueSupplier.<SampleTimeoutOther<Integer, Integer>>one().get());
+        				Queues.<SampleTimeoutOther<Integer, Integer>>one().get());
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
 
@@ -190,7 +190,7 @@ public class FluxSampleTimeoutTest {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxSampleTimeout.SampleTimeoutMain<Integer, Integer> main =
         		new FluxSampleTimeout.SampleTimeoutMain<>(actual, i -> Flux.just(i),
-        				QueueSupplier.<SampleTimeoutOther<Integer, Integer>>one().get());
+        				Queues.<SampleTimeoutOther<Integer, Integer>>one().get());
         FluxSampleTimeout.SampleTimeoutOther<Integer, Integer> test =
         		new FluxSampleTimeout.SampleTimeoutOther<Integer, Integer>(main, 1, 0);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
@@ -26,7 +26,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 public class FluxSwitchMapTest {
 
@@ -292,7 +292,7 @@ public class FluxSwitchMapTest {
     public void scanMain() {
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxSwitchMap.SwitchMapMain<Integer, Integer> test =
-        		new FluxSwitchMap.SwitchMapMain<>(actual, i -> Mono.just(i), QueueSupplier.unbounded().get(), 234);
+        		new FluxSwitchMap.SwitchMapMain<>(actual, i -> Mono.just(i), Queues.unbounded().get(), 234);
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
 
@@ -319,7 +319,7 @@ public class FluxSwitchMapTest {
     public void scanInner() {
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxSwitchMap.SwitchMapMain<Integer, Integer> main =
-        		new FluxSwitchMap.SwitchMapMain<>(actual, i -> Mono.just(i), QueueSupplier.unbounded().get(), 234);
+        		new FluxSwitchMap.SwitchMapMain<>(actual, i -> Mono.just(i), Queues.unbounded().get(), 234);
         FluxSwitchMap.SwitchMapInner<Integer> test = new FluxSwitchMap.SwitchMapInner<Integer>(main, 1, 0);
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
@@ -29,7 +29,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -251,7 +251,7 @@ public class FluxWindowBoundaryTest {
     public void scanMainSubscriber() {
         CoreSubscriber<Flux<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindowBoundary.WindowBoundaryMain<Integer, Integer> test = new FluxWindowBoundary.WindowBoundaryMain<>(actual,
-        		QueueSupplier.unbounded(), QueueSupplier.<Integer>unbounded().get(), QueueSupplier.unbounded().get());
+        		Queues.unbounded(), Queues.<Integer>unbounded().get(), Queues.unbounded().get());
         Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 
@@ -280,7 +280,7 @@ public class FluxWindowBoundaryTest {
     public void scanOtherSubscriber() {
         CoreSubscriber<Flux<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindowBoundary.WindowBoundaryMain<Integer, Integer> main = new FluxWindowBoundary.WindowBoundaryMain<>(actual,
-        		QueueSupplier.unbounded(), QueueSupplier.<Integer>unbounded().get(), QueueSupplier.unbounded().get());
+        		Queues.unbounded(), Queues.<Integer>unbounded().get(), Queues.unbounded().get());
         FluxWindowBoundary.WindowBoundaryOther<Integer> test =
         		new FluxWindowBoundary.WindowBoundaryOther<>(main);
         Subscription parent = Operators.emptySubscription();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
@@ -35,7 +35,7 @@ import reactor.test.StepVerifier;
 import reactor.test.StepVerifierOptions;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.publisher.TestPublisher;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -47,7 +47,7 @@ public class FluxWindowPredicateTest extends
 		return defaultOptions.shouldAssertPostTerminateState(false)
 		                     .fusionMode(Fuseable.ASYNC)
 		                     .fusionModeThreadBarrier(Fuseable.ANY)
-		                     .prefetch(QueueSupplier.SMALL_BUFFER_SIZE);
+		                     .prefetch(Queues.SMALL_BUFFER_SIZE);
 	}
 
 	@Override
@@ -170,9 +170,9 @@ public class FluxWindowPredicateTest extends
 	public void normalUntil() {
 		DirectProcessor<Integer> sp1 = DirectProcessor.create();
 		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(sp1,
-				QueueSupplier.small(),
-				QueueSupplier.unbounded(),
-				QueueSupplier.SMALL_BUFFER_SIZE,
+				Queues.small(),
+				Queues.unbounded(),
+				Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0,
 				Mode.UNTIL);
 
@@ -207,15 +207,15 @@ public class FluxWindowPredicateTest extends
 		Flux<Integer> source = Flux.just(1, 2);
 
 		FluxWindowPredicate<Integer> windowUntil =
-				new FluxWindowPredicate<>(source, QueueSupplier.small(), QueueSupplier.unbounded(), QueueSupplier.SMALL_BUFFER_SIZE,
+				new FluxWindowPredicate<>(source, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 						i -> i >= 3, Mode.UNTIL);
 
 		FluxWindowPredicate<Integer> windowUntilCutBefore =
-				new FluxWindowPredicate<>(source, QueueSupplier.small(), QueueSupplier.unbounded(), QueueSupplier.SMALL_BUFFER_SIZE,
+				new FluxWindowPredicate<>(source, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 						i -> i >= 3, Mode.UNTIL_CUT_BEFORE);
 
 		FluxWindowPredicate<Integer> windowWhile =
-				new FluxWindowPredicate<>(source, QueueSupplier.small(), QueueSupplier.unbounded(), QueueSupplier.SMALL_BUFFER_SIZE,
+				new FluxWindowPredicate<>(source, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 						i -> i < 3, Mode.WHILE);
 
 		StepVerifier.create(windowUntil.flatMap(Flux::collectList))
@@ -239,7 +239,7 @@ public class FluxWindowPredicateTest extends
 	public void mainErrorUntilIsPropagatedToBothWindowAndMain() {
 		DirectProcessor<Integer> sp1 = DirectProcessor.create();
 		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(
-				sp1, QueueSupplier.small(), QueueSupplier.unbounded(), QueueSupplier.SMALL_BUFFER_SIZE,
+				sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.UNTIL);
 
 		StepVerifier.create(windowUntil.flatMap(Flux::materialize))
@@ -266,7 +266,7 @@ public class FluxWindowPredicateTest extends
 	public void predicateErrorUntil() {
 		DirectProcessor<Integer> sp1 = DirectProcessor.create();
 		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(
-				sp1, QueueSupplier.small(), QueueSupplier.unbounded(), QueueSupplier.SMALL_BUFFER_SIZE,
+				sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> {
 					if (i == 5) throw new IllegalStateException("predicate failure");
 					return i % 3 == 0;
@@ -295,7 +295,7 @@ public class FluxWindowPredicateTest extends
 	public void normalUntilCutBefore() {
 		DirectProcessor<Integer> sp1 = DirectProcessor.create();
 		FluxWindowPredicate<Integer> windowUntilCutBefore = new FluxWindowPredicate<>(sp1,
-				QueueSupplier.small(), QueueSupplier.unbounded(), QueueSupplier.SMALL_BUFFER_SIZE,
+				Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.UNTIL_CUT_BEFORE);
 
 		StepVerifier.create(windowUntilCutBefore.flatMap(Flux::materialize))
@@ -327,7 +327,7 @@ public class FluxWindowPredicateTest extends
 	public void mainErrorUntilCutBeforeIsPropagatedToBothWindowAndMain() {
 		DirectProcessor<Integer> sp1 = DirectProcessor.create();
 		FluxWindowPredicate<Integer> windowUntilCutBefore =
-				new FluxWindowPredicate<>(sp1, QueueSupplier.small(), QueueSupplier.unbounded(), QueueSupplier.SMALL_BUFFER_SIZE,
+				new FluxWindowPredicate<>(sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 						i -> i % 3 == 0, Mode.UNTIL_CUT_BEFORE);
 
 		StepVerifier.create(windowUntilCutBefore.flatMap(Flux::materialize))
@@ -355,7 +355,7 @@ public class FluxWindowPredicateTest extends
 	public void predicateErrorUntilCutBefore() {
 		DirectProcessor<Integer> sp1 = DirectProcessor.create();
 		FluxWindowPredicate<Integer> windowUntilCutBefore =
-				new FluxWindowPredicate<>(sp1, QueueSupplier.small(), QueueSupplier.unbounded(), QueueSupplier.SMALL_BUFFER_SIZE,
+				new FluxWindowPredicate<>(sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> {
 					if (i == 5) throw new IllegalStateException("predicate failure");
 					return i % 3 == 0;
@@ -390,7 +390,7 @@ public class FluxWindowPredicateTest extends
 	public void normalWhile() {
 		DirectProcessor<Integer> sp1 = DirectProcessor.create();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
-				sp1, QueueSupplier.small(), QueueSupplier.unbounded(), QueueSupplier.SMALL_BUFFER_SIZE,
+				sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 != 0, Mode.WHILE);
 
 		StepVerifier.create(windowWhile.flatMap(Flux::materialize))
@@ -422,7 +422,7 @@ public class FluxWindowPredicateTest extends
 	public void normalWhileDoesntInitiallyMatch() {
 		DirectProcessor<Integer> sp1 = DirectProcessor.create();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
-				sp1, QueueSupplier.small(), QueueSupplier.unbounded(), QueueSupplier.SMALL_BUFFER_SIZE,
+				sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.WHILE);
 
 		StepVerifier.create(windowWhile.flatMap(Flux::materialize))
@@ -461,7 +461,7 @@ public class FluxWindowPredicateTest extends
 	public void normalWhileDoesntMatch() {
 		DirectProcessor<Integer> sp1 = DirectProcessor.create();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
-				sp1, QueueSupplier.small(), QueueSupplier.unbounded(), QueueSupplier.SMALL_BUFFER_SIZE,
+				sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i > 4, Mode.WHILE);
 
 		StepVerifier.create(windowWhile.flatMap(Flux::materialize))
@@ -497,7 +497,7 @@ public class FluxWindowPredicateTest extends
 	public void mainErrorWhileIsPropagatedToBothWindowAndMain() {
 		DirectProcessor<Integer> sp1 = DirectProcessor.create();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
-				sp1, QueueSupplier.small(), QueueSupplier.unbounded(), QueueSupplier.SMALL_BUFFER_SIZE,
+				sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.WHILE);
 
 		StepVerifier.create(windowWhile.flatMap(Flux::materialize))
@@ -547,7 +547,7 @@ public class FluxWindowPredicateTest extends
 	public void predicateErrorWhile() {
 		DirectProcessor<Integer> sp1 = DirectProcessor.create();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
-				sp1, QueueSupplier.small(), QueueSupplier.unbounded(), QueueSupplier.SMALL_BUFFER_SIZE,
+				sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> {
 					if (i == 3) return true;
 					if (i == 5) throw new IllegalStateException("predicate failure");
@@ -829,7 +829,7 @@ public class FluxWindowPredicateTest extends
     public void scanMainSubscriber() {
         CoreSubscriber<GroupedFlux<Integer, Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindowPredicate.WindowPredicateMain<Integer> test = new FluxWindowPredicate.WindowPredicateMain<>(actual,
-        		QueueSupplier.<GroupedFlux<Integer, Integer>>unbounded().get(), QueueSupplier.unbounded(), 123, i -> true, Mode.WHILE);
+        		Queues.<GroupedFlux<Integer, Integer>>unbounded().get(), Queues.unbounded(), 123, i -> true, Mode.WHILE);
 
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
@@ -861,9 +861,9 @@ public class FluxWindowPredicateTest extends
     public void scanOtherSubscriber() {
         CoreSubscriber<GroupedFlux<Integer, Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindowPredicate.WindowPredicateMain<Integer> main = new FluxWindowPredicate.WindowPredicateMain<>(actual,
-        		QueueSupplier.<GroupedFlux<Integer, Integer>>unbounded().get(), QueueSupplier.unbounded(), 123, i -> true, Mode.WHILE);
+        		Queues.<GroupedFlux<Integer, Integer>>unbounded().get(), Queues.unbounded(), 123, i -> true, Mode.WHILE);
         FluxWindowPredicate.WindowGroupedFlux<Integer> test = new FluxWindowPredicate.WindowGroupedFlux<>(1,
-        		QueueSupplier.<Integer>unbounded().get(), main);
+        		Queues.<Integer>unbounded().get(), main);
 
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTest.java
@@ -31,7 +31,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -582,7 +582,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
     public void scanExactSubscriber() {
         CoreSubscriber<Flux<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindow.WindowExactSubscriber<Integer> test = new FluxWindow.WindowExactSubscriber<Integer>(actual,
-        		123, QueueSupplier.unbounded());
+        		123, Queues.unbounded());
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
 
@@ -603,7 +603,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
     public void scanOverlapSubscriber() {
         CoreSubscriber<Flux<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindow.WindowOverlapSubscriber<Integer> test = new FluxWindow.WindowOverlapSubscriber<Integer>(actual,
-        		123, 3, QueueSupplier.unbounded(), QueueSupplier.<UnicastProcessor<Integer>>unbounded().get());
+        		123, 3, Queues.unbounded(), Queues.<UnicastProcessor<Integer>>unbounded().get());
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
 
@@ -633,7 +633,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 
         CoreSubscriber<Flux<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindow.WindowOverlapSubscriber<Integer> test = new FluxWindow.WindowOverlapSubscriber<Integer>(actual,
-                3,3, QueueSupplier.unbounded(), mockQueue);
+                3,3, Queues.unbounded(), mockQueue);
 
         when(mockQueue.size()).thenReturn(Integer.MAX_VALUE - 2);
         //size() is 1
@@ -650,7 +650,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 
         CoreSubscriber<Flux<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindow.WindowOverlapSubscriber<Integer> test = new FluxWindow.WindowOverlapSubscriber<Integer>(actual,
-                3, 3, QueueSupplier.unbounded(), mockQueue);
+                3, 3, Queues.unbounded(), mockQueue);
 
         when(mockQueue.size()).thenReturn(Integer.MAX_VALUE);
         //size() is 5
@@ -668,7 +668,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
     public void scanSkipSubscriber() {
         CoreSubscriber<Flux<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindow.WindowSkipSubscriber<Integer> test = new FluxWindow.WindowSkipSubscriber<Integer>(actual,
-        		123, 3, QueueSupplier.unbounded());
+        		123, 3, Queues.unbounded());
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
@@ -29,7 +29,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -263,8 +263,8 @@ public class FluxWindowWhenTest {
     public void scanMainSubscriber() {
         CoreSubscriber<Flux<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindowWhen.WindowStartEndMainSubscriber<Integer, Integer, Integer> test =
-        		new FluxWindowWhen.WindowStartEndMainSubscriber<>(actual, QueueSupplier.one().get(),
-        		s -> Flux.just(s), QueueSupplier.unbounded());
+        		new FluxWindowWhen.WindowStartEndMainSubscriber<>(actual, Queues.one().get(),
+        		s -> Flux.just(s), Queues.unbounded());
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -33,7 +33,7 @@ import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuple3;
 import reactor.util.function.Tuple7;
@@ -1280,7 +1280,7 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
     public void scanCoordinator() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		FluxZip.ZipCoordinator<Integer, Integer> test = new FluxZip.ZipCoordinator<Integer, Integer>(actual,
-				i -> 5, 123, QueueSupplier.unbounded(), 345);
+				i -> 5, 123, Queues.unbounded(), 345);
 
         Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(actual);
         test.requested = 35;
@@ -1299,8 +1299,8 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
     public void scanInner() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		FluxZip.ZipCoordinator<Integer, Integer> main = new FluxZip.ZipCoordinator<Integer, Integer>(actual,
-				i -> 5, 123, QueueSupplier.unbounded(), 345);
-		FluxZip.ZipInner<Integer> test = new FluxZip.ZipInner<>(main, 234, 1, QueueSupplier.unbounded());
+				i -> 5, 123, Queues.unbounded(), 345);
+		FluxZip.ZipInner<Integer> test = new FluxZip.ZipInner<>(main, 234, 1, Queues.unbounded());
 
         Assertions.assertThat(test.scan(Scannable.ScannableAttr.ACTUAL)).isSameAs(main);
         Assertions.assertThat(test.scan(Scannable.IntAttr.PREFETCH)).isEqualTo(234);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSequenceEqualTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSequenceEqualTest.java
@@ -29,7 +29,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -135,7 +135,7 @@ public class MonoSequenceEqualTest {
 
 	@Test
 	public void largeSequence() {
-		Flux<Integer> source = Flux.range(1, QueueSupplier.SMALL_BUFFER_SIZE * 4).subscribeOn(Schedulers.elastic());
+		Flux<Integer> source = Flux.range(1, Queues.SMALL_BUFFER_SIZE * 4).subscribeOn(Schedulers.elastic());
 
 		StepVerifier.create(Mono.sequenceEqual(source, source))
 		            .expectNext(Boolean.TRUE)

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
@@ -41,7 +41,7 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -399,14 +399,14 @@ public class ParallelFluxTest {
 	@Test
 	public void fromZeroPrefetchRejected() {
 		Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
-		          .isThrownBy(() -> ParallelFlux.from(Mono.just(1), 1, 0, QueueSupplier.small()))
+		          .isThrownBy(() -> ParallelFlux.from(Mono.just(1), 1, 0, Queues.small()))
 		          .withMessage("prefetch > 0 required but it was 0");
 	}
 
 	@Test
 	public void fromNegativePrefetchRejected() {
 		Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
-		          .isThrownBy(() -> ParallelFlux.from(Mono.just(1), 1, -1, QueueSupplier.small()))
+		          .isThrownBy(() -> ParallelFlux.from(Mono.just(1), 1, -1, Queues.small()))
 		          .withMessage("prefetch > 0 required but it was -1");
 	}
 
@@ -536,7 +536,7 @@ public class ParallelFluxTest {
 	@Test
 	public void fromPublisherDefaultPrefetchIsSmallBufferSize() {
 		assertThat(ParallelFlux.from(Flux.range(1, 5))
-				.getPrefetch()).isEqualTo(QueueSupplier.SMALL_BUFFER_SIZE);
+				.getPrefetch()).isEqualTo(Queues.SMALL_BUFFER_SIZE);
 	}
 
 	@Test
@@ -564,7 +564,7 @@ public class ParallelFluxTest {
 
 	@Test
 	public void transformChangesPrefetch() {
-		assertThat(ParallelFlux.from(Flux.range(1, 10), 3, 12, QueueSupplier.small())
+		assertThat(ParallelFlux.from(Flux.range(1, 10), 3, 12, Queues.small())
 		                       .transform(pf -> pf.runOn(Schedulers.parallel(), 3)
 		                                          .log()
 		                                          .hide())

--- a/reactor-core/src/test/java/reactor/core/publisher/TopicProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/TopicProcessorTest.java
@@ -35,7 +35,7 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 import reactor.util.concurrent.WaitStrategy;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -821,7 +821,7 @@ public class TopicProcessorTest {
 			@Nullable ExecutorService requestTaskExecutor) {
 
 		String expectedName = name != null ? name : TopicProcessor.class.getSimpleName();
-		int expectedBufferSize = bufferSize != null ? bufferSize : QueueSupplier.SMALL_BUFFER_SIZE;
+		int expectedBufferSize = bufferSize != null ? bufferSize : Queues.SMALL_BUFFER_SIZE;
 		boolean expectedAutoCancel = autoCancel != null ? autoCancel : true;
 		WaitStrategy expectedWaitStrategy = waitStrategy != null ? waitStrategy : WaitStrategy.phasedOffLiteLock(200, 100, TimeUnit.MILLISECONDS);
 		Class<?> sequencerClass = shared ? MultiProducerRingBuffer.class : SingleProducerSequencer.class;

--- a/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
@@ -17,22 +17,17 @@ package reactor.core.publisher;
 
 import java.util.PriorityQueue;
 import java.util.Queue;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Consumer;
-
 import javax.annotation.Nullable;
 
 import org.junit.Test;
-
 import reactor.core.Disposable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.QueueSupplier;
 import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -87,7 +82,7 @@ public class UnicastProcessorTest {
 
 	@Test
 	public void createOverrideQueue() {
-		Queue<Integer> queue = QueueSupplier.<Integer>get(10).get();
+		Queue<Integer> queue = Queues.<Integer>get(10).get();
 		UnicastProcessor<Integer> processor = UnicastProcessor.create(queue);
 		assertProcessor(processor, queue, null, null);
 	}
@@ -95,7 +90,7 @@ public class UnicastProcessorTest {
 	@Test
 	public void createOverrideQueueOnTerminate() {
 		Disposable onTerminate = () -> {};
-		Queue<Integer> queue = QueueSupplier.<Integer>get(10).get();
+		Queue<Integer> queue = Queues.<Integer>get(10).get();
 		UnicastProcessor<Integer> processor = UnicastProcessor.create(queue, onTerminate);
 		assertProcessor(processor, queue, null, onTerminate);
 	}
@@ -104,7 +99,7 @@ public class UnicastProcessorTest {
 	public void createOverrideAll() {
 		Disposable onTerminate = () -> {};
 		Consumer<? super Integer> onOverflow = t -> {};
-		Queue<Integer> queue = QueueSupplier.<Integer>get(10).get();
+		Queue<Integer> queue = Queues.<Integer>get(10).get();
 		UnicastProcessor<Integer> processor = UnicastProcessor.create(queue, onOverflow, onTerminate);
 		assertProcessor(processor, queue, onOverflow, onTerminate);
 	}
@@ -113,7 +108,7 @@ public class UnicastProcessorTest {
 			@Nullable Queue<Integer> queue,
 			@Nullable Consumer<? super Integer> onOverflow,
 			@Nullable Disposable onTerminate) {
-		Queue<Integer> expectedQueue = queue != null ? queue : QueueSupplier.<Integer>unbounded().get();
+		Queue<Integer> expectedQueue = queue != null ? queue : Queues.<Integer>unbounded().get();
 		Disposable expectedOnTerminate = onTerminate != null ? onTerminate : null;
 		assertEquals(expectedQueue.getClass(), processor.queue.getClass());
 		assertEquals(expectedOnTerminate, processor.onTerminate);
@@ -124,7 +119,7 @@ public class UnicastProcessorTest {
 	@Test
 	public void bufferSizeReactorUnboundedQueue() {
     	UnicastProcessor processor = UnicastProcessor.create(
-    			QueueSupplier.unbounded(2).get());
+    			Queues.unbounded(2).get());
 
     	assertThat(processor.getBufferSize()).isEqualTo(Integer.MAX_VALUE);
 	}
@@ -133,15 +128,15 @@ public class UnicastProcessorTest {
 	public void bufferSizeReactorBoundedQueue() {
     	//the bounded queue floors at 8 and rounds to the next power of 2
 
-		assertThat(UnicastProcessor.create(QueueSupplier.get(2).get())
+		assertThat(UnicastProcessor.create(Queues.get(2).get())
 		                           .getBufferSize())
 				.isEqualTo(8);
 
-		assertThat(UnicastProcessor.create(QueueSupplier.get(8).get())
+		assertThat(UnicastProcessor.create(Queues.get(8).get())
 		                           .getBufferSize())
 				.isEqualTo(8);
 
-		assertThat(UnicastProcessor.create(QueueSupplier.get(9).get())
+		assertThat(UnicastProcessor.create(Queues.get(9).get())
 		                           .getBufferSize())
 				.isEqualTo(16);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/WorkQueueProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/WorkQueueProcessorTest.java
@@ -48,7 +48,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.util.Logger;
 import reactor.util.Loggers;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 import reactor.util.concurrent.WaitStrategy;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -750,8 +750,8 @@ public class WorkQueueProcessorTest {
 		                                                                              .transform(
 				                                                                              function),
 				                                                               true,
-				                                                               QueueSupplier.SMALL_BUFFER_SIZE,
-				                                                               QueueSupplier.XS_BUFFER_SIZE)))
+				                                                               Queues.SMALL_BUFFER_SIZE,
+				                                                               Queues.XS_BUFFER_SIZE)))
 		                      .sequential()
 		                      .retry())
 		            .then(() -> {
@@ -828,8 +828,8 @@ public class WorkQueueProcessorTest {
 							                      }
 						                      }).subscribeOn(Schedulers.parallel()),
 				                      true,
-				                      QueueSupplier.XS_BUFFER_SIZE,
-				                      QueueSupplier.SMALL_BUFFER_SIZE)
+				                      Queues.XS_BUFFER_SIZE,
+				                      Queues.SMALL_BUFFER_SIZE)
 		                      .retry())
 		            .then(() -> {
 			            wq.onNext(1);
@@ -867,7 +867,7 @@ public class WorkQueueProcessorTest {
 								sink.next(s1);
 							}
 						}).subscribeOn(Schedulers.parallel()),
-				QueueSupplier.XS_BUFFER_SIZE,
+				Queues.XS_BUFFER_SIZE,
 				1)
 		                      .retry())
 		            .then(() -> {
@@ -1413,7 +1413,7 @@ public class WorkQueueProcessorTest {
 			@Nullable ExecutorService requestTaskExecutor) {
 
 		String expectedName = name != null ? name : WorkQueueProcessor.class.getSimpleName();
-		int expectedBufferSize = bufferSize != null ? bufferSize : QueueSupplier.SMALL_BUFFER_SIZE;
+		int expectedBufferSize = bufferSize != null ? bufferSize : Queues.SMALL_BUFFER_SIZE;
 		boolean expectedAutoCancel = autoCancel != null ? autoCancel : true;
 		WaitStrategy expectedWaitStrategy = waitStrategy != null ? waitStrategy : WaitStrategy.liteBlocking();
 		Class<?> sequencerClass = shared ? MultiProducerRingBuffer.class : SingleProducerSequencer.class;

--- a/reactor-core/src/test/java/reactor/test/publisher/BaseOperatorTest.java
+++ b/reactor-core/src/test/java/reactor/test/publisher/BaseOperatorTest.java
@@ -40,7 +40,7 @@ import reactor.core.publisher.ParallelFlux;
 import reactor.core.publisher.ReplayProcessor;
 import reactor.core.publisher.UnicastProcessor;
 import reactor.test.StepVerifier;
-import reactor.util.concurrent.QueueSupplier;
+import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static reactor.core.Fuseable.*;
@@ -329,7 +329,7 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 
 	final int defaultLimit(OperatorScenario<I, PI, O, PO> scenario) {
 		if (scenario.prefetch() == -1) {
-			return QueueSupplier.SMALL_BUFFER_SIZE - (QueueSupplier.SMALL_BUFFER_SIZE >> 2);
+			return Queues.SMALL_BUFFER_SIZE - (Queues.SMALL_BUFFER_SIZE >> 2);
 		}
 		if (scenario.prefetch() == Integer.MAX_VALUE) {
 			return Integer.MAX_VALUE;

--- a/reactor-core/src/test/java/reactor/util/concurrent/QueuesTest.java
+++ b/reactor-core/src/test/java/reactor/util/concurrent/QueuesTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.concurrent;
+
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QueuesTest {
+
+	@Test
+	public void capacityReactorUnboundedQueue() {
+		Queue q = QueueSupplier.unbounded(2).get();
+
+		assertThat(Queues.capacity(q)).isEqualTo(Integer.MAX_VALUE);
+	}
+
+	@Test
+	public void capacityReactorBoundedQueue() {
+		//the bounded queue floors at 8 and rounds to the next power of 2
+
+		assertThat(Queues.capacity(QueueSupplier.get(2).get()))
+				.isEqualTo(8);
+
+		assertThat(Queues.capacity(QueueSupplier.get(8).get()))
+				.isEqualTo(8);
+
+		assertThat(Queues.capacity(QueueSupplier.get(9).get()))
+				.isEqualTo(16);
+	}
+
+	@Test
+	public void capacityBoundedBlockingQueue() {
+		Queue q = new LinkedBlockingQueue<>(10);
+
+		assertThat(Queues.capacity(q)).isEqualTo(10);
+	}
+
+	@Test
+	public void capacityUnboundedBlockingQueue() {
+		Queue q = new LinkedBlockingQueue<>();
+
+		assertThat(Queues.capacity(q)).isEqualTo(Integer.MAX_VALUE);
+
+	}
+
+	@Test
+	public void capacityOtherQueue() {
+		Queue q = new PriorityQueue<>(10);
+
+		assertThat(Queues.capacity(q))
+				.isEqualTo(Integer.MIN_VALUE)
+				.isEqualTo(Queues.CAPACITY_UNSURE);
+	}
+
+}

--- a/reactor-core/src/test/java/reactor/util/concurrent/QueuesTest.java
+++ b/reactor-core/src/test/java/reactor/util/concurrent/QueuesTest.java
@@ -28,7 +28,7 @@ public class QueuesTest {
 
 	@Test
 	public void capacityReactorUnboundedQueue() {
-		Queue q = QueueSupplier.unbounded(2).get();
+		Queue q = Queues.unbounded(2).get();
 
 		assertThat(Queues.capacity(q)).isEqualTo(Integer.MAX_VALUE);
 	}
@@ -37,13 +37,13 @@ public class QueuesTest {
 	public void capacityReactorBoundedQueue() {
 		//the bounded queue floors at 8 and rounds to the next power of 2
 
-		assertThat(Queues.capacity(QueueSupplier.get(2).get()))
+		assertThat(Queues.capacity(Queues.get(2).get()))
 				.isEqualTo(8);
 
-		assertThat(Queues.capacity(QueueSupplier.get(8).get()))
+		assertThat(Queues.capacity(Queues.get(8).get()))
 				.isEqualTo(8);
 
-		assertThat(Queues.capacity(QueueSupplier.get(9).get()))
+		assertThat(Queues.capacity(Queues.get(9).get()))
 				.isEqualTo(16);
 	}
 

--- a/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
+++ b/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
@@ -25,13 +25,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
-import reactor.util.concurrent.QueueSupplier;
-import javax.annotation.Nullable;
+import reactor.util.concurrent.Queues;
 
 /**
  * A {@link Scheduler} that uses a virtual clock, allowing to manipulate time
@@ -177,7 +177,7 @@ public class VirtualTimeScheduler implements Scheduler {
 	}
 
 	final Queue<TimedRunnable> queue =
-			new PriorityBlockingQueue<>(QueueSupplier.XS_BUFFER_SIZE);
+			new PriorityBlockingQueue<>(Queues.XS_BUFFER_SIZE);
 
 	@SuppressWarnings("unused")
 	volatile long counter;


### PR DESCRIPTION
Static methods from `QueueSupplier` have been moved to `Queues` but are still present as deprecated delegating methods. The class itself is deprecated in preparation for its complete removal in 3.1.0.RELEASE.

Alternative more aggressive approach in #737.

**Note this is based on top of #734 and will need a rebase**