### PR TITLE
Improve virtual time scheduler:

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDelaySequenceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDelaySequenceTest.java
@@ -123,8 +123,7 @@ public class FluxDelaySequenceTest {
 
 		StepVerifier.withVirtualTime(test)
 		            .expectSubscription()
-		            .expectNoEvent(Duration.ofMillis(50))
-		            .expectNoEvent(Duration.ofMillis(1000))
+		            .expectNoEvent(Duration.ofMillis(1050))
 		            .expectNext(0L)
 		            .expectNoEvent(Duration.ofMillis(50))
 		            .expectNext(1L)


### PR DESCRIPTION
- always check current timed task on schedule with delay
- only create one worker for direct scheduling

I came across an issue with FluxDelaySequenceTest where i needed two expectNoEvent call to advance time twice given the the recursiveness of the flow (first delay 50ms then delay 1000ms). I believe this can simply be fixed by an enforced check on the current time queue when delayed schedules are used.