### PR TITLE
fix #914 Replace Queue+ synchronized with MPSC Queue

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -4746,8 +4746,7 @@ public abstract class Flux<T> implements Publisher<T> {
 			BiFunction<? super T, ? super TRight, ? extends R> resultSelector
 	) {
 		return onAssembly(new FluxJoin<T, TRight, TLeftEnd, TRightEnd, R>(
-				this, other, leftEnd, rightEnd, resultSelector, Queues
-				.unbounded(Queues.XS_BUFFER_SIZE)));
+				this, other, leftEnd, rightEnd, resultSelector));
 	}
 
 	/**
@@ -7586,9 +7585,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 */
 	public final Flux<Flux<T>> window(Publisher<?> boundary) {
 		return onAssembly(new FluxWindowBoundary<>(this,
-				boundary,
-				Queues.unbounded(Queues.XS_BUFFER_SIZE),
-				Queues.unbounded(Queues.XS_BUFFER_SIZE)));
+				boundary, Queues.unbounded(Queues.XS_BUFFER_SIZE)));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
@@ -107,8 +107,7 @@ final class FluxWindowTimeout<T> extends FluxOperator<T, Flux<T>> {
 				long timespan,
 				Scheduler scheduler) {
 			this.actual = actual;
-			this.queue = Queues.unbounded()
-			                   .get();
+			this.queue = Queues.unboundedMultiproducer().get();
 			this.timespan = timespan;
 			this.scheduler = scheduler;
 			this.maxSize = maxSize;
@@ -239,9 +238,7 @@ final class FluxWindowTimeout<T> extends FluxOperator<T, Flux<T>> {
 				}
 			}
 			else {
-				synchronized (queue) {
-					queue.offer(t);
-				}
+				queue.offer(t);
 				if (!enter()) {
 					return;
 				}
@@ -424,9 +421,7 @@ final class FluxWindowTimeout<T> extends FluxOperator<T, Flux<T>> {
 				WindowTimeoutSubscriber<?> p = parent;
 
 				if (!p.cancelled) {
-					synchronized (p.queue) {
-						p.queue.offer(this);
-					}
+					p.queue.offer(this);
 				}
 				else {
 					p.terminated = true;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCreateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCreateTest.java
@@ -1193,7 +1193,7 @@ public class FluxCreateTest {
 		FluxCreate.BaseSink<String> decorated = new FluxCreate.LatestAsyncSink<>(actual);
 		SerializedSink<String> test = new SerializedSink<>(decorated);
 
-		test.queue.offer("foo");
+		test.mpscQueue.offer("foo");
 		assertThat(test.scan(Scannable.Attr.BUFFERED)).isEqualTo(1);
 		assertThat(decorated.scan(Scannable.Attr.BUFFERED)).isEqualTo(0);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxGroupJoinTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxGroupJoinTest.java
@@ -278,11 +278,10 @@ public class FluxGroupJoinTest {
 	public void scanGroupJoinSubscription() {
 		CoreSubscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, sub -> sub.request(100));
 		FluxGroupJoin.GroupJoinSubscription<String, String, String, String, String> test =
-				new FluxGroupJoin.GroupJoinSubscription<String, String, String, String, String>(actual,
+				new FluxGroupJoin.GroupJoinSubscription<>(actual,
 						s -> Mono.just(s),
 						s -> Mono.just(s),
 						(l, r) -> l,
-						Queues.unbounded().get(),
 						Queues.one());
 
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
@@ -309,11 +308,10 @@ public class FluxGroupJoinTest {
 		CoreSubscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null,
 				sub -> sub.request(100));
 		FluxGroupJoin.GroupJoinSubscription<String, String, String, String, String> parent =
-				new FluxGroupJoin.GroupJoinSubscription<String, String, String, String, String>(actual,
+				new FluxGroupJoin.GroupJoinSubscription<>(actual,
 						s -> Mono.just(s),
 						s -> Mono.just(s),
 						(l, r) -> l,
-						Queues.unbounded().get(),
 						Queues.one());
 		FluxGroupJoin.LeftRightSubscriber test = new FluxGroupJoin.LeftRightSubscriber(parent, true);
 		Subscription sub = Operators.emptySubscription();
@@ -331,11 +329,10 @@ public class FluxGroupJoinTest {
 		CoreSubscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null,
 				sub -> sub.request(100));
 		FluxGroupJoin.GroupJoinSubscription<String, String, String, String, String> parent =
-				new FluxGroupJoin.GroupJoinSubscription<String, String, String, String, String>(actual,
+				new FluxGroupJoin.GroupJoinSubscription<>(actual,
 						s -> Mono.just(s),
 						s -> Mono.just(s),
 						(l, r) -> l,
-						Queues.unbounded().get(),
 						Queues.one());
 		FluxGroupJoin.LeftRightEndSubscriber test = new FluxGroupJoin.LeftRightEndSubscriber(parent, false, 1);
 		Subscription sub = Operators.emptySubscription();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxJoinTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxJoinTest.java
@@ -258,11 +258,10 @@ public class FluxJoinTest {
 	public void scanSubscription() {
 		CoreSubscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, sub -> sub.request(100));
 		FluxJoin.JoinSubscription<String, String, String, String, String> test =
-				new FluxJoin.JoinSubscription<String, String, String, String, String>(actual,
+				new FluxJoin.JoinSubscription<>(actual,
 						s -> Mono.just(s),
 						s -> Mono.just(s),
-						(l, r) -> l,
-						Queues.unbounded().get());
+						(l, r) -> l);
 
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
 		test.request(123);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
@@ -251,7 +251,7 @@ public class FluxWindowBoundaryTest {
     public void scanMainSubscriber() {
         CoreSubscriber<Flux<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindowBoundary.WindowBoundaryMain<Integer, Integer> test = new FluxWindowBoundary.WindowBoundaryMain<>(actual,
-        		Queues.unbounded(), Queues.<Integer>unbounded().get(), Queues.unbounded().get());
+        		Queues.unbounded(), Queues.<Integer>unbounded().get());
         Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 
@@ -280,7 +280,7 @@ public class FluxWindowBoundaryTest {
     public void scanOtherSubscriber() {
         CoreSubscriber<Flux<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindowBoundary.WindowBoundaryMain<Integer, Integer> main = new FluxWindowBoundary.WindowBoundaryMain<>(actual,
-        		Queues.unbounded(), Queues.<Integer>unbounded().get(), Queues.unbounded().get());
+        		Queues.unbounded(), Queues.<Integer>unbounded().get());
         FluxWindowBoundary.WindowBoundaryOther<Integer> test =
         		new FluxWindowBoundary.WindowBoundaryOther<>(main);
         Subscription parent = Operators.emptySubscription();


### PR DESCRIPTION
This commit replaces the internal usage of more generic Queue suppliers
coupled with synchronized() blocks with the internal use of the MPSC
Queue.

Package-private constructors that previously required a Supplier<Queue>
now directly use Queues.unboundedMultiproducer() to enforce the MPSC
semantics.

FluxCreate, FluxJoin, FluxGroupJoin, FluxWindowBoundary and
FluxWindowTimeout are modified. The Flux API itself is left untouched,
as the Supplier parameters were never exposed in the public API.