### PR TITLE
Fix JavaDocs typo in expand function documentation

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3972,7 +3972,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *  A
 	 *  B
 	 *  AA
-	 *  AB
+	 *  BB
 	 *  aa1
 	 *  bb1
 	 * </pre>
@@ -4012,7 +4012,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *  A
 	 *  B
 	 *  AA
-	 *  AB
+	 *  BB
 	 *  aa1
 	 *  bb1
 	 * </pre>


### PR DESCRIPTION
This fixes a typo in the JavaDocs of the `expand()` method.