### PR TITLE
follow-up on #969 Improve FluxBufferWhen buffer tracking

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferWhen.java
@@ -16,14 +16,13 @@
 
 package reactor.core.publisher;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -35,9 +34,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.Exceptions;
-import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
-import reactor.util.concurrent.MpscLinkedQueue;
 
 /**
  * buffers elements into possibly overlapping buffers whose boundaries are determined
@@ -81,60 +78,85 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 	@Override
 	public void subscribe(CoreSubscriber<? super BUFFER> actual) {
 		BufferWhenMainSubscriber<T, OPEN, CLOSE, BUFFER> main =
-				new BufferWhenMainSubscriber<>(actual, bufferSupplier, end);
+				new BufferWhenMainSubscriber<>(actual, bufferSupplier, queueSupplier, start, end);
 
 		actual.onSubscribe(main);
 
-		BufferWhenOpenSubscriber<T, OPEN, CLOSE, BUFFER> bos =
+		BufferWhenOpenSubscriber<OPEN> bos =
 				new BufferWhenOpenSubscriber<>(main);
-		if (main.resources.add(bos)) {
-			main.bos = bos; //keep reference to remove and dispose it if source early onCompletes
-
-			BufferWhenMainSubscriber.WINDOWS.lazySet(main, 1);
-			start.subscribe(bos);
-
+		if (main.subscribers.add(bos)) {
 			source.subscribe(main);
+			start.subscribe(bos);
 		}
 	}
 
 	static final class BufferWhenMainSubscriber<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
-			extends QueueDrainSubscriber<T, BUFFER, BUFFER>
-			implements Disposable {
+			implements InnerOperator<T, BUFFER> {
+
+		final CoreSubscriber<? super BUFFER>                               actual;
+		final Publisher<? extends OPEN>                                    bufferOpen;
 		final Function<? super OPEN, ? extends Publisher<? extends CLOSE>> bufferClose;
 		final Supplier<BUFFER>                                             bufferSupplier;
-		final Composite                                                    resources;
+		final Disposable.Composite                                         subscribers;
+		final Queue<BUFFER>                                                queue;
 
-		Subscription s;
+		volatile long requested;
+		static final AtomicLongFieldUpdater<BufferWhenMainSubscriber> REQUESTED =
+		AtomicLongFieldUpdater.newUpdater(BufferWhenMainSubscriber.class, "requested");
 
-		final List<BUFFER> buffers;
+		volatile Subscription s;
+		static final AtomicReferenceFieldUpdater<BufferWhenMainSubscriber, Subscription> S =
+				AtomicReferenceFieldUpdater.newUpdater(BufferWhenMainSubscriber.class, Subscription.class, "s");
+
+		volatile Throwable errors;
+		static final AtomicReferenceFieldUpdater<BufferWhenMainSubscriber, Throwable>
+				ERRORS =
+				AtomicReferenceFieldUpdater.newUpdater(BufferWhenMainSubscriber.class, Throwable.class, "errors");
 
 		volatile int windows;
 		static final AtomicIntegerFieldUpdater<BufferWhenMainSubscriber> WINDOWS =
 				AtomicIntegerFieldUpdater.newUpdater(BufferWhenMainSubscriber.class, "windows");
 
-		BufferWhenOpenSubscriber<T, OPEN, CLOSE, BUFFER> bos;
+		volatile boolean done;
+		volatile boolean cancelled;
+
+		long                        index;
+		LinkedHashMap<Long, BUFFER> buffers; //linkedHashMap important to keep the buffer order on final drain
+		long                        emitted;
 
 		BufferWhenMainSubscriber(CoreSubscriber<? super BUFFER> actual,
-				Supplier<BUFFER> bufferSupplier,
+				Supplier<BUFFER> bufferSupplier, Supplier<? extends Queue<BUFFER>> queueSupplier,
+				Publisher<? extends OPEN> bufferOpen,
 				Function<? super OPEN, ? extends Publisher<? extends CLOSE>> bufferClose) {
-			super(actual, new MpscLinkedQueue<>());
+			this.actual = actual;
+			this.bufferOpen = bufferOpen;
 			this.bufferClose = bufferClose;
 			this.bufferSupplier = bufferSupplier;
-			this.buffers = new LinkedList<>();
-			this.resources = Disposables.composite();
+			this.queue = queueSupplier.get();
+			this.buffers = new LinkedHashMap<>();
+			this.subscribers = Disposables.composite();
 		}
+
 		@Override
 		public void onSubscribe(Subscription s) {
-			if (Operators.validate(this.s, s)) {
-				this.s = s;
+			if (Operators.setOnce(S, this, s)) {
 				s.request(Long.MAX_VALUE);
 			}
 		}
 
 		@Override
+		public CoreSubscriber<? super BUFFER> actual() {
+			return actual;
+		}
+
+		@Override
 		public void onNext(T t) {
 			synchronized (this) {
-				for (BUFFER b : buffers) {
+				Map<Long, BUFFER> bufs = buffers;
+				if (bufs == null) {
+					return;
+				}
+				for (BUFFER b : bufs.values()) {
 					b.add(t);
 				}
 			}
@@ -142,139 +164,205 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 
 		@Override
 		public void onError(Throwable t) {
-			error = t;
-			done = true;
-			cancel();
-			cancelled = true;
-			synchronized (this) {
-				buffers.clear();
+			if (Exceptions.addThrowable(ERRORS, this, t)) {
+				subscribers.dispose();
+				synchronized (this) {
+					buffers = null;
+				}
+				done = true;
+				drain();
 			}
-			actual.onError(t);
+			else {
+				Operators.onErrorDropped(t, actual.currentContext());
+			}
 		}
 
 		@Override
 		public void onComplete() {
-			done = true;
-			resources.remove(bos);
-			bos.dispose();
-			if (WINDOWS.decrementAndGet(this) == 0) {
-				complete();
-			}
-		}
-
-		void complete() {
-			List<BUFFER> list;
+			subscribers.dispose();
 			synchronized (this) {
-				list = new ArrayList<>(buffers);
-				buffers.clear();
-			}
-
-			Queue<BUFFER> q = queue;
-			for (BUFFER u : list) {
-				q.offer(u);
+				Map<Long, BUFFER> bufs = buffers;
+				if (bufs == null) {
+					return;
+				}
+				for (BUFFER b : bufs.values()) {
+					queue.offer(b);
+				}
+				buffers = null;
 			}
 			done = true;
-			if (enter()) {
-				drainMaxLoop(q, actual, false, this, this);
-			}
+			drain();
 		}
 
 		@Override
 		public void request(long n) {
-			requested(n);
-		}
-
-		@Override
-		public void dispose() {
-			resources.dispose();
-		}
-
-		@Override
-		public boolean isDisposed() {
-			return resources.isDisposed();
+			Operators.addCap(REQUESTED, this, n);
+			drain();
 		}
 
 		@Override
 		public void cancel() {
-			if (!cancelled) {
+			if (Operators.terminate(S, this)) {
 				cancelled = true;
-				dispose();
+				subscribers.dispose();
+				synchronized (this) {
+					buffers = null;
+				}
+				if (WINDOWS.getAndIncrement(this) != 0) {
+					queue.clear();
+				}
 			}
 		}
 
-		@Override
-		public boolean accept(Subscriber<? super BUFFER> a, BUFFER v) {
-			a.onNext(v);
-			return true;
+		void drain() {
+			if (WINDOWS.getAndIncrement(this) != 0) {
+				return;
+			}
+
+			int missed = 1;
+			long e = emitted;
+			Subscriber<? super BUFFER> a = actual;
+			Queue<BUFFER> q = queue;
+
+			for (;;) {
+				long r = requested;
+
+				while (e != r) {
+					if (cancelled) {
+						q.clear();
+						return;
+					}
+
+					boolean d = done;
+					if (d && errors != null) {
+						q.clear();
+						Throwable ex = Exceptions.terminate(ERRORS, this);
+						a.onError(ex);
+						return;
+					}
+
+					BUFFER v = q.poll();
+					boolean empty = v == null;
+
+					if (d && empty) {
+						a.onComplete();
+						return;
+					}
+
+					if (empty) {
+						break;
+					}
+
+					a.onNext(v);
+					e++;
+				}
+
+				if (e == r) {
+					if (cancelled) {
+						q.clear();
+						return;
+					}
+
+					if (done) {
+						if (errors != null) {
+							q.clear();
+							Throwable ex = Exceptions.terminate(ERRORS, this);
+							a.onError(ex);
+							return;
+						} else
+						if (q.isEmpty()) {
+							a.onComplete();
+							return;
+						}
+					}
+				}
+
+				emitted = e;
+				missed = WINDOWS.addAndGet(this, -missed);
+				if (missed == 0) {
+					break;
+				}
+			}
 		}
 
-		void open(OPEN window) {
-			if (cancelled) {
-				return;
-			}
-
-			BUFFER b;
-
-			try {
-				b = Objects.requireNonNull(bufferSupplier.get(), "The buffer supplied is null");
-			} catch (Throwable e) {
-				Exceptions.throwIfFatal(e);
-				onError(e);
-				return;
-			}
-
+		void open(OPEN token) {
 			Publisher<? extends CLOSE> p;
-
+			BUFFER buf;
 			try {
-				p = Objects.requireNonNull(bufferClose.apply(window), "The buffer closing publisher is null");
-			} catch (Throwable e) {
-				Exceptions.throwIfFatal(e);
-				onError(e);
+				buf = Objects.requireNonNull(bufferSupplier.get(), "The bufferSupplier returned a null Collection");
+				p = Objects.requireNonNull(bufferClose.apply(token), "The bufferClose returned a null Publisher");
+			} catch (Throwable ex) {
+				Exceptions.throwIfFatal(ex);
+				Operators.terminate(S, this);
+				if (Exceptions.addThrowable(ERRORS, this, ex)) {
+					subscribers.dispose();
+					synchronized (this) {
+						buffers = null;
+					}
+					done = true;
+					drain();
+				} else {
+					Operators.onErrorDropped(ex, actual.currentContext());
+				}
 				return;
 			}
 
-			if (cancelled) {
-				return;
-			}
-
+			long idx = index;
+			index = idx + 1;
 			synchronized (this) {
-				if (cancelled) {
+				Map<Long, BUFFER> bufs = buffers;
+				if (bufs == null) {
 					return;
 				}
-				buffers.add(b);
+				bufs.put(idx, buf);
 			}
 
-			BufferWhenCloseSubscriber<T, OPEN, CLOSE, BUFFER> bcs =
-					new BufferWhenCloseSubscriber<>(b, this);
-			resources.add(bcs);
-
-			WINDOWS.getAndIncrement(this);
-
-			p.subscribe(bcs);
+			BufferWhenCloseSubscriber<T, BUFFER> bc = new BufferWhenCloseSubscriber<>(this, idx);
+			subscribers.add(bc);
+			p.subscribe(bc);
 		}
 
-		void openFinished(Disposable d) {
-			if (resources.remove(d)) {
-				if (WINDOWS.decrementAndGet(this) == 0) {
-					complete();
-				}
+		void openComplete(BufferWhenOpenSubscriber<OPEN> os) {
+			subscribers.remove(os);
+			if (subscribers.size() == 0) {
+				Operators.terminate(S, this);
+				done = true;
+				drain();
 			}
 		}
 
-		void close(BUFFER b, Disposable d) {
-			boolean e;
+		void close(BufferWhenCloseSubscriber<T, BUFFER> closer, long idx) {
+			subscribers.remove(closer);
+			boolean makeDone = false;
+			if (subscribers.size() == 0) {
+				makeDone = true;
+				Operators.terminate(S, this);
+			}
 			synchronized (this) {
-				e = buffers.remove(b);
-			}
-
-			if (e) {
-				fastPathOrderedEmitMax(b, false, this);
-			}
-
-			if (resources.remove(d)) {
-				if (WINDOWS.decrementAndGet(this) == 0) {
-					complete();
+				Map<Long, BUFFER> bufs = buffers;
+				if (bufs == null) {
+					return;
 				}
+				queue.offer(buffers.remove(idx));
+			}
+			if (makeDone) {
+				done = true;
+			}
+			drain();
+		}
+
+		void boundaryError(Disposable boundary, Throwable ex) {
+			Operators.terminate(S, this);
+			subscribers.remove(boundary);
+			if (Exceptions.addThrowable(ERRORS, this, ex)) {
+				subscribers.dispose();
+				synchronized (this) {
+					buffers = null;
+				}
+				done = true;
+				drain();
+			} else {
+				Operators.onErrorDropped(ex, actual.currentContext());
 			}
 		}
 
@@ -282,26 +370,31 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 		@Nullable
 		public Object scanUnsafe(Attr key) {
 			if (key == Attr.PARENT) return s;
+			if (key == Attr.ACTUAL) return actual;
 			if (key == Attr.PREFETCH) return Integer.MAX_VALUE;
-			if (key == Attr.BUFFERED) return buffers.stream()
+			if (key == Attr.BUFFERED) return buffers.values()
+			                                        .stream()
 			                                        .mapToInt(Collection::size)
 			                                        .sum();
+			if (key == Attr.CANCELLED) return cancelled;
+			if (key == Attr.TERMINATED) return done;
+			if (key == Attr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == Attr.ERROR) return errors;
 
-			return super.scanUnsafe(key);
+			return null;
 		}
 	}
 
-	static final class BufferWhenOpenSubscriber<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
+	static final class BufferWhenOpenSubscriber<OPEN>
 			implements Disposable, InnerConsumer<OPEN> {
 
 		volatile Subscription subscription;
 		static final AtomicReferenceFieldUpdater<BufferWhenOpenSubscriber, Subscription> SUBSCRIPTION =
 				AtomicReferenceFieldUpdater.newUpdater(BufferWhenOpenSubscriber.class, Subscription.class, "subscription");
 
-		final BufferWhenMainSubscriber<T, OPEN, CLOSE, BUFFER> parent;
-		boolean done;
+		final BufferWhenMainSubscriber<?, OPEN, ?, ?> parent;
 
-		BufferWhenOpenSubscriber(BufferWhenMainSubscriber<T, OPEN, CLOSE, BUFFER> parent) {
+		BufferWhenOpenSubscriber(BufferWhenMainSubscriber<?, OPEN, ?, ?> parent) {
 			this.parent = parent;
 		}
 
@@ -324,29 +417,19 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 
 		@Override
 		public void onNext(OPEN t) {
-			if (done) {
-				return;
-			}
 			parent.open(t);
 		}
 
 		@Override
 		public void onError(Throwable t) {
-			if (done) {
-				Operators.onErrorDropped(t, parent.actual.currentContext());
-				return;
-			}
-			done = true;
-			parent.onError(t);
+			SUBSCRIPTION.lazySet(this, Operators.cancelledSubscription());
+			parent.boundaryError(this, t);
 		}
 
 		@Override
 		public void onComplete() {
-			if (done) {
-				return;
-			}
-			done = true;
-			parent.openFinished(this);
+			SUBSCRIPTION.lazySet(this, Operators.cancelledSubscription());
+			parent.openComplete(this);
 		}
 
 		@Override
@@ -363,21 +446,20 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 		}
 	}
 
-	static final class BufferWhenCloseSubscriber<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
-			implements Disposable, InnerConsumer<CLOSE> {
+	static final class BufferWhenCloseSubscriber<T, BUFFER extends Collection<? super T>>
+			implements Disposable, InnerConsumer<Object> {
 
 		volatile Subscription subscription;
 		static final AtomicReferenceFieldUpdater<BufferWhenCloseSubscriber, Subscription> SUBSCRIPTION =
 				AtomicReferenceFieldUpdater.newUpdater(BufferWhenCloseSubscriber.class, Subscription.class, "subscription");
 
-		final BufferWhenMainSubscriber<T, OPEN, CLOSE, BUFFER> parent;
-		final BUFFER                                           value;
-		boolean done;
+		final BufferWhenMainSubscriber<T, ?, ?, BUFFER> parent;
+		final long                                      index;
 
 
-		BufferWhenCloseSubscriber(BUFFER value, BufferWhenMainSubscriber<T, OPEN, CLOSE, BUFFER> parent) {
+		BufferWhenCloseSubscriber(BufferWhenMainSubscriber<T, ?, ?, BUFFER> parent, long index) {
 			this.parent = parent;
-			this.value = value;
+			this.index = index;
 		}
 
 		@Override
@@ -398,26 +480,32 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 		}
 
 		@Override
-		public void onNext(CLOSE t) {
-			onComplete();
+		public void onNext(Object t) {
+			Subscription s = subscription;
+			if (s != Operators.cancelledSubscription()) {
+				SUBSCRIPTION.lazySet(this, Operators.cancelledSubscription());
+				s.cancel();
+				parent.close(this, index);
+			}
 		}
 
 		@Override
 		public void onError(Throwable t) {
-			if (done) {
-				Operators.onErrorDropped(t, parent.actual.currentContext());
-				return;
+			if (subscription != Operators.cancelledSubscription()) {
+				SUBSCRIPTION.lazySet(this, Operators.cancelledSubscription());
+				parent.boundaryError(this, t);
 			}
-			parent.onError(t);
+			else {
+				Operators.onErrorDropped(t, parent.actual.currentContext());
+			}
 		}
 
 		@Override
 		public void onComplete() {
-			if (done) {
-				return;
+			if (subscription != Operators.cancelledSubscription()) {
+				SUBSCRIPTION.lazySet(this, Operators.cancelledSubscription());
+				parent.close(this, index);
 			}
-			done = true;
-			parent.close(value, this);
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferWhen.java
@@ -82,8 +82,7 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 
 		actual.onSubscribe(main);
 
-		BufferWhenOpenSubscriber<OPEN> bos =
-				new BufferWhenOpenSubscriber<>(main);
+		BufferWhenOpenSubscriber<OPEN> bos = new BufferWhenOpenSubscriber<>(main);
 		if (main.subscribers.add(bos)) {
 			source.subscribe(main);
 			start.subscribe(bos);
@@ -269,8 +268,8 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 							Throwable ex = Exceptions.terminate(ERRORS, this);
 							a.onError(ex);
 							return;
-						} else
-						if (q.isEmpty()) {
+						}
+						else if (q.isEmpty()) {
 							a.onComplete();
 							return;
 						}
@@ -291,7 +290,8 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 			try {
 				buf = Objects.requireNonNull(bufferSupplier.get(), "The bufferSupplier returned a null Collection");
 				p = Objects.requireNonNull(bufferClose.apply(token), "The bufferClose returned a null Publisher");
-			} catch (Throwable ex) {
+			}
+			catch (Throwable ex) {
 				Exceptions.throwIfFatal(ex);
 				Operators.terminate(S, this);
 				if (Exceptions.addThrowable(ERRORS, this, ex)) {
@@ -301,7 +301,8 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 					}
 					done = true;
 					drain();
-				} else {
+				}
+				else {
 					Operators.onErrorDropped(ex, actual.currentContext());
 				}
 				return;
@@ -361,7 +362,8 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 				}
 				done = true;
 				drain();
-			} else {
+			}
+			else {
 				Operators.onErrorDropped(ex, actual.currentContext());
 			}
 		}
@@ -435,9 +437,7 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 		@Override
 		@Nullable
 		public Object scanUnsafe(Attr key) {
-			if (key == Attr.ACTUAL) {
-				return parent;
-			}
+			if (key == Attr.ACTUAL) return parent;
 			if (key == Attr.PARENT) return subscription;
 			if (key == Attr.REQUESTED_FROM_DOWNSTREAM) return Long.MAX_VALUE;
 			if (key == Attr.CANCELLED) return isDisposed();
@@ -511,9 +511,7 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 		@Override
 		@Nullable
 		public Object scanUnsafe(Attr key) {
-			if (key == Attr.ACTUAL) {
-				return parent;
-			}
+			if (key == Attr.ACTUAL) return parent;
 			if (key == Attr.PARENT) return subscription;
 			if (key == Attr.REQUESTED_FROM_DOWNSTREAM) return Long.MAX_VALUE;
 			if (key == Attr.CANCELLED) return isDisposed();


### PR DESCRIPTION
This commit improves FluxBufferWhen implementation once again, by:

 - keeping the tracking of buffer in the main subscriber (no reference
 to buffers in close subscribers, to prevent retaining)
 - tracking request in main
 - correctly cancelling the source when the open subscriber completes
 (which means that at this point no new buffer will open) IFF last close
 subscriber has also completed
 - correctly cancel upstream and clear buffers when open/close
 subscribers error.
 - overall simplifies the inner subscribers