### PR TITLE
fix #1080 Only terminate ExecutorScheduler if underlying is shut down

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/ExecutorScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ExecutorScheduler.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
@@ -63,7 +64,9 @@ final class ExecutorScheduler implements Scheduler, Scannable {
 			executor.execute(r);
 		}
 		catch (Throwable ex) {
-			terminated = true;
+			if (executor instanceof ExecutorService && ((ExecutorService) executor).isShutdown()) {
+				terminated = true;
+			}
 			Schedulers.handleError(ex);
 			throw Exceptions.failWithRejected(ex);
 		}


### PR DESCRIPTION
This commit prevents the termination of an `ExecutorScheduler` upon any
exception caught during submit. Such an exception could be transient,
coming from the task itself or even an Executor backed by a temporarily
full queue.

There is still a case where the scheduler can be terminated by a failure
in submit: since `ExecutorScheduler` _can_ be created with a
`ExecutorService`, the scheduler will detect that and check if the
`isShutdown()` status is true, and _only_ in this case would the
Scheduler be terminated.