### PR TITLE
Add reason to default Scheduler exception throwing

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Exceptions.java
+++ b/reactor-core/src/main/java/reactor/core/Exceptions.java
@@ -208,6 +208,16 @@ public abstract class Exceptions {
 	}
 
 	/**
+	 * Return a singleton {@link RejectedExecutionException} with a message indicating
+	 * the reason is due to the scheduler not being time-capable
+	 *
+	 * @return a singleton {@link RejectedExecutionException}
+	 */
+	public static RejectedExecutionException failWithRejectedNotTimeCapable() {
+		return NOT_TIME_CAPABLE_REJECTED_EXECUTION;
+	}
+
+	/**
 	 * Return a new {@link RejectedExecutionException} with standard message and cause
 	 *
 	 * @param cause
@@ -397,6 +407,10 @@ public abstract class Exceptions {
 	}
 
 	static final RejectedExecutionException REJECTED_EXECUTION = new RejectedExecutionException("Scheduler unavailable");
+
+	static final RejectedExecutionException NOT_TIME_CAPABLE_REJECTED_EXECUTION =
+			new RejectedExecutionException(
+					"Scheduler is not capable of time-based scheduling");
 
 	static class CompositeException extends ReactiveException {
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
@@ -193,7 +193,7 @@ final class DelegateServiceScheduler implements Scheduler {
 		public ScheduledFuture<?> schedule(@NotNull Runnable command,
 				long delay,
 				@NotNull TimeUnit unit) {
-			throw Exceptions.failWithRejected();
+			throw Exceptions.failWithRejectedNotTimeCapable();
 		}
 
 		@NotNull
@@ -201,7 +201,7 @@ final class DelegateServiceScheduler implements Scheduler {
 		public <V> ScheduledFuture<V> schedule(@NotNull Callable<V> callable,
 				long delay,
 				@NotNull TimeUnit unit) {
-			throw Exceptions.failWithRejected();
+			throw Exceptions.failWithRejectedNotTimeCapable();
 		}
 
 		@NotNull
@@ -210,7 +210,7 @@ final class DelegateServiceScheduler implements Scheduler {
 				long initialDelay,
 				long period,
 				@NotNull TimeUnit unit) {
-			throw Exceptions.failWithRejected();
+			throw Exceptions.failWithRejectedNotTimeCapable();
 		}
 
 		@NotNull
@@ -219,7 +219,7 @@ final class DelegateServiceScheduler implements Scheduler {
 				long initialDelay,
 				long delay,
 				@NotNull TimeUnit unit) {
-			throw Exceptions.failWithRejected();
+			throw Exceptions.failWithRejectedNotTimeCapable();
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -65,7 +65,7 @@ public interface Scheduler extends Disposable {
 	 * or throw a {@link RejectedExecutionException} if the Scheduler is not capable of scheduling periodically.
 	 */
 	default Disposable schedule(Runnable task, long delay, TimeUnit unit) {
-		throw Exceptions.failWithRejected();
+		throw Exceptions.failWithRejectedNotTimeCapable();
 	}
 
 	/**
@@ -87,7 +87,7 @@ public interface Scheduler extends Disposable {
 	 * or throw a {@link RejectedExecutionException} if the Scheduler is not capable of scheduling periodically.
 	 */
 	default Disposable schedulePeriodically(Runnable task, long initialDelay, long period, TimeUnit unit) {
-		throw Exceptions.failWithRejected();
+		throw Exceptions.failWithRejectedNotTimeCapable();
 	}
 
 	/**
@@ -172,7 +172,7 @@ public interface Scheduler extends Disposable {
 		 * or throw a {@link RejectedExecutionException} if the Worker is not capable of scheduling with delay.
 		 */
 		default Disposable schedule(Runnable task, long delay, TimeUnit unit) {
-			throw Exceptions.failWithRejected();
+			throw Exceptions.failWithRejectedNotTimeCapable();
 		}
 
 		/**
@@ -193,7 +193,7 @@ public interface Scheduler extends Disposable {
 		 * or throw a {@link RejectedExecutionException} if the Worker is not capable of scheduling periodically.
 		 */
 		default Disposable schedulePeriodically(Runnable task, long initialDelay, long period, TimeUnit unit) {
-			throw Exceptions.failWithRejected();
+			throw Exceptions.failWithRejectedNotTimeCapable();
 		}
 	}
 	

--- a/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
@@ -231,7 +231,7 @@ public abstract class AbstractSchedulerTest {
 				assertThatExceptionOfType(RejectedExecutionException.class)
 						.isThrownBy(() -> s.schedule(() -> { }, 10, TimeUnit.MILLISECONDS))
 						.as("Scheduler marked as not supporting time scheduling")
-						.isSameAs(Exceptions.failWithRejected());
+						.isSameAs(Exceptions.failWithRejectedNotTimeCapable());
 				return;
 			}
 
@@ -278,7 +278,7 @@ public abstract class AbstractSchedulerTest {
 				assertThatExceptionOfType(RejectedExecutionException.class)
 						.isThrownBy(() -> w.schedule(() -> { }, 10, TimeUnit.MILLISECONDS))
 						.as("Worker marked as not supporting time scheduling")
-						.isSameAs(Exceptions.failWithRejected());
+						.isSameAs(Exceptions.failWithRejectedNotTimeCapable());
 				return;
 			}
 
@@ -326,7 +326,7 @@ public abstract class AbstractSchedulerTest {
 				assertThatExceptionOfType(RejectedExecutionException.class)
 						.isThrownBy(() -> s.schedule(() -> { }, 10, TimeUnit.MILLISECONDS))
 						.as("Scheduler marked as not supporting time scheduling")
-						.isSameAs(Exceptions.failWithRejected());
+						.isSameAs(Exceptions.failWithRejectedNotTimeCapable());
 				return;
 			}
 
@@ -376,7 +376,7 @@ public abstract class AbstractSchedulerTest {
 				assertThatExceptionOfType(RejectedExecutionException.class)
 						.isThrownBy(() -> w.schedule(() -> { }, 10, TimeUnit.MILLISECONDS))
 						.as("Worker marked as not supporting time scheduling")
-						.isSameAs(Exceptions.failWithRejected());
+						.isSameAs(Exceptions.failWithRejectedNotTimeCapable());
 				return;
 			}
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/DelegateServiceSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/DelegateServiceSchedulerTest.java
@@ -52,21 +52,21 @@ public class DelegateServiceSchedulerTest extends AbstractSchedulerTest {
 		assertThatExceptionOfType(RejectedExecutionException.class)
 				.isThrownBy(() -> s.schedule(() -> {}, 100, TimeUnit.MILLISECONDS))
 				.describedAs("direct delayed scheduling")
-				.isSameAs(Exceptions.failWithRejected());
+				.isSameAs(Exceptions.failWithRejectedNotTimeCapable());
 		assertThatExceptionOfType(RejectedExecutionException.class)
 				.isThrownBy(() -> s.schedulePeriodically(() -> {}, 100, 100, TimeUnit.MILLISECONDS))
 				.describedAs("direct periodic scheduling")
-				.isSameAs(Exceptions.failWithRejected());
+				.isSameAs(Exceptions.failWithRejectedNotTimeCapable());
 
 		Worker w = s.createWorker();
 		assertThatExceptionOfType(RejectedExecutionException.class)
 				.isThrownBy(() -> w.schedule(() -> {}, 100, TimeUnit.MILLISECONDS))
 				.describedAs("worker delayed scheduling")
-				.isSameAs(Exceptions.failWithRejected());
+				.isSameAs(Exceptions.failWithRejectedNotTimeCapable());
 		assertThatExceptionOfType(RejectedExecutionException.class)
 				.isThrownBy(() -> w.schedulePeriodically(() -> {}, 100, 100, TimeUnit.MILLISECONDS))
-				.describedAs("worder periodic scheduling")
-				.isSameAs(Exceptions.failWithRejected());
+				.describedAs("worker periodic scheduling")
+				.isSameAs(Exceptions.failWithRejectedNotTimeCapable());
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTest.java
@@ -58,17 +58,17 @@ public class ExecutorSchedulerTest extends AbstractSchedulerTest {
 		try {
 			assertThatExceptionOfType(RejectedExecutionException.class)
 					.isThrownBy(() -> scheduler.schedule(() -> { }, 100, TimeUnit.MILLISECONDS))
-					.isSameAs(Exceptions.failWithRejected());
+					.isSameAs(Exceptions.failWithRejectedNotTimeCapable());
 			assertThatExceptionOfType(RejectedExecutionException.class)
 					.isThrownBy(() -> scheduler.schedulePeriodically(() -> { }, 100, 100, TimeUnit.MILLISECONDS))
-					.isSameAs(Exceptions.failWithRejected());
+					.isSameAs(Exceptions.failWithRejectedNotTimeCapable());
 
 			assertThatExceptionOfType(RejectedExecutionException.class)
 					.isThrownBy(() -> worker.schedule(() -> { }, 100, TimeUnit.MILLISECONDS))
-					.isSameAs(Exceptions.failWithRejected());
+					.isSameAs(Exceptions.failWithRejectedNotTimeCapable());
 			assertThatExceptionOfType(RejectedExecutionException.class)
 					.isThrownBy(() -> worker.schedulePeriodically(() -> { }, 100, 100, TimeUnit.MILLISECONDS))
-					.isSameAs(Exceptions.failWithRejected());
+					.isSameAs(Exceptions.failWithRejectedNotTimeCapable());
 		}
 		finally {
 			worker.dispose();

--- a/reactor-core/src/test/java/reactor/core/scheduler/ImmediateSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ImmediateSchedulerTest.java
@@ -62,17 +62,17 @@ public class ImmediateSchedulerTest extends AbstractSchedulerTest {
 		try {
 			assertThatExceptionOfType(RejectedExecutionException.class)
 					.isThrownBy(() -> scheduler.schedule(() -> { }, 100, TimeUnit.MILLISECONDS))
-					.isSameAs(Exceptions.failWithRejected());
+					.isSameAs(Exceptions.failWithRejectedNotTimeCapable());
 			assertThatExceptionOfType(RejectedExecutionException.class)
 					.isThrownBy(() -> scheduler.schedulePeriodically(() -> { }, 100, 100, TimeUnit.MILLISECONDS))
-					.isSameAs(Exceptions.failWithRejected());
+					.isSameAs(Exceptions.failWithRejectedNotTimeCapable());
 
 			assertThatExceptionOfType(RejectedExecutionException.class)
 					.isThrownBy(() -> worker.schedule(() -> { }, 100, TimeUnit.MILLISECONDS))
-					.isSameAs(Exceptions.failWithRejected());
+					.isSameAs(Exceptions.failWithRejectedNotTimeCapable());
 			assertThatExceptionOfType(RejectedExecutionException.class)
 					.isThrownBy(() -> worker.schedulePeriodically(() -> { }, 100, 100, TimeUnit.MILLISECONDS))
-					.isSameAs(Exceptions.failWithRejected());
+					.isSameAs(Exceptions.failWithRejectedNotTimeCapable());
 		}
 		finally {
 			worker.dispose();


### PR DESCRIPTION
The `Scheduler` interface contains default implementations for the time-based scheduling methods that throws a `RejectedExceptionException`. Add a reason to the exception to indicate that the Scheduler isn't capable of time-based scheduling.

(also secretly fix a typo of worder -> worker)