### PR TITLE
fix #905 ParallelFlux now considered a THREAD_BARRIER

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelSource.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelSource.java
@@ -173,7 +173,7 @@ final class ParallelSource<T> extends ParallelFlux<T> implements Scannable {
 					@SuppressWarnings("unchecked")
 					Fuseable.QueueSubscription<T> qs = (Fuseable.QueueSubscription<T>) s;
 					
-					int m = qs.requestFusion(Fuseable.ANY);
+					int m = qs.requestFusion(Fuseable.ANY | Fuseable.THREAD_BARRIER);
 					
 					if (m == Fuseable.SYNC) {
 						sourceMode = m;


### PR DESCRIPTION
This commit makes ParallelSource request fusion with the THREAD_BARRIER
flag when subscribing to a Fuseable source. Since most of the time
`parallel()` is immediately followed by `runOn()`, upstream operators
could previously execute on an unwanted thread (which is unexpected for
eg. map and doOn*). Now such operators can decide not to fuse, restoring
their expected behavior.