### PR TITLE
fix #1056 doOnEach correctly passes itself to onSubscribe

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDoOnEach.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDoOnEach.java
@@ -80,7 +80,7 @@ final class FluxDoOnEach<T> extends FluxOperator<T, T> {
 		@Override
 		public void onSubscribe(Subscription s) {
 			this.s = s;
-			actual.onSubscribe(s);
+			actual.onSubscribe(this);
 		}
 
 		@Override


### PR DESCRIPTION
This commit ensures that the FluxDoOnEach DoOnEachSubscriber correctly
passes itself to actual.onSubscribe rather than its own upstream
Subscription, thus ensuring that no short-circuiting fusion is
established between the downstream and upstream.