### PR TITLE
fix #922 Flux.fromStream(Supplier<Stream>)

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxStream.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxStream.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import java.util.Iterator;
 import java.util.Objects;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import reactor.core.CoreSubscriber;
@@ -32,14 +33,24 @@ import reactor.core.Fuseable;
  */
 final class FluxStream<T> extends Flux<T> implements Fuseable {
 
-	final Stream<? extends T> stream;
+	final Supplier<? extends Stream<? extends T>> streamSupplier;
 
-	FluxStream(Stream<? extends T> iterable) {
-		this.stream = Objects.requireNonNull(iterable, "stream");
+	FluxStream(Supplier<? extends Stream<? extends T>> streamSupplier) {
+		this.streamSupplier = Objects.requireNonNull(streamSupplier, "streamSupplier");
 	}
 
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
+		Stream<? extends T> stream;
+		try {
+			stream = Objects.requireNonNull(streamSupplier.get(),
+					"The stream supplier returned a null Stream");
+		}
+		catch (Throwable e) {
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
+			return;
+		}
+
 		Iterator<? extends T> it;
 
 		try {

--- a/src/docs/asciidoc/operatorChoice.adoc
+++ b/src/docs/asciidoc/operatorChoice.adoc
@@ -37,6 +37,7 @@ I want to deal with:
 ** an array: `Flux#fromArray`
 ** a collection or iterable: `Flux#fromIterable`
 ** a range of integers: `Flux#range`
+** a `Stream` supplied for each Subscription: `Flux#fromStream(Supplier<Stream>)`
 * that emits from various single-valued sources such as:
 ** a `Supplier<T>`: `Mono#fromSupplier`
 ** a task: `Mono#fromCallable`, `Mono#fromRunnable`


### PR DESCRIPTION
This commit also gives a hint at how to deal with Streams that need
closing, in the javadoc.