### PR TITLE
Few fixes to documentation pass by jay

### DIFF
--- a/src/docs/asciidoc/advancedFeatures.adoc
+++ b/src/docs/asciidoc/advancedFeatures.adoc
@@ -496,13 +496,10 @@ If, once you've processed your sequence in parallel, you want to revert back to 
 "normal" `Flux` and apply the rest of the operator chain in a sequential manner,
 you can use the `sequential()` method on `ParallelFlux`.
 
-Note that it is the case by default if you `subscribe` to the ParallelFlux with
-a single provided `Subscriber`, but not when using the lambda-based variants of
-`subscribe`.
-//The preceding paragraph is nearly meaningless, because "it" has no logical
-// antecedent. "it" needs to be replaced by a concrete object.
+Note that `sequential()` is implicitly applied if you `subscribe` to the ParallelFlux
+with a `Subscriber`, but not when using the lambda-based variants of `subscribe`.
 
-Note that `subscribe(Subscriber<T>)` merges all the rails, while
+Note also that `subscribe(Subscriber<T>)` merges all the rails, while
 `subscribe(Consumer<T>)` runs all the rails. If the `subscribe()` method has a
 lambda, each lambda is executed as many times as there are rails.
 

--- a/src/docs/asciidoc/coreFeatures.adoc
+++ b/src/docs/asciidoc/coreFeatures.adoc
@@ -51,8 +51,9 @@ As such it offers only a subset of the operators that are available for a
 `Flux`. For instance, combination operators can either ignore the right
 hand-side emissions and return another `Mono` or emit values from both sides,
 in which case they'll switch to a `Flux`.
-// This needs an example of each kind (ignoring the right and emiting from both
-//sides).
+
+For example, `Mono#concatWith(Publisher)` returns a `Flux` while `Mono#then(Mono)`
+returns another `Mono`.
 
 Note that a `Mono` can be used to represent no-value asynchronous processes that
 only have the concept of completion (think `Runnable`). To create one, use an
@@ -225,6 +226,7 @@ elastic scheduler named `yourScheduleName`.
 
 NOTE: Operators are implemented using non-blocking algorithms tuned to
 facilitate the work stealing that can happen in some Schedulers.
+//TODO: the paragraphs below and the `threading.adoc` file have overlap. The latter explains work-stealing a bit
 //Explain work stealing.
 
 `Flux` and `Mono` do not create threads. Some operators, such as `publishOn` do
@@ -675,8 +677,7 @@ up.
 
 In effect, this results in an *empty* flux, but it completes *successfully*.
 Since `retry(3)` on the same flux would have terminated with the latest error,
-this is not entirely the same.
-// Same as what?
+this `retryWhen` example is not exactly the same as a `retry(3)`.
 
 Getting to the same behavior involves a few additional tricks:
 include::snippetRetryWhenRetry.adoc[]

--- a/src/docs/asciidoc/debugging.adoc
+++ b/src/docs/asciidoc/debugging.adoc
@@ -14,7 +14,7 @@ improper parameters that ultimately caused the failure?
 But as soon as you shift to asynchronous code, things can get much more
 complicated...
 
-// The code that generated the following stack trace should be here
+//TODO The code that generated the following stack trace should be here
 
 Consider the following stack trace:
 
@@ -152,7 +152,7 @@ stack.
 <2> Apart from that, the first section of the stack trace is still the same for
 the most part, showing a bit of the operator's internals (so we removed a bit
 of the snippet here)
-// I'd put it back in. Wading through the whole thing is part of the task
+//TODO I'd put it back in. Wading through the whole thing is part of the task
 // you're describing. You might instead highlight the most relevant lines, to
 // teach people what to look for.
 <3> This is where the new stuff from debugging mode starts to appear.
@@ -340,7 +340,7 @@ This prints out (through the logger's console appender):
 10:45:20.205 [main] INFO  reactor.Flux.Range.1 - | cancel() <4>
 ----
 
-Here, in additional to the logger's own formatter (time, thread, level,
+Here, in addition to the logger's own formatter (time, thread, level,
 message), the `log()` operator outputs a few things in its own format:
 
 <1> `reactor.Flux.Range.1` is an automatic _category_ for the log, in case you

--- a/src/docs/asciidoc/faq.adoc
+++ b/src/docs/asciidoc/faq.adoc
@@ -108,7 +108,7 @@ retrying immediately is likely to produce yet another error and add to the
 instability.
 
 Here is how to implement an exponential backoff that delays retries and increase
-the delay between each attempt (psuedocode: delay = attempt number * 100 milliseconds):
+the delay between each attempt (pseudocode: delay = attempt number * 100 milliseconds):
 [source,java]
 ----
 Flux<String> flux =

--- a/src/docs/asciidoc/gettingStarted.adoc
+++ b/src/docs/asciidoc/gettingStarted.adoc
@@ -35,6 +35,8 @@ It only brings a transitive dependency to `org.reactive-streams:reactive-streams
 Reactor 3 uses a BOM (Bill of Materials - a standard Maven artifact)
 model since `reactor-core 3.0.4`, with the `Aluminium` release train.
 
+//TODO re-state that this is a curated list of versions as opposed to generated?
+
 The BOM lets you group artifacts that are meant to work well together without
 having to wonder about the sometimes divergent versioning schemes of these artifacts.
 

--- a/src/docs/asciidoc/operatorChoice.adoc
+++ b/src/docs/asciidoc/operatorChoice.adoc
@@ -85,7 +85,7 @@ I want to deal with:
 *** ...with different types (transforming merge): `Flux#zip` / `Flux#zipWith`
 ** by pairing values:
 *** from 2 Monos into a `Tuple2`: `Mono#and`
-*** from n Monos when they all completed: `Mono#when`
+*** from n Monos when they all completed: `Mono#zip`
 *** into an arbitrary container type:
 **** each time all sides have emitted: `Flux#zip` (up to the smallest cardinality)
 **** each time a new value arrives at either side: `Flux#combineLatest`

--- a/src/docs/asciidoc/producing.adoc
+++ b/src/docs/asciidoc/producing.adoc
@@ -14,8 +14,7 @@ method, which takes a generator function.
 This is for *synchronous* and *one-by-one* emissions, meaning that
 the sink is a `SynchronousSink` and that its `next()` method can only be called
 at most once per callback invocation. You can then additionally call `error(Throwable)`
-or `complete()`.
-// Is calling `error()` or `complete()` optional?
+or `complete()`, but this is optional.
 
 The most useful variant is probably the one that also lets you keep a state
 that you can refer to in your sink usage to decide what to emit next. The generator

--- a/src/docs/asciidoc/reactiveProgramming.adoc
+++ b/src/docs/asciidoc/reactiveProgramming.adoc
@@ -3,8 +3,6 @@
 Reactor is an implementation of the Reactive Programming paradigm, which can be
 summed up as:
 
-//TODO Find a better quotation. What is wrong with this one? What do we want in
-// a quotation here?
 [quote, https://en.wikipedia.org/wiki/Reactive_programming]
 Reactive programming is an asynchronous programming paradigm concerned with data
 streams and the propagation of change. This means that it becomes possible to
@@ -25,14 +23,15 @@ there is a duality to the `Iterable`-`Iterator` pair in all  these libraries.
 One major difference is that while an Iterator is *pull*-based, reactive
 streams are *push*-based.
 
-Using an iterator is essential, even though the method of accessing
-values is solely the responsibility of the `Iterable`. Indeed, it is up to the
+Using an iterator is an imperative programming pattern, even though the method of
+accessing values is solely the responsibility of the `Iterable`. Indeed, it is up to the
 developer to choose when to access the `next()` item in the sequence. In
 reactive streams, the equivalent of the above pair is `Publisher-Subscriber`.
 But it is the `Publisher` that notifies the Subscriber of newly available values
 _as they come_, and this push aspect is key to being reactive. Also, operations
-applied to pushed values are expressed declaratively rather than imperatively.
-// What does "declaratively rather than imperatively" mean? What's the difference?
+applied to pushed values are expressed declaratively rather than imperatively:
+the programmer expresses the expresses the logic of the computation rather than
+describing its exact control flow.
 
 In addition to pushing values, the error handling and completion aspects are
 also covered in a well defined manner. A `Publisher` can push new values to
@@ -154,7 +153,7 @@ userService.getFavorites(userId, new Callback<List<String>>() { //<1>
 when the async process was successful and one invoked in case of an error.
 <2> The first service invokes its callback with the list of favorite IDs.
 <3> If the list is empty, we must go to the `suggestionService`.
-<4> Te `suggestionService` gives a `List<Favorite>` to a second callback.
+<4> The `suggestionService` gives a `List<Favorite>` to a second callback.
 <5> Since we're dealing with UI we need to ensure our consuming code will run in
 the UI thread.
 <6> We use Java 8 `Stream` to limit the number of suggestions processed to 5, and
@@ -304,9 +303,9 @@ assertThat(results).containsExactly( // <8>
 <5> Asynchronously combining these 2 values.
 <6> Aggregate the values into a `List` as they become available.
 <7> In production, we'd continue working with the `Flux` asynchronously by further combining
-it or subscribing to it. Since we're in a test, we'll block waiting for the processing to finish
-instead, directly returning the aggregated list of values.
-// What would the code look like if it weren't blocking?
+it or subscribing to it. Most probably, we'd return the `result` `Mono`. Since we're in a
+test, we'll block waiting for the processing to finish instead, directly returning the
+aggregated list of values.
 <8> Assert the result.
 
 These perils of Callback and Future are similar and are what Reactive
@@ -420,9 +419,8 @@ made for each subscription
 late subscribers will receive signals emitted _after_ they subscribed. Note,
 however, that some hot reactive streams can cache or replay the history of
 emissions totally or partially. From a general perspective, a hot sequence
-will emit whether or not there any subscriber is listening.
-// Is that an exception to the rule of needing a subscriber before anything
-// happens?
+can even emit when no subscriber is listening (an exception to the "nothing
+happens before you subscribe" rule).
 
 For more information on hot vs cold in the context of Reactor, see
 <<reactor.hotCold,this reactor-specific section>>.

--- a/src/docs/asciidoc/subscribe-details.adoc
+++ b/src/docs/asciidoc/subscribe-details.adoc
@@ -77,9 +77,11 @@ ints.subscribe(i -> System.out.println(i),
 <1> Set up a Flux that produces four values when a subscriber attaches.
 <2> Subscribe with a Subscriber that includes a handler for completion events.
 
-Error signals and completion signals are both terminal events. To make the
-completion consumer work, we had to not intentionally create an error. The
-completion matcher is a pair of empty parentheses because it matches the `run`
+Error signals and completion signals are both terminal events, one excluding
+the other. To make the completion consumer work, we had to take care not to
+trigger and error.
+
+The completion matcher is a pair of empty parentheses because it matches the `run`
 method in the `Runnable` interface, which has no parameters. The preceding code
 produces the following output:
 
@@ -132,10 +134,14 @@ public class SampleSubscriber<T> extends BaseSubscriber<T> {
 }
 ----
 
-The SampleSubscriber class extends `BaseSubscriber`, which is the abstract
-class that underlies all `Subscribers` in Reactor. The bare minimum
-implementation is to create `hookOnSubscribe(Subscription subscription)` and
-`hookOnNext(T value)`. In this case, the `hookOnSubscribe` method prints a
+The SampleSubscriber class extends `BaseSubscriber`, which is the recommended
+abstract class for user-defined `Subscribers` in Reactor. The class offers
+hooks that can be overridden to tune the subscriber's behavior. By default,
+it will trigger an unbounded request and behave exactly like `subscribe()`.
+
+It is much more useful however when you want a custom request amount. To that
+effect, the bare minimum implementation is to implement both `hookOnSubscribe(Subscription subscription)`
+and `hookOnNext(T value)`. In this case, the `hookOnSubscribe` method prints a
 statement to standard out and makes the first request. Then the `hookOnNext`
 method prints and statement and processes each of the remaining requests, one
 request at a time.
@@ -151,8 +157,8 @@ Subscribed
 ----
 
 NOTE: You almost certainly want to implement the `hookOnError`, `hookOnCancel`,
-and `hookonComplete` methods. You may also want to implement the `hookFinally`
+and `hookOnComplete` methods. You may also want to implement the `hookFinally`
 method. `SampleSubscribe` is the absolute minimum implementation of a
-`Subscriber`.
+`Subscriber` that performs bounded requests.
 
 We'll see `BaseSubscriber` again soon.

--- a/src/docs/asciidoc/testing.adoc
+++ b/src/docs/asciidoc/testing.adoc
@@ -110,7 +110,7 @@ might use `thenAwait(Duration)`, `then(Runnable)`.
 For terminal events, the corresponding expectation methods (`expectComplete()`
 and `expectError()` and all its variants) will switch to an API where you cannot
 express expectations anymore. In that last step, all you can do is perform some
-additional configuration on the `StepVerifier` an then *trigger the
+additional configuration on the `StepVerifier` and then *trigger the
 verification*, eg. with `verify()`.
 
 What happens at this point is that the StepVerifier subscribes to the tested
@@ -162,7 +162,7 @@ in a lazy fashion. Otherwise, virtual time is not guaranteed. Especially avoid
 instantiating the flux earlier in the test code and having the `Supplier`
 return that variable. Instead, always instantiate the `Flux` inside the lambda.
 
-There are two of expectation methods that deal with time, and they are both
+There are two expectation methods that deal with time, and they are both
 valid with or without virtual time:
 
 - `thenAwait(Duration)` pauses the evaluation of steps (allowing a few signals


### PR DESCRIPTION
@buzzardo doing a review after the fact, found a few elements that needed a change and answered a few of your comments.

Said comments were effectively TODOs and can be marked as such for IDEs to better pick them up by using `//TODO ` as a comment prefix ;)