### PR TITLE
fix #992 Fix eager thenCancel

### DIFF
--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -535,6 +535,12 @@ final class DefaultStepVerifierBuilder<T>
 	}
 
 	@Override
+	public DefaultStepVerifier<T> awaitThenCancel() {
+		this.script.add(new SubscriptionTaskEvent<>(new SubscriptionEvent<>("awaitThenCancel")));
+		return build();
+	}
+
+	@Override
 	public Duration verifyError() {
 		return expectError().verify();
 	}

--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -535,12 +535,6 @@ final class DefaultStepVerifierBuilder<T>
 	}
 
 	@Override
-	public DefaultStepVerifier<T> awaitThenCancel() {
-		this.script.add(new SubscriptionTaskEvent<>(new SubscriptionEvent<>("awaitThenCancel")));
-		return build();
-	}
-
-	@Override
 	public Duration verifyError() {
 		return expectError().verify();
 	}
@@ -1236,11 +1230,15 @@ final class DefaultStepVerifierBuilder<T>
 			try {
 				Event<T> event = this.script.peek();
 				if (event == null) {
+					waitTaskEvent();
+					if (isCancelled()) {
+						return;
+					}
 					setFailure(null, actualSignal, "did not expect: %s", actualSignal);
 					return;
 				}
-
 				onTaskEvent();
+
 				if (event instanceof DefaultStepVerifierBuilder.SignalConsumeWhileEvent) {
 					if (consumeWhile(actualSignal, (SignalConsumeWhileEvent<T>) event)) {
 						return;
@@ -1476,38 +1474,34 @@ final class DefaultStepVerifierBuilder<T>
 			this.completeLatch.countDown();
 		}
 
+		void waitTaskEvent() {
+			Event<T> event;
+			while ((event = taskEvents.poll()) != null) {
+				try {
+					if (event instanceof SubscriptionTaskEvent) {
+						updateRequested(event);
+					}
+					((TaskEvent<T>) event).run(this);
+				}
+				catch (Throwable t) {
+					Exceptions.throwIfFatal(t);
+					cancel();
+					if (t instanceof AssertionError) {
+						throw (AssertionError) t;
+					}
+					throw Exceptions.propagate(t);
+				}
+			}
+		}
+
 		@SuppressWarnings("unchecked")
 		final void pollTaskEventOrComplete(Duration timeout) throws InterruptedException {
 			Objects.requireNonNull(timeout, "timeout");
-			Event<T> event;
 			Instant stop = Instant.now()
 			                      .plus(timeout);
 
-			boolean skip = true;
 			for (; ; ) {
-				while ((event = taskEvents.poll()) != null) {
-					try {
-						skip = false;
-						if (event instanceof SubscriptionTaskEvent) {
-							updateRequested(event);
-						}
-						((TaskEvent<T>) event).run(this);
-					}
-					catch (Throwable t) {
-						Exceptions.throwIfFatal(t);
-						cancel();
-						if(t instanceof AssertionError){
-							throw (AssertionError)t;
-						}
-						throw Exceptions.propagate(t);
-					}
-				}
-				if (!skip) {
-					event = script.peek();
-					if (event instanceof SubscriptionEvent) {
-						serializeDrainAndSubscriptionEvent();
-					}
-				}
+				waitTaskEvent();
 				if (this.completeLatch.await(10, TimeUnit.NANOSECONDS)) {
 					break;
 				}

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -403,10 +403,8 @@ public interface StepVerifier {
 		StepVerifier expectComplete();
 
 		/**
-		 * Cancel the underlying subscription. This happens eagerly when the previous
-		 * step is an expectation, which could lead to short-circuiting said expectation
-		 * is some cases (like when the data is produced on another thread). In case you
-		 * need to be sure the last expectation step is processed, use {@link #awaitThenCancel()}.
+		 * Cancel the underlying subscription. This happens sequentially after the
+		 * previous step.
 		 * <p>
 		 * Note that time-manipulating operators like {@link Step#expectNoEvent(Duration)}
 		 * are detected and waited for before cancellation occurs.
@@ -414,54 +412,9 @@ public interface StepVerifier {
 		 * @return the built verification scenario, ready to be verified
 		 *
 		 * @see Subscription#cancel()
-		 * @see #awaitThenCancel()
-		 * @see #cancelThenVerify()
 		 */
 		StepVerifier thenCancel();
 
-		/**
-		 * Cancel the underlying subscription AFTER the previous step has completed.
-		 * Unlike with {@link #thenCancel()}, this includes onNext expectations.
-		 * It is recommended to {@link #verify(Duration) verify the scenario with a timeout}.
-		 * <p>
-		 * Note that as a result, a source that stops emitting just before the preceding
-		 * expectation will result in the test hanging (eg. one expects {@code 1L, 2L} and
-		 * {@code awaitThenCancel} but the source only emits {@code 1L} then never completes
-		 * => awaitThenCancel won't cancel and the test will hang).
-		 *
-		 * @return the built verification scenario, ready to be verified
-		 *
-		 * @see Subscription#cancel()
-		 * @see #thenCancel()
-		 * @see #verifyThenCancel(Duration)
-		 */
-		StepVerifier awaitThenCancel();
-
-		/**
-		 * Convenience shortcut to {@link #awaitThenCancel()} and {@link #verify(Duration)}.
-		 * Since awaitThenCancel is more subject to hanging, this method enforces the use
-		 * of a timeout on the verification.
-		 *
-		 * @param timeout the maximum allowed {@link Duration} for the test.
-		 * @return the actual {@link Duration} the verification took.
-		 * @see #awaitThenCancel()
-		 * @see #verify(Duration)
-		 * @see #cancelThenVerify()
-		 */
-		default Duration verifyThenCancel(Duration timeout) {
-			return awaitThenCancel().verify(timeout);
-		}
-
-		/**
-		 * Convenience shortcut to {@link #thenCancel()} and {@link #verify()}.
-		 *
-		 * @return the actual {@link Duration} the verification took.
-		 * @see #thenCancel()
-		 * @see #verifyThenCancel(Duration)
-		 */
-		default Duration cancelThenVerify() {
-			return thenCancel().verify();
-		}
 
 		/**
 		 * Trigger the {@link #verify() verification}, expecting an unspecified error

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -403,13 +403,65 @@ public interface StepVerifier {
 		StepVerifier expectComplete();
 
 		/**
-		 * Cancel the underlying subscription.
+		 * Cancel the underlying subscription. This happens eagerly when the previous
+		 * step is an expectation, which could lead to short-circuiting said expectation
+		 * is some cases (like when the data is produced on another thread). In case you
+		 * need to be sure the last expectation step is processed, use {@link #awaitThenCancel()}.
+		 * <p>
+		 * Note that time-manipulating operators like {@link Step#expectNoEvent(Duration)}
+		 * are detected and waited for before cancellation occurs.
 		 *
 		 * @return the built verification scenario, ready to be verified
 		 *
 		 * @see Subscription#cancel()
+		 * @see #awaitThenCancel()
+		 * @see #cancelThenVerify()
 		 */
 		StepVerifier thenCancel();
+
+		/**
+		 * Cancel the underlying subscription AFTER the previous step has completed.
+		 * Unlike with {@link #thenCancel()}, this includes onNext expectations.
+		 * It is recommended to {@link #verify(Duration) verify the scenario with a timeout}.
+		 * <p>
+		 * Note that as a result, a source that stops emitting just before the preceding
+		 * expectation will result in the test hanging (eg. one expects {@code 1L, 2L} and
+		 * {@code awaitThenCancel} but the source only emits {@code 1L} then never completes
+		 * => awaitThenCancel won't cancel and the test will hang).
+		 *
+		 * @return the built verification scenario, ready to be verified
+		 *
+		 * @see Subscription#cancel()
+		 * @see #thenCancel()
+		 * @see #verifyThenCancel(Duration)
+		 */
+		StepVerifier awaitThenCancel();
+
+		/**
+		 * Convenience shortcut to {@link #awaitThenCancel()} and {@link #verify(Duration)}.
+		 * Since awaitThenCancel is more subject to hanging, this method enforces the use
+		 * of a timeout on the verification.
+		 *
+		 * @param timeout the maximum allowed {@link Duration} for the test.
+		 * @return the actual {@link Duration} the verification took.
+		 * @see #awaitThenCancel()
+		 * @see #verify(Duration)
+		 * @see #cancelThenVerify()
+		 */
+		default Duration verifyThenCancel(Duration timeout) {
+			return awaitThenCancel().verify(timeout);
+		}
+
+		/**
+		 * Convenience shortcut to {@link #thenCancel()} and {@link #verify()}.
+		 *
+		 * @return the actual {@link Duration} the verification took.
+		 * @see #thenCancel()
+		 * @see #verifyThenCancel(Duration)
+		 */
+		default Duration cancelThenVerify() {
+			return thenCancel().verify();
+		}
 
 		/**
 		 * Trigger the {@link #verify() verification}, expecting an unspecified error


### PR DESCRIPTION
This PR:
 - clarifies that `thenCancel` will sometimes short-circuit the last expectation
 - adds an `awaitThenCancel` that doesn't, but can hang test
 - adds a convenience `cancelThenVerify` method
 - adds a convenience `verityThenCancel(Duration)` method (timeout enforced because of the potential for hanging)