### PR TITLE
fix #951 Protect doFinally against subscribe() throwing

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDoFinally.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDoFinally.java
@@ -125,8 +125,12 @@ final class FluxDoFinally<T> extends FluxOperator<T, T> {
 
 		@Override
 		public void onError(Throwable t) {
-			actual.onError(t);
-			runFinally(SignalType.ON_ERROR);
+			try {
+				actual.onError(t);
+			}
+			finally {
+				runFinally(SignalType.ON_ERROR);
+			}
 		}
 
 		@Override


### PR DESCRIPTION
This commit wraps the application of doFinally's handler in a
try/finally block, so that in the case where a final subscriber throws
(typically because no error handler was defined), it still executes the
doFinally handler.