### PR TITLE
fix #1088 FluxRefCount DisconnectException on cancellation race

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
@@ -113,9 +113,11 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 			// FIXME think about what happens when subscribers come and go below the connection threshold concurrently
 
 			RefCountInner<T> inner = new RefCountInner<>(s, this);
+
+			int subCount = SUBSCRIBERS.incrementAndGet(this);
 			parent.source.subscribe(inner);
-			
-			if (SUBSCRIBERS.incrementAndGet(this) == n) {
+
+			if (subCount == n) {
 				parent.source.connect(this);
 			}
 		}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
@@ -45,6 +45,41 @@ public class FluxRefCountTest {
 	}*/
 
 	@Test
+	public void cancelDoesntTriggerDisconnectErrorOnFirstSubscribeNoComplete() {
+		AtomicInteger nextCount = new AtomicInteger();
+		AtomicReference<Throwable> errorRef = new AtomicReference<>();
+		Flux<String> flux = Flux.<String>create(sink -> {
+			sink.next("test");
+		})
+				.replay(1)
+				.refCount(1);
+
+		flux.subscribe(v -> nextCount.incrementAndGet(), errorRef::set);
+		flux.next().subscribe(v -> nextCount.incrementAndGet(), errorRef::set);
+
+		assertThat(nextCount).hasValue(2);
+		assertThat(errorRef).hasValue(null);
+	}
+
+	@Test
+	public void cancelDoesntTriggerDisconnectErrorOnFirstSubscribeDoComplete() {
+		AtomicInteger nextCount = new AtomicInteger();
+		AtomicReference<Throwable> errorRef = new AtomicReference<>();
+		Flux<String> flux = Flux.<String>create(sink -> {
+			sink.next("test");
+			sink.complete();
+		})
+				.replay(1)
+				.refCount(1);
+
+		flux.subscribe(v -> nextCount.incrementAndGet(), errorRef::set);
+		flux.next().subscribe(v -> nextCount.incrementAndGet(), errorRef::set);
+
+		assertThat(nextCount).hasValue(2);
+		assertThat(errorRef).hasValue(null);
+	}
+
+	@Test
 	public void normal() {
 		EmitterProcessor<Integer> e = EmitterProcessor.create();
 


### PR DESCRIPTION
This commit reorders the "subscribers" state update and the parallel
source subscription so that an inner source immediately terminating or
immediately cancelling will still see the correct state.

This prevents a `Disconnected` exception when eg. a replaying source is
subscribed twice (once as a Flux and once as a Mono, using next(), which
cancels on first `onNext`).