### PR TITLE
fix #777 Offer way to do requests on original thread with subscribeOn

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -6360,9 +6360,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * Note that if you are using an eager or blocking {@link #create(Consumer, OverflowStrategy)}
 	 * as the source, it can lead to deadlocks due to requests piling up behind the emitter.
-	 * This operator attempts to avoid that situation for the trivial case where the
-	 * {@code create} is right before the {@code subscribeOn}, but if it is further up the
-	 * chain you should explicitly call {@link #subscribeOn(Scheduler, boolean) subscribeOn(scheduler, false)}
+	 * In such case, you should call {@link #subscribeOn(Scheduler, boolean) subscribeOn(scheduler, false)}
 	 * instead.
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.0.M3/src/docs/marble/subscribeon.png" alt="">
@@ -6385,7 +6383,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @see #subscribeOn(Scheduler, boolean)
 	 */
 	public final Flux<T> subscribeOn(Scheduler scheduler) {
-		return subscribeOn(scheduler, !(this instanceof FluxCreate));
+		return subscribeOn(scheduler, true);
 	}
 
 	/**
@@ -6415,7 +6413,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *     {@link Subscription#request(long)} will be propagated to the request caller.
 	 *
 	 * @param scheduler a {@link Scheduler} providing the {@link Worker} where to subscribe
-	 * @param requestOnSeparateThread whether or not to also perform requests on the worker
+	 * @param requestOnSeparateThread whether or not to also perform requests on the worker.
+	 * {@code true} to behave like {@link #subscribeOn(Scheduler)}
 	 *
 	 * @return a {@link Flux} requesting asynchronously
 	 * @see #publishOn(Scheduler)

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -6358,6 +6358,13 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * context of onNext/onError/onComplete signals from the beginning of the chain up to
 	 * the next occurrence of a {@link #publishOn(Scheduler) publishOn}.
 	 * <p>
+	 * Note that if you are using an eager or blocking {@link #create(Consumer, OverflowStrategy)}
+	 * as the source, it can lead to deadlocks due to requests piling up behind the emitter.
+	 * This operator attempts to avoid that situation for the trivial case where the
+	 * {@code create} is right before the {@code subscribeOn}, but if it is further up the
+	 * chain you should explicitly call {@link #subscribeOn(Scheduler, boolean) subscribeOn(scheduler, false)}
+	 * instead.
+	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.0.M3/src/docs/marble/subscribeon.png" alt="">
 	 * <p>
 	 * Typically used for slow publisher e.g., blocking IO, fast consumer(s) scenarios.
@@ -6375,8 +6382,46 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * @return a {@link Flux} requesting asynchronously
 	 * @see #publishOn(Scheduler)
+	 * @see #subscribeOn(Scheduler, boolean)
 	 */
 	public final Flux<T> subscribeOn(Scheduler scheduler) {
+		return subscribeOn(scheduler, !(this instanceof FluxCreate));
+	}
+
+	/**
+	 * Run subscribe and onSubscribe on a specified {@link Scheduler}'s {@link Worker}.
+	 * Request will be run on that worker too depending on the {@code requestOnSeparateThread}
+	 * parameter (which defaults to true in the {@link #subscribeOn(Scheduler)} version).
+	 * As such, placing this operator anywhere in the chain will also impact the execution
+	 * context of onNext/onError/onComplete signals from the beginning of the chain up to
+	 * the next occurrence of a {@link #publishOn(Scheduler) publishOn}.
+	 * <p>
+	 * Note that if you are using an eager or blocking {@link #create(Consumer, OverflowStrategy)}
+	 * as the source, it can lead to deadlocks due to requests piling up behind the emitter.
+	 * Thus this operator has a {@code requestOnSeparateThread} parameter, which should be
+	 * set to {@code false} in this case.
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.0.M3/src/docs/marble/subscribeon.png" alt="">
+	 * <p>
+	 * Typically used for slow publisher e.g., blocking IO, fast consumer(s) scenarios.
+	 *
+	 * <blockquote><pre>
+	 * {@code flux.subscribeOn(Schedulers.single()).subscribe() }
+	 * </pre></blockquote>
+	 *
+	 * <p>
+	 *     Note that {@link Scheduler.Worker#schedule(Runnable)} raising
+	 *     {@link java.util.concurrent.RejectedExecutionException} on late
+	 *     {@link Subscription#request(long)} will be propagated to the request caller.
+	 *
+	 * @param scheduler a {@link Scheduler} providing the {@link Worker} where to subscribe
+	 * @param requestOnSeparateThread whether or not to also perform requests on the worker
+	 *
+	 * @return a {@link Flux} requesting asynchronously
+	 * @see #publishOn(Scheduler)
+	 * @see #subscribeOn(Scheduler)
+	 */
+	public final Flux<T> subscribeOn(Scheduler scheduler, boolean requestOnSeparateThread) {
 		if (this instanceof Callable) {
 			if (this instanceof Fuseable.ScalarCallable) {
 				try {
@@ -6391,7 +6436,7 @@ public abstract class Flux<T> implements Publisher<T> {
 			Callable<T> c = (Callable<T>)this;
 			return onAssembly(new FluxSubscribeOnCallable<>(c, scheduler));
 		}
-		return onAssembly(new FluxSubscribeOn<>(this, scheduler));
+		return onAssembly(new FluxSubscribeOn<>(this, scheduler, requestOnSeparateThread));
 	}
 
 	/**

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnTest.java
@@ -18,15 +18,20 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.util.concurrent.Queues;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static reactor.core.publisher.FluxSink.OverflowStrategy.DROP;
 
 public class FluxSubscribeOnTest {
 
@@ -162,17 +167,121 @@ public class FluxSubscribeOnTest {
     public void scanMainSubscriber() {
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxSubscribeOn.SubscribeOnSubscriber<Integer> test =
-        		new FluxSubscribeOn.SubscribeOnSubscriber<>(Flux.just(1), actual, Schedulers.single().createWorker());
+        		new FluxSubscribeOn.SubscribeOnSubscriber<>(Flux.just(1), actual, Schedulers.single().createWorker(), true);
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
 
-        Assertions.assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
-        Assertions.assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
+        assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
         test.requested = 35;
-        Assertions.assertThat(test.scan(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(35L);
+        assertThat(test.scan(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(35L);
 
-        Assertions.assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+        assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
         test.cancel();
-        Assertions.assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
+        assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
     }
+
+	@Test
+	public void createJustBeforeSubscribeOnDoesntScheduleRequests() {
+		Flux<Integer> test = Flux.<Integer>create(sink -> {
+			for (int i = 1; i < 1001; i++) {
+				sink.next(i);
+				try {
+					Thread.sleep(1);
+				}
+				catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+			}
+			sink.complete();
+		}, DROP)
+				.subscribeOn(Schedulers.newSingle("test"))
+				.publishOn(Schedulers.elastic());
+
+		AtomicInteger count = new AtomicInteger();
+		StepVerifier.create(test)
+		            .thenConsumeWhile(t -> count.incrementAndGet() != -1)
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(5));
+
+		assertThat(count.get()).isGreaterThan(Queues.SMALL_BUFFER_SIZE);
+	}
+
+	@Test
+	public void createNotJustBeforeSubscribeOnDoesScheduleRequests() {
+		Flux<Integer> test = Flux.<Integer>create(sink -> {
+			for (int i = 1; i < 1001; i++) {
+				sink.next(i);
+				try {
+					Thread.sleep(1);
+				}
+				catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+			}
+			sink.complete();
+		}, DROP)
+		        .map(Flux.identityFunction())
+				.subscribeOn(Schedulers.newSingle("test"))
+				.publishOn(Schedulers.elastic());
+
+		StepVerifier.create(test)
+		            .expectNextCount(Queues.SMALL_BUFFER_SIZE)
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(5));
+	}
+
+	@Test
+	public void forceNoScheduledRequests() {
+		Flux<Integer> test = Flux.<Integer>create(sink -> {
+			for (int i = 1; i < 1001; i++) {
+				sink.next(i);
+				try {
+					Thread.sleep(1);
+				}
+				catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+			}
+			sink.complete();
+		}, DROP)
+				.map(Function.identity())
+				.subscribeOn(Schedulers.single(), false)
+				.publishOn(Schedulers.elastic());
+
+		AtomicInteger count = new AtomicInteger();
+		StepVerifier.create(test)
+		            .thenConsumeWhile(t -> count.incrementAndGet() != -1)
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(5));
+
+		assertThat(count.get()).isGreaterThan(Queues.SMALL_BUFFER_SIZE);
+	}
+
+	@Test
+	public void forceScheduledRequests() {
+		Flux<Integer> test = Flux.<Integer>create(sink -> {
+			for (int i = 1; i < 1001; i++) {
+				sink.next(i);
+				try {
+					Thread.sleep(1);
+				}
+				catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+			}
+			sink.complete();
+		}, DROP)
+				.map(Function.identity())
+				.subscribeOn(Schedulers.single(), true)
+				.publishOn(Schedulers.elastic());
+
+		AtomicInteger count = new AtomicInteger();
+		StepVerifier.create(test)
+		            .thenConsumeWhile(t -> count.incrementAndGet() != -1)
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(5));
+
+		assertThat(count.get()).isEqualTo(Queues.SMALL_BUFFER_SIZE);
+	}
 }


### PR DESCRIPTION
This commit adds a requestOnSeparateThread parameter to subscribeOn. Its
purpose is to make possible to NOT do the requests on the subscribeOn
worker when set to `false` for cases like when there is an eager or
blocking create as the source.

This case would previously deadlock because having the requests
would pile up behind the eager generator processing.