### PR TITLE
Further improvements to the Context API

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -6305,21 +6305,50 @@ public abstract class Flux<T> implements Publisher<T> {
 	public abstract void subscribe(CoreSubscriber<? super T> actual);
 
 	/**
+	 * Enrich a potentially empty downstream {@link Context} by adding all values
+	 * from the given {@link Context}, producing a new {@link Context} that is propagated
+	 * upstream.
+	 * <p>
+	 * Lifecycle for {@link Context} propagation is as such :
+	 * <ol>
+	 *     <li>
+	 *         During right-to-left {@code subscribe(Subscriber)} phase {@link #subscriberContext(Function)}
+	 *         will read the target {@link Subscriber} context and merge it with the given Context.
+	 *     </li>
+	 *     <li>
+	 *         {@link #subscriberContext(Context)} will then propagate the resulting
+	 *         {@link Context} upstream using {@code Flux#subscribe(Subscriber,Context)}.
+	 *     </li>
+	 * </ol>
+	 * <p>
+	 * Note this all happens once per-subscription, not on each onNext.
+	 *
+	 * @param mergeContext the {@link Context} to merge with a previous {@link Context}
+	 * state, returning a new one which is propagated if not empty and different from the
+	 * original.
+	 *
+	 * @return a contextualized {@link Flux}
+	 * @see Context
+	 */
+	public final Flux<T> subscriberContext(Context mergeContext) {
+		return subscriberContext(c -> c.putAll(mergeContext));
+	}
+
+	/**
 	 * Enrich a potentially empty downstream {@link Context}, producing a new
-	 * {@link Context}
-	 * that is propagated upstream. If the returned {@link Context} is empty, the
+	 * {@link Context} that is propagated upstream. If the returned {@link Context} is empty, the
 	 * propagation will be halted.
 	 * <p>
 	 * Lifecycle for {@link Context} propagation is as such :
 	 * <ol>
 	 *     <li>
-	 *         During right-to-left {@code subscribe(Subscriber)} phase, contextInit will
-	 *         read the target {@link Subscriber} context and call the given
-	 *         {@link Function}.
+	 *         During right-to-left {@code subscribe(Subscriber)} phase,
+	 *         {@link #subscriberContext(Function)} will read the target
+	 *         {@link Subscriber} context and apply the given {@link Function}.
 	 *     </li>
 	 *     <li>
-	 *         contextInit will then propagate the resulting {@link Context} upstream
-	 *         using {@code Flux#subscribe(Subscriber,Context)} is invoked.
+	 *         {@link #subscriberContext(Function)} will then propagate the resulting
+	 *         {@link Context} upstream using {@code Flux#subscribe(Subscriber,Context)}.
 	 *     </li>
 	 * </ol>
 	 * <p>

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -173,7 +173,8 @@ public abstract class Mono<T> implements Publisher<T> {
 
 	/**
 	 * Create a {@link Mono} emitting the {@link Context} available on subscribe.
-	 * If no {@link Context is available}, the mono will simply complete.
+	 * If no Context is available, the mono will simply emit the
+	 * {@link Context#empty() empty Context}.
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.0.M3/src/docs/marble/justorempty.png" alt="">

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -3217,21 +3217,50 @@ public abstract class Mono<T> implements Publisher<T> {
 	public abstract void subscribe(CoreSubscriber<? super T> actual);
 
 	/**
+	 * Enrich a potentially empty downstream {@link Context} by adding all values
+	 * from the given {@link Context}, producing a new {@link Context} that is propagated
+	 * upstream.
+	 * <p>
+	 * Lifecycle for {@link Context} propagation is as such :
+	 * <ol>
+	 *     <li>
+	 *         During right-to-left {@code subscribe(Subscriber)} phase {@link #subscriberContext(Function)}
+	 *         will read the target {@link Subscriber} context and merge it with the given Context.
+	 *     </li>
+	 *     <li>
+	 *         {@link #subscriberContext(Context)} will then propagate the resulting
+	 *         {@link Context} upstream using {@code Flux#subscribe(Subscriber,Context)}.
+	 *     </li>
+	 * </ol>
+	 * <p>
+	 * Note this all happens once per-subscription, not on each onNext.
+	 *
+	 * @param mergeContext the {@link Context} to merge with a previous {@link Context}
+	 * state, returning a new one which is propagated if not empty and different from the
+	 * original.
+	 *
+	 * @return a contextualized {@link Mono}
+	 * @see Context
+	 */
+	public final Mono<T> subscriberContext(Context mergeContext) {
+		return subscriberContext(c -> c.putAll(mergeContext));
+	}
+
+	/**
 	 * Enrich a potentially empty downstream {@link Context}, producing a new
-	 * {@link Context}
-	 * that is propagated upstream. If the returned {@link Context} is empty, the
+	 * {@link Context} that is propagated upstream. If the returned {@link Context} is empty, the
 	 * propagation will be halted.
 	 * <p>
 	 * Lifecycle for {@link Context} propagation is as such :
 	 * <ol>
 	 *     <li>
-	 *         During right-to-left {@code subscribe(Subscriber)} phase, contextInit will
-	 *         read the target {@link Subscriber} context and call the given
-	 *         {@link Function}.
+	 *         During right-to-left {@code subscribe(Subscriber)} phase,
+	 *         {@link #subscriberContext(Function)} will read the target
+	 *         {@link Subscriber} context and apply the given {@link Function}.
 	 *     </li>
 	 *     <li>
-	 *         contextInit will then propagate the resulting {@link Context} upstream
-	 *         using {@code Flux#subscribe(Subscriber,Context)} is invoked.
+	 *         {@link #subscriberContext(Function)} will then propagate the resulting
+	 *         {@link Context} upstream using {@code Flux#subscribe(Subscriber,Context)}.
 	 *     </li>
 	 * </ol>
 	 * <p>

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCurrentContext.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCurrentContext.java
@@ -30,11 +30,6 @@ final class MonoCurrentContext extends Mono<Context> implements Fuseable {
 	@SuppressWarnings("unchecked")
 	public void subscribe(CoreSubscriber<? super Context> s) {
 		Context ctx = s.currentContext();
-		if (ctx != Context.empty()) {
-			s.onSubscribe(Operators.scalarSubscription(s, ctx));
-		}
-		else {
-			Operators.complete(s);
-		}
+		s.onSubscribe(Operators.scalarSubscription(s, ctx));
 	}
 }

--- a/reactor-core/src/main/java/reactor/util/context/Context.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context.java
@@ -230,6 +230,18 @@ public interface Context {
 	Context put(Object key, Object value);
 
 	/**
+	 * Return a new {@link Context} that will resolve all existing keys except the
+	 * removed one, {@code key}.
+	 * <p>
+	 * Note that if this {@link Context} doesn't contain the key, this method simply
+	 * returns this same instance.
+	 *
+	 * @param key the key to remove.
+	 * @return a new {@link Context} that doesn't include the provided key
+	 */
+	Context delete(Object key);
+
+	/**
 	 * Stream key/value pairs from this {@link Context}
 	 *
 	 * @return a {@link Stream} of key/value pairs held by this context

--- a/reactor-core/src/main/java/reactor/util/context/Context0.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context0.java
@@ -32,6 +32,11 @@ final class Context0 implements Context {
 	}
 
 	@Override
+	public Context delete(Object key) {
+		return this;
+	}
+
+	@Override
 	public <T> T get(Object key) {
 		throw new NoSuchElementException("Context is empty");
 	}

--- a/reactor-core/src/main/java/reactor/util/context/Context1.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context1.java
@@ -43,6 +43,15 @@ final class Context1 implements Context, Map.Entry<Object, Object> {
 	}
 
 	@Override
+	public Context delete(Object key) {
+		Objects.requireNonNull(key, "key");
+		if (this.key.equals(key)) {
+			return Context.empty();
+		}
+		return this;
+	}
+
+	@Override
 	public boolean hasKey(Object key) {
 		return this.key.equals(key);
 	}

--- a/reactor-core/src/main/java/reactor/util/context/Context2.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context2.java
@@ -51,6 +51,24 @@ final class Context2 implements Context {
 		return new Context3(this.key1, this.value1, this.key2, this.value2, key, value);
 	}
 
+
+	@Override
+	public Context delete(Object key) {
+		Objects.requireNonNull(key, "key");
+
+		if(this.key1.equals(key)){
+			return new Context1(key2, value2);
+		}
+
+		if (this.key2.equals(key)) {
+			return new Context1(key1, value1);
+		}
+
+		return this;
+	}
+
+
+
 	@Override
 	public boolean hasKey(Object key) {
 		return this.key1.equals(key) || this.key2.equals(key);

--- a/reactor-core/src/main/java/reactor/util/context/Context3.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context3.java
@@ -62,6 +62,25 @@ final class Context3 implements Context {
 	}
 
 	@Override
+	public Context delete(Object key) {
+		Objects.requireNonNull(key, "key");
+
+		if(this.key1.equals(key)){
+			return new Context2(key2, value2, key3, value3);
+		}
+
+		if (this.key2.equals(key)) {
+			return new Context2(key1, value1, key3, value3);
+		}
+
+		if (this.key3.equals(key)) {
+			return new Context2(key1, value1, key2, value2);
+		}
+
+		return this;
+	}
+
+	@Override
 	public boolean hasKey(Object key) {
 		return this.key1.equals(key) || this.key2.equals(key) || this.key3.equals(key);
 	}

--- a/reactor-core/src/main/java/reactor/util/context/Context4.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context4.java
@@ -72,6 +72,29 @@ final class Context4 implements Context {
 	}
 
 	@Override
+	public Context delete(Object key) {
+		Objects.requireNonNull(key, "key");
+
+		if(this.key1.equals(key)){
+			return new Context3(key2, value2, key3, value3, key4, value4);
+		}
+
+		if (this.key2.equals(key)) {
+			return new Context3(key1, value1, key3, value3, key4, value4);
+		}
+
+		if (this.key3.equals(key)) {
+			return new Context3(key1, value1, key2, value2, key4, value4);
+		}
+
+		if (this.key4.equals(key)) {
+			return new Context3(key1, value1, key2, value2, key3, value3);
+		}
+
+		return this;
+	}
+
+	@Override
 	public boolean hasKey(Object key) {
 		return this.key1.equals(key) || this.key2.equals(key) || this.key3.equals(key) || this.key4.equals(key);
 	}

--- a/reactor-core/src/main/java/reactor/util/context/Context5.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context5.java
@@ -80,6 +80,33 @@ final class Context5 implements Context {
 	}
 
 	@Override
+	public Context delete(Object key) {
+		Objects.requireNonNull(key, "key");
+
+		if(this.key1.equals(key)){
+			return new Context4(key2, value2, key3, value3, key4, value4, key5, value5);
+		}
+
+		if (this.key2.equals(key)) {
+			return new Context4(key1, value1, key3, value3, key4, value4, key5, value5);
+		}
+
+		if (this.key3.equals(key)) {
+			return new Context4(key1, value1, key2, value2, key4, value4, key5, value5);
+		}
+
+		if (this.key4.equals(key)) {
+			return new Context4(key1, value1, key2, value2, key3, value3, key5, value5);
+		}
+
+		if (this.key5.equals(key)) {
+			return new Context4(key1, value1, key2, value2, key3, value3, key4, value4);
+		}
+
+		return this;
+	}
+
+	@Override
 	public boolean hasKey(Object key) {
 		return this.key1.equals(key) || this.key2.equals(key) || this.key3.equals(key)
 				|| this.key4.equals(key) || this.key5.equals(key);

--- a/reactor-core/src/test/java/reactor/core/publisher/ContextTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ContextTests.java
@@ -15,6 +15,7 @@
  */
 package reactor.core.publisher;
 
+import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
@@ -110,27 +111,24 @@ public class ContextTests {
 
 	@Test
 	public void currentContext() throws InterruptedException {
-
 		StepVerifier.create(Mono.just("foo")
 		                        .flatMap(d -> Mono.currentContext()
 		                                          .map(c -> d + c.get(Integer.class)))
 		                        .subscriberContext(ctx ->
 				                        ctx.put(Integer.class, ctx.get(Integer.class) + 1))
 		                        .flatMapMany(Mono::just)
-		                        .subscriberContext(ctx -> ctx.put(Integer.class, 0))
-		                        .log())
+		                        .subscriberContext(ctx -> ctx.put(Integer.class, 0)))
 		            .expectNext("foo1")
 		            .verifyComplete();
 	}
 
 	@Test
-	public void currentContextEmpty() throws InterruptedException {
-
+	public void currentContextWithEmpty() throws InterruptedException {
 		StepVerifier.create(Mono.just("foo")
 		                        .flatMap(d -> Mono.currentContext()
-		                                          .map(c -> d + c.get(Integer.class)))
-		                        .log())
-		            .verifyComplete();
+		                                          .map(c -> d + c.get(Integer.class))))
+		            .verifyErrorMatches(t -> t instanceof NoSuchElementException
+				            && "Context is empty".equals(t.getMessage()));
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/ContextTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ContextTests.java
@@ -179,4 +179,76 @@ public class ContextTests {
 		            .expectNext("barfoo1")
 		            .verifyComplete();
 	}
+
+	@Test
+	public void monoSubscriberContextPutsAll() {
+		StepVerifier.create(
+				Mono.just("foo")
+				    .flatMap(v -> Mono.currentContext())
+				    .subscriberContext(Context.of("foo", "bar", 1, "baz"))
+					.subscriberContext(Context.of("initial", "value"))
+		)
+		            .expectNextMatches(c -> c.hasKey("foo") && c.hasKey(1) && c.hasKey("initial"))
+		            .verifyComplete();
+	}
+
+	@Test
+	public void monoSubscriberContextWithMergedEmpty() {
+		StepVerifier.create(
+				Mono.just("foo")
+				    .flatMap(v -> Mono.currentContext())
+				    .subscriberContext(Context.empty())
+				    .subscriberContext(Context.of("initial", "value"))
+		)
+		            .expectNextMatches(c -> c.hasKey("initial"))
+		            .verifyComplete();
+	}
+
+	@Test
+	public void monoSubscriberContextWithBothEmpty() {
+		StepVerifier.create(
+				Mono.just("foo")
+				    .flatMap(v -> Mono.currentContext())
+				    .subscriberContext(Context.empty())
+				    .subscriberContext(Context.empty())
+		)
+		            .expectNextMatches(Context::isEmpty)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxSubscriberContextPutsAll() {
+		StepVerifier.create(
+				Flux.just("foo")
+				    .flatMap(v -> Mono.currentContext())
+				    .subscriberContext(Context.of("foo", "bar", 1, "baz"))
+					.subscriberContext(Context.of("initial", "value"))
+		)
+		            .expectNextMatches(c -> c.hasKey("foo") && c.hasKey(1) && c.hasKey("initial"))
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxSubscriberContextWithMergedEmpty() {
+		StepVerifier.create(
+				Flux.just("foo")
+				    .flatMap(v -> Mono.currentContext())
+				    .subscriberContext(Context.empty())
+				    .subscriberContext(Context.of("initial", "value"))
+		)
+		            .expectNextMatches(c -> c.hasKey("initial"))
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxSubscriberContextWithBothEmpty() {
+		StepVerifier.create(
+				Flux.just("foo")
+				    .flatMap(v -> Mono.currentContext())
+				    .subscriberContext(Context.empty())
+				    .subscriberContext(Context.empty())
+		)
+		            .expectNextMatches(Context::isEmpty)
+		            .verifyComplete();
+	}
 }

--- a/reactor-core/src/test/java/reactor/util/context/Context0Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context0Test.java
@@ -18,7 +18,6 @@ package reactor.util.context;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.stream.Collectors;
 
 import org.junit.Test;
 
@@ -49,6 +48,11 @@ public class Context0Test {
 	@Test
 	public void hasKey() throws Exception {
 		assertThat(c.hasKey(1)).as("hasKey(1)").isFalse();
+	}
+
+	@Test
+	public void removeKeys() {
+		assertThat(c.delete(1)).isSameAs(c);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/context/Context1Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context1Test.java
@@ -16,8 +16,6 @@
 
 package reactor.util.context;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -26,6 +24,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static reactor.util.context.ContextTest.key;
 
 public class Context1Test {
 
@@ -59,6 +58,17 @@ public class Context1Test {
 	public void hasKey() throws Exception {
 		assertThat(c.hasKey(1)).as("hasKey(1)").isTrue();
 		assertThat(c.hasKey(2)).as("hasKey(2)").isFalse();
+	}
+
+
+	@Test
+	public void removeKeys() {
+		assertThat(c.delete(1))
+				.as("delete(1)")
+				.isInstanceOf(Context0.class)
+				.doesNotHave(key(1));
+
+		assertThat(c.delete(2)).isSameAs(c);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/context/Context2Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context2Test.java
@@ -16,8 +16,6 @@
 
 package reactor.util.context;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -26,6 +24,8 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static reactor.util.context.ContextTest.key;
+import static reactor.util.context.ContextTest.keyValue;
 
 public class Context2Test {
 
@@ -73,6 +73,23 @@ public class Context2Test {
 		assertThat(c.hasKey(1)).as("hasKey(1)").isTrue();
 		assertThat(c.hasKey(2)).as("hasKey(2)").isTrue();
 		assertThat(c.hasKey(3)).as("hasKey(3)").isFalse();
+	}
+
+	@Test
+	public void removeKeys() {
+		assertThat(c.delete(1))
+				.as("delete(1)")
+				.isInstanceOf(Context1.class)
+				.has(keyValue(2, "B"))
+				.doesNotHave(key(1));
+
+		assertThat(c.delete(2))
+				.as("delete(2)")
+				.isInstanceOf(Context1.class)
+				.has(keyValue(1, "A"))
+				.doesNotHave(key(2));
+
+		assertThat(c.delete(3)).isSameAs(c);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/context/Context3Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context3Test.java
@@ -16,8 +16,6 @@
 
 package reactor.util.context;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -26,6 +24,8 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static reactor.util.context.ContextTest.key;
+import static reactor.util.context.ContextTest.keyValue;
 
 public class Context3Test {
 
@@ -87,6 +87,32 @@ public class Context3Test {
 		assertThat(c.hasKey(2)).as("hasKey(2)").isTrue();
 		assertThat(c.hasKey(3)).as("hasKey(3)").isTrue();
 		assertThat(c.hasKey(4)).as("hasKey(4)").isFalse();
+	}
+
+	@Test
+	public void removeKeys() {
+		assertThat(c.delete(1))
+				.as("delete(1)")
+				.isInstanceOf(Context2.class)
+				.has(keyValue(2, "B"))
+				.has(keyValue(3, "C"))
+				.doesNotHave(key(1));
+
+		assertThat(c.delete(2))
+				.as("delete(2)")
+				.isInstanceOf(Context2.class)
+				.has(keyValue(1, "A"))
+				.has(keyValue(3, "C"))
+				.doesNotHave(key(2));
+
+		assertThat(c.delete(3))
+				.as("delete(3)")
+				.isInstanceOf(Context2.class)
+				.has(keyValue(1, "A"))
+				.has(keyValue(2, "B"))
+				.doesNotHave(key(3));
+
+		assertThat(c.delete(4)).isSameAs(c);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/context/Context4Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context4Test.java
@@ -16,8 +16,6 @@
 
 package reactor.util.context;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -26,6 +24,8 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static reactor.util.context.ContextTest.key;
+import static reactor.util.context.ContextTest.keyValue;
 
 public class Context4Test {
 
@@ -101,6 +101,43 @@ public class Context4Test {
 		assertThat(c.hasKey(3)).as("hasKey(3)").isTrue();
 		assertThat(c.hasKey(4)).as("hasKey(4)").isTrue();
 		assertThat(c.hasKey(5)).as("hasKey(5)").isFalse();
+	}
+
+	@Test
+	public void removeKeys() {
+		assertThat(c.delete(1))
+				.as("delete(1)")
+				.isInstanceOf(Context3.class)
+				.has(keyValue(2, "B"))
+				.has(keyValue(3, "C"))
+				.has(keyValue(4, "D"))
+				.doesNotHave(key(1));
+
+		assertThat(c.delete(2))
+				.as("delete(2)")
+				.isInstanceOf(Context3.class)
+				.has(keyValue(1, "A"))
+				.has(keyValue(3, "C"))
+				.has(keyValue(4, "D"))
+				.doesNotHave(key(2));
+
+		assertThat(c.delete(3))
+				.as("delete(3)")
+				.isInstanceOf(Context3.class)
+				.has(keyValue(1, "A"))
+				.has(keyValue(2, "B"))
+				.has(keyValue(4, "D"))
+				.doesNotHave(key(3));
+
+		assertThat(c.delete(4))
+				.as("delete(4)")
+				.isInstanceOf(Context3.class)
+				.has(keyValue(1, "A"))
+				.has(keyValue(2, "B"))
+				.has(keyValue(3, "C"))
+				.doesNotHave(key(4));
+
+		assertThat(c.delete(5)).isSameAs(c);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/context/Context5Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context5Test.java
@@ -16,9 +16,7 @@
 
 package reactor.util.context;
 
-import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -27,6 +25,8 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static reactor.util.context.ContextTest.key;
+import static reactor.util.context.ContextTest.keyValue;
 
 public class Context5Test {
 
@@ -117,6 +117,56 @@ public class Context5Test {
 		assertThat(c.hasKey(4)).as("hasKey(4)").isTrue();
 		assertThat(c.hasKey(5)).as("hasKey(5)").isTrue();
 		assertThat(c.hasKey(6)).as("hasKey(6)").isFalse();
+	}
+
+	@Test
+	public void removeKeys() {
+		assertThat(c.delete(1))
+				.as("delete(1)")
+				.isInstanceOf(Context4.class)
+				.has(keyValue(2, "B"))
+				.has(keyValue(3, "C"))
+				.has(keyValue(4, "D"))
+				.has(keyValue(5, "E"))
+				.doesNotHave(key(1));
+
+		assertThat(c.delete(2))
+				.as("delete(2)")
+				.isInstanceOf(Context4.class)
+				.has(keyValue(1, "A"))
+				.has(keyValue(3, "C"))
+				.has(keyValue(4, "D"))
+				.has(keyValue(5, "E"))
+				.doesNotHave(key(2));
+
+		assertThat(c.delete(3))
+				.as("delete(3)")
+				.isInstanceOf(Context4.class)
+				.has(keyValue(1, "A"))
+				.has(keyValue(2, "B"))
+				.has(keyValue(4, "D"))
+				.has(keyValue(5, "E"))
+				.doesNotHave(key(3));
+
+		assertThat(c.delete(4))
+				.as("delete(4)")
+				.isInstanceOf(Context4.class)
+				.has(keyValue(1, "A"))
+				.has(keyValue(2, "B"))
+				.has(keyValue(3, "C"))
+				.has(keyValue(5, "E"))
+				.doesNotHave(key(4));
+
+		assertThat(c.delete(5))
+				.as("delete(5)")
+				.isInstanceOf(Context4.class)
+				.has(keyValue(1, "A"))
+				.has(keyValue(2, "B"))
+				.has(keyValue(3, "C"))
+				.has(keyValue(4, "D"))
+				.doesNotHave(key(5));
+
+		assertThat(c.delete(6)).isSameAs(c);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/context/ContextNTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextNTest.java
@@ -16,21 +16,26 @@
 
 package reactor.util.context;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static reactor.util.context.ContextTest.*;
 
 public class ContextNTest {
 
-	ContextN c = new ContextN(1, "A", 2, "B", 3, "C",
+	Context c;
+
+	@Before
+	public void initContext() {
+		c = new ContextN(1, "A", 2, "B", 3, "C",
 			4, "D", 5, "E", 6, "F");
+	}
 
 	@Test
 	public void replaceKey1NewContext() throws Exception {
@@ -133,13 +138,102 @@ public class ContextNTest {
 	}
 
 	@Test
+	public void removeKeys() {
+		assertThat(c.delete(1))
+				.as("delete(1)")
+				.isInstanceOf(Context5.class)
+				.has(keyValue(2, "B"))
+				.has(keyValue(3, "C"))
+				.has(keyValue(4, "D"))
+				.has(keyValue(5, "E"))
+				.has(keyValue(6, "F"))
+				.doesNotHave(key(1));
+
+		assertThat(c.delete(2))
+				.as("delete(2)")
+				.isInstanceOf(Context5.class)
+				.has(keyValue(1, "A"))
+				.has(keyValue(3, "C"))
+				.has(keyValue(4, "D"))
+				.has(keyValue(5, "E"))
+				.has(keyValue(6, "F"))
+				.doesNotHave(key(2));
+
+		assertThat(c.delete(3))
+				.as("delete(3)")
+				.isInstanceOf(Context5.class)
+				.has(keyValue(1, "A"))
+				.has(keyValue(2, "B"))
+				.has(keyValue(4, "D"))
+				.has(keyValue(5, "E"))
+				.has(keyValue(6, "F"))
+				.doesNotHave(key(3));
+
+		assertThat(c.delete(4))
+				.as("delete(4)")
+				.isInstanceOf(Context5.class)
+				.has(keyValue(1, "A"))
+				.has(keyValue(2, "B"))
+				.has(keyValue(3, "C"))
+				.has(keyValue(5, "E"))
+				.has(keyValue(6, "F"))
+				.doesNotHave(key(4));
+
+		assertThat(c.delete(5))
+				.as("delete(5)")
+				.isInstanceOf(Context5.class)
+				.has(keyValue(1, "A"))
+				.has(keyValue(2, "B"))
+				.has(keyValue(3, "C"))
+				.has(keyValue(4, "D"))
+				.has(keyValue(6, "F"))
+				.doesNotHave(key(5));
+
+		assertThat(c.delete(6))
+				.as("delete(6)")
+				.isInstanceOf(Context5.class)
+				.has(keyValue(1, "A"))
+				.has(keyValue(2, "B"))
+				.has(keyValue(3, "C"))
+				.has(keyValue(4, "D"))
+				.has(keyValue(5, "E"))
+				.doesNotHave(key(6));
+
+		assertThat(c.delete(7)).isSameAs(c);
+
+		assertThat(c).has(size(6)); //sanity check size unchanged for c
+	}
+
+	@Test
+	public void removeKeysOver6ReturnsSame() {
+		Context largerThan6 = c.put(100, 200);
+		assertThat(largerThan6)
+				.isNotSameAs(c)
+				.has(size(7));
+
+		Context test = largerThan6.delete(6);
+
+		assertThat(test)
+				.has(size(6))
+				.isNotSameAs(c)
+				.isNotSameAs(largerThan6)
+				.has(key(1))
+				.has(key(2))
+				.has(key(3))
+				.has(key(4))
+				.has(key(5))
+				.has(key(100))
+				.doesNotHave(key(6));
+	}
+
+	@Test
 	public void get() throws Exception {
-		assertThat(c.get(1)).isEqualTo("A");
-		assertThat(c.get(2)).isEqualTo("B");
-		assertThat(c.get(3)).isEqualTo("C");
-		assertThat(c.get(4)).isEqualTo("D");
-		assertThat(c.get(5)).isEqualTo("E");
-		assertThat(c.get(6)).isEqualTo("F");
+		assertThat((Object) c.get(1)).isEqualTo("A");
+		assertThat((Object) c.get(2)).isEqualTo("B");
+		assertThat((Object) c.get(3)).isEqualTo("C");
+		assertThat((Object) c.get(4)).isEqualTo("D");
+		assertThat((Object) c.get(5)).isEqualTo("E");
+		assertThat((Object) c.get(6)).isEqualTo("F");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/context/ContextTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextTest.java
@@ -16,11 +16,44 @@
 
 package reactor.util.context;
 
+import org.assertj.core.api.Condition;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ContextTest {
+
+	static Condition<Context> key(Object k) {
+		return new Condition<>(c -> c.hasKey(k), "key <%s>", k);
+	}
+
+	static Condition<Context> keyValue(Object k, Object value) {
+		return new Condition<>(c -> c.getOrEmpty(k)
+		                             .map(v -> v.equals(value))
+		                             .orElse(false),
+				"key <%s> with value <%s>", k, value);
+	}
+
+	private static final Condition<Context> SIZE_0 = new Condition<>(c -> c instanceof Context0, "size 0");
+	private static final Condition<Context> SIZE_1 = new Condition<>(c -> c instanceof Context1, "size 1");
+	private static final Condition<Context> SIZE_2 = new Condition<>(c -> c instanceof Context2, "size 2");
+	private static final Condition<Context> SIZE_3 = new Condition<>(c -> c instanceof Context3, "size 3");
+	private static final Condition<Context> SIZE_4 = new Condition<>(c -> c instanceof Context4, "size 4");
+	private static final Condition<Context> SIZE_5 = new Condition<>(c -> c instanceof Context5, "size 5");
+
+	static Condition<Context> size(int n) {
+		switch (n) {
+			case 0: return SIZE_0;
+			case 1: return SIZE_1;
+			case 2: return SIZE_2;
+			case 3: return SIZE_3;
+			case 4: return SIZE_4;
+			case 5: return SIZE_5;
+			default: return new Condition<>(c -> c instanceof ContextN
+					&& c.stream().count() == n,
+					"size %d", n);
+		}
+	}
 
 	@Test
 	public void empty() throws Exception {


### PR DESCRIPTION
See #816 #817 #818.

@smaldini there was more and more problems with `ContextN` extending `HashMap`, I made it delegate to a `Map` instead.
If you really think the overhead is too much, we'll need to change the `remove` to `removeKey` or something like that.