### PR TITLE
Clarify backpressure overflow error message of `interval`

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -942,7 +942,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	/**
 	 * Create a {@link Flux} that emits long values starting with 0 and incrementing at
 	 * specified time intervals on the global timer. If demand is not produced in time,
-	 * an onError will be signalled. The {@link Flux} will never complete.
+	 * an onError will be signalled with an {@link Exceptions#isOverflow(Throwable) overflow}
+	 * {@code IllegalStateException} detailing the tick that couldn't be emitted.
+	 * In normal conditions, the {@link Flux} will never complete.
 	 * <p>
 	 * Runs on the {@link Schedulers#parallel()} Scheduler.
 	 * <p>
@@ -958,7 +960,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	/**
 	 * Create a {@link Flux} that emits long values starting with 0 and incrementing at
 	 * specified time intervals, after an initial delay, on the global timer. If demand is
-	 * not produced in time, an onError will be signalled. The {@link Flux} will never complete.
+	 * not produced in time, an onError will be signalled with an
+	 * {@link Exceptions#isOverflow(Throwable) overflow} {@code IllegalStateException}
+	 * detailing the tick that couldn't be emitted. In normal conditions, the {@link Flux}
+	 * will never complete.
 	 * <p>
 	 * Runs on the {@link Schedulers#parallel()} Scheduler.
 	 * <p>
@@ -975,8 +980,10 @@ public abstract class Flux<T> implements Publisher<T> {
 
 	/**
 	 * Create a {@link Flux} that emits long values starting with 0 and incrementing at
-	 * specified time intervals, on the specified {@link Scheduler}. If demand is
-	 * not produced in time, an onError will be signalled. The {@link Flux} will never complete.
+	 * specified time intervals, on the specified {@link Scheduler}. If demand is not
+	 * produced in time, an onError will be signalled with an {@link Exceptions#isOverflow(Throwable) overflow}
+	 * {@code IllegalStateException} detailing the tick that couldn't be emitted.
+	 * In normal conditions, the {@link Flux} will never complete.
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.0.RC1/src/docs/marble/interval.png" alt="">
 	 * <p>
@@ -992,7 +999,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	/**
 	 * Create a {@link Flux} that emits long values starting with 0 and incrementing at
 	 * specified time intervals, after an initial delay, on the specified {@link Scheduler}.
-	 * If demand is not produced in time, an onError will be signalled. The {@link Flux}
+	 * If demand is not produced in time, an onError will be signalled with an
+	 * {@link Exceptions#isOverflow(Throwable) overflow} {@code IllegalStateException}
+	 * detailing the tick that couldn't be emitted. In normal conditions, the {@link Flux}
 	 * will never complete.
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.0.RC1/src/docs/marble/intervald.png" alt="">

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxInterval.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxInterval.java
@@ -118,7 +118,8 @@ final class FluxInterval extends Flux<Long> {
 				} else {
 					cancel();
 					
-					actual.onError(Exceptions.failWithOverflow("Could not emit value " + count + " due to lack of requests"));
+					actual.onError(Exceptions.failWithOverflow("Could not emit tick " + count + " due to lack of requests" +
+							" (interval doesn't support small downstream requests that replenish slower than the ticks)"));
 				}
 			}
 		}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxIntervalTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxIntervalTest.java
@@ -152,4 +152,14 @@ public class FluxIntervalTest {
         test.cancel();
         assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
     }
+
+    @Test
+	public void tickOverflow() {
+		StepVerifier.withVirtualTime(() ->
+				Flux.interval(Duration.ofMillis(50))
+				    .delayUntil(i -> Mono.delay(Duration.ofMillis(250))))
+		            .thenAwait(Duration.ofMinutes(1))
+		            .expectNextCount(6)
+		            .verifyErrorMessage("Could not emit tick 32 due to lack of requests (interval doesn't support small downstream requests that replenish slower than the ticks)");
+    }
 }


### PR DESCRIPTION
This commit clarifies the javadoc and the error message propagated when
a `Flux#interval` ticks beyond downstream requests, resulting in an
OverflowException.

The message and javadoc make it more explicit that the error is coming
from the fact that interval doesn't really support backpressure, and
that the downstream should replenish requested amount before all the
ticks have been emitted.