### PR TITLE
Remove delayUntil aliases for now:

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3227,7 +3227,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a delayed {@link Flux}
 	 */
 	public final Flux<T> delayElements(Duration delay, Scheduler timer) {
-		return delayUntilOther(Mono.delay(delay, timer));
+		return delayUntil(d -> Mono.delay(delay, timer));
 	}
 
 	/**
@@ -3254,85 +3254,6 @@ public abstract class Flux<T> implements Publisher<T> {
 		                          .delayUntil(triggerProvider));
 	}
 
-	/**
-	 * Subscribe to this {@link Flux} and generate a {@link Publisher} from each of this
-	 * Flux elements, each acting as a trigger for relaying said element.
-	 * <p>
-	 * That is to say, the resulting {@link Flux} delays each of its emission until the
-	 * associated trigger Publisher terminates.
-	 * <p>
-	 * In case of an error in a trigger, the element associated with the failed
-	 * trigger is dropped but subsequent elements are still propagated and delayed. Any
-	 * error in the source is propagated immediately downstream.
-	 * Note that unlike with the {@link Mono#delayUntil(Function) Mono variant} there is
-	 * no fusion of subsequent calls.
-	 * <p>
-	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.0.M2/src/docs/marble/delayUntil.png" alt="">
-	 *
-	 * @param triggerProvider a {@link Function} that maps each element into a
-	 * {@link Publisher} whose termination will trigger relaying the value.
-	 *
-	 * @return this Flux, but with elements delayed until their derived publisher terminates.
-	 */
-	public final Flux<T> delayUntilDelayError(Function<? super T, ? extends Publisher<?>> triggerProvider) {
-		return concatMapDelayError(v -> Mono.just(v)
-		                                    //no need for delayError variant since no macro fusion of triggers
-		                                    .delayUntil(triggerProvider),
-				true, Queues.XS_BUFFER_SIZE);
-	}
-
-	/**
-	 * Subscribe to this {@link Flux} and subscribe to a common {@link Publisher} whenever
-	 * an element is emitted, which acts as a trigger for relaying said element.
-	 * <p>
-	 * That is to say, the resulting {@link Flux} delays each of its emission until the
-	 * associated trigger Publisher terminates. Be careful with hot publishers as their
-	 * state will be shared between subscriptions, probably only delaying the first
-	 * emission as a result.
-	 * <p>
-	 * In case of an error either in the source or in a trigger, that error is propagated
-	 * immediately downstream.
-	 * Note that unlike with the {@link Mono#delayUntilOther(Publisher) Mono variant} there is
-	 * no fusion of subsequent calls.
-	 * <p>
-	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.0.M2/src/docs/marble/delayUntilOther.png" alt="">
-	 *
-	 * @param triggerPublisher a {@link Publisher} whose termination will trigger relaying the value.
-	 *
-	 * @return this Flux, but with elements delayed until the trigger publisher terminates.
-	 */
-	public final Flux<T> delayUntilOther(Publisher<?> triggerPublisher) {
-		return concatMap(v -> Mono.just(v)
-		                          .delayUntilOther(triggerPublisher));
-	}
-
-	/**
-	 * Subscribe to this {@link Flux} and subscribe to a common {@link Publisher} whenever
-	 * an element is emitted, which acts as a trigger for relaying said element.
-	 * <p>
-	 * That is to say, the resulting {@link Flux} delays each of its emission until the
-	 * associated trigger Publisher terminates. Be careful with hot publishers as their
-	 * state will be shared between subscriptions, probably only delaying the first
-	 * emission as a result.
-	 * <p>
-	 * In case of an error in a trigger, the element associated with the failed
-	 * trigger is dropped but subsequent elements are still propagated and delayed. Any
-	 * error in the source is propagated immediately downstream.
-	 * Note that unlike with the {@link Mono#delayUntilOtherDelayError(Publisher) Mono variant} there is
-	 * no fusion of subsequent calls.
-	 * <p>
-	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.0.M2/src/docs/marble/delayUntilOther.png" alt="">
-	 *
-	 * @param triggerPublisher a {@link Publisher} whose termination will trigger relaying the value.
-	 *
-	 * @return this Flux, but with elements delayed until the trigger publisher terminates.
-	 */
-	public final Flux<T> delayUntilOtherDelayError(Publisher<?> triggerPublisher) {
-		return concatMapDelayError(v -> Mono.just(v)
-		                                    //no need for delayError variant since no macro fusion of triggers
-		                                    .delayUntilOther(triggerPublisher),
-				true, Queues.XS_BUFFER_SIZE);
-	}
 
 	/**
 	 * Delay the {@link Flux#subscribe(Subscriber) subscription} to this {@link Flux} source until the given

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDelayUntilTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDelayUntilTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -144,31 +144,6 @@ public class FluxDelayUntilTest {
 
 
 	@Test
-	public void sourceAndTriggerHaveErrorsDelayedShortCircuits() {
-		IllegalStateException boom1 = new IllegalStateException("boom1");
-		IllegalStateException boom2 = new IllegalStateException("boom2");
-		StepVerifier.create(Flux.error(boom1)
-		                        .delayUntilDelayError(a -> Mono.<Integer>error(boom2)))
-		            .verifyErrorMessage("boom1");
-	}
-
-	@Test
-	public void triggersWithErrorsDelayed() {
-		IllegalStateException boom1 = new IllegalStateException("boom1");
-		IllegalStateException boom2 = new IllegalStateException("boom2");
-		StepVerifier.create(
-				Flux.just(1, 2, 3)
-				    .delayUntilDelayError(i -> i == 1 ? Mono.error(boom1) : i == 2 ? Mono.error(boom2) : Mono.empty())
-		)
-		            .expectNext(3)
-		            .consumeErrorWith(e -> assertThat(e)
-						            .hasMessage("Multiple exceptions")
-				                    .hasSuppressedException(boom1)
-				                    .hasSuppressedException(boom2))
-		            .verify();
-	}
-
-	@Test
 	public void testAPIDelayUntil() {
 		StepVerifier.withVirtualTime(() -> Flux.just("foo")
 		                                       .delayUntil(a -> Mono.delay(Duration.ofSeconds(2))))
@@ -185,30 +160,6 @@ public class FluxDelayUntilTest {
 		                        .delayUntil(a -> Mono.delay(Duration.ofSeconds(2))))
 		            .expectErrorMessage("boom")
 		            .verify(Duration.ofMillis(200)); //at least, less than 2s
-	}
-
-	@Test
-	public void testAPIDelayUntilDelayErrorNoError() {
-		StepVerifier.withVirtualTime(() -> Flux.just("foo", "bar")
-		                                       .delayUntilDelayError(a -> Mono.delay(Duration.ofSeconds(2))))
-		            .expectSubscription()
-		            .expectNoEvent(Duration.ofSeconds(2))
-		            .expectNext("foo")
-		            .expectNoEvent(Duration.ofSeconds(2))
-		            .expectNext("bar")
-		            .verifyComplete();
-	}
-
-	@Test
-	public void testAPIDelayUntilDelayErrorWaitsOtherTriggers() {
-		IllegalArgumentException boom = new IllegalArgumentException("boom");
-
-		StepVerifier.withVirtualTime(() -> Mono.just("ok")
-		                                       .delayUntilDelayError(a -> Mono.error(boom))
-		                                       .delayUntilDelayError(a -> Mono.delay(Duration.ofSeconds(2))))
-		            .expectSubscription()
-		            .expectNoEvent(Duration.ofSeconds(2))
-		            .verifyErrorMessage("boom");
 	}
 
 	@Test
@@ -259,9 +210,6 @@ public class FluxDelayUntilTest {
 	@Test
 	public void isAlias() {
 		assertThat(Flux.range(1, 10).delayUntil(a -> Mono.empty()))
-				.isInstanceOf(FluxConcatMap.class);
-
-		assertThat(Flux.range(1, 10).delayUntilDelayError(a -> Mono.empty()))
 				.isInstanceOf(FluxConcatMap.class);
 	}
 


### PR DESCRIPTION
in flux concatMap can be used to achieve similar delayError effect
in mono, delay error doesn't really make sense