### PR TITLE
Add local error consumer hooks

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/BaseSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/BaseSubscriber.java
@@ -129,7 +129,7 @@ public abstract class BaseSubscriber<T> implements CoreSubscriber<T>, Subscripti
 	 * cancel). The hook is executed in addition to and after {@link #hookOnError(Throwable)},
 	 * {@link #hookOnComplete()} and {@link #hookOnCancel()} hooks, even if these callbacks
 	 * fail. Defaults to doing nothing. A failure of the callback will be caught by
-	 * {@link Operators#onErrorDropped(Throwable)}.
+	 * {@link Operators#onErrorDropped(Throwable, reactor.util.context.Context)}.
 	 *
 	 * @param type the type of termination event that triggered the hook
 	 * ({@link SignalType#ON_ERROR}, {@link SignalType#ON_COMPLETE} or
@@ -169,7 +169,7 @@ public abstract class BaseSubscriber<T> implements CoreSubscriber<T>, Subscripti
 		if (S.getAndSet(this, Operators.cancelledSubscription()) == Operators
 				.cancelledSubscription()) {
 			//already cancelled concurrently
-			Operators.onErrorDropped(t);
+			Operators.onErrorDropped(t, currentContext());
 			return;
 		}
 
@@ -181,7 +181,7 @@ public abstract class BaseSubscriber<T> implements CoreSubscriber<T>, Subscripti
 			if (e != t) {
 				e.addSuppressed(t);
 			}
-			Operators.onErrorDropped(e);
+			Operators.onErrorDropped(e, currentContext());
 		}
 		finally {
 			safeHookFinally(SignalType.ON_ERROR);
@@ -243,7 +243,7 @@ public abstract class BaseSubscriber<T> implements CoreSubscriber<T>, Subscripti
 			hookFinally(type);
 		}
 		catch (Throwable finallyFailure) {
-			Operators.onErrorDropped(finallyFailure);
+			Operators.onErrorDropped(finallyFailure, currentContext());
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/BaseSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/BaseSubscriber.java
@@ -146,7 +146,7 @@ public abstract class BaseSubscriber<T> implements CoreSubscriber<T>, Subscripti
 				hookOnSubscribe(s);
 			}
 			catch (Throwable throwable) {
-				onError(Operators.onOperatorError(s, throwable));
+				onError(Operators.onOperatorError(s, throwable, currentContext()));
 			}
 		}
 	}
@@ -158,7 +158,7 @@ public abstract class BaseSubscriber<T> implements CoreSubscriber<T>, Subscripti
 			hookOnNext(value);
 		}
 		catch (Throwable throwable) {
-			onError(Operators.onOperatorError(subscription, throwable, value));
+			onError(Operators.onOperatorError(subscription, throwable, value, currentContext()));
 		}
 	}
 
@@ -198,7 +198,7 @@ public abstract class BaseSubscriber<T> implements CoreSubscriber<T>, Subscripti
 			}
 			catch (Throwable throwable) {
 				//onError itself will short-circuit due to the CancelledSubscription being push above
-				hookOnError(Operators.onOperatorError(throwable));
+				hookOnError(Operators.onOperatorError(throwable, currentContext()));
 			}
 			finally {
 				safeHookFinally(SignalType.ON_COMPLETE);
@@ -230,7 +230,7 @@ public abstract class BaseSubscriber<T> implements CoreSubscriber<T>, Subscripti
 				hookOnCancel();
 			}
 			catch (Throwable throwable) {
-				hookOnError(Operators.onOperatorError(subscription, throwable));
+				hookOnError(Operators.onOperatorError(subscription, throwable, currentContext()));
 			}
 			finally {
 				safeHookFinally(SignalType.CANCEL);

--- a/reactor-core/src/main/java/reactor/core/publisher/BlockingIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/BlockingIterable.java
@@ -35,6 +35,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
+import reactor.util.context.Context;
 
 /**
  * An iterable that consumes a Publisher in a blocking fashion.
@@ -221,7 +222,7 @@ final class BlockingIterable<T> implements Iterable<T>, Scannable {
 
 				onError(Operators.onOperatorError(null,
 						Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL),
-						t));
+						t, currentContext()));
 			}
 			else {
 				signalConsumer();

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
@@ -98,7 +98,7 @@ public final class DirectProcessor<T> extends FluxProcessor<T, T> {
 		DirectInner<T>[] inners = subscribers;
 
 		if (inners == TERMINATED) {
-			Operators.onNextDropped(t);
+			Operators.onNextDropped(t, currentContext());
 			return;
 		}
 
@@ -114,7 +114,7 @@ public final class DirectProcessor<T> extends FluxProcessor<T, T> {
 		DirectInner<T>[] inners = subscribers;
 
 		if (inners == TERMINATED) {
-			Operators.onErrorDropped(t);
+			Operators.onErrorDropped(t, currentContext());
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -228,6 +228,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	@SuppressWarnings("unchecked")
 	public void onNext(T t) {
 		if (done) {
+			Operators.onNextDropped(t);
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -228,7 +228,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	@SuppressWarnings("unchecked")
 	public void onNext(T t) {
 		if (done) {
-			Operators.onNextDropped(t);
+			Operators.onNextDropped(t, currentContext());
 			return;
 		}
 
@@ -269,7 +269,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	public void onError(Throwable t) {
 		Objects.requireNonNull(t, "onError");
 		if (done) {
-			Operators.onErrorDropped(t);
+			Operators.onErrorDropped(t, currentContext());
 			return;
 		}
 		if (Exceptions.addThrowable(ERROR, this, t)) {
@@ -374,8 +374,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 					}
 					catch (Throwable ex) {
 						Exceptions.addThrowable(ERROR,
-								this,
-								Operators.onOperatorError(s, ex));
+								this, Operators.onOperatorError(s, ex, currentContext()));
 						d = true;
 						v = null;
 					}
@@ -399,8 +398,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 					}
 					catch (Throwable ex) {
 						Exceptions.addThrowable(ERROR,
-								this,
-								Operators.onOperatorError(s, ex));
+								this, Operators.onOperatorError(s, ex, currentContext()));
 						d = true;
 						v = null;
 					}

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -277,7 +277,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 			drain();
 		}
 		else {
-			Operators.onErrorDropped(t);
+			Operators.onErrorDroppedMulticast(t);
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/EventLoopProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EventLoopProcessor.java
@@ -31,7 +31,6 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.reactivestreams.Subscription;
-import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.util.concurrent.Queues;
 import reactor.util.concurrent.WaitStrategy;
@@ -427,7 +426,7 @@ abstract class EventLoopProcessor<IN> extends FluxProcessor<IN, IN>
 				}
 			}
 			catch (Throwable t) {
-				onError(Operators.onOperatorError(s, t));
+				onError(Operators.onOperatorError(s, t, currentContext()));
 			}
 		}
 	}
@@ -448,7 +447,7 @@ abstract class EventLoopProcessor<IN> extends FluxProcessor<IN, IN>
 			requestTaskExecutor.shutdown();
 		}
 		catch (Throwable t) {
-			onError(Operators.onOperatorError(t));
+			onError(Operators.onOperatorError(t, currentContext()));
 		}
 	}
 
@@ -527,7 +526,7 @@ abstract class EventLoopProcessor<IN> extends FluxProcessor<IN, IN>
 					}
 					return;
 				}
-				parent.onError(Operators.onOperatorError(t));
+				parent.onError(Operators.onOperatorError(t, parent.currentContext()));
 			}
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3535,7 +3535,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * receives any request.
 	 * <p>
 	 *     Note that non fatal error raised in the callback will not be propagated and
-	 *     will simply trigger {@link Operators#onOperatorError(Throwable)}.
+	 *     will simply trigger {@link Operators#onOperatorError(Throwable, Context)}.
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.0.M3/src/docs/marble/doonrequest.png" alt="">

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBuffer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBuffer.java
@@ -140,7 +140,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxOperator<
 							"The bufferSupplier returned a null buffer");
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					return;
 				}
 				buffer = b;
@@ -285,7 +285,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxOperator<
 							"The bufferSupplier returned a null buffer");
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					return;
 				}
 
@@ -464,7 +464,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxOperator<
 							"The bufferSupplier returned a null buffer");
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					return;
 				}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBuffer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBuffer.java
@@ -129,7 +129,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxOperator<
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -157,7 +157,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxOperator<
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -271,7 +271,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxOperator<
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -306,7 +306,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxOperator<
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -450,7 +450,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxOperator<
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -495,7 +495,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends FluxOperator<
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
@@ -167,7 +167,7 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 				}
 			}
 
-			Operators.onNextDropped(t);
+			Operators.onNextDropped(t, actual.currentContext());
 		}
 
 		@Override
@@ -181,7 +181,7 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 				actual.onError(t);
 				return;
 			}
-			Operators.onErrorDropped(t);
+			Operators.onErrorDropped(t, actual.currentContext());
 		}
 
 		@Override
@@ -242,7 +242,7 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 				actual.onError(t);
 				return;
 			}
-			Operators.onErrorDropped(t);
+			Operators.onErrorDropped(t, actual.currentContext());
 		}
 
 		void otherNext() {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
@@ -68,7 +68,7 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 					"The bufferSupplier returned a null buffer");
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 
@@ -253,7 +253,7 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 						"The bufferSupplier returned a null buffer");
 			}
 			catch (Throwable e) {
-				otherError(Operators.onOperatorError(other, e));
+				otherError(Operators.onOperatorError(other, e, actual.currentContext()));
 				return;
 			}
 
@@ -281,7 +281,7 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 			}
 			else {
 				actual.onError(Operators.onOperatorError(this, Exceptions
-						.failWithOverflow(), b));
+						.failWithOverflow(), b, actual.currentContext()));
 
 				return false;
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
@@ -84,7 +84,7 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 					"The bufferSupplier returned a null initial buffer");
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 
@@ -195,7 +195,7 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 				match = predicate.test(t);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return true;
 			}
 
@@ -237,7 +237,7 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 						"The bufferSupplier returned a null buffer");
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e));
+				onError(Operators.onOperatorError(s, e, actual.currentContext()));
 				return null;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
@@ -185,7 +185,7 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 
@@ -261,7 +261,7 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeOrSize.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeOrSize.java
@@ -199,7 +199,8 @@ final class FluxBufferTimeOrSize<T, C extends Collection<? super T>> extends Flu
 					timespanRegistration = timer.schedule(flushTask, timespan, TimeUnit.MILLISECONDS);
 				}
 				catch (RejectedExecutionException ree) {
-					onError(Operators.onRejectedExecution(ree, this, null, value));
+					onError(Operators.onRejectedExecution(ree, this, null, value,
+							actual.currentContext()));
 					return;
 				}
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferWhen.java
@@ -328,7 +328,7 @@ final class FluxBufferWhen<T, U, V, C extends Collection<? super T>>
 				"The bufferSupplier returned a null buffer");
 			}
 			catch (Throwable e) {
-				anyError(Operators.onOperatorError(starter, e, u));
+				anyError(Operators.onOperatorError(starter, e, u, actual.currentContext()));
 				return;
 			}
 
@@ -348,7 +348,7 @@ final class FluxBufferWhen<T, U, V, C extends Collection<? super T>>
 				"The end returned a null publisher");
 			}
 			catch (Throwable e) {
-				anyError(Operators.onOperatorError(starter, e, u));
+				anyError(Operators.onOperatorError(starter, e, u, actual.currentContext()));
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferWhen.java
@@ -185,7 +185,7 @@ final class FluxBufferWhen<T, U, V, C extends Collection<? super T>>
 				}
 			}
 
-			Operators.onNextDropped(t);
+			Operators.onNextDropped(t, actual.currentContext());
 		}
 
 		@Override
@@ -206,7 +206,7 @@ final class FluxBufferWhen<T, U, V, C extends Collection<? super T>>
 				anyError(t);
 			}
 			else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 			}
 		}
 
@@ -312,7 +312,7 @@ final class FluxBufferWhen<T, U, V, C extends Collection<? super T>>
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCallable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCallable.java
@@ -45,7 +45,7 @@ final class FluxCallable<T> extends Flux<T> implements Callable<T>, Fuseable {
 			v = Objects.requireNonNull(callable.call(), "callable returned null");
 		}
 		catch (Throwable ex) {
-			actual.onError(Operators.onOperatorError(ex));
+			actual.onError(Operators.onOperatorError(ex, actual.currentContext()));
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCancelOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCancelOn.java
@@ -110,7 +110,7 @@ final class FluxCancelOn<T> extends FluxOperator<T, T> {
 					scheduler.schedule(this);
 				}
 				catch (RejectedExecutionException ree) {
-					throw Operators.onRejectedExecution(ree);
+					throw Operators.onRejectedExecution(ree, actual.currentContext());
 				}
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCombineLatest.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCombineLatest.java
@@ -355,7 +355,7 @@ final class FluxCombineLatest<T, R> extends Flux<R> implements Fuseable {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCombineLatest.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCombineLatest.java
@@ -106,7 +106,8 @@ final class FluxCombineLatest<T, R> extends Flux<R> implements Fuseable {
 				it = Objects.requireNonNull(iterable.iterator(), "The iterator returned is null");
 			}
 			catch (Throwable e) {
-				Operators.error(actual, Operators.onOperatorError(e));
+				Operators.error(actual, Operators.onOperatorError(e,
+						actual.currentContext()));
 				return;
 			}
 
@@ -118,7 +119,8 @@ final class FluxCombineLatest<T, R> extends Flux<R> implements Fuseable {
 					b = it.hasNext();
 				}
 				catch (Throwable e) {
-					Operators.error(actual, Operators.onOperatorError(e));
+					Operators.error(actual, Operators.onOperatorError(e,
+							actual.currentContext()));
 					return;
 				}
 
@@ -133,7 +135,8 @@ final class FluxCombineLatest<T, R> extends Flux<R> implements Fuseable {
 							"The Publisher returned by the iterator is null");
 				}
 				catch (Throwable e) {
-					Operators.error(actual, Operators.onOperatorError(e));
+					Operators.error(actual, Operators.onOperatorError(e,
+							actual.currentContext()));
 					return;
 				}
 
@@ -307,7 +310,8 @@ final class FluxCombineLatest<T, R> extends Flux<R> implements Fuseable {
 							new SourceAndArray(subscribers[index], os.clone());
 
 					if (!queue.offer(sa)) {
-						innerError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL)));
+						innerError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL),
+								actual.currentContext()));
 						return;
 					}
 
@@ -432,7 +436,8 @@ final class FluxCombineLatest<T, R> extends Flux<R> implements Fuseable {
 						w = Objects.requireNonNull(combiner.apply(v.array), "Combiner returned null");
 					}
 					catch (Throwable ex) {
-						ex = Operators.onOperatorError(this,	ex,	v.array);
+						ex = Operators.onOperatorError(this,	ex,	v.array,
+								actual.currentContext());
 						Exceptions.addThrowable(ERROR, this, ex);
 						//noinspection ConstantConditions
 						ex = Exceptions.terminate(ERROR, this);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatArray.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatArray.java
@@ -247,7 +247,7 @@ final class FluxConcatArray<T> extends Flux<T> {
 			if (Exceptions.addThrowable(ERROR, this, t)) {
 				onComplete();
 			} else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatIterable.java
@@ -48,7 +48,7 @@ final class FluxConcatIterable<T> extends Flux<T> {
 					"The Iterator returned is null");
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 
@@ -102,7 +102,8 @@ final class FluxConcatIterable<T> extends Flux<T> {
 						b = a.hasNext();
 					}
 					catch (Throwable e) {
-						onError(Operators.onOperatorError(this, e));
+						onError(Operators.onOperatorError(this, e,
+								actual.currentContext()));
 						return;
 					}
 
@@ -122,7 +123,8 @@ final class FluxConcatIterable<T> extends Flux<T> {
 								"The Publisher returned by the iterator is null");
 					}
 					catch (Throwable e) {
-						actual.onError(Operators.onOperatorError(this, e));
+						actual.onError(Operators.onOperatorError(this, e,
+								actual.currentContext()));
 						return;
 					}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
@@ -254,7 +254,7 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 				}
 			}
 			else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 			}
 		}
 
@@ -297,7 +297,7 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 				}
 			}
 			else {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 
@@ -584,7 +584,7 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 			}
 		}
 
@@ -616,7 +616,7 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
@@ -234,7 +234,8 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 				drain();
 			}
 			else if (!queue.offer(t)) {
-				onError(Operators.onOperatorError(s, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t));
+				onError(Operators.onOperatorError(s, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t,
+						actual.currentContext()));
 			}
 			else {
 				drain();
@@ -337,7 +338,8 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 							v = queue.poll();
 						}
 						catch (Throwable e) {
-							actual.onError(Operators.onOperatorError(s, e));
+							actual.onError(Operators.onOperatorError(s, e,
+									actual.currentContext()));
 							return;
 						}
 
@@ -356,7 +358,8 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 								"The mapper returned a null Publisher");
 							}
 							catch (Throwable e) {
-								actual.onError(Operators.onOperatorError(s, e, v));
+								actual.onError(Operators.onOperatorError(s, e, v,
+										actual.currentContext()));
 								return;
 							}
 
@@ -381,7 +384,8 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 									vr = callable.call();
 								}
 								catch (Throwable e) {
-									actual.onError(Operators.onOperatorError(s, e, v));
+									actual.onError(Operators.onOperatorError(s, e, v,
+											actual.currentContext()));
 									return;
 								}
 
@@ -570,7 +574,8 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 				drain();
 			}
 			else if (!queue.offer(t)) {
-				onError(Operators.onOperatorError(s, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t));
+				onError(Operators.onOperatorError(s, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t,
+						actual.currentContext()));
 			}
 			else {
 				drain();
@@ -664,7 +669,8 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 							v = queue.poll();
 						}
 						catch (Throwable e) {
-							actual.onError(Operators.onOperatorError(s, e));
+							actual.onError(Operators.onOperatorError(s, e,
+									actual.currentContext()));
 							return;
 						}
 
@@ -689,7 +695,8 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 										"The mapper returned a null Publisher");
 							}
 							catch (Throwable e) {
-								actual.onError(Operators.onOperatorError(s, e, v));
+								actual.onError(Operators.onOperatorError(s, e, v,
+										actual.currentContext()));
 								return;
 							}
 
@@ -714,7 +721,8 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 									vr = supplier.call();
 								}
 								catch (Throwable e) {
-									actual.onError(Operators.onOperatorError(s, e, v));
+									actual.onError(Operators.onOperatorError(s, e, v,
+											actual.currentContext()));
 									return;
 								}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxContextStart.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxContextStart.java
@@ -42,7 +42,7 @@ final class FluxContextStart<T> extends FluxOperator<T, T> implements Fuseable {
 			c = doOnContext.apply(actual.currentContext());
 		}
 		catch (Throwable t) {
-			Operators.error(actual, Operators.onOperatorError(t));
+			Operators.error(actual, Operators.onOperatorError(t, actual.currentContext()));
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
@@ -95,7 +95,7 @@ final class FluxCreate<T> extends Flux<T> {
 		}
 		catch (Throwable ex) {
 			Exceptions.throwIfFatal(ex);
-			sink.error(Operators.onOperatorError(ex));
+			sink.error(Operators.onOperatorError(ex, actual.currentContext()));
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
@@ -137,6 +137,7 @@ final class FluxCreate<T> extends Flux<T> {
 		@Override
 		public FluxSink<T> next(T t) {
 			if (sink.isCancelled() || done) {
+				Operators.onNextDropped(t, sink.currentContext());
 				return this;
 			}
 			//noinspection ConstantConditions
@@ -165,7 +166,7 @@ final class FluxCreate<T> extends Flux<T> {
 		@Override
 		public void error(Throwable t) {
 			if (sink.isCancelled() || done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, sink.currentContext());
 				return;
 			}
 			//noinspection ConstantConditions
@@ -177,7 +178,7 @@ final class FluxCreate<T> extends Flux<T> {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, sink.currentContext());
 			}
 		}
 
@@ -418,6 +419,7 @@ final class FluxCreate<T> extends Flux<T> {
 		@Override
 		public void error(Throwable e) {
 			if (isCancelled()) {
+				Operators.onErrorDropped(e, actual.currentContext());
 				return;
 			}
 			try {
@@ -567,6 +569,7 @@ final class FluxCreate<T> extends Flux<T> {
 		@Override
 		public FluxSink<T> next(T t) {
 			if (isCancelled()) {
+				Operators.onNextDropped(t, actual.currentContext());
 				return this;
 			}
 
@@ -591,6 +594,7 @@ final class FluxCreate<T> extends Flux<T> {
 		@Override
 		public final FluxSink<T> next(T t) {
 			if (isCancelled()) {
+				Operators.onNextDropped(t, actual.currentContext());
 				return this;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDefer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDefer.java
@@ -47,7 +47,7 @@ final class FluxDefer<T> extends Flux<T> {
 					"The Publisher returned by the supplier is null");
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDelaySubscription.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDelaySubscription.java
@@ -125,7 +125,7 @@ final class FluxDelaySubscription<T, U> extends FluxOperator<T, T>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDematerialize.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDematerialize.java
@@ -94,7 +94,7 @@ final class FluxDematerialize<T> extends FluxOperator<Signal<T>, T> {
 		@Override
 		public void onNext(Signal<T> t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			if (t.isOnComplete()) {
@@ -119,7 +119,7 @@ final class FluxDematerialize<T> extends FluxOperator<Signal<T>, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDistinct.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDistinct.java
@@ -118,7 +118,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 
@@ -153,7 +153,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -230,7 +230,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -266,7 +266,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 
@@ -297,7 +297,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -391,7 +391,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 				return true;
 			}
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 
@@ -426,7 +426,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDistinct.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDistinct.java
@@ -64,7 +64,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 					"The collectionSupplier returned a null collection");
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 
@@ -129,7 +129,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 				"The distinct extractor returned a null value.");
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return true;
 			}
 
@@ -139,7 +139,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 				b = collection.add(k);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return true;
 			}
 
@@ -241,7 +241,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 				"The distinct extractor returned a null value.");
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 
@@ -251,7 +251,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 				b = collection.add(k);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 
@@ -277,7 +277,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 						"The distinct extractor returned a null value.");
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return true;
 			}
 
@@ -287,7 +287,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 				b = collection.add(k);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return true;
 			}
 
@@ -402,7 +402,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 						"The distinct extractor returned a null value.");
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(qs, e, t));
+				onError(Operators.onOperatorError(qs, e, t, actual.currentContext()));
 				return true;
 			}
 
@@ -412,7 +412,7 @@ final class FluxDistinct<T, K, C extends Collection<? super K>> extends
 				b = collection.add(k);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(qs, e, t));
+				onError(Operators.onOperatorError(qs, e, t, actual.currentContext()));
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDistinctFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDistinctFuseable.java
@@ -60,7 +60,7 @@ final class FluxDistinctFuseable<T, K, C extends Collection<? super K>>
 					"The collectionSupplier returned a null collection");
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
@@ -107,7 +107,7 @@ final class FluxDistinctUntilChanged<T, K> extends FluxOperator<T, T> {
 				"The distinct extractor returned a null value.");
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return true;
 			}
 
@@ -123,7 +123,7 @@ final class FluxDistinctUntilChanged<T, K> extends FluxOperator<T, T> {
 				equiv = keyComparator.test(lastKey, k);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return true;
 			}
 
@@ -233,7 +233,7 @@ final class FluxDistinctUntilChanged<T, K> extends FluxOperator<T, T> {
 				"The distinct extractor returned a null value.");
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return true;
 			}
 
@@ -248,7 +248,7 @@ final class FluxDistinctUntilChanged<T, K> extends FluxOperator<T, T> {
 				equiv = keyComparator.test(lastKey, k);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
@@ -96,7 +96,7 @@ final class FluxDistinctUntilChanged<T, K> extends FluxOperator<T, T> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 
@@ -139,7 +139,7 @@ final class FluxDistinctUntilChanged<T, K> extends FluxOperator<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -222,7 +222,7 @@ final class FluxDistinctUntilChanged<T, K> extends FluxOperator<T, T> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 
@@ -263,7 +263,7 @@ final class FluxDistinctUntilChanged<T, K> extends FluxOperator<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDoFinally.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDoFinally.java
@@ -35,7 +35,7 @@ import reactor.core.Fuseable.QueueSubscription;
  * {@link SignalType#CANCEL}).
  * <p>
  * Note that any exception thrown by the hook are caught and bubbled up
- * using {@link Operators#onErrorDropped(Throwable)}.
+ * using {@link Operators#onErrorDropped(Throwable, reactor.util.context.Context)}.
  *
  * @param <T> the value type
  * @author Simon Baslé
@@ -152,7 +152,7 @@ final class FluxDoFinally<T> extends FluxOperator<T, T> {
 					onFinally.accept(signalType);
 				} catch (Throwable ex) {
 					Exceptions.throwIfFatal(ex);
-					Operators.onErrorDropped(ex);
+					Operators.onErrorDropped(ex, actual.currentContext());
 				}
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDoFinallyFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDoFinallyFuseable.java
@@ -29,7 +29,7 @@ import reactor.core.Fuseable;
  * {@link SignalType#CANCEL}).
  * <p>
  * Note that any exception thrown by the hook are caught and bubbled up
- * using {@link Operators#onErrorDropped(Throwable)}.
+ * using {@link Operators#onErrorDropped(Throwable, reactor.util.context.Context)}.
  *
  * @param <T> the value type
  * @author Simon Baslé

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDoOnEach.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDoOnEach.java
@@ -17,7 +17,6 @@
 package reactor.core.publisher;
 
 import java.util.Objects;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
@@ -98,7 +97,7 @@ final class FluxDoOnEach<T> extends FluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			try {
@@ -117,7 +116,7 @@ final class FluxDoOnEach<T> extends FluxOperator<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDoOnEach.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDoOnEach.java
@@ -106,7 +106,7 @@ final class FluxDoOnEach<T> extends FluxOperator<T, T> {
 				onSignal.accept(this);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 
@@ -126,7 +126,7 @@ final class FluxDoOnEach<T> extends FluxOperator<T, T> {
 			}
 			catch (Throwable e) {
 				//this performs a throwIfFatal or suppresses t in e
-				t = Operators.onOperatorError(null, e, t);
+				t = Operators.onOperatorError(null, e, t, actual.currentContext());
 			}
 
 			try {
@@ -152,7 +152,7 @@ final class FluxDoOnEach<T> extends FluxOperator<T, T> {
 			}
 			catch (Throwable e) {
 				done = false;
-				onError(Operators.onOperatorError(s, e));
+				onError(Operators.onOperatorError(s, e, actual.currentContext()));
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxError.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxError.java
@@ -18,12 +18,8 @@ package reactor.core.publisher;
 
 import java.util.Objects;
 
-import org.reactivestreams.Subscriber;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
-import reactor.util.context.Context;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import javax.annotation.Nullable;
 
 import reactor.core.CoreSubscriber;
 
@@ -44,7 +40,7 @@ final class FluxError<T> extends Flux<T> implements Fuseable.ScalarCallable {
 
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
-		Operators.error(actual, Operators.onOperatorError(error));
+		Operators.error(actual, Operators.onOperatorError(error, actual.currentContext()));
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilter.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilter.java
@@ -80,7 +80,7 @@ final class FluxFilter<T> extends FluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -104,7 +104,7 @@ final class FluxFilter<T> extends FluxOperator<T, T> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return false;
 			}
 
@@ -126,7 +126,7 @@ final class FluxFilter<T> extends FluxOperator<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -196,7 +196,7 @@ final class FluxFilter<T> extends FluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -220,7 +220,7 @@ final class FluxFilter<T> extends FluxOperator<T, T> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return false;
 			}
 
@@ -239,7 +239,7 @@ final class FluxFilter<T> extends FluxOperator<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilter.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilter.java
@@ -90,7 +90,7 @@ final class FluxFilter<T> extends FluxOperator<T, T> {
 				b = predicate.test(t);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 			if (b) {
@@ -114,7 +114,7 @@ final class FluxFilter<T> extends FluxOperator<T, T> {
 				b = predicate.test(t);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return false;
 			}
 			if (b) {
@@ -206,7 +206,7 @@ final class FluxFilter<T> extends FluxOperator<T, T> {
 				b = predicate.test(t);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 			if (b) {
@@ -230,7 +230,7 @@ final class FluxFilter<T> extends FluxOperator<T, T> {
 				b = predicate.test(t);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return false;
 			}
 			return b && actual.tryOnNext(t);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
@@ -88,7 +88,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t);
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 				boolean b;
@@ -112,7 +112,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return false;
 			}
 
@@ -135,7 +135,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -269,7 +269,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t);
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 				boolean b;
@@ -293,7 +293,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return false;
 			}
 
@@ -312,7 +312,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
@@ -97,7 +97,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 					b = predicate.test(t);
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					return;
 				}
 				if (b) {
@@ -122,7 +122,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 				b = predicate.test(t);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return false;
 			}
 			if (b) {
@@ -278,7 +278,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 					b = predicate.test(t);
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					return;
 				}
 				if (b) {
@@ -303,7 +303,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 				b = predicate.test(t);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return false;
 			}
 			return b && actual.tryOnNext(t);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilterWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilterWhen.java
@@ -439,7 +439,7 @@ class FluxFilterWhen<T> extends FluxOperator<T, T> {
 				done = true;
 				parent.innerError(t);
 			} else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, parent.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFirstEmitting.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFirstEmitting.java
@@ -68,7 +68,8 @@ final class FluxFirstEmitting<T> extends Flux<T> {
 						"The iterator returned is null");
 			}
 			catch (Throwable e) {
-				Operators.error(actual, Operators.onOperatorError(e));
+				Operators.error(actual, Operators.onOperatorError(e,
+						actual.currentContext()));
 				return;
 			}
 
@@ -80,7 +81,8 @@ final class FluxFirstEmitting<T> extends Flux<T> {
 					b = it.hasNext();
 				}
 				catch (Throwable e) {
-					Operators.error(actual, Operators.onOperatorError(e));
+					Operators.error(actual, Operators.onOperatorError(e,
+							actual.currentContext()));
 					return;
 				}
 
@@ -95,7 +97,8 @@ final class FluxFirstEmitting<T> extends Flux<T> {
 							"The Publisher returned by the iterator is null");
 				}
 				catch (Throwable e) {
-					Operators.error(actual, Operators.onOperatorError(e));
+					Operators.error(actual, Operators.onOperatorError(e,
+							actual.currentContext()));
 					return;
 				}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -343,7 +343,7 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -391,7 +391,7 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			if (Exceptions.addThrowable(ERROR, this, t)) {
@@ -399,7 +399,7 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 			}
 		}
 
@@ -622,7 +622,8 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 									catch (Throwable ex) {
 										ex = Operators.onOperatorError(inner, ex);
 										if (!Exceptions.addThrowable(ERROR, this, ex)) {
-											Operators.onErrorDropped(ex);
+											Operators.onErrorDropped(ex,
+													actual.currentContext());
 										}
 										v = null;
 										d = true;
@@ -790,7 +791,7 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 
@@ -800,7 +801,7 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 					v);
 
 			if (!Exceptions.addThrowable(ERROR, this, e)) {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 				return false;
 			}
 			return true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -126,7 +126,7 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 				t = ((Callable<? extends T>) source).call();
 			}
 			catch (Throwable e) {
-				Operators.error(s, Operators.onOperatorError(e));
+				Operators.error(s, Operators.onOperatorError(e, s.currentContext()));
 				return true;
 			}
 
@@ -142,7 +142,7 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 						"The mapper returned a null Publisher");
 			}
 			catch (Throwable e) {
-				Operators.error(s, Operators.onOperatorError(null, e, t));
+				Operators.error(s, Operators.onOperatorError(null, e, t, s.currentContext()));
 				return true;
 			}
 
@@ -153,7 +153,7 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 					v = ((Callable<R>) p).call();
 				}
 				catch (Throwable e) {
-					Operators.error(s, Operators.onOperatorError(null, e, t));
+					Operators.error(s, Operators.onOperatorError(null, e, t, s.currentContext()));
 					return true;
 				}
 
@@ -354,7 +354,7 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 				"The mapper returned a null Publisher");
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 
@@ -364,7 +364,7 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 					v = ((Callable<R>) p).call();
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					return;
 				}
 				tryEmitScalar(v);
@@ -620,7 +620,8 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 										v = q.poll();
 									}
 									catch (Throwable ex) {
-										ex = Operators.onOperatorError(inner, ex);
+										ex = Operators.onOperatorError(inner, ex,
+												actual.currentContext());
 										if (!Exceptions.addThrowable(ERROR, this, ex)) {
 											Operators.onErrorDropped(ex,
 													actual.currentContext());
@@ -798,7 +799,7 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 		boolean failOverflow(R v, Subscription toCancel){
 			Throwable e = Operators.onOperatorError(toCancel,
 					Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL),
-					v);
+					v, actual.currentContext());
 
 			if (!Exceptions.addThrowable(ERROR, this, e)) {
 				Operators.onErrorDropped(e, actual.currentContext());

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
@@ -77,7 +77,8 @@ final class FluxFlattenIterable<T, R> extends FluxOperator<T, R> implements Fuse
 				v = ((Callable<T>) source).call();
 			}
 			catch (Throwable ex) {
-				Operators.error(actual, Operators.onOperatorError(ex));
+				Operators.error(actual, Operators.onOperatorError(ex,
+						actual.currentContext()));
 				return;
 			}
 
@@ -94,7 +95,8 @@ final class FluxFlattenIterable<T, R> extends FluxOperator<T, R> implements Fuse
 				it = iter.iterator();
 			}
 			catch (Throwable ex) {
-				Operators.error(actual, Operators.onOperatorError(ex));
+				Operators.error(actual, Operators.onOperatorError(ex,
+						actual.currentContext()));
 				return;
 			}
 
@@ -228,7 +230,8 @@ final class FluxFlattenIterable<T, R> extends FluxOperator<T, R> implements Fuse
 		public void onNext(T t) {
 			if (fusionMode != Fuseable.ASYNC) {
 				if (!queue.offer(t)) {
-					onError(Operators.onOperatorError(s,Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL)));
+					onError(Operators.onOperatorError(s,Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL),
+							actual.currentContext()));
 					return;
 				}
 			}
@@ -326,7 +329,8 @@ final class FluxFlattenIterable<T, R> extends FluxOperator<T, R> implements Fuse
 						}
 						catch (Throwable exc) {
 							it = null;
-							onError(Operators.onOperatorError(s, exc, t));
+							onError(Operators.onOperatorError(s, exc, t,
+									actual.currentContext()));
 							continue;
 						}
 
@@ -372,7 +376,8 @@ final class FluxFlattenIterable<T, R> extends FluxOperator<T, R> implements Fuse
 									"iterator returned null");
 						}
 						catch (Throwable exc) {
-							onError(Operators.onOperatorError(s, exc));
+							onError(Operators.onOperatorError(s, exc,
+									actual.currentContext()));
 							continue;
 						}
 
@@ -392,7 +397,8 @@ final class FluxFlattenIterable<T, R> extends FluxOperator<T, R> implements Fuse
 							b = it.hasNext();
 						}
 						catch (Throwable exc) {
-							onError(Operators.onOperatorError(s, exc));
+							onError(Operators.onOperatorError(s, exc,
+									actual.currentContext()));
 							continue;
 						}
 
@@ -500,7 +506,8 @@ final class FluxFlattenIterable<T, R> extends FluxOperator<T, R> implements Fuse
 						}
 						catch (Throwable exc) {
 							current = null;
-							a.onError(Operators.onOperatorError(s, exc, t));
+							a.onError(Operators.onOperatorError(s, exc, t,
+									actual.currentContext()));
 							return;
 						}
 
@@ -530,7 +537,8 @@ final class FluxFlattenIterable<T, R> extends FluxOperator<T, R> implements Fuse
 						}
 						catch (Throwable exc) {
 							current = null;
-							a.onError(Operators.onOperatorError(s, exc));
+							a.onError(Operators.onOperatorError(s, exc,
+									actual.currentContext()));
 							return;
 						}
 
@@ -551,7 +559,8 @@ final class FluxFlattenIterable<T, R> extends FluxOperator<T, R> implements Fuse
 						}
 						catch (Throwable exc) {
 							current = null;
-							a.onError(Operators.onOperatorError(s, exc));
+							a.onError(Operators.onOperatorError(s, exc,
+									actual.currentContext()));
 							return;
 						}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
@@ -242,7 +242,7 @@ final class FluxFlattenIterable<T, R> extends FluxOperator<T, R> implements Fuse
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGenerate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGenerate.java
@@ -77,7 +77,7 @@ extends Flux<T> implements Fuseable {
 		try {
 			state = stateSupplier.call();
 		} catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 		actual.onSubscribe(new GenerateSubscription<>(actual, state, generator, stateConsumer));
@@ -219,7 +219,7 @@ extends Flux<T> implements Fuseable {
 				} catch (Throwable e) {
 					cleanup(s);
 
-					actual.onError(Operators.onOperatorError(e));
+					actual.onError(Operators.onOperatorError(e, actual.currentContext()));
 					return;
 				}
 				if (terminate || cancelled) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGenerate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGenerate.java
@@ -145,7 +145,7 @@ extends Flux<T> implements Fuseable {
 		@Override
 		public void next(T t) {
 			if (terminate) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			if (hasValue) {
@@ -306,7 +306,7 @@ extends Flux<T> implements Fuseable {
 
 				stateConsumer.accept(s);
 			} catch (Throwable e) {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 		

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGroupBy.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGroupBy.java
@@ -174,7 +174,7 @@ final class FluxGroupBy<T, K, V> extends FluxOperator<T, GroupedFlux<K, V>>
 		@Override
 		public void onNext(T t) {
 			if(done){
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -218,7 +218,7 @@ final class FluxGroupBy<T, K, V> extends FluxOperator<T, GroupedFlux<K, V>>
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGroupBy.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGroupBy.java
@@ -186,7 +186,7 @@ final class FluxGroupBy<T, K, V> extends FluxOperator<T, GroupedFlux<K, V>>
 				value = Objects.requireNonNull(valueSelector.apply(t), "The valueSelector returned a null value");
 			}
 			catch (Throwable ex) {
-				onError(Operators.onOperatorError(s, ex, t));
+				onError(Operators.onOperatorError(s, ex, t, actual.currentContext()));
 				return;
 			}
 
@@ -663,7 +663,8 @@ final class FluxGroupBy<T, K, V> extends FluxOperator<T, GroupedFlux<K, V>>
 			Subscriber<? super V> a = actual;
 
 			if (!queue.offer(t)) {
-				onError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t));
+				onError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t,
+						actual.currentContext()));
 				return;
 			}
 			if (outputFused) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGroupJoin.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGroupJoin.java
@@ -466,7 +466,7 @@ final class FluxGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R>
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(ex);
+				Operators.onErrorDropped(ex, actual.currentContext());
 			}
 		}
 
@@ -499,7 +499,7 @@ final class FluxGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R>
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(ex);
+				Operators.onErrorDropped(ex, actual.currentContext());
 			}
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGroupJoin.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGroupJoin.java
@@ -328,7 +328,8 @@ final class FluxGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R>
 						catch (Throwable exc) {
 							Exceptions.addThrowable(ERROR,
 									this,
-									Operators.onOperatorError(this, exc, left));
+									Operators.onOperatorError(this, exc, left,
+											actual.currentContext()));
 							errorAll(a);
 							return;
 						}
@@ -355,7 +356,8 @@ final class FluxGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R>
 						}
 						catch (Throwable exc) {
 							Exceptions.addThrowable(ERROR,
-									this, Operators.onOperatorError(this, exc, up));
+									this, Operators.onOperatorError(this, exc, up,
+											actual.currentContext()));
 							errorAll(a);
 							return;
 						}
@@ -374,7 +376,8 @@ final class FluxGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R>
 									Exceptions.addThrowable(ERROR,
 											this,
 											Operators.onOperatorError(this,
-													Exceptions.failWithOverflow()));
+													Exceptions.failWithOverflow(),
+													actual.currentContext()));
 									errorAll(a);
 									return;
 								}
@@ -412,7 +415,8 @@ final class FluxGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R>
 						catch (Throwable exc) {
 							Exceptions.addThrowable(ERROR,
 									this,
-									Operators.onOperatorError(this, exc, right));
+									Operators.onOperatorError(this, exc, right,
+											actual.currentContext()));
 							errorAll(a);
 							return;
 						}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
@@ -89,7 +89,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -121,7 +121,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return false;
 			}
 
@@ -153,7 +153,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -251,7 +251,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -283,7 +283,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return false;
 			}
 
@@ -316,7 +316,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
@@ -97,7 +97,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 				handler.accept(t, this);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 			R v = data;
@@ -108,7 +108,8 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 			if(stop){
 				s.cancel();
 				if(error != null){
-					onError(Operators.onOperatorError(null, error, t));
+					onError(Operators.onOperatorError(null, error, t,
+							actual.currentContext()));
 					return;
 				}
 				onComplete();
@@ -129,7 +130,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 				handler.accept(t, this);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return false;
 			}
 			R v = data;
@@ -140,7 +141,8 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 			if(stop){
 				s.cancel();
 				if(error != null){
-					onError(Operators.onOperatorError(null, error, t));
+					onError(Operators.onOperatorError(null, error, t,
+							actual.currentContext()));
 				}
 				else {
 					onComplete();
@@ -259,7 +261,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 				handler.accept(t, this);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 			R v = data;
@@ -270,7 +272,8 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 			if(done){
 				s.cancel();
 				if(error != null){
-					actual.onError(Operators.onOperatorError(null, error, t));
+					actual.onError(Operators.onOperatorError(null, error, t,
+							actual.currentContext()));
 					return;
 				}
 				actual.onComplete();
@@ -291,7 +294,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 				handler.accept(t, this);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return false;
 			}
 			R v = data;
@@ -303,7 +306,8 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 			if(done){
 				s.cancel();
 				if(error != null){
-					actual.onError(Operators.onOperatorError(null, error, t));
+					actual.onError(Operators.onOperatorError(null, error, t,
+							actual.currentContext()));
 				}
 				else {
 					actual.onComplete();

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
@@ -104,7 +104,7 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 				handler.accept(t, this);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return false;
 			}
 			R v = data;
@@ -114,7 +114,8 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 			}
 			if (done) {
 				if (error != null) {
-					actual.onError(Operators.onOperatorError(s, error, t));
+					actual.onError(Operators.onOperatorError(s, error, t,
+							actual.currentContext()));
 				}
 				else {
 					s.cancel();
@@ -148,7 +149,7 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 					handler.accept(t, this);
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					return;
 				}
 				R v = data;
@@ -159,7 +160,8 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 				if (done) {
 					s.cancel();
 					if (error != null) {
-						actual.onError(Operators.onOperatorError(null, error, t));
+						actual.onError(Operators.onOperatorError(null, error, t,
+								actual.currentContext()));
 						return;
 					}
 					actual.onComplete();
@@ -236,7 +238,7 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 							s.cancel();
 							if (error != null) {
 								throw Exceptions.propagate(Operators.onOperatorError
-										(null, error, v));
+										(null, error, v, actual.currentContext()));
 							}
 							else {
 								actual.onComplete();
@@ -267,7 +269,7 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 						if (done) {
 							if (error != null) {
 								throw Exceptions.propagate(Operators.onOperatorError
-										(null, error, v));
+										(null, error, v, actual.currentContext()));
 							}
 							return u;
 						}
@@ -380,7 +382,7 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 					handler.accept(t, this);
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					return;
 				}
 				R v = data;
@@ -391,7 +393,8 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 				if (done) {
 					s.cancel();
 					if (error != null) {
-						actual.onError(Operators.onOperatorError(null, error, v));
+						actual.onError(Operators.onOperatorError(null, error, v,
+								actual.currentContext()));
 						return;
 					}
 					actual.onComplete();
@@ -413,7 +416,7 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 				handler.accept(t, this);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return false;
 			}
 			R v = data;
@@ -425,7 +428,8 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 			if (done) {
 				s.cancel();
 				if (error != null) {
-					actual.onError(Operators.onOperatorError(null, error, v));
+					actual.onError(Operators.onOperatorError(null, error, v,
+							actual.currentContext()));
 				}
 				else {
 					actual.onComplete();
@@ -520,7 +524,7 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 							s.cancel();
 							if (error != null) {
 								throw Exceptions.propagate(Operators.onOperatorError
-										(null, error, v));
+										(null, error, v, actual.currentContext()));
 							}
 							else {
 								actual.onComplete();
@@ -551,7 +555,7 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 						if (done) {
 							if (error != null) {
 								throw Exceptions.propagate(Operators.onOperatorError
-										(null, error, v));
+										(null, error, v, actual.currentContext()));
 							}
 							return u;
 						}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
@@ -96,7 +96,7 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 
@@ -141,7 +141,7 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t);
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 				try {
@@ -173,7 +173,7 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -373,7 +373,7 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 			}
 			else  {
 				if (done) {
-					Operators.onNextDropped(t);
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 				try {
@@ -405,7 +405,7 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 
@@ -438,7 +438,7 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxInterval.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxInterval.java
@@ -69,7 +69,8 @@ final class FluxInterval extends Flux<Long> {
 		}
 		catch (RejectedExecutionException ree) {
 			if (!r.cancelled) {
-				actual.onError(Operators.onRejectedExecution(ree, r, null, null));
+				actual.onError(Operators.onRejectedExecution(ree, r, null, null,
+						actual.currentContext()));
 			}
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxIterable.java
@@ -48,7 +48,7 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable {
 			it = iterable.iterator();
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 
@@ -75,7 +75,7 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable {
 			b = it.hasNext();
 		}
 		catch (Throwable e) {
-			Operators.error(s, Operators.onOperatorError(e));
+			Operators.error(s, Operators.onOperatorError(e, s.currentContext()));
 			return;
 		}
 		if (!b) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxJoin.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxJoin.java
@@ -279,7 +279,8 @@ final class FluxJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
 						catch (Throwable exc) {
 							Exceptions.addThrowable(ERROR,
 									this,
-									Operators.onOperatorError(this, exc, left));
+									Operators.onOperatorError(this, exc, left,
+											actual.currentContext()));
 							errorAll(a);
 							return;
 						}
@@ -314,7 +315,7 @@ final class FluxJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
 								Exceptions.addThrowable(ERROR,
 										this,
 										Operators.onOperatorError(this,
-												exc, right));
+												exc, right, actual.currentContext()));
 								errorAll(a);
 								return;
 							}
@@ -346,7 +347,8 @@ final class FluxJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
 									Exceptions.addThrowable(ERROR,
 											this,
 											Operators.onOperatorError(this,
-													Exceptions.failWithOverflow()));
+													Exceptions.failWithOverflow(),
+													actual.currentContext()));
 									errorAll(a);
 									return;
 								}
@@ -373,7 +375,8 @@ final class FluxJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
 						catch (Throwable exc) {
 							Exceptions.addThrowable(ERROR,
 									this,
-									Operators.onOperatorError(this, exc, right));
+									Operators.onOperatorError(this, exc, right,
+											actual.currentContext()));
 							errorAll(a);
 							return;
 						}
@@ -407,7 +410,8 @@ final class FluxJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
 							catch (Throwable exc) {
 								Exceptions.addThrowable(ERROR,
 										this,
-										Operators.onOperatorError(this, exc, left));
+										Operators.onOperatorError(this, exc, left,
+												actual.currentContext()));
 								errorAll(a);
 								return;
 							}
@@ -439,7 +443,8 @@ final class FluxJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
 									Exceptions.addThrowable(ERROR,
 											this,
 											Operators.onOperatorError(this,
-													Exceptions.failWithOverflow()));
+													Exceptions.failWithOverflow(),
+													actual.currentContext()));
 									errorAll(a);
 									return;
 								}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxJoin.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxJoin.java
@@ -478,7 +478,7 @@ final class FluxJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(ex);
+				Operators.onErrorDropped(ex, actual.currentContext());
 			}
 		}
 
@@ -511,7 +511,7 @@ final class FluxJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(ex);
+				Operators.onErrorDropped(ex, actual.currentContext());
 			}
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMap.java
@@ -101,7 +101,7 @@ final class FluxMap<T, R> extends FluxOperator<T, R> {
 						"The mapper returned a null value.");
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 
@@ -194,7 +194,7 @@ final class FluxMap<T, R> extends FluxOperator<T, R> {
 						"The mapper returned a null value.");
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 
@@ -216,7 +216,7 @@ final class FluxMap<T, R> extends FluxOperator<T, R> {
 			}
 			catch (Throwable e) {
 				done = true;
-				actual.onError(Operators.onOperatorError(s, e, t));
+				actual.onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMap.java
@@ -90,7 +90,7 @@ final class FluxMap<T, R> extends FluxOperator<T, R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -111,7 +111,7 @@ final class FluxMap<T, R> extends FluxOperator<T, R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -183,7 +183,7 @@ final class FluxMap<T, R> extends FluxOperator<T, R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -204,7 +204,7 @@ final class FluxMap<T, R> extends FluxOperator<T, R> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 
@@ -226,7 +226,7 @@ final class FluxMap<T, R> extends FluxOperator<T, R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMapFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMapFuseable.java
@@ -108,7 +108,7 @@ final class FluxMapFuseable<T, R> extends FluxOperator<T, R> implements Fuseable
 							"The mapper returned a null value.");
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					return;
 				}
 
@@ -259,7 +259,7 @@ final class FluxMapFuseable<T, R> extends FluxOperator<T, R> implements Fuseable
 							"The mapper returned a null value.");
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					return;
 				}
 
@@ -281,7 +281,7 @@ final class FluxMapFuseable<T, R> extends FluxOperator<T, R> implements Fuseable
 						"The mapper returned a null value.");
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMapFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMapFuseable.java
@@ -98,7 +98,7 @@ final class FluxMapFuseable<T, R> extends FluxOperator<T, R> implements Fuseable
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t);
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 				R v;
@@ -119,7 +119,7 @@ final class FluxMapFuseable<T, R> extends FluxOperator<T, R> implements Fuseable
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -248,7 +248,7 @@ final class FluxMapFuseable<T, R> extends FluxOperator<T, R> implements Fuseable
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t);
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 
@@ -270,7 +270,7 @@ final class FluxMapFuseable<T, R> extends FluxOperator<T, R> implements Fuseable
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 
@@ -291,7 +291,7 @@ final class FluxMapFuseable<T, R> extends FluxOperator<T, R> implements Fuseable
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMapSignal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMapSignal.java
@@ -123,7 +123,7 @@ final class FluxMapSignal<T, R> extends FluxOperator<T, R> {
         @Override
         public void onNext(T t) {
 	        if (done) {
-	            Operators.onNextDropped(t);
+	            Operators.onNextDropped(t, actual.currentContext());
                 return;
             }
 
@@ -150,7 +150,7 @@ final class FluxMapSignal<T, R> extends FluxOperator<T, R> {
         @Override
         public void onError(Throwable t) {
             if (done) {
-                Operators.onErrorDropped(t);
+                Operators.onErrorDropped(t, actual.currentContext());
                 return;
             }
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMapSignal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMapSignal.java
@@ -139,7 +139,7 @@ final class FluxMapSignal<T, R> extends FluxOperator<T, R> {
             }
             catch (Throwable e) {
 	            done = true;
-	            actual.onError(Operators.onOperatorError(s, e, t));
+	            actual.onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
                 return;
             }
 
@@ -169,7 +169,7 @@ final class FluxMapSignal<T, R> extends FluxOperator<T, R> {
 	        }
 	        catch (Throwable e) {
 		        done = true;
-		        actual.onError(Operators.onOperatorError(s, e, t));
+		        actual.onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 		        return;
 	        }
 
@@ -201,7 +201,7 @@ final class FluxMapSignal<T, R> extends FluxOperator<T, R> {
 	        }
 	        catch (Throwable e) {
 		        done = true;
-		        actual.onError(Operators.onOperatorError(s, e));
+		        actual.onError(Operators.onOperatorError(s, e, actual.currentContext()));
 		        return;
 	        }
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMaterialize.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMaterialize.java
@@ -92,7 +92,7 @@ final class FluxMaterialize<T> extends FluxOperator<T, Signal<T>> {
 		@Override
 		public void onNext(T ev) {
 			if(terminalSignal != null){
-				Operators.onNextDropped(ev);
+				Operators.onNextDropped(ev, actual.currentContext());
 				return;
 			}
 		    produced++;
@@ -102,7 +102,7 @@ final class FluxMaterialize<T> extends FluxOperator<T, Signal<T>> {
 		@Override
 		public void onError(Throwable ev) {
 			if(terminalSignal != null){
-				Operators.onErrorDropped(ev);
+				Operators.onErrorDropped(ev, actual.currentContext());
 				return;
 			}
 			terminalSignal = Signal.error(ev);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMergeSequential.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMergeSequential.java
@@ -242,7 +242,7 @@ final class FluxMergeSequential<T, R> extends FluxOperator<T, R> {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 			}
 		}
 
@@ -307,7 +307,7 @@ final class FluxMergeSequential<T, R> extends FluxOperator<T, R> {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMergeSequential.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMergeSequential.java
@@ -201,7 +201,7 @@ final class FluxMergeSequential<T, R> extends FluxOperator<T, R> {
 				publisher = Objects.requireNonNull(mapper.apply(t), "publisher");
 			}
 			catch (Throwable ex) {
-				onError(Operators.onOperatorError(s, ex, t));
+				onError(Operators.onOperatorError(s, ex, t, actual.currentContext()));
 				return;
 			}
 
@@ -219,7 +219,7 @@ final class FluxMergeSequential<T, R> extends FluxOperator<T, R> {
 						new IllegalStateException("Too many subscribers for " +
 								"fluxMergeSequential on item: " + t +
 								"; subscribers: " + badSize),
-						t));
+						t, actual.currentContext()));
 				return;
 			}
 
@@ -294,7 +294,8 @@ final class FluxMergeSequential<T, R> extends FluxOperator<T, R> {
 			}
 			else {
 				inner.cancel();
-				onError(Operators.onOperatorError(null, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), value));
+				onError(Operators.onOperatorError(null, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), value,
+						actual.currentContext()));
 			}
 		}
 
@@ -396,7 +397,8 @@ final class FluxMergeSequential<T, R> extends FluxOperator<T, R> {
 							catch (Throwable ex) {
 								current = null;
 								inner.cancel();
-								ex = Operators.onOperatorError(ex);
+								ex = Operators.onOperatorError(ex,
+										actual.currentContext());
 								cancelAll();
 								a.onError(ex);
 								return;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBuffer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBuffer.java
@@ -142,7 +142,7 @@ final class FluxOnBackpressureBuffer<O> extends FluxOperator<O, O> implements Fu
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			if (!queue.offer(t)) {
@@ -166,7 +166,7 @@ final class FluxOnBackpressureBuffer<O> extends FluxOperator<O, O> implements Fu
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			error = t;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBuffer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBuffer.java
@@ -147,7 +147,8 @@ final class FluxOnBackpressureBuffer<O> extends FluxOperator<O, O> implements Fu
 			}
 			if (!queue.offer(t)) {
 				Throwable ex =
-						Operators.onOperatorError(s, Exceptions.failWithOverflow(), t);
+						Operators.onOperatorError(s, Exceptions.failWithOverflow(), t,
+								actual.currentContext());
 				if (onOverflow != null) {
 					try {
 						onOverflow.accept(t);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
@@ -166,14 +166,16 @@ final class FluxOnBackpressureBufferStrategy<O> extends FluxOperator<O, O> {
 					onOverflow.accept(overflowElement);
 				}
 				catch (Throwable e) {
-					Throwable ex = Operators.onOperatorError(s, e, overflowElement);
+					Throwable ex = Operators.onOperatorError(s, e, overflowElement,
+							actual.currentContext());
 					onError(ex);
 					return;
 				}
 			}
 
 			if (callOnError) {
-				Throwable ex = Operators.onOperatorError(s, Exceptions.failWithOverflow(), overflowElement);
+				Throwable ex = Operators.onOperatorError(s, Exceptions.failWithOverflow(), overflowElement,
+						actual.currentContext());
 				onError(ex);
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
@@ -132,7 +132,7 @@ final class FluxOnBackpressureBufferStrategy<O> extends FluxOperator<O, O> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -185,7 +185,7 @@ final class FluxOnBackpressureBufferStrategy<O> extends FluxOperator<O, O> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			error = t;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferTimeout.java
@@ -289,7 +289,7 @@ final class FluxOnBackpressureBufferTimeout<O> extends FluxOperator<O, O> {
 								evicted,
 								ex);
 					}
-					Operators.onErrorDropped(ex);
+					Operators.onErrorDropped(ex, actual.currentContext());
 				}
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferTimeout.java
@@ -222,7 +222,8 @@ final class FluxOnBackpressureBufferTimeout<O> extends FluxOperator<O, O> {
 			}
 			catch (RejectedExecutionException re) {
 				done = true;
-				error = Operators.onRejectedExecution(re, this, null, t);
+				error = Operators.onRejectedExecution(re, this, null, t,
+						actual.currentContext());
 			}
 			drain();
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureDrop.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureDrop.java
@@ -110,7 +110,7 @@ final class FluxOnBackpressureDrop<T> extends FluxOperator<T, T> {
 					onDrop.accept(t);
 				}
 				catch (Throwable e) {
-					Operators.onErrorDropped(e);
+					Operators.onErrorDropped(e, actual.currentContext());
 				}
 				return;
 			}
@@ -136,7 +136,7 @@ final class FluxOnBackpressureDrop<T> extends FluxOperator<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureDrop.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureDrop.java
@@ -128,7 +128,7 @@ final class FluxOnBackpressureDrop<T> extends FluxOperator<T, T> {
 					onDrop.accept(t);
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				}
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnErrorResume.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnErrorResume.java
@@ -88,7 +88,7 @@ final class FluxOnErrorResume<T> extends FluxOperator<T, T> {
 					"The nextFactory returned a null Publisher");
 				}
 				catch (Throwable e) {
-					Throwable _e = Operators.onOperatorError(e);
+					Throwable _e = Operators.onOperatorError(e, actual.currentContext());
 					if (t != _e) {
 						_e.addSuppressed(t);
 					}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPeek.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPeek.java
@@ -124,7 +124,7 @@ final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
 					requestHook.accept(n);
 				}
 				catch (Throwable e) {
-					Operators.onOperatorError(e);
+					Operators.onOperatorError(e, actual.currentContext());
 				}
 			}
 			s.request(n);
@@ -138,7 +138,7 @@ final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
 					cancelHook.run();
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e));
+					onError(Operators.onOperatorError(s, e, actual.currentContext()));
 					return;
 				}
 			}
@@ -154,7 +154,8 @@ final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
 						subscribeHook.accept(s);
 					}
 					catch (Throwable e) {
-						Operators.error(actual, Operators.onOperatorError(s, e));
+						Operators.error(actual, Operators.onOperatorError(s, e,
+								actual.currentContext()));
 						return;
 					}
 				}
@@ -176,7 +177,7 @@ final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
 					nextHook.accept(t);
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					return;
 				}
 			}
@@ -198,7 +199,7 @@ final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
 				}
 				catch (Throwable e) {
 					//this performs a throwIfFatal or suppresses t in e
-					t = Operators.onOperatorError(null, e, t);
+					t = Operators.onOperatorError(null, e, t, actual.currentContext());
 				}
 			}
 
@@ -235,7 +236,7 @@ final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
 					completeHook.run();
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e));
+					onError(Operators.onOperatorError(s, e, actual.currentContext()));
 					return;
 				}
 			}
@@ -308,7 +309,7 @@ final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
 	 * callback that fails during onComplete. It drops the error to the global hook.
 	 * <ul>
 	 *     <li>The callback failure is thrown immediately if fatal.</li>
-	 *     <li>{@link Operators#onOperatorError(Throwable)} is called</li>
+	 *     <li>{@link Operators#onOperatorError(Throwable, Context)} is called</li>
 	 *     <li>{@link Operators#onErrorDropped(Throwable, Context)} is called</li>
 	 * </ul>
 	 * <p>
@@ -322,7 +323,7 @@ final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
 			Throwable callbackFailure, Context context) {
 
 		Exceptions.throwIfFatal(callbackFailure);
-		Throwable _e = Operators.onOperatorError(callbackFailure);
+		Throwable _e = Operators.onOperatorError(callbackFailure, context);
 		Operators.onErrorDropped(_e, context);
 	}
 
@@ -331,7 +332,7 @@ final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
 	 * callback that fails during onError. It drops the error to the global hook.
 	 * <ul>
 	 *     <li>The callback failure is thrown immediately if fatal.</li>
-	 *     <li>{@link Operators#onOperatorError(Subscription, Throwable, Object)} is
+	 *     <li>{@link Operators#onOperatorError(Subscription, Throwable, Object, Context)} is
 	 *     called, adding the original error as suppressed</li>
 	 *     <li>{@link Operators#onErrorDropped(Throwable, Context)} is called</li>
 	 * </ul>
@@ -346,7 +347,7 @@ final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
 	static <T> void afterErrorWithFailure(SignalPeek<T> parent,
 			Throwable callbackFailure, Throwable originalError, Context context) {
 		Exceptions.throwIfFatal(callbackFailure);
-		Throwable _e = Operators.onOperatorError(null, callbackFailure, originalError);
+		Throwable _e = Operators.onOperatorError(null, callbackFailure, originalError, context);
 		Operators.onErrorDropped(_e, context);
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPeek.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPeek.java
@@ -166,7 +166,7 @@ final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -187,7 +187,7 @@ final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -219,7 +219,7 @@ final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
 					afterTerminateHook.run();
 				}
 				catch (Throwable e) {
-					afterErrorWithFailure(parent, e, t);
+					afterErrorWithFailure(parent, e, t, actual.currentContext());
 				}
 			}
 		}
@@ -249,7 +249,7 @@ final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
 					afterTerminateHook.run();
 				}
 				catch (Throwable e) {
-					afterCompleteWithFailure(parent, e);
+					afterCompleteWithFailure(parent, e, actual.currentContext());
 				}
 			}
 		}
@@ -309,20 +309,21 @@ final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
 	 * <ul>
 	 *     <li>The callback failure is thrown immediately if fatal.</li>
 	 *     <li>{@link Operators#onOperatorError(Throwable)} is called</li>
-	 *     <li>{@link Operators#onErrorDropped(Throwable)} is called</li>
+	 *     <li>{@link Operators#onErrorDropped(Throwable, Context)} is called</li>
 	 * </ul>
 	 * <p>
 	 *
 	 * @param parent the {@link SignalPeek} from which to get the callbacks
 	 * @param callbackFailure the afterTerminate callback failure
+	 * @param context subscriber context
 	 */
 	//see https://github.com/reactor/reactor-core/issues/270
 	static <T> void afterCompleteWithFailure(SignalPeek<T> parent,
-			Throwable callbackFailure) {
+			Throwable callbackFailure, Context context) {
 
 		Exceptions.throwIfFatal(callbackFailure);
 		Throwable _e = Operators.onOperatorError(callbackFailure);
-		Operators.onErrorDropped(_e);
+		Operators.onErrorDropped(_e, context);
 	}
 
 	/**
@@ -332,20 +333,21 @@ final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
 	 *     <li>The callback failure is thrown immediately if fatal.</li>
 	 *     <li>{@link Operators#onOperatorError(Subscription, Throwable, Object)} is
 	 *     called, adding the original error as suppressed</li>
-	 *     <li>{@link Operators#onErrorDropped(Throwable)} is called</li>
+	 *     <li>{@link Operators#onErrorDropped(Throwable, Context)} is called</li>
 	 * </ul>
 	 * <p>
 	 *
 	 * @param parent the {@link SignalPeek} from which to get the callbacks
 	 * @param callbackFailure the afterTerminate callback failure
 	 * @param originalError the onError throwable
+	 * @param context subscriber context
 	 */
 	//see https://github.com/reactor/reactor-core/issues/270
 	static <T> void afterErrorWithFailure(SignalPeek<T> parent,
-			Throwable callbackFailure, Throwable originalError) {
+			Throwable callbackFailure, Throwable originalError, Context context) {
 		Exceptions.throwIfFatal(callbackFailure);
 		Throwable _e = Operators.onOperatorError(null, callbackFailure, originalError);
-		Operators.onErrorDropped(_e);
+		Operators.onErrorDropped(_e, context);
 	}
 
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
@@ -132,7 +132,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 					requestHook.accept(n);
 				}
 				catch (Throwable e) {
-					Operators.onOperatorError(e);
+					Operators.onOperatorError(e, actual.currentContext());
 				}
 			}
 			s.request(n);
@@ -146,7 +146,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 					cancelHook.run();
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e));
+					onError(Operators.onOperatorError(s, e, actual.currentContext()));
 					return;
 				}
 			}
@@ -163,7 +163,8 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 						subscribeHook.accept(s);
 					}
 					catch (Throwable e) {
-						Operators.error(actual, Operators.onOperatorError(s, e));
+						Operators.error(actual, Operators.onOperatorError(s, e,
+								actual.currentContext()));
 						return;
 					}
 				}
@@ -189,7 +190,8 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 						nextHook.accept(t);
 					}
 					catch (Throwable e) {
-						onError(Operators.onOperatorError(s, e, t));
+						onError(Operators.onOperatorError(s, e, t,
+								actual.currentContext()));
 						return;
 					}
 				}
@@ -212,7 +214,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 				}
 				catch (Throwable e) {
 					//this performs a throwIfFatal or suppresses t in e
-					t = Operators.onOperatorError(null, e, t);
+					t = Operators.onOperatorError(null, e, t, actual.currentContext());
 				}
 			}
 
@@ -254,7 +256,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 						completeHook.run();
 					}
 					catch (Throwable e) {
-						onError(Operators.onOperatorError(s, e));
+						onError(Operators.onOperatorError(s, e, actual.currentContext()));
 						return;
 					}
 				}
@@ -294,10 +296,12 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 						errorHook.accept(e);
 					}
 					catch (Throwable errorCallbackError) {
-						throw Exceptions.propagate(Operators.onOperatorError(s, errorCallbackError, e));
+						throw Exceptions.propagate(Operators.onOperatorError(s, errorCallbackError, e,
+								actual.currentContext()));
 					}
 				}
-				throw Exceptions.propagate(Operators.onOperatorError(s, e));
+				throw Exceptions.propagate(Operators.onOperatorError(s, e,
+						actual.currentContext()));
 			}
 
 			final Consumer<? super T> nextHook = parent.onNextCall();
@@ -306,7 +310,8 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 					nextHook.accept(v);
 				}
 				catch (Throwable e) {
-					throw Exceptions.propagate(Operators.onOperatorError(s, e, v));
+					throw Exceptions.propagate(Operators.onOperatorError(s, e, v,
+							actual.currentContext()));
 				}
 			}
 			if (v == null && (d || sourceMode == SYNC)) {
@@ -398,7 +403,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 					requestHook.accept(n);
 				}
 				catch (Throwable e) {
-					Operators.onOperatorError(e);
+					Operators.onOperatorError(e, actual.currentContext());
 				}
 			}
 			s.request(n);
@@ -412,7 +417,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 					cancelHook.run();
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e));
+					onError(Operators.onOperatorError(s, e, actual.currentContext()));
 					return;
 				}
 			}
@@ -429,7 +434,8 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 						subscribeHook.accept(s);
 					}
 					catch (Throwable e) {
-						Operators.error(actual, Operators.onOperatorError(s, e));
+						Operators.error(actual, Operators.onOperatorError(s, e,
+								actual.currentContext()));
 						return;
 					}
 				}
@@ -455,7 +461,8 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 						nextHook.accept(t);
 					}
 					catch (Throwable e) {
-						onError(Operators.onOperatorError(s, e, t));
+						onError(Operators.onOperatorError(s, e, t,
+								actual.currentContext()));
 						return;
 					}
 				}
@@ -476,7 +483,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 					nextHook.accept(t);
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					return true;
 				}
 			}
@@ -498,7 +505,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 				}
 				catch (Throwable e) {
 					//this performs a throwIfFatal or suppresses t in e
-					t = Operators.onOperatorError(null, e, t);
+					t = Operators.onOperatorError(null, e, t, actual.currentContext());
 				}
 			}
 
@@ -540,7 +547,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 						completeHook.run();
 					}
 					catch (Throwable e) {
-						onError(Operators.onOperatorError(s, e));
+						onError(Operators.onOperatorError(s, e, actual.currentContext()));
 						return;
 					}
 				}
@@ -579,10 +586,12 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 						errorHook.accept(e);
 					}
 					catch (Throwable errorCallbackError) {
-						throw Exceptions.propagate(Operators.onOperatorError(s, errorCallbackError, e));
+						throw Exceptions.propagate(Operators.onOperatorError(s, errorCallbackError, e,
+								actual.currentContext()));
 					}
 				}
-				throw Exceptions.propagate(Operators.onOperatorError(s, e));
+				throw Exceptions.propagate(Operators.onOperatorError(s, e,
+						actual.currentContext()));
 			}
 
 			final Consumer<? super T> nextHook = parent.onNextCall();
@@ -591,7 +600,8 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 					nextHook.accept(v);
 				}
 				catch (Throwable e) {
-					throw Exceptions.propagate(Operators.onOperatorError(s, e, v));
+					throw Exceptions.propagate(Operators.onOperatorError(s, e, v,
+							actual.currentContext()));
 				}
 			}
 			if (v == null && (d || sourceMode == SYNC)) {
@@ -712,7 +722,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 					requestHook.accept(n);
 				}
 				catch (Throwable e) {
-					Operators.onOperatorError(e);
+					Operators.onOperatorError(e, actual.currentContext());
 				}
 			}
 			s.request(n);
@@ -726,7 +736,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 					cancelHook.run();
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e));
+					onError(Operators.onOperatorError(s, e, actual.currentContext()));
 					return;
 				}
 			}
@@ -742,7 +752,8 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 						subscribeHook.accept(s);
 					}
 					catch (Throwable e) {
-						Operators.error(actual, Operators.onOperatorError(s, e));
+						Operators.error(actual, Operators.onOperatorError(s, e,
+								actual.currentContext()));
 						return;
 					}
 				}
@@ -773,7 +784,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 					nextHook.accept(t);
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					return;
 				}
 			}
@@ -793,7 +804,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 					nextHook.accept(t);
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					return true;
 				}
 			}
@@ -815,7 +826,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 				}
 				catch (Throwable e) {
 					//this performs a throwIfFatal or suppresses t in e
-					t = Operators.onOperatorError(null, e, t);
+					t = Operators.onOperatorError(null, e, t, actual.currentContext());
 				}
 			}
 
@@ -851,7 +862,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 					completeHook.run();
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e));
+					onError(Operators.onOperatorError(s, e, actual.currentContext()));
 					return;
 				}
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
@@ -179,7 +179,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t);
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 
@@ -200,7 +200,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -232,7 +232,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 					afterTerminateHook.run();
 				}
 				catch (Throwable e) {
-					FluxPeek.afterErrorWithFailure(parent, e, t);
+					FluxPeek.afterErrorWithFailure(parent, e, t, actual.currentContext());
 				}
 			}
 		}
@@ -268,7 +268,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 						afterTerminateHook.run();
 					}
 					catch (Throwable e) {
-						FluxPeek.afterCompleteWithFailure(parent, e);
+						FluxPeek.afterCompleteWithFailure(parent, e, actual.currentContext());
 					}
 				}
 			}
@@ -445,7 +445,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t);
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 
@@ -466,7 +466,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return false;
 			}
 
@@ -486,7 +486,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -518,7 +518,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 					afterTerminateHook.run();
 				}
 				catch (Throwable e) {
-					FluxPeek.afterErrorWithFailure(parent, e, t);
+					FluxPeek.afterErrorWithFailure(parent, e, t, actual.currentContext());
 				}
 			}
 		}
@@ -553,7 +553,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 						afterTerminateHook.run();
 					}
 					catch (Throwable e) {
-						FluxPeek.afterCompleteWithFailure(parent, e);
+						FluxPeek.afterCompleteWithFailure(parent, e, actual.currentContext());
 					}
 				}
 			}
@@ -763,7 +763,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -783,7 +783,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return false;
 			}
 
@@ -803,7 +803,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -835,7 +835,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 					afterTerminateHook.run();
 				}
 				catch (Throwable e) {
-					FluxPeek.afterErrorWithFailure(parent, e, t);
+					FluxPeek.afterErrorWithFailure(parent, e, t, actual.currentContext());
 				}
 			}
 		}
@@ -865,7 +865,7 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 					afterTerminateHook.run();
 				}
 				catch (Throwable e) {
-					FluxPeek.afterCompleteWithFailure(parent, e);
+					FluxPeek.afterCompleteWithFailure(parent, e, actual.currentContext());
 				}
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -242,7 +242,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 		public void onNext(T t) {
 			if (done) {
 				if (t != null) {
-					Operators.onNextDropped(t);
+					Operators.onNextDropped(t, currentContext());
 				}
 				return;
 			}
@@ -253,8 +253,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 
 			if (!queue.offer(t)) {
 				Throwable ex = Operators.onOperatorError(s,
-						Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL),
-						t);
+						Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t, currentContext());
 				if (!Exceptions.addThrowable(ERROR, this, ex)) {
 					Operators.onErrorDropped(ex);
 					return;
@@ -414,7 +413,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 						catch (Throwable ex) {
 							Exceptions.addThrowable(ERROR,
 									this,
-									Operators.onOperatorError(s, ex));
+									Operators.onOperatorError(s, ex, currentContext()));
 							d = true;
 							v = null;
 						}
@@ -439,7 +438,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 						catch (Throwable ex) {
 							Exceptions.addThrowable(ERROR,
 									this,
-									Operators.onOperatorError(s, ex));
+									Operators.onOperatorError(s, ex, currentContext()));
 							d = true;
 							v = null;
 						}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -255,7 +255,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 				Throwable ex = Operators.onOperatorError(s,
 						Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t, currentContext());
 				if (!Exceptions.addThrowable(ERROR, this, ex)) {
-					Operators.onErrorDropped(ex);
+					Operators.onErrorDroppedMulticast(ex);
 					return;
 				}
 				done = true;
@@ -266,7 +266,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDroppedMulticast(t);
 				return;
 			}
 			if (Exceptions.addThrowable(ERROR, this, t)) {
@@ -274,7 +274,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDroppedMulticast(t);
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
@@ -248,7 +248,7 @@ final class FluxPublishMulticast<T, R> extends FluxOperator<T, R> implements Fus
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, context);
 				return;
 			}
 
@@ -266,7 +266,7 @@ final class FluxPublishMulticast<T, R> extends FluxOperator<T, R> implements Fus
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, context);
 				return;
 			}
 			error = t;
@@ -726,7 +726,7 @@ final class FluxPublishMulticast<T, R> extends FluxOperator<T, R> implements Fus
 		@Override
 		public void onError(Throwable t) {
 			if(!parent.terminate()){
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			actual.onError(t);
@@ -825,7 +825,7 @@ final class FluxPublishMulticast<T, R> extends FluxOperator<T, R> implements Fus
 		@Override
 		public void onError(Throwable t) {
 			if(!parent.terminate()){
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			actual.onError(t);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
@@ -83,7 +83,7 @@ final class FluxPublishMulticast<T, R> extends FluxOperator<T, R> implements Fus
 					"The transform returned a null Publisher");
 		}
 		catch (Throwable ex) {
-			Operators.error(actual, Operators.onOperatorError(ex));
+			Operators.error(actual, Operators.onOperatorError(ex, actual.currentContext()));
 			return;
 		}
 
@@ -256,7 +256,7 @@ final class FluxPublishMulticast<T, R> extends FluxOperator<T, R> implements Fus
 				if (!queue.offer(t)) {
 					onError(Operators.onOperatorError(s,
 							Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL),
-							t));
+							t, context));
 					return;
 				}
 			}
@@ -334,7 +334,7 @@ final class FluxPublishMulticast<T, R> extends FluxOperator<T, R> implements Fus
 								v = queue.poll();
 							}
 							catch (Throwable ex) {
-								error = Operators.onOperatorError(s, ex);
+								error = Operators.onOperatorError(s, ex, context);
 								queue.clear();
 								a = SUBSCRIBERS.getAndSet(this, TERMINATED);
 								n = a.length;
@@ -432,7 +432,7 @@ final class FluxPublishMulticast<T, R> extends FluxOperator<T, R> implements Fus
 							}
 							catch (Throwable ex) {
 								queue.clear();
-								error = Operators.onOperatorError(s, ex);
+								error = Operators.onOperatorError(s, ex, context);
 								a = SUBSCRIBERS.getAndSet(this, TERMINATED);
 								n = a.length;
 								for (int i = 0; i < n; i++) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
@@ -220,7 +220,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 			}
 
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			if (!queue.offer(t)) {
@@ -235,7 +235,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			error = t;
@@ -699,7 +699,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 			}
 
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			if (!queue.offer(t)) {
@@ -712,7 +712,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 		@Override
 		public void onError(Throwable t) {
 			if(done){
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			error = t;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
@@ -79,7 +79,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 					"The scheduler returned a null worker");
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 
@@ -226,7 +226,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 			if (!queue.offer(t)) {
 				error = Operators.onOperatorError(s,
 						Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL),
-						t);
+						t, actual.currentContext());
 				done = true;
 			}
 			trySchedule(this, null, t);
@@ -290,7 +290,8 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 			}
 			catch (RejectedExecutionException ree) {
 				queue.clear();
-				actual.onError(Operators.onRejectedExecution(ree, subscription, suppressed, dataSignal));
+				actual.onError(Operators.onRejectedExecution(ree, subscription, suppressed, dataSignal,
+						actual.currentContext()));
 			}
 		}
 
@@ -313,7 +314,8 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 						v = q.poll();
 					}
 					catch (Throwable ex) {
-						doError(a, Operators.onOperatorError(s, ex));
+						doError(a, Operators.onOperatorError(s, ex,
+								actual.currentContext()));
 						return;
 					}
 
@@ -377,7 +379,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 						s.cancel();
 						q.clear();
 
-						doError(a, Operators.onOperatorError(ex));
+						doError(a, Operators.onOperatorError(ex, actual.currentContext()));
 						return;
 					}
 
@@ -703,7 +705,8 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 				return;
 			}
 			if (!queue.offer(t)) {
-				error = Operators.onOperatorError(s, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t);
+				error = Operators.onOperatorError(s, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t,
+						actual.currentContext());
 				done = true;
 			}
 			trySchedule(this, null, t);
@@ -765,7 +768,8 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 			}
 			catch (RejectedExecutionException ree) {
 				queue.clear();
-				actual.onError(Operators.onRejectedExecution(ree, subscription, suppressed, dataSignal));
+				actual.onError(Operators.onRejectedExecution(ree, subscription, suppressed, dataSignal,
+						actual.currentContext()));
 			}
 		}
 
@@ -787,7 +791,8 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 						v = q.poll();
 					}
 					catch (Throwable ex) {
-						doError(a, Operators.onOperatorError(s, ex));
+						doError(a, Operators.onOperatorError(s, ex,
+								actual.currentContext()));
 						return;
 					}
 
@@ -851,7 +856,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 						s.cancel();
 						q.clear();
 
-						doError(a, Operators.onOperatorError(ex));
+						doError(a, Operators.onOperatorError(ex, actual.currentContext()));
 						return;
 					}
 					boolean empty = v == null;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatPredicate.java
@@ -85,7 +85,7 @@ final class FluxRepeatPredicate<T> extends FluxOperator<T, T> {
 			try {
 				b = predicate.getAsBoolean();
 			} catch (Throwable e) {
-				actual.onError(Operators.onOperatorError(e));
+				actual.onError(Operators.onOperatorError(e, actual.currentContext()));
 				return;
 			}
 			

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
@@ -74,7 +74,7 @@ final class FluxRepeatWhen<T> extends FluxOperator<T, T> {
 					"The whenSourceFactory returned a null Publisher");
 		}
 		catch (Throwable e) {
-			actual.onError(Operators.onOperatorError(e));
+			actual.onError(Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -1151,7 +1151,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 		public void onNext(T t) {
 			ReplayBuffer<T> b = buffer;
 			if (b.isDone()) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, currentContext());
 			}
 			else {
 				b.add(t);
@@ -1165,7 +1165,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 		public void onError(Throwable t) {
 			ReplayBuffer<T> b = buffer;
 			if (b.isDone()) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, currentContext());
 			}
 			else {
 				b.onError(t);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRetryPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRetryPredicate.java
@@ -87,7 +87,7 @@ final class FluxRetryPredicate<T> extends FluxOperator<T, T> {
 			try {
 				b = predicate.test(t);
 			} catch (Throwable e) {
-				Throwable _t = Operators.onOperatorError(e);
+				Throwable _t = Operators.onOperatorError(e, actual.currentContext());
 				if (_t != t) {
 					_t.addSuppressed(t);
 				}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRetryWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRetryWhen.java
@@ -71,7 +71,7 @@ final class FluxRetryWhen<T> extends FluxOperator<T, T> {
 			"The whenSourceFactory returned a null Publisher");
 		}
 		catch (Throwable e) {
-			s.onError(Operators.onOperatorError(e));
+			s.onError(Operators.onOperatorError(e, s.currentContext()));
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSampleFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSampleFirst.java
@@ -175,7 +175,7 @@ final class FluxSampleFirst<T, U> extends FluxOperator<T, T> {
 				}
 				catch (Throwable e) {
 					Operators.terminate(S, this);
-					error(Operators.onOperatorError(null, e, t));
+					error(Operators.onOperatorError(null, e, t, actual.currentContext()));
 					return;
 				}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSampleFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSampleFirst.java
@@ -204,7 +204,7 @@ final class FluxSampleFirst<T, U> extends FluxOperator<T, T> {
 				}
 			}
 			else {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSampleTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSampleTimeout.java
@@ -191,7 +191,7 @@ final class FluxSampleTimeout<T, U> extends FluxOperator<T, T> {
 						"throttler returned a null publisher");
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSampleTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSampleTimeout.java
@@ -208,7 +208,7 @@ final class FluxSampleTimeout<T, U> extends FluxOperator<T, T> {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 			}
 		}
 
@@ -243,7 +243,7 @@ final class FluxSampleTimeout<T, U> extends FluxOperator<T, T> {
 				error(e);
 			}
 			else {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 
@@ -386,7 +386,7 @@ final class FluxSampleTimeout<T, U> extends FluxOperator<T, T> {
 				main.otherError(index, t);
 			}
 			else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, main.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxScan.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxScan.java
@@ -96,7 +96,7 @@ final class FluxScan<T> extends FluxOperator<T, T> {
 							"The accumulator returned a null value");
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					return;
 				}
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxScan.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxScan.java
@@ -84,7 +84,7 @@ final class FluxScan<T> extends FluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -107,7 +107,7 @@ final class FluxScan<T> extends FluxOperator<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxScanSeed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxScanSeed.java
@@ -189,7 +189,7 @@ final class FluxScanSeed<T, R> extends FluxOperator<T, R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -199,7 +199,7 @@ final class FluxScanSeed<T, R> extends FluxOperator<T, R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxScanSeed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxScanSeed.java
@@ -115,7 +115,7 @@ final class FluxScanSeed<T, R> extends FluxOperator<T, R> {
 									"The initial value supplied is null");
 						}
 						catch (Throwable e) {
-							onError(Operators.onOperatorError(e));
+							onError(Operators.onOperatorError(e, actual.currentContext()));
 							return;
 						}
 
@@ -210,7 +210,7 @@ final class FluxScanSeed<T, R> extends FluxOperator<T, R> {
 						"The accumulator returned a null value");
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSkipUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSkipUntil.java
@@ -72,7 +72,7 @@ final class FluxSkipUntil<T> extends FluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -101,7 +101,7 @@ final class FluxSkipUntil<T> extends FluxOperator<T, T> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 
@@ -132,7 +132,7 @@ final class FluxSkipUntil<T> extends FluxOperator<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSkipUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSkipUntil.java
@@ -85,7 +85,7 @@ final class FluxSkipUntil<T> extends FluxOperator<T, T> {
 			try {
 				b = predicate.test(t);
 			} catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 
@@ -115,7 +115,7 @@ final class FluxSkipUntil<T> extends FluxOperator<T, T> {
 				b = predicate.test(t);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 
 				return true;
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSkipUntilOther.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSkipUntilOther.java
@@ -101,7 +101,7 @@ final class FluxSkipUntilOther<T, U> extends FluxOperator<T, T> {
 		public void onError(Throwable t) {
 			SkipUntilMainSubscriber<?> m = main;
 			if (m.gate) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, main.currentContext());
 				return;
 			}
 			m.onError(t);
@@ -217,7 +217,7 @@ final class FluxSkipUntilOther<T, U> extends FluxOperator<T, T> {
 					return;
 			}
 			else if (main == Operators.cancelledSubscription()){
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			cancel();

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSkipWhile.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSkipWhile.java
@@ -72,7 +72,7 @@ final class FluxSkipWhile<T> extends FluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -102,7 +102,7 @@ final class FluxSkipWhile<T> extends FluxOperator<T, T> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 
@@ -133,7 +133,7 @@ final class FluxSkipWhile<T> extends FluxOperator<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSkipWhile.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSkipWhile.java
@@ -86,7 +86,7 @@ final class FluxSkipWhile<T> extends FluxOperator<T, T> {
 				b = predicate.test(t);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 
@@ -116,7 +116,7 @@ final class FluxSkipWhile<T> extends FluxOperator<T, T> {
 				b = predicate.test(t);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 
 				return true;
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxStream.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxStream.java
@@ -47,7 +47,7 @@ final class FluxStream<T> extends Flux<T> implements Fuseable {
 			"The stream returned a null Iterator");
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOn.java
@@ -57,7 +57,7 @@ final class FluxSubscribeOn<T> extends FluxOperator<T, T> {
 			worker = Objects.requireNonNull(scheduler.createWorker(),
 					"The scheduler returned a null Function");
 		} catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 
@@ -70,7 +70,8 @@ final class FluxSubscribeOn<T> extends FluxOperator<T, T> {
 		}
 		catch (RejectedExecutionException ree) {
 			if (parent.s != Operators.cancelledSubscription()) {
-				actual.onError(Operators.onRejectedExecution(ree, parent, null, null));
+				actual.onError(Operators.onRejectedExecution(ree, parent, null, null,
+						actual.currentContext()));
 			}
 		}
 	}
@@ -138,7 +139,8 @@ final class FluxSubscribeOn<T> extends FluxOperator<T, T> {
 						//FIXME should not throw but if we implement strict
 						// serialization like in StrictSubscriber, onNext will carry an
 						// extra cost
-						throw Operators.onRejectedExecution(ree, this, null, null);
+						throw Operators.onRejectedExecution(ree, this, null, null,
+								actual.currentContext());
 					}
 				}
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOnCallable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOnCallable.java
@@ -57,7 +57,7 @@ final class FluxSubscribeOnCallable<T> extends Flux<T> implements Fuseable {
 		}
 		catch (RejectedExecutionException ree) {
 			if(parent.state != CallableSubscribeOnSubscription.HAS_CANCELLED) {
-				actual.onError(Operators.onRejectedExecution(ree));
+				actual.onError(Operators.onRejectedExecution(ree, actual.currentContext()));
 			}
 		}
 	}
@@ -216,7 +216,8 @@ final class FluxSubscribeOnCallable<T> extends Flux<T> implements Fuseable {
 				v = callable.call();
 			}
 			catch (Throwable ex) {
-				actual.onError(Operators.onOperatorError(this, ex));
+				actual.onError(Operators.onOperatorError(this, ex,
+						actual.currentContext()));
 				return;
 			}
 
@@ -262,7 +263,8 @@ final class FluxSubscribeOnCallable<T> extends Flux<T> implements Fuseable {
 								setRequestFuture(f);
 							}
 							catch (RejectedExecutionException ree) {
-								actual.onError(Operators.onRejectedExecution(ree));
+								actual.onError(Operators.onRejectedExecution(ree,
+										actual.currentContext()));
 							}
 						}
 						return;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOnValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOnValue.java
@@ -59,7 +59,8 @@ final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable {
 			}
 			catch (RejectedExecutionException ree) {
 				if (parent.future != OperatorDisposables.DISPOSED) {
-					actual.onError(Operators.onRejectedExecution(ree));
+					actual.onError(Operators.onRejectedExecution(ree,
+							actual.currentContext()));
 				}
 			}
 		}
@@ -141,7 +142,7 @@ final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable {
 							actual.onError(Operators.onRejectedExecution(ree,
 									this,
 									null,
-									value));
+									value, actual.currentContext()));
 						}
 					}
 				}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
@@ -196,7 +196,7 @@ final class FluxSwitchMap<T, R> extends FluxOperator<T, R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -231,7 +231,7 @@ final class FluxSwitchMap<T, R> extends FluxOperator<T, R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -246,7 +246,7 @@ final class FluxSwitchMap<T, R> extends FluxOperator<T, R> {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 			}
 		}
 
@@ -415,7 +415,7 @@ final class FluxSwitchMap<T, R> extends FluxOperator<T, R> {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
@@ -215,7 +215,7 @@ final class FluxSwitchMap<T, R> extends FluxOperator<T, R> {
 				"The mapper returned a null publisher");
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTake.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTake.java
@@ -100,7 +100,7 @@ final class FluxTake<T> extends FluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -127,7 +127,7 @@ final class FluxTake<T> extends FluxOperator<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -217,7 +217,7 @@ final class FluxTake<T> extends FluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -244,7 +244,7 @@ final class FluxTake<T> extends FluxOperator<T, T> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 
@@ -272,7 +272,7 @@ final class FluxTake<T> extends FluxOperator<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -372,7 +372,7 @@ final class FluxTake<T> extends FluxOperator<T, T> {
 				return;
 			}
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -399,7 +399,7 @@ final class FluxTake<T> extends FluxOperator<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntil.java
@@ -70,7 +70,7 @@ final class FluxTakeUntil<T> extends FluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -96,7 +96,7 @@ final class FluxTakeUntil<T> extends FluxOperator<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntil.java
@@ -81,7 +81,7 @@ final class FluxTakeUntil<T> extends FluxOperator<T, T> {
 			try {
 				b = predicate.test(t);
 			} catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 
 				return;
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTakeWhile.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTakeWhile.java
@@ -78,7 +78,7 @@ final class FluxTakeWhile<T> extends FluxOperator<T, T> {
 			try {
 				b = predicate.test(t);
 			} catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 
 				return;
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTakeWhile.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTakeWhile.java
@@ -69,7 +69,7 @@ final class FluxTakeWhile<T> extends FluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -97,7 +97,7 @@ final class FluxTakeWhile<T> extends FluxOperator<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTimeout.java
@@ -153,7 +153,8 @@ final class FluxTimeout<T, U, V> extends FluxOperator<T, T> {
 						"The itemTimeout returned a null Publisher");
 			}
 			catch (Throwable e) {
-				actual.onError(Operators.onOperatorError(this, e, t));
+				actual.onError(Operators.onOperatorError(this, e, t,
+						actual.currentContext()));
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTimeout.java
@@ -133,12 +133,12 @@ final class FluxTimeout<T, U, V> extends FluxOperator<T, T> {
 			long idx = index;
 			if (idx == Long.MIN_VALUE) {
 				s.cancel();
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			if (!INDEX.compareAndSet(this, idx, idx + 1)) {
 				s.cancel();
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -170,11 +170,11 @@ final class FluxTimeout<T, U, V> extends FluxOperator<T, T> {
 		public void onError(Throwable t) {
 			long idx = index;
 			if (idx == Long.MIN_VALUE) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			if (!INDEX.compareAndSet(this, idx, Long.MIN_VALUE)) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxUsing.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxUsing.java
@@ -74,7 +74,7 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 			resource = resourceSupplier.call();
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 
@@ -90,11 +90,11 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 				resourceCleanup.accept(resource);
 			}
 			catch (Throwable ex) {
-				ex.addSuppressed(Operators.onOperatorError(e));
+				ex.addSuppressed(Operators.onOperatorError(e, actual.currentContext()));
 				e = ex;
 			}
 
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 
@@ -202,7 +202,7 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 					resourceCleanup.accept(resource);
 				}
 				catch (Throwable e) {
-					Throwable _e = Operators.onOperatorError(e);
+					Throwable _e = Operators.onOperatorError(e, actual.currentContext());
 					if (_e != t) {
 						_e.addSuppressed(t);
 					}
@@ -224,7 +224,7 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 					resourceCleanup.accept(resource);
 				}
 				catch (Throwable e) {
-					actual.onError(Operators.onOperatorError(e));
+					actual.onError(Operators.onOperatorError(e, actual.currentContext()));
 					return;
 				}
 			}
@@ -355,7 +355,7 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 					resourceCleanup.accept(resource);
 				}
 				catch (Throwable e) {
-					Throwable _e = Operators.onOperatorError(e);
+					Throwable _e = Operators.onOperatorError(e, actual.currentContext());
 					if (_e != t) {
 						_e.addSuppressed(t);
 					}
@@ -377,7 +377,7 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 					resourceCleanup.accept(resource);
 				}
 				catch (Throwable e) {
-					actual.onError(Operators.onOperatorError(e));
+					actual.onError(Operators.onOperatorError(e, actual.currentContext()));
 					return;
 				}
 			}
@@ -519,7 +519,7 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 					resourceCleanup.accept(resource);
 				}
 				catch (Throwable e) {
-					Throwable _e = Operators.onOperatorError(e);
+					Throwable _e = Operators.onOperatorError(e, actual.currentContext());
 					if (_e != t) {
 						_e.addSuppressed(t);
 					}
@@ -541,7 +541,7 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 					resourceCleanup.accept(resource);
 				}
 				catch (Throwable e) {
-					actual.onError(Operators.onOperatorError(e));
+					actual.onError(Operators.onOperatorError(e, actual.currentContext()));
 					return;
 				}
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxUsing.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxUsing.java
@@ -177,7 +177,7 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 				resourceCleanup.accept(resource);
 			}
 			catch (Throwable e) {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 
@@ -329,7 +329,7 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 				resourceCleanup.accept(resource);
 			}
 			catch (Throwable e) {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 
@@ -489,7 +489,7 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 				resourceCleanup.accept(resource);
 			}
 			catch (Throwable e) {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindow.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindow.java
@@ -148,7 +148,7 @@ final class FluxWindow<T> extends FluxOperator<T, Flux<T>> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -181,7 +181,7 @@ final class FluxWindow<T> extends FluxOperator<T, Flux<T>> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -315,7 +315,7 @@ final class FluxWindow<T> extends FluxOperator<T, Flux<T>> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -355,7 +355,7 @@ final class FluxWindow<T> extends FluxOperator<T, Flux<T>> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -517,7 +517,7 @@ final class FluxWindow<T> extends FluxOperator<T, Flux<T>> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -566,7 +566,7 @@ final class FluxWindow<T> extends FluxOperator<T, Flux<T>> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
@@ -172,7 +172,7 @@ final class FluxWindowBoundary<T, U> extends FluxOperator<T, Flux<T>> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			synchronized (this) {
@@ -184,7 +184,7 @@ final class FluxWindowBoundary<T, U> extends FluxOperator<T, Flux<T>> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -255,7 +255,7 @@ final class FluxWindowBoundary<T, U> extends FluxOperator<T, Flux<T>> {
 			if (Exceptions.addThrowable(ERROR, this, e)) {
 				drain();
 			} else {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
@@ -202,7 +202,8 @@ final class FluxWindowPredicate<T> extends FluxOperator<T, Flux<T>>
 				window = g;
 
 				if (!queue.offer(g)) {
-					onError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), emitInNewWindow));
+					onError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), emitInNewWindow,
+							actual.currentContext()));
 					return;
 				}
 				drain();
@@ -222,7 +223,7 @@ final class FluxWindowPredicate<T> extends FluxOperator<T, Flux<T>>
 				match = predicate.test(t);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(s, e, t));
+				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 
@@ -705,7 +706,8 @@ final class FluxWindowPredicate<T> extends FluxOperator<T, Flux<T>>
 			Subscriber<? super T> a = actual;
 
 			if (!queue.offer(t)) {
-				onError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t));
+				onError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t,
+						actual.currentContext()));
 				return;
 			}
 			if (enableOperatorFusion) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
@@ -212,7 +212,7 @@ final class FluxWindowPredicate<T> extends FluxOperator<T, Flux<T>>
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			WindowFlux<T> g = window;
@@ -253,7 +253,7 @@ final class FluxWindowPredicate<T> extends FluxOperator<T, Flux<T>>
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeOrSize.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeOrSize.java
@@ -194,7 +194,8 @@ final class FluxWindowTimeOrSize<T> extends FluxOperator<T, Flux<T>> {
 				//or the first emission, which will follow the subscribe
 			}
 			catch (RejectedExecutionException ree) {
-				RuntimeException error = Operators.onRejectedExecution(ree, subscription, null, null);
+				RuntimeException error = Operators.onRejectedExecution(ree, subscription, null, null,
+						actual.currentContext());
 				Operators.error(actual, error);
 			}
 		}
@@ -235,7 +236,7 @@ final class FluxWindowTimeOrSize<T> extends FluxOperator<T, Flux<T>> {
 				return true;
 			}
 			catch (RejectedExecutionException ree) {
-				onError(Operators.onRejectedExecution(ree));
+				onError(Operators.onRejectedExecution(ree, actual.currentContext()));
 				return false;
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
@@ -195,7 +195,7 @@ final class FluxWindowWhen<T, U, V> extends FluxOperator<T, Flux<T>> {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 			}
 		}
 
@@ -237,7 +237,7 @@ final class FluxWindowWhen<T, U, V> extends FluxOperator<T, Flux<T>> {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 
@@ -262,7 +262,7 @@ final class FluxWindowWhen<T, U, V> extends FluxOperator<T, Flux<T>> {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
@@ -402,7 +402,7 @@ final class FluxWindowWhen<T, U, V> extends FluxOperator<T, Flux<T>> {
 										this,
 										Operators.onOperatorError(s,
 												ex,
-												newWindow.value));
+												newWindow.value, actual.currentContext()));
 								continue;
 							}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWithLatestFrom.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWithLatestFrom.java
@@ -187,7 +187,7 @@ final class FluxWithLatestFrom<T, U, R> extends FluxOperator<T, R> {
 					"The combiner returned a null value");
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(this, e, t));
+					onError(Operators.onOperatorError(this, e, t, actual.currentContext()));
 					return;
 				}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxZip.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxZip.java
@@ -153,7 +153,8 @@ final class FluxZip<T, R> extends Flux<R> {
 			if (p == null) {
 				Operators.error(s,
 						Operators.onOperatorError(new NullPointerException(
-								"The sourcesIterable returned a null Publisher")));
+								"The sourcesIterable returned a null Publisher"),
+								s.currentContext()));
 				return;
 			}
 
@@ -166,7 +167,8 @@ final class FluxZip<T, R> extends Flux<R> {
 					v = callable.call();
 				}
 				catch (Throwable e) {
-					Operators.error(s, Operators.onOperatorError(e));
+					Operators.error(s, Operators.onOperatorError(e,
+							s.currentContext()));
 					return;
 				}
 
@@ -243,7 +245,8 @@ final class FluxZip<T, R> extends Flux<R> {
 					v = ((Callable<? extends T>) p).call();
 				}
 				catch (Throwable e) {
-					Operators.error(s, Operators.onOperatorError(e));
+					Operators.error(s, Operators.onOperatorError(e,
+							s.currentContext()));
 					return;
 				}
 
@@ -306,7 +309,7 @@ final class FluxZip<T, R> extends Flux<R> {
 							"The zipper returned a null value");
 				}
 				catch (Throwable e) {
-					s.onError(Operators.onOperatorError(e));
+					s.onError(Operators.onOperatorError(e, s.currentContext()));
 					return;
 				}
 
@@ -379,7 +382,8 @@ final class FluxZip<T, R> extends Flux<R> {
 							"The zipper returned a null value");
 				}
 				catch (Throwable e) {
-					actual.onError(Operators.onOperatorError(this, e, value));
+					actual.onError(Operators.onOperatorError(this, e, value,
+							actual.currentContext()));
 					return;
 				}
 
@@ -682,7 +686,8 @@ final class FluxZip<T, R> extends Flux<R> {
 								}
 							}
 							catch (Throwable ex) {
-								ex = Operators.onOperatorError(ex);
+								ex = Operators.onOperatorError(ex,
+										actual.currentContext());
 
 								cancelAll();
 
@@ -708,7 +713,8 @@ final class FluxZip<T, R> extends Flux<R> {
 					}
 					catch (Throwable ex) {
 
-						ex = Operators.onOperatorError(null, ex, values.clone());
+						ex = Operators.onOperatorError(null, ex, values.clone(),
+								actual.currentContext());
 						cancelAll();
 
 						Exceptions.addThrowable(ERROR, this, ex);
@@ -762,7 +768,8 @@ final class FluxZip<T, R> extends Flux<R> {
 								}
 							}
 							catch (Throwable ex) {
-								ex = Operators.onOperatorError(null, ex, values);
+								ex = Operators.onOperatorError(null, ex, values,
+										actual.currentContext());
 
 								cancelAll();
 
@@ -873,7 +880,8 @@ final class FluxZip<T, R> extends Flux<R> {
 		public void onNext(T t) {
 			if (sourceMode != ASYNC) {
 				if (!queue.offer(t)) {
-					onError(Operators.onOperatorError(s, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t));
+					onError(Operators.onOperatorError(s, Exceptions.failWithOverflow
+							(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), currentContext()));
 					return;
 				}
 			}
@@ -888,7 +896,7 @@ final class FluxZip<T, R> extends Flux<R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t, parent.actual.currentContext());
+				Operators.onErrorDropped(t, currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxZip.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxZip.java
@@ -393,7 +393,7 @@ final class FluxZip<T, R> extends Flux<R> {
 				actual.onError(e);
 			}
 			else {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 
@@ -482,7 +482,7 @@ final class FluxZip<T, R> extends Flux<R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, parent.currentContext());
 				return;
 			}
 			done = true;
@@ -493,7 +493,7 @@ final class FluxZip<T, R> extends Flux<R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, parent.currentContext());
 				return;
 			}
 			done = true;
@@ -612,7 +612,7 @@ final class FluxZip<T, R> extends Flux<R> {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 
@@ -888,7 +888,7 @@ final class FluxZip<T, R> extends Flux<R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, parent.actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxZipIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxZipIterable.java
@@ -56,7 +56,7 @@ final class FluxZipIterable<T, U, R> extends FluxOperator<T, R> {
 					"The other iterable produced a null iterator");
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 
@@ -66,7 +66,7 @@ final class FluxZipIterable<T, U, R> extends FluxOperator<T, R> {
 			b = it.hasNext();
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 
@@ -130,7 +130,7 @@ final class FluxZipIterable<T, U, R> extends FluxOperator<T, R> {
 			}
 			catch (Throwable e) {
 				done = true;
-				actual.onError(Operators.onOperatorError(s, e, t));
+				actual.onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 
@@ -142,7 +142,7 @@ final class FluxZipIterable<T, U, R> extends FluxOperator<T, R> {
 			}
 			catch (Throwable e) {
 				done = true;
-				actual.onError(Operators.onOperatorError(s, e, t));
+				actual.onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 
@@ -155,7 +155,7 @@ final class FluxZipIterable<T, U, R> extends FluxOperator<T, R> {
 			}
 			catch (Throwable e) {
 				done = true;
-				actual.onError(Operators.onOperatorError(s, e, t));
+				actual.onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxZipIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxZipIterable.java
@@ -119,7 +119,7 @@ final class FluxZipIterable<T, U, R> extends FluxOperator<T, R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -169,7 +169,7 @@ final class FluxZipIterable<T, U, R> extends FluxOperator<T, R> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/LambdaMonoSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/LambdaMonoSubscriber.java
@@ -128,7 +128,7 @@ final class LambdaMonoSubscriber<T> implements InnerConsumer<T>, Disposable {
 	public final void onNext(T x) {
 		Subscription s = S.getAndSet(this, Operators.cancelledSubscription());
 		if (s == Operators.cancelledSubscription()) {
-			Operators.onNextDropped(x);
+			Operators.onNextDropped(x, currentContext());
 			return;
 		}
 		if (consumer != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/LambdaMonoSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/LambdaMonoSubscriber.java
@@ -24,6 +24,7 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
+import reactor.util.context.Context;
 
 /**
  * An unbounded Java Lambda adapter to {@link Subscriber}, targetted at {@link Mono}.
@@ -100,7 +101,7 @@ final class LambdaMonoSubscriber<T> implements InnerConsumer<T>, Disposable {
 				completeConsumer.run();
 			}
 			catch (Throwable t) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, Context.empty());
 			}
 		}
 	}
@@ -109,7 +110,7 @@ final class LambdaMonoSubscriber<T> implements InnerConsumer<T>, Disposable {
 	public final void onError(Throwable t) {
 		Subscription s = S.getAndSet(this, Operators.cancelledSubscription());
 		if (s == Operators.cancelledSubscription()) {
-			Operators.onErrorDropped(t);
+			Operators.onErrorDropped(t, Context.empty());
 			return;
 		}
 		doError(t);
@@ -128,7 +129,7 @@ final class LambdaMonoSubscriber<T> implements InnerConsumer<T>, Disposable {
 	public final void onNext(T x) {
 		Subscription s = S.getAndSet(this, Operators.cancelledSubscription());
 		if (s == Operators.cancelledSubscription()) {
-			Operators.onNextDropped(x, currentContext());
+			Operators.onNextDropped(x, Context.empty());
 			return;
 		}
 		if (consumer != null) {
@@ -136,7 +137,7 @@ final class LambdaMonoSubscriber<T> implements InnerConsumer<T>, Disposable {
 				consumer.accept(x);
 			}
 			catch (Throwable t) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, Context.empty());
 				return;
 			}
 		}
@@ -145,7 +146,7 @@ final class LambdaMonoSubscriber<T> implements InnerConsumer<T>, Disposable {
 				completeConsumer.run();
 			}
 			catch (Throwable t) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, Context.empty());
 			}
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/LambdaSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/LambdaSubscriber.java
@@ -23,6 +23,8 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
+import reactor.util.context.Context;
+
 import javax.annotation.Nullable;
 
 /**
@@ -110,7 +112,7 @@ final class LambdaSubscriber<T>
 	public final void onError(Throwable t) {
 		Subscription s = S.getAndSet(this, Operators.cancelledSubscription());
 		if (s == Operators.cancelledSubscription()) {
-			Operators.onErrorDropped(t);
+			Operators.onErrorDropped(t, Context.empty());
 			return;
 		}
 		if (errorConsumer != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -2159,7 +2159,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * Add behavior triggering a {@link LongConsumer} when the {@link Mono} receives any request.
 	 * <p>
 	 *     Note that non fatal error raised in the callback will not be propagated and
-	 *     will simply trigger {@link Operators#onOperatorError(Throwable)}.
+	 *     will simply trigger {@link Operators#onOperatorError(Throwable, Context)}.
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.0.M3/src/docs/marble/doonrequest1.png" alt="">

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoAll.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoAll.java
@@ -98,7 +98,7 @@ final class MonoAll<T> extends MonoFromFluxOperator<T, Boolean>
 				b = predicate.test(t);
 			} catch (Throwable e) {
 				done = true;
-				actual.onError(Operators.onOperatorError(s, e, t));
+				actual.onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 			if (!b) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoAll.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoAll.java
@@ -112,7 +112,7 @@ final class MonoAll<T> extends MonoFromFluxOperator<T, Boolean>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoAny.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoAny.java
@@ -113,7 +113,7 @@ final class MonoAny<T> extends MonoFromFluxOperator<T, Boolean>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoAny.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoAny.java
@@ -99,7 +99,7 @@ final class MonoAny<T> extends MonoFromFluxOperator<T, Boolean>
 				b = predicate.test(t);
 			} catch (Throwable e) {
 				done = true;
-				actual.onError(Operators.onOperatorError(s, e, t));
+				actual.onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 				return;
 			}
 			if (b) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
@@ -114,7 +114,7 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
 		static final AtomicReferenceFieldUpdater<CoordinatorSubscriber, Operators.MonoSubscriber[]> SUBSCRIBERS =
 				AtomicReferenceFieldUpdater.newUpdater(CoordinatorSubscriber.class, Operators.MonoSubscriber[].class, "subscribers");
 
-		public CoordinatorSubscriber(MonoCacheTime<T> main) {
+		CoordinatorSubscriber(MonoCacheTime<T> main) {
 			this.main = main;
 			//noinspection unchecked
 			this.subscribers = EMPTY;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
@@ -248,7 +248,7 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
 		@Override
 		public void onNext(T t) {
 			if (main.state != this) {
-				Operators.onNextDropped(t);
+				Operators.onNextDroppedMulticast(t);
 				return;
 			}
 			signalCached(Signal.next(t));
@@ -257,7 +257,7 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
 		@Override
 		public void onError(Throwable t) {
 			if (main.state != this) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDroppedMulticast(t);
 				return;
 			}
 			signalCached(Signal.error(t));

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCallable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCallable.java
@@ -58,7 +58,7 @@ extends Mono<T>
 			t = Objects.requireNonNull(callable.call(), "callable returned null");
 		}
 		catch (Throwable e) {
-			actual.onError(Operators.onOperatorError(e));
+			actual.onError(Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollect.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollect.java
@@ -111,7 +111,7 @@ final class MonoCollect<T, R> extends MonoFromFluxOperator<T, R>
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -126,7 +126,7 @@ final class MonoCollect<T, R> extends MonoFromFluxOperator<T, R>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollect.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollect.java
@@ -59,7 +59,7 @@ final class MonoCollect<T, R> extends MonoFromFluxOperator<T, R>
 					"The supplier returned a null container");
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 
@@ -119,7 +119,7 @@ final class MonoCollect<T, R> extends MonoFromFluxOperator<T, R>
 				action.accept(value, t);
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(this, e, t));
+				onError(Operators.onOperatorError(this, e, t, actual.currentContext()));
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
@@ -52,7 +52,7 @@ final class MonoCollectList<T, C extends Collection<? super T>>
 					"The collectionSupplier returned a null collection");
 		}
 		catch (Throwable ex) {
-			Operators.error(actual, Operators.onOperatorError(ex));
+			Operators.error(actual, Operators.onOperatorError(ex, actual.currentContext()));
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
@@ -53,7 +53,7 @@ final class MonoCreate<T> extends Mono<T> {
 			callback.accept(emitter);
 		}
 		catch (Throwable ex) {
-			emitter.error(Operators.onOperatorError(ex));
+			emitter.error(Operators.onOperatorError(ex, actual.currentContext()));
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
@@ -163,7 +163,7 @@ final class MonoCreate<T> extends Mono<T> {
 				}
 			}
 			else {
-				Operators.onErrorDropped(e);
+				Operators.onErrorDropped(e, actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDefer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDefer.java
@@ -45,7 +45,7 @@ final class MonoDefer<T> extends Mono<T> {
 					"The Mono returned by the supplier is null");
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
@@ -58,7 +58,8 @@ final class MonoDelay extends Mono<Long> {
 		}
 		catch (RejectedExecutionException ree) {
 			if(r.cancel != OperatorDisposables.DISPOSED) {
-				actual.onError(Operators.onRejectedExecution(ree, r, null, null));
+				actual.onError(Operators.onRejectedExecution(ree, r, null, null,
+						actual.currentContext()));
 			}
 		}
 	}
@@ -110,7 +111,7 @@ final class MonoDelay extends Mono<Long> {
 					}
 				}
 				catch (Throwable t){
-					actual.onError(Operators.onOperatorError(t));
+					actual.onError(Operators.onOperatorError(t, actual.currentContext()));
 				}
 			} else {
 				actual.onError(Exceptions.failWithOverflow("Could not emit value due to lack of requests"));

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelayElement.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelayElement.java
@@ -107,7 +107,7 @@ final class MonoDelayElement<T> extends MonoOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			this.done = true;
@@ -131,7 +131,7 @@ final class MonoDelayElement<T> extends MonoOperator<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			this.done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelayElement.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelayElement.java
@@ -115,7 +115,8 @@ final class MonoDelayElement<T> extends MonoOperator<T, T> {
 				this.task = scheduler.schedule(() -> complete(t), delay, unit);
 			}
 			catch (RejectedExecutionException ree) {
-				throw Operators.onRejectedExecution(ree, this, null, t);
+				throw Operators.onRejectedExecution(ree, this, null, t,
+						actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDoFinally.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDoFinally.java
@@ -28,7 +28,7 @@ import reactor.core.CoreSubscriber;
  * {@link SignalType#CANCEL}).
  * <p>
  * Note that any exception thrown by the hook are caught and bubbled up
- * using {@link Operators#onErrorDropped(Throwable)}.
+ * using {@link Operators#onErrorDropped(Throwable, reactor.util.context.Context)}.
  *
  * @param <T> the value type
  * @author Simon Baslé

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDoFinallyFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDoFinallyFuseable.java
@@ -29,7 +29,7 @@ import reactor.core.Fuseable;
  * {@link SignalType#CANCEL}).
  * <p>
  * Note that any exception thrown by the hook are caught and bubbled up
- * using {@link Operators#onErrorDropped(Throwable)}.
+ * using {@link Operators#onErrorDropped(Throwable, reactor.util.context.Context)}.
  *
  * @param <T> the value type
  * @author Simon Baslé

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoElementAt.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoElementAt.java
@@ -150,7 +150,7 @@ final class MonoElementAt<T> extends MonoFromFluxOperator<T, T>
 			}
 			else{
 				actual.onError(Operators.onOperatorError(new
-						IndexOutOfBoundsException()));
+						IndexOutOfBoundsException(), actual.currentContext()));
 			}
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoElementAt.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoElementAt.java
@@ -111,7 +111,7 @@ final class MonoElementAt<T> extends MonoFromFluxOperator<T, T>
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -130,7 +130,7 @@ final class MonoElementAt<T> extends MonoFromFluxOperator<T, T>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoError.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoError.java
@@ -49,7 +49,7 @@ final class MonoError<T> extends Mono<T> implements Fuseable.ScalarCallable{
 
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
-		Operators.error(actual, Operators.onOperatorError(error));
+		Operators.error(actual, Operators.onOperatorError(error, actual.currentContext()));
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFilterWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFilterWhen.java
@@ -262,7 +262,7 @@ class MonoFilterWhen<T> extends MonoOperator<T, T> {
 				done = true;
 				main.innerError(t);
 			} else {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, main.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFirst.java
@@ -77,7 +77,8 @@ final class MonoFirst<T> extends Mono<T> {
 				it = Objects.requireNonNull(iterable.iterator(), "The iterator returned is null");
 			}
 			catch (Throwable e) {
-				Operators.error(actual, Operators.onOperatorError(e));
+				Operators.error(actual, Operators.onOperatorError(e,
+						actual.currentContext()));
 				return;
 			}
 
@@ -89,7 +90,8 @@ final class MonoFirst<T> extends Mono<T> {
 					b = it.hasNext();
 				}
 				catch (Throwable e) {
-					Operators.error(actual, Operators.onOperatorError(e));
+					Operators.error(actual, Operators.onOperatorError(e,
+							actual.currentContext()));
 					return;
 				}
 
@@ -104,7 +106,8 @@ final class MonoFirst<T> extends Mono<T> {
 					"The Publisher returned by the iterator is null");
 				}
 				catch (Throwable e) {
-					Operators.error(actual, Operators.onOperatorError(e));
+					Operators.error(actual, Operators.onOperatorError(e,
+							actual.currentContext()));
 					return;
 				}
 
@@ -130,7 +133,8 @@ final class MonoFirst<T> extends Mono<T> {
 
 			if (p == null) {
 				Operators.error(actual,
-						Operators.onOperatorError(new NullPointerException("The single source Publisher is null")));
+						Operators.onOperatorError(new NullPointerException("The single source Publisher is null"),
+								actual.currentContext()));
 			}
 			else {
 				p.subscribe(actual);

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMap.java
@@ -119,7 +119,8 @@ final class MonoFlatMap<T, R> extends MonoOperator<T, R> implements Fuseable {
 						"The mapper returned a null Mono");
 			}
 			catch (Throwable ex) {
-				actual.onError(Operators.onOperatorError(s, ex, t));
+				actual.onError(Operators.onOperatorError(s, ex, t,
+						actual.currentContext()));
 				return;
 			}
 
@@ -131,7 +132,8 @@ final class MonoFlatMap<T, R> extends MonoOperator<T, R> implements Fuseable {
 					v = c.call();
 				}
 				catch (Throwable ex) {
-					actual.onError(Operators.onOperatorError(s, ex, t));
+					actual.onError(Operators.onOperatorError(s, ex, t,
+							actual.currentContext()));
 					return;
 				}
 
@@ -148,7 +150,8 @@ final class MonoFlatMap<T, R> extends MonoOperator<T, R> implements Fuseable {
 				m.subscribe(second);
 			}
 			catch (Throwable e) {
-				actual.onError(Operators.onOperatorError(this, e, t));
+				actual.onError(Operators.onOperatorError(this, e, t,
+						actual.currentContext()));
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMap.java
@@ -107,7 +107,7 @@ final class MonoFlatMap<T, R> extends MonoOperator<T, R> implements Fuseable {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -155,7 +155,7 @@ final class MonoFlatMap<T, R> extends MonoOperator<T, R> implements Fuseable {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -231,7 +231,7 @@ final class MonoFlatMap<T, R> extends MonoOperator<T, R> implements Fuseable {
 		@Override
 		public void onNext(R t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, parent.currentContext());
 				return;
 			}
 			done = true;
@@ -241,7 +241,7 @@ final class MonoFlatMap<T, R> extends MonoOperator<T, R> implements Fuseable {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, parent.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMapMany.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMapMany.java
@@ -154,7 +154,8 @@ final class MonoFlatMapMany<T, R> extends FluxFromMonoOperator<T, R> {
 						"The mapper returned a null Publisher.");
 			}
 			catch (Throwable ex) {
-				actual.onError(Operators.onOperatorError(this, ex, t));
+				actual.onError(Operators.onOperatorError(this, ex, t,
+						actual.currentContext()));
 				return;
 			}
 
@@ -165,7 +166,8 @@ final class MonoFlatMapMany<T, R> extends FluxFromMonoOperator<T, R> {
 					v = ((Callable<R>) p).call();
 				}
 				catch (Throwable ex) {
-					actual.onError(Operators.onOperatorError(this, ex, t));
+					actual.onError(Operators.onOperatorError(this, ex, t,
+							actual.currentContext()));
 					return;
 				}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMapMany.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMapMany.java
@@ -185,7 +185,7 @@ final class MonoFlatMapMany<T, R> extends FluxFromMonoOperator<T, R> {
 		@Override
 		public void onError(Throwable t) {
 			if (hasValue) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			actual.onError(t);

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFlattenIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFlattenIterable.java
@@ -71,7 +71,8 @@ final class MonoFlattenIterable<T, R> extends FluxFromMonoOperator<T, R>
 				v = ((Callable<T>) source).call();
 			}
 			catch (Throwable ex) {
-				Operators.error(actual, Operators.onOperatorError(ex));
+				Operators.error(actual, Operators.onOperatorError(ex,
+						actual.currentContext()));
 				return;
 			}
 
@@ -88,7 +89,8 @@ final class MonoFlattenIterable<T, R> extends FluxFromMonoOperator<T, R>
 				it = iter.iterator();
 			}
 			catch (Throwable ex) {
-				Operators.error(actual, Operators.onOperatorError(ex));
+				Operators.error(actual, Operators.onOperatorError(ex,
+						actual.currentContext()));
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoIgnoreThen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoIgnoreThen.java
@@ -281,7 +281,7 @@ final class MonoIgnoreThen<T> extends Mono<T> implements Fuseable {
         @Override
         public void onNext(T t) {
             if (done) {
-                Operators.onNextDropped(t);
+                Operators.onNextDropped(t, parent.currentContext());
                 return;
             }
             done = true;
@@ -291,7 +291,7 @@ final class MonoIgnoreThen<T> extends Mono<T> implements Fuseable {
         @Override
         public void onError(Throwable t) {
             if (done) {
-                Operators.onErrorDropped(t);
+                Operators.onErrorDropped(t, parent.currentContext());
                 return;
             }
             done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoIgnoreThen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoIgnoreThen.java
@@ -130,7 +130,8 @@ final class MonoIgnoreThen<T> extends Mono<T> implements Fuseable {
                                 v = ((Callable<T>)m).call();
                             }
                             catch (Throwable ex) {
-	                            actual.onError(Operators.onOperatorError(ex));
+	                            actual.onError(Operators.onOperatorError(ex,
+                                        actual.currentContext()));
 	                            return;
                             }
                             
@@ -154,7 +155,8 @@ final class MonoIgnoreThen<T> extends Mono<T> implements Fuseable {
                                 ((Callable<?>)m).call();
                             }
                             catch (Throwable ex) {
-	                            actual.onError(Operators.onOperatorError(ex));
+	                            actual.onError(Operators.onOperatorError(ex,
+                                        actual.currentContext()));
 	                            return;
                             }
                             

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoNext.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoNext.java
@@ -68,7 +68,7 @@ final class MonoNext<T> extends MonoFromFluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -80,7 +80,7 @@ final class MonoNext<T> extends MonoFromFluxOperator<T, T> {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPeekTerminal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPeekTerminal.java
@@ -154,7 +154,7 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t);
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 				//implementation note: this operator doesn't expect the source to be anything but a Mono
@@ -188,7 +188,8 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 					}
 					catch (Throwable e) {
 						//don't invoke error callback, see https://github.com/reactor/reactor-core/issues/270
-						Operators.onErrorDropped(Operators.onOperatorError(s, e, t));
+						Operators.onErrorDropped(Operators.onOperatorError(s, e, t),
+								actual.currentContext());
 					}
 				}
 			}
@@ -197,7 +198,7 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return false;
 			}
 			if (actualConditional == null) {
@@ -236,7 +237,8 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 				}
 				catch (Throwable e) {
 					//don't invoke error callback, see https://github.com/reactor/reactor-core/issues/270
-					Operators.onErrorDropped(Operators.onOperatorError(s, e, t));
+					Operators.onErrorDropped(Operators.onOperatorError(s, e, t),
+							actual.currentContext());
 				}
 			}
 
@@ -246,7 +248,7 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -275,7 +277,8 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 				}
 				catch (Throwable e) {
 					//don't invoke error callback, see https://github.com/reactor/reactor-core/issues/270
-					Operators.onErrorDropped(Operators.onOperatorError(e));
+					Operators.onErrorDropped(Operators.onOperatorError(e),
+							actual.currentContext());
 				}
 			}
 		}
@@ -315,7 +318,8 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 				}
 				catch (Throwable e) {
 					//don't invoke error callback, see https://github.com/reactor/reactor-core/issues/270
-					Operators.onErrorDropped(Operators.onOperatorError(e));
+					Operators.onErrorDropped(Operators.onOperatorError(e),
+							actual.currentContext());
 				}
 			}
 		}
@@ -353,7 +357,8 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 						parent.onAfterTerminateCall.accept(v, null);
 					}
 					catch (Throwable t) {
-						Operators.onErrorDropped(Operators.onOperatorError(t));
+						Operators.onErrorDropped(Operators.onOperatorError(t),
+								actual.currentContext());
 					}
 				}
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPeekTerminal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPeekTerminal.java
@@ -166,7 +166,8 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 						parent.onTerminateCall.accept(t, null);
 					}
 					catch (Throwable e) {
-						onError(Operators.onOperatorError(s, e, t));
+						onError(Operators.onOperatorError(s, e, t,
+								actual.currentContext()));
 						return;
 					}
 				}
@@ -175,7 +176,8 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 						parent.onSuccessCall.accept(t);
 					}
 					catch (Throwable e) {
-						onError(Operators.onOperatorError(s, e, t));
+						onError(Operators.onOperatorError(s, e, t,
+								actual.currentContext()));
 						return;
 					}
 				}
@@ -188,7 +190,8 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 					}
 					catch (Throwable e) {
 						//don't invoke error callback, see https://github.com/reactor/reactor-core/issues/270
-						Operators.onErrorDropped(Operators.onOperatorError(s, e, t),
+						Operators.onErrorDropped(Operators.onOperatorError(s, e, t,
+								actual.currentContext()),
 								actual.currentContext());
 					}
 				}
@@ -215,7 +218,7 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 					parent.onTerminateCall.accept(t, null);
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					return false;
 				}
 			}
@@ -224,7 +227,7 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 					parent.onSuccessCall.accept(t);
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t));
+					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					return false;
 				}
 			}
@@ -237,7 +240,8 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 				}
 				catch (Throwable e) {
 					//don't invoke error callback, see https://github.com/reactor/reactor-core/issues/270
-					Operators.onErrorDropped(Operators.onOperatorError(s, e, t),
+					Operators.onErrorDropped(Operators.onOperatorError(s, e, t,
+							actual.currentContext()),
 							actual.currentContext());
 				}
 			}
@@ -258,7 +262,7 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 					parent.onTerminateCall.accept(null, t);
 				}
 				catch (Throwable e) {
-					t = Operators.onOperatorError(null, e, t);
+					t = Operators.onOperatorError(null, e, t, actual.currentContext());
 				}
 			}
 
@@ -277,7 +281,8 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 				}
 				catch (Throwable e) {
 					//don't invoke error callback, see https://github.com/reactor/reactor-core/issues/270
-					Operators.onErrorDropped(Operators.onOperatorError(e),
+					Operators.onErrorDropped(Operators.onOperatorError(e,
+							actual.currentContext()),
 							actual.currentContext());
 				}
 			}
@@ -294,7 +299,7 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 						parent.onTerminateCall.accept(null, null);
 					}
 					catch (Throwable e) {
-						onError(Operators.onOperatorError(s, e));
+						onError(Operators.onOperatorError(s, e, actual.currentContext()));
 						return;
 					}
 				}
@@ -303,7 +308,7 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 						parent.onSuccessCall.accept(null);
 					}
 					catch (Throwable e) {
-						onError(Operators.onOperatorError(s, e));
+						onError(Operators.onOperatorError(s, e, actual.currentContext()));
 						return;
 					}
 				}
@@ -318,7 +323,8 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 				}
 				catch (Throwable e) {
 					//don't invoke error callback, see https://github.com/reactor/reactor-core/issues/270
-					Operators.onErrorDropped(Operators.onOperatorError(e),
+					Operators.onErrorDropped(Operators.onOperatorError(e,
+							actual.currentContext()),
 							actual.currentContext());
 				}
 			}
@@ -341,7 +347,8 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 						parent.onTerminateCall.accept(v, null);
 					}
 					catch (Throwable e) {
-						throw Exceptions.propagate(Operators.onOperatorError(s, e, v));
+						throw Exceptions.propagate(Operators.onOperatorError(s, e, v,
+								actual.currentContext()));
 					}
 				}
 				if (parent.onSuccessCall != null) {
@@ -349,7 +356,8 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 						parent.onSuccessCall.accept(v);
 					}
 					catch (Throwable e) {
-						throw Exceptions.propagate(Operators.onOperatorError(s, e, v));
+						throw Exceptions.propagate(Operators.onOperatorError(s, e, v,
+								actual.currentContext()));
 					}
 				}
 				if (parent.onAfterTerminateCall != null) {
@@ -357,7 +365,8 @@ final class MonoPeekTerminal<T> extends MonoOperator<T, T> implements Fuseable {
 						parent.onAfterTerminateCall.accept(v, null);
 					}
 					catch (Throwable t) {
-						Operators.onErrorDropped(Operators.onOperatorError(t),
+						Operators.onErrorDropped(Operators.onOperatorError(t,
+								actual.currentContext()),
 								actual.currentContext());
 					}
 				}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -33,6 +33,7 @@ import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.util.concurrent.WaitStrategy;
+import reactor.util.context.Context;
 
 /**
  * A {@code MonoProcessor} is a {@link Mono} extension that implements stateful semantics. Multi-subscribe is allowed.
@@ -275,7 +276,7 @@ public final class MonoProcessor<O> extends Mono<O>
 		Subscription s = subscription;
 
 		if ((source != null && s == null) || this.error != null) {
-			Operators.onErrorDropped(cause);
+			Operators.onErrorDroppedMulticast(cause);
 			return;
 		}
 
@@ -286,7 +287,7 @@ public final class MonoProcessor<O> extends Mono<O>
 		int state = this.state;
 		for (; ; ) {
 			if (state != STATE_READY && state != STATE_SUBSCRIBED && state != STATE_POST_SUBSCRIBED) {
-				Operators.onErrorDropped(cause);
+				Operators.onErrorDroppedMulticast(cause);
 				return;
 			}
 			if (STATE.compareAndSet(this, state, STATE_ERROR)) {
@@ -305,7 +306,7 @@ public final class MonoProcessor<O> extends Mono<O>
 		Subscription s = subscription;
 
 		if (value != null && ((source != null && s == null) || this.value != null)) {
-			Operators.onNextDropped(value);
+			Operators.onNextDroppedMulticast(value);
 			return;
 		}
 		subscription = null;
@@ -328,7 +329,7 @@ public final class MonoProcessor<O> extends Mono<O>
 		for (; ; ) {
 			if (state != STATE_READY && state != STATE_SUBSCRIBED && state != STATE_POST_SUBSCRIBED) {
 				if(value != null) {
-					Operators.onNextDropped(value);
+					Operators.onNextDroppedMulticast(value);
 				}
 				return;
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPublishMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPublishMulticast.java
@@ -57,7 +57,7 @@ final class MonoPublishMulticast<T, R> extends MonoOperator<T, R> implements Fus
 					"The transform returned a null Mono");
 		}
 		catch (Throwable ex) {
-			Operators.error(actual, Operators.onOperatorError(ex));
+			Operators.error(actual, Operators.onOperatorError(ex, actual.currentContext()));
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPublishOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPublishOn.java
@@ -136,7 +136,7 @@ final class MonoPublishOn<T> extends MonoOperator<T, T> {
 				}
 				catch (RejectedExecutionException ree) {
 					actual.onError(Operators.onRejectedExecution(ree, subscription,
-							suppressed,	dataSignal));
+							suppressed,	dataSignal, actual.currentContext()));
 				}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoReduce.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoReduce.java
@@ -83,7 +83,7 @@ final class MonoReduce<T> extends MonoFromFluxOperator<T, T>
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			T r = result;
@@ -109,7 +109,7 @@ final class MonoReduce<T> extends MonoFromFluxOperator<T, T>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoReduce.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoReduce.java
@@ -98,7 +98,8 @@ final class MonoReduce<T> extends MonoFromFluxOperator<T, T>
 				catch (Throwable ex) {
 					result = null;
 					done = true;
-					actual.onError(Operators.onOperatorError(s, ex, t));
+					actual.onError(Operators.onOperatorError(s, ex, t,
+							actual.currentContext()));
 					return;
 				}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoReduceSeed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoReduceSeed.java
@@ -132,7 +132,7 @@ final class MonoReduceSeed<T, R> extends MonoFromFluxOperator<T, R>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoReduceSeed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoReduceSeed.java
@@ -58,7 +58,7 @@ final class MonoReduceSeed<T, R> extends MonoFromFluxOperator<T, R>
 					"The initial value supplied is null");
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 
@@ -122,7 +122,7 @@ final class MonoReduceSeed<T, R> extends MonoFromFluxOperator<T, R>
 
 			}
 			catch (Throwable e) {
-				onError(Operators.onOperatorError(this, e, t));
+				onError(Operators.onOperatorError(this, e, t, actual.currentContext()));
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoRepeatWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoRepeatWhen.java
@@ -69,7 +69,7 @@ final class MonoRepeatWhen<T> extends FluxFromMonoOperator<T, T> {
 					"The whenSourceFactory returned a null Publisher");
 		}
 		catch (Throwable e) {
-			actual.onError(Operators.onOperatorError(e));
+			actual.onError(Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoRunnable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoRunnable.java
@@ -39,7 +39,7 @@ final class MonoRunnable<T> extends Mono<T> implements Callable<Void> {
         try {
             run.run();
         } catch (Throwable ex) {
-            Operators.error(actual, Operators.onOperatorError(ex));
+            Operators.error(actual, Operators.onOperatorError(ex, actual.currentContext()));
             return;
         }
         Operators.complete(actual);

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSequenceEqual.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSequenceEqual.java
@@ -240,7 +240,8 @@ final class MonoSequenceEqual<T> extends Mono<Boolean> {
 							Exceptions.throwIfFatal(ex);
 							cancel(s1, q1, s2, q2);
 
-							actual.onError(Operators.onOperatorError(ex));
+							actual.onError(Operators.onOperatorError(ex,
+									actual.currentContext()));
 							return;
 						}
 
@@ -328,7 +329,8 @@ final class MonoSequenceEqual<T> extends Mono<Boolean> {
 		public void onNext(T t) {
 			if (!queue.offer(t)) {
 				onError(Operators.onOperatorError(cachedSubscription, Exceptions
-						.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t));
+						.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t,
+						currentContext()));
 				return;
 			}
 			parent.drain();

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSingle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSingle.java
@@ -117,7 +117,7 @@ final class MonoSingle<T> extends MonoFromFluxOperator<T, T>
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			value = t;
@@ -132,7 +132,7 @@ final class MonoSingle<T> extends MonoFromFluxOperator<T, T>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSingle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSingle.java
@@ -162,7 +162,8 @@ final class MonoSingle<T> extends MonoFromFluxOperator<T, T>
 				}
 				else {
 					actual.onError(Operators.onOperatorError(this,
-							new NoSuchElementException("Source was empty")));
+							new NoSuchElementException("Source was empty"),
+							actual.currentContext()));
 				}
 			}
 			else if (c == 1) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoStreamCollector.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoStreamCollector.java
@@ -118,7 +118,7 @@ final class MonoStreamCollector<T, A, R> extends MonoFromFluxOperator<T, R>
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			try {
@@ -132,7 +132,7 @@ final class MonoStreamCollector<T, A, R> extends MonoFromFluxOperator<T, R>
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoStreamCollector.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoStreamCollector.java
@@ -62,7 +62,7 @@ final class MonoStreamCollector<T, A, R> extends MonoFromFluxOperator<T, R>
 			finisher = collector.finisher();
 		}
 		catch (Throwable ex) {
-			Operators.error(actual, Operators.onOperatorError(ex));
+			Operators.error(actual, Operators.onOperatorError(ex, actual.currentContext()));
 			return;
 		}
 
@@ -125,7 +125,7 @@ final class MonoStreamCollector<T, A, R> extends MonoFromFluxOperator<T, R>
 				accumulator.accept(container, t);
 			}
 			catch (Throwable ex) {
-				onError(Operators.onOperatorError(s, ex, t));
+				onError(Operators.onOperatorError(s, ex, t, actual.currentContext()));
 			}
 		}
 
@@ -156,7 +156,7 @@ final class MonoStreamCollector<T, A, R> extends MonoFromFluxOperator<T, R>
 				r = finisher.apply(a);
 			}
 			catch (Throwable ex) {
-				actual.onError(Operators.onOperatorError(ex));
+				actual.onError(Operators.onOperatorError(ex, actual.currentContext()));
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOn.java
@@ -56,7 +56,8 @@ final class MonoSubscribeOn<T> extends MonoOperator<T, T> {
 		}
 		catch (RejectedExecutionException ree) {
 			if (parent.s != Operators.cancelledSubscription()) {
-				actual.onError(Operators.onRejectedExecution(ree, parent, null, null));
+				actual.onError(Operators.onRejectedExecution(ree, parent, null, null,
+						actual.currentContext()));
 			}
 		}
 	}
@@ -168,7 +169,8 @@ final class MonoSubscribeOn<T> extends MonoOperator<T, T> {
 			}
 			catch (RejectedExecutionException ree) {
 				if (!worker.isDisposed()) {
-					actual.onError(Operators.onRejectedExecution(ree, this, null, null));
+					actual.onError(Operators.onRejectedExecution(ree, this, null, null,
+							actual.currentContext()));
 				}
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOnCallable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOnCallable.java
@@ -21,7 +21,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.RejectedExecutionException;
 
 import reactor.core.CoreSubscriber;
-import reactor.core.Disposable;
 import reactor.core.Fuseable;
 import reactor.core.scheduler.Scheduler;
 
@@ -53,7 +52,7 @@ final class MonoSubscribeOnCallable<T> extends Mono<T> implements Fuseable {
 		}
 		catch (RejectedExecutionException ree) {
 			if(parent.state != FluxSubscribeOnCallable.CallableSubscribeOnSubscription.HAS_CANCELLED) {
-				actual.onError(Operators.onRejectedExecution(ree));
+				actual.onError(Operators.onRejectedExecution(ree, actual.currentContext()));
 			}
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOnValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOnValue.java
@@ -52,7 +52,8 @@ final class MonoSubscribeOnValue<T> extends Mono<T> {
 			}
 			catch (RejectedExecutionException ree) {
 				if (parent.future != OperatorDisposables.DISPOSED) {
-					actual.onError(Operators.onRejectedExecution(ree));
+					actual.onError(Operators.onRejectedExecution(ree,
+							actual.currentContext()));
 				}
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSubscriberContext.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSubscriberContext.java
@@ -40,7 +40,7 @@ final class MonoSubscriberContext<T> extends MonoOperator<T, T> implements Fusea
 			c = doOnContext.apply(actual.currentContext());
 		}
 		catch (Throwable t) {
-			Operators.error(actual, Operators.onOperatorError(t));
+			Operators.error(actual, Operators.onOperatorError(t, actual.currentContext()));
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSupplier.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSupplier.java
@@ -57,7 +57,7 @@ extends Mono<T>
 					"The supplier source returned null");
 		}
 		catch (Throwable e) {
-			actual.onError(Operators.onOperatorError(e));
+			actual.onError(Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTakeLastOne.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTakeLastOne.java
@@ -98,7 +98,8 @@ final class MonoTakeLastOne<T> extends MonoFromFluxOperator<T, T>
 					}
 					else {
 						actual.onError(Operators.onOperatorError(new NoSuchElementException(
-								"Flux#last() didn't observe any " + "onNext signal")));
+								"Flux#last() didn't observe any " + "onNext signal"),
+								actual.currentContext()));
 					}
 				}
 				else {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoToCompletableFuture.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoToCompletableFuture.java
@@ -58,7 +58,7 @@ final class MonoToCompletableFuture<T> extends CompletableFuture<T> implements C
 			s.cancel();
 		}
 		else {
-			Operators.onNextDropped(t);
+			Operators.onNextDropped(t, currentContext());
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoToCompletableFuture.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoToCompletableFuture.java
@@ -18,7 +18,6 @@ package reactor.core.publisher;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoUsing.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoUsing.java
@@ -70,7 +70,7 @@ final class MonoUsing<T, S> extends Mono<T> implements Fuseable {
 			resource = resourceSupplier.call();
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 
@@ -86,11 +86,11 @@ final class MonoUsing<T, S> extends Mono<T> implements Fuseable {
 				resourceCleanup.accept(resource);
 			}
 			catch (Throwable ex) {
-				ex.addSuppressed(Operators.onOperatorError(e));
+				ex.addSuppressed(Operators.onOperatorError(e, actual.currentContext()));
 				e = ex;
 			}
 
-			Operators.error(actual, Operators.onOperatorError(e));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoZip.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoZip.java
@@ -240,7 +240,8 @@ final class MonoZip<T, R> extends Mono<R> {
 				            "zipper produced a null value");
 	            }
 	            catch (Throwable t) {
-		            actual.onError(Operators.onOperatorError(null, t, o));
+		            actual.onError(Operators.onOperatorError(null, t, o,
+				            actual.currentContext()));
 		            return;
 	            }
 	            complete(r);

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -66,6 +66,13 @@ public abstract class Operators {
 	public static final String KEY_ON_OPERATOR_ERROR = "reactor.onOperatorError.local";
 
 	/**
+	 * A key that can be used to store a sequence-specific {@link Hooks#onOperatorError(BiFunction)}
+	 * hook THAT IS ONLY APPLIED TO Operators{@link #onRejectedExecution(Throwable, Context) onRejectedExecution}
+	 * in a {@link Context}, as a {@link BiFunction BiFunction&lt;Throwable, Object, Throwable&gt;}.
+	 */
+	public static final String KEY_ON_REJECTED_EXECUTION = "reactor.onRejectedExecution.local";
+
+	/**
 	 * Concurrent addition bound to Long.MAX_VALUE. Any concurrent write will "happen
 	 * before" this operation.
 	 *
@@ -470,6 +477,11 @@ public abstract class Operators {
 			@Nullable Throwable suppressed,
 			@Nullable Object dataSignal,
 			Context context) {
+		//we "cheat" to apply the special key for onRejectedExecution in onOperatorError
+		if (context.hasKey(KEY_ON_REJECTED_EXECUTION)) {
+			context = context.put(KEY_ON_OPERATOR_ERROR, context.get(KEY_ON_REJECTED_EXECUTION));
+		}
+
 		//FIXME only create REE if original is REE singleton OR there's suppressed OR there's Throwable dataSignal
 		RejectedExecutionException ree = Exceptions.failWithRejected(original);
 		if (suppressed != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -48,6 +48,24 @@ import reactor.util.context.Context;
 public abstract class Operators {
 
 	/**
+	 * A key that can be used to store a sequence-specific {@link Hooks#onErrorDropped(Consumer)}
+	 * hook in a {@link Context}, as a {@link Consumer Consumer&lt;Throwable&gt;}.
+	 */
+	public static final String KEY_ON_ERROR_DROPPED = "reactor.onErrorDropped.local";
+
+	/**
+	 * A key that can be used to store a sequence-specific {@link Hooks#onNextDropped(Consumer)}
+	 * hook in a {@link Context}, as a {@link Consumer Consumer&lt;Object&gt;}.
+	 */
+	public static final String KEY_ON_NEXT_DROPPED = "reactor.onNextDropped.local";
+
+	/**
+	 * A key that can be used to store a sequence-specific {@link Hooks#onOperatorError(BiFunction)}
+	 * hook in a {@link Context}, as a {@link BiFunction BiFunction&lt;Throwable, Object, Throwable&gt;}.
+	 */
+	public static final String KEY_ON_OPERATOR_ERROR = "reactor.onOperatorError.local";
+
+	/**
 	 * Concurrent addition bound to Long.MAX_VALUE. Any concurrent write will "happen
 	 * before" this operation.
 	 *
@@ -275,7 +293,7 @@ public abstract class Operators {
 	 * @see #onErrorDropped(Throwable, Context)
 	 */
 	public static void onErrorDroppedMulticast(Throwable e) {
-		//FIXME let this method go through multiple contexts and use their local handlers
+		//TODO let this method go through multiple contexts and use their local handlers
 		//if at least one has no local handler, also call onErrorDropped(e, Context.empty())
 		onErrorDropped(e, Context.empty());
 	}
@@ -284,11 +302,13 @@ public abstract class Operators {
 	 * An unexpected exception is about to be dropped.
 	 *
 	 * @param e the dropped exception
-	 * @param context a context that might hold a local error consumer
+	 * @param context a context that might hold a local error consumer (see {@link #KEY_ON_ERROR_DROPPED})
 	 */
 	public static void onErrorDropped(Throwable e, Context context) {
-		//FIXME check for hook in context first
-		Consumer<? super Throwable> hook = Hooks.onErrorDroppedHook;
+		Consumer<? super Throwable> hook = context.getOrDefault(KEY_ON_ERROR_DROPPED,null);
+		if (hook == null) {
+			hook = Hooks.onErrorDroppedHook;
+		}
 		if (hook == null) {
 			throw Exceptions.bubble(e);
 		}
@@ -307,7 +327,7 @@ public abstract class Operators {
 	 * @see #onNextDropped(Object, Context)
 	 */
 	public static <T> void onNextDroppedMulticast(T t) {
-		//FIXME let this method go through multiple contexts and use their local handlers
+		//TODO let this method go through multiple contexts and use their local handlers
 		//if at least one has no local handler, also call onNextDropped(t, Context.empty())
 		onNextDropped(t, Context.empty());
 	}
@@ -320,13 +340,15 @@ public abstract class Operators {
 	 *
 	 * @param <T> the dropped value type
 	 * @param t the dropped data
-	 * @param context a context that might hold a local error consumer
+	 * @param context a context that might hold a local next consumer (see {@link #KEY_ON_NEXT_DROPPED})
 	 */
 	public static <T> void onNextDropped(T t, Context context) {
 		Objects.requireNonNull(t, "onNext");
 		Objects.requireNonNull(context, "context");
-		//FIXME check for hook in context first
-		Consumer<Object> hook = Hooks.onNextDroppedHook;
+		Consumer<Object> hook = context.getOrDefault(KEY_ON_NEXT_DROPPED, null);
+		if (hook == null) {
+			hook = Hooks.onNextDroppedHook;
+		}
 		if (hook != null) {
 			hook.accept(t);
 		}
@@ -393,9 +415,11 @@ public abstract class Operators {
 		}
 
 		Throwable t = Exceptions.unwrap(error);
-		//FIXME check for hook in context first
 		BiFunction<? super Throwable, Object, ? extends Throwable> hook =
-				Hooks.onOperatorErrorHook;
+				context.getOrDefault(KEY_ON_OPERATOR_ERROR, null);
+		if (hook == null) {
+			hook = Hooks.onOperatorErrorHook;
+		}
 		if (hook == null) {
 			if (dataSignal != null) {
 				if (dataSignal != t && dataSignal instanceof Throwable) {
@@ -452,13 +476,10 @@ public abstract class Operators {
 			ree.addSuppressed(suppressed);
 		}
 		if (dataSignal != null) {
-			return Exceptions.propagate(Operators.onOperatorError(subscription, ree, dataSignal,
-					//TODO shouldn't we use the passed Context here?
-					Context.empty()));
+			return Exceptions.propagate(Operators.onOperatorError(subscription, ree,
+					dataSignal, context));
 		}
-		return Exceptions.propagate(Operators.onOperatorError(subscription, ree,
-				//TODO shouldn't we use the passed Context here?
-				Context.empty()));
+		return Exceptions.propagate(Operators.onOperatorError(subscription, ree, context));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelCollect.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelCollect.java
@@ -137,7 +137,7 @@ final class ParallelCollect<T, C> extends ParallelFlux<C> implements Scannable, 
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -152,7 +152,7 @@ final class ParallelCollect<T, C> extends ParallelFlux<C> implements Scannable, 
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelCollect.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelCollect.java
@@ -81,7 +81,8 @@ final class ParallelCollect<T, C> extends ParallelFlux<C> implements Scannable, 
 						"The initialSupplier returned a null value");
 			}
 			catch (Throwable ex) {
-				reportError(subscribers, Operators.onOperatorError(ex));
+				reportError(subscribers, Operators.onOperatorError(ex,
+						subscribers[i].currentContext()));
 				return;
 			}
 
@@ -145,7 +146,7 @@ final class ParallelCollect<T, C> extends ParallelFlux<C> implements Scannable, 
 				collector.accept(collection, t);
 			}
 			catch (Throwable ex) {
-				onError(Operators.onOperatorError(this, ex, t));
+				onError(Operators.onOperatorError(this, ex, t, actual.currentContext()));
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeReduce.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeReduce.java
@@ -160,7 +160,7 @@ final class ParallelMergeReduce<T> extends Mono<T> implements Scannable, Fuseabl
 				actual.onError(ex);
 			}
 			else if(error != ex) {
-				Operators.onErrorDropped(ex);
+				Operators.onErrorDropped(ex, actual.currentContext());
 			}
 		}
 
@@ -252,7 +252,7 @@ final class ParallelMergeReduce<T> extends Mono<T> implements Scannable, Fuseabl
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, parent.currentContext());
 				return;
 			}
 			T v = value;
@@ -277,7 +277,7 @@ final class ParallelMergeReduce<T> extends Mono<T> implements Scannable, Fuseabl
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, parent.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeReduce.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeReduce.java
@@ -176,7 +176,8 @@ final class ParallelMergeReduce<T> extends Mono<T> implements Scannable, Fuseabl
 									sp.second), "The reducer returned a null value");
 						}
 						catch (Throwable ex) {
-							innerError(Operators.onOperatorError(this, ex));
+							innerError(Operators.onOperatorError(this, ex,
+									actual.currentContext()));
 							return;
 						}
 					}
@@ -252,7 +253,7 @@ final class ParallelMergeReduce<T> extends Mono<T> implements Scannable, Fuseabl
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, parent.currentContext());
+				Operators.onNextDropped(t, currentContext());
 				return;
 			}
 			T v = value;
@@ -266,7 +267,7 @@ final class ParallelMergeReduce<T> extends Mono<T> implements Scannable, Fuseabl
 					v = Objects.requireNonNull(reducer.apply(v, t), "The reducer returned a null value");
 				}
 				catch (Throwable ex) {
-					onError(Operators.onOperatorError(s, ex, t));
+					onError(Operators.onOperatorError(s, ex, t, currentContext()));
 					return;
 				}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeSequential.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeSequential.java
@@ -208,7 +208,7 @@ final class ParallelMergeSequential<T> extends Flux<T> implements Scannable {
 				drain();
 			}
 			else if(error != ex) {
-				Operators.onErrorDropped(ex);
+				Operators.onErrorDropped(ex, actual.currentContext());
 			}
 		}
 		

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeSequential.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeSequential.java
@@ -179,7 +179,8 @@ final class ParallelMergeSequential<T> extends Flux<T> implements Scannable {
 					Queue<T> q = inner.getQueue(queueSupplier);
 
 					if(!q.offer(value)){
-						onError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), value));
+						onError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), value,
+								actual.currentContext()));
 						return;
 					}
 				}
@@ -190,7 +191,8 @@ final class ParallelMergeSequential<T> extends Flux<T> implements Scannable {
 				Queue<T> q = inner.getQueue(queueSupplier);
 
 				if(!q.offer(value)){
-					onError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), value));
+					onError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), value,
+							actual.currentContext()));
 					return;
 				}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeSort.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeSort.java
@@ -191,7 +191,7 @@ final class ParallelMergeSort<T> extends Flux<T> implements Scannable {
 				drain();
 			}
 			else if(error != ex) {
-				Operators.onErrorDropped(ex);
+				Operators.onErrorDropped(ex, actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelReduceSeed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelReduceSeed.java
@@ -82,7 +82,8 @@ final class ParallelReduceSeed<T, R> extends ParallelFlux<R> implements
 						"The initialSupplier returned a null value");
 			}
 			catch (Throwable ex) {
-				reportError(subscribers, Operators.onOperatorError(ex));
+				reportError(subscribers, Operators.onOperatorError(ex,
+						subscribers[i].currentContext()));
 				return;
 			}
 			parents[i] =
@@ -147,7 +148,7 @@ final class ParallelReduceSeed<T, R> extends ParallelFlux<R> implements
 				v = Objects.requireNonNull(reducer.apply(accumulator, t), "The reducer returned a null value");
 			}
 			catch (Throwable ex) {
-				onError(Operators.onOperatorError(this, ex, t));
+				onError(Operators.onOperatorError(this, ex, t, actual.currentContext()));
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelReduceSeed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelReduceSeed.java
@@ -137,7 +137,7 @@ final class ParallelReduceSeed<T, R> extends ParallelFlux<R> implements
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -157,7 +157,7 @@ final class ParallelReduceSeed<T, R> extends ParallelFlux<R> implements
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelSource.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelSource.java
@@ -226,7 +226,7 @@ final class ParallelSource<T> extends ParallelFlux<T> implements Scannable {
 			}
 			if (sourceMode == Fuseable.NONE) {
 				if (!queue.offer(t)) {
-					onError(Operators.onOperatorError(s, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t));
+					onError(Operators.onOperatorError(s, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t, currentContext()));
 					return;
 				}
 			}
@@ -268,7 +268,7 @@ final class ParallelSource<T> extends ParallelFlux<T> implements Scannable {
 			int missed = 1;
 			
 			Queue<T> q = queue;
-			Subscriber<? super T>[] a = this.subscribers;
+			CoreSubscriber<? super T>[] a = this.subscribers;
 			AtomicLongArray r = this.requests;
 			long[] e = this.emissions;
 			int n = e.length;
@@ -319,7 +319,7 @@ final class ParallelSource<T> extends ParallelFlux<T> implements Scannable {
 						try {
 							v = q.poll();
 						} catch (Throwable ex) {
-							ex = Operators.onOperatorError(s, ex);
+							ex = Operators.onOperatorError(s, ex, a[idx].currentContext());
 							for (Subscriber<? super T> s : a) {
 								s.onError(ex);
 							}
@@ -372,7 +372,7 @@ final class ParallelSource<T> extends ParallelFlux<T> implements Scannable {
 			int missed = 1;
 			
 			Queue<T> q = queue;
-			Subscriber<? super T>[] a = this.subscribers;
+			CoreSubscriber<? super T>[] a = this.subscribers;
 			AtomicLongArray r = this.requests;
 			long[] e = this.emissions;
 			int n = e.length;
@@ -388,19 +388,7 @@ final class ParallelSource<T> extends ParallelFlux<T> implements Scannable {
 						return;
 					}
 					
-					boolean empty;
-					
-					try {
-						empty = q.isEmpty();
-					} catch (Throwable ex) {
-						ex = Operators.onOperatorError(s, ex);
-						for (Subscriber<? super T> s : a) {
-							s.onError(ex);
-						}
-						return;
-					}
-					
-					if (empty) {
+					if (q.isEmpty()) {
 						for (Subscriber<? super T> s : a) {
 							s.onComplete();
 						}
@@ -416,7 +404,7 @@ final class ParallelSource<T> extends ParallelFlux<T> implements Scannable {
 						try {
 							v = q.poll();
 						} catch (Throwable ex) {
-							ex = Operators.onOperatorError(s, ex);
+							ex = Operators.onOperatorError(s, ex, a[idx].currentContext());
 							for (Subscriber<? super T> s : a) {
 								s.onError(ex);
 							}

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelSource.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelSource.java
@@ -221,7 +221,7 @@ final class ParallelSource<T> extends ParallelFlux<T> implements Scannable {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t);
+				Operators.onNextDropped(t, currentContext());
 				return;
 			}
 			if (sourceMode == Fuseable.NONE) {
@@ -236,7 +236,7 @@ final class ParallelSource<T> extends ParallelFlux<T> implements Scannable {
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t);
+				Operators.onErrorDropped(t, currentContext());
 				return;
 			}
 			error = t;

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -423,7 +423,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	public void onNext(T t) {
 		FluxReplay.ReplayBuffer<T> b = buffer;
 		if (b.isDone()) {
-			Operators.onNextDropped(t);
+			Operators.onNextDropped(t, currentContext());
 		}
 		else {
 			b.add(t);

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -27,7 +27,6 @@ import javax.annotation.Nullable;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
-import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -437,7 +437,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	public void onError(Throwable t) {
 		FluxReplay.ReplayBuffer<T> b = buffer;
 		if (b.isDone()) {
-			Operators.onErrorDropped(t);
+			Operators.onErrorDroppedMulticast(t);
 		}
 		else {
 			b.onError(t);

--- a/reactor-core/src/main/java/reactor/core/publisher/StrictSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/StrictSubscriber.java
@@ -26,6 +26,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
+import reactor.util.context.Context;
 
 /**
  * Reactive Streams Commons safe exit
@@ -106,7 +107,7 @@ final class StrictSubscriber<T> implements Scannable, CoreSubscriber<T>, Subscri
 			}
 		}
 		else {
-			Operators.onErrorDropped(t);
+			Operators.onErrorDropped(t, Context.empty());
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -307,7 +307,7 @@ public final class UnicastProcessor<T>
 	@Override
 	public void onNext(T t) {
 		if (done || cancelled) {
-			Operators.onNextDropped(t);
+			Operators.onNextDropped(t, actual.currentContext());
 			return;
 		}
 
@@ -332,7 +332,7 @@ public final class UnicastProcessor<T>
 	@Override
 	public void onError(Throwable t) {
 		if (done || cancelled) {
-			Operators.onErrorDropped(t);
+			Operators.onErrorDropped(t, actual.currentContext());
 			return;
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -41,6 +41,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -534,7 +535,7 @@ public class HooksTest {
 			throw new TestException("errorDrop");
 		});
 
-		Throwable w = Operators.onOperatorError(null, new Exception(), "hello");
+		Throwable w = Operators.onOperatorError(null, new Exception(), "hello", Context.empty());
 
 		Assert.assertTrue(w instanceof TestException);
 		Assert.assertTrue(w.getMessage()
@@ -599,7 +600,7 @@ public class HooksTest {
 			return error;
 		});
 
-		Operators.onOperatorError(null, null, "foo");
+		Operators.onOperatorError(null, null, "foo", Context.empty());
 
 		assertThat(ref.get()).isEqualTo("foobar");
 

--- a/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
@@ -542,7 +542,7 @@ public class HooksTest {
 		                   .equals("hello"));
 
 		try {
-			Operators.onNextDropped("hello");
+			Operators.onNextDropped("hello", Context.empty());
 			Assert.fail();
 		}
 		catch (Throwable t) {
@@ -553,7 +553,7 @@ public class HooksTest {
 		}
 
 		try {
-			Operators.onErrorDropped(new Exception());
+			Operators.onErrorDropped(new Exception(), Context.empty());
 			Assert.fail();
 		}
 		catch (Throwable t) {
@@ -573,7 +573,7 @@ public class HooksTest {
 			ref.set(ref.get()+"bar");
 		});
 
-		Operators.onNextDropped("foo");
+		Operators.onNextDropped("foo", Context.empty());
 
 		assertThat(ref.get()).isEqualTo("foobar");
 
@@ -584,7 +584,7 @@ public class HooksTest {
 			ref.set(ref.get()+"bar");
 		});
 
-		Operators.onErrorDropped(new Exception("foo"));
+		Operators.onErrorDropped(new Exception("foo"), Context.empty());
 
 		assertThat(ref.get()).isEqualTo("foobar");
 

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorDisposablesTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorDisposablesTest.java
@@ -23,6 +23,7 @@ import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.RaceTestUtils;
+import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -61,7 +62,8 @@ public class OperatorDisposablesTest {
 		Hooks.onErrorDropped(e -> assertThat(e).isInstanceOf(NullPointerException.class)
 		                                       .hasMessage("next is null"));
 		try {
-			assertThat(OperatorDisposables.validate(null, null, Operators::onErrorDropped)).isFalse();
+			assertThat(OperatorDisposables.validate(null, null,
+					e -> Operators.onErrorDropped(e, Context.empty()))).isFalse();
 		} finally {
 			Hooks.resetOnErrorDropped();
 		}

--- a/reactor-test/src/test/java/reactor/test/StepVerifierAssertionsTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierAssertionsTests.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;
+import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -423,8 +424,8 @@ public class StepVerifierAssertionsTests {
 			StepVerifier.create(Flux.from(s -> {
 				s.onSubscribe(Operators.emptySubscription());
 				s.onError(err1);
-				Operators.onOperatorError(err2);
-				Operators.onOperatorError(err3);
+				Operators.onOperatorError(err2, Context.empty());
+				Operators.onOperatorError(err3, Context.empty());
 			}).buffer(1))
 			            .expectError()
 			            .verifyThenAssertThat()
@@ -446,8 +447,8 @@ public class StepVerifierAssertionsTests {
 			StepVerifier.create(Flux.from(s -> {
 				s.onSubscribe(Operators.emptySubscription());
 				s.onError(err1);
-				Operators.onOperatorError(err2);
-				Operators.onOperatorError(err3);
+				Operators.onOperatorError(err2, Context.empty());
+				Operators.onOperatorError(err3, Context.empty());
 			}).buffer(1))
 			            .expectError()
 			            .verifyThenAssertThat()
@@ -470,8 +471,8 @@ public class StepVerifierAssertionsTests {
 			StepVerifier.create(Flux.from(s -> {
 				s.onSubscribe(Operators.emptySubscription());
 				s.onError(err1);
-				Operators.onOperatorError(err2);
-				Operators.onOperatorError(err3);
+				Operators.onOperatorError(err2, Context.empty());
+				Operators.onOperatorError(err3, Context.empty());
 			}).buffer(1))
 			            .expectError()
 			            .verifyThenAssertThat()
@@ -564,7 +565,7 @@ public class StepVerifierAssertionsTests {
 		try {
 			StepVerifier.create(Flux.from(f -> {
 				f.onSubscribe(Operators.emptySubscription());
-				Operators.onOperatorError(null, null, "foo");
+				Operators.onOperatorError(null, null, "foo", Context.empty());
 				f.onComplete();
 			}))
 			            .expectComplete()


### PR DESCRIPTION
Related to #435 
- contextualize Operators.onErrorDropped and onNextDropped
- remove unused Operators.onErrorDropped(error, supp)
- add few missing Operators.onNextDropped
- contextualize Operators.onOperatorsError
- contextualize Operators.onRejectedExecution