### PR TITLE
Clarify that sink() will subscribe the emitter

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -180,7 +180,8 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 
 	/**
 	 * Create a {@link FluxSink} that safely gates multi-threaded producer
-	 * {@link Subscriber#onNext(Object)}.
+	 * {@link Subscriber#onNext(Object)}. This processor will be subscribed to 
+	 * that {@link FluxSink}, and any previous subscribers will be unsubscribed.
 	 *
 	 * <p> The returned {@link FluxSink} will not apply any
 	 * {@link FluxSink.OverflowStrategy} and overflowing {@link FluxSink#next(Object)}
@@ -199,7 +200,8 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 
 	/**
 	 * Create a {@link FluxSink} that safely gates multi-threaded producer
-	 * {@link Subscriber#onNext(Object)}.
+	 * {@link Subscriber#onNext(Object)}.  This processor will be subscribed to 
+	 * that {@link FluxSink}, and any previous subscribers will be unsubscribed.
 	 *
 	 * <p> The returned {@link FluxSink} will not apply any
 	 * {@link FluxSink.OverflowStrategy} and overflowing {@link FluxSink#next(Object)}


### PR DESCRIPTION
Added JavaDoc language clarifying that sink() and sink(OverflowStrategy) will create new FluxSink, and subscribe the processor to the new FluxSink. Also clarifies that any other subscriber will be unsubscribed from the processor.