### PR TITLE
- Schedulers.directSchedulePeriodically modified to create disposable periodic tasks

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/EmptyCompositeDisposable.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/EmptyCompositeDisposable.java
@@ -1,0 +1,38 @@
+package reactor.core.scheduler;
+
+import reactor.core.Disposable;
+
+import java.util.Collection;
+
+final class EmptyCompositeDisposable implements Disposable.Composite {
+
+    @Override
+    public boolean add(Disposable d) {
+        return false;
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends Disposable> ds) {
+        return false;
+    }
+
+    @Override
+    public boolean remove(Disposable d) {
+        return false;
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public void dispose() {
+    }
+
+    @Override
+    public boolean isDisposed() {
+        return false;
+    }
+
+}

--- a/reactor-core/src/main/java/reactor/core/scheduler/PeriodicSchedulerTask.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/PeriodicSchedulerTask.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.scheduler;
+
+import reactor.core.Disposable;
+import reactor.util.annotation.Nullable;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+final class PeriodicSchedulerTask implements Runnable, Disposable, Callable<Void> {
+
+	final Runnable task;
+
+	static final Future<Void> CANCELLED = new FutureTask<>(() -> null);
+
+	volatile Future<?> future;
+	static final AtomicReferenceFieldUpdater<PeriodicSchedulerTask, Future> FUTURE =
+			AtomicReferenceFieldUpdater.newUpdater(PeriodicSchedulerTask.class, Future.class, "future");
+
+	Thread thread;
+
+	PeriodicSchedulerTask(Runnable task) {
+		this.task = task;
+	}
+
+	@Override
+	@Nullable
+	public Void call() {
+		thread = Thread.currentThread();
+		try {
+			try {
+				task.run();
+			}
+			catch (Throwable ex) {
+				Schedulers.handleError(ex);
+			}
+		}
+		finally {
+			thread = null;
+		}
+		return null;
+	}
+
+	@Override
+	public void run() {
+		call();
+	}
+
+	void setFuture(Future<?> f) {
+		for (;;) {
+			Future o = future;
+			if (o == CANCELLED) {
+				f.cancel(thread != Thread.currentThread());
+				return;
+			}
+			if (FUTURE.compareAndSet(this, o, f)) {
+				return;
+			}
+		}
+	}
+
+	@Override
+	public boolean isDisposed() {
+		return future == CANCELLED;
+	}
+
+	@Override
+	public void dispose() {
+		for (;;) {
+			Future f = future;
+			if (f == CANCELLED) {
+				break;
+			}
+			if (FUTURE.compareAndSet(this, f, CANCELLED)) {
+				if (f != null) {
+					f.cancel(thread != Thread.currentThread());
+				}
+				break;
+			}
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -720,7 +720,7 @@ public abstract class Schedulers {
 			long period,
 			TimeUnit unit) {
 
-		WorkerTask sr = new WorkerTask(task, tasks);
+		PeriodicWorkerTask sr = new PeriodicWorkerTask(task, tasks);
 		if (!tasks.add(sr)) {
 			throw Exceptions.failWithRejected();
 		}

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -675,7 +675,7 @@ public abstract class Schedulers {
 			long period,
 			TimeUnit unit) {
 
-		SchedulerTask sr = new SchedulerTask(task);
+		PeriodicSchedulerTask sr = new PeriodicSchedulerTask(task);
 
 		Future<?> f = exec.scheduleAtFixedRate(sr, initialDelay, period, unit);
 		sr.setFuture(f);


### PR DESCRIPTION
Found during the development of the Aeron functionality.

Currently method Schedulers.directSchedulePeriodically schedules a task periodically and returns Disposable using which it's impossible to stop the execution of the scheduled task.

**For example**
```
Disposable disposable = Schedulers.single().schedulePeriodically(() -> {
    System.out.println("One more run!");
}, 500, 500, TimeUnit.MILLISECONDS);

Thread.sleep(1000);
disposable.dispose();
System.out.println("Disposed");
Thread.sleep(1000);
```
**Actual output**
```
One more run!
One more run!
Disposed
One more run!
One more run!

```
The current fix allows creating of periodic tasks which stop running once .disposed in called.