### PR TITLE
fix #1089 Add Flux.split extension

### DIFF
--- a/reactor-core/src/main/kotlin/reactor/core/publisher/FluxExtensions.kt
+++ b/reactor-core/src/main/kotlin/reactor/core/publisher/FluxExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -194,3 +194,11 @@ fun <T : Any, E : Throwable> Flux<T>.onErrorResume(exceptionType: KClass<E>, fal
  */
 fun <T : Any, E : Throwable> Flux<T>.onErrorReturn(exceptionType: KClass<E>, value: T): Flux<T> =
         onErrorReturn(exceptionType.java, value)
+
+/**
+ * Extension for flattening [Flux] of [Iterable]
+ *
+ * @author Igor Perikov
+ * @since 3.1
+ */
+fun <T : Any> Flux<out Iterable<T>>.split(): Flux<T> = this.flatMapIterable { it }

--- a/reactor-core/src/test/kotlin/reactor/core/publisher/FluxExtensionsTests.kt
+++ b/reactor-core/src/test/kotlin/reactor/core/publisher/FluxExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -211,6 +211,15 @@ class FluxExtensionsTests {
         assertThat(f).isNotSameAs(m)
         f.test()
                 .expectNext(2)
+                .verifyComplete()
+    }
+
+    @Test
+    fun splitFlux() {
+        val f = listOf(listOf(1, 2), listOf(3, 4)).toFlux()
+        StepVerifier
+                .create(f.split())
+                .expectNext(1, 2, 3, 4)
                 .verifyComplete()
     }
 


### PR DESCRIPTION
Add kotlin extension for flattening `Flux<Iterable<T>>` to `Flux<T>`

related issue - https://github.com/reactor/reactor-core/issues/1089