### PR TITLE
fix #799 Add Disposable empty(), disposed() and never() factories

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Disposable.java
+++ b/reactor-core/src/main/java/reactor/core/Disposable.java
@@ -68,12 +68,12 @@ public interface Disposable {
 	}
 
 	/**
-	 * Return a new {@link Disposable} instance that is initially not disposed but can be
-	 * by calling {@link Disposable#dispose()}.
+	 * Return a new simple {@link Disposable} instance that is initially not disposed but
+	 * can be by calling {@link Disposable#dispose()}.
 	 *
 	 * @return a new {@link Disposable} initially not yet disposed.
 	 */
-	static Disposable empty() {
+	static Disposable single() {
 		return new DefaultDisposable.SimpleDisposable();
 	}
 

--- a/reactor-core/src/main/java/reactor/core/Disposable.java
+++ b/reactor-core/src/main/java/reactor/core/Disposable.java
@@ -68,6 +68,35 @@ public interface Disposable {
 	}
 
 	/**
+	 * Return a new {@link Disposable} instance that is initially not disposed but can be
+	 * by calling {@link Disposable#dispose()}.
+	 *
+	 * @return a new {@link Disposable} initially not yet disposed.
+	 */
+	static Disposable empty() {
+		return new DefaultDisposable.SimpleDisposable();
+	}
+
+	/**
+	 * Return a new {@link Disposable} that is already disposed.
+	 *
+	 * @return a new disposed {@link Disposable}.
+	 */
+	static Disposable disposed() {
+		return new DefaultDisposable.AlwaysDisposable();
+	}
+
+	/**
+	 * Return a new {@link Disposable} that can never be disposed. Calling {@link #dispose()}
+	 * is a NO-OP and {@link #isDisposed()} always return false.
+	 *
+	 * @return a new {@link Disposable} that can never be disposed.
+	 */
+	static Disposable never() {
+		return new DefaultDisposable.NeverDisposable();
+	}
+
+	/**
 	 * Cancel or dispose the underlying task or resource.
 	 * <p>
 	 * Implementations are required to make this method idempotent.

--- a/reactor-core/src/main/java/reactor/core/publisher/Disposables.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Disposables.java
@@ -36,17 +36,7 @@ final class Disposables {
 	 * leaked to clients.
 	 */
 	//NOTE: There is a private similar DISPOSED singleton in DefaultDisposable as well
-	static final Disposable DISPOSED = new Disposable() {
-		@Override
-		public void dispose() {
-			//NO-OP
-		}
-
-		@Override
-		public boolean isDisposed() {
-			return true;
-		}
-	};
+	static final Disposable DISPOSED = Disposable.disposed();
 
 	/**
 	 * Atomically push the field to a {@link Disposable} and dispose the old content.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOnValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOnValue.java
@@ -88,8 +88,7 @@ final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable {
 						Disposable.class,
 						"future");
 
-		static final Disposable FINISHED = () -> {
-		};
+		static final Disposable FINISHED = Disposable.disposed();
 
 		int fusionState;
 
@@ -219,8 +218,7 @@ final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable {
 						Disposable.class,
 						"future");
 
-		static final Disposable FINISHED = () -> {
-		};
+		static final Disposable FINISHED = Disposable.disposed();
 
 		ScheduledEmpty(Subscriber<?> actual) {
 			this.actual = actual;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
@@ -73,7 +73,7 @@ final class MonoDelay extends Mono<Long> {
 
 		volatile boolean requested;
 
-		static final Disposable FINISHED = () -> { };
+		static final Disposable FINISHED = Disposable.disposed();
 
 		MonoDelayRunnable(CoreSubscriber<? super Long> actual) {
 			this.actual = actual;

--- a/reactor-core/src/main/java/reactor/core/scheduler/ImmediateScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ImmediateScheduler.java
@@ -38,12 +38,12 @@ final class ImmediateScheduler implements Scheduler {
         
     }
     
-    static final Disposable EMPTY = () -> { };
+    static final Disposable FINISHED = Disposable.disposed();
     
     @Override
     public Disposable schedule(Runnable task) {
         task.run();
-        return EMPTY;
+        return FINISHED;
     }
 
     @Override
@@ -66,7 +66,7 @@ final class ImmediateScheduler implements Scheduler {
                 throw Exceptions.failWithRejected();
             }
             task.run();
-            return EMPTY;
+            return FINISHED;
         }
 
         @Override

--- a/reactor-core/src/test/java/reactor/core/DefaultDisposableTest.java
+++ b/reactor-core/src/test/java/reactor/core/DefaultDisposableTest.java
@@ -116,7 +116,7 @@ public class DefaultDisposableTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					DefaultDisposable.replace(DISPOSABLE_UPDATER, this, Disposable.empty());
+					DefaultDisposable.replace(DISPOSABLE_UPDATER, this, Disposable.single());
 				}
 			};
 
@@ -130,7 +130,7 @@ public class DefaultDisposableTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					DefaultDisposable.set(DISPOSABLE_UPDATER, this, Disposable.empty());
+					DefaultDisposable.set(DISPOSABLE_UPDATER, this, Disposable.single());
 				}
 			};
 
@@ -150,7 +150,7 @@ public class DefaultDisposableTest {
 
 	@Test
 	public void dispose() {
-		Disposable u = Disposable.empty();
+		Disposable u = Disposable.single();
 		TestDisposable r = new TestDisposable(u);
 
 		DefaultDisposable.dispose(DISPOSABLE_UPDATER, r);

--- a/reactor-core/src/test/java/reactor/core/DefaultDisposableTest.java
+++ b/reactor-core/src/test/java/reactor/core/DefaultDisposableTest.java
@@ -69,22 +69,6 @@ public class DefaultDisposableTest {
 			DISPOSABLE_UPDATER =
 			AtomicReferenceFieldUpdater.newUpdater(TestDisposable.class, Disposable.class, "disp");
 
-	private static Disposable empty() {
-		return new Disposable() {
-			volatile boolean disposed = false;
-
-			@Override
-			public void dispose() {
-				this.disposed = true;
-			}
-
-			@Override
-			public boolean isDisposed() {
-				return disposed;
-			}
-		};
-	}
-
 	private static class TestDisposable implements Runnable {
 		volatile Disposable disp;
 
@@ -107,6 +91,7 @@ public class DefaultDisposableTest {
 		assertThat(DefaultDisposable.DISPOSED.isDisposed()).isTrue();
 		DefaultDisposable.DISPOSED.dispose();
 		assertThat(DefaultDisposable.DISPOSED.isDisposed()).isTrue();
+		assertThat(DefaultDisposable.DISPOSED).isNotSameAs(Disposable.disposed());
 	}
 
 	@Test
@@ -131,7 +116,7 @@ public class DefaultDisposableTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					DefaultDisposable.replace(DISPOSABLE_UPDATER, this, empty());
+					DefaultDisposable.replace(DISPOSABLE_UPDATER, this, Disposable.empty());
 				}
 			};
 
@@ -145,7 +130,7 @@ public class DefaultDisposableTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					DefaultDisposable.set(DISPOSABLE_UPDATER, this, empty());
+					DefaultDisposable.set(DISPOSABLE_UPDATER, this, Disposable.empty());
 				}
 			};
 
@@ -165,7 +150,7 @@ public class DefaultDisposableTest {
 
 	@Test
 	public void dispose() {
-		Disposable u = empty();
+		Disposable u = Disposable.empty();
 		TestDisposable r = new TestDisposable(u);
 
 		DefaultDisposable.dispose(DISPOSABLE_UPDATER, r);

--- a/reactor-core/src/test/java/reactor/core/DisposableTest.java
+++ b/reactor-core/src/test/java/reactor/core/DisposableTest.java
@@ -175,24 +175,24 @@ public class DisposableTest {
 	}
 
 	@Test
-	public void emptyDisposableInitiallyNotDisposed() {
-		Disposable empty = Disposable.empty();
+	public void singleDisposableInitiallyNotDisposed() {
+		Disposable single = Disposable.single();
 
-		assertThat(empty.isDisposed()).isFalse();
+		assertThat(single.isDisposed()).isFalse();
 	}
 
 	@Test
-	public void emptyDisposableCanBeDisposed() {
-		Disposable empty = Disposable.empty();
-		assertThat(empty.isDisposed()).isFalse();
+	public void singleDisposableCanBeDisposed() {
+		Disposable single = Disposable.single();
+		assertThat(single.isDisposed()).isFalse();
 
-		empty.dispose();
-		assertThat(empty.isDisposed()).isTrue();
+		single.dispose();
+		assertThat(single.isDisposed()).isTrue();
 	}
 
 	@Test
-	public void emptyDisposableCreatesInstances() {
-		assertThat(Disposable.empty()).isNotSameAs(Disposable.empty());
+	public void singleDisposableCreatesInstances() {
+		assertThat(Disposable.single()).isNotSameAs(Disposable.single());
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/DisposableTest.java
+++ b/reactor-core/src/test/java/reactor/core/DisposableTest.java
@@ -174,4 +174,54 @@ public class DisposableTest {
 		assertThat(d3.isDisposed()).isTrue();
 	}
 
+	@Test
+	public void emptyDisposableInitiallyNotDisposed() {
+		Disposable empty = Disposable.empty();
+
+		assertThat(empty.isDisposed()).isFalse();
+	}
+
+	@Test
+	public void emptyDisposableCanBeDisposed() {
+		Disposable empty = Disposable.empty();
+		assertThat(empty.isDisposed()).isFalse();
+
+		empty.dispose();
+		assertThat(empty.isDisposed()).isTrue();
+	}
+
+	@Test
+	public void emptyDisposableCreatesInstances() {
+		assertThat(Disposable.empty()).isNotSameAs(Disposable.empty());
+	}
+
+	@Test
+	public void disposedInitiallyDisposed() {
+		assertThat(Disposable.disposed().isDisposed()).isTrue();
+	}
+
+	@Test
+	public void disposedCreatesInstances() {
+		assertThat(Disposable.disposed()).isNotSameAs(Disposable.disposed());
+	}
+
+	@Test
+	public void neverInitiallyNotDisposed() {
+		assertThat(Disposable.never().isDisposed()).isFalse();
+	}
+
+	@Test
+	public void neverImmutable() {
+		Disposable never = Disposable.never();
+		assertThat(never.isDisposed()).isFalse();
+
+		never.dispose();
+		assertThat(never.isDisposed()).isFalse();
+	}
+
+	@Test
+	public void neverCreatesInstances() {
+		assertThat(Disposable.never()).isNotSameAs(Disposable.never());
+	}
+
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/DisposablesTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/DisposablesTest.java
@@ -30,22 +30,6 @@ public class DisposablesTest {
 	static final AtomicReferenceFieldUpdater<TestDisposable, Disposable> DISPOSABLE_UPDATER =
 			AtomicReferenceFieldUpdater.newUpdater(TestDisposable.class, Disposable.class, "disp");
 	
-	private static Disposable empty() {
-		return new Disposable() {
-			volatile boolean disposed = false;
-			
-			@Override
-			public void dispose() {
-				this.disposed = true;
-			}
-
-			@Override
-			public boolean isDisposed() {
-				return disposed;
-			}
-		};
-	}
-
 	private static class TestDisposable implements Runnable {
 		volatile Disposable disp;
 
@@ -68,6 +52,7 @@ public class DisposablesTest {
 		assertThat(Disposables.DISPOSED.isDisposed()).isTrue();
 		Disposables.DISPOSED.dispose();
 		assertThat(Disposables.DISPOSED.isDisposed()).isTrue();
+		assertThat(Disposables.DISPOSED).isNotSameAs(Disposable.disposed());
 	}
 
 	@Test
@@ -103,7 +88,7 @@ public class DisposablesTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					Disposables.replace(DISPOSABLE_UPDATER, this, empty());
+					Disposables.replace(DISPOSABLE_UPDATER, this, Disposable.empty());
 				}
 			};
 
@@ -117,7 +102,7 @@ public class DisposablesTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					Disposables.set(DISPOSABLE_UPDATER, this, empty());
+					Disposables.set(DISPOSABLE_UPDATER, this, Disposable.empty());
 				}
 			};
 
@@ -137,7 +122,7 @@ public class DisposablesTest {
 
 	@Test
 	public void dispose() {
-		Disposable u = empty();
+		Disposable u = Disposable.empty();
 		TestDisposable r = new TestDisposable(u);
 
 		Disposables.dispose(DISPOSABLE_UPDATER, r);
@@ -149,11 +134,11 @@ public class DisposablesTest {
 	public void trySet() {
 		TestDisposable r = new TestDisposable();
 
-		Disposable d1 = empty();
+		Disposable d1 = Disposable.empty();
 
 		assertThat(Disposables.trySet(DISPOSABLE_UPDATER, r, d1)).isTrue();
 
-		Disposable d2 = empty();
+		Disposable d2 = Disposable.empty();
 
 		assertThat(Disposables.trySet(DISPOSABLE_UPDATER, r, d2)).isFalse();
 
@@ -163,7 +148,7 @@ public class DisposablesTest {
 
 		Disposables.dispose(DISPOSABLE_UPDATER, r);
 
-		Disposable d3 = empty();
+		Disposable d3 = Disposable.empty();
 
 		assertThat(Disposables.trySet(DISPOSABLE_UPDATER, r, d3)).isFalse();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/DisposablesTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/DisposablesTest.java
@@ -88,7 +88,7 @@ public class DisposablesTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					Disposables.replace(DISPOSABLE_UPDATER, this, Disposable.empty());
+					Disposables.replace(DISPOSABLE_UPDATER, this, Disposable.single());
 				}
 			};
 
@@ -102,7 +102,7 @@ public class DisposablesTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					Disposables.set(DISPOSABLE_UPDATER, this, Disposable.empty());
+					Disposables.set(DISPOSABLE_UPDATER, this, Disposable.single());
 				}
 			};
 
@@ -122,7 +122,7 @@ public class DisposablesTest {
 
 	@Test
 	public void dispose() {
-		Disposable u = Disposable.empty();
+		Disposable u = Disposable.single();
 		TestDisposable r = new TestDisposable(u);
 
 		Disposables.dispose(DISPOSABLE_UPDATER, r);
@@ -134,11 +134,11 @@ public class DisposablesTest {
 	public void trySet() {
 		TestDisposable r = new TestDisposable();
 
-		Disposable d1 = Disposable.empty();
+		Disposable d1 = Disposable.single();
 
 		assertThat(Disposables.trySet(DISPOSABLE_UPDATER, r, d1)).isTrue();
 
-		Disposable d2 = Disposable.empty();
+		Disposable d2 = Disposable.single();
 
 		assertThat(Disposables.trySet(DISPOSABLE_UPDATER, r, d2)).isFalse();
 
@@ -148,7 +148,7 @@ public class DisposablesTest {
 
 		Disposables.dispose(DISPOSABLE_UPDATER, r);
 
-		Disposable d3 = Disposable.empty();
+		Disposable d3 = Disposable.single();
 
 		assertThat(Disposables.trySet(DISPOSABLE_UPDATER, r, d3)).isFalse();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnValueTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnValueTest.java
@@ -18,7 +18,6 @@ package reactor.core.publisher;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
@@ -27,11 +26,18 @@ import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class FluxSubscribeOnValueTest {
 
 	ConcurrentMap<Integer, Integer> execs = new ConcurrentHashMap<>();
+
+	@Test
+	public void finishedConstantsAreNotSame() {
+		assertThat(FluxSubscribeOnValue.ScheduledScalar.FINISHED)
+				.isNotSameAs(FluxSubscribeOnValue.ScheduledEmpty.FINISHED);
+	}
 
 	@Test
 	public void testSubscribeOnValueFusion() {
@@ -74,15 +80,15 @@ public class FluxSubscribeOnValueTest {
         FluxSubscribeOnValue.ScheduledScalar<Integer> test =
         		new FluxSubscribeOnValue.ScheduledScalar<Integer>(actual, 1, Schedulers.single());
 
-        Assertions.assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
-        Assertions.assertThat(test.scan(Scannable.Attr.BUFFERED)).isEqualTo(1);
+        assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
+        assertThat(test.scan(Scannable.Attr.BUFFERED)).isEqualTo(1);
 
-        Assertions.assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
+        assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
         test.future = FluxSubscribeOnValue.ScheduledScalar.FINISHED;
-        Assertions.assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
+        assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
 
-        Assertions.assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+        assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
         test.future = Disposables.DISPOSED;
-        Assertions.assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
+        assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
     }
 }

--- a/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
+++ b/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
@@ -466,11 +466,8 @@ public class VirtualTimeScheduler implements Scheduler {
 		}
 	}
 
-	static final Disposable CANCELLED = () -> {
-	};
-	static final Disposable EMPTY = () -> {
-	};
-
+	static final Disposable CANCELLED = Disposable.disposed();
+	static final Disposable EMPTY = Disposable.never();
 
 	static boolean replace(AtomicReference<Disposable> ref, @Nullable Disposable c) {
 		for (; ; ) {

--- a/reactor-test/src/test/java/reactor/test/scheduler/VirtualTimeSchedulerTests.java
+++ b/reactor-test/src/test/java/reactor/test/scheduler/VirtualTimeSchedulerTests.java
@@ -34,6 +34,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class VirtualTimeSchedulerTests {
 
 	@Test
+	public void cancelledAndEmptyConstantsAreNotSame() {
+		assertThat(VirtualTimeScheduler.CANCELLED).isNotSameAs(VirtualTimeScheduler.EMPTY);
+
+		assertThat(VirtualTimeScheduler.CANCELLED.isDisposed()).isTrue();
+		assertThat(VirtualTimeScheduler.EMPTY.isDisposed()).isFalse();
+	}
+
+	@Test
 	public void allEnabled() {
 		Assert.assertFalse(Schedulers.newParallel("") instanceof VirtualTimeScheduler);
 		Assert.assertFalse(Schedulers.newElastic("") instanceof VirtualTimeScheduler);


### PR DESCRIPTION
The first one creates a new mutable Disposable while the two others
produce immutable new instances.

Creating new instances allows operators to declare multiple constants
using these methods and internally do == comparisons, including the
DISPOSED internal constants in Disposables and DefaultDisposable (which
must not be leaked to users).