### PR TITLE
fix #1115 assembly operator have special operatorName, improve Scannable

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Scannable.java
+++ b/reactor-core/src/main/java/reactor/core/Scannable.java
@@ -333,13 +333,24 @@ public interface Scannable {
 
 	/**
 	 * Return a {@link Stream} navigating the {@link org.reactivestreams.Subscriber}
-	 * chain (downward).
+	 * chain (downward). The current {@link Scannable} is not included.
 	 *
 	 * @return a {@link Stream} navigating the {@link org.reactivestreams.Subscriber}
-	 * chain (downward)
+	 * chain (downward, current {@link Scannable} not included).
 	 */
 	default Stream<? extends Scannable> actuals() {
 		return Attr.recurse(this, Attr.ACTUAL);
+	}
+
+	/**
+	 * Return a {@link Stream} navigating the {@link org.reactivestreams.Subscriber}
+	 * chain (downward), current {@link Scannable} included.
+	 *
+	 * @return a {@link Stream} navigating the {@link org.reactivestreams.Subscriber}
+	 * chain (downward, current {@link Scannable} included).
+	 */
+	default Stream<? extends Scannable> thisAndActuals() {
+		return Stream.concat(Stream.of(this), actuals());
 	}
 
 	/**
@@ -361,12 +372,24 @@ public interface Scannable {
 	}
 
 	/**
-	 * Check this {@link Scannable}e and its {@link #parents()} for a name an return the
+	 * Check this {@link Scannable} and its {@link #parents()} for a name an return the
+	 * first one that is reachable.
+	 *
+	 * @return the name of the first parent that has one defined (including this scannable)
+	 * @deprecated use {@link #sequenceName()} instead
+	 */
+	@Deprecated
+	default String name() {
+		return sequenceName();
+	}
+
+	/**
+	 * Check this {@link Scannable} and its {@link #parents()} for a name an return the
 	 * first one that is reachable.
 	 *
 	 * @return the name of the first parent that has one defined (including this scannable)
 	 */
-	default String name() {
+	default String sequenceName() {
 		String thisName = this.scan(Attr.NAME);
 		if (thisName != null) {
 			return thisName;
@@ -380,10 +403,7 @@ public interface Scannable {
 	}
 
 	/**
-	 * Check this {@link Scannable}e and its {@link #parents()} for a name an return the
-	 * first one that is reachable.
-	 *
-	 * @return the name of the first parent that has one defined (including this scannable)
+	 * @return the default operatorName of this operator
 	 */
 	default String operatorName() {
 		String stripped = toString()
@@ -398,13 +418,24 @@ public interface Scannable {
 
 	/**
 	 * Return a {@link Stream} navigating the {@link org.reactivestreams.Subscription}
-	 * chain (upward).
+	 * chain (upward). The current {@link Scannable} is not included.
 	 *
 	 * @return a {@link Stream} navigating the {@link org.reactivestreams.Subscription}
-	 * chain (upward)
+	 * chain (upward, current {@link Scannable} not included).
 	 */
 	default Stream<? extends Scannable> parents() {
 		return Attr.recurse(this, Attr.PARENT);
+	}
+
+	/**
+	 * Return a {@link Stream} navigating the {@link org.reactivestreams.Subscription}
+	 * chain (upward), current {@link Scannable} included.
+	 *
+	 * @return a {@link Stream} navigating the {@link org.reactivestreams.Subscription}
+	 * chain (upward, current {@link Scannable} included).
+	 */
+	default Stream<? extends Scannable> thisAndParents() {
+		return Stream.concat(Stream.of(this), parents());
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -5346,7 +5346,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Give a name to this sequence, which can be retrieved using {@link Scannable#name()}
+	 * Give a name to this sequence, which can be retrieved using {@link Scannable#sequenceName()}
 	 * as long as this is the first reachable {@link Scannable#parents()}.
 	 *
 	 * @param name a name for the sequence

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCallableOnAssembly.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCallableOnAssembly.java
@@ -56,4 +56,14 @@ final class FluxCallableOnAssembly<T> extends FluxOperator<T, T>
 	public T call() throws Exception {
 		return ((Callable<T>) source).call();
 	}
+
+	@Override
+	public String operatorName() {
+		return stacktrace.stackFirst().trim();
+	}
+
+	@Override
+	public String toString() {
+		return stacktrace.stackFirst();
+	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnAssembly.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnAssembly.java
@@ -83,6 +83,11 @@ final class FluxOnAssembly<T> extends FluxOperator<T, T> implements Fuseable,
 	}
 
 	@Override
+	public String operatorName() {
+		return snapshotStack.stackFirst().trim();
+	}
+
+	@Override
 	public String toString() {
 		return snapshotStack.stackFirst();
 	}
@@ -443,6 +448,11 @@ final class FluxOnAssembly<T> extends FluxOperator<T, T> implements Fuseable,
 			if (key == Attr.PARENT) return s;
 
 			return InnerOperator.super.scanUnsafe(key);
+		}
+
+		@Override
+		public String operatorName() {
+			return "Subscriber to " + snapshotStack.stackFirst().trim();
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/InnerConsumer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InnerConsumer.java
@@ -28,4 +28,9 @@ import reactor.core.Scannable;
  */
 interface InnerConsumer<I>
 		extends CoreSubscriber<I>, Scannable {
+
+	@Override
+	default String operatorName() {
+		return getClass().getSimpleName();
+	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -2427,7 +2427,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Give a name to this sequence, which can be retrieved using {@link Scannable#name()}
+	 * Give a name to this sequence, which can be retrieved using {@link Scannable#sequenceName()}
 	 * as long as this is the first reachable {@link Scannable#parents()}.
 	 *
 	 * @param name a name for the sequence

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCallableOnAssembly.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCallableOnAssembly.java
@@ -91,6 +91,11 @@ final class MonoCallableOnAssembly<T> extends MonoOperator<T, T>
 	}
 
 	@Override
+	public String operatorName() {
+		return stacktrace.stackFirst().trim();
+	}
+
+	@Override
 	public String toString() {
 		return stacktrace.stackFirst();
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoOnAssembly.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoOnAssembly.java
@@ -80,6 +80,11 @@ final class MonoOnAssembly<T> extends MonoOperator<T, T> implements Fuseable,
 	}
 
 	@Override
+	public String operatorName() {
+		return stacktrace.stackFirst().trim();
+	}
+
+	@Override
 	public String toString() {
 		return stacktrace.stackFirst();
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -727,7 +727,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Give a name to this sequence, which can be retrieved using {@link Scannable#name()}
+	 * Give a name to this sequence, which can be retrieved using {@link Scannable#sequenceName()}
 	 * as long as this is the first reachable {@link Scannable#parents()}.
 	 *
 	 * @param name a name for the sequence

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxOnAssembly.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxOnAssembly.java
@@ -124,6 +124,11 @@ final class ParallelFluxOnAssembly<T> extends ParallelFlux<T>
 	}
 
 	@Override
+	public String operatorName() {
+		return stacktrace.stackFirst().trim();
+	}
+
+	@Override
 	public String toString() {
 		return stacktrace.stackFirst();
 	}

--- a/reactor-core/src/test/java/reactor/core/ScannableTest.java
+++ b/reactor-core/src/test/java/reactor/core/ScannableTest.java
@@ -16,12 +16,13 @@
 
 package reactor.core;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.assertj.core.api.Condition;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.ParallelFlux;
 import reactor.util.function.Tuple2;
@@ -134,8 +135,8 @@ public class ScannableTest {
 		                             .name("multiple of 3 100s")
 		                             .hide();
 
-		assertThat(Scannable.from(named1).name()).isEqualTo("100s");
-		assertThat(Scannable.from(named2).name()).isEqualTo("multiple of 3 100s");
+		assertThat(Scannable.from(named1).sequenceName()).isEqualTo("100s");
+		assertThat(Scannable.from(named2).sequenceName()).isEqualTo("multiple of 3 100s");
 	}
 
 
@@ -150,8 +151,8 @@ public class ScannableTest {
 		                             .name("multiple of 3 100s")
 		                             .hide();
 
-		assertThat(Scannable.from(named1).name()).isEqualTo("100s");
-		assertThat(Scannable.from(named2).name()).isEqualTo("multiple of 3 100s");
+		assertThat(Scannable.from(named1).sequenceName()).isEqualTo("100s");
+		assertThat(Scannable.from(named2).sequenceName()).isEqualTo("multiple of 3 100s");
 	}
 
 	@Test
@@ -165,8 +166,8 @@ public class ScannableTest {
 		                             .name("multiple of 3 100s")
 		                             .hide();
 
-		assertThat(Scannable.from(named1).name()).isEqualTo("100s");
-		assertThat(Scannable.from(named2).name()).isEqualTo("multiple of 3 100s");
+		assertThat(Scannable.from(named1).sequenceName()).isEqualTo("100s");
+		assertThat(Scannable.from(named2).sequenceName()).isEqualTo("multiple of 3 100s");
 	}
 
 	@Test
@@ -181,8 +182,8 @@ public class ScannableTest {
 		                             .name("multiple of 3 100s")
 		                             .hide();
 
-		assertThat(Scannable.from(named1).name()).isEqualTo("100s");
-		assertThat(Scannable.from(named2).name()).isEqualTo("multiple of 3 100s");
+		assertThat(Scannable.from(named1).sequenceName()).isEqualTo("100s");
+		assertThat(Scannable.from(named2).sequenceName()).isEqualTo("multiple of 3 100s");
 	}
 
 	@Test
@@ -190,7 +191,7 @@ public class ScannableTest {
 		final Flux<Integer> flux = Flux.range(1, 10)
 		                               .map(i -> i + 10);
 
-		assertThat(Scannable.from(flux).name())
+		assertThat(Scannable.from(flux).sequenceName())
 				.isEqualTo(Scannable.from(flux).operatorName())
 				.isEqualTo("map");
 	}
@@ -265,8 +266,8 @@ public class ScannableTest {
 		                             .name("multiple of 3 100s")
 		                             .hide();
 
-		assertThat(Scannable.from(named1).name()).isEqualTo("100s");
-		assertThat(Scannable.from(named2).name()).isEqualTo("multiple of 3 100s");
+		assertThat(Scannable.from(named1).sequenceName()).isEqualTo("100s");
+		assertThat(Scannable.from(named2).sequenceName()).isEqualTo("multiple of 3 100s");
 	}
 
 
@@ -281,8 +282,8 @@ public class ScannableTest {
 		                             .name("multiple of 3 100s")
 		                             .hide();
 
-		assertThat(Scannable.from(named1).name()).isEqualTo("100s");
-		assertThat(Scannable.from(named2).name()).isEqualTo("multiple of 3 100s");
+		assertThat(Scannable.from(named1).sequenceName()).isEqualTo("100s");
+		assertThat(Scannable.from(named2).sequenceName()).isEqualTo("multiple of 3 100s");
 	}
 
 	@Test
@@ -296,8 +297,8 @@ public class ScannableTest {
 		                             .name("multiple of 3 100s")
 		                             .hide();
 
-		assertThat(Scannable.from(named1).name()).isEqualTo("100s");
-		assertThat(Scannable.from(named2).name()).isEqualTo("multiple of 3 100s");
+		assertThat(Scannable.from(named1).sequenceName()).isEqualTo("100s");
+		assertThat(Scannable.from(named2).sequenceName()).isEqualTo("multiple of 3 100s");
 	}
 
 	@Test
@@ -312,8 +313,8 @@ public class ScannableTest {
 		                             .name("multiple of 3 100s")
 		                             .hide();
 
-		assertThat(Scannable.from(named1).name()).isEqualTo("100s");
-		assertThat(Scannable.from(named2).name()).isEqualTo("multiple of 3 100s");
+		assertThat(Scannable.from(named1).sequenceName()).isEqualTo("100s");
+		assertThat(Scannable.from(named2).sequenceName()).isEqualTo("multiple of 3 100s");
 	}
 
 	@Test
@@ -321,7 +322,7 @@ public class ScannableTest {
 		final Mono<Integer> flux = Mono.just(1)
 		                               .map(i -> i + 10);
 
-		assertThat(Scannable.from(flux).name())
+		assertThat(Scannable.from(flux).sequenceName())
 				.isEqualTo(Scannable.from(flux).operatorName())
 				.isEqualTo("map");
 	}
@@ -396,8 +397,8 @@ public class ScannableTest {
 		                             .name("multiple of 3 100s")
 		                             .hide();
 
-		assertThat(Scannable.from(named1).name()).isEqualTo("100s");
-		assertThat(Scannable.from(named2).name()).isEqualTo("multiple of 3 100s");
+		assertThat(Scannable.from(named1).sequenceName()).isEqualTo("100s");
+		assertThat(Scannable.from(named2).sequenceName()).isEqualTo("multiple of 3 100s");
 	}
 
 	@Test
@@ -411,8 +412,8 @@ public class ScannableTest {
 		                             .name("multiple of 3 100s")
 		                             .hide();
 
-		assertThat(Scannable.from(named1).name()).isEqualTo("100s");
-		assertThat(Scannable.from(named2).name()).isEqualTo("multiple of 3 100s");
+		assertThat(Scannable.from(named1).sequenceName()).isEqualTo("100s");
+		assertThat(Scannable.from(named2).sequenceName()).isEqualTo("multiple of 3 100s");
 	}
 
 	@Test
@@ -420,7 +421,7 @@ public class ScannableTest {
 		final ParallelFlux<Integer> flux = ParallelFlux.from(Mono.just(1))
 		                               .map(i -> i + 10);
 
-		assertThat(Scannable.from(flux).name())
+		assertThat(Scannable.from(flux).sequenceName())
 				.isEqualTo(Scannable.from(flux).operatorName())
 				.isEqualTo("map");
 	}
@@ -504,6 +505,49 @@ public class ScannableTest {
 		assertThat(Scannable.Attr.PREFETCH.isConversionSafe()).as("PREFETCH").isFalse();
 		assertThat(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM.isConversionSafe()).as("REQUESTED_FROM_DOWNSTREAM").isFalse();
 		assertThat(Scannable.Attr.TERMINATED.isConversionSafe()).as("TERMINATED").isFalse();
+	}
+
+	@Test
+	public void operatorNamesWithDebugMode() {
+		Hooks.onOperatorDebug();
+
+		List<String> downstream = new ArrayList<>();
+		List<String> upstream = new ArrayList<>();
+
+		try {
+			Mono<?> m=
+					Flux.from(s -> Scannable.from(s)
+					                        .thisAndActuals()
+					                        .forEach(sc -> downstream.add(sc.operatorName())))
+					    .map(a -> a)
+					    .filter(a -> true)
+					    .reduce((a, b) -> b);
+
+			m.subscribe();
+
+			Scannable.from(m)
+			         .thisAndParents()
+			         .forEach(sc -> upstream.add(sc.operatorName()));
+		}
+		finally {
+			Hooks.resetOnOperatorDebug();
+		}
+
+		assertThat(downstream).contains("MapConditionalSubscriber",
+				"Subscriber to Flux.map(ScannableTest.java:523)",
+				"FilterFuseableSubscriber",
+				"Subscriber to Flux.filter(ScannableTest.java:524)",
+				"ReduceSubscriber",
+				"Subscriber to Flux.reduce(ScannableTest.java:525)",
+				"LambdaMonoSubscriber");
+
+		assertThat(upstream).contains("Flux.reduce(ScannableTest.java:525)",
+				"reduce",
+				"Flux.filter(ScannableTest.java:524)",
+				"filter",
+				"Flux.map(ScannableTest.java:523)",
+				"map",
+				"source");
 	}
 
 }


### PR DESCRIPTION
This commit disambiguates the `Scannable#name()` by aliasing it to
`sequenceName()`. It also adds convenience stream variants to `parents`
and `actuals` that include the current `Scannable`.

`InnerConsumer` subscribers have an `operatorName()` implementation that
returns their simple class name.

Finally, this commit adds a special implementation of operatorName to
the various `xxxOnAssembly` operators and subscribers which returns the
assembly stack trace's first line (trimmed of whitespaces/tabs).