### PR TITLE
fix #906 Add Mono#blockOptional

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/BlockingOptionalMonoSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/BlockingOptionalMonoSubscriber.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.reactivestreams.Subscription;
+import reactor.core.Disposable;
+import reactor.core.Exceptions;
+import reactor.util.annotation.Nullable;
+
+/**
+ * Blocks assuming the upstream is a Mono, until it signals its value or completes.
+ * Similar to {@link BlockingSingleSubscriber}, except blockGet methods return an {@link Optional}
+ * and thus aren't nullable..
+ *
+ * @param <T> the value type
+ * @see <a href="https://github.com/reactor/reactive-streams-commons">https://github.com/reactor/reactive-streams-commons</a>
+ */
+final class BlockingOptionalMonoSubscriber<T> extends CountDownLatch
+		implements InnerConsumer<T>, Disposable {
+
+	T         value;
+	Throwable error;
+
+	Subscription s;
+
+	volatile boolean cancelled;
+
+	BlockingOptionalMonoSubscriber() {
+		super(1);
+	}
+
+	@Override
+	public void onNext(T t) {
+		if (value == null) {
+			value = t;
+			countDown();
+		}
+	}
+
+	@Override
+	public void onError(Throwable t) {
+		if (value == null) {
+			error = t;
+		}
+		countDown();
+	}
+
+	@Override
+	public final void onSubscribe(Subscription s) {
+		this.s = s;
+		if (!cancelled) {
+			s.request(Long.MAX_VALUE);
+		}
+	}
+
+	@Override
+	public final void onComplete() {
+		countDown();
+	}
+
+	@Override
+	public final void dispose() {
+		cancelled = true;
+		Subscription s = this.s;
+		if (s != null) {
+			this.s = null;
+			s.cancel();
+		}
+	}
+
+	/**
+	 * Block until the first value arrives or the source completes empty, and return it
+	 * as an {@link Optional}. Rethrow any exception.
+	 *
+	 * @return an Optional representing the first value (or empty Optional if the source is empty)
+	 */
+	final Optional<T> blockingGet() {
+		if (getCount() != 0) {
+			try {
+				await();
+			}
+			catch (InterruptedException ex) {
+				dispose();
+				RuntimeException re = Exceptions.propagate(ex);
+				//this is ok, as re is always a new non-singleton instance
+				re.addSuppressed(new Exception("#blockOptional() has been interrupted"));
+				throw re;
+			}
+		}
+
+		Throwable e = error;
+		if (e != null) {
+			RuntimeException re = Exceptions.propagate(e);
+			//this is ok, as re is always a new non-singleton instance
+			re.addSuppressed(new Exception("#block terminated with an error"));
+			throw re;
+		}
+		return Optional.ofNullable(value);
+	}
+
+	/**
+	 * Block until the first value arrives or the source completes empty, and return it
+	 * as an {@link Optional}. Rethrow any exception.
+	 *
+	 * @param timeout the timeout to wait
+	 * @param unit the time unit
+	 *
+	 * @return an Optional representing the first value (or empty Optional if the source is empty)
+	 */
+	final Optional<T> blockingGet(long timeout, TimeUnit unit) {
+		if (getCount() != 0) {
+			try {
+				if (!await(timeout, unit)) {
+					dispose();
+					throw new IllegalStateException("Timeout on blocking read for " + timeout + " " + unit);
+				}
+			}
+			catch (InterruptedException ex) {
+				dispose();
+				RuntimeException re = Exceptions.propagate(ex);
+				//this is ok, as re is always a new non-singleton instance
+				re.addSuppressed(new Exception("#blockOptional(timeout) has been interrupted"));
+				throw re;
+			}
+		}
+
+		Throwable e = error;
+		if (e != null) {
+			RuntimeException re = Exceptions.propagate(e);
+			//this is ok, as re is always a new non-singleton instance
+			re.addSuppressed(new Exception("#block terminated with an error"));
+			throw re;
+		}
+		return Optional.ofNullable(value);
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.TERMINATED) return getCount() == 0;
+		if (key == Attr.PARENT) return  s;
+		if (key == Attr.CANCELLED) return cancelled;
+		if (key == Attr.ERROR) return error;
+		if (key == Attr.PREFETCH) return Integer.MAX_VALUE;
+
+		return null;
+	}
+
+	@Override
+	public boolean isDisposed() {
+		return cancelled || getCount() == 0;
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1186,6 +1186,52 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
+	 * Subscribe to this {@link Mono} and <strong>block indefinitely</strong> until a next signal is
+	 * received or the Mono completes empty. Returns an {@link Optional}, which can be used
+	 * to replace the empty case with an Exception via {@link Optional#orElseThrow(Supplier)}.
+	 * In case the Mono itself errors, the original exception is thrown (wrapped in a
+	 * {@link RuntimeException} if it was a checked exception).
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.1.RELEASE/src/docs/marble/block.png" alt="">
+	 * <p>
+	 * Note that each blockOptional() will trigger a new subscription: in other words, the result
+	 * might miss signal from hot publishers.
+	 *
+	 * @return T the result
+	 */
+	public Optional<T> blockOptional() {
+		BlockingOptionalMonoSubscriber<T> subscriber = new BlockingOptionalMonoSubscriber<>();
+		onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		return subscriber.blockingGet();
+	}
+
+	/**
+	 * Subscribe to this {@link Mono} and <strong>block</strong> until a next signal is
+	 * received, the Mono completes empty or a timeout expires. Returns an {@link Optional}
+	 * for the first two cases, which can be used to replace the empty case with an
+	 * Exception via {@link Optional#orElseThrow(Supplier)}.
+	 * In case the Mono itself errors, the original exception is thrown (wrapped in a
+	 * {@link RuntimeException} if it was a checked exception).
+	 * If the provided timeout expires, a {@link RuntimeException} is thrown.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.1.RELEASE/src/docs/marble/block.png" alt="">
+	 * <p>
+	 * Note that each block() will trigger a new subscription: in other words, the result
+	 * might miss signal from hot publishers.
+	 *
+	 * @param timeout maximum time period to wait for before raising a {@link RuntimeException}
+	 *
+	 * @return T the result
+	 */
+	public Optional<T> blockOptional(Duration timeout) {
+		BlockingOptionalMonoSubscriber<T> subscriber = new BlockingOptionalMonoSubscriber<>();
+		onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
+	}
+
+	/**
 	 * Cast the current {@link Mono} produced type into a target produced type.
 	 *
 	 * <p>

--- a/reactor-core/src/test/java/reactor/core/publisher/BlockingOptionalMonoSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BlockingOptionalMonoSubscriberTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+import reactor.core.Scannable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class BlockingOptionalMonoSubscriberTest {
+
+	@Test
+	public void optionalValued() {
+		Optional<String> result = Mono.just("foo").blockOptional();
+
+		assertThat(result).contains("foo");
+	}
+
+	@Test
+	public void optionalValuedDelayed() {
+		Optional<String> result = Mono.just("foo")
+		                              .delayElement(Duration.ofMillis(500))
+		                              .blockOptional();
+
+		assertThat(result).contains("foo");
+	}
+
+	@Test
+	public void optionalEmpty() {
+		Optional<String> result = Mono.<String>empty().blockOptional();
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	public void optionalEmptyDelayed() {
+		Optional<String> result = Mono.<String>empty()
+				.delayElement(Duration.ofMillis(500))
+				.blockOptional();
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	public void optionalError() {
+		Mono<String> source = Mono.error(new IllegalStateException("boom"));
+		assertThatExceptionOfType(IllegalStateException.class)
+				.isThrownBy(source::blockOptional)
+				.withMessage("boom");
+	}
+
+	@Test
+	public void timeoutOptionalValued() {
+		Optional<String> result = Mono.just("foo")
+		                              .blockOptional(Duration.ofMillis(500));
+
+		assertThat(result).contains("foo");
+	}
+
+	@Test
+	public void timeoutOptionalEmpty() {
+		Optional<String> result = Mono.<String>empty()
+		                              .blockOptional(Duration.ofMillis(500));
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	public void timeoutOptionalError() {
+		Mono<String> source = Mono.error(new IllegalStateException("boom"));
+
+		assertThatExceptionOfType(IllegalStateException.class)
+				.isThrownBy(() -> source.blockOptional(Duration.ofMillis(500)))
+				.withMessage("boom");
+	}
+
+	@Test
+	public void timeoutOptionalTimingOut() {
+		Mono<Long> source = Mono.delay(Duration.ofSeconds(1));
+
+		assertThatExceptionOfType(IllegalStateException.class)
+				.isThrownBy(() -> source.blockOptional(Duration.ofMillis(500)))
+				.withMessage("Timeout on blocking read for 500 MILLISECONDS");
+	}
+
+	@Test
+	public void isDisposedBecauseCancelled() {
+		BlockingOptionalMonoSubscriber<String> test = new BlockingOptionalMonoSubscriber<>();
+
+		assertThat(test.isDisposed()).isFalse();
+
+		test.dispose();
+
+		assertThat(test.isDisposed()).isTrue();
+	}
+
+	@Test
+	public void isDisposedBecauseValued() {
+		BlockingOptionalMonoSubscriber<String> test = new BlockingOptionalMonoSubscriber<>();
+
+		assertThat(test.isDisposed()).isFalse();
+
+		test.onNext("foo");
+
+		assertThat(test.isDisposed()).isTrue();
+	}
+
+	@Test
+	public void isDisposedBecauseComplete() {
+		BlockingOptionalMonoSubscriber<String> test = new BlockingOptionalMonoSubscriber<>();
+
+		assertThat(test.isDisposed()).isFalse();
+
+		test.onComplete();
+
+		assertThat(test.isDisposed()).isTrue();
+	}
+
+	@Test
+	public void isDisposedBecauseError() {
+		BlockingOptionalMonoSubscriber<String> test = new BlockingOptionalMonoSubscriber<>();
+
+		assertThat(test.isDisposed()).isFalse();
+
+		test.onError(new IllegalArgumentException("boom"));
+
+		assertThat(test.isDisposed()).isTrue();
+	}
+
+	@Test
+	public void scanOperator() {
+		BlockingOptionalMonoSubscriber<String> test = new BlockingOptionalMonoSubscriber<>();
+
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		assertThat(test.scan(Scannable.Attr.NAME)).as("NAME (not covered)").isNull();
+
+		assertThat(test.scan(Scannable.Attr.PARENT)).as("PARENT").isSameAs(parent);
+		assertThat(test.scan(Scannable.Attr.PREFETCH)).as("PREFETCH").isEqualTo(Integer.MAX_VALUE);
+
+
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).as("TERMINATED").isFalse();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).as("CANCELLED").isFalse();
+		assertThat(test.scan(Scannable.Attr.ERROR)).as("ERROR").isNull();
+
+		test.onError(new IllegalArgumentException());
+
+		assertThat(test.scan(Scannable.Attr.ERROR)).as("ERROR after onError").isInstanceOf(IllegalArgumentException.class);
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).as("TERMINATED after onError").isTrue();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).as("CANCELLED after onError").isFalse();
+
+		test.dispose();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).as("CANCELLED after dispose()").isTrue();
+	}
+
+	@Test
+	public void interruptBlock() throws InterruptedException {
+		BlockingOptionalMonoSubscriber<String> test = new BlockingOptionalMonoSubscriber<>();
+		AtomicReference<Throwable> errorHandler = new AtomicReference<>();
+
+		Thread t = new Thread(test::blockingGet);
+		t.setUncaughtExceptionHandler((t1, e) -> errorHandler.set(e));
+		t.start();
+		t.interrupt();
+		t.join();
+
+		assertThat(test.isDisposed()).as("interrupt disposes").isTrue();
+		assertThat(errorHandler.get())
+				.isNotNull()
+				.isInstanceOf(RuntimeException.class)
+				.hasCauseInstanceOf(InterruptedException.class)
+				.hasSuppressedException(new Exception("#blockOptional() has been interrupted"));
+	}
+
+	@Test
+	public void interruptBlockTimeout() throws InterruptedException {
+		BlockingOptionalMonoSubscriber<String> test = new BlockingOptionalMonoSubscriber<>();
+		AtomicReference<Throwable> errorHandler = new AtomicReference<>();
+
+		Thread t = new Thread(() -> test.blockingGet(2, TimeUnit.SECONDS));
+		t.setUncaughtExceptionHandler((t1, e) -> errorHandler.set(e));
+		t.start();
+		t.interrupt();
+		t.join();
+
+		assertThat(test.isDisposed()).as("interrupt disposes").isTrue();
+		assertThat(errorHandler.get())
+				.isNotNull()
+				.isInstanceOf(RuntimeException.class)
+				.hasCauseInstanceOf(InterruptedException.class)
+				.hasSuppressedException(new Exception("#blockOptional(timeout) has been interrupted"));
+	}
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/BlockingTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BlockingTests.java
@@ -214,4 +214,14 @@ public class BlockingTests {
 
 		assertThat(cancelCount.get()).isEqualTo(0);
 	}
+
+	@Test
+	public void monoBlockOptionalDoesntCancel() {
+		AtomicLong cancelCount = new AtomicLong();
+		Mono.just("data")
+	        .doOnCancel(cancelCount::incrementAndGet)
+	        .blockOptional();
+
+		assertThat(cancelCount.get()).isEqualTo(0);
+	}
 }


### PR DESCRIPTION
 - a valued Mono<T> gives a valued Optional<T>
 - an empty Mono gives an empty Optional
 - a failing Mono will see its exception thrown
 - a timing out Mono will throw an IllegalStateException

The fact that Optional is returned allows to transform the empty case
into an Exception like NoSuchElementException, via Optional#orElseThrow.

Edit: actually for `NoSuchElementException` the shortest path is to call `.blockingOptional().get()` since `Optional.get()` throws that exception when not valued 😄 