### PR TITLE
fix #925 Enrich timeout's TimeoutException message

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -7057,7 +7057,7 @@ public abstract class Flux<T> implements Publisher<T> {
 		final Function<T, Publisher<Long>> rest = o -> _timer;
 
 		if(fallback == null) {
-			return timeout(_timer, rest);
+			return timeout(_timer, rest, timeout.toMillis() + "ms");
 		}
 		return timeout(_timer, rest, fallback);
 	}
@@ -7102,7 +7102,13 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public final <U, V> Flux<T> timeout(Publisher<U> firstTimeout,
 			Function<? super T, ? extends Publisher<V>> nextTimeoutFactory) {
-		return onAssembly(new FluxTimeout<>(this, firstTimeout, nextTimeoutFactory));
+		return timeout(firstTimeout, nextTimeoutFactory, "first signal from a Publisher");
+	}
+
+	private final <U, V> Flux<T> timeout(Publisher<U> firstTimeout,
+			Function<? super T, ? extends Publisher<V>> nextTimeoutFactory,
+			String timeoutDescription) {
+			return onAssembly(new FluxTimeout<>(this, firstTimeout, nextTimeoutFactory, timeoutDescription));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -3241,7 +3241,7 @@ public abstract class Mono<T> implements Publisher<T> {
 		final Mono<Long> _timer = Mono.delay(timeout, timer).onErrorReturn(0L);
 
 		if(fallback == null) {
-			return onAssembly(new MonoTimeout<>(this, _timer));
+			return onAssembly(new MonoTimeout<>(this, _timer, timeout.toMillis() + "ms"));
 		}
 		return onAssembly(new MonoTimeout<>(this, _timer, fallback));
 	}
@@ -3260,7 +3260,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 *
 	 */
 	public final <U> Mono<T> timeout(Publisher<U> firstTimeout) {
-		return onAssembly(new MonoTimeout<>(this, firstTimeout));
+		return onAssembly(new MonoTimeout<>(this, firstTimeout, "first signal from a Publisher"));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTimeout.java
@@ -37,15 +37,18 @@ final class MonoTimeout<T, U, V> extends MonoOperator<T, T> {
 	final Publisher<U> firstTimeout;
 
 	final Publisher<? extends T> other;
+	final String timeoutDescription; //only useful when no `other`
 
 	@SuppressWarnings("rawtypes")
     final static Function NEVER = e -> Flux.never();
 
 	MonoTimeout(Mono<? extends T> source,
-			Publisher<U> firstTimeout) {
+			Publisher<U> firstTimeout,
+			String timeoutDescription) {
 		super(source);
 		this.firstTimeout = Objects.requireNonNull(firstTimeout, "firstTimeout");
 		this.other = null;
+		this.timeoutDescription = timeoutDescription;
 	}
 
 	MonoTimeout(Mono<? extends T> source,
@@ -54,6 +57,7 @@ final class MonoTimeout<T, U, V> extends MonoOperator<T, T> {
 		super(source);
 		this.firstTimeout = Objects.requireNonNull(firstTimeout, "firstTimeout");
 		this.other = Objects.requireNonNull(other, "other");
+		this.timeoutDescription = null;
 	}
 
 	@Override
@@ -63,7 +67,7 @@ final class MonoTimeout<T, U, V> extends MonoOperator<T, T> {
 		CoreSubscriber<T> serial = Operators.serialize(actual);
 
 		FluxTimeout.TimeoutMainSubscriber<T, V> main =
-				new FluxTimeout.TimeoutMainSubscriber<>(serial, NEVER, other);
+				new FluxTimeout.TimeoutMainSubscriber<>(serial, NEVER, other, timeoutDescription);
 
 		serial.onSubscribe(main);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
@@ -122,4 +122,24 @@ public class MonoTimeoutTest {
 		            .thenAwait(Duration.ofMillis(500))
 		            .verifyError(TimeoutException.class);
 	}
+
+	@Test
+	public void timeoutDurationMessage() {
+		StepVerifier.withVirtualTime(() -> Mono.never()
+		                                       .timeout(Duration.ofHours(1)))
+		            .thenAwait(Duration.ofHours(2))
+		            .expectErrorMessage("Did not observe any item or terminal signal within " +
+				            "3600000ms (and no fallback has been configured)")
+		            .verify();
+	}
+
+
+	@Test
+	public void timeoutNotDurationMessage() {
+		StepVerifier.create(Mono.never()
+		                        .timeout(Mono.just("immediate")))
+		            .expectErrorMessage("Did not observe any item or terminal signal within " +
+				            "first signal from a Publisher (and no fallback has been configured)")
+		            .verify();
+	}
 }


### PR DESCRIPTION
This commit enriches the TimeoutException message from timeout
operators with a description that is provided by the Flux/Mono API when
no fallback is provided (as otherwise no TimeoutException is generated).

In case of a Duration based timeout, this message includes the timing in
milliseconds. In case of a Publisher based timeout, it just mentions
"within first signal from a Publisher" instead.