### PR TITLE
fix #963 Add Flux#mergeOrdered, mergeOrderedWith and ParallelFlux#ordered

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -1234,23 +1234,59 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
+	 * Merge data from provided {@link Publisher} sequences into an ordered merged sequence,
+	 * by picking the smallest values from each source (as defined by their natural order).
+	 * This is not a {@link #sort()}, as it doesn't consider the whole of each sequences.
+	 * <p>
+	 * Instead, this operator considers only one value from each source and picks the
+	 * smallest of all these values, then replenishes the slot for that picked source.
 	 *
-	 * @param sources
-	 * @param <I>
-	 * @return
+	 * @param sources {@link Publisher} sources of {@link Comparable} to merge
+	 * @param <I> a {@link Comparable} merged type that has a {@link Comparator#naturalOrder() natural order}
+	 * @return a merged {@link Flux} that , subscribing early but keeping the original ordering
 	 */
 	@SafeVarargs
 	public static <I extends Comparable<? super I>> Flux<I> mergeOrdered(Publisher<? extends I>... sources) {
 		return mergeOrdered(Queues.SMALL_BUFFER_SIZE, Comparator.naturalOrder(), sources);
 	}
 
+	/**
+	 * Merge data from provided {@link Publisher} sequences into an ordered merged sequence,
+	 * by picking the smallest values from each source (as defined by the provided
+	 * {@link Comparator}). This is not a {@link #sort(Comparator)}, as it doesn't consider
+	 * the whole of each sequences.
+	 * <p>
+	 * Instead, this operator considers only one value from each source and picks the
+	 * smallest of all these values, then replenishes the slot for that picked source.
+	 *
+	 * @param comparator the {@link Comparator} to use to find the smallest value
+	 * @param sources {@link Publisher} sources to merge
+	 * @param <T> the merged type
+	 * @return a merged {@link Flux} that , subscribing early but keeping the original ordering
+	 */
 	@SafeVarargs
-	public static <I> Flux<I> mergeOrdered(Comparator<? super I> comparator, Publisher<? extends I>... sources) {
+	public static <T> Flux<T> mergeOrdered(Comparator<? super T> comparator, Publisher<? extends T>... sources) {
 		return mergeOrdered(Queues.SMALL_BUFFER_SIZE, comparator, sources);
 	}
 
+	/**
+	 * Merge data from provided {@link Publisher} sequences into an ordered merged sequence,
+	 * by picking the smallest values from each source (as defined by the provided
+	 * {@link Comparator}). This is not a {@link #sort(Comparator)}, as it doesn't consider
+	 * the whole of each sequences.
+	 * <p>
+	 * Instead, this operator considers only one value from each source and picks the
+	 * smallest of all these values, then replenishes the slot for that picked source.
+	 *
+	 * @param prefetch the number of elements to prefetch from each source (avoiding too
+	 * many small requests to the source when picking)
+	 * @param comparator the {@link Comparator} to use to find the smallest value
+	 * @param sources {@link Publisher} sources to merge
+	 * @param <T> the merged type
+	 * @return a merged {@link Flux} that , subscribing early but keeping the original ordering
+	 */
 	@SafeVarargs
-	public static <I> Flux<I> mergeOrdered(int prefetch, Comparator<? super I> comparator, Publisher<? extends I>... sources) {
+	public static <T> Flux<T> mergeOrdered(int prefetch, Comparator<? super T> comparator, Publisher<? extends T>... sources) {
 		if (sources.length == 0) {
 			return empty();
 		}
@@ -4958,6 +4994,35 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public final Flux<Signal<T>> materialize() {
 		return onAssembly(new FluxMaterialize<>(this));
+	}
+
+	/**
+	 * Merge data from this {@link Flux} and a {@link Publisher} into a reordered merge
+	 * sequence, by picking the smallest value from each sequence as defined by a provided
+	 * {@link Comparator}. Note that subsequent calls are combined, and their comparators are
+	 * in lexicographic order as defined by {@link Comparator#thenComparing(Comparator)}.
+	 * <p>
+	 * The combination step is avoided if the two {@link Comparator Comparators} are
+	 * {@link Comparator#equals(Object) equal} (which can easily be achieved by using the
+	 * same reference, and is also always true of {@link Comparator#naturalOrder()}).
+	 * <p>
+	 * Note that merge is tailored to work with asynchronous sources or finite sources. When dealing with
+	 * an infinite source that doesn't already publish on a dedicated Scheduler, you must isolate that source
+	 * in its own Scheduler, as merge would otherwise attempt to drain it before subscribing to
+	 * another source.
+	 *
+	 * @param other the {@link Publisher} to merge with
+	 * @param otherComparator the {@link Comparator} to use for merging
+	 *
+	 * @return a new {@link Flux}
+	 */
+	public final Flux<T> mergeOrderedWith(Publisher<? extends T> other,
+			Comparator<? super T> otherComparator) {
+		if (this instanceof FluxMergeOrdered) {
+			FluxMergeOrdered<T> fluxMerge = (FluxMergeOrdered<T>) this;
+			return fluxMerge.mergeAdditionalSource(other, otherComparator);
+		}
+		return mergeOrdered(otherComparator, this, other);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -1234,6 +1234,33 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
+	 *
+	 * @param sources
+	 * @param <I>
+	 * @return
+	 */
+	@SafeVarargs
+	public static <I extends Comparable<? super I>> Flux<I> mergeOrdered(Publisher<? extends I>... sources) {
+		return mergeOrdered(Queues.SMALL_BUFFER_SIZE, Comparator.naturalOrder(), sources);
+	}
+
+	@SafeVarargs
+	public static <I> Flux<I> mergeOrdered(Comparator<? super I> comparator, Publisher<? extends I>... sources) {
+		return mergeOrdered(Queues.SMALL_BUFFER_SIZE, comparator, sources);
+	}
+
+	@SafeVarargs
+	public static <I> Flux<I> mergeOrdered(int prefetch, Comparator<? super I> comparator, Publisher<? extends I>... sources) {
+		if (sources.length == 0) {
+			return empty();
+		}
+		if (sources.length == 1) {
+			return from(sources[0]);
+		}
+		return onAssembly(new FluxMergeOrdered<>(prefetch, Queues.get(prefetch), comparator, sources));
+	}
+
+	/**
 	 * Merge data from {@link Publisher} sequences emitted by the passed {@link Publisher}
 	 * into an ordered merged sequence. Unlike concat, the inner publishers are subscribed to
 	 * eagerly. Unlike merge, their emitted values are merged into the final sequence in

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMergeOrdered.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMergeOrdered.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Supplier;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
+import reactor.core.Scannable;
+import reactor.util.annotation.Nullable;
+import reactor.util.concurrent.Queues;
+
+/**
+ * Merges the provided sources {@link org.reactivestreams.Publisher}, assuming a total order
+ * of the values, by picking the smallest available value from each publisher, resulting in
+ * a single totally ordered {@link Flux} sequence. This operator considers its primary
+ * parent to be the first of the sources, for the purpose of {@link reactor.core.Scannable.Attr#PARENT}.
+ *
+ * @param <T> the value type
+ * @author David Karnok
+ * @author Simon Baslé
+ */
+//source: http://akarnokd.blogspot.fr/2017/09/java-9-flow-api-ordered-merge.html
+final class FluxMergeOrdered<T> extends Flux<T> implements Scannable {
+
+	final int                      prefetch;
+	final Supplier<Queue<T>>       queueSupplier;
+	final Comparator<? super T>    valueComparator;
+	final Publisher<? extends T>[] sources;
+
+	@SafeVarargs
+	FluxMergeOrdered(int prefetch,
+			Supplier<Queue<T>> queueSupplier,
+			Comparator<? super T> valueComparator,
+			Publisher<? extends T>... sources) {
+		if (prefetch <= 0) {
+			throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
+		}
+		this.sources = Objects.requireNonNull(sources, "sources must be non-null");
+		this.prefetch = prefetch;
+		this.queueSupplier = queueSupplier;
+		this.valueComparator = valueComparator;
+	}
+
+	/**
+	 * Returns a new instance which has the additional source to be merged together with
+	 * the current array of sources.
+	 * <p>
+	 * This operation doesn't change the current {@link FluxMergeOrdered} instance.
+	 *
+	 * @param source the new source to merge with the others
+	 * @return the new {@link FluxMergeOrdered} instance
+	 */
+	FluxMergeOrdered<T> mergeAdditionalSource(Publisher<? extends T> source) {
+		int n = sources.length;
+		@SuppressWarnings("unchecked")
+		Publisher<? extends T>[] newArray = new Publisher[n + 1];
+		System.arraycopy(sources, 0, newArray, 0, n);
+		newArray[n] = source;
+		return new FluxMergeOrdered<>(prefetch, queueSupplier, valueComparator, newArray);
+	}
+
+	@Override
+	public int getPrefetch() {
+		return prefetch;
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PARENT) return sources.length > 0 ? sources[0] : null;
+		if (key == Attr.PREFETCH) return prefetch;
+		if (key == Attr.DELAY_ERROR) return true;
+
+		return null;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super T> actual) {
+		MergeOrderedMainProducer<T> main = new MergeOrderedMainProducer<>(actual, valueComparator, prefetch, sources.length);
+		actual.onSubscribe(main);
+		main.subscribe(sources);
+	}
+
+
+	static final class MergeOrderedMainProducer<T> implements InnerProducer<T> {
+
+		static final Object DONE = new Object();
+
+		final CoreSubscriber<? super T> actual;
+		final MergeOrderedInnerSubscriber<T>[] subscribers;
+		final Comparator<? super T> comparator;
+		final Object[] values;
+
+		volatile Throwable error;
+		static final AtomicReferenceFieldUpdater<MergeOrderedMainProducer, Throwable> ERROR =
+				AtomicReferenceFieldUpdater.newUpdater(MergeOrderedMainProducer.class, Throwable.class, "error");
+
+		volatile int cancelled;
+		static final AtomicIntegerFieldUpdater<MergeOrderedMainProducer> CANCELLED =
+				AtomicIntegerFieldUpdater.newUpdater(MergeOrderedMainProducer.class, "cancelled");
+
+		volatile long requested;
+		static final AtomicLongFieldUpdater<MergeOrderedMainProducer> REQUESTED =
+				AtomicLongFieldUpdater.newUpdater(MergeOrderedMainProducer.class, "requested");
+
+		volatile long emitted;
+		static final AtomicLongFieldUpdater<MergeOrderedMainProducer> EMITTED =
+				AtomicLongFieldUpdater.newUpdater(MergeOrderedMainProducer.class, "emitted");
+
+		volatile int wip;
+		static final AtomicIntegerFieldUpdater<MergeOrderedMainProducer> WIP =
+				AtomicIntegerFieldUpdater.newUpdater(MergeOrderedMainProducer.class, "wip");
+
+		MergeOrderedMainProducer(CoreSubscriber<? super T> actual,
+				Comparator<? super T> comparator, int prefetch, int n) {
+			this.actual = actual;
+			this.comparator = comparator;
+			//noinspection unchecked
+			this.subscribers = new MergeOrderedInnerSubscriber[n];
+			for (int i = 0; i < n; i++) {
+				this.subscribers[i] = new MergeOrderedInnerSubscriber<>(this, prefetch);
+			}
+			this.values = new Object[n];
+		}
+
+		void subscribe(Publisher<? extends T>[] sources) {
+			if (sources.length != subscribers.length) {
+				throw new IllegalArgumentException("must subscribe with " + subscribers.length + " sources");
+			}
+			for (int i = 0; i < sources.length; i++) {
+				Objects.requireNonNull(sources[i], "subscribed with a null source: sources[" + i + "]")
+				       .subscribe(subscribers[i]);
+			}
+		}
+
+		@Override
+		public CoreSubscriber<? super T> actual() {
+			return this.actual;
+		}
+
+		@Override
+		public void request(long n) {
+			Operators.addCap(REQUESTED, this, n);
+			drain();
+		}
+
+		@Override
+		public void cancel() {
+			if (CANCELLED.compareAndSet(this, 0, 1)) {
+				for (MergeOrderedInnerSubscriber<T> subscriber : subscribers) {
+					subscriber.cancel();
+				}
+
+				if (WIP.getAndIncrement(this) == 0) {
+					Arrays.fill(values, null);
+					for (MergeOrderedInnerSubscriber<T> subscriber : subscribers) {
+						subscriber.queue.clear();
+					}
+				}
+			}
+		}
+
+		void onInnerError(MergeOrderedInnerSubscriber<T> inner, Throwable ex) {
+			Exceptions.addThrowable(ERROR, this, ex);
+			inner.done = true;
+			drain();
+		}
+
+		void drain() {
+			if (WIP.getAndIncrement(this) != 0) {
+				return;
+			}
+
+			int missed = 1;
+			CoreSubscriber<? super T> actual = this.actual;
+			Comparator<? super T> comparator = this.comparator;
+
+			MergeOrderedInnerSubscriber<T>[] subscribers = this.subscribers;
+			int n = subscribers.length;
+
+			Object[] values = this.values;
+
+			long e = emitted;
+
+			for (;;) {
+				long r = requested;
+
+				for (;;) {
+					if (cancelled != 0) {
+						Arrays.fill(values, null);
+
+						for (MergeOrderedInnerSubscriber<T> inner : subscribers) {
+							inner.queue.clear();
+						}
+						return;
+					}
+
+					int done = 0;
+					int nonEmpty = 0;
+					for (int i = 0; i < n; i++) {
+						Object o = values[i];
+						if (o == DONE) {
+							done++;
+							nonEmpty++;
+						}
+						else if (o == null) {
+							boolean innerDone = subscribers[i].done;
+							o = subscribers[i].queue.poll();
+							if (o != null) {
+								values[i] = o;
+								nonEmpty++;
+							}
+							else if (innerDone) {
+								values[i] = DONE;
+								done++;
+								nonEmpty++;
+							}
+						}
+						else {
+							nonEmpty++;
+						}
+					}
+
+					if (done == n) {
+						Throwable ex = error;
+						if (ex == null) {
+							actual.onComplete();
+						} else {
+							actual.onError(ex);
+						}
+						return;
+					}
+
+					if (nonEmpty != n || e >= r) {
+						break;
+					}
+
+					T min = null;
+					int minIndex = -1;
+
+					int i = 0;
+					for (Object o : values) {
+						if (o != DONE) {
+							boolean smaller;
+							try {
+								//noinspection unchecked
+								smaller = min == null || comparator.compare(min, (T) o) > 0;
+							} catch (Throwable ex) {
+								Exceptions.addThrowable(ERROR, this, ex);
+								cancel();
+								actual.onError(Exceptions.terminate(ERROR, this));
+								return;
+							}
+							if (smaller) {
+								//noinspection unchecked
+								min = (T) o;
+								minIndex = i;
+							}
+						}
+						i++;
+					}
+
+					values[minIndex] = null;
+
+					actual.onNext(min);
+
+					e++;
+					subscribers[minIndex].request(1);
+				}
+
+				this.emitted = e;
+				missed = WIP.addAndGet(this, -missed);
+				if (missed == 0) {
+					break;
+				}
+			}
+		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.ACTUAL) return actual;
+			if (key == Attr.CANCELLED) return this.cancelled > 0;
+			if (key == Attr.ERROR) return this.error;
+			if (key == Attr.DELAY_ERROR) return true;
+			if (key == Attr.REQUESTED_FROM_DOWNSTREAM) return requested - emitted;
+
+			return null;
+		}
+	}
+
+	static final class MergeOrderedInnerSubscriber<T> implements InnerOperator<T, T> {
+
+		final MergeOrderedMainProducer<T> parent;
+		final int prefetch;
+		final int limit;
+		final Queue<T> queue;
+
+		int consumed;
+
+		volatile boolean done;
+
+		volatile Subscription s;
+		AtomicReferenceFieldUpdater<MergeOrderedInnerSubscriber, Subscription> S =
+				AtomicReferenceFieldUpdater.newUpdater(MergeOrderedInnerSubscriber.class, Subscription.class, "s");
+
+		MergeOrderedInnerSubscriber(MergeOrderedMainProducer<T> parent,
+				int prefetch) {
+			this.parent = parent;
+			this.prefetch = prefetch;
+			this.limit = prefetch - (prefetch >> 2);
+			this.queue = Queues.<T>small().get();
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.setOnce(S, this, s)) {
+				s.request(prefetch);
+			}
+		}
+
+		@Override
+		public void onNext(T item) {
+			queue.offer(item);
+			parent.drain();
+		}
+
+		@Override
+		public void onError(Throwable throwable) {
+			parent.onInnerError(this, throwable);
+		}
+
+		@Override
+		public void onComplete() {
+			done = true;
+			parent.drain();
+		}
+
+		/**
+		 * @param n is ignored and considered to be 1
+		 */
+		@Override
+		public void request(long n) {
+			int c = consumed + 1;
+			if (c == limit) {
+				consumed = 0;
+				Subscription sub = s;
+				if (sub != this) {
+					sub.request(c);
+				}
+			}
+			else {
+				consumed = c;
+			}
+		}
+
+		@Override
+		public void cancel() {
+			Subscription sub  = S.getAndSet(this, this);
+			if (sub != null && sub != this) {
+				sub.cancel();
+			}
+		}
+
+		@Override
+		public CoreSubscriber<? super T> actual() {
+			return parent.actual; //TODO check
+		}
+
+		@Override
+		@Nullable
+		public Object scanUnsafe(Attr key){
+			if (key == Attr.ACTUAL) return parent; //TODO does that check out?
+			if (key == Attr.PARENT) return s;
+			if (key == Attr.PREFETCH) return prefetch;
+			if (key == Attr.TERMINATED) return done;
+			if (key == Attr.BUFFERED) return queue.size();
+
+			return null;
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMergeOrdered.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMergeOrdered.java
@@ -67,19 +67,28 @@ final class FluxMergeOrdered<T> extends Flux<T> implements Scannable {
 
 	/**
 	 * Returns a new instance which has the additional source to be merged together with
-	 * the current array of sources.
+	 * the current array of sources. The provided {@link Comparator} is tested for equality
+	 * with the current comparator, and if different is combined by {@link Comparator#thenComparing(Comparator)}.
 	 * <p>
 	 * This operation doesn't change the current {@link FluxMergeOrdered} instance.
 	 *
 	 * @param source the new source to merge with the others
 	 * @return the new {@link FluxMergeOrdered} instance
 	 */
-	FluxMergeOrdered<T> mergeAdditionalSource(Publisher<? extends T> source) {
+	FluxMergeOrdered<T> mergeAdditionalSource(Publisher<? extends T> source,
+			Comparator<? super T> otherComparator) {
 		int n = sources.length;
 		@SuppressWarnings("unchecked")
 		Publisher<? extends T>[] newArray = new Publisher[n + 1];
 		System.arraycopy(sources, 0, newArray, 0, n);
 		newArray[n] = source;
+
+		if (!valueComparator.equals(otherComparator)) {
+			@SuppressWarnings("unchecked")
+			Comparator<T> currentComparator = (Comparator<T>) this.valueComparator;
+			final Comparator<T> newComparator = currentComparator.thenComparing(otherComparator);
+			return new FluxMergeOrdered<>(prefetch, queueSupplier, newComparator, newArray);
+		}
 		return new FluxMergeOrdered<>(prefetch, queueSupplier, valueComparator, newArray);
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -734,6 +734,37 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	}
 
 	/**
+	 * Merges the values from each 'rail', but choose which one to merge by way of a
+	 * provided {@link Comparator}, picking the smallest of all rails. The result is
+	 * exposed back as a {@link Flux}.
+	 * <p>
+	 * This version uses a default prefetch of {@link Queues#SMALL_BUFFER_SIZE}.
+	 *
+	 * @param comparator the comparator to choose the smallest value available from all rails
+	 * @return the new Flux instance
+	 *
+	 * @see ParallelFlux#ordered(Comparator, int)
+	 */
+	public final Flux<T> ordered(Comparator<? super T> comparator) {
+		return ordered(comparator, Queues.SMALL_BUFFER_SIZE);
+	}
+
+	/**
+	 * Merges the values from each 'rail', but choose which one to merge by way of a
+	 * provided {@link Comparator}, picking the smallest of all rails. The result is
+	 * exposed back as a {@link Flux}.
+	 *
+	 * @param comparator the comparator to choose the smallest value available from all rails
+	 * @param prefetch the prefetch to use
+	 * @return the new Flux instance
+	 *
+	 * @see ParallelFlux#ordered(Comparator)
+	 */
+	public final Flux<T> ordered(Comparator<? super T> comparator, int prefetch) {
+		return new ParallelMergeOrdered<>(this, prefetch, Queues.get(prefetch), comparator);
+	}
+
+	/**
 	 * Returns the number of expected parallel Subscribers.
 	 *
 	 * @return the number of expected parallel Subscribers

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeOrdered.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeOrdered.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Comparator;
+import java.util.Queue;
+import java.util.function.Supplier;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Scannable;
+import reactor.util.annotation.Nullable;
+
+/**
+ * Merges the individual 'rails' of the source {@link ParallelFlux} assuming a total order
+ * of the values, by picking the smallest available value from each rail, resulting in
+ * a single regular Publisher sequence (exposed as a {@link Flux}).
+ *
+ * @param <T> the value type
+ * @author Simon Baslé
+ */
+final class ParallelMergeOrdered<T> extends Flux<T> implements Scannable {
+
+	final ParallelFlux<? extends T> source;
+	final int                       prefetch;
+	final Supplier<Queue<T>>        queueSupplier;
+	final Comparator<? super T>     valueComparator;
+
+	ParallelMergeOrdered(ParallelFlux<? extends T> source, int prefetch,
+			Supplier<Queue<T>> queueSupplier, Comparator<? super T> valueComparator) {
+		if (prefetch <= 0) {
+			throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
+		}
+		this.source = source;
+		this.prefetch = prefetch;
+		this.queueSupplier = queueSupplier;
+		this.valueComparator = valueComparator;
+	}
+
+	@Override
+	public int getPrefetch() {
+		return prefetch;
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PARENT) return source;
+		if (key == Attr.PREFETCH) return prefetch;
+
+		return null;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super T> actual) {
+		FluxMergeOrdered.MergeOrderedMainProducer<T>
+				main = new FluxMergeOrdered.MergeOrderedMainProducer<>(actual, valueComparator, prefetch, source.parallelism());
+		actual.onSubscribe(main);
+		source.subscribe(main.subscribers);
+	}
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelMergeOrderedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelMergeOrderedTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import org.junit.Test;
+import reactor.core.Scannable;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.function.Tuple2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+public class ParallelMergeOrderedTest {
+
+	@Test
+	public void reorderingByIndex() {
+		final int LOOPS = 100;
+		final int PARALLELISM = 2;
+		final List<Integer> ordered = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+		int notShuffled = 0;
+		for (int i = 0; i < LOOPS; i++) {
+			final Scheduler SCHEDULER = Schedulers.newParallel("test", PARALLELISM);
+			final List<Integer> disordered = Collections.synchronizedList(new ArrayList<>());
+
+			List<Integer> reordered = Flux.fromIterable(ordered)
+			                         .hide()
+			                         .index()
+			                         .parallel(PARALLELISM)
+			                         .runOn(SCHEDULER)
+			                         .doOnNext(t2 -> disordered.add(t2.getT2()))
+			                         .ordered(Comparator.comparing(Tuple2::getT1))
+			                         .map(Tuple2::getT2)
+			                         .collectList()
+			                         .block();
+
+			SCHEDULER.dispose();
+
+			assertThat(reordered).containsExactlyElementsOf(ordered);
+			assertThat(disordered).containsExactlyInAnyOrderElementsOf(ordered);
+
+			try {
+				assertThat(disordered).doesNotContainSequence(ordered);
+				System.out.println("parallel shuffled the collection into " + disordered);
+				break;
+			}
+			catch (AssertionError e) {
+				notShuffled++;
+			}
+		}
+		if (notShuffled > 0) {
+			System.out.println("not shuffled loops: " + notShuffled);
+		}
+
+		assertThat(LOOPS - notShuffled)
+				.as("at least one run shuffled")
+				.isGreaterThan(0);
+	}
+
+	@Test
+	public void rejectPrefetchZero() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new ParallelMergeOrdered<>(null, 0, null, null))
+				.withMessage("prefetch > 0 required but it was 0");
+	}
+
+	@Test
+	public void rejectPrefetchNegative() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new ParallelMergeOrdered<>(null,-1, null, null))
+				.withMessage("prefetch > 0 required but it was -1");
+	}
+
+	@Test
+	public void getPrefetch() {
+		ParallelMergeOrdered<Integer> test = new ParallelMergeOrdered<>(null, 123, null, null);
+
+		assertThat(test.getPrefetch()).isEqualTo(123);
+	}
+
+	@Test
+	public void getPrefetchAPI() {
+		Flux<Integer> test = Flux.range(1, 10)
+		                         .parallel()
+		                         .ordered(Comparator.naturalOrder(), 123);
+
+		assertThat(test.getPrefetch()).isEqualTo(123);
+	}
+
+	@Test
+	public void scanUnsafe() {
+		ParallelFlux<Integer> source = Flux.range(1, 10)
+		                                   .parallel(2);
+		ParallelMergeOrdered<Integer> test = new ParallelMergeOrdered<>(source, 123, null, null);
+
+		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);
+		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(123);
+
+		assertThat(test.scan(Scannable.Attr.NAME)).isNull();
+	}
+}


### PR DESCRIPTION
source: http://akarnokd.blogspot.fr/2017/09/java-9-flow-api-ordered-merge.html (thanks @akarnokd)