### PR TITLE
Making erroneously public classes from last release package private

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -274,7 +274,7 @@ project('reactor-core') {
 	//TODO after a release, bump the gradle.properties baseline
 	//TODO after a release, remove the reactor-core exclusions below if any
 	//gh-1036
-	classExcludes = ['reactor.core.publisher.FluxIndex', 'reactor.core.publisher.FluxIndexFuseable', 'reactor.core.publisher.FluxDelaySequence']
+	classExcludes = ['reactor.core.publisher.FluxIndex', 'reactor.core.publisher.FluxIndexFuseable', 'reactor.core.publisher.FluxDelaySequence', 'reactor.util.concurrent.MpscLinkedQueue']
   }
 
   javadoc {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ plugins {
   id 'org.asciidoctor.convert' version '1.5.6'
   id "me.champeau.gradle.jmh" version "0.4.4" apply false
   id "org.jetbrains.dokka" version "0.9.15"
-  id "me.champeau.gradle.japicmp" version "0.2.5"
+  id "me.champeau.gradle.japicmp" version "0.2.6"
 }
 
 apply from: "gradle/doc.gradle"
@@ -270,6 +270,9 @@ project('reactor-core') {
 	txtOutputFile = file("${project.buildDir}/reports/japi.txt")
 	ignoreMissingClasses = true
 	includeSynthetic = true
+
+	//TODO after a release, bump the gradle.properties baseline
+	//TODO after a release, remove the reactor-core exclusions below if any
   }
 
   javadoc {
@@ -438,6 +441,8 @@ project('reactor-test') {
 	txtOutputFile = file("${project.buildDir}/reports/japi.txt")
 	ignoreMissingClasses = true
 	includeSynthetic = true
+
+	//TODO after a release, remove the reactor-test exclusions below if any
   }
 
   javadoc {

--- a/build.gradle
+++ b/build.gradle
@@ -273,6 +273,8 @@ project('reactor-core') {
 
 	//TODO after a release, bump the gradle.properties baseline
 	//TODO after a release, remove the reactor-core exclusions below if any
+	//gh-1036
+	classExcludes = ['reactor.core.publisher.FluxIndex', 'reactor.core.publisher.FluxIndexFuseable', 'reactor.core.publisher.FluxDelaySequence']
   }
 
   javadoc {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=3.1.4.BUILD-SNAPSHOT
-compatibleVersion=3.1.0.RELEASE
+compatibleVersion=3.1.3.RELEASE

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDelaySequence.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDelaySequence.java
@@ -28,12 +28,12 @@ import reactor.core.scheduler.Scheduler;
  * @author Simon Baslé
  */
 //adapted from RxJava2 FlowableDelay: https://github.com/ReactiveX/RxJava/blob/2.x/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelay.java
-public final class FluxDelaySequence<T> extends FluxOperator<T, T> {
+final class FluxDelaySequence<T> extends FluxOperator<T, T> {
 
 	final Duration  delay;
 	final Scheduler scheduler;
 
-	public FluxDelaySequence(Flux<T> source, Duration delay, Scheduler scheduler) {
+	FluxDelaySequence(Flux<T> source, Duration delay, Scheduler scheduler) {
 		super(source);
 		this.delay = delay;
 		this.scheduler = scheduler;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxIndex.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxIndex.java
@@ -34,7 +34,7 @@ import reactor.util.function.Tuple2;
  *
  * @author Simon Baslé
  */
-public class FluxIndex<T, I> extends FluxOperator<T, I> {
+final class FluxIndex<T, I> extends FluxOperator<T, I> {
 
 	private final BiFunction<? super Long, ? super T, ? extends I> indexMapper;
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxIndexFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxIndexFuseable.java
@@ -51,7 +51,7 @@ import reactor.util.function.Tuple2;
  *
  * @author Simon Baslé
  */
-public class FluxIndexFuseable<T, I> extends FluxOperator<T, I>
+final class FluxIndexFuseable<T, I> extends FluxOperator<T, I>
 		implements Fuseable {
 
 	private final BiFunction<? super Long, ? super T, ? extends I> indexMapper;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
@@ -33,7 +33,7 @@ import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.Exceptions;
 import reactor.util.annotation.Nullable;
-import reactor.util.concurrent.MpscLinkedQueue;
+import reactor.util.concurrent.Queues;
 
 /**
  * Splits the source sequence into potentially overlapping windowEnds controlled by items
@@ -110,7 +110,7 @@ final class FluxWindowWhen<T, U, V> extends FluxOperator<T, Flux<T>> {
 		WindowWhenMainSubscriber(CoreSubscriber<? super Flux<T>> actual,
 				Publisher<U> open, Function<? super U, ? extends Publisher<V>> close,
 				Supplier<? extends Queue<T>> processorQueueSupplier) {
-			super(actual, new MpscLinkedQueue<>());
+			super(actual, Queues.unboundedMultiproducer().get());
 			this.open = open;
 			this.close = close;
 			this.processorQueueSupplier = processorQueueSupplier;

--- a/reactor-core/src/main/java/reactor/util/concurrent/MpscLinkedQueue.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/MpscLinkedQueue.java
@@ -32,7 +32,7 @@ import reactor.util.annotation.Nullable;
  * A multi-producer single consumer unbounded queue.
  * @param <E> the contained value type
  */
-public class MpscLinkedQueue<E> extends AbstractQueue<E> implements BiPredicate<E, E> {
+final class MpscLinkedQueue<E> extends AbstractQueue<E> implements BiPredicate<E, E> {
 	private volatile LinkedQueueNode<E> producerNode;
 
 	private final static AtomicReferenceFieldUpdater<MpscLinkedQueue, LinkedQueueNode> PRODUCER_NODE_UPDATER

--- a/reactor-core/src/main/java/reactor/util/concurrent/Queues.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/Queues.java
@@ -188,6 +188,17 @@ public final class Queues {
 		return XS_SUPPLIER;
 	}
 
+	/**
+	 * Returns an unbounded queue suitable for multi-producer/single-consumer (MPSC)
+	 * scenarios.
+	 *
+	 * @param <T> the reified {@link Queue} generic type
+	 * @return an unbounded MPSC {@link Queue} {@link Supplier}
+	 */
+	public static <T> Supplier<Queue<T>> unboundedMultiproducer() {
+		return MpscLinkedQueue::new;
+	}
+
 	private Queues() {
 		//prevent construction
 	}

--- a/reactor-core/src/test/java/reactor/util/concurrent/MpscLinkedQueueTest.java
+++ b/reactor-core/src/test/java/reactor/util/concurrent/MpscLinkedQueueTest.java
@@ -4,9 +4,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MpscLinkedQueueTest {
+
+	@Test
+	public void mpscQueuesAPI() {
+		assertThat(Queues.unboundedMultiproducer().get()).isInstanceOf(MpscLinkedQueue.class);
+	}
 
 	@Test(expected = NullPointerException.class)
 	public void shouldRejectNullableValues() {
@@ -25,9 +30,9 @@ public class MpscLinkedQueueTest {
 		MpscLinkedQueue<Object> q = new MpscLinkedQueue<Object>();
 		q.test(1, 2);
 
-		assertEquals(1, q.poll());
-		assertEquals(2, q.poll());
-		assertNull(q.poll());
+		assertThat(q.poll()).isEqualTo(1);
+		assertThat(q.poll()).isEqualTo(2);
+		assertThat(q.poll()).isNull();
 	}
 
 	@Test(expected = UnsupportedOperationException.class)
@@ -50,13 +55,13 @@ public class MpscLinkedQueueTest {
 		MpscLinkedQueue<Object> q = new MpscLinkedQueue<>();
 		q.test(1, 2);
 
-		assertFalse(q.isEmpty());
-		assertEquals(2, q.size());
+		assertThat(q.isEmpty()).as("isEmpty() false").isFalse();
+		assertThat(q).hasSize(2);
 
 		q.clear();
 
-		assertTrue(q.isEmpty());
-		assertEquals(0, q.size());
+		assertThat(q.isEmpty()).as("isEmpty() true").isTrue();
+		assertThat(q).hasSize(0);
 	}
 
 	@Test
@@ -65,8 +70,8 @@ public class MpscLinkedQueueTest {
 		q.test(1, 2);
 
 		for (int i = 0; i < 100; i++) {
-			assertEquals(1, q.peek());
-			assertEquals(2, q.size());
+			assertThat(q.peek()).isEqualTo(1);
+			assertThat(q).hasSize(2);
 		}
 	}
 


### PR DESCRIPTION
@smaldini pulled the breaking change hammer on this one, which shouldn't be a huge problem for the operators (not likely that someone has directly used or extended them).
The MPSC queue is a bit more touchy IMHO, but breaking binary compatibility now could arguably be acceptable instead of deprecating and removing in the next release.

Bumped the japicmp plugin so that we can set exclusions TEMPORARILY until the next release.