### PR TITLE
Scannable.name() method conflicts with java.lang.Enum.name()

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -815,8 +815,8 @@ public abstract class Operators {
 	};
 
 	//
-	enum CancelledSubscription implements Subscription, Scannable {
-		INSTANCE;
+	final static class CancelledSubscription implements Subscription, Scannable {
+		static final CancelledSubscription INSTANCE = new CancelledSubscription();
 
 		@Override
 		@Nullable
@@ -841,8 +841,8 @@ public abstract class Operators {
 
 	}
 
-	enum EmptySubscription implements Fuseable.QueueSubscription<Object>, Scannable {
-		INSTANCE;
+	final static class EmptySubscription implements Fuseable.QueueSubscription<Object>, Scannable {
+		static final EmptySubscription INSTANCE = new EmptySubscription();
 
 		@Override
 		public void cancel() {


### PR DESCRIPTION
java.lang.Enum has a final name() method which conflicts with Scannable.name(). The compiler isn't very helpful in generating a warning here, but I suspect the Enum.name() method is the one that will be used rather than the intended Scannable.name().