### PR TITLE
fix #898 Add Context testing features

### DIFF
--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
@@ -47,6 +48,8 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
+import reactor.core.Scannable;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Operators;
 import reactor.core.publisher.Signal;
@@ -54,6 +57,7 @@ import reactor.test.scheduler.VirtualTimeScheduler;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
@@ -208,6 +212,28 @@ final class DefaultStepVerifierBuilder<T>
 					"consumeSubscriptionWith"));
 		}
 		return this;
+	}
+
+	@Override
+	public StepVerifier.ContextExpectations<T> expectAccessibleContext() {
+		return new DefaultContextExpectations<>(this);
+	}
+
+	@Override
+	public DefaultStepVerifierBuilder<T> expectNoAccessibleContext() {
+		return consumeSubscriptionWith(sub -> {
+					Scannable lowest = Scannable.from(sub);
+					Scannable verifierSubscriber = Scannable.from(lowest.scan(Scannable.Attr.ACTUAL));
+
+					Context c = Flux.fromStream(verifierSubscriber.parents())
+					                .ofType(CoreSubscriber.class)
+					                .map(CoreSubscriber::currentContext)
+					                .blockLast();
+
+					if (c != null) {
+						throw new AssertionError("Expected no accessible Context, got " + c);
+					}
+				});
 	}
 
 	@Override
@@ -690,6 +716,7 @@ final class DefaultStepVerifierBuilder<T>
 							this.requestedFusionMode,
 							this.expectedFusionMode,
 							this.debugEnabled,
+							this.parent.options.getInitialContext(),
 							vts);
 
 					publisher.subscribe(newVerifier);
@@ -735,6 +762,7 @@ final class DefaultStepVerifierBuilder<T>
 					this.requestedFusionMode,
 					this.expectedFusionMode,
 					this.debugEnabled,
+					this.parent.options.getInitialContext(),
 					vts);
 		}
 
@@ -742,7 +770,7 @@ final class DefaultStepVerifierBuilder<T>
 
 	final static class DefaultVerifySubscriber<T>
 			extends AtomicReference<Subscription>
-			implements StepVerifier, CoreSubscriber<T> {
+			implements StepVerifier, CoreSubscriber<T>, Scannable {
 
 		final CountDownLatch                completeLatch;
 		final Queue<Event<T>>               script;
@@ -750,6 +778,7 @@ final class DefaultStepVerifierBuilder<T>
 		final int                           requestedFusionMode;
 		final int                           expectedFusionMode;
 		final long                          initialRequest;
+		final Context                       initialContext;
 		final VirtualTimeScheduler          virtualTimeScheduler;
 
 		Logger                        logger;
@@ -781,6 +810,7 @@ final class DefaultStepVerifierBuilder<T>
 				int requestedFusionMode,
 				int expectedFusionMode,
 				boolean debugEnabled,
+				@Nullable Context initialContext,
 				@Nullable VirtualTimeScheduler vts) {
 			this.virtualTimeScheduler = vts;
 			this.requestedFusionMode = requestedFusionMode;
@@ -804,6 +834,7 @@ final class DefaultStepVerifierBuilder<T>
 			this.unasserted = 0L;
 			this.completeLatch = new CountDownLatch(1);
 			this.requested = initialRequest;
+			this.initialContext = initialContext == null ? Context.empty() : initialContext;
 		}
 
 		static <R> Queue<Event<R>> conflateScript(List<Event<R>> script, @Nullable Logger logger) {
@@ -853,6 +884,21 @@ final class DefaultStepVerifierBuilder<T>
 			//TODO simplified whole algo, remove DescriptionTasks
 
 			return conflated;
+		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) {
+				Subscription s = this.get();
+				if (s instanceof Scannable) return s;
+			}
+
+			return null;
+		}
+
+		@Override
+		public Context currentContext() {
+			return initialContext;
 		}
 
 		/**
@@ -2196,6 +2242,152 @@ final class DefaultStepVerifierBuilder<T>
 				return Optional.empty();
 			}
 		}, desc);
+	}
+
+	static final class DefaultContextExpectations<T>
+			implements StepVerifier.ContextExpectations<T> {
+
+		private final StepVerifier.Step<T> step;
+		private Consumer<Context>          contextExpectations;
+
+		DefaultContextExpectations(StepVerifier.Step<T> step) {
+			this.step = step;
+			this.contextExpectations = c -> {
+				if (c == null) throw new AssertionError("No propagated Context");
+			};
+		}
+
+		@Override
+		public StepVerifier.Step<T> then() {
+			return step.consumeSubscriptionWith(s -> {
+				Scannable lowest = Scannable.from(s);
+				Scannable verifierSubscriber = Scannable.from(lowest.scan(Scannable.Attr.ACTUAL));
+
+				Context c = Flux.fromStream(verifierSubscriber.parents())
+						.ofType(CoreSubscriber.class)
+						.map(CoreSubscriber::currentContext)
+						.blockLast();
+
+				this.contextExpectations.accept(c);
+			});
+		}
+
+		@Override
+		public StepVerifier.ContextExpectations<T> hasKey(Object key) {
+			this.contextExpectations = this.contextExpectations.andThen(c -> {
+					if (!c.hasKey(key))
+						throw new AssertionError(String.format(
+								"Key %s not found in Context %s", key, c));
+			});
+			return this;
+		}
+
+		@Override
+		public StepVerifier.ContextExpectations<T> hasSize(int size) {
+			this.contextExpectations = this.contextExpectations.andThen(c -> {
+				long realSize = c.stream().count();
+				if (realSize != size)
+					throw new AssertionError(String.format(
+							"Expected Context of size %d, got %d for Context %s", size, realSize, c));
+			});
+			return this;
+		}
+
+		@Override
+		public StepVerifier.ContextExpectations<T> contains(Object key, Object value) {
+			this.contextExpectations = this.contextExpectations.andThen(c -> {
+				Object realValue = c.getOrDefault(key, null);
+				if (realValue == null)
+					throw new AssertionError(String.format(
+							"Expected value %s for key %s, key not present in Context %s", value, key, c));
+
+				if (!value.equals(realValue))
+					throw new AssertionError(String.format(
+							"Expected value %s for key %s, got %s in Context %s", value, key, realValue, c));
+			});
+			return this;
+		}
+
+		@Override
+		public StepVerifier.ContextExpectations<T> containsAllOf(Context other) {
+			this.contextExpectations = this.contextExpectations.andThen(c -> {
+				boolean all = other.stream().allMatch(e -> e.getValue().equals(c.getOrDefault(e.getKey(), null)));
+				if (!all) {
+					throw new AssertionError(String.format("Expected Context %s to contain all of %s", c, other));
+				}
+			});
+			return this;
+		}
+
+		@Override
+		public StepVerifier.ContextExpectations<T> containsAllOf(Map<?, ?> other) {
+			this.contextExpectations = this.contextExpectations.andThen(c -> {
+				boolean all = other.entrySet()
+				                   .stream()
+				                   .allMatch(e -> e.getValue().equals(c.getOrDefault(e.getKey(), null)));
+				if (!all) {
+					throw new AssertionError(String.format("Expected Context %s to contain all of %s", c, other));
+				}
+			});
+			return this;
+		}
+
+		@Override
+		public StepVerifier.ContextExpectations<T> containsOnly(Context other) {
+			this.contextExpectations = this.contextExpectations.andThen(c -> {
+				if (c.stream().count() != other.stream().count()) {
+					throw new AssertionError(String.format("Expected Context %s to contain same values as %s, but they differ in size", c, other));
+				}
+				boolean all = other.stream()
+				                   .allMatch(e -> e.getValue().equals(c.getOrDefault(e.getKey(), null)));
+				if (!all) {
+					throw new AssertionError(String.format("Expected Context %s to contain same values as %s, but they differ in content", c, other));
+				}
+			});
+			return this;
+		}
+
+		@Override
+		public StepVerifier.ContextExpectations<T> containsOnly(Map<?, ?> other) {
+			this.contextExpectations = this.contextExpectations.andThen(c -> {
+				if (c.stream().count() != other.size()) {
+					throw new AssertionError(String.format("Expected Context %s to contain same values as %s, but they differ in size", c, other));
+				}
+				boolean all = other.entrySet()
+				                   .stream()
+				                   .allMatch(e -> e.getValue().equals(c.getOrDefault(e.getKey(), null)));
+				if (!all) {
+					throw new AssertionError(String.format("Expected Context %s to contain same values as %s, but they differ in content", c, other));
+				}
+			});
+			return this;
+		}
+
+		@Override
+		public StepVerifier.ContextExpectations<T> assertThat(Consumer<Context> assertingConsumer) {
+			this.contextExpectations = this.contextExpectations.andThen(assertingConsumer);
+			return this;
+		}
+
+		@Override
+		public StepVerifier.ContextExpectations<T> matches(Predicate<Context> predicate) {
+			this.contextExpectations = this.contextExpectations.andThen(c -> {
+				if (!predicate.test(c)) {
+					throw new AssertionError(String.format("Context %s doesn't match predicate", c));
+				}
+			});
+			return this;
+		}
+
+		@Override
+		public StepVerifier.ContextExpectations<T> matches(Predicate<Context> predicate, String description) {
+			this.contextExpectations = this.contextExpectations.andThen(c -> {
+				if (!predicate.test(c)) {
+					throw new AssertionError(String.format("Context %s doesn't match predicate %s", c, description));
+				}
+			});
+			return this;
+		}
 	}
 
 	static final SignalEvent DEFAULT_ONSUBSCRIBE_STEP = newOnSubscribeStep("defaultOnSubscribe");

--- a/reactor-test/src/main/java/reactor/test/StepVerifierOptions.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifierOptions.java
@@ -19,6 +19,7 @@ import java.util.function.Supplier;
 
 import reactor.test.scheduler.VirtualTimeScheduler;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * Options for a {@link StepVerifier}, including the initial request amount,
@@ -31,6 +32,7 @@ public class StepVerifierOptions {
 	private boolean checkUnderRequesting = true;
 	private long initialRequest = Long.MAX_VALUE;
 	private Supplier<? extends VirtualTimeScheduler> vtsLookup = null;
+	private Context initialContext;
 
 	/**
 	 * Create a new default push of options for a {@link StepVerifier} that can be tuned
@@ -102,5 +104,25 @@ public class StepVerifierOptions {
 	@Nullable
 	public Supplier<? extends VirtualTimeScheduler> getVirtualTimeSchedulerSupplier() {
 		return vtsLookup;
+	}
+
+	/**
+	 * Set an initial {@link Context} to be propagated by the {@link StepVerifier} when it
+	 * subscribes to the sequence under test.
+	 *
+	 * @param context the {@link Context} to propagate.
+	 * @return this instance, to continue setting the options.
+	 */
+	public StepVerifierOptions withInitialContext(Context context) {
+		this.initialContext = context;
+		return this;
+	}
+
+	/**
+	 * @return the {@link Context} to be propagated initially by the {@link StepVerifier}.
+	 */
+	@Nullable
+	public Context getInitialContext() {
+		return this.initialContext;
 	}
 }

--- a/reactor-test/src/test/java/reactor/test/DefaultContextExpectationsTest.java
+++ b/reactor-test/src/test/java/reactor/test/DefaultContextExpectationsTest.java
@@ -83,7 +83,7 @@ public class DefaultContextExpectationsTest {
 	@Test
 	public void notContextAccessible() {
 		assertContextExpectationFails(s -> s, e -> e)
-				.withMessage("No propagated Context (does the sequence only contain a generator?)");
+				.withMessage("No propagated Context");
 	}
 
 	@Test

--- a/reactor-test/src/test/java/reactor/test/DefaultContextExpectationsTest.java
+++ b/reactor-test/src/test/java/reactor/test/DefaultContextExpectationsTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssertAlternative;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.DefaultStepVerifierBuilder.DefaultContextExpectations;
+import reactor.test.StepVerifier.ContextExpectations;
+import reactor.test.StepVerifier.Step;
+import reactor.util.context.Context;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class DefaultContextExpectationsTest {
+
+	private void assertContextExpectation(
+			Function<Flux<Integer>, Flux<Integer>> sourceTransformer,
+			Function<DefaultContextExpectations<Integer>, ContextExpectations<Integer>> expectations,
+			long count) {
+		Flux<Integer> source = sourceTransformer.apply(Flux.range(1, 10));
+		Step<Integer> step = StepVerifier.create(source);
+		final DefaultContextExpectations<Integer> base = new DefaultContextExpectations<>(step);
+
+		expectations
+				.apply(base)
+				.then()
+				.expectNextCount(count)
+				.verifyComplete();
+	}
+
+	private void assertContextExpectation(
+			Function<Flux<Integer>, Flux<Integer>> sourceTransformer,
+			Function<DefaultContextExpectations<Integer>, ContextExpectations<Integer>> expectations) {
+		assertContextExpectation(sourceTransformer, expectations, 10);
+	}
+
+	private ThrowableAssertAlternative<AssertionError> assertContextExpectationFails(
+			Function<Flux<Integer>, Flux<Integer>> sourceTransformer,
+			Function<DefaultContextExpectations<Integer>, ContextExpectations<Integer>> expectations) {
+		return assertThatExceptionOfType(AssertionError.class)
+				.isThrownBy(() -> assertContextExpectation(sourceTransformer, expectations));
+	}
+
+	@Test
+	public void contextAccessibleLastInChain() {
+		assertContextExpectation(s -> s.take(3).subscriberContext(Context.of("a", "b")),
+				e -> e, 3);
+	}
+
+	@Test
+	public void contextAccessibleFirstInChain() {
+		assertContextExpectation(s -> s.subscriberContext(Context.of("a", "b")).take(3),
+				e -> e, 3);
+	}
+
+	@Test
+	public void contextAccessibleSoloInChain() {
+		assertContextExpectation(s -> s.subscriberContext(Context.of("a", "b")), e -> e);
+	}
+
+	@Test
+	public void notContextAccessible() {
+		assertContextExpectationFails(s -> s, e -> e)
+				.withMessage("No propagated Context (does the sequence only contain a generator?)");
+	}
+
+	@Test
+	public void hasKey() throws Exception {
+		assertContextExpectation(s -> s.subscriberContext(Context.of("foo", "bar")),
+				e -> e.hasKey("foo"));
+	}
+	@Test
+	public void notHasKey() throws Exception {
+		assertContextExpectationFails(s -> s.subscriberContext(Context.of("foo", "bar")),
+				e -> e.hasKey("bar"))
+				.withMessage("Key bar not found in Context Context1{foo=bar}");
+	}
+
+	@Test
+	public void hasSize() throws Exception {
+		assertContextExpectation(s -> s.subscriberContext(Context.of("foo", "bar", "foobar", "baz")),
+				e -> e.hasSize(2));
+	}
+
+	@Test
+	public void notHasSize() throws Exception {
+		assertContextExpectationFails(s -> s.subscriberContext(Context.of("foo", "bar", "foobar", "baz"))
+		                                    .subscriberContext(Context.of("fails", true)),
+				e -> e.hasSize(2))
+				.withMessageStartingWith("Expected Context of size 2, got 3 for Context Context3{");
+	}
+
+	@Test
+	public void contains() throws Exception {
+		assertContextExpectation(s -> s.subscriberContext(Context.of("foo", "bar", "foobar", "baz")),
+				e -> e.contains("foo", "bar"));
+	}
+
+	@Test
+	public void notContainsKey() throws Exception {
+		assertContextExpectationFails(s -> s.subscriberContext(Context.of("foo", "bar", "foobar", "baz")),
+				e -> e.contains("fooz", "bar"))
+				.withMessage("Expected value bar for key fooz, key not present in Context " +
+						"Context2{foo=bar, foobar=baz}");
+	}
+
+	@Test
+	public void notContainsValue() throws Exception {
+		assertContextExpectationFails(s -> s.subscriberContext(Context.of("foo", "bar", "foobar", "baz")),
+				e -> e.contains("foo", "baz"))
+				.withMessage("Expected value baz for key foo, got bar in Context " +
+						"Context2{foo=bar, foobar=baz}");
+	}
+
+	@Test
+	public void containsAllOfContext() throws Exception {
+		assertContextExpectation(s -> s.subscriberContext(Context.of("foo", "bar", "foobar", "baz")),
+				e -> e.containsAllOf(Context.of("foo", "bar")));
+	}
+
+	@Test
+	public void notContainsAllOfContext() throws Exception {
+		assertContextExpectationFails(s -> s.subscriberContext(Context.of("foo", "bar", "foobar", "baz")),
+				e -> e.containsAllOf(Context.of("foo", "bar", "other", "stuff")))
+				.withMessage("Expected Context Context2{foo=bar, foobar=baz} to contain all " +
+						"of Context2{foo=bar, other=stuff}");
+	}
+
+	@Test
+	public void containsAllOfMap() throws Exception {
+		assertContextExpectation(s -> s.subscriberContext(Context.of("foo", "bar", "foobar", "baz")),
+				e -> e.containsAllOf(Collections.singletonMap("foo", "bar")));
+	}
+
+	@Test
+	public void notContainsAllOfMap() throws Exception {
+		Map<String, String> expected = new HashMap<>();
+		expected.put("foo", "bar");
+		expected.put("other", "stuff");
+
+		assertContextExpectationFails(s -> s.subscriberContext(Context.of("foo", "bar", "foobar", "baz")),
+				e -> e.containsAllOf(expected))
+				.withMessage("Expected Context Context2{foo=bar, foobar=baz} to contain all " +
+						"of {other=stuff, foo=bar}");
+	}
+
+	@Test
+	public void containsOnlyOfContext() throws Exception {
+		assertContextExpectation(s -> s.subscriberContext(Context.of("foo", "bar")),
+				e -> e.containsOnly(Context.of("foo", "bar")));
+	}
+
+	@Test
+	public void notContainsOnlyOfContextSize() throws Exception {
+		Context expected = Context.of("foo", "bar", "other", "stuff");
+
+		assertContextExpectationFails(s -> s.subscriberContext(Context.of("foo", "bar")),
+				e -> e.containsOnly(expected))
+				.withMessage("Expected Context Context1{foo=bar} to contain same values as " +
+						"Context2{foo=bar, other=stuff}, but they differ in size");
+	}
+
+	@Test
+	public void notContainsOnlyOfContextContent() throws Exception {
+		Context expected = Context.of("foo", "bar", "other", "stuff");
+
+		assertContextExpectationFails(s -> s.subscriberContext(Context.of("foo", "bar", "foobar", "baz")),
+				e -> e.containsOnly(expected))
+				.withMessage("Expected Context Context2{foo=bar, foobar=baz} to contain " +
+						"same values as Context2{foo=bar, other=stuff}, but they differ in content");
+	}
+
+	@Test
+	public void containsOnlyOfMap() throws Exception {
+		assertContextExpectation(s -> s.subscriberContext(Context.of("foo", "bar")),
+				e -> e.containsOnly(Collections.singletonMap("foo", "bar")));
+	}
+
+	@Test
+	public void notContainsOnlyOfMapSize() throws Exception {
+		Map<String, String> expected = new HashMap<>();
+		expected.put("foo", "bar");
+		expected.put("other", "stuff");
+
+		assertContextExpectationFails(s -> s.subscriberContext(Context.of("foo", "bar")),
+				e -> e.containsOnly(expected))
+				.withMessage("Expected Context Context1{foo=bar} to contain same values as " +
+						"{other=stuff, foo=bar}, but they differ in size");
+	}
+
+	@Test
+	public void notContainsOnlyOfMapContent() throws Exception {
+		Map<String, String> expected = new HashMap<>();
+		expected.put("foo", "bar");
+		expected.put("other", "stuff");
+
+		assertContextExpectationFails(s -> s.subscriberContext(Context.of("foo", "bar", "foobar", "baz")),
+				e -> e.containsOnly(expected))
+				.withMessage("Expected Context Context2{foo=bar, foobar=baz} to contain " +
+						"same values as {other=stuff, foo=bar}, but they differ in content");
+	}
+
+	@Test
+	public void assertThat() throws Exception {
+		assertContextExpectation(s -> s.subscriberContext(Context.of("foo", "bar")),
+				e -> e.assertThat(c -> Assertions.assertThat(c).isNotNull()));
+	}
+
+	@Test
+	public void notAssertThat() throws Exception {
+		assertContextExpectationFails(s -> s.subscriberContext(Context.of("foo", "bar")),
+				e -> e.assertThat(c -> { throw new AssertionError("boom"); }))
+				.withMessage("boom");
+	}
+
+	@Test
+	public void matches() throws Exception {
+		assertContextExpectation(s -> s.subscriberContext(Context.of("foo", "bar")),
+				e -> e.matches(Objects::nonNull));
+	}
+
+	@Test
+	public void notMatches() throws Exception {
+		assertContextExpectationFails(s -> s.subscriberContext(Context.of("foo", "bar")),
+				e -> e.matches(Objects::isNull))
+				.withMessage("Context Context1{foo=bar} doesn't match predicate");
+	}
+
+	@Test
+	public void matchesWithDescription() throws Exception {
+		assertContextExpectation(s -> s.subscriberContext(Context.of("foo", "bar")),
+				e -> e.matches(Objects::nonNull, "desc"));
+	}
+
+	@Test
+	public void notMatchesWithDescription() throws Exception {
+		assertContextExpectationFails(s -> s.subscriberContext(Context.of("foo", "bar")),
+				e -> e.matches(Objects::isNull, "desc"))
+				.withMessage("Context Context1{foo=bar} doesn't match predicate desc");
+	}
+
+}

--- a/src/docs/asciidoc/testing.adoc
+++ b/src/docs/asciidoc/testing.adoc
@@ -212,6 +212,42 @@ assert a few elements of state once the whole scenario has played out successful
 elements that have been dropped by some operator and assert them (see the section on
 <<hooks,Hooks>>).
 
+== Testing the `Context`
+For more information about the `Context`, see <<context>>.
+
+`StepVerifier` comes with a couple of expectations around the propagation of a `Context`:
+
+  - `expectAccessibleContext`: returns a `ContextExpectations` object that you can use
+  to set up expectations on the propagated `Context`. Be sure to call `then()` to return
+  to the set up of sequence expectations.
+
+  - `expectNoAccessibleContext`: set up an expectation that NO `Context` can be propagated
+  up the chain of operators under test. This most likely occurs when the `Publisher` under
+  test is not a Reactor one, or doesn't have any operator that can propagate the `Context`
+  (e.g. just a _generator_ source).
+
+Additionally, one can associate a test-specific initial `Context` to a `StepVerifier` by
+using `StepVerifierOptions` to create the verifier.
+
+These features are demonstrated in the following snippet:
+
+[source,java]
+----
+StepVerifier.create(Mono.just(1).map(i -> i + 10),
+				StepVerifierOptions.create().withInitialContext(Context.of("foo", "bar"))) // <1>
+		            .expectAccessibleContext() //<2>
+		            .contains("foo", "bar") // <3>
+		            .then() // <4>
+		            .expectNext(11)
+		            .verifyComplete(); // <5>
+----
+<1> Create the `StepVerifier` using `StepVerifierOptions` and pass in an initial `Context`
+<2> Start setting up expectations about `Context` propagation. This alone ensures that a
+`Context` *was* propagated.
+<3> An example of a `Context`-specific expectation: it must contain value "bar" for key "foo".
+<4> We `then()` switch back to setting up normal expectations on the data.
+<5> Let's not forget to `verify()` the whole set of expectations.
+
 == Manually Emitting with `TestPublisher`
 For more advanced test cases, it might be useful to have complete mastery over the source
 of data, in order to trigger finely chosen signals that closely match the particular


### PR DESCRIPTION
- set up an initial Context for a StepVerifier using options
 - set up expectations on the furthest reachable Context in the source
 chain