### PR TITLE
fix #916 Process fatal exceptions in Schedulers.handleError, don't throw

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -571,7 +571,6 @@ public abstract class Schedulers {
 	static void handleError(Throwable ex) {
 		Thread thread = Thread.currentThread();
 		Throwable t = unwrap(ex);
-		Exceptions.throwIfJvmFatal(t);
 		Thread.UncaughtExceptionHandler x = thread.getUncaughtExceptionHandler();
 		if (x != null) {
 			x.uncaughtException(thread, t);


### PR DESCRIPTION
The fatal exceptions will probably be thrown down the line and they are
still considered irrecoverable, but when they happen within a Thread
from a Scheduler, they should be passed to the handleError hook
as well as to the Thread's uncaughtExceptionHandler if any.

Such a sequence may hang, as the test demonstrates, but the fatal error
has a chance to be logged.