### PR TITLE
fix #1118 onErrorDropped also logs error, MonoCompletionStage drops

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -244,6 +244,9 @@ public abstract class Operators {
 
 	/**
 	 * An unexpected exception is about to be dropped.
+	 * <p>
+	 * If no hook is registered for {@link Hooks#onErrorDropped(Consumer)}, the dropped
+	 * error is logged at ERROR level and thrown (via {@link Exceptions#bubble(Throwable)}.
 	 *
 	 * @param e the dropped exception
 	 * @param context a context that might hold a local error consumer
@@ -254,6 +257,7 @@ public abstract class Operators {
 			hook = Hooks.onErrorDroppedHook;
 		}
 		if (hook == null) {
+			log.error("Operator called default onErrorDropped", e);
 			throw Exceptions.bubble(e);
 		}
 		hook.accept(e);


### PR DESCRIPTION
This commit makes the MonoCompletionStage drop errors that are thrown
inside the future.whenComplete block (which can happen with fatal
exceptions). Additionally, the default onErrorDropped behavior also logs
the dropped error.

This results in these errors being visible in the logs, where they were
previously swallowed by CompletionFuture.whenComplete.