### PR TITLE
Prevent windowWhen from retaining windows

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Disposable.java
+++ b/reactor-core/src/main/java/reactor/core/Disposable.java
@@ -17,6 +17,7 @@
 package reactor.core;
 
 import java.util.Collection;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import reactor.util.annotation.Nullable;
@@ -88,7 +89,7 @@ public interface Disposable {
 	 *
 	 * @author Simon Baslé
 	 */
-	interface Composite extends Disposable {
+	interface Composite<T extends Disposable> extends Disposable {
 
 		/**
 		 * Add a {@link Disposable} to this container, if it is not {@link #isDisposed() disposed}.
@@ -97,7 +98,7 @@ public interface Disposable {
 		 * @param d the {@link Disposable} to add.
 		 * @return true if the disposable could be added, false otherwise.
 		 */
-		boolean add(Disposable d);
+		boolean add(T d);
 
 		/**
 		 * Adds the given collection of Disposables to the container or disposes them
@@ -110,9 +111,9 @@ public interface Disposable {
 		 * @param ds the collection of Disposables
 		 * @return true if the operation was successful, false if the container has been disposed
 		 */
-		default boolean addAll(Collection<? extends Disposable> ds) {
+		default boolean addAll(Collection<? extends T> ds) {
 			boolean abort = isDisposed();
-			for (Disposable d : ds) {
+			for (T d : ds) {
 				if (abort) {
 					//multi-add aborted,
 					d.dispose();
@@ -137,6 +138,17 @@ public interface Disposable {
 		void dispose();
 
 		/**
+		 * In a best effort fashion, apply an operation to each {@link Disposable} in this
+		 * {@link Composite}. Note that the order in which this operation is applied to
+		 * each Disposable is not guaranteed.
+		 *
+		 * @param consumer the operation to apply
+		 */
+		default void forEach(Consumer<? super T> consumer) {
+			throw new UnsupportedOperationException("forEach default");
+		}
+
+		/**
 		 * Indicates if the container has already been disposed.
 		 * <p>Note that if that is the case, attempts to add new disposable to it via
 		 * {@link #add(Disposable)} and {@link #addAll(Collection)} will be rejected.
@@ -157,7 +169,7 @@ public interface Disposable {
 		 * @param d the {@link Disposable} to remove.
 		 * @return true if the disposable was successfully deleted, false otherwise.
 		 */
-		boolean remove(Disposable d);
+		boolean remove(T d);
 
 		/**
 		 * Returns the number of currently held Disposables.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
@@ -257,7 +257,14 @@ final class FluxWindowWhen<T, U, V> extends FluxOperator<T, Flux<T>> {
 				queue.offer(end);
 			}
 			drain();
-			windows.remove(end.window);
+			removeWindow(end.window);
+		}
+
+		void removeWindow(UnicastProcessor<T> window) {
+			Composite<UnicastProcessor<T>> w = windows;
+			if (w != null) {
+				w.remove(window);
+			}
 		}
 
 		void endError(Throwable e, WindowStartEndEnder<T, V> end) {
@@ -268,7 +275,7 @@ final class FluxWindowWhen<T, U, V> extends FluxOperator<T, Flux<T>> {
 			else {
 				Operators.onErrorDropped(e, actual.currentContext());
 			}
-			windows.remove(end.window);
+			removeWindow(end.window);
 		}
 
 		void closeMain(boolean cancel) {

--- a/reactor-core/src/main/java/reactor/core/scheduler/EmptyCompositeDisposable.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/EmptyCompositeDisposable.java
@@ -3,8 +3,9 @@ package reactor.core.scheduler;
 import reactor.core.Disposable;
 
 import java.util.Collection;
+import java.util.function.Consumer;
 
-final class EmptyCompositeDisposable implements Disposable.Composite {
+final class EmptyCompositeDisposable implements Disposable.Composite<Disposable> {
 
     @Override
     public boolean add(Disposable d) {
@@ -35,4 +36,8 @@ final class EmptyCompositeDisposable implements Disposable.Composite {
         return false;
     }
 
+    @Override
+    public void forEach(Consumer<? super Disposable> consumer) {
+        //NO-OP
+    }
 }

--- a/reactor-core/src/test/java/reactor/core/CompositeDisposableTest.java
+++ b/reactor-core/src/test/java/reactor/core/CompositeDisposableTest.java
@@ -16,6 +16,7 @@
 
 package reactor.core;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -247,6 +248,21 @@ public class CompositeDisposableTest {
 
 			RaceTestUtils.race(cd::size, cd::dispose, Schedulers.elastic());
 		}
+	}
+
+	@Test
+	public void forEachTyped() {
+		FakeDisposable fakeDisposable1 = new FakeDisposable();
+		FakeDisposable fakeDisposable2 = new FakeDisposable();
+
+		Disposable.Composite<FakeDisposable> composite = new CompositeDisposable<>(fakeDisposable1, fakeDisposable2);
+
+		List<FakeDisposable> content = new ArrayList<>(2);
+		composite.forEach(content::add);
+
+		System.out.println(content);
+
+		assertThat(content).containsExactlyInAnyOrder(fakeDisposable1, fakeDisposable2);
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/DisposableTest.java
+++ b/reactor-core/src/test/java/reactor/core/DisposableTest.java
@@ -17,6 +17,7 @@
 package reactor.core;
 
 import java.util.Arrays;
+import java.util.function.Consumer;
 
 import org.junit.Test;
 import reactor.test.FakeDisposable;
@@ -59,6 +60,11 @@ public class DisposableTest {
 			@Override
 			public boolean isDisposed() {
 				return disposed;
+			}
+
+			@Override
+			public void forEach(Consumer consumer) {
+				//NO-OP
 			}
 		};
 
@@ -106,6 +112,11 @@ public class DisposableTest {
 			@Override
 			public boolean isDisposed() {
 				return disposed;
+			}
+
+			@Override
+			public void forEach(Consumer consumer) {
+				//NO-OP
 			}
 		};
 
@@ -161,6 +172,11 @@ public class DisposableTest {
 			@Override
 			public boolean isDisposed() {
 				return disposed;
+			}
+
+			@Override
+			public void forEach(Consumer consumer) {
+				//NO-OP
 			}
 		};
 


### PR DESCRIPTION
see #975

@smaldini as I wanted to use `Disposable.Composite`, I came across the need for a mean of applying an operation to each Disposable.
This in turn brought up the need for the `Composite` to have a generic type, so the `forEach` `Consumer` could meaningfully work with the data.

On top of that, in a second commit, I used the newly augmented `Composite` to manage windows and clean a `window` when it expires.

wdyt?