### PR TITLE
Map nullable returns types to non-nullable Monos.

### DIFF
--- a/reactor-core/src/main/kotlin/reactor/core/publisher/FluxExtensions.kt
+++ b/reactor-core/src/main/kotlin/reactor/core/publisher/FluxExtensions.kt
@@ -30,7 +30,7 @@ import kotlin.reflect.KClass
  * @author Simon Baslé
  * @since 3.1.1
  */
-fun <T> Publisher<T>.toFlux(): Flux<T> = Flux.from(this)
+fun <T : Any> Publisher<T>.toFlux(): Flux<T> = Flux.from(this)
 
 /**
  * Extension for transforming an [Iterator] to a [Flux].
@@ -38,7 +38,7 @@ fun <T> Publisher<T>.toFlux(): Flux<T> = Flux.from(this)
  * @author Sebastien Deleuze
  * @since 3.1
  */
-fun <T> Iterator<T>.toFlux(): Flux<T> = toIterable().toFlux()
+fun <T : Any> Iterator<T>.toFlux(): Flux<T> = toIterable().toFlux()
 
 /**
  * Extension for transforming an [Iterable] to a [Flux].
@@ -46,7 +46,7 @@ fun <T> Iterator<T>.toFlux(): Flux<T> = toIterable().toFlux()
  * @author Sebastien Deleuze
  * @since 3.1
  */
-fun <T> Iterable<T>.toFlux(): Flux<T> = Flux.fromIterable(this)
+fun <T : Any> Iterable<T>.toFlux(): Flux<T> = Flux.fromIterable(this)
 
 /**
  * Extension for transforming a [Sequence] to a [Flux].
@@ -54,7 +54,7 @@ fun <T> Iterable<T>.toFlux(): Flux<T> = Flux.fromIterable(this)
  * @author Sebastien Deleuze
  * @since 3.1
  */
-fun <T> Sequence<T>.toFlux(): Flux<T> = Flux.fromIterable(object : Iterable<T> {
+fun <T : Any> Sequence<T>.toFlux(): Flux<T> = Flux.fromIterable(object : Iterable<T> {
     override fun iterator(): Iterator<T> = this@toFlux.iterator()
 })
 
@@ -64,7 +64,7 @@ fun <T> Sequence<T>.toFlux(): Flux<T> = Flux.fromIterable(object : Iterable<T> {
  * @author Sebastien Deleuze
  * @since 3.1
  */
-fun <T> Stream<T>.toFlux(): Flux<T> = Flux.fromStream(this)
+fun <T : Any> Stream<T>.toFlux(): Flux<T> = Flux.fromStream(this)
 
 /**
  * Extension for transforming a [BooleanArray] to a [Flux].

--- a/reactor-core/src/main/kotlin/reactor/core/publisher/MonoExtensions.kt
+++ b/reactor-core/src/main/kotlin/reactor/core/publisher/MonoExtensions.kt
@@ -39,7 +39,7 @@ fun <T> Publisher<T>.toMono(): Mono<T> = Mono.from(this)
  *
  * @author Sergio Dos Santos
  */
-fun <T> (() -> T).toMono(): Mono<T> = Mono.fromSupplier(this)
+fun <T> (() -> T?).toMono(): Mono<T> = Mono.fromSupplier(this)
 
 /**
  * Extension for transforming an object to a [Mono].
@@ -47,7 +47,7 @@ fun <T> (() -> T).toMono(): Mono<T> = Mono.fromSupplier(this)
  * @author Sebastien Deleuze
  * @since 3.1
  */
-fun <T> T.toMono(): Mono<T> = Mono.just(this)
+fun <T : Any> T.toMono(): Mono<T> = Mono.just(this)
 
 /**
  * Extension for transforming an [CompletableFuture] to a [Mono].
@@ -55,7 +55,7 @@ fun <T> T.toMono(): Mono<T> = Mono.just(this)
  * @author Sebastien Deleuze
  * @since 3.1
  */
-fun <T> CompletableFuture<T>.toMono(): Mono<T> = Mono.fromFuture(this)
+fun <T> CompletableFuture<out T?>.toMono(): Mono<T> = Mono.fromFuture(this)
 
 /**
  * Extension for transforming an [Callable] to a [Mono].
@@ -63,7 +63,7 @@ fun <T> CompletableFuture<T>.toMono(): Mono<T> = Mono.fromFuture(this)
  * @author Sebastien Deleuze
  * @since 3.1
  */
-fun <T> Callable<T>.toMono(): Mono<T> = Mono.fromCallable(this::call)
+fun <T> Callable<T?>.toMono(): Mono<T> = Mono.fromCallable(this::call)
 
 /**
  * Extension for transforming an exception to a [Mono] that completes with the specified error.

--- a/reactor-core/src/test/kotlin/reactor/core/publisher/MonoExtensionsTests.kt
+++ b/reactor-core/src/test/kotlin/reactor/core/publisher/MonoExtensionsTests.kt
@@ -94,11 +94,54 @@ class MonoExtensionsTests {
     }
 
     @Test
+    fun nullableCompletableFutureToMonoWithMap() {
+        val future = CompletableFuture<String?>()
+
+        val verifier = StepVerifier.create(future.toMono().map { it.toUpperCase() })
+            .expectComplete()
+        future.complete(null)
+        verifier.verify()
+    }
+
+    @Test
     fun callableToMono() {
         val callable = Callable { "foo" }
         val verifier = StepVerifier.create(callable.toMono())
                 .expectNext("foo")
                 .expectComplete()
+        verifier.verify()
+    }
+
+    @Test
+    fun nullableCallableToMonoWithMap() {
+        val callable = Callable<String?> { "foo" }
+        val verifier = StepVerifier.create(callable.toMono().map { it.toUpperCase() })
+            .expectNext("FOO")
+            .expectComplete()
+        verifier.verify()
+    }
+
+    @Test
+    fun nullableCallableToEmptyMonoWitMap() {
+        val callable = Callable<String?> { null }
+        val verifier = StepVerifier.create(callable.toMono().map { it.toUpperCase() })
+            .expectComplete()
+        verifier.verify()
+    }
+
+    @Test
+    fun nullableLambdaToEmptyMono() {
+        val callable = { null }
+        val verifier = StepVerifier.create(callable.toMono())
+            .expectComplete()
+        verifier.verify()
+    }
+
+    @Test
+    fun nullableLambdaToEmptyMonoWithMap() {
+        val callable = { null as String? }
+        val verifier = StepVerifier.create(callable.toMono().map { it.toUpperCase() })
+            .expectComplete()
         verifier.verify()
     }
 


### PR DESCRIPTION
Map nullable returns types to non-nullable Monos and only allow non-nullable Fluxes. This avoids handling nulls inside Mono operations like `map` when the Mono was created from a nullable type like `String?` for example.