### PR TITLE
fix #934 concat[Map]DelayError(veryEnd) delays Callable errors

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -2999,7 +2999,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * </ul>
 	 *
 	 * <p>
-	 * Errors will be delayed after all concatenated sources terminate.
+	 * Errors in the individual publishers will be delayed after the current concat backlog,
+	 * usually stopping the sequence at the source that triggered the error.
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.1.RELEASE/src/docs/marble/concatmap.png" alt="">
@@ -3033,8 +3034,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * </ul>
 	 *
 	 * <p>
-	 * Errors will be delayed after all concatenated sources terminate. The prefetch argument
-	 * allows to give an arbitrary prefetch size to the inner {@link Publisher}.
+	 * Errors in the individual publishers will be delayed after the current concat backlog,
+	 * usually stopping the sequence at the source that triggered the error.
+	 * The prefetch argument allows to give an arbitrary prefetch size to the inner {@link Publisher}.
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.1.RELEASE/src/docs/marble/concatmap.png" alt="">
@@ -3071,9 +3073,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * </ul>
 	 *
 	 * <p>
-	 * Errors will be delayed after the current concat backlog if delayUntilEnd is
-	 * false or after all sources if delayUntilEnd is true. The prefetch argument
-	 * allows to give an arbitrary prefetch size to the inner {@link Publisher}.
+	 * Errors in the individual publishers will be delayed after the current concat
+	 * backlog if delayUntilEnd is false or after all sources if delayUntilEnd is true.
+	 * The prefetch argument allows to give an arbitrary prefetch size to the inner {@link Publisher}.
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.1.RELEASE/src/docs/marble/concatmap.png" alt="">

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
@@ -721,9 +721,14 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 									vr = supplier.call();
 								}
 								catch (Throwable e) {
-									actual.onError(Operators.onOperatorError(s, e, v,
-											actual.currentContext()));
-									return;
+									if (veryEnd && Exceptions.addThrowable(ERROR, this, e)) {
+										continue;
+									}
+									else {
+										actual.onError(Operators.onOperatorError(s, e, v,
+												actual.currentContext()));
+										return;
+									}
 								}
 
 								if (vr == null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -358,7 +358,11 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 					v = ((Callable<R>) p).call();
 				}
 				catch (Throwable e) {
-					onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
+					if (delayError && Exceptions.addThrowable(ERROR, this, e)) {
+					}
+					else {
+						onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
+					}
 					return;
 				}
 				tryEmitScalar(v);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -358,9 +358,7 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 					v = ((Callable<R>) p).call();
 				}
 				catch (Throwable e) {
-					if (delayError && Exceptions.addThrowable(ERROR, this, e)) {
-					}
-					else {
+					if (!delayError || !Exceptions.addThrowable(ERROR, this, e)) {
 						onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 					}
 					return;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatArrayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatArrayTest.java
@@ -233,6 +233,32 @@ public class FluxConcatArrayTest {
 		            .verifyComplete();
 	}
 
+	//see https://github.com/reactor/reactor-core/issues/936
+	@Test
+	public void concatArrayDelayErrorWithFluxError() {
+		StepVerifier.create(
+				Flux.concatDelayError(
+						Flux.just(1, 2),
+						Flux.error(new Exception("test")),
+						Flux.just(3, 4))
+		)
+		            .expectNext(1, 2, 3, 4)
+		            .verifyErrorMessage("test");
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/936
+	@Test
+	public void concatArrayDelayErrorWithMonoError() {
+		StepVerifier.create(
+				Flux.concatDelayError(
+								Flux.just(1, 2),
+								Mono.error(new Exception("test")),
+								Flux.just(3, 4))
+		)
+		            .expectNext(1, 2, 3, 4)
+		            .verifyErrorMessage("test");
+	}
+
 	@Test
 	public void scanDelayErrorSubscriber() {
 		CoreSubscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
@@ -772,6 +772,58 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 				.isEqualTo(Long.MAX_VALUE);
 	}
 
+	//see https://github.com/reactor/reactor-core/issues/936
+	@Test
+	public void concatDelayErrorWithFluxError() {
+		StepVerifier.create(
+				Flux.concatDelayError(
+						Flux.just(
+								Flux.just(1, 2),
+								Flux.error(new Exception("test")),
+								Flux.just(3, 4))))
+		            .expectNext(1, 2, 3, 4)
+		            .verifyErrorMessage("test");
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/936
+	@Test
+	public void concatDelayErrorWithMonoError() {
+		StepVerifier.create(
+				Flux.concatDelayError(
+						Flux.just(
+								Flux.just(1, 2),
+								Mono.error(new Exception("test")),
+								Flux.just(3, 4))))
+		            .expectNext(1, 2, 3, 4)
+		            .verifyErrorMessage("test");
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/936
+	@Test
+	public void concatMapDelayErrorWithFluxError() {
+		StepVerifier.create(
+				Flux.just(
+						Flux.just(1, 2),
+						Flux.<Integer>error(new Exception("test")),
+						Flux.just(3, 4))
+				    .concatMapDelayError(f -> f, true, 32))
+		            .expectNext(1, 2, 3, 4)
+		            .verifyErrorMessage("test");
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/936
+	@Test
+	public void concatMapDelayErrorWithMonoError() {
+		StepVerifier.create(
+				Flux.just(
+						Flux.just(1, 2),
+						Mono.<Integer>error(new Exception("test")),
+						Flux.just(3, 4))
+				    .concatMapDelayError(f -> f, true, 32))
+		            .expectNext(1, 2, 3, 4)
+		            .verifyErrorMessage("test");
+	}
+
 	@Test
 	public void scanConcatMapDelayed() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -1319,6 +1319,33 @@ public class FluxFlatMapTest {
 		assertThat(onNextSignals.get()).isEqualTo(10);
 	}
 
+
+	//see https://github.com/reactor/reactor-core/issues/936
+	@Test
+	public void delayErrorWithFluxError() {
+		StepVerifier.create(
+				Flux.just(
+						Flux.just(1, 2),
+						Flux.<Integer>error(new Exception("test")),
+						Flux.just(3, 4))
+				    .flatMapDelayError(f -> f, 4, 4))
+		            .expectNext(1, 2, 3, 4)
+		            .verifyErrorMessage("test");
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/936
+	@Test
+	public void delayErrorWithMonoError() {
+		StepVerifier.create(
+				Flux.just(
+						Flux.just(1, 2),
+						Mono.<Integer>error(new Exception("test")),
+						Flux.just(3, 4))
+				    .flatMapDelayError(f -> f, 4, 4))
+		            .expectNext(1, 2, 3, 4)
+		            .verifyErrorMessage("test");
+	}
+
     @Test
     public void scanMain() {
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
@@ -711,6 +711,62 @@ public class FluxMergeSequentialTest {
 		            .verifyComplete();
 	}
 
+	//see https://github.com/reactor/reactor-core/issues/936
+	@Test
+	public void flatMapSequentialDelayErrorWithFluxError() {
+		StepVerifier.create(
+				Flux.just(
+						Flux.just(1, 2),
+						Flux.<Integer>error(new Exception("test")),
+						Flux.just(3, 4))
+				    .flatMapSequentialDelayError(f -> f, 4, 4))
+		            .expectNext(1, 2, 3, 4)
+		            .verifyErrorMessage("test");
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/936
+	@Test
+	public void flatMapSequentialDelayErrorWithMonoError() {
+		StepVerifier.create(
+				Flux.just(
+						Flux.just(1, 2),
+						Mono.<Integer>error(new Exception("test")),
+						Flux.just(3, 4))
+				    .flatMapSequentialDelayError(f -> f, 4, 4))
+		            .expectNext(1, 2, 3, 4)
+		            .verifyErrorMessage("test");
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/936
+	@Test
+	public void mergeSequentialDelayErrorWithFluxError() {
+		StepVerifier.create(
+				Flux.mergeSequentialDelayError(
+						Flux.just(
+								Flux.just(1, 2),
+								Flux.error(new Exception("test")),
+								Flux.just(3, 4))
+				, 4, 4)
+		)
+		            .expectNext(1, 2, 3, 4)
+		            .verifyErrorMessage("test");
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/936
+	@Test
+	public void mergeSequentialDelayErrorWithMonoError() {
+		StepVerifier.create(
+				Flux.mergeSequentialDelayError(
+						Flux.just(
+								Flux.just(1, 2),
+								Mono.error(new Exception("test")),
+								Flux.just(3, 4))
+				, 4, 4)
+		)
+		            .expectNext(1, 2, 3, 4)
+		            .verifyErrorMessage("test");
+	}
+
     @Test
     public void scanMain() {
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeTest.java
@@ -118,4 +118,29 @@ public class FluxMergeTest {
 		            .expectNext(1, 2, 3, 4)
 		            .verifyErrorSatisfies(e -> assertThat(e).isEqualTo(boom));
 	}
+
+	//see https://github.com/reactor/reactor-core/issues/936
+	@Test
+	public void delayErrorWithFluxError() {
+		StepVerifier.create(
+				Flux.mergeDelayError(32, Flux.just(1, 2),
+						Flux.error(new Exception("test")),
+						Flux.just(3, 4))
+		)
+		            .expectNext(1, 2, 3, 4)
+		            .verifyErrorMessage("test");
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/936
+	@Test
+	public void delayErrorWithMonoError() {
+		StepVerifier.create(
+				Flux.mergeDelayError(32,
+						Flux.just(1, 2),
+						Mono.error(new Exception("test")),
+						Flux.just(3, 4))
+				)
+		            .expectNext(1, 2, 3, 4)
+		            .verifyErrorMessage("test");
+	}
 }


### PR DESCRIPTION
This commit ensures that concatDelayError and concatMapDelayError both
correctly delay the error from a Callable source (like Mono.error(t))
when the `veryEnd` mode is used, letting other sources be concatenated
before the error is propagated.