### PR TITLE
fix #836 Mono.do*Terminate alignment with Flux

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1978,27 +1978,6 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Add behavior triggered after the {@link Mono} terminates, either by completing downstream successfully or with an error.
-	 * The arguments will be null depending on success, success with data and error:
-	 * <ul>
-	 *     <li>null, null : completed without data</li>
-	 *     <li>T, null : completed with data</li>
-	 *     <li>null, Throwable : failed with/without data</li>
-	 * </ul>
-	 *
-	 * <p>
-	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.0.M3/src/docs/marble/doafterterminate1.png" alt="">
-	 * <p>
-	 * @param afterSuccessOrError the callback to call after {@link Subscriber#onNext}, {@link Subscriber#onComplete} without preceding {@link Subscriber#onNext} or {@link Subscriber#onError}
-	 *
-	 * @return a new {@link Mono}
-	 */
-	public final Mono<T> doAfterSuccessOrError(BiConsumer<? super T, Throwable> afterSuccessOrError) {
-		Objects.requireNonNull(afterSuccessOrError, "afterSuccessOrError");
-		return onAssembly(new MonoPeekTerminal<>(this, null, null, afterSuccessOrError));
-	}
-
-	/**
 	 * Add behavior (side-effect) triggered after the {@link Mono} terminates, either by
 	 * completing downstream successfully or with an error.
 	 * <p>
@@ -2010,7 +1989,8 @@ public abstract class Mono<T> implements Publisher<T> {
 	 */
 	public final Mono<T> doAfterTerminate(Runnable afterTerminate) {
 		Objects.requireNonNull(afterTerminate, "afterTerminate");
-		return doAfterSuccessOrError((s, e)  -> afterTerminate.run());
+		return onAssembly(new MonoPeekTerminal<>(this, null, null,
+				(s, e)  -> afterTerminate.run()));
 	}
 
 	/**

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
@@ -349,16 +349,16 @@ public class MonoDelayElementTest {
 			s.onSubscribe(Operators.emptySubscription());
 			s.onNext("foo");
 		})
-		.doOnCancel(() -> sourceOnCancel.incrementAndGet())
-		.doOnTerminate((v, e) -> sourceOnTerminate.incrementAndGet());
+		.doOnCancel(sourceOnCancel::incrementAndGet)
+		.doOnSuccessOrError((v, e) -> sourceOnTerminate.incrementAndGet());
 
 
 		StepVerifier.withVirtualTime(() -> new MonoDelayElement<>(source,
 				2,
 				TimeUnit.SECONDS,
 				defaultSchedulerForDelay())
-				.doOnCancel(() -> onCancel.incrementAndGet())
-				.doOnTerminate((v, e) -> onTerminate.incrementAndGet()))
+				.doOnCancel(onCancel::incrementAndGet)
+				.doOnSuccessOrError((v, e) -> onTerminate.incrementAndGet()))
 		            .expectSubscription()
 		            .expectNoEvent(Duration.ofSeconds(2))
 		            .expectNext("foo")

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPeekAfterTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPeekAfterTest.java
@@ -130,7 +130,7 @@ public class MonoPeekAfterTest {
 	}
 
 	@Test
-	public void onTerminateNormal() {
+	public void onSuccessOrErrorNormal() {
 		LongAdder invoked = new LongAdder();
 		AtomicBoolean completedEmpty = new AtomicBoolean();
 		AtomicReference<Throwable> error = new AtomicReference<>();
@@ -139,7 +139,7 @@ public class MonoPeekAfterTest {
 				.range(1, 10)
 				.reduce((a, b) -> a + b)
 				.hide()
-				.doOnTerminate((v, t) -> {
+				.doOnSuccessOrError((v, t) -> {
 					if (v == null && t == null) completedEmpty.set(true);
 					if (t != null) error.set(t);
 					invoked.increment();
@@ -157,7 +157,7 @@ public class MonoPeekAfterTest {
 	}
 
 	@Test
-	public void onTerminateNormalConditional() {
+	public void onSuccessOrErrorNormalConditional() {
 		LongAdder invoked = new LongAdder();
 		AtomicBoolean completedEmpty = new AtomicBoolean();
 		AtomicReference<Throwable> error = new AtomicReference<>();
@@ -167,7 +167,7 @@ public class MonoPeekAfterTest {
 				.reduce((a, b) -> a + b)
 				.hide()
 				.filter(v -> true)
-				.doOnTerminate((v, t) -> {
+				.doOnSuccessOrError((v, t) -> {
 					if (v == null && t == null) completedEmpty.set(true);
 					if (t != null) error.set(t);
 					invoked.increment();
@@ -185,7 +185,7 @@ public class MonoPeekAfterTest {
 	}
 
 	@Test
-	public void onTerminateFusion() {
+	public void onSuccessOrErrorFusion() {
 		LongAdder invoked = new LongAdder();
 		AtomicBoolean completedEmpty = new AtomicBoolean();
 		AtomicReference<Throwable> error = new AtomicReference<>();
@@ -193,7 +193,7 @@ public class MonoPeekAfterTest {
 		Mono<Integer> mono = Flux
 				.range(1, 10)
 				.reduce((a, b) -> a + b)
-				.doOnTerminate((v, t) -> {
+				.doOnSuccessOrError((v, t) -> {
 					if (v == null && t == null) completedEmpty.set(true);
 					if (t != null) error.set(t);
 					invoked.increment();
@@ -211,7 +211,7 @@ public class MonoPeekAfterTest {
 	}
 
 	@Test
-	public void onTerminateFusionConditional() {
+	public void onSuccessOrErrorFusionConditional() {
 		LongAdder invoked = new LongAdder();
 		AtomicBoolean completedEmpty = new AtomicBoolean();
 		AtomicReference<Throwable> error = new AtomicReference<>();
@@ -220,7 +220,7 @@ public class MonoPeekAfterTest {
 				.range(1, 10)
 				.reduce((a, b) -> a + b)
 				.filter(v -> true)
-				.doOnTerminate((v, t) -> {
+				.doOnSuccessOrError((v, t) -> {
 					if (v == null && t == null) completedEmpty.set(true);
 					if (t != null) error.set(t);
 					invoked.increment();
@@ -238,7 +238,7 @@ public class MonoPeekAfterTest {
 	}
 
 	@Test
-	public void onAfterTerminateNormal() {
+	public void onAfterSuccessOrErrorNormal() {
 		LongAdder invoked = new LongAdder();
 		AtomicBoolean completedEmpty = new AtomicBoolean();
 		AtomicReference<Throwable> error = new AtomicReference<>();
@@ -247,7 +247,7 @@ public class MonoPeekAfterTest {
 				.range(1, 10)
 				.reduce((a, b) -> a + b)
 				.hide()
-				.doAfterTerminate((v, t) -> {
+				.doAfterSuccessOrError((v, t) -> {
 					if (v == null && t == null) completedEmpty.set(true);
 					if (t != null) error.set(t);
 					invoked.increment();
@@ -265,7 +265,7 @@ public class MonoPeekAfterTest {
 	}
 
 	@Test
-	public void onAfterTerminateNormalConditional() {
+	public void onAfterSuccessOrErrorNormalConditional() {
 		LongAdder invoked = new LongAdder();
 		AtomicBoolean completedEmpty = new AtomicBoolean();
 		AtomicReference<Throwable> error = new AtomicReference<>();
@@ -275,7 +275,7 @@ public class MonoPeekAfterTest {
 				.reduce((a, b) -> a + b)
 				.hide()
 				.filter(v -> true)
-				.doAfterTerminate((v, t) -> {
+				.doAfterSuccessOrError((v, t) -> {
 					if (v == null && t == null) completedEmpty.set(true);
 					if (t != null) error.set(t);
 					invoked.increment();
@@ -293,7 +293,7 @@ public class MonoPeekAfterTest {
 	}
 
 	@Test
-	public void onAfterTerminateFusion() {
+	public void onAfterSuccessOrErrorFusion() {
 		LongAdder invoked = new LongAdder();
 		AtomicBoolean completedEmpty = new AtomicBoolean();
 		AtomicReference<Throwable> error = new AtomicReference<>();
@@ -301,7 +301,7 @@ public class MonoPeekAfterTest {
 		Mono<Integer> mono = Flux
 				.range(1, 10)
 				.reduce((a, b) -> a + b)
-				.doAfterTerminate((v, t) -> {
+				.doAfterSuccessOrError((v, t) -> {
 					if (v == null && t == null) completedEmpty.set(true);
 					if (t != null) error.set(t);
 					invoked.increment();
@@ -319,7 +319,7 @@ public class MonoPeekAfterTest {
 	}
 
 	@Test
-	public void onAfterTerminateFusionConditional() {
+	public void onAfterSuccessOrErrorFusionConditional() {
 		LongAdder invoked = new LongAdder();
 		AtomicBoolean completedEmpty = new AtomicBoolean();
 		AtomicReference<Throwable> error = new AtomicReference<>();
@@ -328,7 +328,7 @@ public class MonoPeekAfterTest {
 				.range(1, 10)
 				.reduce((a, b) -> a + b)
 				.filter(v -> true)
-				.doAfterTerminate((v, t) -> {
+				.doAfterSuccessOrError((v, t) -> {
 					if (v == null && t == null) completedEmpty.set(true);
 					if (t != null) error.set(t);
 					invoked.increment();
@@ -359,10 +359,10 @@ public class MonoPeekAfterTest {
 	}
 
 	@Test
-	public void onTerminateCallbackFailureInterruptsOnNext() {
+	public void onSuccessOrErrorCallbackFailureInterruptsOnNext() {
 		LongAdder invoked = new LongAdder();
 		StepVerifier.create(Mono.just("foo")
-		                        .doOnTerminate((v, t) -> {
+		                        .doOnSuccessOrError((v, t) -> {
 			                        invoked.increment();
 			                        throw new IllegalArgumentException(v);
 		                        }))
@@ -373,11 +373,11 @@ public class MonoPeekAfterTest {
 	}
 
 	@Test
-	public void afterTerminateCallbackFailureInterruptsOnNextAndThrows() {
+	public void afterSuccessOrErrorCallbackFailureInterruptsOnNextAndThrows() {
 		LongAdder invoked = new LongAdder();
 		try {
 			StepVerifier.create(Mono.just("foo")
-			                        .doAfterTerminate((v, t) -> {
+			                        .doAfterSuccessOrError((v, t) -> {
 				                        invoked.increment();
 				                        throw new IllegalArgumentException(v);
 			                        }))
@@ -389,6 +389,28 @@ public class MonoPeekAfterTest {
 			Throwable e = Exceptions.unwrap(t);
 			assertEquals(IllegalArgumentException.class, e.getClass());
 			assertEquals("foo", e.getMessage());
+		}
+
+		assertEquals(1, invoked.intValue());
+	}
+
+	@Test
+	public void afterTerminateCallbackFailureInterruptsOnNextAndThrows() {
+		LongAdder invoked = new LongAdder();
+		try {
+			StepVerifier.create(Mono.just("foo")
+			                        .doAfterTerminate(() -> {
+				                        invoked.increment();
+				                        throw new IllegalArgumentException("boom");
+			                        }))
+			            .expectNext("bar") //irrelevant
+			            .expectErrorMessage("baz") //irrelevant
+			            .verify();
+		}
+		catch (Throwable t) {
+			Throwable e = Exceptions.unwrap(t);
+			assertEquals(IllegalArgumentException.class, e.getClass());
+			assertEquals("boom", e.getMessage());
 		}
 
 		assertEquals(1, invoked.intValue());
@@ -408,7 +430,7 @@ public class MonoPeekAfterTest {
 	}
 
 	@Test
-	public void onTerminateForOnError() {
+	public void onSuccessOrErrorForOnError() {
 		LongAdder invoked = new LongAdder();
 		AtomicReference<String> value = new AtomicReference<>();
 		AtomicReference<Throwable> error = new AtomicReference<>();
@@ -416,7 +438,7 @@ public class MonoPeekAfterTest {
 		IllegalArgumentException err = new IllegalArgumentException("boom");
 
 		StepVerifier.create(Mono.<String>error(err)
-		                        .doOnTerminate((v, t) -> {
+		                        .doOnSuccessOrError((v, t) -> {
 			                        invoked.increment();
 			                        value.set(v);
 			                        error.set(t);
@@ -430,7 +452,7 @@ public class MonoPeekAfterTest {
 	}
 
 	@Test
-	public void afterTerminateForOnError() {
+	public void afterSuccessOrErrorForOnError() {
 		LongAdder invoked = new LongAdder();
 		AtomicReference<String> value = new AtomicReference<>();
 		AtomicReference<Throwable> error = new AtomicReference<>();
@@ -438,7 +460,7 @@ public class MonoPeekAfterTest {
 		IllegalArgumentException err = new IllegalArgumentException("boom");
 
 		StepVerifier.create(Mono.<String>error(err)
-				.doAfterTerminate((v, t) -> {
+				.doAfterSuccessOrError((v, t) -> {
 					invoked.increment();
 					value.set(v);
 					error.set(t);
@@ -469,13 +491,13 @@ public class MonoPeekAfterTest {
 	}
 
 	@Test
-	public void onTerminateForEmpty() {
+	public void onSuccessOrErrorForEmpty() {
 		LongAdder invoked = new LongAdder();
 		AtomicReference<String> value = new AtomicReference<>();
 		AtomicReference<Throwable> error = new AtomicReference<>();
 
 		StepVerifier.create(Mono.<String>empty()
-				.doOnTerminate((v, t) -> {
+				.doOnSuccessOrError((v, t) -> {
 					invoked.increment();
 					value.set(v);
 					error.set(t);
@@ -489,13 +511,13 @@ public class MonoPeekAfterTest {
 	}
 
 	@Test
-	public void afterTerminateForEmpty() {
+	public void afterSuccessOrErrorForEmpty() {
 		LongAdder invoked = new LongAdder();
 		AtomicReference<String> value = new AtomicReference<>();
 		AtomicReference<Throwable> error = new AtomicReference<>();
 
 		StepVerifier.create(Mono.<String>empty()
-				.doAfterTerminate((v, t) -> {
+				.doAfterSuccessOrError((v, t) -> {
 					invoked.increment();
 					value.set(v);
 					error.set(t);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTest.java
@@ -15,6 +15,7 @@
  */
 package reactor.core.publisher;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
@@ -26,25 +27,47 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MonoPeekTest {
 
 	@Test
-	public void onMonoRejectedDoOnTerminate() {
+	public void onMonoRejectedDoOnSuccessOrError() {
 		Mono<String> mp = Mono.error(new Exception("test"));
 		AtomicReference<Throwable> ref = new AtomicReference<>();
 
-		mp.doOnTerminate((s, f) -> ref.set(f))
+		mp.doOnSuccessOrError((s, f) -> ref.set(f))
 		  .subscribe();
 
 		assertThat(ref.get()).hasMessage("test");
 	}
 
 	@Test
-	public void onMonoSuccessDoOnTerminate() {
+	public void onMonoSuccessDoOnSuccessOrError() {
 		Mono<String> mp = Mono.just("test");
 		AtomicReference<String> ref = new AtomicReference<>();
 
-		mp.doOnTerminate((s, f) -> ref.set(s))
+		mp.doOnSuccessOrError((s, f) -> ref.set(s))
 		  .subscribe();
 
 		assertThat(ref.get()).isEqualToIgnoringCase("test");
+	}
+
+	@Test
+	public void onMonoRejectedDoOnTerminate() {
+		Mono<String> mp = Mono.error(new Exception("test"));
+		AtomicInteger invoked = new AtomicInteger();
+
+		mp.doOnTerminate(invoked::incrementAndGet)
+		  .subscribe();
+
+		assertThat(invoked.get()).isEqualTo(1);
+	}
+
+	@Test
+	public void onMonoSuccessDoOnTerminate() {
+		Mono<String> mp = Mono.just("test");
+		AtomicInteger invoked = new AtomicInteger();
+
+		mp.doOnTerminate(invoked::incrementAndGet)
+		  .subscribe();
+
+		assertThat(invoked.get()).isEqualTo(1);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
@@ -131,14 +131,27 @@ public class MonoProcessorTest {
 	}
 
 	@Test
-	public void MonoProcessorRejectedDoOnTerminate() {
+	public void MonoProcessorRejectedDoOnSuccessOrError() {
 		MonoProcessor<String> mp = MonoProcessor.create();
 		AtomicReference<Throwable> ref = new AtomicReference<>();
 
-		mp.doOnTerminate((s, f) -> ref.set(f)).subscribe();
+		mp.doOnSuccessOrError((s, f) -> ref.set(f)).subscribe();
 		mp.onError(new Exception("test"));
 
 		assertThat(ref.get()).hasMessage("test");
+		assertThat(mp.isSuccess()).isFalse();
+		assertThat(mp.isError()).isTrue();
+	}
+
+	@Test
+	public void MonoProcessorRejectedDoOnTerminate() {
+		MonoProcessor<String> mp = MonoProcessor.create();
+		AtomicInteger invoked = new AtomicInteger();
+
+		mp.doOnTerminate(invoked::incrementAndGet).subscribe();
+		mp.onError(new Exception("test"));
+
+		assertThat(invoked.get()).isEqualTo(1);
 		assertThat(mp.isSuccess()).isFalse();
 		assertThat(mp.isError()).isTrue();
 	}
@@ -157,14 +170,27 @@ public class MonoProcessorTest {
 	}
 
 	@Test
-	public void MonoProcessorSuccessDoOnTerminate() {
+	public void MonoProcessorSuccessDoOnSuccessOrError() {
 		MonoProcessor<String> mp = MonoProcessor.create();
 		AtomicReference<String> ref = new AtomicReference<>();
 
-		mp.doOnTerminate((s, f) -> ref.set(s)).subscribe();
+		mp.doOnSuccessOrError((s, f) -> ref.set(s)).subscribe();
 		mp.onNext("test");
 
 		assertThat(ref.get()).isEqualToIgnoringCase("test");
+		assertThat(mp.isSuccess()).isTrue();
+		assertThat(mp.isError()).isFalse();
+	}
+
+	@Test
+	public void MonoProcessorSuccessDoOnTerminate() {
+		MonoProcessor<String> mp = MonoProcessor.create();
+		AtomicInteger invoked = new AtomicInteger();
+
+		mp.doOnTerminate(invoked::incrementAndGet).subscribe();
+		mp.onNext("test");
+
+		assertThat(invoked.get()).isEqualTo(1);
 		assertThat(mp.isSuccess()).isTrue();
 		assertThat(mp.isError()).isFalse();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoUsingTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoUsingTest.java
@@ -19,11 +19,9 @@ package reactor.core.publisher;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
 import org.junit.Assert;
 import org.junit.Test;
-import org.testng.remote.strprotocol.IStringMessage;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
@@ -55,7 +53,7 @@ public class MonoUsingTest {
 		AtomicInteger cleanup = new AtomicInteger();
 
 		Mono.using(() -> 1, r -> Mono.just(1), cleanup::set, false)
-		    .doAfterTerminate((v, e) ->  Assert.assertEquals(0, cleanup.get()))
+		    .doAfterSuccessOrError((v, e) ->  Assert.assertEquals(0, cleanup.get()))
 		    .subscribe(ts);
 
 		ts.assertValues(1)
@@ -72,7 +70,7 @@ public class MonoUsingTest {
 		AtomicInteger cleanup = new AtomicInteger();
 
 		Mono.using(() -> 1, r -> Mono.just(1), cleanup::set)
-		    .doAfterTerminate((v, e) ->  Assert.assertEquals(0, cleanup.get()))
+		    .doAfterSuccessOrError((v, e) ->  Assert.assertEquals(0, cleanup.get()))
 		    .subscribe(ts);
 
 		ts.assertValues(1)

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoUsingTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoUsingTest.java
@@ -53,7 +53,7 @@ public class MonoUsingTest {
 		AtomicInteger cleanup = new AtomicInteger();
 
 		Mono.using(() -> 1, r -> Mono.just(1), cleanup::set, false)
-		    .doAfterSuccessOrError((v, e) ->  Assert.assertEquals(0, cleanup.get()))
+		    .doAfterTerminate(() ->  Assert.assertEquals(0, cleanup.get()))
 		    .subscribe(ts);
 
 		ts.assertValues(1)
@@ -70,7 +70,7 @@ public class MonoUsingTest {
 		AtomicInteger cleanup = new AtomicInteger();
 
 		Mono.using(() -> 1, r -> Mono.just(1), cleanup::set)
-		    .doAfterSuccessOrError((v, e) ->  Assert.assertEquals(0, cleanup.get()))
+		    .doAfterTerminate(() ->  Assert.assertEquals(0, cleanup.get()))
 		    .subscribe(ts);
 
 		ts.assertValues(1)

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -1409,7 +1409,7 @@ public class FluxTests extends AbstractReactorTest {
 		final MonoProcessor<List<String>> listPromise = joinStream.flatMap(Flux::fromIterable)
 		                                                 .log("resultStream")
 		                                                 .collectList()
-		                                                 .doOnTerminate((v, e) -> doneSemaphore.release())
+		                                                 .doOnTerminate(doneSemaphore::release)
 		                                                 .toProcessor();
 		listPromise.subscribe();
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/DelegateServiceSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/DelegateServiceSchedulerTest.java
@@ -100,7 +100,7 @@ public class DelegateServiceSchedulerTest extends AbstractSchedulerTest {
 						.delay(Duration.ofMillis(100), s)
 						.log()
 						.doOnSubscribe(sub -> start.set(System.nanoTime()))
-						.doOnTerminate((v, e) -> end.set(System.nanoTime()))
+						.doOnTerminate(() -> end.set(System.nanoTime()))
 				)
 				            .expectSubscription()
 				            .expectNext(0L)

--- a/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
@@ -115,7 +115,7 @@ public class ElasticSchedulerTest extends AbstractSchedulerTest {
 				StepVerifier.create(Mono
 						.delay(Duration.ofMillis(100), s)
 						.doOnSubscribe(sub -> start.set(System.nanoTime()))
-						.doOnTerminate((v, e) -> end.set(System.nanoTime()))
+						.doOnTerminate(() -> end.set(System.nanoTime()))
 				)
 				            .expectSubscription()
 				            .expectNext(0L)

--- a/reactor-core/src/test/java/reactor/core/scheduler/ParallelSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ParallelSchedulerTest.java
@@ -80,7 +80,7 @@ public class ParallelSchedulerTest extends AbstractSchedulerTest {
 				StepVerifier.create(Mono
 						.delay(Duration.ofMillis(100), s)
 						.doOnSubscribe(sub -> start.set(System.nanoTime()))
-						.doOnTerminate((v, e) -> end.set(System.nanoTime()))
+						.doOnTerminate(() -> end.set(System.nanoTime()))
 				)
 				            .expectSubscription()
 				            .expectNext(0L)

--- a/reactor-core/src/test/java/reactor/core/scheduler/SingleSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SingleSchedulerTest.java
@@ -55,7 +55,7 @@ public class SingleSchedulerTest extends AbstractSchedulerTest {
 						.delay(Duration.ofMillis(100), s)
 						.log()
 						.doOnSubscribe(sub -> start.set(System.nanoTime()))
-						.doOnTerminate((v, e) -> end.set(System.nanoTime()))
+						.doOnTerminate(() -> end.set(System.nanoTime()))
 				)
 				            .expectSubscription()
 				            .expectNext(0L)


### PR DESCRIPTION
The doOnTerminate and doAfterTerminate align with their Flux counterpart
by taking a Runnable parameter.

~Old Mono.doOnTerminate and doAfterTerminate with BiConsumer have been
renamed doOnSuccessOrError and doAfterSuccessOrError respectively.~

Old Mono.doOnTerminate with BiConsumer has been renamed doOnSuccessOrError and Mono.doAfterTerminate(BiConsumer) has been removed entirely.