### PR TITLE
Put Disposable factory methods in a separate class

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Disposable.java
+++ b/reactor-core/src/main/java/reactor/core/Disposable.java
@@ -34,7 +34,7 @@ public interface Disposable {
 	 * @return an empty atomic {@link Composite}
 	 */
 	static Composite composite() {
-		return new DefaultDisposable.CompositeDisposable();
+		return new Disposables.CompositeDisposable();
 	}
 
 	/**
@@ -44,7 +44,7 @@ public interface Disposable {
 	 * @return a pre-filled atomic {@link Composite}
 	 */
 	static Composite composite(Disposable... disposables) {
-		return new DefaultDisposable.CompositeDisposable(disposables);
+		return new Disposables.CompositeDisposable(disposables);
 	}
 
 	/**
@@ -54,7 +54,7 @@ public interface Disposable {
 	 * @return a pre-filled atomic {@link Composite}
 	 */
 	static Composite composite(Iterable<? extends Disposable> disposables) {
-		return new DefaultDisposable.CompositeDisposable(disposables);
+		return new Disposables.CompositeDisposable(disposables);
 	}
 
 	/**
@@ -64,7 +64,7 @@ public interface Disposable {
 	 * @return an empty atomic {@link Swap}
 	 */
 	static Swap swap() {
-		return new DefaultDisposable.SwapDisposable();
+		return new Disposables.SwapDisposable();
 	}
 
 	/**
@@ -74,7 +74,7 @@ public interface Disposable {
 	 * @return a new {@link Disposable} initially not yet disposed.
 	 */
 	static Disposable single() {
-		return new DefaultDisposable.SimpleDisposable();
+		return new Disposables.SimpleDisposable();
 	}
 
 	/**
@@ -83,7 +83,7 @@ public interface Disposable {
 	 * @return a new disposed {@link Disposable}.
 	 */
 	static Disposable disposed() {
-		return new DefaultDisposable.AlwaysDisposable();
+		return new Disposables.AlwaysDisposable();
 	}
 
 	/**
@@ -93,7 +93,7 @@ public interface Disposable {
 	 * @return a new {@link Disposable} that can never be disposed.
 	 */
 	static Disposable never() {
-		return new DefaultDisposable.NeverDisposable();
+		return new Disposables.NeverDisposable();
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/Disposable.java
+++ b/reactor-core/src/main/java/reactor/core/Disposable.java
@@ -28,75 +28,6 @@ import javax.annotation.Nullable;
 public interface Disposable {
 
 	/**
-	 * Create a new empty {@link Composite} with atomic guarantees on all mutative
-	 * operations.
-	 *
-	 * @return an empty atomic {@link Composite}
-	 */
-	static Composite composite() {
-		return new Disposables.CompositeDisposable();
-	}
-
-	/**
-	 * Create and initialize a new {@link Composite} with atomic guarantees on
-	 * all mutative operations.
-	 *
-	 * @return a pre-filled atomic {@link Composite}
-	 */
-	static Composite composite(Disposable... disposables) {
-		return new Disposables.CompositeDisposable(disposables);
-	}
-
-	/**
-	 * Create and initialize a new {@link Composite} with atomic guarantees on
-	 * all mutative operations.
-	 *
-	 * @return a pre-filled atomic {@link Composite}
-	 */
-	static Composite composite(Iterable<? extends Disposable> disposables) {
-		return new Disposables.CompositeDisposable(disposables);
-	}
-
-	/**
-	 * Create a new empty {@link Swap} with atomic guarantees on all mutative
-	 * operations.
-	 *
-	 * @return an empty atomic {@link Swap}
-	 */
-	static Swap swap() {
-		return new Disposables.SwapDisposable();
-	}
-
-	/**
-	 * Return a new simple {@link Disposable} instance that is initially not disposed but
-	 * can be by calling {@link Disposable#dispose()}.
-	 *
-	 * @return a new {@link Disposable} initially not yet disposed.
-	 */
-	static Disposable single() {
-		return new Disposables.SimpleDisposable();
-	}
-
-	/**
-	 * Return a new {@link Disposable} that is already disposed.
-	 *
-	 * @return a new disposed {@link Disposable}.
-	 */
-	static Disposable disposed() {
-		return new Disposables.AlwaysDisposable();
-	}
-
-	/**
-	 * Return a new {@link Disposable} that can never be disposed. Calling {@link #dispose()}
-	 * is a NO-OP and {@link #isDisposed()} always return false.
-	 *
-	 * @return a new {@link Disposable} that can never be disposed.
-	 */
-	static Disposable never() {
-		return new Disposables.NeverDisposable();
-	}
-
-	/**
 	 * Cancel or dispose the underlying task or resource.
 	 * <p>
 	 * Implementations are required to make this method idempotent.
@@ -174,7 +105,7 @@ public interface Disposable {
 		 * @implNote The default implementation is not atomic, meaning that if the container is
 		 * disposed while the content of the collection is added, first elements might be
 		 * effectively added. Stronger consistency is enforced by composites created via
-		 * {@link Disposable#composite()} variants.
+		 * {@link Disposables#composite()} variants.
 		 * @param ds the collection of Disposables
 		 * @return true if the operation was successful, false if the container has been disposed
 		 */

--- a/reactor-core/src/main/java/reactor/core/Disposables.java
+++ b/reactor-core/src/main/java/reactor/core/Disposables.java
@@ -28,16 +28,16 @@ import javax.annotation.Nullable;
 import reactor.util.concurrent.Queues;
 
 /**
- * A support class that offers implementations for the specialized {@link Disposable}
- * sub-interfaces ({@link Disposable.Composite Disposable.Composite},
+ * A support class that offers factory methods for implementations of the specialized
+ * {@link Disposable} sub-interfaces ({@link Disposable.Composite Disposable.Composite},
  * {@link Disposable.Swap Disposable.Swap}).
  *
  * @author Simon Baslé
  * @author Stephane Maldini
  */
-abstract class DefaultDisposable {
+public abstract class Disposables {
 
-	DefaultDisposable() { }
+	Disposables() { }
 
 	/**
 	 * A {@link Disposable.Composite} that allows to atomically add, remove and mass dispose.
@@ -363,12 +363,12 @@ abstract class DefaultDisposable {
 
 		@Override
 		public boolean update(Disposable next) {
-			return DefaultDisposable.set(INNER, this, next);
+			return Disposables.set(INNER, this, next);
 		}
 
 		@Override
 		public boolean replace(@Nullable Disposable next) {
-			return DefaultDisposable.replace(INNER, this, next);
+			return Disposables.replace(INNER, this, next);
 		}
 
 		@Override
@@ -379,12 +379,12 @@ abstract class DefaultDisposable {
 
 		@Override
 		public void dispose() {
-			DefaultDisposable.dispose(INNER, this);
+			Disposables.dispose(INNER, this);
 		}
 
 		@Override
 		public boolean isDisposed() {
-			return DefaultDisposable.isDisposed(INNER.get(this));
+			return Disposables.isDisposed(INNER.get(this));
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/Disposables.java
+++ b/reactor-core/src/main/java/reactor/core/Disposables.java
@@ -35,10 +35,9 @@ import reactor.util.concurrent.Queues;
  * @author Simon Baslé
  * @author Stephane Maldini
  */
-public abstract class Disposables {
+public final class Disposables {
 
-	Disposables() { }
-
+	private Disposables() { }
 
 	/**
 	 * Create a new empty {@link Disposable.Composite} with atomic guarantees on all mutative
@@ -111,7 +110,6 @@ public abstract class Disposables {
 	}
 
 	//==== STATIC package private implementations ====
-
 
 	/**
 	 * A {@link Disposable.Composite} that allows to atomically add, remove and mass dispose.

--- a/reactor-core/src/main/java/reactor/core/Disposables.java
+++ b/reactor-core/src/main/java/reactor/core/Disposables.java
@@ -39,6 +39,80 @@ public abstract class Disposables {
 
 	Disposables() { }
 
+
+	/**
+	 * Create a new empty {@link Disposable.Composite} with atomic guarantees on all mutative
+	 * operations.
+	 *
+	 * @return an empty atomic {@link Disposable.Composite}
+	 */
+	public static Disposable.Composite composite() {
+		return new CompositeDisposable();
+	}
+
+	/**
+	 * Create and initialize a new {@link Disposable.Composite} with atomic guarantees on
+	 * all mutative operations.
+	 *
+	 * @return a pre-filled atomic {@link Disposable.Composite}
+	 */
+	public static Disposable.Composite composite(Disposable... disposables) {
+		return new CompositeDisposable(disposables);
+	}
+
+	/**
+	 * Create and initialize a new {@link Disposable.Composite} with atomic guarantees on
+	 * all mutative operations.
+	 *
+	 * @return a pre-filled atomic {@link Disposable.Composite}
+	 */
+	public static Disposable.Composite composite(
+			Iterable<? extends Disposable> disposables) {
+		return new CompositeDisposable(disposables);
+	}
+
+	/**
+	 * Return a new {@link Disposable} that is already disposed.
+	 *
+	 * @return a new disposed {@link Disposable}.
+	 */
+	public static Disposable disposed() {
+		return new AlwaysDisposable();
+	}
+
+	/**
+	 * Return a new {@link Disposable} that can never be disposed. Calling {@link Disposable#dispose()}
+	 * is a NO-OP and {@link Disposable#isDisposed()} always return false.
+	 *
+	 * @return a new {@link Disposable} that can never be disposed.
+	 */
+	public static Disposable never() {
+		return new NeverDisposable();
+	}
+
+	/**
+	 * Return a new simple {@link Disposable} instance that is initially not disposed but
+	 * can be by calling {@link Disposable#dispose()}.
+	 *
+	 * @return a new {@link Disposable} initially not yet disposed.
+	 */
+	public static Disposable single() {
+		return new SimpleDisposable();
+	}
+
+	/**
+	 * Create a new empty {@link Disposable.Swap} with atomic guarantees on all mutative
+	 * operations.
+	 *
+	 * @return an empty atomic {@link Disposable.Swap}
+	 */
+	public static Disposable.Swap swap() {
+		return new SwapDisposable();
+	}
+
+	//==== STATIC package private implementations ====
+
+
 	/**
 	 * A {@link Disposable.Composite} that allows to atomically add, remove and mass dispose.
 	 *
@@ -446,7 +520,7 @@ public abstract class Disposables {
 	 * leaked to clients.
 	 */
 	//NOTE: There is a private similar DISPOSED singleton in Disposables as well
-	static final Disposable DISPOSED = Disposable.disposed();
+	static final Disposable DISPOSED = disposed();
 
 	/**
 	 * Atomically push the field to a {@link Disposable} and dispose the old content.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
@@ -436,9 +436,9 @@ final class FluxCreate<T> extends Flux<T> {
 
 		void disposeResource(boolean isCancel) {
 			Disposable d = disposable;
-			if (d != Disposables.DISPOSED) {
-				d = DISPOSABLE.getAndSet(this, Disposables.DISPOSED);
-				if (d != null && d != Disposables.DISPOSED) {
+			if (d != OperatorDisposables.DISPOSED) {
+				d = DISPOSABLE.getAndSet(this, OperatorDisposables.DISPOSED);
+				if (d != null && d != OperatorDisposables.DISPOSED) {
 					if (isCancel && d instanceof SinkDisposable) {
 						((SinkDisposable) d).cancel();
 					}
@@ -458,7 +458,7 @@ final class FluxCreate<T> extends Flux<T> {
 
 		@Override
 		public final boolean isCancelled() {
-			return Disposables.isDisposed(disposable);
+			return OperatorDisposables.isDisposed(disposable);
 		}
 
 		@Override
@@ -528,7 +528,7 @@ final class FluxCreate<T> extends Flux<T> {
 			SinkDisposable sd = new SinkDisposable(d, null);
 			if (!DISPOSABLE.compareAndSet(this, null, sd)) {
 				Disposable c = disposable;
-				if (c == Disposables.DISPOSED) {
+				if (c == OperatorDisposables.DISPOSED) {
 					d.dispose();
 				}
 				else if (c instanceof SinkDisposable) {
@@ -548,7 +548,7 @@ final class FluxCreate<T> extends Flux<T> {
 		@Nullable
 		public Object scanUnsafe(Attr key) {
 			if (key == Attr.TERMINATED || key == Attr.CANCELLED) {
-				return Disposables.isDisposed(disposable);
+				return OperatorDisposables.isDisposed(disposable);
 			}
 			if (key == Attr.REQUESTED_FROM_DOWNSTREAM) {
 				return requested;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGroupJoin.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGroupJoin.java
@@ -35,6 +35,7 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.util.context.Context;
@@ -190,7 +191,7 @@ final class FluxGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R>
 				Supplier<? extends
 						Queue<TRight>> processorQueueSupplier) {
 			this.actual = actual;
-			this.cancellations = Disposable.composite();
+			this.cancellations = Disposables.composite();
 			this.queue = queue;
 			this.processorQueueSupplier = processorQueueSupplier;
 			if (!(queue instanceof BiPredicate)) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxJoin.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxJoin.java
@@ -34,6 +34,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.core.publisher.FluxGroupJoin.JoinSupport;
@@ -154,7 +155,7 @@ final class FluxJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
 				BiFunction<? super TLeft, ? super TRight, ? extends R> resultSelector,
 				Queue<Object> queue) {
 			this.actual = actual;
-			this.cancellations = Disposable.composite();
+			this.cancellations = Disposables.composite();
 			this.queue = queue;
 			if (!(queue instanceof BiPredicate)) {
 				throw new IllegalArgumentException("The provided queue must implement " + "BiPredicate to expose atomic dual insert");

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
@@ -64,7 +64,7 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 		
 		for (;;) {
 			state = connection;
-			if (state == null || Disposables.isDisposed(state.disconnect)) {
+			if (state == null || OperatorDisposables.isDisposed(state.disconnect)) {
 				RefCountMonitor<T> u = new RefCountMonitor<>(n, this);
 				
 				if (!CONNECTION.compareAndSet(this, state, u)) {
@@ -129,14 +129,14 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 
 		void innerCancelled() {
 			if (SUBSCRIBERS.decrementAndGet(this) == 0) {
-				Disposables.dispose(DISCONNECT, this);
+				OperatorDisposables.dispose(DISCONNECT, this);
 			}
 		}
 		
 		void upstreamFinished() {
 			Disposable a = disconnect;
-			if (a != Disposables.DISPOSED) {
-				DISCONNECT.getAndSet(this, Disposables.DISPOSED);
+			if (a != OperatorDisposables.DISPOSED) {
+				DISCONNECT.getAndSet(this, OperatorDisposables.DISPOSED);
 			}
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
@@ -115,7 +116,7 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 				timeout(rc);
 				return;
 			}
-			sd = Disposable.swap();
+			sd = Disposables.swap();
 			rc.timer = sd;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
@@ -134,7 +134,7 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 	void timeout(RefConnection rc) {
 		synchronized (this) {
 			if (rc.subscriberCount == 0 && rc == connection) {
-				Disposables.dispose(RefConnection.SOURCE_DISCONNECTOR, rc);
+				OperatorDisposables.dispose(RefConnection.SOURCE_DISCONNECTOR, rc);
 				if (source instanceof Disposable) {
 					((Disposable) source).dispose();
 				}
@@ -167,7 +167,7 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 
 		@Override
 		public void accept(Disposable t) {
-			Disposables.replace(SOURCE_DISCONNECTOR, this, t);
+			OperatorDisposables.replace(SOURCE_DISCONNECTOR, this, t);
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOnCallable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOnCallable.java
@@ -132,16 +132,16 @@ final class FluxSubscribeOnCallable<T> extends Flux<T> implements Fuseable {
 			state = HAS_CANCELLED;
 			fusionState = COMPLETE;
 			Disposable a = mainFuture;
-			if (a != Disposables.DISPOSED) {
-				a = MAIN_FUTURE.getAndSet(this, Disposables.DISPOSED);
-				if (a != null && a != Disposables.DISPOSED) {
+			if (a != OperatorDisposables.DISPOSED) {
+				a = MAIN_FUTURE.getAndSet(this, OperatorDisposables.DISPOSED);
+				if (a != null && a != OperatorDisposables.DISPOSED) {
 					a.dispose();
 				}
 			}
 			a = requestFuture;
-			if (a != Disposables.DISPOSED) {
-				a = REQUEST_FUTURE.getAndSet(this, Disposables.DISPOSED);
-				if (a != null && a != Disposables.DISPOSED) {
+			if (a != OperatorDisposables.DISPOSED) {
+				a = REQUEST_FUTURE.getAndSet(this, OperatorDisposables.DISPOSED);
+				if (a != null && a != OperatorDisposables.DISPOSED) {
 					a.dispose();
 				}
 			}
@@ -185,7 +185,7 @@ final class FluxSubscribeOnCallable<T> extends Flux<T> implements Fuseable {
 		void setMainFuture(Disposable c) {
 			for (; ; ) {
 				Disposable a = mainFuture;
-				if (a == Disposables.DISPOSED) {
+				if (a == OperatorDisposables.DISPOSED) {
 					c.dispose();
 					return;
 				}
@@ -198,7 +198,7 @@ final class FluxSubscribeOnCallable<T> extends Flux<T> implements Fuseable {
 		void setRequestFuture(Disposable c) {
 			for (; ; ) {
 				Disposable a = requestFuture;
-				if (a == Disposables.DISPOSED) {
+				if (a == OperatorDisposables.DISPOSED) {
 					c.dispose();
 					return;
 				}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOnValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOnValue.java
@@ -57,7 +57,7 @@ final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable {
 				parent.setFuture(scheduler.schedule(parent));
 			}
 			catch (RejectedExecutionException ree) {
-				if (parent.future != Disposables.DISPOSED) {
+				if (parent.future != OperatorDisposables.DISPOSED) {
 					s.onError(Operators.onRejectedExecution(ree));
 				}
 			}
@@ -111,7 +111,7 @@ final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable {
 		@Nullable
 		public Object scanUnsafe(Scannable.Attr key) {
 			if (key == Attr.CANCELLED) {
-				return future == Disposables.DISPOSED;
+				return future == OperatorDisposables.DISPOSED;
 			}
 			if (key == Attr.TERMINATED) {
 				return future == FINISHED;
@@ -131,12 +131,12 @@ final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable {
 						Disposable f = scheduler.schedule(this);
 						if (!FUTURE.compareAndSet(this,
 								null,
-								f) && future != FINISHED && future != Disposables.DISPOSED) {
+								f) && future != FINISHED && future != OperatorDisposables.DISPOSED) {
 							f.dispose();
 						}
 					}
 					catch (RejectedExecutionException ree) {
-						if (future != FINISHED && future != Disposables.DISPOSED) {
+						if (future != FINISHED && future != OperatorDisposables.DISPOSED) {
 							actual.onError(Operators.onRejectedExecution(ree,
 									this,
 									null,
@@ -151,9 +151,9 @@ final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable {
 		public void cancel() {
 			ONCE.lazySet(this, 1);
 			Disposable f = future;
-			if (f != Disposables.DISPOSED && future != FINISHED) {
-				f = FUTURE.getAndSet(this, Disposables.DISPOSED);
-				if (f != null && f != Disposables.DISPOSED && f != FINISHED) {
+			if (f != OperatorDisposables.DISPOSED && future != FINISHED) {
+				f = FUTURE.getAndSet(this, OperatorDisposables.DISPOSED);
+				if (f != null && f != OperatorDisposables.DISPOSED && f != FINISHED) {
 					f.dispose();
 				}
 			}
@@ -232,9 +232,9 @@ final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable {
 		@Override
 		public void cancel() {
 			Disposable f = future;
-			if (f != Disposables.DISPOSED && f != FINISHED) {
-				f = FUTURE.getAndSet(this, Disposables.DISPOSED);
-				if (f != null && f != Disposables.DISPOSED && f != FINISHED) {
+			if (f != OperatorDisposables.DISPOSED && f != FINISHED) {
+				f = FUTURE.getAndSet(this, OperatorDisposables.DISPOSED);
+				if (f != null && f != OperatorDisposables.DISPOSED && f != FINISHED) {
 					f.dispose();
 				}
 			}
@@ -253,7 +253,7 @@ final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable {
 		void setFuture(Disposable f) {
 			if (!FUTURE.compareAndSet(this, null, f)) {
 				Disposable a = future;
-				if (a != FINISHED && a != Disposables.DISPOSED) {
+				if (a != FINISHED && a != OperatorDisposables.DISPOSED) {
 					f.dispose();
 				}
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOnValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOnValue.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import org.reactivestreams.Subscriber;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
@@ -88,7 +89,7 @@ final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable {
 						Disposable.class,
 						"future");
 
-		static final Disposable FINISHED = Disposable.disposed();
+		static final Disposable FINISHED = Disposables.disposed();
 
 		int fusionState;
 
@@ -218,7 +219,7 @@ final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable {
 						Disposable.class,
 						"future");
 
-		static final Disposable FINISHED = Disposable.disposed();
+		static final Disposable FINISHED = Disposables.disposed();
 
 		ScheduledEmpty(Subscriber<?> actual) {
 			this.actual = actual;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
@@ -104,7 +104,7 @@ final class MonoCreate<T> extends Mono<T> {
 				return state == HAS_REQUEST_HAS_VALUE || state == NO_REQUEST_HAS_VALUE;
 			}
 			if (key == Attr.CANCELLED) {
-				return Disposables.isDisposed(disposable);
+				return OperatorDisposables.isDisposed(disposable);
 			}
 
 			return InnerProducer.super.scanUnsafe(key);
@@ -261,9 +261,9 @@ final class MonoCreate<T> extends Mono<T> {
 
 		void disposeResource(boolean isCancel) {
 			Disposable d = disposable;
-			if (d != Disposables.DISPOSED) {
-				d = DISPOSABLE.getAndSet(this, Disposables.DISPOSED);
-				if (d != null && d != Disposables.DISPOSED) {
+			if (d != OperatorDisposables.DISPOSED) {
+				d = DISPOSABLE.getAndSet(this, OperatorDisposables.DISPOSED);
+				if (d != null && d != OperatorDisposables.DISPOSED) {
 					if (isCancel && d instanceof SinkDisposable) {
 						((SinkDisposable) d).cancel();
 					}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.Exceptions;
 import reactor.core.scheduler.Scheduler;
 
@@ -73,7 +74,7 @@ final class MonoDelay extends Mono<Long> {
 
 		volatile boolean requested;
 
-		static final Disposable FINISHED = Disposable.disposed();
+		static final Disposable FINISHED = Disposables.disposed();
 
 		MonoDelayRunnable(CoreSubscriber<? super Long> actual) {
 			this.actual = actual;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
@@ -56,7 +56,7 @@ final class MonoDelay extends Mono<Long> {
 			r.setCancel(timedScheduler.schedule(r, delay, unit));
 		}
 		catch (RejectedExecutionException ree) {
-			if(r.cancel != Disposables.DISPOSED) {
+			if(r.cancel != OperatorDisposables.DISPOSED) {
 				s.onError(Operators.onRejectedExecution(ree, r, null, null));
 			}
 		}
@@ -94,7 +94,7 @@ final class MonoDelay extends Mono<Long> {
 		@Nullable
 		public Object scanUnsafe(Attr key) {
 			if (key == Attr.TERMINATED) return cancel == FINISHED;
-			if (key == Attr.CANCELLED) return cancel == Disposables.DISPOSED;
+			if (key == Attr.CANCELLED) return cancel == OperatorDisposables.DISPOSED;
 
 			return InnerProducer.super.scanUnsafe(key);
 		}
@@ -103,7 +103,7 @@ final class MonoDelay extends Mono<Long> {
 		public void run() {
 			if (requested) {
 				try {
-					if (CANCEL.getAndSet(this, FINISHED) != Disposables.DISPOSED) {
+					if (CANCEL.getAndSet(this, FINISHED) != OperatorDisposables.DISPOSED) {
 						actual.onNext(0L);
 						actual.onComplete();
 					}
@@ -119,9 +119,9 @@ final class MonoDelay extends Mono<Long> {
 		@Override
 		public void cancel() {
 			Disposable c = cancel;
-			if (c != Disposables.DISPOSED && c != FINISHED) {
-				c =  CANCEL.getAndSet(this, Disposables.DISPOSED);
-				if (c != null && c != Disposables.DISPOSED && c != FINISHED) {
+			if (c != OperatorDisposables.DISPOSED && c != FINISHED) {
+				c =  CANCEL.getAndSet(this, OperatorDisposables.DISPOSED);
+				if (c != null && c != OperatorDisposables.DISPOSED && c != FINISHED) {
 					c.dispose();
 				}
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPublishOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPublishOn.java
@@ -82,7 +82,7 @@ final class MonoPublishOn<T> extends MonoOperator<T, T> {
 		@Override
 		@Nullable
 		public Object scanUnsafe(Attr key) {
-			if (key == Attr.CANCELLED) return future == Disposables.DISPOSED;
+			if (key == Attr.CANCELLED) return future == OperatorDisposables.DISPOSED;
 			if (key == Attr.PARENT) return s;
 			if (key == Attr.ERROR) return error;
 
@@ -148,9 +148,9 @@ final class MonoPublishOn<T> extends MonoOperator<T, T> {
 		@Override
 		public void cancel() {
 			Disposable c = future;
-			if (c != Disposables.DISPOSED) {
-				c = FUTURE.getAndSet(this, Disposables.DISPOSED);
-				if (c != null && !Disposables.isDisposed(c)) {
+			if (c != OperatorDisposables.DISPOSED) {
+				c = FUTURE.getAndSet(this, OperatorDisposables.DISPOSED);
+				if (c != null && !OperatorDisposables.isDisposed(c)) {
 					c.dispose();
 				}
 				value = null;
@@ -161,7 +161,7 @@ final class MonoPublishOn<T> extends MonoOperator<T, T> {
 		@Override
 		@SuppressWarnings("unchecked")
 		public void run() {
-			if (Disposables.isDisposed(future)) {
+			if (OperatorDisposables.isDisposed(future)) {
 				return;
 			}
 			T v = (T)VALUE.getAndSet(this, null);

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOnValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOnValue.java
@@ -21,7 +21,6 @@ import java.util.concurrent.RejectedExecutionException;
 import javax.annotation.Nullable;
 
 import reactor.core.CoreSubscriber;
-import reactor.core.Disposable;
 import reactor.core.publisher.FluxSubscribeOnValue.ScheduledEmpty;
 import reactor.core.publisher.FluxSubscribeOnValue.ScheduledScalar;
 import reactor.core.scheduler.Scheduler;
@@ -52,7 +51,7 @@ final class MonoSubscribeOnValue<T> extends Mono<T> {
 				parent.setFuture(scheduler.schedule(parent));
 			}
 			catch (RejectedExecutionException ree) {
-				if (parent.future != Disposables.DISPOSED) {
+				if (parent.future != OperatorDisposables.DISPOSED) {
 					s.onError(Operators.onRejectedExecution(ree));
 				}
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/OperatorDisposables.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/OperatorDisposables.java
@@ -29,7 +29,7 @@ import reactor.core.Disposable;
  * @author Simon Baslé
  * @author David Karnok
  */
-final class Disposables {
+final class OperatorDisposables {
 
 	/**
 	 * A singleton {@link Disposable} that represents a disposed instance. Should not be

--- a/reactor-core/src/main/java/reactor/core/publisher/OperatorDisposables.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/OperatorDisposables.java
@@ -22,6 +22,7 @@ import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 import reactor.core.Disposable;
+import reactor.core.Disposables;
 
 /**
  * Utility methods to work with {@link Disposable} atomically.
@@ -36,7 +37,7 @@ final class OperatorDisposables {
 	 * leaked to clients.
 	 */
 	//NOTE: There is a private similar DISPOSED singleton in DefaultDisposable as well
-	static final Disposable DISPOSED = Disposable.disposed();
+	static final Disposable DISPOSED = Disposables.disposed();
 
 	/**
 	 * Atomically push the field to a {@link Disposable} and dispose the old content.

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -30,6 +30,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
+import reactor.core.Disposables;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -38,6 +38,7 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.Scannable;
 import reactor.core.publisher.FluxConcatMap.ErrorMode;
 import reactor.core.scheduler.Scheduler;
@@ -976,7 +977,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 		}
 
 		onLastAssembly(this).subscribe(subscribers);
-		return Disposable.composite(subscribers);
+		return Disposables.composite(subscribers);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.Exceptions;
 
 import static reactor.core.scheduler.ExecutorServiceScheduler.CANCELLED;
@@ -273,7 +274,7 @@ final class ElasticScheduler implements Scheduler, Supplier<ScheduledExecutorSer
 		CachedWorker(ScheduledExecutorService executor, ElasticScheduler parent) {
 			this.executor = executor;
 			this.parent = parent;
-			this.tasks = Disposable.composite();
+			this.tasks = Disposables.composite();
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/ExecutorScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ExecutorScheduler.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.Exceptions;
 
 /**
@@ -194,7 +195,7 @@ final class ExecutorScheduler implements Scheduler {
 
 		ExecutorSchedulerWorker(Executor executor) {
 			this.executor = executor;
-			this.tasks = Disposable.composite();
+			this.tasks = Disposables.composite();
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/ExecutorServiceScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ExecutorServiceScheduler.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.Exceptions;
 
 /**
@@ -137,7 +138,7 @@ final class ExecutorServiceScheduler implements Scheduler {
 		ExecutorServiceWorker(ExecutorService executor, boolean interruptOnCancel) {
 			this.executor = executor;
 			this.interruptOnCancel = interruptOnCancel;
-			this.tasks = Disposable.composite();
+			this.tasks = Disposables.composite();
 		}
 
 		boolean isTimeCapable() {

--- a/reactor-core/src/main/java/reactor/core/scheduler/ImmediateScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ImmediateScheduler.java
@@ -16,6 +16,7 @@
 package reactor.core.scheduler;
 
 import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.Exceptions;
 
 /**
@@ -38,7 +39,7 @@ final class ImmediateScheduler implements Scheduler {
         
     }
     
-    static final Disposable FINISHED = Disposable.disposed();
+    static final Disposable FINISHED = Disposables.disposed();
     
     @Override
     public Disposable schedule(Runnable task) {

--- a/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Supplier;
 
 import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.Exceptions;
 
 /**
@@ -184,7 +185,7 @@ final class ParallelScheduler implements Scheduler, Supplier<ScheduledExecutorSe
         
         ParallelWorker(ScheduledExecutorService exec) {
             this.exec = exec;
-            this.tasks = Disposable.composite();
+            this.tasks = Disposables.composite();
         }
 
 	    @Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
@@ -16,7 +16,6 @@
 
 package reactor.core.scheduler;
 
-import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
@@ -29,6 +28,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Supplier;
 
 import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.Exceptions;
 
 /**
@@ -155,7 +155,7 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 
 		SingleWorker(ScheduledExecutorService exec) {
 			this.exec = exec;
-			this.tasks = Disposable.composite();
+			this.tasks = Disposables.composite();
 		}
 
 		@Override

--- a/reactor-core/src/test/java/reactor/core/CompositeDisposableTest.java
+++ b/reactor-core/src/test/java/reactor/core/CompositeDisposableTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
-import reactor.core.DefaultDisposable.CompositeDisposable;
+import reactor.core.Disposables.CompositeDisposable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.FakeDisposable;
 import reactor.test.RaceTestUtils;

--- a/reactor-core/src/test/java/reactor/core/DisposableTest.java
+++ b/reactor-core/src/test/java/reactor/core/DisposableTest.java
@@ -176,14 +176,14 @@ public class DisposableTest {
 
 	@Test
 	public void singleDisposableInitiallyNotDisposed() {
-		Disposable single = Disposable.single();
+		Disposable single = Disposables.single();
 
 		assertThat(single.isDisposed()).isFalse();
 	}
 
 	@Test
 	public void singleDisposableCanBeDisposed() {
-		Disposable single = Disposable.single();
+		Disposable single = Disposables.single();
 		assertThat(single.isDisposed()).isFalse();
 
 		single.dispose();
@@ -192,27 +192,27 @@ public class DisposableTest {
 
 	@Test
 	public void singleDisposableCreatesInstances() {
-		assertThat(Disposable.single()).isNotSameAs(Disposable.single());
+		assertThat(Disposables.single()).isNotSameAs(Disposables.single());
 	}
 
 	@Test
 	public void disposedInitiallyDisposed() {
-		assertThat(Disposable.disposed().isDisposed()).isTrue();
+		assertThat(Disposables.disposed().isDisposed()).isTrue();
 	}
 
 	@Test
 	public void disposedCreatesInstances() {
-		assertThat(Disposable.disposed()).isNotSameAs(Disposable.disposed());
+		assertThat(Disposables.disposed()).isNotSameAs(Disposables.disposed());
 	}
 
 	@Test
 	public void neverInitiallyNotDisposed() {
-		assertThat(Disposable.never().isDisposed()).isFalse();
+		assertThat(Disposables.never().isDisposed()).isFalse();
 	}
 
 	@Test
 	public void neverImmutable() {
-		Disposable never = Disposable.never();
+		Disposable never = Disposables.never();
 		assertThat(never.isDisposed()).isFalse();
 
 		never.dispose();
@@ -221,7 +221,7 @@ public class DisposableTest {
 
 	@Test
 	public void neverCreatesInstances() {
-		assertThat(Disposable.never()).isNotSameAs(Disposable.never());
+		assertThat(Disposables.never()).isNotSameAs(Disposables.never());
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/DisposablesTest.java
+++ b/reactor-core/src/test/java/reactor/core/DisposablesTest.java
@@ -26,7 +26,7 @@ import reactor.test.RaceTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DefaultDisposableTest {
+public class DisposablesTest {
 
 	//==== PUBLIC API TESTS ====
 
@@ -88,10 +88,10 @@ public class DefaultDisposableTest {
 
 	@Test
 	public void singletonIsDisposed() {
-		assertThat(DefaultDisposable.DISPOSED.isDisposed()).isTrue();
-		DefaultDisposable.DISPOSED.dispose();
-		assertThat(DefaultDisposable.DISPOSED.isDisposed()).isTrue();
-		assertThat(DefaultDisposable.DISPOSED).isNotSameAs(Disposable.disposed());
+		assertThat(Disposables.DISPOSED.isDisposed()).isTrue();
+		Disposables.DISPOSED.dispose();
+		assertThat(Disposables.DISPOSED.isDisposed()).isTrue();
+		assertThat(Disposables.DISPOSED).isNotSameAs(Disposable.disposed());
 	}
 
 	@Test
@@ -101,7 +101,7 @@ public class DefaultDisposableTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					DefaultDisposable.dispose(DISPOSABLE_UPDATER, this);
+					Disposables.dispose(DISPOSABLE_UPDATER, this);
 				}
 			};
 
@@ -116,7 +116,7 @@ public class DefaultDisposableTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					DefaultDisposable.replace(DISPOSABLE_UPDATER, this, Disposable.single());
+					Disposables.replace(DISPOSABLE_UPDATER, this, Disposable.single());
 				}
 			};
 
@@ -130,7 +130,7 @@ public class DefaultDisposableTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					DefaultDisposable.set(DISPOSABLE_UPDATER, this, Disposable.single());
+					Disposables.set(DISPOSABLE_UPDATER, this, Disposable.single());
 				}
 			};
 
@@ -142,10 +142,10 @@ public class DefaultDisposableTest {
 	public void setReplaceNull() {
 		TestDisposable r = new TestDisposable();
 
-		DefaultDisposable.dispose(DISPOSABLE_UPDATER, r);
+		Disposables.dispose(DISPOSABLE_UPDATER, r);
 
-		assertThat(DefaultDisposable.set(DISPOSABLE_UPDATER, r, null)).isFalse();
-		assertThat(DefaultDisposable.replace(DISPOSABLE_UPDATER, r, null)).isFalse();
+		assertThat(Disposables.set(DISPOSABLE_UPDATER, r, null)).isFalse();
+		assertThat(Disposables.replace(DISPOSABLE_UPDATER, r, null)).isFalse();
 	}
 
 	@Test
@@ -153,7 +153,7 @@ public class DefaultDisposableTest {
 		Disposable u = Disposable.single();
 		TestDisposable r = new TestDisposable(u);
 
-		DefaultDisposable.dispose(DISPOSABLE_UPDATER, r);
+		Disposables.dispose(DISPOSABLE_UPDATER, r);
 
 		assertThat(u.isDisposed()).isTrue();
 	}

--- a/reactor-core/src/test/java/reactor/core/DisposablesTest.java
+++ b/reactor-core/src/test/java/reactor/core/DisposablesTest.java
@@ -32,13 +32,13 @@ public class DisposablesTest {
 
 	@Test
 	public void sequentialEmpty() {
-		assertThat(Disposable.swap()
-		                     .get()).isNull();
+		assertThat(Disposables.swap()
+		                      .get()).isNull();
 	}
 
 	@Test
 	public void compositeEmpty() {
-		Disposable.Composite cd = Disposable.composite();
+		Disposable.Composite cd = Disposables.composite();
 		assertThat(cd.size()).isZero();
 		assertThat(cd.isDisposed()).isFalse();
 	}
@@ -48,7 +48,7 @@ public class DisposablesTest {
 		Disposable d1 = new FakeDisposable();
 		Disposable d2 = new FakeDisposable();
 
-		Disposable.Composite cd = Disposable.composite(d1, d2);
+		Disposable.Composite cd = Disposables.composite(d1, d2);
 		assertThat(cd.size()).isEqualTo(2);
 		assertThat(cd.isDisposed()).isFalse();
 	}
@@ -58,7 +58,7 @@ public class DisposablesTest {
 		Disposable d1 = new FakeDisposable();
 		Disposable d2 = new FakeDisposable();
 
-		Disposable.Composite cd = Disposable.composite(Arrays.asList(d1, d2));
+		Disposable.Composite cd = Disposables.composite(Arrays.asList(d1, d2));
 		assertThat(cd.size()).isEqualTo(2);
 		assertThat(cd.isDisposed()).isFalse();
 	}
@@ -91,7 +91,7 @@ public class DisposablesTest {
 		assertThat(Disposables.DISPOSED.isDisposed()).isTrue();
 		Disposables.DISPOSED.dispose();
 		assertThat(Disposables.DISPOSED.isDisposed()).isTrue();
-		assertThat(Disposables.DISPOSED).isNotSameAs(Disposable.disposed());
+		assertThat(Disposables.DISPOSED).isNotSameAs(Disposables.disposed());
 	}
 
 	@Test
@@ -116,7 +116,7 @@ public class DisposablesTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					Disposables.replace(DISPOSABLE_UPDATER, this, Disposable.single());
+					Disposables.replace(DISPOSABLE_UPDATER, this, Disposables.single());
 				}
 			};
 
@@ -130,7 +130,7 @@ public class DisposablesTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					Disposables.set(DISPOSABLE_UPDATER, this, Disposable.single());
+					Disposables.set(DISPOSABLE_UPDATER, this, Disposables.single());
 				}
 			};
 
@@ -150,7 +150,7 @@ public class DisposablesTest {
 
 	@Test
 	public void dispose() {
-		Disposable u = Disposable.single();
+		Disposable u = Disposables.single();
 		TestDisposable r = new TestDisposable(u);
 
 		Disposables.dispose(DISPOSABLE_UPDATER, r);

--- a/reactor-core/src/test/java/reactor/core/SwapDisposableTest.java
+++ b/reactor-core/src/test/java/reactor/core/SwapDisposableTest.java
@@ -35,11 +35,11 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class SwapDisposableTest {
 
-	private DefaultDisposable.SwapDisposable sequentialDisposable;
+	private Disposables.SwapDisposable sequentialDisposable;
 
 	@Before
 	public void setUp() {
-		sequentialDisposable = new DefaultDisposable.SwapDisposable();
+		sequentialDisposable = new Disposables.SwapDisposable();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnValueTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnValueTest.java
@@ -88,7 +88,7 @@ public class FluxSubscribeOnValueTest {
         assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
 
         assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
-        test.future = Disposables.DISPOSED;
+        test.future = OperatorDisposables.DISPOSED;
         assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
     }
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorDisposablesTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorDisposablesTest.java
@@ -25,7 +25,7 @@ import reactor.test.RaceTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DisposablesTest {
+public class OperatorDisposablesTest {
 
 	static final AtomicReferenceFieldUpdater<TestDisposable, Disposable> DISPOSABLE_UPDATER =
 			AtomicReferenceFieldUpdater.newUpdater(TestDisposable.class, Disposable.class, "disp");
@@ -49,10 +49,10 @@ public class DisposablesTest {
 	
 	@Test
 	public void singletonIsDisposed() {
-		assertThat(Disposables.DISPOSED.isDisposed()).isTrue();
-		Disposables.DISPOSED.dispose();
-		assertThat(Disposables.DISPOSED.isDisposed()).isTrue();
-		assertThat(Disposables.DISPOSED).isNotSameAs(Disposable.disposed());
+		assertThat(OperatorDisposables.DISPOSED.isDisposed()).isTrue();
+		OperatorDisposables.DISPOSED.dispose();
+		assertThat(OperatorDisposables.DISPOSED.isDisposed()).isTrue();
+		assertThat(OperatorDisposables.DISPOSED).isNotSameAs(Disposable.disposed());
 	}
 
 	@Test
@@ -60,7 +60,7 @@ public class DisposablesTest {
 		Hooks.onErrorDropped(e -> assertThat(e).isInstanceOf(NullPointerException.class)
 		                                       .hasMessage("next is null"));
 		try {
-			assertThat(Disposables.validate(null, null, Operators::onErrorDropped)).isFalse();
+			assertThat(OperatorDisposables.validate(null, null, Operators::onErrorDropped)).isFalse();
 		} finally {
 			Hooks.resetOnErrorDropped();
 		}
@@ -73,7 +73,7 @@ public class DisposablesTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					Disposables.dispose(DISPOSABLE_UPDATER, this);
+					OperatorDisposables.dispose(DISPOSABLE_UPDATER, this);
 				}
 			};
 
@@ -88,7 +88,7 @@ public class DisposablesTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					Disposables.replace(DISPOSABLE_UPDATER, this, Disposable.single());
+					OperatorDisposables.replace(DISPOSABLE_UPDATER, this, Disposable.single());
 				}
 			};
 
@@ -102,7 +102,7 @@ public class DisposablesTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					Disposables.set(DISPOSABLE_UPDATER, this, Disposable.single());
+					OperatorDisposables.set(DISPOSABLE_UPDATER, this, Disposable.single());
 				}
 			};
 
@@ -114,10 +114,10 @@ public class DisposablesTest {
 	public void setReplaceNull() {
 		TestDisposable r = new TestDisposable();
 
-		Disposables.dispose(DISPOSABLE_UPDATER, r);
+		OperatorDisposables.dispose(DISPOSABLE_UPDATER, r);
 
-		assertThat(Disposables.set(DISPOSABLE_UPDATER, r, null)).isFalse();
-		assertThat(Disposables.replace(DISPOSABLE_UPDATER, r, null)).isFalse();
+		assertThat(OperatorDisposables.set(DISPOSABLE_UPDATER, r, null)).isFalse();
+		assertThat(OperatorDisposables.replace(DISPOSABLE_UPDATER, r, null)).isFalse();
 	}
 
 	@Test
@@ -125,7 +125,7 @@ public class DisposablesTest {
 		Disposable u = Disposable.single();
 		TestDisposable r = new TestDisposable(u);
 
-		Disposables.dispose(DISPOSABLE_UPDATER, r);
+		OperatorDisposables.dispose(DISPOSABLE_UPDATER, r);
 
 		assertThat(u.isDisposed()).isTrue();
 	}
@@ -136,21 +136,21 @@ public class DisposablesTest {
 
 		Disposable d1 = Disposable.single();
 
-		assertThat(Disposables.trySet(DISPOSABLE_UPDATER, r, d1)).isTrue();
+		assertThat(OperatorDisposables.trySet(DISPOSABLE_UPDATER, r, d1)).isTrue();
 
 		Disposable d2 = Disposable.single();
 
-		assertThat(Disposables.trySet(DISPOSABLE_UPDATER, r, d2)).isFalse();
+		assertThat(OperatorDisposables.trySet(DISPOSABLE_UPDATER, r, d2)).isFalse();
 
 		assertThat(d1.isDisposed()).isFalse();
 
 		assertThat(d2.isDisposed()).isFalse();
 
-		Disposables.dispose(DISPOSABLE_UPDATER, r);
+		OperatorDisposables.dispose(DISPOSABLE_UPDATER, r);
 
 		Disposable d3 = Disposable.single();
 
-		assertThat(Disposables.trySet(DISPOSABLE_UPDATER, r, d3)).isFalse();
+		assertThat(OperatorDisposables.trySet(DISPOSABLE_UPDATER, r, d3)).isFalse();
 
 		assertThat(d3.isDisposed()).isTrue();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorDisposablesTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorDisposablesTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import org.junit.Test;
 import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.RaceTestUtils;
 
@@ -52,7 +53,7 @@ public class OperatorDisposablesTest {
 		assertThat(OperatorDisposables.DISPOSED.isDisposed()).isTrue();
 		OperatorDisposables.DISPOSED.dispose();
 		assertThat(OperatorDisposables.DISPOSED.isDisposed()).isTrue();
-		assertThat(OperatorDisposables.DISPOSED).isNotSameAs(Disposable.disposed());
+		assertThat(OperatorDisposables.DISPOSED).isNotSameAs(Disposables.disposed());
 	}
 
 	@Test
@@ -88,7 +89,7 @@ public class OperatorDisposablesTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					OperatorDisposables.replace(DISPOSABLE_UPDATER, this, Disposable.single());
+					OperatorDisposables.replace(DISPOSABLE_UPDATER, this, Disposables.single());
 				}
 			};
 
@@ -102,7 +103,7 @@ public class OperatorDisposablesTest {
 			TestDisposable r = new TestDisposable() {
 				@Override
 				public void run() {
-					OperatorDisposables.set(DISPOSABLE_UPDATER, this, Disposable.single());
+					OperatorDisposables.set(DISPOSABLE_UPDATER, this, Disposables.single());
 				}
 			};
 
@@ -122,7 +123,7 @@ public class OperatorDisposablesTest {
 
 	@Test
 	public void dispose() {
-		Disposable u = Disposable.single();
+		Disposable u = Disposables.single();
 		TestDisposable r = new TestDisposable(u);
 
 		OperatorDisposables.dispose(DISPOSABLE_UPDATER, r);
@@ -134,11 +135,11 @@ public class OperatorDisposablesTest {
 	public void trySet() {
 		TestDisposable r = new TestDisposable();
 
-		Disposable d1 = Disposable.single();
+		Disposable d1 = Disposables.single();
 
 		assertThat(OperatorDisposables.trySet(DISPOSABLE_UPDATER, r, d1)).isTrue();
 
-		Disposable d2 = Disposable.single();
+		Disposable d2 = Disposables.single();
 
 		assertThat(OperatorDisposables.trySet(DISPOSABLE_UPDATER, r, d2)).isFalse();
 
@@ -148,7 +149,7 @@ public class OperatorDisposablesTest {
 
 		OperatorDisposables.dispose(DISPOSABLE_UPDATER, r);
 
-		Disposable d3 = Disposable.single();
+		Disposable d3 = Disposables.single();
 
 		assertThat(OperatorDisposables.trySet(DISPOSABLE_UPDATER, r, d3)).isFalse();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
@@ -20,7 +20,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
 import org.junit.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -133,7 +132,7 @@ public class OperatorsTest {
 
 	@Test
 	public void noopFluxCancelled(){
-		Disposables.DISPOSED.dispose(); //noop
+		OperatorDisposables.DISPOSED.dispose(); //noop
 	}
 
 	@Test

--- a/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
+++ b/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
@@ -28,6 +28,7 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.Exceptions;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -466,8 +467,8 @@ public class VirtualTimeScheduler implements Scheduler {
 		}
 	}
 
-	static final Disposable CANCELLED = Disposable.disposed();
-	static final Disposable EMPTY = Disposable.never();
+	static final Disposable CANCELLED = Disposables.disposed();
+	static final Disposable EMPTY = Disposables.never();
 
 	static boolean replace(AtomicReference<Disposable> ref, @Nullable Disposable c) {
 		for (; ; ) {


### PR DESCRIPTION
See #812. This avoids a clash between Flux.never() and Disposable.never() for instance.