### PR TITLE
fix #968 ParallelFlux#composeGroup maintains parallelism()

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -290,7 +290,14 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	 */
 	public final <U> ParallelFlux<U> composeGroup(Function<? super GroupedFlux<Integer, T>,
 			? extends Publisher<? extends U>> composer) {
-		return from(groups().flatMap(composer::apply));
+		if (getPrefetch() > -1) {
+			return from(groups().flatMap(composer::apply),
+				parallelism(), getPrefetch(),
+				Queues.small());
+		}
+		else {
+			return from(groups().flatMap(composer::apply), parallelism());
+		}
 	}
 
 	/**


### PR DESCRIPTION
(and prefetch as well if relevant)

cc @dfeist 