### PR TITLE
fix #967 If Level is FINE/FINEST, log errors using debug()/trace()

### DIFF
--- a/reactor-core/src/test/resources/logback.xml
+++ b/reactor-core/src/test/resources/logback.xml
@@ -30,6 +30,9 @@
     <logger name="reactor.core.publisher.WorkQueueProcessor" level="off"/>
     <logger name="after-flatmap" level="debug"/>
     <logger name="reactor.core.publisher.UnsafeSupport" level="trace"/>
+    <logger name="logError.default" level="trace"/>
+    <logger name="logError.fine" level="trace"/>
+    <logger name="logError.finest" level="trace"/>
 
     <root level="info">
         <appender-ref ref="stdout"/>


### PR DESCRIPTION
otherwise, always use the error() method as was the case before.

This is a middle ground between previous behavior and the ability to
say "I want to log errors in this chain only if logger is configured
for verbosity".

what do you think @rstoyanchev @snicoll ? The aim here would be that if you explicitly use a `log(... FINE/FINEST...)`, then even errors will be logged at that level. so it becomes more discrete if your logger configuration doesn't allow debug/traces.

for any other `Level` set on a `log()` operator, the errors will be treated slightly differently and outputted at `error` severity (as it is the case right now).