### PR TITLE
Fix tests and #985 (NPE for debug mode via system properties)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -354,6 +354,15 @@ project('reactor-core') {
 	}
   }
 
+  task testStaticInit(type: Test, group: 'verification') {
+	systemProperty 'reactor.trace.operatorStacktrace', 'true'
+	includes.clear()
+	include '**/*TestStaticInit.*'
+	doFirst {
+	  println "Additional tests from `testStaticInit` ($includes)"
+	}
+  }
+
   sourceSets.test.resources.srcDirs = ["src/test/resources", "src/test/java"]
 
   if (!JavaVersion.current().isJava9Compatible()) {

--- a/build.gradle
+++ b/build.gradle
@@ -334,15 +334,24 @@ project('reactor-core') {
 	from("${project.buildDir}/docs/kdoc")
   }
 
-  task loops(type: Test) {
-	exclude '**/*'
+  task loops(type: Test, group: 'verification') {
+	includes.clear()
 	include '**/*Loop.*'
+	doFirst {
+	  println "Additional tests from `loops` ($includes)"
+	}
   }
 
-  task testNG(type: Test) {
-	exclude '**/*'
-	include '**/*Verification.*'
+  task testNG(type: Test, group: 'verification') {
 	useTestNG()
+
+	//FIXME smaldini the testNG test randomly fail on local, fail on CI
+	exclude '**/*.*'
+	includes.clear()
+	include '**/*Verification.*'
+	doFirst {
+	  println "Additional tests from `testNG` ($includes)"
+	}
   }
 
   sourceSets.test.resources.srcDirs = ["src/test/resources", "src/test/java"]
@@ -369,6 +378,7 @@ project('reactor-core') {
 	  archives kdocZip
   }
 
+  test.dependsOn testStaticInit
   jacocoTestReport.dependsOn testNG
   check.dependsOn jacocoTestReport
   jar.finalizedBy(japicmp)

--- a/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
@@ -463,6 +463,36 @@ public abstract class Hooks {
 		return Collections.unmodifiableMap(onOperatorErrorHooks);
 	}
 
+	static final Logger log = Loggers.getLogger(Hooks.class);
+
+	/**
+	 * A key that can be used to store a sequence-specific {@link Hooks#onErrorDropped(Consumer)}
+	 * hook in a {@link Context}, as a {@link Consumer Consumer&lt;Throwable&gt;}.
+	 */
+	static final String KEY_ON_ERROR_DROPPED = "reactor.onErrorDropped.local";
+	/**
+	 * A key that can be used to store a sequence-specific {@link Hooks#onNextDropped(Consumer)}
+	 * hook in a {@link Context}, as a {@link Consumer Consumer&lt;Object&gt;}.
+	 */
+	static final String KEY_ON_NEXT_DROPPED = "reactor.onNextDropped.local";
+	/**
+	 * A key that can be used to store a sequence-specific {@link Hooks#onOperatorError(BiFunction)}
+	 * hook in a {@link Context}, as a {@link BiFunction BiFunction&lt;Throwable, Object, Throwable&gt;}.
+	 */
+	static final String KEY_ON_OPERATOR_ERROR = "reactor.onOperatorError.local";
+	/**
+	 * A key that can be used to store a sequence-specific {@link Hooks#onOperatorError(BiFunction)}
+	 * hook THAT IS ONLY APPLIED TO Operators{@link Operators#onRejectedExecution(Throwable, Context) onRejectedExecution}
+	 * in a {@link Context}, as a {@link BiFunction BiFunction&lt;Throwable, Object, Throwable&gt;}.
+	 */
+	static final String KEY_ON_REJECTED_EXECUTION = "reactor.onRejectedExecution.local";
+
+	/**
+	 * A key used by {@link #onOperatorDebug()} to hook the debug handler, augmenting
+	 * every single operator with an assembly traceback.
+	 */
+	static final String ON_OPERATOR_DEBUG_KEY = "onOperatorDebug";
+
 	static {
 		onEachOperatorHooks = new LinkedHashMap<>(1);
 		onLastOperatorHooks = new LinkedHashMap<>(1);
@@ -473,7 +503,7 @@ public abstract class Hooks {
 						"false"));
 
 		if (globalTrace) {
-			onEachOperator(OnOperatorDebug.instance());
+			onEachOperator(ON_OPERATOR_DEBUG_KEY, OnOperatorDebug.instance());
 		}
 	}
 
@@ -513,29 +543,4 @@ public abstract class Hooks {
 		}
 	}
 
-	static final Logger log = Loggers.getLogger(Hooks.class);
-
-	/**
-	 * A key that can be used to store a sequence-specific {@link Hooks#onErrorDropped(Consumer)}
-	 * hook in a {@link Context}, as a {@link Consumer Consumer&lt;Throwable&gt;}.
-	 */
-	static final String KEY_ON_ERROR_DROPPED = "reactor.onErrorDropped.local";
-	/**
-	 * A key that can be used to store a sequence-specific {@link Hooks#onNextDropped(Consumer)}
-	 * hook in a {@link Context}, as a {@link Consumer Consumer&lt;Object&gt;}.
-	 */
-	static final String KEY_ON_NEXT_DROPPED = "reactor.onNextDropped.local";
-	/**
-	 * A key that can be used to store a sequence-specific {@link Hooks#onOperatorError(BiFunction)}
-	 * hook in a {@link Context}, as a {@link BiFunction BiFunction&lt;Throwable, Object, Throwable&gt;}.
-	 */
-	static final String KEY_ON_OPERATOR_ERROR = "reactor.onOperatorError.local";
-	/**
-	 * A key that can be used to store a sequence-specific {@link Hooks#onOperatorError(BiFunction)}
-	 * hook THAT IS ONLY APPLIED TO Operators{@link Operators#onRejectedExecution(Throwable, Context) onRejectedExecution}
-	 * in a {@link Context}, as a {@link BiFunction BiFunction&lt;Throwable, Object, Throwable&gt;}.
-	 */
-	static final String KEY_ON_REJECTED_EXECUTION = "reactor.onRejectedExecution.local";
-
-	static final String ON_OPERATOR_DEBUG_KEY = "onOperatorDebug";
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
@@ -414,7 +414,7 @@ public class FluxPeekFuseableTest {
 
 	@Test
 	public void afterTerminateCallbackErrorAndErrorCallbackError() {
-		IllegalStateException err = new IllegalStateException("afterTerminate");
+		IllegalStateException err = new IllegalStateException("expected afterTerminate");
 		IllegalArgumentException err2 = new IllegalArgumentException("error");
 
 		FluxPeekFuseable<String> flux = new FluxPeekFuseable<>(
@@ -793,7 +793,6 @@ public class FluxPeekFuseableTest {
 			    })
 			    .blockLast();
 
-			System.out.println(rs);
 			assertEquals(10, count.get());
 		}
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnValueTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnValueTest.java
@@ -17,6 +17,7 @@ package reactor.core.publisher;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Level;
 
 import org.junit.Test;
 import reactor.core.CoreSubscriber;
@@ -45,7 +46,7 @@ public class FluxSubscribeOnValueTest {
 		StepVerifier.create(Flux.range(1, 100)
 		                        .flatMap(f -> Flux.just(f)
 		                                          .subscribeOn(Schedulers.parallel())
-		                                          .log()
+		                                          .log("testSubscribeOnValueFusion", Level.FINE)
 		                                          .map(this::slow)))
 		            .expectFusion(Fuseable.ASYNC, Fuseable.NONE)
 		            .expectNextCount(100)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
+import java.util.logging.Level;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
@@ -646,12 +647,12 @@ public class FluxWindowPredicateTest extends
 
 		Flux<Integer> source = Flux.range(1, 20)
 		                           .doOnRequest(req::addAndGet)
-		                           .log()
+		                           .log("source", Level.FINE)
 		                           .hide();
 
 		StepVerifier.create(source.windowUntil(i -> i % 5 == 0, false, prefetch)
 		                          .concatMap(w -> w, 1)
-				.log("downstream"),  0)
+				.log("downstream", Level.FINE),  0)
 		            .thenRequest(2)
 		            .expectNext(1, 2)
 		            .thenRequest(6)
@@ -670,12 +671,12 @@ public class FluxWindowPredicateTest extends
 
 		Flux<Integer> source = Flux.range(1, 20)
 		                           .doOnRequest(req::addAndGet)
-		                           .log("source")
+		                           .log("source", Level.FINE)
 		                           .hide();
 
 		StepVerifier.create(source.windowWhile(i -> i % 5 != 0, prefetch)
-		                          .concatMap(w -> w.log(), 1)
-		                          .log("downstream"),  0)
+		                          .concatMap(w -> w.log("window", Level.FINE), 1)
+		                          .log("downstream", Level.FINE),  0)
 		            .thenRequest(2)
 		            .expectNext(1, 2)
 		            .thenRequest(6)
@@ -696,13 +697,13 @@ public class FluxWindowPredicateTest extends
 		StepVerifier.create(
 				source
 				.doOnRequest(req::addAndGet)
-				.log("source")
+				.log("source", Level.FINE)
 				.windowWhile(s -> !"#".equals(s), 2)
-				.log("windowWhile")
+				.log("windowWhile", Level.FINE)
 				.concatMap(w -> w.collectList()
-				                 .log("window")
+				                 .log("window", Level.FINE)
 						, 1)
-				.log("downstream")
+				.log("downstream", Level.FINE)
 			, StepVerifierOptions.create().checkUnderRequesting(false).initialRequest(1))
 		            .expectNextMatches(List::isEmpty)
 		            .thenRequest(1)
@@ -726,13 +727,13 @@ public class FluxWindowPredicateTest extends
 		StepVerifier.create(
 		source
 				.doOnRequest(req::addAndGet)
-				.log("source")
+				.log("source", Level.FINE)
 				.windowWhile(s -> !"#".equals(s), 2)
-				.log("windowWhile")
+				.log("windowWhile", Level.FINE)
 				.concatMap(w -> w.collectList()
-				                 .log("window")
+				                 .log("window", Level.FINE)
 						, 1)
-				.log("downstream")
+				.log("downstream", Level.FINE)
 		)
 		            .expectNextMatches(List::isEmpty)
 		            .assertNext(l -> assertThat(l).containsExactly("1A", "1B", "1C"))
@@ -752,13 +753,13 @@ public class FluxWindowPredicateTest extends
 		StepVerifier.create(
 		source
 				.doOnRequest(req::addAndGet)
-				.log("source")
+				.log("source", Level.FINE)
 				.windowUntil(s -> "#".equals(s), false, 2)
-				.log("windowUntil")
+				.log("windowUntil", Level.FINE)
 				.concatMap(w -> w.collectList()
-								 .log("window")
+								 .log("window", Level.FINE)
 						, 1)
-				.log("downstream")
+				.log("downstream", Level.FINE)
 		)
 		            .assertNext(l -> assertThat(l).containsExactly("#"))
 		            .assertNext(l -> assertThat(l).containsExactly("1A", "1B", "1C", "#"))

--- a/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
@@ -805,20 +805,20 @@ public class HooksTest {
 				}));
 
 		StepVerifier.create(Flux.just(1, 2, 3)
-		                        .log()
-		                        .log())
+		                        .log("log", Level.FINE)
+		                        .log("log", Level.FINE))
 		            .expectNext(2, 3, 4)
 		            .verifyComplete();
 
 		StepVerifier.create(Mono.just(1)
-		                        .log()
-		                        .log())
+		                        .log("log", Level.FINE)
+		                        .log("log", Level.FINE))
 		            .expectNext(2)
 		            .verifyComplete();
 
 		StepVerifier.create(ParallelFlux.from(Mono.just(1), Mono.just(1))
-		                        .log()
-		                        .log())
+		                        .log("log", Level.FINE)
+		                        .log("log", Level.FINE))
 		            .expectNext(2, 2)
 		            .verifyComplete();
 	}
@@ -852,40 +852,40 @@ public class HooksTest {
 
 		StepVerifier.create(Flux.just(1, 2, 3)
 		                        .tag("metric", "test")
-		                        .log()
-		                        .log())
+		                        .log("log", Level.FINE)
+		                        .log("log", Level.FINE))
 		            .expectNext(2, 3, 4)
 		            .verifyComplete();
 
 		StepVerifier.create(Mono.just(1)
 		                        .tag("metric", "test")
-		                        .log()
-		                        .log())
+		                        .log("log", Level.FINE)
+		                        .log("log", Level.FINE))
 		            .expectNext(2)
 		            .verifyComplete();
 
 		StepVerifier.create(ParallelFlux.from(Mono.just(1), Mono.just(1))
 		                                .tag("metric", "test")
-		                                .log()
-		                                .log())
+		                                .log("log", Level.FINE)
+		                                .log("log", Level.FINE))
 		            .expectNext(2, 2)
 		            .verifyComplete();
 
 		StepVerifier.create(Flux.just(1, 2, 3)
-		                        .log()
-		                        .log())
+		                        .log("log", Level.FINE)
+		                        .log("log", Level.FINE))
 		            .expectNext(1, 2, 3)
 		            .verifyComplete();
 
 		StepVerifier.create(Mono.just(1)
-		                        .log()
-		                        .log())
+		                        .log("log", Level.FINE)
+		                        .log("log", Level.FINE))
 		            .expectNext(1)
 		            .verifyComplete();
 
 		StepVerifier.create(ParallelFlux.from(Mono.just(1), Mono.just(1))
-		                                .log()
-		                                .log())
+		                                .log("log", Level.FINE)
+		                                .log("log", Level.FINE))
 		            .expectNext(1, 1)
 		            .verifyComplete();
 	}
@@ -916,20 +916,20 @@ public class HooksTest {
 				}));
 
 		StepVerifier.create(Flux.just(1, 2, 3)
-		                        .log()
-		                        .log())
+		                        .log("log", Level.FINE)
+		                        .log("log", Level.FINE))
 		            .expectNext(4, 5, 6)
 		            .verifyComplete();
 
 		StepVerifier.create(Mono.just(1)
-		                        .log()
-		                        .log())
+		                        .log("log", Level.FINE)
+		                        .log("log", Level.FINE))
 		            .expectNext(4)
 		            .verifyComplete();
 
 		StepVerifier.create(ParallelFlux.from(Mono.just(1), Mono.just(1))
-		                                .log()
-		                                .log())
+		                                .log("log", Level.FINE)
+		                                .log("log", Level.FINE))
 		            .expectNext(6, 6)
 		            .verifyComplete();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/HooksTestStaticInit.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/HooksTestStaticInit.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HooksTestStaticInit {
+
+	//IMPORTANT: this test case depends on System property
+	// `reactor.trace.operatorStacktrace` be set to `true`
+
+	@After
+	public void resetAllHooks() {
+		Hooks.resetOnOperatorError();
+		Hooks.resetOnNextDropped();
+		Hooks.resetOnErrorDropped();
+//		Hooks.resetOnOperatorDebug(); //superseded by resetOnEachOperator
+		Hooks.resetOnEachOperator();
+		Hooks.resetOnLastOperator();
+	}
+
+	@Test
+	public void syspropDebugModeShouldNotFail() {
+		assertThat(System.getProperties())
+				.as("debug mode set via system property")
+				.containsEntry("reactor.trace.operatorStacktrace", "true");
+		assertThat(Hooks.getOnEachOperatorHooks())
+				.as("debug hook activated")
+				.containsKey(Hooks.ON_OPERATOR_DEBUG_KEY);
+		//would throw NPE due to https://github.com/reactor/reactor-core/issues/985
+		Mono.just("hello").subscribe();
+	}
+
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPeekAfterTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPeekAfterTest.java
@@ -26,11 +26,15 @@ import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
+import reactor.util.Logger;
+import reactor.util.Loggers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 public class MonoPeekAfterTest {
+
+	private static final Logger LOG = Loggers.getLogger(MonoPeekAfterTest.class);
 
 	@Test
 	public void onSuccessNormal() {
@@ -726,7 +730,7 @@ public class MonoPeekAfterTest {
 			                      .subscribeOn(Schedulers.parallel())
 			                      .reduce((l, r) -> l + "_" + r)
 			                      .doOnSuccess(s -> {
-				                      System.out.println("success " + x + ": " + s);
+				                      LOG.debug("success " + x + ": " + s);
 				                      count.incrementAndGet();
 			                      }))
 			    .blockLast();

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelCollectTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelCollectTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.logging.Level;
 
 import org.junit.Test;
 import org.reactivestreams.Subscription;
@@ -45,7 +46,7 @@ public class ParallelCollectTest {
 		    .collect(as, (a, b) -> a.add(b))
 		    .sequential()
 		    .flatMapIterable(v -> v)
-		    .log()
+		    .log("ParallelCollectTest#collect", Level.FINE)
 		    .subscribe(ts);
 
 		ts.assertContainValues(new HashSet<>(Arrays.asList(1,

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -43,6 +43,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -81,6 +82,8 @@ import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.junit.Assert.*;
 
 public class FluxTests extends AbstractReactorTest {
+
+	static final Logger LOG = Loggers.getLogger(FluxTests.class);
 
 	static final String2Integer STRING_2_INTEGER = new String2Integer();
 
@@ -246,7 +249,7 @@ public class FluxTests extends AbstractReactorTest {
 			                          @Override
 			                          public Integer apply(Integer i) {
 				                          if (i >= 5) {
-					                          throw new IllegalArgumentException();
+					                          throw new IllegalArgumentException("expected");
 				                          }
 				                          sum += i;
 				                          return sum;
@@ -843,8 +846,8 @@ public class FluxTests extends AbstractReactorTest {
 						                                         return s;
 			                                          }))
 			    .take(Duration.ofSeconds(2))
-			    .log("parallelStream")
-			    .subscribe(System.out::println);
+			    .log("parallelStream", Level.FINE)
+			    .subscribe(LOG::debug);
 		}
 
 		latch.await(15, TimeUnit.SECONDS);
@@ -882,13 +885,13 @@ public class FluxTests extends AbstractReactorTest {
 
 		CountDownLatch countDownLatch = new CountDownLatch(tasks.size());
 		Flux<Integer> worker = Flux.fromIterable(tasks)
-		                                 .log("before")
+		                                 .log("before", Level.FINE)
 		                                 .publishOn(asyncGroup);
 
-		/*Disposable tail = */worker.log("after")
+		/*Disposable tail = */worker.log("after", Level.FINE)
 		                          .parallel(2)
 		                          .groups()
-		                          .subscribe(s -> s.log("w"+s.key())
+		                          .subscribe(s -> s.log("w"+s.key(), Level.FINE)
 		                                    .publishOn(asyncGroup)
 		                                    .map(v -> v)
 		                                    .subscribe(v -> countDownLatch.countDown(), Throwable::printStackTrace));
@@ -1130,7 +1133,7 @@ public class FluxTests extends AbstractReactorTest {
 		CountDownLatch latch = new CountDownLatch(100);
 
 		Flux.range(1, 100)
-		       .log("testOn")
+		       .log("testOn", Level.FINE)
 		       .subscribeOn(ioGroup)
 		       .publishOn(asyncGroup)
 		        .limitRate(1)

--- a/reactor-core/src/test/java/reactor/core/publisher/tck/FluxWithProcessorVerification.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/tck/FluxWithProcessorVerification.java
@@ -29,7 +29,7 @@ import reactor.core.publisher.WorkQueueProcessor;
 /**
  * @author Stephane Maldini
  */
-@org.testng.annotations.Test
+@org.testng.annotations.Test //FIXME
 public class FluxWithProcessorVerification extends AbstractProcessorVerification {
 
 	final AtomicLong cumulated = new AtomicLong(0);


### PR DESCRIPTION
@smaldini while working on #985, as I wanted to add a separate test task for this issue (to avoid too early execution of Hooks static block), I found out that `loops` and `testNG` tasks where always skipped as `NO-SOURCE`. This seemingly was due to their `exclude` pattern (which takes priority over the `include` pattern). 

I fixed that and also reduced the verbosity of quite a few tests, which should make the whole test suite steps visible in IDEA console. Configure logger at DEBUG to get the full test logs again.

:warning: This PR should be merged as 2 separate commits (one for the tests, one for the fix).