### PR TITLE
fix #1078 - do not throw dropped errors and callback hook

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -166,7 +166,7 @@ final class FluxCreate<T> extends Flux<T> {
 		public void error(Throwable t) {
 			Objects.requireNonNull(t, "t is null in sink.error(t)");
 			if (sink.isCancelled() || done) {
-				Operators.onErrorDropped(t, sink.currentContext());
+				Operators.onOperatorError(t, sink.currentContext());
 				return;
 			}
 			if (Exceptions.addThrowable(ERROR, this, t)) {
@@ -174,7 +174,7 @@ final class FluxCreate<T> extends Flux<T> {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(t, sink.currentContext());
+				Operators.onOperatorError(t, sink.currentContext());
 			}
 		}
 
@@ -411,7 +411,7 @@ final class FluxCreate<T> extends Flux<T> {
 		@Override
 		public void error(Throwable e) {
 			if (isCancelled()) {
-				Operators.onErrorDropped(e, actual.currentContext());
+				Operators.onOperatorError(e, actual.currentContext());
 				return;
 			}
 			try {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,6 +131,7 @@ final class MonoCreate<T> extends Mono<T> {
 			for (; ; ) {
 				int s = state;
 				if (s == HAS_REQUEST_HAS_VALUE || s == NO_REQUEST_HAS_VALUE) {
+					Operators.onNextDropped(value, actual.currentContext());
 					return;
 				}
 				if (s == HAS_REQUEST_NO_VALUE) {
@@ -163,7 +164,7 @@ final class MonoCreate<T> extends Mono<T> {
 				}
 			}
 			else {
-				Operators.onErrorDropped(e, actual.currentContext());
+				Operators.onOperatorError(e, actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCreateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCreateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -194,15 +194,10 @@ public class MonoCreateTest {
 			sink.error(new IllegalArgumentException("boom"));
 		});
 
-		Assertions.assertThatExceptionOfType(RuntimeException.class)
-		          .isThrownBy(secondIsError::subscribe)
-		          .matches(Exceptions::isBubbling)
-		          .satisfies(e -> assertThat(Exceptions.unwrap(e)).hasMessage("boom"));
-
 		StepVerifier.create(secondIsError)
 		            .expectComplete()
 		            .verifyThenAssertThat()
-		            .hasDroppedErrorWithMessage("boom");
+		            .hasOperatorErrorWithMessage("boom");
 	}
 
 	@Test
@@ -236,16 +231,11 @@ public class MonoCreateTest {
 			sink.error(new IllegalArgumentException("boom"));
 		});
 
-		Assertions.assertThatExceptionOfType(RuntimeException.class)
-		          .isThrownBy(secondIsError::subscribe)
-		          .matches(Exceptions::isBubbling)
-		          .satisfies(e -> assertThat(Exceptions.unwrap(e)).hasMessage("boom"));
-
 		StepVerifier.create(secondIsError)
 		            .expectNext("foo")
 		            .expectComplete()
 		            .verifyThenAssertThat()
-		            .hasDroppedErrorWithMessage("boom");
+		            .hasOperatorErrorWithMessage("boom");
 	}
 
 	@Test
@@ -277,15 +267,10 @@ public class MonoCreateTest {
 			sink.error(new IllegalArgumentException("boom2"));
 		});
 
-		Assertions.assertThatExceptionOfType(RuntimeException.class)
-		          .isThrownBy(() -> secondIsError.subscribe(v -> {}, e -> {}))
-		          .matches(Exceptions::isBubbling, "exception is bubbling")
-		          .satisfies(e -> assertThat(Exceptions.unwrap(e)).hasMessage("boom2"));
-
-		StepVerifier.create(secondIsError)
+	StepVerifier.create(secondIsError)
 		            .expectErrorMessage("boom1")
 		            .verifyThenAssertThat()
-		            .hasDroppedErrorWithMessage("boom2");
+		            .hasOperatorErrorWithMessage("boom2");
 	}
 
 	@Test


### PR DESCRIPTION
+ add missing onNextDropped hook in Mono.create