### PR TITLE
fix #1077 Allow naming of a whole StepVerifier scenario through options

### DIFF
--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -77,6 +77,12 @@ final class DefaultStepVerifierBuilder<T>
 	 */
 	static Duration defaultVerifyTimeout = StepVerifier.DEFAULT_VERIFY_TIMEOUT;
 
+	/**
+	 * The {@link ErrorFormatter} used for cases where no scenario name has been provided
+	 * through {@link StepVerifierOptions}.
+	 */
+	static final ErrorFormatter NO_NAME_ERROR_FORMATTER = new ErrorFormatter(null);
+
 	static void checkPositive(long n) {
 		if (n < 0) {
 			throw new IllegalArgumentException("'n' should be >= 0 but was " + n);
@@ -113,7 +119,7 @@ final class DefaultStepVerifierBuilder<T>
 			@Nullable Supplier<? extends Publisher<? extends T>> sourceSupplier) {
 		this.initialRequest = options.getInitialRequest();
 		this.options = options;
-		this.errorFormatter = new ErrorFormatter(options.getScenarioName());
+		this.errorFormatter = options.getScenarioName() == null ? NO_NAME_ERROR_FORMATTER : new ErrorFormatter(options.getScenarioName());
 		this.vtsLookup = options.getVirtualTimeSchedulerSupplier();
 		this.sourceSupplier = sourceSupplier;
 		this.script = new ArrayList<>();

--- a/reactor-test/src/main/java/reactor/test/ErrorFormatter.java
+++ b/reactor-test/src/main/java/reactor/test/ErrorFormatter.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.test;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import reactor.util.annotation.Nullable;
+
+/**
+ * A utility class to format error messages in all of the default implementation of {@link StepVerifier}.
+ * Formats events and is capable of prepending messages with a {@link StepVerifierOptions#scenarioName(String) scenario name}.
+ *
+ * @author Simon Baslé
+ */
+final class ErrorFormatter {
+
+	final String scenarioPrefix;
+
+	ErrorFormatter(@Nullable final String scenarioName) {
+		if (scenarioName == null || scenarioName.isEmpty()) {
+			scenarioPrefix = "";
+		}
+		else {
+			scenarioPrefix = "[" + scenarioName + "] ";
+		}
+	}
+
+	/**
+	 * Format an event, message with argument placeholders (in the style of {@link String#format(String, Object...)})
+	 * and produce an {@link AssertionError}.
+	 *
+	 * @param event the event that caused an expectation failure
+	 * @param msg the message, possibly with {@link String#format(String, Object...)} style placeholders
+	 * @param args the optional values for the placeholders in msg
+	 * @return an {@link AssertionError} with a standardized message potentially prefixed with the associated scenario name
+	 */
+	AssertionError fail(@Nullable DefaultStepVerifierBuilder.Event<?> event, String msg, Object... args) {
+		String prefix;
+		if (event != null && event.getDescription()
+		                          .length() > 0) {
+			prefix = String.format("expectation \"%s\" failed (", event.getDescription());
+		}
+		else {
+			prefix = "expectation failed (";
+		}
+
+		return failPrefix(prefix, msg, args);
+	}
+
+	/**
+	 * Format an event, message with argument placeholders (in the style of {@link String#format(String, Object...)})
+	 * and produce an {@link AssertionError} wrapped in an {@link Optional}.
+	 *
+	 * @param event the event that caused an expectation failure
+	 * @param msg the message, possibly with {@link String#format(String, Object...)} style placeholders
+	 * @param args the optional values for the placeholders in msg
+	 * @return an {@link AssertionError} with a standardized message potentially prefixed with the associated scenario name,
+	 * wrapped in an {@link Optional}
+	 */
+	Optional<AssertionError> failOptional(@Nullable DefaultStepVerifierBuilder.Event<?> event, String msg,
+			Object... args) {
+		return Optional.of(fail(event, msg, args));
+	}
+
+	/**
+	 * Formats a two-part message: a prefix that should end in an opening parenthesis and
+	 * a second part with argument placeholders (in the style of {@link String#format(String, Object...)}).
+	 * This method adds the closing parenthesis after that second part, and then produces
+	 * an {@link AssertionError} out of the formatted message.
+	 *
+	 * @param prefix the first part of the message, should en with an opening parenthesis
+	 * @param msg the second part (detail) of the message, possibly with {@link String#format(String, Object...)} style placeholders
+	 * @param args the optional values for the placeholders in msg
+	 * @return an {@link AssertionError} with a standardized message potentially prefixed with the associated scenario name
+	 */
+	AssertionError failPrefix(String prefix, String msg, Object... args) {
+		return assertionError(prefix + String.format(msg, args) + ")");
+	}
+
+	/**
+	 * Produce an {@link AssertionError} out of a given plain message, potentially prefixing
+	 * it with the associated scenario name.
+	 *
+	 * @param msg the plain message
+	 * @return an {@link AssertionError} with a standardized message potentially prefixed with the associated scenario name
+	 */
+	AssertionError assertionError(String msg) {
+		return new AssertionError(scenarioPrefix + msg);
+	}
+
+	/**
+	 * Produce an {@link AssertionError} out of a given plain message and a cause,
+	 * potentially prefixing it with the associated scenario name.
+	 *
+	 * @param msg the plain message
+	 * @param cause the cause to add to the {@link AssertionError}
+	 * @return an {@link AssertionError} with a cause and a standardized message
+	 * potentially prefixed with the associated scenario name
+	 */
+	AssertionError assertionError(String msg, Throwable cause) {
+		return new AssertionError(scenarioPrefix + msg, cause);
+	}
+
+	/**
+	 * Produce an arbitrary {@link Throwable} with a standardized message comprised of
+	 * the given plain message and an optional prefix if the associated scenario is named.
+	 *
+	 * @param errorProducer the error producer (usually an Exception constructor method reference)
+	 * @param message the plain message
+	 * @param <T> the type of the {@link Exception}
+	 * @return a {@link T} with a message potentially prefixed with the associated scenario name
+	 */
+	<T extends Throwable> T error(Function<String, T> errorProducer, String message) {
+		return errorProducer.apply(scenarioPrefix + message);
+	}
+}

--- a/reactor-test/src/main/java/reactor/test/ErrorFormatter.java
+++ b/reactor-test/src/main/java/reactor/test/ErrorFormatter.java
@@ -29,11 +29,13 @@ import reactor.util.annotation.Nullable;
  */
 final class ErrorFormatter {
 
+	private static final String EMPTY = "";
+
 	final String scenarioPrefix;
 
 	ErrorFormatter(@Nullable final String scenarioName) {
 		if (scenarioName == null || scenarioName.isEmpty()) {
-			scenarioPrefix = "";
+			scenarioPrefix = EMPTY;
 		}
 		else {
 			scenarioPrefix = "[" + scenarioName + "] ";

--- a/reactor-test/src/main/java/reactor/test/StepVerifierOptions.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifierOptions.java
@@ -29,6 +29,9 @@ import reactor.util.context.Context;
  */
 public class StepVerifierOptions {
 
+	@Nullable
+	private String scenarioName = null;
+
 	private boolean checkUnderRequesting = true;
 	private long initialRequest = Long.MAX_VALUE;
 	private Supplier<? extends VirtualTimeScheduler> vtsLookup = null;
@@ -124,5 +127,14 @@ public class StepVerifierOptions {
 	@Nullable
 	public Context getInitialContext() {
 		return this.initialContext;
+	}
+
+	public StepVerifierOptions scenarioName(@Nullable String scenarioName) {
+		this.scenarioName = scenarioName;
+		return this;
+	}
+
+	public String getScenarioName() {
+		return this.scenarioName;
 	}
 }

--- a/reactor-test/src/main/java/reactor/test/StepVerifierOptions.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifierOptions.java
@@ -129,11 +129,24 @@ public class StepVerifierOptions {
 		return this.initialContext;
 	}
 
+	/**
+	 * Give a name to the whole scenario tested by the configured {@link StepVerifier}. That
+	 * name would be mentioned in exceptions and assertion errors raised by the StepVerifier,
+	 * allowing to better distinguish error sources in unit tests where multiple StepVerifier
+	 * are used.
+	 *
+	 * @param scenarioName the name of the scenario, null to deactivate
+	 * @return this instance, to continue setting the options.
+	 */
 	public StepVerifierOptions scenarioName(@Nullable String scenarioName) {
 		this.scenarioName = scenarioName;
 		return this;
 	}
 
+	/**
+	 * @return the name given to the configured {@link StepVerifier}, or null if none.
+	 */
+	@Nullable
 	public String getScenarioName() {
 		return this.scenarioName;
 	}

--- a/reactor-test/src/test/java/reactor/test/ErrorFormatterTest.java
+++ b/reactor-test/src/test/java/reactor/test/ErrorFormatterTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.test;
+
+import java.time.Duration;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ErrorFormatterTest {
+
+	@Test
+	public void noScenarioEmpty() {
+		assertThat(new ErrorFormatter("").scenarioPrefix)
+				.isNotNull()
+				.isEmpty();
+	}
+
+	@Test
+	public void nullScenarioEmpty() {
+		assertThat(new ErrorFormatter(null).scenarioPrefix)
+				.isNotNull()
+				.isEmpty();
+	}
+
+	@Test
+	public void givenScenarioWrapped() {
+		assertThat(new ErrorFormatter("foo").scenarioPrefix)
+				.isEqualTo("[foo] ");
+	}
+
+	// === Tests with an empty scenario name ===
+	static final ErrorFormatter noScenario = new ErrorFormatter("");
+
+	@Test
+	public void noScenarioFailNullEventNoArgs() {
+		assertThat(noScenario.fail(null, "details"))
+				.hasMessage("expectation failed (details)");
+	}
+
+	@Test
+	public void noScenarioFailNoDescriptionNoArgs() {
+		DefaultStepVerifierBuilder.Event event = new DefaultStepVerifierBuilder.NoEvent(Duration.ofMillis(5),
+				"");
+
+		assertThat(noScenario.fail(event, "details"))
+				.hasMessage("expectation failed (details)");
+	}
+
+	@Test
+	public void noScenarioFailDescriptionNoArgs() {
+		DefaultStepVerifierBuilder.Event event = new DefaultStepVerifierBuilder.NoEvent(Duration.ofMillis(5),
+				"eventDescription");
+
+		assertThat(noScenario.fail(event, "details"))
+				.hasMessage("expectation \"eventDescription\" failed (details)");
+	}
+
+	@Test
+	public void noScenarioFailNullEventHasArgs() {
+		assertThat(noScenario.fail(null, "details = %s", "bar"))
+				.hasMessage("expectation failed (details = bar)");
+	}
+
+
+	@Test
+	public void noScenarioFailNoDescriptionHasArgs() {
+		DefaultStepVerifierBuilder.Event event = new DefaultStepVerifierBuilder.NoEvent(Duration.ofMillis(5),
+				"");
+
+		assertThat(noScenario.fail(event, "details = %s", "bar"))
+				.hasMessage("expectation failed (details = bar)");
+	}
+
+	@Test
+	public void noScenarioFailDescriptionHasArgs() {
+		DefaultStepVerifierBuilder.Event event = new DefaultStepVerifierBuilder.NoEvent(Duration.ofMillis(5),
+				"eventDescription");
+
+		assertThat(noScenario.fail(event, "details = %s", "bar"))
+				.hasMessage("expectation \"eventDescription\" failed (details = bar)");
+	}
+
+	@Test
+	public void noScenarioFailOptional() {
+		assertThat(noScenario.failOptional(null, "foo"))
+				.hasValueSatisfying(ae -> assertThat(ae).hasMessage("expectation failed (foo)"));
+	}
+
+	@Test
+	public void noScenarioFailPrefixNoArgs() {
+		assertThat(noScenario.failPrefix("firstPart", "secondPart"))
+				.hasMessage("firstPartsecondPart)"); //note the prefix doesn't have an opening parenthesis
+	}
+
+	@Test
+	public void noScenarioFailPrefixHasArgs() {
+		assertThat(noScenario.failPrefix("firstPart(", "secondPart = %s", "foo"))
+				.hasMessage("firstPart(secondPart = foo)");
+	}
+
+	@Test
+	public void noScenarioAssertionError() {
+		assertThat(noScenario.assertionError("plain"))
+				.hasMessage("plain")
+				.hasNoCause();
+	}
+
+	@Test
+	public void noScenarioAssertionErrorWithCause() {
+		Throwable cause = new IllegalArgumentException("boom");
+		assertThat(noScenario.assertionError("plain", cause))
+				.hasMessage("plain")
+				.hasCause(cause);
+	}
+	
+	@Test
+	public void noScenarioIllegalStateException() {
+		assertThat(noScenario.<Throwable>error(IllegalStateException::new, "plain"))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessage("plain");
+	}
+	
+	
+	// === Tests with a scenario name ===
+	static final ErrorFormatter withScenario = new ErrorFormatter("ErrorFormatterTest");
+
+	@Test
+	public void withScenarioFailNullEventNoArgs() {
+		assertThat(withScenario.fail(null, "details"))
+				.hasMessage("[ErrorFormatterTest] expectation failed (details)");
+	}
+
+	@Test
+	public void withScenarioFailNoDescriptionNoArgs() {
+		DefaultStepVerifierBuilder.Event event = new DefaultStepVerifierBuilder.NoEvent(Duration.ofMillis(5),
+				"");
+
+		assertThat(withScenario.fail(event, "details"))
+				.hasMessage("[ErrorFormatterTest] expectation failed (details)");
+	}
+
+	@Test
+	public void withScenarioFailDescriptionNoArgs() {
+		DefaultStepVerifierBuilder.Event event = new DefaultStepVerifierBuilder.NoEvent(Duration.ofMillis(5),
+				"eventDescription");
+
+		assertThat(withScenario.fail(event, "details"))
+				.hasMessage("[ErrorFormatterTest] expectation \"eventDescription\" failed (details)");
+	}
+
+	@Test
+	public void withScenarioFailNullEventHasArgs() {
+		assertThat(withScenario.fail(null, "details = %s", "bar"))
+				.hasMessage("[ErrorFormatterTest] expectation failed (details = bar)");
+	}
+
+
+	@Test
+	public void withScenarioFailNoDescriptionHasArgs() {
+		DefaultStepVerifierBuilder.Event event = new DefaultStepVerifierBuilder.NoEvent(Duration.ofMillis(5),
+				"");
+
+		assertThat(withScenario.fail(event, "details = %s", "bar"))
+				.hasMessage("[ErrorFormatterTest] expectation failed (details = bar)");
+	}
+
+	@Test
+	public void withScenarioFailDescriptionHasArgs() {
+		DefaultStepVerifierBuilder.Event event = new DefaultStepVerifierBuilder.NoEvent(Duration.ofMillis(5),
+				"eventDescription");
+
+		assertThat(withScenario.fail(event, "details = %s", "bar"))
+				.hasMessage("[ErrorFormatterTest] expectation \"eventDescription\" failed (details = bar)");
+	}
+
+	@Test
+	public void withScenarioFailOptional() {
+		assertThat(withScenario.failOptional(null, "foo"))
+				.hasValueSatisfying(ae -> assertThat(ae).hasMessage("[ErrorFormatterTest] expectation failed (foo)"));
+	}
+
+	@Test
+	public void withScenarioFailPrefixNoArgs() {
+		assertThat(withScenario.failPrefix("firstPart", "secondPart"))
+				.hasMessage("[ErrorFormatterTest] firstPartsecondPart)"); //note the prefix doesn't have an opening parenthesis
+	}
+
+	@Test
+	public void withScenarioFailPrefixHasArgs() {
+		assertThat(withScenario.failPrefix("firstPart(", "secondPart = %s", "foo"))
+				.hasMessage("[ErrorFormatterTest] firstPart(secondPart = foo)");
+	}
+
+	@Test
+	public void withScenarioAssertionError() {
+		assertThat(withScenario.assertionError("plain"))
+				.hasMessage("[ErrorFormatterTest] plain")
+				.hasNoCause();
+	}
+
+	@Test
+	public void withScenarioAssertionErrorWithCause() {
+		Throwable cause = new IllegalArgumentException("boom");
+		assertThat(withScenario.assertionError("plain", cause))
+				.hasMessage("[ErrorFormatterTest] plain")
+				.hasCause(cause);
+	}
+	
+	@Test
+	public void withScenarioIllegalStateException() {
+		assertThat(withScenario.<Throwable>error(IllegalStateException::new, "plain"))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessage("[ErrorFormatterTest] plain");
+	}
+}

--- a/reactor-test/src/test/java/reactor/test/StepVerifierAssertionsTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierAssertionsTests.java
@@ -24,6 +24,7 @@ import reactor.core.publisher.Operators;
 import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 
 public class StepVerifierAssertionsTests {
@@ -515,9 +516,23 @@ public class StepVerifierAssertionsTests {
 
 	@Test
 	public void assertDurationConsidersEqualsASuccess() {
-		new DefaultStepVerifierBuilder.DefaultStepVerifierAssertions(null, null, null, Duration.ofSeconds(3))
+		new DefaultStepVerifierBuilder.DefaultStepVerifierAssertions(null, null, null,
+				Duration.ofSeconds(3),
+				new ErrorFormatter(null))
 				.tookLessThan(Duration.ofMillis(3000L))
 				.tookMoreThan(Duration.ofSeconds(3));
+	}
+
+	@Test
+	public void assertDurationFailureWithScenarioName() {
+		assertThatExceptionOfType(AssertionError.class)
+				.isThrownBy(() ->
+						new DefaultStepVerifierBuilder.DefaultStepVerifierAssertions(null, null, null
+								, Duration.ofSeconds(3),
+								new ErrorFormatter("fooScenario"))
+								.tookLessThan(Duration.ofMillis(200))
+				)
+				.withMessage("[fooScenario] Expected scenario to be verified in less than 200ms, took 3000ms.");
 	}
 
 	@Test

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -1235,6 +1235,42 @@ public class StepVerifierTests {
 	}
 
 	@Test
+	public void testWithDescriptionAndScenarioName() {
+		StepVerifierOptions options = StepVerifierOptions.create()
+		                                                 .initialRequest(3)
+		                                                 .scenarioName("some scenario name");
+		StepVerifier stepVerifier = StepVerifier
+				.create(Flux.just("foo", "bar", "baz"), options)
+				.expectNext("foo")
+				.as("first")
+				.expectNext("bar")
+				.as("second")
+				.expectNext("bar")
+				.as("third")
+				.as("this is ignored")
+				.expectComplete()
+				.log();
+
+		assertThatExceptionOfType(AssertionError.class)
+				.isThrownBy(stepVerifier::verify)
+				.withMessage("[some scenario name] expectation \"third\" failed (expected value: bar; actual value: baz)");
+	}
+
+	@Test
+	public void testDurationFailureWithScenarioName() {
+		StepVerifierOptions options = StepVerifierOptions.create()
+		                                                 .scenarioName("some scenario name");
+		StepVerifier stepVerifier = StepVerifier
+				.create(Mono.delay(Duration.ofMillis(100)), options)
+				.expectNextCount(1)
+				.expectComplete();
+
+		assertThatExceptionOfType(AssertionError.class)
+				.isThrownBy(() -> stepVerifier.verify(Duration.ofMillis(10)))
+				.withMessageStartingWith("[some scenario name] VerifySubscriber timed out on reactor.core.publisher.MonoDelay$MonoDelayRunnable@");
+	}
+
+	@Test
 	public void noCancelOnUnexpectedErrorSignal() {
 		LongAdder cancelled = new LongAdder();
 		assertThatExceptionOfType(AssertionError.class)

--- a/src/docs/asciidoc/testing.adoc
+++ b/src/docs/asciidoc/testing.adoc
@@ -127,6 +127,22 @@ TIP: By default, the `verify()` method and derived shortcut methods (`verifyThen
 `StepVerifier.setDefaultTimeout(Duration)` to globally set a timeout for these methods,
 or specify one on a per-call basis with `verify(Duration)`.
 
+=== Better identifying test failures
+`StepVerifier` provides two options to better identify exactly which expectation step caused
+a test to fail:
+
+ - `as(String)`: this method can be used **after** most `expect*` methods to give a description
+ to the preceding expectation. If the expectation fails, its error message will contain the
+ description. Terminal expectations and `verify` cannot be described that way.
+ - `StepVerifierOptions.create().scenarioName(String)`: Using `StepVerifierOptions` to create
+ you `StepVerifier`, you can use the `scenarioName` method to give the whole scenario a
+ name, which will also be used in assertion error messages.
+
+Note that in both cases, the use of the description/name in messages is only guaranteed for
+`StepVerifier` methods that produce their own `AssertionError` (eg. throwing an exception
+manually or through an assertion library in `assertNext` won't add the description/name to
+said error's message).
+
 == Manipulating Time
 
 `StepVerifier` can be used with time-based operators to avoid long run times for


### PR DESCRIPTION
This commit allows a user to name a given `StepVerifier` by providing
a `StepVerifierOptions` that has a `scenarioName(String)` set.

The scenario name will appear in all StepVerifier-produced exceptions
as a prefix wrapped in square brackets, followed by a single space.

Methods of StepVerifier that execute user code which can throw 3rd party
Exceptions will continue propagating these as-is, without the scenario
name prefix (eg. assertNext).

Additionally, the formatting of error messages has been externalized in
a package-protected ErrorFormatter utility class, centralizing the
assembly of error messages (and the prefixing with the scenario name).