### PR TITLE
Scheduler introspection via Scannable

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Scannable.java
+++ b/reactor-core/src/main/java/reactor/core/Scannable.java
@@ -248,6 +248,11 @@ public interface Scannable {
 			public boolean isScanAvailable() {
 				return false;
 			}
+
+			@Override
+			public String toString() {
+				return "UNAVAILABLE_SCAN";
+			}
 		};
 
 		/**
@@ -263,6 +268,11 @@ public interface Scannable {
 			@Override
 			public boolean isScanAvailable() {
 				return false;
+			}
+
+			@Override
+			public String toString() {
+				return "NULL_SCAN";
 			}
 		};
 

--- a/reactor-core/src/main/java/reactor/core/Scannable.java
+++ b/reactor-core/src/main/java/reactor/core/Scannable.java
@@ -23,6 +23,8 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Scheduler.Worker;
 import reactor.util.annotation.Nullable;
 import reactor.util.function.Tuple2;
 
@@ -143,6 +145,15 @@ public interface Scannable {
 		 */
 		public static final Attr<Scannable> PARENT = new Attr<>(null,
 				Scannable::from);
+
+		/**
+		 * A key that links a {@link Scannable} to another {@link Scannable} it runs on.
+		 * Usually exposes a link between an operator/subscriber and its {@link Worker} or
+		 * {@link Scheduler}, provided these are {@link Scannable}. Will return
+		 * {@link Attr#UNAVAILABLE_SCAN} if the supporting execution is not Scannable or
+		 * {@link Attr#NULL_SCAN} if the operator doesn't define a specific runtime.
+		 */
+		public static final Attr<Scannable> RUN_ON = new Attr<>(null, Scannable::from);
 
 		/**
 		 * Prefetch is an {@link Integer} attribute defining the rate of processing in a

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
@@ -70,7 +70,12 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends FluxOp
 				bufferSupplier));
 	}
 
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_ON) return timer;
 
+		return super.scanUnsafe(key);
+	}
 
 	final static class BufferTimeoutSubscriber<T, C extends Collection<? super T>>
 			implements InnerOperator<T, C> {
@@ -206,6 +211,7 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends FluxOp
 			if (key == Attr.REQUESTED_FROM_DOWNSTREAM) return requested;
 			if (key == Attr.CAPACITY) return batchSize;
 			if (key == Attr.BUFFERED) return batchSize - index;
+			if (key == Attr.RUN_ON) return timer;
 
 			return InnerOperator.super.scanUnsafe(key);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCancelOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCancelOn.java
@@ -39,6 +39,13 @@ final class FluxCancelOn<T> extends FluxOperator<T, T> {
 		source.subscribe(new CancelSubscriber<T>(actual, scheduler));
 	}
 
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_ON) return scheduler;
+
+		return super.scanUnsafe(key);
+	}
+
 	static final class CancelSubscriber<T>
 			implements InnerOperator<T, T>, Runnable {
 
@@ -69,6 +76,7 @@ final class FluxCancelOn<T> extends FluxOperator<T, T> {
 		public Object scanUnsafe(Attr key) {
 			if (key == Attr.PARENT) return s;
 			if (key == Attr.CANCELLED) return cancelled == 1;
+			if (key == Attr.RUN_ON) return scheduler;
 
 			return InnerOperator.super.scanUnsafe(key);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxElapsed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxElapsed.java
@@ -43,6 +43,13 @@ final class FluxElapsed<T> extends FluxOperator<T, Tuple2<Long, T>> implements F
 		source.subscribe(new ElapsedSubscriber<>(actual, scheduler));
 	}
 
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_ON) return scheduler;
+
+		return super.scanUnsafe(key);
+	}
+
 	static final class ElapsedSubscriber<T>
 			implements InnerOperator<T, Tuple2<Long, T>>,
 			           QueueSubscription<Tuple2<Long, T>> {
@@ -65,6 +72,7 @@ final class FluxElapsed<T> extends FluxOperator<T, Tuple2<Long, T>> implements F
 		@Nullable
 		public Object scanUnsafe(Attr key) {
 			if (key == Attr.PARENT) return s;
+			if (key == Attr.RUN_ON) return scheduler;
 
 			return InnerOperator.super.scanUnsafe(key);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferTimeout.java
@@ -78,6 +78,13 @@ final class FluxOnBackpressureBufferTimeout<O> extends FluxOperator<O, O> {
 		return Integer.MAX_VALUE;
 	}
 
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_ON) return ttlScheduler;
+
+		return super.scanUnsafe(key);
+	}
+
 	static final class BackpressureBufferTimeoutSubscriber<T> extends ArrayDeque<Object>
 			implements InnerOperator<T, T>, Runnable {
 
@@ -148,6 +155,7 @@ final class FluxOnBackpressureBufferTimeout<O> extends FluxOperator<O, O> {
 			if (key == Attr.DELAY_ERROR) {
 				return false;
 			}
+			if (key == Attr.RUN_ON) return ttlScheduler;
 
 			return InnerOperator.super.scanUnsafe(key);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
@@ -69,6 +69,13 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 	}
 
 	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_ON) return scheduler;
+
+		return super.scanUnsafe(key);
+	}
+
+	@Override
 	public int getPrefetch() {
 		return prefetch;
 	}
@@ -520,6 +527,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 			if (key == Attr.ERROR) return error;
 			if (key == Attr.DELAY_ERROR) return delayError;
 			if (key == Attr.PREFETCH) return prefetch;
+			if (key == Attr.RUN_ON) return worker;
 
 			return InnerOperator.super.scanUnsafe(key);
 		}
@@ -941,6 +949,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 			if (key == Attr.ERROR) return error;
 			if (key == Attr.DELAY_ERROR) return delayError;
 			if (key == Attr.PREFETCH) return prefetch;
+			if (key == Attr.RUN_ON) return worker;
 
 			return InnerOperator.super.scanUnsafe(key);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -1093,6 +1093,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 	public Object scanUnsafe(Scannable.Attr key) {
 		if (key == Attr.PREFETCH) return getPrefetch();
 		if (key == Attr.PARENT) return source;
+		if (key == Attr.RUN_ON) return scheduler;
 
 		return null;
 	}
@@ -1368,6 +1369,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 			if (key == Attr.BUFFERED) return size();
 			if (key == Attr.CANCELLED) return isCancelled();
 			if (key == Attr.REQUESTED_FROM_DOWNSTREAM) return Math.max(0L, requested);
+			if (key == Attr.RUN_ON) return parent.parent.scheduler;
 
 			return ReplaySubscription.super.scanUnsafe(key);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOnCallable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOnCallable.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Fuseable;
+import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 import reactor.util.annotation.Nullable;
 
@@ -34,7 +35,7 @@ import reactor.util.annotation.Nullable;
  * @param <T> the value type
  * @see <a href="https://github.com/reactor/reactive-streams-commons">https://github.com/reactor/reactive-streams-commons</a>
  */
-final class FluxSubscribeOnCallable<T> extends Flux<T> implements Fuseable {
+final class FluxSubscribeOnCallable<T> extends Flux<T> implements Fuseable, Scannable {
 
 	final Callable<? extends T> callable;
 
@@ -60,6 +61,13 @@ final class FluxSubscribeOnCallable<T> extends Flux<T> implements Fuseable {
 				actual.onError(Operators.onRejectedExecution(ree, actual.currentContext()));
 			}
 		}
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_ON) return scheduler;
+
+		return null;
 	}
 
 	static final class CallableSubscribeOnSubscription<T>
@@ -123,6 +131,7 @@ final class FluxSubscribeOnCallable<T> extends Flux<T> implements Fuseable {
 		public Object scanUnsafe(Attr key) {
 			if (key == Attr.CANCELLED) return state == HAS_CANCELLED;
 			if (key == Attr.BUFFERED) return value != null ? 1 : 0;
+			if (key == Attr.RUN_ON) return scheduler;
 
 			return InnerProducer.super.scanUnsafe(key);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOnValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOnValue.java
@@ -37,7 +37,7 @@ import reactor.util.annotation.Nullable;
  *
  * @see <a href="https://github.com/reactor/reactive-streams-commons">https://github.com/reactor/reactive-streams-commons</a>
  */
-final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable {
+final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable, Scannable {
 
 	final T value;
 
@@ -67,6 +67,13 @@ final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable {
 		else {
 			actual.onSubscribe(new ScheduledScalar<>(actual, v, scheduler));
 		}
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_ON) return scheduler;
+
+		return null;
 	}
 
 	static final class ScheduledScalar<T>
@@ -121,6 +128,7 @@ final class FluxSubscribeOnValue<T> extends Flux<T> implements Fuseable {
 			if (key == Attr.BUFFERED) {
 				return 1;
 			}
+			if (key == Attr.RUN_ON) return scheduler;
 
 			return InnerProducer.super.scanUnsafe(key);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
@@ -63,6 +63,13 @@ final class FluxWindowTimeout<T> extends FluxOperator<T, Flux<T>> {
 				timer));
 	}
 
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_ON) return timer;
+
+		return super.scanUnsafe(key);
+	}
+
 	static final class WindowTimeoutSubscriber<T> implements InnerOperator<T, Flux<T>> {
 
 		final CoreSubscriber<? super Flux<T>> actual;
@@ -133,6 +140,7 @@ final class FluxWindowTimeout<T> extends FluxOperator<T, Flux<T>> {
 			if (key == Attr.REQUESTED_FROM_DOWNSTREAM) return requested;
 			if (key == Attr.CAPACITY) return maxSize;
 			if (key == Attr.BUFFERED) return queue.size();
+			if (key == Attr.RUN_ON) return worker;
 			return InnerOperator.super.scanUnsafe(key);
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCancelOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCancelOn.java
@@ -32,4 +32,11 @@ final class MonoCancelOn<T> extends MonoOperator<T, T> {
 	public void subscribe(CoreSubscriber<? super T> actual) {
 		source.subscribe(new FluxCancelOn.CancelSubscriber<T>(actual, scheduler));
 	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_ON) return scheduler;
+
+		return super.scanUnsafe(key);
+	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
@@ -24,6 +24,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.Exceptions;
+import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 import reactor.util.annotation.Nullable;
 
@@ -33,7 +34,7 @@ import reactor.util.annotation.Nullable;
  * wraps other form of async-delayed execution of tasks.
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
-final class MonoDelay extends Mono<Long> {
+final class MonoDelay extends Mono<Long> implements Scannable {
 
 	final Scheduler timedScheduler;
 
@@ -62,6 +63,13 @@ final class MonoDelay extends Mono<Long> {
 						actual.currentContext()));
 			}
 		}
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_ON) return timedScheduler;
+
+		return null;
 	}
 
 	static final class MonoDelayRunnable implements Runnable, InnerProducer<Long> {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelayElement.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelayElement.java
@@ -55,6 +55,13 @@ final class MonoDelayElement<T> extends MonoOperator<T, T> {
 		source.subscribe(new DelayElementSubscriber<>(actual, timedScheduler, delay, unit));
 	}
 
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_ON) return timedScheduler;
+
+		return super.scanUnsafe(key);
+	}
+
 	static final class DelayElementSubscriber<T> extends Operators.MonoSubscriber<T,T> {
 
 		final long delay;
@@ -79,6 +86,7 @@ final class MonoDelayElement<T> extends MonoOperator<T, T> {
 		public Object scanUnsafe(Attr key) {
 			if (key == Attr.TERMINATED) return done;
 			if (key == Attr.PARENT) return s;
+			if (key == Attr.RUN_ON) return scheduler;
 
 			return super.scanUnsafe(key);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoElapsed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoElapsed.java
@@ -37,4 +37,11 @@ final class MonoElapsed<T> extends MonoOperator<T, Tuple2<Long, T>> implements F
 	public void subscribe(CoreSubscriber<? super Tuple2<Long, T>> actual) {
 		source.subscribe(new FluxElapsed.ElapsedSubscriber<T>(actual, scheduler));
 	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_ON) return scheduler;
+
+		return super.scanUnsafe(key);
+	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPublishOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPublishOn.java
@@ -45,6 +45,13 @@ final class MonoPublishOn<T> extends MonoOperator<T, T> {
 		source.subscribe(new PublishOnSubscriber<T>(actual, scheduler));
 	}
 
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_ON) return scheduler;
+
+		return super.scanUnsafe(key);
+	}
+
 	static final class PublishOnSubscriber<T>
 			implements InnerOperator<T, T>, Runnable {
 
@@ -85,6 +92,7 @@ final class MonoPublishOn<T> extends MonoOperator<T, T> {
 			if (key == Attr.CANCELLED) return future == OperatorDisposables.DISPOSED;
 			if (key == Attr.PARENT) return s;
 			if (key == Attr.ERROR) return error;
+			if (key == Attr.RUN_ON) return scheduler;
 
 			return InnerOperator.super.scanUnsafe(key);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOn.java
@@ -62,6 +62,13 @@ final class MonoSubscribeOn<T> extends MonoOperator<T, T> {
 		}
 	}
 
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_ON) return scheduler;
+
+		return super.scanUnsafe(key);
+	}
+
 	static final class SubscribeOnSubscriber<T>
 			implements InnerOperator<T, T>, Runnable {
 
@@ -105,6 +112,7 @@ final class MonoSubscribeOn<T> extends MonoOperator<T, T> {
 			if (key == Attr.CANCELLED) return s == Operators.cancelledSubscription();
 			if (key == Attr.PARENT) return s;
 			if (key == Attr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == Attr.RUN_ON) return worker;
 
 			return InnerOperator.super.scanUnsafe(key);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOnCallable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOnCallable.java
@@ -22,6 +22,7 @@ import java.util.concurrent.RejectedExecutionException;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
+import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 
 /**
@@ -30,7 +31,7 @@ import reactor.core.scheduler.Scheduler;
  * @param <T> the value type
  * @see <a href="https://github.com/reactor/reactive-streams-commons">https://github.com/reactor/reactive-streams-commons</a>
  */
-final class MonoSubscribeOnCallable<T> extends Mono<T> implements Fuseable {
+final class MonoSubscribeOnCallable<T> extends Mono<T> implements Fuseable, Scannable{
 
 	final Callable<? extends T> callable;
 
@@ -55,5 +56,12 @@ final class MonoSubscribeOnCallable<T> extends Mono<T> implements Fuseable {
 				actual.onError(Operators.onRejectedExecution(ree, actual.currentContext()));
 			}
 		}
+	}
+
+	@Override
+	public Object scanUnsafe(Scannable.Attr key) {
+		if (key == Scannable.Attr.RUN_ON) return scheduler;
+
+		return null;
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOnValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOnValue.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.concurrent.RejectedExecutionException;
 
 import reactor.core.CoreSubscriber;
+import reactor.core.Scannable;
 import reactor.core.publisher.FluxSubscribeOnValue.ScheduledEmpty;
 import reactor.core.publisher.FluxSubscribeOnValue.ScheduledScalar;
 import reactor.core.scheduler.Scheduler;
@@ -30,7 +31,7 @@ import reactor.util.annotation.Nullable;
  *
  * @param <T>
  */
-final class MonoSubscribeOnValue<T> extends Mono<T> {
+final class MonoSubscribeOnValue<T> extends Mono<T> implements Scannable {
 
 	final T value;
 
@@ -60,5 +61,12 @@ final class MonoSubscribeOnValue<T> extends Mono<T> {
 		else {
 			actual.onSubscribe(new ScheduledScalar<>(actual, v, scheduler));
 		}
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_ON) return scheduler;
+
+		return null;
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
@@ -31,6 +31,7 @@ import java.util.function.Supplier;
 import org.jetbrains.annotations.NotNull;
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
+import reactor.core.Scannable;
 
 /**
  * A simple {@link Scheduler} which uses a backing {@link ExecutorService} to schedule
@@ -40,7 +41,7 @@ import reactor.core.Exceptions;
  * @author Stephane Maldini
  * @author Simon Baslé
  */
-final class DelegateServiceScheduler implements Scheduler {
+final class DelegateServiceScheduler implements Scheduler, Scannable {
 
 	final ScheduledExecutorService executor;
 
@@ -92,6 +93,14 @@ final class DelegateServiceScheduler implements Scheduler {
 			return (ScheduledExecutorService) executor;
 		}
 		return new UnsupportedScheduledExecutorService(executor);
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.TERMINATED || key == Attr.CANCELLED) return isDisposed();
+		if (key == Attr.NAME) return Schedulers.FROM_EXECUTOR_SERVICE + "(" + executor + ")";
+
+		return Schedulers.scanExecutor(executor, key);
 	}
 
 	static final class UnsupportedScheduledExecutorService
@@ -220,6 +229,11 @@ final class DelegateServiceScheduler implements Scheduler {
 				long delay,
 				@NotNull TimeUnit unit) {
 			throw Exceptions.failWithRejectedNotTimeCapable();
+		}
+
+		@Override
+		public String toString() {
+			return exec.toString();
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
@@ -222,7 +222,7 @@ final class ElasticScheduler implements Scheduler, Supplier<ScheduledExecutorSer
 			if (e.expireMillis < now) {
 				if (cache.remove(e)) {
 					e.cached.exec.shutdownNow();
-					//TODO shouldn't we remove from all at some point?
+					all.remove(e.cached);
 				}
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/scheduler/ExecutorServiceWorker.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ExecutorServiceWorker.java
@@ -21,15 +21,17 @@ import java.util.concurrent.TimeUnit;
 
 import reactor.core.Disposable;
 import reactor.core.Disposables;
+import reactor.core.Scannable;
 
 /**
  * @author Stephane Maldini
  */
-final class ExecutorServiceWorker implements Scheduler.Worker, Disposable {
+final class ExecutorServiceWorker implements Scheduler.Worker, Disposable, Scannable {
 
 	final ScheduledExecutorService exec;
 
 	final Composite tasks;
+
 
 	ExecutorServiceWorker(ScheduledExecutorService exec) {
 		this.exec = exec;
@@ -67,5 +69,14 @@ final class ExecutorServiceWorker implements Scheduler.Worker, Disposable {
 	@Override
 	public boolean isDisposed() {
 		return tasks.isDisposed();
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.BUFFERED) return tasks.size();
+		if (key == Attr.TERMINATED || key == Attr.CANCELLED) return isDisposed();
+		if (key == Attr.NAME) return "ExecutorServiceWorker"; //could be parallel, single or fromExecutorService
+
+		return Schedulers.scanExecutor(exec, key);
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/scheduler/ImmediateScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ImmediateScheduler.java
@@ -18,6 +18,7 @@ package reactor.core.scheduler;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.Exceptions;
+import reactor.core.Scannable;
 
 /**
  * Executes tasks on the caller's thread immediately.
@@ -27,7 +28,7 @@ import reactor.core.Exceptions;
  *
  * @author Stephane Maldini
  */
-final class ImmediateScheduler implements Scheduler {
+final class ImmediateScheduler implements Scheduler, Scannable {
 
     private static final ImmediateScheduler INSTANCE = new ImmediateScheduler();
     
@@ -52,12 +53,21 @@ final class ImmediateScheduler implements Scheduler {
         //NO-OP
     }
 
+
+    @Override
+    public Object scanUnsafe(Attr key) {
+        if (key == Attr.TERMINATED || key == Attr.CANCELLED) return isDisposed();
+        if (key == Attr.NAME) return Schedulers.IMMEDIATE;
+
+        return null;
+    }
+
     @Override
     public Worker createWorker() {
         return new ImmediateSchedulerWorker();
     }
-    
-    static final class ImmediateSchedulerWorker implements Scheduler.Worker {
+
+    static final class ImmediateSchedulerWorker implements Scheduler.Worker, Scannable {
         
         volatile boolean shutdown;
 
@@ -78,6 +88,14 @@ final class ImmediateScheduler implements Scheduler {
         @Override
         public boolean isDisposed() {
             return shutdown;
+        }
+
+        @Override
+        public Object scanUnsafe(Attr key) {
+            if (key == Attr.TERMINATED || key == Attr.CANCELLED) return shutdown;
+            if (key == Attr.NAME) return Schedulers.IMMEDIATE + ".worker";
+
+            return null;
         }
     }
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
+import reactor.core.Scannable;
 
 /**
  * Provides an abstract asynchronous boundary to operators.
@@ -195,11 +196,6 @@ public interface Scheduler extends Disposable {
 		default Disposable schedulePeriodically(Runnable task, long initialDelay, long period, TimeUnit unit) {
 			throw Exceptions.failWithRejectedNotTimeCapable();
 		}
+
 	}
-	
-	/**
-	 * Returned by the schedule() methods if the Scheduler or the Worker has ben shut down,
-	 * or is incapable of scheduling tasks with a delay/periodically (not "time capable").
-	 */
-//	Disposable REJECTED = new RejectedDisposable();
 }

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -24,16 +24,20 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
+import reactor.core.Scannable;
 import reactor.util.Logger;
 import reactor.util.Loggers;
+import reactor.util.annotation.Nullable;
 
 import static reactor.core.Exceptions.unwrap;
 
@@ -481,10 +485,13 @@ public abstract class Schedulers {
 	}
 
 	// Internals
-	static final String ELASTIC  = "elastic"; // IO stuff
-	static final String PARALLEL = "parallel"; //scale up common tasks
-	static final String SINGLE   = "single"; //non blocking tasks
-	static final String TIMER    = "timer"; //timed tasks
+	static final String ELASTIC               = "elastic"; // IO stuff
+	static final String PARALLEL              = "parallel"; //scale up common tasks
+	static final String SINGLE                = "single"; //non blocking tasks
+	static final String IMMEDIATE             = "immediate";
+	static final String FROM_EXECUTOR         = "fromExecutor";
+	static final String FROM_EXECUTOR_SERVICE = "fromExecutorService";
+
 
 	// Cached schedulers in atomic references:
 	static AtomicReference<CachedScheduler> CACHED_ELASTIC  = new AtomicReference<>();
@@ -583,7 +590,7 @@ public abstract class Schedulers {
 		}
 	}
 
-	static class CachedScheduler implements Scheduler, Supplier<Scheduler> {
+	static class CachedScheduler implements Scheduler, Supplier<Scheduler>, Scannable {
 
 		final Scheduler cached;
 		final String    key;
@@ -633,6 +640,16 @@ public abstract class Schedulers {
 		@Override
 		public boolean isDisposed() {
 			return cached.isDisposed();
+		}
+
+		@Override
+		public String toString() {
+			return cached.toString();
+		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			return Scannable.from(cached).scanUnsafe(key);
 		}
 
 		/**
@@ -741,6 +758,45 @@ public abstract class Schedulers {
 	static ScheduledExecutorService decorateExecutorService(String schedulerType,
 			Supplier<? extends ScheduledExecutorService> actual) {
 		return factory.decorateExecutorService(schedulerType, actual);
+	}
+
+	/**
+	 * Scan an {@link Executor} or {@link ExecutorService}, recognizing several special
+	 * implementations. Unwraps some decorating schedulers, recognizes {@link Scannable}
+	 * schedulers and delegates to their {@link Scannable#scanUnsafe(Scannable.Attr)}
+	 * method, introspects {@link ThreadPoolExecutor} instances.
+	 * <p>
+	 * If no data can be extracted, defaults to the provided {@code orElse}
+	 * {@link Scannable#scanUnsafe(Scannable.Attr) scanUnsafe}.
+	 *
+	 * @param executor the executor to introspect in a best effort manner.
+	 * @param key the key to scan for. CAPACITY and BUFFERED mainly.
+	 * @return an equivalent of {@link Scannable#scanUnsafe(Scannable.Attr)} but that can
+	 * also work on some implementations of {@link Executor}
+	 */
+	@Nullable
+	static final Object scanExecutor(Executor executor, Scannable.Attr key) {
+		if (executor instanceof DelegateServiceScheduler.UnsupportedScheduledExecutorService) {
+			executor = ((DelegateServiceScheduler.UnsupportedScheduledExecutorService) executor).get();
+		}
+		if (executor instanceof Scannable) {
+			return ((Scannable) executor).scanUnsafe(key);
+		}
+
+		if (executor instanceof ExecutorService) {
+			ExecutorService service = (ExecutorService) executor;
+			if (key == Scannable.Attr.TERMINATED) return service.isTerminated();
+			if (key == Scannable.Attr.CANCELLED) return service.isShutdown();
+		}
+
+		if (executor instanceof ThreadPoolExecutor) {
+				final ThreadPoolExecutor poolExecutor = (ThreadPoolExecutor) executor;
+				if (key == Scannable.Attr.CAPACITY) return poolExecutor.getMaximumPoolSize();
+				if (key == Scannable.Attr.BUFFERED) return ((Long) (poolExecutor.getTaskCount() - poolExecutor.getCompletedTaskCount())).intValue();
+				if (key == Scannable.Attr.LARGE_BUFFERED) return poolExecutor.getTaskCount() - poolExecutor.getCompletedTaskCount();
+		}
+
+		return null;
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCancelOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCancelOnTest.java
@@ -53,6 +53,13 @@ public class FluxCancelOnTest {
 		Assert.assertNull(threadHash.get());
 	}
 
+	@Test
+	public void scanOperator() {
+		final Flux<Integer> flux = Flux.just(1).cancelOn(Schedulers.elastic());
+
+		assertThat(flux).isInstanceOf(Scannable.class);
+		assertThat(((Scannable) flux).scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.elastic());
+	}
 
 	@Test
 	public void scanSubscriber() {
@@ -61,6 +68,7 @@ public class FluxCancelOnTest {
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 
+		assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.single());
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxElapsedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxElapsedTest.java
@@ -26,6 +26,8 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.util.function.Tuple2;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class FluxElapsedTest {
 
 	Flux<Tuple2<Long, String>> scenario_aFluxCanBeBenchmarked(){
@@ -43,13 +45,22 @@ public class FluxElapsedTest {
 	}
 
 	@Test
+    public void scanOperator() {
+		Flux<Tuple2<Long, Integer>> test = Flux.just(1).elapsed(Schedulers.single());
+
+		assertThat(test).isInstanceOf(Scannable.class);
+		assertThat(((Scannable) test).scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.single());
+    }
+
+	@Test
     public void scanSubscriber() {
         CoreSubscriber<Tuple2<Long, String>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxElapsed.ElapsedSubscriber<String> test = new FluxElapsed.ElapsedSubscriber<>(actual, Schedulers.single());
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
 
-        Assertions.assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
-        Assertions.assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
+        assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
+        assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
+        assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.single());
     }
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
@@ -1459,4 +1459,21 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 			throw exception();
 		}
 	}
+
+	@Test
+	public void scanRunOn() {
+		Scannable publishOnScannable = Scannable.from(
+				Flux.just(1).hide()
+				    .publishOn(Schedulers.elastic())
+		);
+		Scannable runOnScannable = publishOnScannable.scan(Scannable.Attr.RUN_ON);
+
+		Assertions.assertThat(runOnScannable).isNotNull()
+		                          .matches(Scannable::isScanAvailable, "isScanAvailable");
+
+		System.out.println(runOnScannable + " isScannable " + runOnScannable.isScanAvailable());
+		System.out.println(runOnScannable.scan(Scannable.Attr.NAME));
+		runOnScannable.parents().forEach(System.out::println);
+		System.out.println(runOnScannable.scan(Scannable.Attr.BUFFERED));
+	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxReplayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxReplayTest.java
@@ -291,6 +291,7 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 
         Assertions.assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
         Assertions.assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(25);
+        Assertions.assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.single());
     }
 
 	@Test
@@ -306,7 +307,9 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
         Assertions.assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
         Assertions.assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
         Assertions.assertThat(test.scan(Scannable.Attr.BUFFERED)).isEqualTo(0); // RS: TODO non-zero size
-        test.request(35);
+		Assertions.assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.single());
+
+		test.request(35);
         Assertions.assertThat(test.scan(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(35);
 
         Assertions.assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnCallableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnCallableTest.java
@@ -178,12 +178,20 @@ public class FluxSubscribeOnCallableTest {
 	}
 
 	@Test
+	public void scanOperator() {
+		FluxSubscribeOnCallable test = new FluxSubscribeOnCallable<>(() -> "foo", Schedulers.immediate());
+
+		assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.immediate());
+	}
+
+	@Test
     public void scanMainSubscriber() {
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxSubscribeOnCallable.CallableSubscribeOnSubscription<Integer> test =
         		new FluxSubscribeOnCallable.CallableSubscribeOnSubscription<Integer>(actual, () -> 1, Schedulers.single());
 
         Assertions.assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
+        Assertions.assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.single());
         test.value = 1;
         Assertions.assertThat(test.scan(Scannable.Attr.BUFFERED)).isEqualTo(1);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnValueTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnValueTest.java
@@ -76,6 +76,16 @@ public class FluxSubscribeOnValueTest {
 	}
 
 	@Test
+    public void scanOperator() {
+		final Flux<Integer> test = Flux.just(1).subscribeOn(Schedulers.immediate());
+
+		assertThat(test).isInstanceOf(Scannable.class)
+		                .isInstanceOf(FluxSubscribeOnValue.class);
+
+		assertThat(((Scannable) test).scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.immediate());
+	}
+
+	@Test
     public void scanMainSubscriber() {
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxSubscribeOnValue.ScheduledScalar<Integer> test =
@@ -91,5 +101,7 @@ public class FluxSubscribeOnValueTest {
         assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
         test.future = OperatorDisposables.DISPOSED;
         assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
+
+        assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.single());
     }
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCancelOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCancelOnTest.java
@@ -20,8 +20,11 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
 import org.junit.Test;
+import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoCancelOnTest {
 
@@ -46,5 +49,12 @@ public class MonoCancelOnTest {
 
 		latch.await();
 		Assert.assertNull(threadHash.get());
+	}
+
+	@Test
+	public void scanOperator() {
+		MonoCancelOn<String> test = new MonoCancelOn<>(Mono.empty(), Schedulers.immediate());
+
+		assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.immediate());
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
@@ -371,6 +371,13 @@ public class MonoDelayElementTest {
 	}
 
 	@Test
+	public void scanOperator() {
+		MonoDelayElement<String> test = new MonoDelayElement<>(Mono.empty(), 1, TimeUnit.SECONDS, Schedulers.immediate());
+
+		assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.immediate());
+	}
+
+	@Test
 	public void scanSubscriber() {
 		CoreSubscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
 		MonoDelayElement.DelayElementSubscriber<String> test = new MonoDelayElement.DelayElementSubscriber<>(
@@ -379,6 +386,7 @@ public class MonoDelayElementTest {
 		test.onSubscribe(parent);
 
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+		assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.single());
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDelayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDelayTest.java
@@ -16,12 +16,14 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Test;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -67,6 +69,13 @@ public class MonoDelayTest {
 
 		Thread.sleep(110);
 		assertThat(counter.intValue()).isEqualTo(4);
+	}
+
+	@Test
+	public void scanOperator() {
+		MonoDelay test = new MonoDelay(1, TimeUnit.SECONDS, Schedulers.immediate());
+
+		assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.immediate());
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoElapsedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoElapsedTest.java
@@ -18,8 +18,12 @@ package reactor.core.publisher;
 import java.time.Duration;
 
 import org.junit.Test;
+import reactor.core.Scannable;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.util.function.Tuple2;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoElapsedTest {
 
@@ -36,5 +40,12 @@ public class MonoElapsedTest {
 		            .thenRequest(1)
 		            .expectNextMatches(t -> t.getT1() == 2000 && t.getT2().equals("test"))
 		            .verifyComplete();
+	}
+
+	@Test
+	public void scanOperator() {
+		MonoElapsed<String> test = new MonoElapsed<>(Mono.empty(), Schedulers.immediate());
+
+		assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.immediate());
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPublishOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPublishOnTest.java
@@ -346,6 +346,13 @@ public class MonoPublishOnTest {
 	}
 
 	@Test
+	public void scanOperator() {
+		MonoPublishOn<String> test = new MonoPublishOn<>(Mono.empty(), Schedulers.immediate());
+
+		Assertions.assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.immediate());
+	}
+
+	@Test
 	public void scanSubscriber() {
 		CoreSubscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
 		MonoPublishOn.PublishOnSubscriber<String> test = new MonoPublishOn.PublishOnSubscriber<>(
@@ -353,6 +360,7 @@ public class MonoPublishOnTest {
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 
+		Assertions.assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.single());
 		Assertions.assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		Assertions.assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
 
@@ -371,8 +379,6 @@ public class MonoPublishOnTest {
 		test.onError(new IllegalStateException("boom"));
 		Assertions.assertThat(test.scan(Scannable.Attr.ERROR)).hasMessage("boom");
 	}
-
-
 
 	@Test
 	public void error() {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSubscribeOnCallableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSubscribeOnCallableTest.java
@@ -19,8 +19,11 @@ import java.io.IOException;
 import java.time.Duration;
 
 import org.junit.Test;
+import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoSubscribeOnCallableTest {
 
@@ -69,5 +72,12 @@ public class MonoSubscribeOnCallableTest {
 		            .expectSubscription()
 		            .expectComplete()
 		            .verify();
+	}
+
+	@Test
+	public void scanOperator() {
+		MonoSubscribeOnCallable<String> test = new MonoSubscribeOnCallable<>(() -> "foo", Schedulers.immediate());
+
+		assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.immediate());
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSubscribeOnValueTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSubscribeOnValueTest.java
@@ -18,10 +18,11 @@ package reactor.core.publisher;
 import org.junit.Test;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
+import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoSubscribeOnValueTest {
 
@@ -45,5 +46,12 @@ public class MonoSubscribeOnValueTest {
 		catch (InterruptedException e) {
 			throw Exceptions.bubble(e);
 		}
+	}
+
+	@Test
+	public void scanOperator() {
+		MonoSubscribeOnValue<String> test = new MonoSubscribeOnValue<>("foo", Schedulers.immediate());
+
+		assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.immediate());
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/scheduler/DelegateServiceSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/DelegateServiceSchedulerTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Test;
 import reactor.core.Exceptions;
+import reactor.core.Scannable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler.Worker;
@@ -139,5 +140,49 @@ public class DelegateServiceSchedulerTest extends AbstractSchedulerTest {
 		finally {
 			s.dispose();
 		}
+	}
+
+	@Test
+	public void scanName() {
+		Scheduler fixedThreadPool = Schedulers.fromExecutorService(Executors.newFixedThreadPool(3));
+		Scheduler cachedThreadPool = Schedulers.fromExecutorService(Executors.newCachedThreadPool());
+		Scheduler singleThread = Schedulers.fromExecutorService(Executors.newSingleThreadExecutor());
+
+		try {
+			assertThat(Scannable.from(fixedThreadPool).scan(Scannable.Attr.NAME))
+					.as("fixedThreadPool")
+					.startsWith("fromExecutorService(java.util.concurrent.ThreadPoolExecutor@")
+					.endsWith("[Running, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 0])");
+			assertThat(Scannable.from(cachedThreadPool).scan(Scannable.Attr.NAME))
+					.as("cachedThreadPool")
+					.startsWith("fromExecutorService(java.util.concurrent.ThreadPoolExecutor@")
+					.endsWith("[Running, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 0])");
+			assertThat(Scannable.from(singleThread).scan(Scannable.Attr.NAME))
+					.as("singleThread")
+					.startsWith("fromExecutorService(java.util.concurrent.Executors$FinalizableDelegatedExecutorService@")
+					.endsWith(")");
+		}
+		finally {
+			fixedThreadPool.dispose();
+			cachedThreadPool.dispose();
+			singleThread.dispose();
+		}
+	}
+
+	@Test
+	public void scanExecutorAttributes() {
+		Scheduler fixedThreadPool = Schedulers.fromExecutorService(Executors.newFixedThreadPool(3));
+
+		Long test = Integer.MAX_VALUE + 1L;
+		System.out.println(test.intValue() == Integer.MAX_VALUE);
+
+		assertThat(Scannable.from(fixedThreadPool).scan(Scannable.Attr.CAPACITY)).isEqualTo(3);
+		assertThat(Scannable.from(fixedThreadPool).scan(Scannable.Attr.BUFFERED)).isZero();
+		assertThat(Scannable.from(fixedThreadPool).scan(Scannable.Attr.LARGE_BUFFERED)).isZero();
+
+		fixedThreadPool.schedule(() -> {
+			assertThat(Scannable.from(fixedThreadPool).scan(Scannable.Attr.BUFFERED)).isNotZero();
+			assertThat(Scannable.from(fixedThreadPool).scan(Scannable.Attr.LARGE_BUFFERED)).isNotZero();
+		});
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTest.java
@@ -15,13 +15,16 @@
  */
 package reactor.core.scheduler;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import reactor.core.Exceptions;
+import reactor.core.Scannable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -114,5 +117,125 @@ public class ExecutorSchedulerTest extends AbstractSchedulerTest {
 				.isSameAs(Exceptions.failWithRejected());
 
 		assertThat(count.get()).isEqualTo(1);
+	}
+
+	static final class ScannableExecutor implements Executor, Scannable {
+
+		@Override
+		public void execute(@NotNull Runnable command) {
+			command.run();
+		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.CAPACITY) return 123;
+			if (key == Attr.BUFFERED) return 1024;
+			if (key == Attr.NAME) return toString();
+			return null;
+		}
+
+		@Override
+		public String toString() {
+			return "scannableExecutor";
+		}
+	}
+
+	static final class PlainExecutor implements Executor {
+		@Override
+		public void execute(@NotNull Runnable command) {
+			command.run();
+		}
+
+		@Override
+		public String toString() {
+			return "\"plain\"";
+		}
+	}
+
+	@Test
+	public void scanName() {
+		Executor executor = new PlainExecutor();
+
+		Scheduler noTrampoline = Schedulers.fromExecutor(executor, false);
+		Scheduler withTrampoline = Schedulers.fromExecutor(executor, true);
+
+		Scheduler.Worker workerNoTrampoline = noTrampoline.createWorker();
+		Scheduler.Worker workerWithTrampoline = withTrampoline.createWorker();
+
+		try {
+			assertThat(Scannable.from(noTrampoline).scan(Scannable.Attr.NAME))
+					.as("noTrampoline")
+					.isEqualTo("fromExecutor(\"plain\")");
+
+			assertThat(Scannable.from(withTrampoline).scan(Scannable.Attr.NAME))
+					.as("withTrampoline")
+					.isEqualTo("fromExecutor(\"plain\",trampolining)");
+
+			assertThat(Scannable.from(workerNoTrampoline).scan(Scannable.Attr.NAME))
+					.as("workerNoTrampoline")
+					.isEqualTo("fromExecutor(\"plain\").worker");
+
+			assertThat(Scannable.from(workerWithTrampoline).scan(Scannable.Attr.NAME))
+					.as("workerWithTrampoline")
+					.isEqualTo("fromExecutor(\"plain\",trampolining).worker");
+		}
+		finally {
+			noTrampoline.dispose();
+			withTrampoline.dispose();
+			workerNoTrampoline.dispose();
+			workerWithTrampoline.dispose();
+		}
+	}
+
+	@Test
+	public void scanParent() {
+		Executor plainExecutor = new PlainExecutor();
+		Executor scannableExecutor = new ScannableExecutor();
+
+		Scheduler.Worker workerScannableParent =
+				new ExecutorScheduler.ExecutorSchedulerWorker(scannableExecutor);
+		Scheduler.Worker workerPlainParent =
+				new ExecutorScheduler.ExecutorSchedulerWorker(plainExecutor);
+
+		try {
+			assertThat(Scannable.from(workerScannableParent).scan(Scannable.Attr.PARENT))
+					.as("workerScannableParent")
+					.isSameAs(scannableExecutor);
+
+			assertThat(Scannable.from(workerPlainParent).scan(Scannable.Attr.PARENT))
+					.as("workerPlainParent")
+					.isNull();
+		}
+		finally {
+			workerPlainParent.dispose();
+			workerScannableParent.dispose();
+		}
+	}
+
+
+	@Test
+	public void scanBuffered() {
+		ExecutorScheduler.ExecutorSchedulerWorker worker =
+				new ExecutorScheduler.ExecutorSchedulerWorker(task -> new Thread(task, "scanBuffered_NotTrampolining").start());
+
+		Runnable task = () -> {
+			System.out.println(Thread.currentThread().getName());
+			try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		};
+		try {
+			//the tasks are all added to the list and started on a dedicated thread
+			worker.schedule(task);
+			worker.schedule(task);
+			worker.schedule(task);
+
+			assertThat(worker.scan(Scannable.Attr.BUFFERED)).isEqualTo(3);
+
+			worker.dispose();
+
+			assertThat(worker.scan(Scannable.Attr.BUFFERED)).isZero();
+		}
+		finally {
+			worker.dispose();
+		}
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/scheduler/ImmediateSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ImmediateSchedulerTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 import reactor.core.Exceptions;
+import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler.Worker;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -77,5 +78,27 @@ public class ImmediateSchedulerTest extends AbstractSchedulerTest {
 		finally {
 			worker.dispose();
 		}
+	}
+
+	@Test
+	public void scanScheduler() {
+		ImmediateScheduler s = (ImmediateScheduler) Schedulers.immediate();
+
+		assertThat(s.scan(Scannable.Attr.NAME)).isEqualTo(Schedulers.IMMEDIATE);
+		//don't test TERMINATED as this would shutdown the only instance
+	}
+
+	@Test
+	public void scanWorker() {
+		Worker worker = Schedulers.immediate().createWorker();
+		Scannable s = (Scannable) worker;
+
+		assertThat(s.scan(Scannable.Attr.TERMINATED)).isFalse();
+		assertThat(s.scan(Scannable.Attr.CANCELLED)).isFalse();
+		assertThat(s.scan(Scannable.Attr.NAME)).isEqualTo(Schedulers.IMMEDIATE + ".worker");
+
+		worker.dispose();
+		assertThat(s.scan(Scannable.Attr.TERMINATED)).isTrue();
+		assertThat(s.scan(Scannable.Attr.CANCELLED)).isTrue();
 	}
 }


### PR DESCRIPTION
See #1050

@smaldini First step was to have MVP introspection of the Schedulers and ThreadPoolExecutor.

Second step (WIP) would be to have all operators that take a Scheduler or Worker return it upon a `scan(RUN_ON)` (new `Attr`).