### PR TITLE
fix #980 Don't retain reference to UnicastProcessor subscriber on cancel

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -409,6 +409,7 @@ public final class UnicastProcessor<T>
 		if (!outputFused) {
 			if (WIP.getAndIncrement(this) == 0) {
 				queue.clear();
+				actual = null;
 			}
 		}
 	}


### PR DESCRIPTION
This commit makes the UnicastProcessor forget about its `actual` when
the associated Disposable obtained by subscribing is disposed.