### PR TITLE
Fix some tests missing verify() call

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
@@ -473,7 +473,7 @@ public class FluxBufferWhenTest {
 						source.complete();
 		            })
 		            .expectNextMatches(List::isEmpty)
-		            .expectComplete();
+		            .verifyComplete();
 
 		open.assertNoSubscribers();
 		close.assertNoSubscribers();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
@@ -462,10 +462,10 @@ public class FluxBufferWhenTest {
 				.flux()
 				.bufferWhen(open, o -> close))
 		            .then(() -> {
-		            	source.assertSubscribers();
-		            	open.assertSubscribers();
-		            	close.assertSubscribers();
-		            	open.next(1);
+			            source.assertSubscribers();
+			            open.assertSubscribers();
+			            close.assertNoSubscribers();
+			            open.next(1);
 		            })
 		            .then(() -> {
 						open.assertSubscribers();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
@@ -153,7 +153,7 @@ public class FluxFilterWhenTest {
 	public void predicateThrows() {
 		StepVerifier.create(Flux.just(1)
 		                        .filterWhen(v -> { throw new IllegalStateException(); }))
-		            .expectError(IllegalStateException.class);
+		            .verifyError(IllegalStateException.class);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
@@ -156,7 +156,7 @@ public class MonoFilterWhenTest {
 	public void predicateThrows() {
 		StepVerifier.create(Mono.just(1)
 		                        .filterWhen(v -> { throw new IllegalStateException(); }))
-		            .expectError(IllegalStateException.class);
+		            .verifyError(IllegalStateException.class);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreEmptyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreEmptyTest.java
@@ -30,14 +30,14 @@ public class MonoIgnoreEmptyTest {
 	public void normal() {
 		StepVerifier.create(Flux.just(1)
 		                        .thenEmpty(Flux.empty()))
-		            .expectComplete();
+		            .verifyComplete();
 	}
 
 	@Test
 	public void normal3() {
 		StepVerifier.create(Flux.just(1)
 		                        .then())
-		            .expectComplete();
+		            .verifyComplete();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoThenIgnoreTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoThenIgnoreTest.java
@@ -33,7 +33,7 @@ public class MonoThenIgnoreTest {
 	public void normal() {
 		StepVerifier.create(Mono.just(1)
 		                        .thenEmpty(Flux.empty()))
-		            .expectComplete();
+		            .verifyComplete();
 	}
 
 	Publisher<Void> scenario(){
@@ -45,7 +45,7 @@ public class MonoThenIgnoreTest {
 	public void normal3() {
 		StepVerifier.create(Mono.just(1)
 		                        .then())
-		            .expectComplete();
+		            .verifyComplete();
 	}
 
 	@Test
@@ -54,14 +54,14 @@ public class MonoThenIgnoreTest {
 		                        .then(Mono.just(1))
 		                        .then(Mono.just(2)))
 		            .expectNext(2)
-		            .expectComplete();
+		            .verifyComplete();
 	}
 
 	@Test
 	public void normalTime() {
 		StepVerifier.withVirtualTime(this::scenario)
 		            .thenAwait(Duration.ofSeconds(123))
-		            .expectComplete();
+		            .verifyComplete();
 	}
 
 	@Test


### PR DESCRIPTION
A bunch of tests were using `expectComplete` and `expectError*` without a `verify()` call.
One test would fail after the fix, but because the as-of-yet-unexecuted assertion was in fact wrong.

Note that looking for `expect.*;` regexp would yield a few false positives: some tests will affect the resulting `StepVerifier` instance to a variable before calling `verify()` a few rows below 👍 