### PR TITLE
fix #1114 Cache the Context for FluxReplay, Flux.cache and Mono.cache

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -40,7 +40,7 @@ import reactor.util.context.Context;
 
 /**
  * @param <T>
- * @see <a href="https://giReplaySubscriptionthub.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
+ * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
 final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fuseable {
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -326,6 +326,11 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
 		@Override
 		public void onComplete() {
 			signalCached(Signal.complete());
+		}
+
+		@Override
+		public Context currentContext() {
+			return Operators.multiSubscribersContext(subscribers);
 		}
 
 		@Nullable

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -401,16 +401,6 @@ public final class MonoProcessor<O> extends Mono<O>
 	}
 
 	@Override
-	public Context currentContext() {
-		//FIXME when #1114 merged
-		NextInner<O>[] inners = this.subscribers;
-		if (inners.length > 0) {
-			return inners[0].actual.currentContext();
-		}
-		return Context.empty();
-	}
-
-	@Override
 	public Stream<? extends Scannable> inners() {
 		return Stream.of(subscribers);
 	}
@@ -478,6 +468,11 @@ public final class MonoProcessor<O> extends Mono<O>
 		if (parent != null && SUBSCRIBERS.compareAndSet(this, EMPTY_WITH_SOURCE, EMPTY)) {
 			parent.subscribe(this);
 		}
+	}
+
+	@Override
+	public Context currentContext() {
+		return Operators.multiSubscribersContext(subscribers);
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -846,6 +846,13 @@ public abstract class Operators {
 		}
 
 		return _actual;
+	}
+
+	static Context multiSubscribersContext(InnerProducer<?>[] subscribers){
+		if (subscribers.length > 0){
+			return subscribers[0].actual().currentContext();
+		}
+		return Context.empty();
 	}
 
 	static <T> long addCapCancellable(AtomicLongFieldUpdater<T> updater, T instance,

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
+import reactor.util.context.Context;
 
 import static reactor.core.publisher.FluxReplay.ReplaySubscriber.EMPTY;
 import static reactor.core.publisher.FluxReplay.ReplaySubscriber.TERMINATED;
@@ -417,6 +418,11 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 			subscription = s;
 			s.request(Long.MAX_VALUE);
 		}
+	}
+
+	@Override
+	public Context currentContext() {
+		return Operators.multiSubscribersContext(subscribers);
 	}
 
 	@Override

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCacheTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCacheTest.java
@@ -24,6 +24,8 @@ import reactor.test.StepVerifier;
 import reactor.test.scheduler.VirtualTimeScheduler;
 import reactor.util.function.Tuple2;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class FluxCacheTest {
 
 	@Test
@@ -141,6 +143,70 @@ public class FluxCacheTest {
 		finally {
 			VirtualTimeScheduler.reset();
 		}
+	}
+
+	@Test
+	public void cacheContextHistory() {
+		AtomicInteger contextFillCount = new AtomicInteger();
+		Flux<String> cached = Flux.just(1, 2)
+		                          .flatMap(i -> Mono.subscriberContext()
+		                                            .map(ctx -> ctx.getOrDefault("a", "BAD"))
+		                          )
+		                          .cache(1)
+		                          .subscriberContext(ctx -> ctx.put("a", "GOOD" + contextFillCount.incrementAndGet()));
+
+		//at first pass, the context is captured
+		String cacheMiss = cached.blockLast();
+		assertThat(cacheMiss).as("cacheMiss").isEqualTo("GOOD1");
+		assertThat(contextFillCount).as("cacheMiss").hasValue(1);
+
+		//at second subscribe, the Context fill attempt is still done, but ultimately ignored since first context is cached
+		String cacheHit = cached.blockLast();
+		assertThat(cacheHit).as("cacheHit").isEqualTo("GOOD1"); //value from the cache
+		assertThat(contextFillCount).as("cacheHit").hasValue(2); //function was still invoked
+
+		//at third subscribe, function is called for the 3rd time, but the context is still cached
+		String cacheHit2 = cached.blockLast();
+		assertThat(cacheHit2).as("cacheHit2").isEqualTo("GOOD1");
+		assertThat(contextFillCount).as("cacheHit2").hasValue(3);
+
+		//at fourth subscribe, function is called for the 4th time, but the context is still cached
+		String cacheHit3 = cached.blockLast();
+		assertThat(cacheHit3).as("cacheHit3").isEqualTo("GOOD1");
+		assertThat(contextFillCount).as("cacheHit3").hasValue(4);
+	}
+
+	@Test
+	public void cacheContextTime() throws InterruptedException {
+		AtomicInteger contextFillCount = new AtomicInteger();
+		Flux<String> cached = Flux.just(1)
+		                          .flatMap(i -> Mono.subscriberContext()
+		                                            .map(ctx -> ctx.getOrDefault("a", "BAD"))
+		                          )
+		                          .cache(Duration.ofMillis(500))
+		                          .subscriberContext(ctx -> ctx.put("a", "GOOD" + contextFillCount.incrementAndGet()));
+
+		//at first pass, the context is captured
+		String cacheMiss = cached.blockLast();
+		assertThat(cacheMiss).as("cacheMiss").isEqualTo("GOOD1");
+		assertThat(contextFillCount).as("cacheMiss").hasValue(1);
+
+		//at second subscribe, the Context fill attempt is still done, but ultimately ignored since Mono.subscriberContext() result is cached
+		String cacheHit = cached.blockLast();
+		assertThat(cacheHit).as("cacheHit").isEqualTo("GOOD1"); //value from the cache
+		assertThat(contextFillCount).as("cacheHit").hasValue(2); //function was still invoked
+
+		Thread.sleep(500);
+
+		//at third subscribe, after the expiration delay, function is called for the 3rd time, but this time the resulting context is cached
+		String cacheExpired = cached.blockLast();
+		assertThat(cacheExpired).as("cacheExpired").isEqualTo("GOOD3");
+		assertThat(contextFillCount).as("cacheExpired").hasValue(3);
+
+		//at fourth subscribe, function is called but ignored, the cached context is visible
+		String cachePostExpired = cached.blockLast();
+		assertThat(cachePostExpired).as("cachePostExpired").isEqualTo("GOOD3");
+		assertThat(contextFillCount).as("cachePostExpired").hasValue(4);
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxReplayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxReplayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,6 +29,7 @@ import reactor.test.StepVerifier;
 import reactor.test.publisher.MonoOperatorTest;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.util.RaceTestUtils;
+import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -608,6 +609,36 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 		System.gc();
 
 		assertThat(refCoordinator.get()).isNull();
+	}
+
+	@Test
+	public void contextFromFirstSubscriberCached() throws InterruptedException {
+		AtomicInteger contextFillCount = new AtomicInteger();
+		Mono<Context> cached = Mono.subscriberContext()
+		                           .cache(Duration.ofMillis(500))
+		                           .subscriberContext(ctx -> ctx.put("a", "GOOD" + contextFillCount.incrementAndGet()));
+
+		//at first pass, the context is captured
+		String cacheMiss = cached.map(x -> x.getOrDefault("a", "BAD")).block();
+		assertThat(cacheMiss).as("cacheMiss").isEqualTo("GOOD1");
+		assertThat(contextFillCount).as("cacheMiss").hasValue(1);
+
+		//at second subscribe, the Context fill attempt is still done, but ultimately ignored since Mono.subscriberContext() result is cached
+		String cacheHit = cached.map(x -> x.getOrDefault("a", "BAD")).block();
+		assertThat(cacheHit).as("cacheHit").isEqualTo("GOOD1"); //value from the cache
+		assertThat(contextFillCount).as("cacheHit").hasValue(2); //function was still invoked
+
+		Thread.sleep(500);
+
+		//at third subscribe, after the expiration delay, function is called for the 3rd time, but this time the resulting context is cached
+		String cacheExpired = cached.map(x -> x.getOrDefault("a", "BAD")).block();
+		assertThat(cacheExpired).as("cacheExpired").isEqualTo("GOOD3");
+		assertThat(contextFillCount).as("cacheExpired").hasValue(3);
+
+		//at fourth subscribe, function is called but ignored, the cached context is visible
+		String cachePostExpired = cached.map(x -> x.getOrDefault("a", "BAD")).block();
+		assertThat(cachePostExpired).as("cachePostExpired").isEqualTo("GOOD3");
+		assertThat(contextFillCount).as("cachePostExpired").hasValue(4);
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/MonoTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/MonoTests.java
@@ -243,4 +243,33 @@ public class MonoTests {
 		          .isEqualTo(source.get())
 		          .isEqualTo(2);
 	}
+
+	@Test
+	public void monoCacheContextHistory() {
+		AtomicInteger contextFillCount = new AtomicInteger();
+		Mono<String> cached = Mono.subscriberContext()
+		                          .map(ctx -> ctx.getOrDefault("a", "BAD"))
+		                          .cache()
+		                          .subscriberContext(ctx -> ctx.put("a", "GOOD" + contextFillCount.incrementAndGet()));
+
+		//at first pass, the context is captured
+		String cacheMiss = cached.block();
+		Assertions.assertThat(cacheMiss).as("cacheMiss").isEqualTo("GOOD1");
+		Assertions.assertThat(contextFillCount).as("cacheMiss").hasValue(1);
+
+		//at second subscribe, the Context fill attempt is still done, but ultimately ignored since first context is cached
+		String cacheHit = cached.block();
+		Assertions.assertThat(cacheHit).as("cacheHit").isEqualTo("GOOD1"); //value from the cache
+		Assertions.assertThat(contextFillCount).as("cacheHit").hasValue(2); //function was still invoked
+
+		//at third subscribe, function is called for the 3rd time, but the context is still cached
+		String cacheHit2 = cached.block();
+		Assertions.assertThat(cacheHit2).as("cacheHit2").isEqualTo("GOOD1");
+		Assertions.assertThat(contextFillCount).as("cacheHit2").hasValue(3);
+
+		//at fourth subscribe, function is called for the 4th time, but the context is still cached
+		String cacheHit3 = cached.block();
+		Assertions.assertThat(cacheHit3).as("cacheHit3").isEqualTo("GOOD1");
+		Assertions.assertThat(contextFillCount).as("cacheHit3").hasValue(4);
+	}
 }


### PR DESCRIPTION
Whenever a downstream Subscriber triggers a cache miss, these operators
now all capture that Subscriber's `Context`. If the `Context` is
peeked upstream, the cached Context will be visible.

Note that due to the multi-subscriber nature of caching, calls to eg.
`subscriberContext(Context)` will still be invoked for each subscriber,
but ultimately only the invocations that correspond to a cache miss will
be visible upstream of the `cache`.