### PR TITLE
fix #758 Safely suppress exceptions through Exceptions.addSuppressed

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Exceptions.java
+++ b/reactor-core/src/main/java/reactor/core/Exceptions.java
@@ -43,7 +43,7 @@ public abstract class Exceptions {
 	 * don't leak this!
 	 */
 	@SuppressWarnings("ThrowableInstanceNeverThrown")
-	public static final Throwable TERMINATED = new Throwable("No further exceptions");
+	public static final Throwable TERMINATED = new Throwable("Operator has been terminated");
 
 	/**
 	 * Update an empty atomic reference with the given exception, or combine further added
@@ -71,6 +71,7 @@ public abstract class Exceptions {
 			}
 
 			if (current instanceof CompositeException) {
+				//this is ok, composite exceptions are never singletons
 				current.addSuppressed(exception);
 				return true;
 			}
@@ -90,7 +91,7 @@ public abstract class Exceptions {
 
 	/**
 	 * Create a composite exception that wraps the given {@link Throwable Throwable(s)},
-	 * as suppressed exceptions.Instances create by this method can be detected using the
+	 * as suppressed exceptions. Instances create by this method can be detected using the
 	 * {@link #isMultiple(Throwable)} check. The {@link #unwrapMultiple(Throwable)} method
 	 * will correctly unwrap these to a {@link List} of the suppressed exceptions. Note
 	 * that is will also be consistent in producing a List for other types of exceptions
@@ -106,17 +107,32 @@ public abstract class Exceptions {
 		//noinspection ConstantConditions
 		if (throwables != null) {
 			for (Throwable t : throwables) {
+				//this is ok, multiple is always a new non-singleton instance
 				multiple.addSuppressed(t);
 			}
 		}
 		return multiple;
 	}
 
+	/**
+	 * Create a composite exception that wraps the given {@link Throwable Throwable(s)},
+	 * as suppressed exceptions. Instances create by this method can be detected using the
+	 * {@link #isMultiple(Throwable)} check. The {@link #unwrapMultiple(Throwable)} method
+	 * will correctly unwrap these to a {@link List} of the suppressed exceptions. Note
+	 * that is will also be consistent in producing a List for other types of exceptions
+	 * by putting the input inside a single-element List.
+	 *
+	 * @param throwables the exceptions to wrap into a composite
+	 * @return a composite exception with a standard message, and the given throwables as
+	 * suppressed exceptions
+	 * @see #addThrowable(AtomicReferenceFieldUpdater, Object, Throwable)
+	 */
 	public static RuntimeException multiple(Iterable<Throwable> throwables) {
 		RuntimeException multiple = new RuntimeException("Multiple exceptions");
 		//noinspection ConstantConditions
 		if (throwables != null) {
 			for (Throwable t : throwables) {
+				//this is ok, multiple is always a new non-singleton instance
 				multiple.addSuppressed(t);
 			}
 		}
@@ -220,10 +236,25 @@ public abstract class Exceptions {
 	/**
 	 * Return a new {@link RejectedExecutionException} with standard message and cause
 	 *
-	 * @param cause
+	 * @param cause the original exception that caused the rejection
 	 * @return a new {@link RejectedExecutionException} with standard message and cause
 	 */
 	public static RejectedExecutionException failWithRejected(Throwable cause) {
+		return new ReactorRejectedExecutionException("Scheduler unavailable", cause);
+	}
+
+	/**
+	 * Return a new {@link RejectedExecutionException} with standard message and cause,
+	 * unless the {@code cause} is already a {@link RejectedExecutionException} created
+	 * via {@link #failWithRejected(Throwable)} (not the singleton-producing variants).
+	 *
+	 * @param cause the original exception that caused the rejection
+	 * @return a new {@link RejectedExecutionException} with standard message and cause
+	 */
+	public static RejectedExecutionException asRejected(Throwable cause) {
+		if (cause instanceof ReactorRejectedExecutionException) {
+			return (RejectedExecutionException) cause;
+		}
 		return new RejectedExecutionException("Scheduler unavailable", cause);
 	}
 
@@ -403,6 +434,41 @@ public abstract class Exceptions {
 		return Collections.singletonList(potentialMultiple);
 	}
 
+	public static final RuntimeException addSuppressed(RuntimeException original, Throwable suppressed) {
+		if (original == suppressed) {
+			return original;
+		}
+		if (original == REJECTED_EXECUTION || original == NOT_TIME_CAPABLE_REJECTED_EXECUTION) {
+			RejectedExecutionException ree = new RejectedExecutionException(original.getMessage());
+			ree.addSuppressed(suppressed);
+			return ree;
+		}
+		else {
+			original.addSuppressed(suppressed);
+			return original;
+		}
+	}
+
+	public static final Throwable addSuppressed(Throwable original, final Throwable suppressed) {
+		if (original == suppressed) {
+			return original;
+		}
+
+		if (original == TERMINATED) {
+			return original;
+		}
+
+		if (original == REJECTED_EXECUTION || original == NOT_TIME_CAPABLE_REJECTED_EXECUTION) {
+			RejectedExecutionException ree = new RejectedExecutionException(original.getMessage());
+			ree.addSuppressed(suppressed);
+			return ree;
+		}
+		else {
+			original.addSuppressed(suppressed);
+			return original;
+		}
+	}
+
 	Exceptions() {
 	}
 
@@ -490,6 +556,13 @@ public abstract class Exceptions {
 
 		OverflowException(String s) {
 			super(s);
+		}
+	}
+
+	static final class ReactorRejectedExecutionException extends RejectedExecutionException {
+
+		ReactorRejectedExecutionException(String message, Throwable cause) {
+			super(message, cause);
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/Exceptions.java
+++ b/reactor-core/src/main/java/reactor/core/Exceptions.java
@@ -234,16 +234,6 @@ public abstract class Exceptions {
 	}
 
 	/**
-	 * Return a new {@link RejectedExecutionException} with standard message and cause
-	 *
-	 * @param cause the original exception that caused the rejection
-	 * @return a new {@link RejectedExecutionException} with standard message and cause
-	 */
-	public static RejectedExecutionException failWithRejected(Throwable cause) {
-		return new ReactorRejectedExecutionException("Scheduler unavailable", cause);
-	}
-
-	/**
 	 * Return a new {@link RejectedExecutionException} with standard message and cause,
 	 * unless the {@code cause} is already a {@link RejectedExecutionException} created
 	 * via {@link #failWithRejected(Throwable)} (not the singleton-producing variants).
@@ -251,7 +241,7 @@ public abstract class Exceptions {
 	 * @param cause the original exception that caused the rejection
 	 * @return a new {@link RejectedExecutionException} with standard message and cause
 	 */
-	public static RejectedExecutionException asRejected(Throwable cause) {
+	public static RejectedExecutionException failWithRejected(Throwable cause) {
 		if (cause instanceof ReactorRejectedExecutionException) {
 			return (RejectedExecutionException) cause;
 		}

--- a/reactor-core/src/main/java/reactor/core/Exceptions.java
+++ b/reactor-core/src/main/java/reactor/core/Exceptions.java
@@ -255,7 +255,7 @@ public abstract class Exceptions {
 		if (cause instanceof ReactorRejectedExecutionException) {
 			return (RejectedExecutionException) cause;
 		}
-		return new RejectedExecutionException("Scheduler unavailable", cause);
+		return new ReactorRejectedExecutionException("Scheduler unavailable", cause);
 	}
 
 	/**
@@ -434,6 +434,23 @@ public abstract class Exceptions {
 		return Collections.singletonList(potentialMultiple);
 	}
 
+	/**
+	 * Safely suppress a {@link Throwable} on a {@link RuntimeException}. The returned
+	 * {@link RuntimeException}, bearing the suppressed exception, is most often the same
+	 * as the original exception unless:
+	 * <ul>
+	 *     <li>original and tentatively suppressed exceptions are one and the same: do
+	 *     nothing but return the original.</li>
+	 *     <li>original is one of the singleton {@link RejectedExecutionException} created
+	 *     by Reactor: make a copy the {@link RejectedExecutionException}, add the
+	 *     suppressed exception to it and return that copy.</li>
+	 *
+	 * </ul>
+	 * @param original the original {@link RuntimeException} to bear a suppressed exception
+	 * @param suppressed the {@link Throwable} to suppress
+	 * @return the (most of the time original) {@link RuntimeException} bearing the
+	 * suppressed {@link Throwable}
+	 */
 	public static final RuntimeException addSuppressed(RuntimeException original, Throwable suppressed) {
 		if (original == suppressed) {
 			return original;
@@ -449,6 +466,25 @@ public abstract class Exceptions {
 		}
 	}
 
+	/**
+	 * Safely suppress a {@link Throwable} on an original {@link Throwable}. The returned
+	 * {@link Throwable}, bearing the suppressed exception, is most often the same
+	 * as the original one unless:
+	 * <ul>
+	 *     <li>original and tentatively suppressed exceptions are one and the same: do
+	 *     nothing but return the original.</li>
+	 *     <li>original is one of the singleton {@link RejectedExecutionException} created
+	 *     by Reactor: make a copy the {@link RejectedExecutionException}, add the
+	 *     suppressed exception to it and return that copy.</li>
+	 *     <li>original is a special internal TERMINATED singleton instance: return it
+	 *     without suppressing the exception.</li>
+	 *
+	 * </ul>
+	 * @param original the original {@link Throwable} to bear a suppressed exception
+	 * @param suppressed the {@link Throwable} to suppress
+	 * @return the (most of the time original) {@link Throwable} bearing the
+	 * suppressed {@link Throwable}
+	 */
 	public static final Throwable addSuppressed(Throwable original, final Throwable suppressed) {
 		if (original == suppressed) {
 			return original;

--- a/reactor-core/src/main/java/reactor/core/publisher/BaseSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/BaseSubscriber.java
@@ -178,9 +178,7 @@ public abstract class BaseSubscriber<T> implements CoreSubscriber<T>, Subscripti
 			hookOnError(t);
 		}
 		catch (Throwable e) {
-			if (e != t) {
-				e.addSuppressed(t);
-			}
+			e = Exceptions.addSuppressed(e, t);
 			Operators.onErrorDropped(e, currentContext());
 		}
 		finally {

--- a/reactor-core/src/main/java/reactor/core/publisher/BlockingSingleSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/BlockingSingleSubscriber.java
@@ -85,6 +85,7 @@ abstract class BlockingSingleSubscriber<T> extends CountDownLatch
 		Throwable e = error;
 		if (e != null) {
 			RuntimeException re = Exceptions.propagate(e);
+			//this is ok, as re is always a new non-singleton instance
 			re.addSuppressed(new Exception("#block terminated with an error"));
 			throw re;
 		}
@@ -112,6 +113,7 @@ abstract class BlockingSingleSubscriber<T> extends CountDownLatch
 			catch (InterruptedException ex) {
 				dispose();
 				RuntimeException re = Exceptions.propagate(ex);
+				//this is ok, as re is always a new non-singleton instance
 				re.addSuppressed(new Exception("#block has been interrupted"));
 				throw re;
 			}
@@ -120,6 +122,7 @@ abstract class BlockingSingleSubscriber<T> extends CountDownLatch
 		Throwable e = error;
 		if (e != null) {
 			RuntimeException re = Exceptions.propagate(e);
+			//this is ok, as re is always a new non-singleton instance
 			re.addSuppressed(new Exception("#block terminated with an error"));
 			throw re;
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/EventLoopProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EventLoopProcessor.java
@@ -31,6 +31,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.reactivestreams.Subscription;
+import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.util.concurrent.Queues;
 import reactor.util.concurrent.WaitStrategy;
@@ -63,9 +64,7 @@ abstract class EventLoopProcessor<IN> extends FluxProcessor<IN, IN>
 		});
 		if (error != null) {
 			if (t != null) {
-				if (t != error) {
-					t.addSuppressed(error);
-				}
+				t = Exceptions.addSuppressed(t, error);
 				return concat(bufferIterable, Flux.error(t));
 			}
 			return concat(bufferIterable, Flux.error(error));

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnErrorResume.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnErrorResume.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
 
 /**
  * Resumes the failed main sequence with another sequence returned by
@@ -89,9 +90,7 @@ final class FluxOnErrorResume<T> extends FluxOperator<T, T> {
 				}
 				catch (Throwable e) {
 					Throwable _e = Operators.onOperatorError(e, actual.currentContext());
-					if (t != _e) {
-						_e.addSuppressed(t);
-					}
+					_e = Exceptions.addSuppressed(_e, t);
 					actual.onError(_e);
 					return;
 				}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRetryPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRetryPredicate.java
@@ -21,6 +21,7 @@ import java.util.function.Predicate;
 
 import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
 
 /**
  * Repeatedly subscribes to the source if the predicate returns true after
@@ -88,9 +89,7 @@ final class FluxRetryPredicate<T> extends FluxOperator<T, T> {
 				b = predicate.test(t);
 			} catch (Throwable e) {
 				Throwable _t = Operators.onOperatorError(e, actual.currentContext());
-				if (_t != t) {
-					_t.addSuppressed(t);
-				}
+				_t = Exceptions.addSuppressed(_t, t);
 				actual.onError(_t);
 				return;
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxUsing.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxUsing.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 
 /**
@@ -85,16 +86,15 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 					"The sourceFactory returned a null value");
 		}
 		catch (Throwable e) {
-
+			Throwable _e = Operators.onOperatorError(e, actual.currentContext());
 			try {
 				resourceCleanup.accept(resource);
 			}
 			catch (Throwable ex) {
-				ex.addSuppressed(Operators.onOperatorError(e, actual.currentContext()));
-				e = ex;
+				_e = Exceptions.addSuppressed(ex, _e);
 			}
 
-			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
+			Operators.error(actual, _e);
 			return;
 		}
 
@@ -203,10 +203,7 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 				}
 				catch (Throwable e) {
 					Throwable _e = Operators.onOperatorError(e, actual.currentContext());
-					if (_e != t) {
-						_e.addSuppressed(t);
-					}
-					t = _e;
+					t = Exceptions.addSuppressed(_e, t);
 				}
 			}
 
@@ -356,10 +353,7 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 				}
 				catch (Throwable e) {
 					Throwable _e = Operators.onOperatorError(e, actual.currentContext());
-					if (_e != t) {
-						_e.addSuppressed(t);
-					}
-					t = _e;
+					t = Exceptions.addSuppressed(_e, t);
 				}
 			}
 
@@ -520,10 +514,7 @@ final class FluxUsing<T, S> extends Flux<T> implements Fuseable {
 				}
 				catch (Throwable e) {
 					Throwable _e = Operators.onOperatorError(e, actual.currentContext());
-					if (_e != t) {
-						_e.addSuppressed(t);
-					}
-					t = _e;
+					t = Exceptions.addSuppressed(_e, t);
 				}
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
@@ -184,6 +184,7 @@ final class MonoDelayUntil<T> extends Mono<T> {
 				Throwable e = mt.error;
 				if (e != null) {
 					if (compositeError != null) {
+						//this is ok as the composite created by multiple is never a singleton
 						compositeError.addSuppressed(e);
 					} else
 					if (error != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -171,7 +171,7 @@ public final class MonoProcessor<O> extends Mono<O>
 						return value;
 					case STATE_ERROR:
 						RuntimeException re = Exceptions.propagate(error);
-						re.addSuppressed(new Exception("Mono#block terminated with an error"));
+						re = Exceptions.addSuppressed(re, new Exception("Mono#block terminated with an error"));
 						throw re;
 					case STATE_COMPLETE_NO_VALUE:
 						return null;
@@ -389,7 +389,7 @@ public final class MonoProcessor<O> extends Mono<O>
 		}
 		else if (endState == STATE_ERROR) {
 			RuntimeException re = Exceptions.propagate(error);
-			re.addSuppressed(new Exception("Mono#peek terminated with an error"));
+			re = Exceptions.addSuppressed(re, new Exception("Mono#peek terminated with an error"));
 			throw re;
 		}
 		else {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoUsing.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoUsing.java
@@ -22,6 +22,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 
 /**
@@ -86,8 +87,7 @@ final class MonoUsing<T, S> extends Mono<T> implements Fuseable {
 				resourceCleanup.accept(resource);
 			}
 			catch (Throwable ex) {
-				ex.addSuppressed(Operators.onOperatorError(e, actual.currentContext()));
-				e = ex;
+				e = Exceptions.addSuppressed(ex, Operators.onOperatorError(e, actual.currentContext()));
 			}
 
 			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoWhen.java
@@ -181,6 +181,7 @@ final class MonoWhen extends Mono<Void> {
 				Throwable e = m.error;
 				if (e != null) {
 					if (compositeError != null) {
+						//this is ok as the composite created below is never a singleton
 						compositeError.addSuppressed(e);
 					}
 					else if (error != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoZip.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoZip.java
@@ -217,6 +217,7 @@ final class MonoZip<T, R> extends Mono<R> {
 					Throwable e = m.error;
 					if (e != null) {
 						if (compositeError != null) {
+							//this is ok as the composite created below is never a singleton
 							compositeError.addSuppressed(e);
 						}
 						else if (error != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -375,7 +375,7 @@ public abstract class Operators {
 		if (hook == null) {
 			if (dataSignal != null) {
 				if (dataSignal != t && dataSignal instanceof Throwable) {
-					t.addSuppressed((Throwable) dataSignal);
+					t = Exceptions.addSuppressed(t, (Throwable) dataSignal);
 				}
 				//do not wrap original value to avoid strong references
 				/*else {
@@ -407,7 +407,7 @@ public abstract class Operators {
 	 * operator. This exception denotes that an execution was rejected by a
 	 * {@link reactor.core.scheduler.Scheduler}, notably when it was already disposed.
 	 * <p>
-	 * Wrapping is done by calling both {@link Exceptions#bubble(Throwable)} and
+	 * Wrapping is done by calling both {@link Exceptions#asRejected(Throwable)} and
 	 * {@link #onOperatorError(Subscription, Throwable, Object, Context)} (with the passed
 	 * {@link Subscription}).
 	 *
@@ -427,8 +427,8 @@ public abstract class Operators {
 			context = context.put(Hooks.KEY_ON_OPERATOR_ERROR, context.get(Hooks.KEY_ON_REJECTED_EXECUTION));
 		}
 
-		//FIXME only create REE if original is REE singleton OR there's suppressed OR there's Throwable dataSignal
-		RejectedExecutionException ree = Exceptions.failWithRejected(original);
+		//don't create REE if original is a reactor-produced REE (not including singletons)
+		RejectedExecutionException ree = Exceptions.asRejected(original);
 		if (suppressed != null) {
 			ree.addSuppressed(suppressed);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -407,7 +407,7 @@ public abstract class Operators {
 	 * operator. This exception denotes that an execution was rejected by a
 	 * {@link reactor.core.scheduler.Scheduler}, notably when it was already disposed.
 	 * <p>
-	 * Wrapping is done by calling both {@link Exceptions#asRejected(Throwable)} and
+	 * Wrapping is done by calling both {@link Exceptions#failWithRejected(Throwable)} and
 	 * {@link #onOperatorError(Subscription, Throwable, Object, Context)} (with the passed
 	 * {@link Subscription}).
 	 *
@@ -428,7 +428,7 @@ public abstract class Operators {
 		}
 
 		//don't create REE if original is a reactor-produced REE (not including singletons)
-		RejectedExecutionException ree = Exceptions.asRejected(original);
+		RejectedExecutionException ree = Exceptions.failWithRejected(original);
 		if (suppressed != null) {
 			ree.addSuppressed(suppressed);
 		}

--- a/reactor-core/src/test/java/reactor/core/ExceptionsTest.java
+++ b/reactor-core/src/test/java/reactor/core/ExceptionsTest.java
@@ -287,36 +287,36 @@ public class ExceptionsTest {
 	}
 
 	@Test
-	public void asRejectedNormalWraps() {
+	public void failWithRejectedNormalWraps() {
 		Throwable test = new IllegalStateException("boom");
-		assertThat(Exceptions.asRejected(test))
+		assertThat(Exceptions.failWithRejected(test))
 				.isInstanceOf(Exceptions.ReactorRejectedExecutionException.class)
 				.hasMessage("Scheduler unavailable")
 				.hasCause(test);
 	}
 
 	@Test
-	public void asRejectedSingletonReeWraps() {
+	public void failWithRejectedSingletonReeWraps() {
 		Throwable test = REJECTED_EXECUTION;
-		assertThat(Exceptions.asRejected(test))
+		assertThat(Exceptions.failWithRejected(test))
 				.isInstanceOf(Exceptions.ReactorRejectedExecutionException.class)
 				.hasMessage("Scheduler unavailable")
 				.hasCause(test);
 	}
 
 	@Test
-	public void asRejectedNormalReeWraps() {
+	public void failWithRejectedNormalReeWraps() {
 		Throwable test = new RejectedExecutionException("boom");
-		assertThat(Exceptions.asRejected(test))
+		assertThat(Exceptions.failWithRejected(test))
 				.isInstanceOf(Exceptions.ReactorRejectedExecutionException.class)
 				.hasMessage("Scheduler unavailable")
 				.hasCause(test);
 	}
 
 	@Test
-	public void asRejectedReactorReeNoOp() {
+	public void failWithRejectedReactorReeNoOp() {
 		Throwable test = new Exceptions.ReactorRejectedExecutionException("boom", REJECTED_EXECUTION);
-		assertThat(Exceptions.asRejected(test))
+		assertThat(Exceptions.failWithRejected(test))
 				.isSameAs(test)
 				.hasCause(REJECTED_EXECUTION);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
@@ -352,4 +352,34 @@ public class OperatorsTest {
 		                                .hasMessage("Scheduler unavailable")
 		                                .hasCause(failure);
 	}
+
+	@Test
+	public void testOnRejectedWithReactorRee() {
+		Exception originalCause = new Exception("boom");
+		RejectedExecutionException original = Exceptions.failWithRejected(originalCause);
+		Exception suppressed = new Exception("suppressed");
+
+		RuntimeException test = Operators.onRejectedExecution(original,
+				null, suppressed, null, Context.empty());
+
+		assertThat(test)
+				.isSameAs(original)
+				.hasSuppressedException(suppressed);
+	}
+
+	@Test
+	public void testOnRejectedWithOutsideRee() {
+		RejectedExecutionException original = new RejectedExecutionException("outside");
+		Exception suppressed = new Exception("suppressed");
+
+		RuntimeException test = Operators.onRejectedExecution(original,
+				null, suppressed, null, Context.empty());
+
+		assertThat(test)
+				.isNotSameAs(original)
+				.isInstanceOf(RejectedExecutionException.class)
+				.hasMessage("Scheduler unavailable")
+				.hasCause(original)
+				.hasSuppressedException(suppressed);
+	}
 }


### PR DESCRIPTION
This utility checks that:
 - the suppressed exception is not the same as the original
 - the original exception is not the TERMINATED singleton (which is left
 untouched)
 - the original exception is not a singleton RejectedExecutionException
 (in that case, a new copy is made to bear the suppressed exception)

As a consequence, the returned Throwable should always be used to
update the original variable, in case the method changed it.

In all other cases, the `suppressed` parameter is added as a suppressed
exception to `original`, which is then returned.