### PR TITLE
Kotlin extension to create a Mono from a supplier

### DIFF
--- a/reactor-core/src/main/kotlin/reactor/core/publisher/MonoExtensions.kt
+++ b/reactor-core/src/main/kotlin/reactor/core/publisher/MonoExtensions.kt
@@ -19,6 +19,7 @@ package reactor.core.publisher
 import org.reactivestreams.Publisher
 import java.util.concurrent.Callable
 import java.util.concurrent.CompletableFuture
+import java.util.function.Supplier
 import kotlin.reflect.KClass
 
 /**
@@ -32,6 +33,13 @@ import kotlin.reflect.KClass
  * @since 3.1.1
  */
 fun <T> Publisher<T>.toMono(): Mono<T> = Mono.from(this)
+
+/**
+ * Extension to convert any [Supplier] of [T] to a [Mono] that emits supplied element.
+ *
+ * @author Sergio Dos Santos
+ */
+fun <T> (() -> T).toMono(): Mono<T> = Mono.fromSupplier(this)
 
 /**
  * Extension for transforming an object to a [Mono].

--- a/reactor-core/src/test/kotlin/reactor/core/publisher/MonoExtensionsTests.kt
+++ b/reactor-core/src/test/kotlin/reactor/core/publisher/MonoExtensionsTests.kt
@@ -73,9 +73,9 @@ class MonoExtensionsTests {
 
     @Test
     fun completableFutureToMono() {
-        var future = CompletableFuture<String>()
+        val future = CompletableFuture<String>()
 
-        var verifier = StepVerifier.create(future.toMono())
+        val verifier = StepVerifier.create(future.toMono())
                 .expectNext("foo")
                 .expectComplete()
         future.complete("foo")
@@ -85,7 +85,7 @@ class MonoExtensionsTests {
     @Test
     fun callableToMono() {
         val callable = Callable { "foo" }
-        var verifier = StepVerifier.create(callable.toMono())
+        val verifier = StepVerifier.create(callable.toMono())
                 .expectNext("foo")
                 .expectComplete()
         verifier.verify()

--- a/reactor-core/src/test/kotlin/reactor/core/publisher/MonoExtensionsTests.kt
+++ b/reactor-core/src/test/kotlin/reactor/core/publisher/MonoExtensionsTests.kt
@@ -38,6 +38,17 @@ class MonoExtensionsTests {
     }
 
     @Test
+    fun supplierToMono() {
+        val supplier: () -> String = { "a" }
+
+        val m = supplier.toMono()
+
+        m.test()
+                .expectNext("a")
+                .verifyComplete()
+    }
+
+    @Test
     fun publisherToMono() {
         //fake naive publisher
         val p: Publisher<String> = Publisher {

--- a/reactor-core/src/test/kotlin/reactor/core/publisher/MonoExtensionsTests.kt
+++ b/reactor-core/src/test/kotlin/reactor/core/publisher/MonoExtensionsTests.kt
@@ -16,7 +16,6 @@
 
 package reactor.core.publisher
 
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert
 import org.junit.Test


### PR DESCRIPTION
This extension allows emitting supplied value instead of supplier itself.

Before:
```kotlin
{ "Some value" }.toMono().subscribe { item: () -> String -> println(item) }
```
After:
```kotlin
{ "Some value" }.toMono().subscribe { item: String -> println(item) }
```
