### PR TITLE
fix #895 Safer scan of ACTUAL and PARENT

### DIFF
--- a/reactor-core/src/test/java/reactor/core/ScannableTest.java
+++ b/reactor-core/src/test/java/reactor/core/ScannableTest.java
@@ -474,13 +474,19 @@ public class ScannableTest {
 	public void scanForRawParentOrActual() {
 		Scannable scannable = key -> "String";
 
-		assertThat(scannable.scan(Scannable.RawAttr.ACTUAL_RAW))
+		assertThat(scannable.scanUnsafe(Scannable.Attr.ACTUAL))
 				.isInstanceOf(String.class)
 				.isEqualTo("String");
 
-		assertThat(scannable.scan(Scannable.RawAttr.PARENT_RAW))
+		assertThat(scannable.scan(Scannable.Attr.ACTUAL))
+				.isSameAs(Scannable.Attr.UNAVAILABLE_SCAN);
+
+		assertThat(scannable.scanUnsafe(Scannable.Attr.PARENT))
 				.isInstanceOf(String.class)
 				.isEqualTo("String");
+
+		assertThat(scannable.scan(Scannable.Attr.PARENT))
+				.isSameAs(Scannable.Attr.UNAVAILABLE_SCAN);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/ScannableTest.java
+++ b/reactor-core/src/test/java/reactor/core/ScannableTest.java
@@ -19,6 +19,7 @@ package reactor.core;
 import java.util.Collections;
 import java.util.List;
 
+import org.assertj.core.api.Condition;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -453,5 +454,50 @@ public class ScannableTest {
 				.containsExactlyInAnyOrder(Tuples.of("1", "One"), Tuples.of( "2", "Two"));
 	}
 
+	@Test
+	public void scanForParentIsSafe() {
+		Scannable scannable = key -> "String";
+
+		assertThat(scannable.scan(Scannable.Attr.PARENT))
+				.isSameAs(Scannable.Attr.UNAVAILABLE_SCAN);
+	}
+
+	@Test
+	public void scanForActualIsSafe() {
+		Scannable scannable = key -> "String";
+
+		assertThat(scannable.scan(Scannable.Attr.ACTUAL))
+				.isSameAs(Scannable.Attr.UNAVAILABLE_SCAN);
+	}
+
+	@Test
+	public void scanForRawParentOrActual() {
+		Scannable scannable = key -> "String";
+
+		assertThat(scannable.scan(Scannable.RawAttr.ACTUAL_RAW))
+				.isInstanceOf(String.class)
+				.isEqualTo("String");
+
+		assertThat(scannable.scan(Scannable.RawAttr.PARENT_RAW))
+				.isInstanceOf(String.class)
+				.isEqualTo("String");
+	}
+
+	@Test
+	public void attributeIsConversionSafe() {
+		assertThat(Scannable.Attr.ACTUAL.isConversionSafe()).as("ACTUAL").isTrue();
+		assertThat(Scannable.Attr.PARENT.isConversionSafe()).as("PARENT").isTrue();
+
+		assertThat(Scannable.Attr.BUFFERED.isConversionSafe()).as("BUFFERED").isFalse();
+		assertThat(Scannable.Attr.CAPACITY.isConversionSafe()).as("CAPACITY").isFalse();
+		assertThat(Scannable.Attr.CANCELLED.isConversionSafe()).as("CANCELLED").isFalse();
+		assertThat(Scannable.Attr.DELAY_ERROR.isConversionSafe()).as("DELAY_ERROR").isFalse();
+		assertThat(Scannable.Attr.ERROR.isConversionSafe()).as("ERROR").isFalse();
+		assertThat(Scannable.Attr.LARGE_BUFFERED.isConversionSafe()).as("LARGE_BUFFERED").isFalse();
+		assertThat(Scannable.Attr.NAME.isConversionSafe()).as("NAME").isFalse();
+		assertThat(Scannable.Attr.PREFETCH.isConversionSafe()).as("PREFETCH").isFalse();
+		assertThat(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM.isConversionSafe()).as("REQUESTED_FROM_DOWNSTREAM").isFalse();
+		assertThat(Scannable.Attr.TERMINATED.isConversionSafe()).as("TERMINATED").isFalse();
+	}
 
 }


### PR DESCRIPTION
This commit makes scanning of ACTUAL and PARENT safer by introducing a
safe converter in the Attr class. By default, no converter is defined
and the old behavior of force-casting is still used.

For the two attributes above however, the value from `scanUnsafe` goes
through `Scannable#from` first when calling `scan` or `scanOrDefaul`.
That way, even though a lot of operators blindly return something that
is Scannable _in most case but not necessarily_ (e.g. a Publisher),
the outer scan will not fail.

Added companion `RawAttr` for ACTUAL and PARENT which are `Attr<Object>`
always returning the raw value from the operator (downcasted to Object).