### PR TITLE
Catch fused flattenIterable polling failures

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
@@ -306,7 +306,14 @@ final class FluxFlattenIterable<T, R> extends FluxOperator<T, R> implements Fuse
 
 					T t;
 
-					t = q.poll();
+					try {
+						t = q.poll();
+					} catch (Throwable pollEx) {
+						current = null;
+						q.clear();
+						a.onError(pollEx);
+						return;
+					}
 
 					boolean empty = t == null;
 
@@ -464,7 +471,6 @@ final class FluxFlattenIterable<T, R> extends FluxOperator<T, R> implements Fuse
 
 		void drainSync() {
 			final Subscriber<? super R> a = actual;
-//			final Queue<T> q = queue;
 
 			int missed = 1;
 
@@ -482,8 +488,16 @@ final class FluxFlattenIterable<T, R> extends FluxOperator<T, R> implements Fuse
 					boolean d = done;
 
 					T t;
+					Queue<T> q = queue;
 
-					t = queue.poll();
+					try {
+						t = q.poll();
+					} catch (Throwable pollEx) {
+						current = null;
+						q.clear();
+						a.onError(pollEx);
+						return;
+					}
 
 					boolean empty = t == null;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
@@ -16,8 +16,10 @@
 
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
@@ -370,5 +372,27 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
         test.cancel();
         assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
 
+    }
+
+    public void asyncDrainWithPollFailure() {
+	    Flux<Integer> p = Flux.range(1, 3)
+	                       .collectList()
+			               .filter(l -> { throw new IllegalStateException("boom"); })
+			               .flatMapIterable(Function.identity());
+
+	    StepVerifier.create(p)
+	                .expectErrorMessage("boom")
+	                .verify(Duration.ofSeconds(1));
+    }
+
+    @Test
+	public void syncDrainWithPollFailure() {
+	    Flux<Integer> p = Mono.just(Arrays.asList(1, 2, 3))
+			    .filter(l -> { throw new IllegalStateException("boom"); })
+			    .flatMapIterable(Function.identity());
+
+	    StepVerifier.create(p)
+	                .expectErrorMessage("boom")
+	                .verify(Duration.ofSeconds(1));
     }
 }

--- a/reactor-core/src/test/resources/logback.xml
+++ b/reactor-core/src/test/resources/logback.xml
@@ -25,7 +25,6 @@
     </appender>
 
     <!--<logger name="reactor.core.publisher.tck" level="debug"/>-->
-    <logger name="reactor.core.publisher.MonoCacheTime" level="debug"/>
     <logger name="reactor" level="info"/>
     <logger name="wqp" level="off"/>
     <logger name="reactor.core.publisher.WorkQueueProcessor" level="off"/>


### PR DESCRIPTION
see #841, also fixes a leftover logging configuration.