### PR TITLE
Add .ordered() merge option on ParallelFlux

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -898,6 +898,31 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	}
 
 	/**
+	 * Merges the values from each 'rail' in the same ordered as they were produced and
+	 * exposes it as a regular Publisher sequence, running with a give prefetch value for
+	 * the rails.
+	 *
+	 * @return the new Flux instance
+	 */
+	public final Flux<T> ordered() {
+		return ordered(Queues.SMALL_BUFFER_SIZE);
+	}
+
+	/**
+	 * Merges the values from each 'rail' in the same ordered as they were produced and
+	 * exposes it as a regular Publisher sequence, running with a give prefetch value for
+	 * the rails.
+	 *
+	 * @param prefetch the prefetch amount to use for each rail
+	 * @return the new Flux instance
+	 */
+	public final Flux<T> ordered(int prefetch) {
+		return Flux.onAssembly(new ParallelMergeOrdered<>(this,
+				prefetch,
+				Queues.get(prefetch)));
+	}
+
+	/**
 	 * Subscribes an array of Subscribers to this {@link ParallelFlux} and triggers the
 	 * execution chain for all 'rails'.
 	 *

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeOrdered.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeOrdered.java
@@ -1,0 +1,488 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
+import reactor.core.Scannable;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+
+/**
+ * Merges the individual 'rails' of the source ParallelFlux, ordered, into a single
+ * regular Publisher sequence (exposed as reactor.core.publisher.Flux).
+ *
+ * @param <T> the value type
+ */
+final class ParallelMergeOrdered<T> extends Flux<T> implements Scannable {
+
+	final ParallelFlux<? extends T> source;
+	final int                       prefetch;
+	final Supplier<Queue<T>>        queueSupplier;
+
+	ParallelMergeOrdered(ParallelFlux<? extends T> source,
+			int prefetch,
+			Supplier<Queue<T>> queueSupplier) {
+		if (prefetch <= 0) {
+			throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
+		}
+		this.source = source;
+		this.prefetch = prefetch;
+		this.queueSupplier = queueSupplier;
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PARENT) {
+			return source;
+		}
+		if (key == Attr.PREFETCH) {
+			return getPrefetch();
+		}
+
+		return null;
+	}
+
+	@Override
+	public int getPrefetch() {
+		return prefetch;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super T> actual) {
+		MergeSequentialMain<T> parent = new MergeSequentialMain<>(actual,
+				source.parallelism(),
+				prefetch,
+				queueSupplier);
+		actual.onSubscribe(parent);
+		source.subscribe(parent.subscribers);
+	}
+
+	static final class MergeSequentialMain<T> implements InnerProducer<T> {
+
+		final MergeSequentialInner<T>[] subscribers;
+
+		final Supplier<Queue<T>>        queueSupplier;
+		final CoreSubscriber<? super T> actual;
+
+		@SuppressWarnings("rawtypes")
+		static final AtomicReferenceFieldUpdater<MergeSequentialMain, Throwable> ERROR =
+				AtomicReferenceFieldUpdater.newUpdater(MergeSequentialMain.class,
+						Throwable.class,
+						"error");
+
+		volatile int wip;
+
+		@SuppressWarnings("rawtypes")
+		static final AtomicIntegerFieldUpdater<MergeSequentialMain> WIP =
+				AtomicIntegerFieldUpdater.newUpdater(MergeSequentialMain.class, "wip");
+		volatile long requested;
+
+		@SuppressWarnings("rawtypes")
+		static final AtomicIntegerFieldUpdater<MergeSequentialMain> NEXT_RAIL =
+				AtomicIntegerFieldUpdater.newUpdater(MergeSequentialMain.class,
+						"nextRail");
+		volatile int nextRail;
+
+		@SuppressWarnings("rawtypes")
+		static final AtomicLongFieldUpdater<MergeSequentialMain> REQUESTED =
+				AtomicLongFieldUpdater.newUpdater(MergeSequentialMain.class, "requested");
+		volatile boolean cancelled;
+
+		volatile int done;
+
+		@SuppressWarnings("rawtypes")
+		static final AtomicIntegerFieldUpdater<MergeSequentialMain> DONE =
+				AtomicIntegerFieldUpdater.newUpdater(MergeSequentialMain.class, "done");
+		volatile Throwable error;
+
+		MergeSequentialMain(CoreSubscriber<? super T> actual,
+				int n,
+				int prefetch,
+				Supplier<Queue<T>> queueSupplier) {
+			this.actual = actual;
+			this.queueSupplier = queueSupplier;
+			@SuppressWarnings("unchecked") MergeSequentialInner<T>[] a =
+					new MergeSequentialInner[n];
+
+			for (int i = 0; i < n; i++) {
+				a[i] = new MergeSequentialInner<>(this, i, prefetch);
+			}
+
+			this.subscribers = a;
+			DONE.lazySet(this, n);
+		}
+
+		@Override
+		public final CoreSubscriber<? super T> actual() {
+			return actual;
+		}
+
+		@Override
+		@Nullable
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.CANCELLED) {
+				return cancelled;
+			}
+			if (key == Attr.REQUESTED_FROM_DOWNSTREAM) {
+				return requested;
+			}
+			if (key == Attr.TERMINATED) {
+				return done == 0;
+			}
+			if (key == Attr.ERROR) {
+				return error;
+			}
+
+			return InnerProducer.super.scanUnsafe(key);
+		}
+
+		@Override
+		public Stream<? extends Scannable> inners() {
+			return Stream.of(subscribers);
+		}
+
+		@Override
+		public void request(long n) {
+			if (Operators.validate(n)) {
+				Operators.addCap(REQUESTED, this, n);
+				drain();
+			}
+		}
+
+		@Override
+		public void cancel() {
+			if (!cancelled) {
+				cancelled = true;
+
+				cancelAll();
+
+				if (WIP.getAndIncrement(this) == 0) {
+					cleanup();
+				}
+			}
+		}
+
+		void cancelAll() {
+			for (MergeSequentialInner<T> s : subscribers) {
+				s.cancel();
+			}
+		}
+
+		void cleanup() {
+			for (MergeSequentialInner<T> s : subscribers) {
+				s.queue = null;
+			}
+		}
+
+		void onNext(MergeSequentialInner<T> inner, T value, int rail) {
+			System.out.println("element arrived " + value + ", rail " + rail + ", currently reading on " + nextRail);
+			if (wip == 0 && WIP.compareAndSet(this, 0, 1)) {
+				if (requested != 0 && nextRail == rail) {
+					actual.onNext(value);
+					NEXT_RAIL.compareAndSet(this,
+							nextRail,
+							(nextRail + 1) % subscribers.length);
+					System.out.println("on next " + value + ", current rail " + rail + ", next rail " + nextRail);
+					if (requested != Long.MAX_VALUE) {
+						REQUESTED.decrementAndGet(this);
+					}
+					inner.requestOne();
+				}
+				else {
+					Queue<T> q = inner.getQueue(queueSupplier);
+
+					if (!q.offer(value)) {
+						onError(Operators.onOperatorError(this,
+								Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL),
+								value,
+								actual.currentContext()));
+						return;
+					}
+				}
+				if (WIP.decrementAndGet(this) == 0) {
+					return;
+				}
+			}
+			else {
+				Queue<T> q = inner.getQueue(queueSupplier);
+
+				if (!q.offer(value)) {
+					onError(Operators.onOperatorError(this,
+							Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL),
+							value,
+							actual.currentContext()));
+					return;
+				}
+
+				if (WIP.getAndIncrement(this) != 0) {
+					return;
+				}
+			}
+
+			drainLoop();
+		}
+
+		void onError(Throwable ex) {
+			if (ERROR.compareAndSet(this, null, ex)) {
+				cancelAll();
+				drain();
+			}
+			else if (error != ex) {
+				Operators.onErrorDropped(ex, actual.currentContext());
+			}
+		}
+
+		void onComplete() {
+			if (DONE.decrementAndGet(this) < 0) {
+				return;
+			}
+			drain();
+		}
+
+		void drain() {
+			if (WIP.getAndIncrement(this) != 0) {
+				return;
+			}
+
+			drainLoop();
+		}
+
+		void drainLoop() {
+			int missed = 1;
+
+			MergeSequentialInner<T>[] s = this.subscribers;
+			int n = s.length;
+			Subscriber<? super T> a = this.actual;
+
+			for (; ; ) {
+
+				long r = requested;
+				long e = 0;
+
+				middle:
+				while (e != r) {
+					if (cancelled) {
+						cleanup();
+						return;
+					}
+
+					Throwable ex = error;
+					if (ex != null) {
+						cleanup();
+						a.onError(ex);
+						return;
+					}
+
+					boolean d = done == 0;
+
+					boolean empty = true;
+
+					MergeSequentialInner<T> inner = s[nextRail];
+
+					Queue<T> q = inner.queue;
+					if (q != null) {
+						T v = q.poll();
+
+						if (v != null) {
+							empty = false;
+							a.onNext(v);
+							int rail = nextRail;
+							NEXT_RAIL.compareAndSet(this, nextRail, (nextRail + 1) % n);
+							System.out.println("on next " + v + ", current rail " + rail + ", next rail " + nextRail);
+							inner.requestOne();
+							if (++e == r) {
+								break;
+							}
+						}
+					}
+
+					if (d && empty) {
+						a.onComplete();
+						return;
+					}
+
+					if (empty) {
+						break;
+					}
+				}
+
+				if (e == r) {
+					if (cancelled) {
+						cleanup();
+						return;
+					}
+
+					Throwable ex = error;
+					if (ex != null) {
+						cleanup();
+						a.onError(ex);
+						return;
+					}
+
+					boolean d = done == 0;
+
+					boolean empty = true;
+
+					MergeSequentialInner<T> inner = s[nextRail];
+
+					Queue<T> q = inner.queue;
+					if (q != null && !q.isEmpty()) {
+						empty = false;
+					}
+
+					if (d && empty) {
+						a.onComplete();
+						return;
+					}
+				}
+
+				if (e != 0 && r != Long.MAX_VALUE) {
+					REQUESTED.addAndGet(this, -e);
+				}
+
+				int w = wip;
+				if (w == missed) {
+					missed = WIP.addAndGet(this, -missed);
+					if (missed == 0) {
+						break;
+					}
+				}
+				else {
+					missed = w;
+				}
+			}
+		}
+	}
+
+	static final class MergeSequentialInner<T> implements InnerConsumer<T> {
+
+		final MergeSequentialMain<T> parent;
+
+		final int rail;
+
+		final int prefetch;
+
+		final int limit;
+
+		long produced;
+
+		volatile Subscription s;
+		@SuppressWarnings("rawtypes")
+		static final AtomicReferenceFieldUpdater<MergeSequentialInner, Subscription> S =
+				AtomicReferenceFieldUpdater.newUpdater(MergeSequentialInner.class,
+						Subscription.class,
+						"s");
+
+		volatile Queue<T> queue;
+
+		volatile boolean done;
+
+		MergeSequentialInner(MergeSequentialMain<T> parent, int rail, int prefetch) {
+			this.parent = parent;
+			this.rail = rail;
+			this.prefetch = prefetch;
+			this.limit = Operators.unboundedOrLimit(prefetch);
+		}
+
+		@Override
+		@Nullable
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.CANCELLED) {
+				return s == Operators.cancelledSubscription();
+			}
+			if (key == Attr.PARENT) {
+				return s;
+			}
+			if (key == Attr.ACTUAL) {
+				return parent;
+			}
+			if (key == Attr.PREFETCH) {
+				return prefetch;
+			}
+			if (key == Attr.BUFFERED) {
+				return queue != null ? queue.size() : 0;
+			}
+			if (key == Attr.TERMINATED) {
+				return done;
+			}
+
+			return null;
+		}
+
+		@Override
+		public Context currentContext() {
+			return parent.actual.currentContext();
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.setOnce(S, this, s)) {
+				s.request(Operators.unboundedOrPrefetch(prefetch));
+			}
+		}
+
+		@Override
+		public void onNext(T t) {
+			parent.onNext(this, t, rail);
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			parent.onError(t);
+		}
+
+		@Override
+		public void onComplete() {
+			parent.onComplete();
+		}
+
+		void requestOne() {
+			long p = produced + 1;
+			if (p == limit) {
+				produced = 0;
+				s.request(p);
+			}
+			else {
+				produced = p;
+			}
+		}
+
+		public void cancel() {
+			Operators.terminate(S, this);
+		}
+
+		Queue<T> getQueue(Supplier<Queue<T>> queueSupplier) {
+			Queue<T> q = queue;
+			if (q == null) {
+				q = queueSupplier.get();
+				this.queue = q;
+			}
+			return q;
+		}
+	}
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelMergeOrderedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelMergeOrderedTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Scannable;
+import reactor.core.publisher.ParallelMergeSequential.MergeSequentialInner;
+import reactor.core.publisher.ParallelMergeSequential.MergeSequentialMain;
+import reactor.util.concurrent.Queues;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ParallelMergeOrderedTest {
+
+	@Test
+	public void scanOperator() {
+		ParallelFlux<Integer> source = Flux.just(500, 300)
+		                                   .parallel(10);
+		ParallelMergeSequential<Integer> test =
+				new ParallelMergeSequential<>(source, 123, Queues.one());
+
+		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);
+		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(123);
+	}
+
+	@Test
+	public void scanMainSubscriber() {
+		LambdaSubscriber<Integer> subscriber = new LambdaSubscriber<>(null, e -> {
+		}, null, s -> s.request(2));
+		MergeSequentialMain<Integer> test =
+				new MergeSequentialMain<>(subscriber, 4, 123, Queues.small());
+
+		subscriber.onSubscribe(test);
+
+		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(subscriber);
+		assertThat(test.scan(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(2);
+
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.Attr.ERROR)).isNull();
+
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+		test.cancel();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
+	}
+
+	@Test
+	public void scanMainSubscriberDoneAfterNComplete() {
+		LambdaSubscriber<Integer> subscriber = new LambdaSubscriber<>(null, e -> {
+		}, null, s -> s.request(2));
+
+		int n = 4;
+
+		MergeSequentialMain<Integer> test =
+				new MergeSequentialMain<>(subscriber, n, 123, Queues.small());
+
+		subscriber.onSubscribe(test);
+
+		for (int i = 0; i < n; i++) {
+			assertThat(test.scan(Scannable.Attr.TERMINATED)).as("complete " + i)
+			                                                .isFalse();
+			test.onComplete();
+		}
+
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
+	}
+
+	@Test
+	public void scanMainSubscriberError() {
+		LambdaSubscriber<Integer> subscriber = new LambdaSubscriber<>(null, e -> {
+		}, null, s -> s.request(2));
+		MergeSequentialMain<Integer> test =
+				new MergeSequentialMain<>(subscriber, 4, 123, Queues.small());
+
+		subscriber.onSubscribe(test);
+
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.Attr.ERROR)).isNull();
+
+		test.onError(new IllegalStateException("boom"));
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.Attr.ERROR)).hasMessage("boom");
+	}
+
+	@Test
+	public void scanInnerSubscriber() {
+		CoreSubscriber<Integer> mainActual = new LambdaSubscriber<>(null, e -> {
+		}, null, null);
+		MergeSequentialMain<Integer> main =
+				new MergeSequentialMain<>(mainActual, 2, 123, Queues.small());
+		MergeSequentialInner<Integer> test = new MergeSequentialInner<>(main, 456);
+
+		Subscription subscription = Operators.emptySubscription();
+		test.onSubscribe(subscription);
+	}
+}


### PR DESCRIPTION
Add the ability on a parallel flux to be merge in the order it was given
to the parallel flux.
Instead of draining the flux by getting the first available element, we
get element from each 'rail' in a the same round-robin fashion as it was
produced. This means that if an element arrive in an other rail before
an element on the expected rail, it will stay in the queue of that.

---------------------

I added this because we have a need on a flux to do some transformations that require IO on the elements in a parallel flux while in the end keeping the original order of the elements.

As described in the commit I do that by merging elements from the rails in a round-robin fashion but while stopping a the 'rail' on which we want the element.

I'm not sure it is the right way to do it because I'm not sure  if the parallel flux always put the elements in a round-robin fashion at the "start" of the flux. If it is valid, This PR would need a lot more unit tests that I can write but I would need some guidance on how to test that better.

I did not put any `@Since` tag yet.

Finally, as a workarround, we implemented that without this feature by:
1. decorating elements at the "start" of the flux with a number
2. buffer them in a list after `merge` using a `bufffer.until` that checks if we have all consecutive elements
3. reordering elements after the buffer and flating it

It could be an alternative idea to implement this feature if you think it is useful.

(iCLA signed)

