### PR TITLE
Fix bad html closing tags for code examples

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -562,7 +562,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *         button.removeListener(al);
 	 *     });
 	 * });
-	 * <code></pre>
+	 * </code></pre>
 	 *
 	 * @param <T> The type of values in the sequence
 	 * @param emitter Consume the {@link FluxSink} provided per-subscriber by Reactor to generate signals.
@@ -599,7 +599,7 @@ public abstract class Flux<T> implements Publisher<T> {
      *         button.removeListener(al);
      *     });
      * }, FluxSink.OverflowStrategy.LATEST);
-     * <code></pre>
+     * </code></pre>
      *
 	 * @param <T> The type of values in the sequence
 	 * @param backpressure the backpressure mode, see {@link OverflowStrategy} for the
@@ -638,7 +638,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *		 button.removeListener(al);
 	 *	 });
 	 * }, FluxSink.OverflowStrategy.LATEST);
-	 * <code></pre>
+	 * </code></pre>
 	 *
 	 * @param <T> The type of values in the sequence
 	 * @param emitter Consume the {@link FluxSink} provided per-subscriber by Reactor to generate signals.
@@ -675,7 +675,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *		 button.removeListener(al);
 	 *	 });
 	 * }, FluxSink.OverflowStrategy.LATEST);
-	 * <code></pre>
+	 * </code></pre>
 	 *
 	 * @param <T> The type of values in the sequence
 	 * @param backpressure the backpressure mode, see {@link OverflowStrategy} for the

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -161,7 +161,7 @@ public abstract class Mono<T> implements Publisher<T> {
      *         }
      *     });
      * }); 
-     * <code></pre>
+     * </code></pre>
 	 *
 	 * @param callback Consume the {@link MonoSink} provided per-subscriber by Reactor to generate signals.
 	 * @param <T> The type of the value emitted


### PR DESCRIPTION
This PR fixes a couple of cases where the `<code>` block was not closed properly with `</code>` causing an unnice javadoc display.