### PR TITLE
fix #1101 concatMapDelayError default behavior is END

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3090,8 +3090,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * </ul>
 	 *
 	 * <p>
-	 * Errors in the individual publishers will be delayed after the current concat backlog,
-	 * usually stopping the sequence at the source that triggered the error.
+	 * Errors in the individual publishers will be delayed at the end of the whole concat
+	 * sequence (possibly getting combined into a {@link Exceptions#isMultiple(Throwable) composite}
+	 * if several sources error.
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/concatmap.png" alt="">
@@ -3103,7 +3104,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a concatenated {@link Flux}
 	 *
 	 */
-	public final <V> Flux<V> concatMapDelayError(Function<? super T, Publisher<? extends V>> mapper) {
+	public final <V> Flux<V> concatMapDelayError(Function<? super T, ? extends Publisher<? extends V>> mapper) {
 		return concatMapDelayError(mapper, Queues.XS_BUFFER_SIZE);
 	}
 
@@ -3125,8 +3126,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * </ul>
 	 *
 	 * <p>
-	 * Errors in the individual publishers will be delayed after the current concat backlog,
-	 * usually stopping the sequence at the source that triggered the error.
+	 * Errors in the individual publishers will be delayed at the end of the whole concat
+	 * sequence (possibly getting combined into a {@link Exceptions#isMultiple(Throwable) composite}
+	 * if several sources error.
 	 * The prefetch argument allows to give an arbitrary prefetch size to the inner {@link Publisher}.
 	 *
 	 * <p>
@@ -3143,7 +3145,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	public final <V> Flux<V> concatMapDelayError(Function<? super T, ? extends Publisher<?
 			extends V>> mapper, int prefetch) {
 		return onAssembly(new FluxConcatMap<>(this, mapper, Queues.get(prefetch), prefetch,
-				FluxConcatMap.ErrorMode.BOUNDARY));
+				FluxConcatMap.ErrorMode.END));
 	}
 
 	/**

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
@@ -466,7 +466,8 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 		DirectProcessor<Integer> source1 = DirectProcessor.create();
 		DirectProcessor<Integer> source2 = DirectProcessor.create();
 
-		source.concatMapDelayError(v -> v == 1 ? source1 : source2)
+		//gh-1101: default changed from BOUNDARY to END
+		source.concatMapDelayError(v -> v == 1 ? source1 : source2, false, Queues.XS_BUFFER_SIZE)
 		      .subscribe(ts);
 
 		ts.assertNoValues()


### PR DESCRIPTION
This aligns the behavior with that of `flatMapDelayError`. The simplest
signature of `concatMapDelayError` has also been fixed to have the
Function return a `? extends Publisher` instead of `Publisher`.