### PR TITLE
further fix #801 Add direct edit link in HTML5 at end of most sections

### DIFF
--- a/src/docs/asciidoc/aboutDoc.adoc
+++ b/src/docs/asciidoc/aboutDoc.adoc
@@ -1,3 +1,4 @@
+[[about-doc]]
 = About the Documentation
 This section provides a brief overview of Reactor reference documentation.
 You can read this reference guide in a linear fashion, or you can skip
@@ -17,8 +18,20 @@ The reference guide is written in http://asciidoctor.org/docs/asciidoc-writers-g
 format and sources can be found at https://github.com/reactor/reactor-core/tree/master/src/docs/asciidoc.
 
 If you come up with any improvement, we'll be happy to get a pull-request from you!
-For example, you can directly edit the <<core-features>> section in GitHub's UI
-https://github.com/reactor/reactor-core/edit/master/src/docs/asciidoc/coreFeatures.adoc[here]
+
+It is recommended to check out a local copy of the repository so that you can generate
+the documentation using the `asciidoctor` gradle task and check the rendering. Some of
+the sections rely on included files, so GitHub rendering is not always relevant.
+
+TIP: To facilitate documentation edits, most sections have a link at the end that opens
+an edit UI directly on GitHub, for the main source file for that section.
+ifeval::["{backend}" != "html5"]
+These links are only present in the HTML5 version of this reference guide.
+endif::[]
+ifeval::["{backend}" == "html5"]
+They look like this:
+https://github.com/reactor/reactor-core/edit/master/src/docs/asciidoc/aboutDoc.adoc[Suggest Edit^, role="fa fa-edit"].
+endif::[]
 
 == Getting help
 There are several ways to reach out for help with Reactor.

--- a/src/docs/asciidoc/advancedFeatures.adoc
+++ b/src/docs/asciidoc/advancedFeatures.adoc
@@ -1,3 +1,4 @@
+[[advanced]]
 = Advanced features and concepts
 
 == Mutualizing operator usage

--- a/src/docs/asciidoc/debugging.adoc
+++ b/src/docs/asciidoc/debugging.adoc
@@ -1,3 +1,4 @@
+[[debugging]]
 = Debugging Reactor
 Switching from an imperative and synchronous programming paradigm to a reactive
 and asynchronous one can sometimes be daunting. One of the steepest steps in the

--- a/src/docs/asciidoc/faq.adoc
+++ b/src/docs/asciidoc/faq.adoc
@@ -1,3 +1,4 @@
+[[faq]]
 = FAQ, best practices and other "How do I...?"
 [[faq.chain]]
 == I just used an operator on my `Flux` but it doesn't seem to apply... What gives?

--- a/src/docs/asciidoc/index.asciidoc
+++ b/src/docs/asciidoc/index.asciidoc
@@ -8,26 +8,63 @@ ifndef::host-github[:ext-relative: {outfilesuffix}]
 :toc:
 :sectnums:
 :sectanchors:
+:linkattrs:
 
 include::aboutDoc.adoc[leveloffset=1]
+ifeval::["{backend}" == "html5"]
+https://github.com/reactor/reactor-core/edit/master/src/docs/asciidoc/aboutDoc.adoc[Suggest Edit^, title="Suggest an edit to the above section via github", role="fa fa-edit"]
+to "<<about-doc>>"
+endif::[]
 
 include::gettingStarted.adoc[leveloffset=1]
+ifeval::["{backend}" == "html5"]
+https://github.com/reactor/reactor-core/edit/master/src/docs/asciidoc/gettingStarted.adoc[Suggest Edit, title="Suggest an edit to the above section via github", role="fa fa-edit"]
+to "<<getting-started>>"
+endif::[]
 
 include::reactiveProgramming.adoc[leveloffset=1]
+ifeval::["{backend}" == "html5"]
+https://github.com/reactor/reactor-core/edit/master/src/docs/asciidoc/reactiveProgramming.adoc[Suggest Edit, title="Suggest an edit to the above section via github", role="fa fa-edit"]
+to "<<intro-reactive>>"
+endif::[]
 
 include::coreFeatures.adoc[leveloffset=1]
+ifeval::["{backend}" == "html5"]
+https://github.com/reactor/reactor-core/edit/master/src/docs/asciidoc/coreFeatures.adoc[Suggest Edit, title="Suggest an edit to the above section via github", role="fa fa-edit"]
+to "<<core-features>>"
+endif::[]
 
 //TODO see other sections from consuming.adoc
 
 include::operatorChoice.adoc[leveloffset=1]
+ifeval::["{backend}" == "html5"]
+https://github.com/reactor/reactor-core/edit/master/src/docs/asciidoc/operatorChoice.adoc[Suggest Edit, title="Suggest an edit to the above section via github", role="fa fa-edit"]
+to "<<which-operator>>"
+endif::[]
 
 include::testing.adoc[leveloffset=1]
+ifeval::["{backend}" == "html5"]
+https://github.com/reactor/reactor-core/edit/master/src/docs/asciidoc/testing.adoc[Suggest Edit, title="Suggest an edit to the above section via github", role="fa fa-edit"]
+to "<<testing>>"
+endif::[]
 
 include::debugging.adoc[leveloffset=1]
+ifeval::["{backend}" == "html5"]
+https://github.com/reactor/reactor-core/edit/master/src/docs/asciidoc/debugging.adoc[Suggest Edit, title="Suggest an edit to the above section via github", role="fa fa-edit"]
+to "<<debugging>>"
+endif::[]
 
 include::advancedFeatures.adoc[leveloffset=1]
+ifeval::["{backend}" == "html5"]
+https://github.com/reactor/reactor-core/edit/master/src/docs/asciidoc/advancedFeatures.adoc[Suggest Edit, title="Suggest an edit to the above section via github", role="fa fa-edit"]
+to "<<advanced>>"
+endif::[]
 
 include::faq.adoc[leveloffset=1]
+ifeval::["{backend}" == "html5"]
+https://github.com/reactor/reactor-core/edit/master/src/docs/asciidoc/faq.adoc[Suggest Edit, title="Suggest an edit to the above section via github", role="fa fa-edit"]
+to "<<faq>>"
+endif::[]
 
 [appendix]
 include::apdx-implem.adoc[]


### PR DESCRIPTION
This commit adds an edit link to most sections, at the end of the
section (and only in the HTML5 rendering). Amended the "contributing to
docs" paragraph.