### PR TITLE
fix #1090 Warn on doOnSubscribe usage

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3759,7 +3759,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * This method is <strong>not</strong> intended for capturing the subscription and calling its methods,
 	 * but for side effects like monitoring. For instance, the correct way to cancel a subscription is
-	 * to call {@link Disposable#dispose()} on the Disposable returned by {@link Mono#subscribe()}.
+	 * to call {@link Disposable#dispose()} on the Disposable returned by {@link Flux#subscribe()}.
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/doonsubscribe.png" alt="">
 	 * <p>

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3757,9 +3757,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	/**
 	 * Add behavior (side-effect) triggered when the {@link Flux} is subscribed.
 	 * <p>
-	 * This method is <strong>not</strong> intended for capturing the subscription and calling {@link Subscription#cancel()}.
-	 * The correct way to cancel a subscription is to call {@link Disposable#dispose()}
-	 * on the Disposable returned by {@link Flux#subscribe()}.
+	 * This method is <strong>not</strong> intended for capturing the subscription and calling its methods,
+	 * but for side effects like monitoring. For instance, the correct way to cancel a subscription is
+	 * to call {@link Disposable#dispose()} on the Disposable returned by {@link Mono#subscribe()}.
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/doonsubscribe.png" alt="">
 	 * <p>

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3757,6 +3757,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	/**
 	 * Add behavior (side-effect) triggered when the {@link Flux} is subscribed.
 	 * <p>
+	 * This method is <strong>not</strong> intended for capturing the subscription and calling {@link Subscription#cancel()}.
+	 * The correct way to cancel a subscription is to call {@link Disposable#dispose()}
+	 * on the Disposable returned by {@link Flux#subscribe()}.
+	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/doonsubscribe.png" alt="">
 	 * <p>
 	 * @param onSubscribe the callback to call on {@link Subscriber#onSubscribe}

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1780,9 +1780,9 @@ public abstract class Mono<T> implements Publisher<T> {
 	/**
 	 * Add behavior triggered when the {@link Mono} is subscribed.
 	 * <p>
-	 * This method is <strong>not</strong> intended for capturing the subscription and calling {@link Subscription#cancel()}.
-	 * The correct way to cancel a subscription is to call {@link Disposable#dispose()}
-	 * on the Disposable returned by {@link Mono#subscribe()}.
+	 * This method is <strong>not</strong> intended for capturing the subscription and calling its methods,
+	 * but for side effects like monitoring. For instance, the correct way to cancel a subscription is
+	 * to call {@link Disposable#dispose()} on the Disposable returned by {@link Mono#subscribe()}.
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/doonsubscribe.png" alt="">
 	 * <p>

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1779,7 +1779,10 @@ public abstract class Mono<T> implements Publisher<T> {
 
 	/**
 	 * Add behavior triggered when the {@link Mono} is subscribed.
-	 *
+	 * <p>
+	 * This method is <strong>not</strong> intended for capturing the subscription and calling {@link Subscription#cancel()}.
+	 * The correct way to cancel a subscription is to call {@link Disposable#dispose()}
+	 * on the Disposable returned by {@link Mono#subscribe()}.
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/doonsubscribe.png" alt="">
 	 * <p>

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -429,6 +429,10 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	/**
 	 * Call the specified callback when a 'rail' receives a Subscription from its
 	 * upstream.
+	 * <p>
+	 * This method is <strong>not</strong> intended for capturing the subscription and calling {@link Subscription#cancel()}.
+	 * The correct way to cancel a subscription is to call {@link Disposable#dispose()}
+	 * on the Disposable returned by {@link ParallelFlux#subscribe()}.
 	 *
 	 * @param onSubscribe the callback
 	 *

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -430,9 +430,9 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	 * Call the specified callback when a 'rail' receives a Subscription from its
 	 * upstream.
 	 * <p>
-	 * This method is <strong>not</strong> intended for capturing the subscription and calling {@link Subscription#cancel()}.
-	 * The correct way to cancel a subscription is to call {@link Disposable#dispose()}
-	 * on the Disposable returned by {@link ParallelFlux#subscribe()}.
+	 * This method is <strong>not</strong> intended for capturing the subscription and calling its methods,
+	 * but for side effects like monitoring. For instance, the correct way to cancel a subscription is
+	 * to call {@link Disposable#dispose()} on the Disposable returned by {@link ParallelFlux#subscribe()}.
 	 *
 	 * @param onSubscribe the callback
 	 *


### PR DESCRIPTION
`doOnSubscribe` should not be used to capture the subscription itself.
Also explain that the right way to cancel a flux is to call dispose on
the `Disposable` returned by `subscribe()`


see https://github.com/reactor/reactor-core/issues/1090