### PR TITLE
fix #1125 Add TTL-generator variant to Mono.cache

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
@@ -19,9 +19,12 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
 import reactor.core.scheduler.Scheduler;
 import reactor.util.Logger;
 import reactor.util.Loggers;
@@ -38,8 +41,8 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
 
 	private static final Logger LOGGER = Loggers.getLogger(MonoCacheTime.class);
 
-	final Duration ttl;
-	final Scheduler clock;
+	final Function<? super Signal<T>, Duration> ttlGenerator;
+	final Scheduler                             clock;
 
 	volatile Signal<T> state;
 	static final AtomicReferenceFieldUpdater<MonoCacheTime, Signal> STATE =
@@ -49,7 +52,32 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
 
 	MonoCacheTime(Mono<? extends T> source, Duration ttl, Scheduler clock) {
 		super(source);
-		this.ttl = ttl;
+		this.ttlGenerator = ignoredSignal -> ttl;
+		this.clock = clock;
+		//noinspection unchecked
+		this.state = (Signal<T>) EMPTY;
+	}
+
+	MonoCacheTime(Mono<? extends T> source, Function<? super Signal<T>, Duration> ttlGenerator,
+			Scheduler clock) {
+		super(source);
+		this.ttlGenerator = ttlGenerator;
+		this.clock = clock;
+		//noinspection unchecked
+		this.state = (Signal<T>) EMPTY;
+	}
+
+	MonoCacheTime(Mono<? extends T> source,
+			Function<? super T, Duration> valueTtlGenerator,
+			Function<Throwable, Duration> errorTtlGenerator,
+			Supplier<Duration> emptyTtlGenerator,
+			Scheduler clock) {
+		super(source);
+		this.ttlGenerator = sig -> {
+			if (sig.isOnNext()) return valueTtlGenerator.apply(sig.get());
+			if (sig.isOnError()) return errorTtlGenerator.apply(sig.getThrowable());
+			return emptyTtlGenerator.get();
+		};
 		this.clock = clock;
 		@SuppressWarnings("unchecked")
 		Signal<T> emptyState = (Signal<T>) EMPTY;
@@ -234,7 +262,32 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
 		@SuppressWarnings("unchecked")
 		private void signalCached(Signal<T> signal) {
 			if (STATE.compareAndSet(main, this, signal)) {
-				main.clock.schedule(main, main.ttl.toMillis(), TimeUnit.MILLISECONDS);
+				Duration ttl = null;
+				try {
+					ttl = main.ttlGenerator.apply(signal);
+				}
+				catch (Throwable generatorError) {
+					STATE.set(main, Signal.error(generatorError));
+					if (signal.isOnError()) {
+						//noinspection ThrowableNotThrown
+						Exceptions.addSuppressed(generatorError, signal.getThrowable());
+					}
+				}
+
+				if (ttl != null) {
+					main.clock.schedule(main, ttl.toMillis(), TimeUnit.MILLISECONDS);
+				}
+				else {
+					//error during TTL generation, signal != updatedSignal, aka dropped
+					if (signal.isOnNext()) {
+						Operators.onNextDropped(signal.get(), currentContext());
+					}
+					else if (signal.isOnError()) {
+						Operators.onErrorDropped(signal.getThrowable(), currentContext());
+					}
+					//mark for immediate cache clear
+					main.clock.schedule(main, 0, TimeUnit.MILLISECONDS);
+				}
 			}
 
 			for (Operators.MonoSubscriber<T, T> inner : SUBSCRIBERS.getAndSet(this, TERMINATED)) {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
@@ -21,18 +21,333 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import org.junit.Test;
 import reactor.core.Disposable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.RaceTestUtils;
 import reactor.test.StepVerifier;
+import reactor.test.StepVerifierOptions;
 import reactor.test.publisher.MonoOperatorTest;
 import reactor.test.publisher.TestPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
+
+	@Test
+	public void cacheDependingOnSignal() throws InterruptedException {
+		AtomicInteger count = new AtomicInteger();
+
+		Mono<Integer> source = Mono.fromCallable(count::incrementAndGet);
+
+		Mono<Integer> cached = new MonoCacheTime<>(source,
+				sig -> {
+					if (sig.isOnNext()) {
+						return Duration.ofMillis(100 * sig.get());
+					}
+					return Duration.ZERO;
+				}, Schedulers.parallel());
+
+		cached.block();
+		cached.block();
+		assertThat(cached.block())
+				.as("after 110ms")
+				.isEqualTo(1);
+
+		Thread.sleep(110);
+		cached.block();
+		assertThat(cached.block())
+				.as("after 220ms")
+				.isEqualTo(2);
+
+		Thread.sleep(110);
+		assertThat(cached.block())
+				.as("after 330ms")
+				.isEqualTo(2);
+
+		Thread.sleep(110);
+		cached.block();
+		assertThat(cached.block())
+				.as("after 440ms")
+				.isEqualTo(3);
+
+		assertThat(count).hasValue(3);
+	}
+
+	@Test
+	public void cacheDependingOnValueAndError() throws InterruptedException {
+		AtomicInteger count = new AtomicInteger();
+
+		Mono<Integer> source = Mono.fromCallable(count::incrementAndGet)
+				.map(i -> {
+					if (i == 2) throw new IllegalStateException("transient boom");
+					return i;
+				});
+
+		AtomicInteger onNextTtl = new AtomicInteger();
+		AtomicInteger onErrorTtl = new AtomicInteger();
+		AtomicInteger onEmptyTtl = new AtomicInteger();
+
+		Mono<Integer> cached = new MonoCacheTime<>(source,
+				v -> { onNextTtl.incrementAndGet(); return Duration.ofMillis(100 * v);},
+				e -> { onErrorTtl.incrementAndGet(); return Duration.ofMillis(300);},
+				() -> { onEmptyTtl.incrementAndGet(); return Duration.ZERO;} ,
+				Schedulers.parallel());
+
+		cached.block();
+		cached.block();
+		assertThat(cached.block())
+				.as("1")
+				.isEqualTo(1);
+
+		Thread.sleep(110);
+		assertThatExceptionOfType(IllegalStateException.class)
+				.as("2 errors")
+				.isThrownBy(cached::block);
+
+		Thread.sleep(210);
+		assertThatExceptionOfType(IllegalStateException.class)
+				.as("2 still errors")
+				.isThrownBy(cached::block);
+		assertThat(count).as("2 is cached").hasValue(2);
+
+		Thread.sleep(110);
+		assertThat(cached.block())
+				.as("3 emits again")
+				.isEqualTo(3);
+
+		Thread.sleep(210);
+		assertThat(cached.block())
+				.as("3 is cached")
+				.isEqualTo(3);
+
+		assertThat(count).hasValue(3);
+		assertThat(onNextTtl).as("onNext TTL generations").hasValue(2);
+		assertThat(onErrorTtl).as("onError TTL generations").hasValue(1);
+		assertThat(onEmptyTtl).as("onEmpty TTL generations").hasValue(0);
+	}
+
+	@Test
+	public void cacheDependingOnEmpty() throws InterruptedException {
+		AtomicInteger count = new AtomicInteger();
+
+		Mono<Integer> source = Mono.fromCallable(count::incrementAndGet)
+		                           .filter(i -> i > 1);
+
+		AtomicInteger onNextTtl = new AtomicInteger();
+		AtomicInteger onErrorTtl = new AtomicInteger();
+		AtomicInteger onEmptyTtl = new AtomicInteger();
+
+		Mono<Integer> cached = new MonoCacheTime<>(source,
+				v -> { onNextTtl.incrementAndGet(); return Duration.ofMillis(100 * v);},
+				e -> { onErrorTtl.incrementAndGet(); return Duration.ofMillis(4000);},
+				() -> { onEmptyTtl.incrementAndGet(); return Duration.ofMillis(300);} ,
+				Schedulers.parallel());
+
+		assertThat(cached.block())
+				.as("1 immediate")
+				.isNull();
+
+		Thread.sleep(110);
+		assertThat(cached.block())
+				.as("1 after 100ms")
+				.isNull();
+
+		Thread.sleep(110);
+		assertThat(cached.block())
+				.as("1 after 200ms")
+				.isNull();
+
+		Thread.sleep(110);
+		assertThat(cached.block())
+				.as("2")
+				.isEqualTo(2);
+
+		Thread.sleep(110);
+		assertThat(cached.block())
+				.as("2 after 100ms")
+				.isEqualTo(2);
+
+		Thread.sleep(110);
+		assertThat(cached.block())
+				.as("3 after 200ms")
+				.isEqualTo(3);
+
+		assertThat(count).hasValue(3);
+		assertThat(onNextTtl).as("onNext TTL generations").hasValue(2);
+		assertThat(onErrorTtl).as("onError TTL generations").hasValue(0);
+		assertThat(onEmptyTtl).as("onEmpty TTL generations").hasValue(1);
+	}
+
+	@Test
+	public void nextTtlGeneratorFailure() {
+		Mono<Integer> cached = new MonoCacheTime<>(Mono.just(0),
+				v -> Duration.ofMillis(400 / v),
+				t -> Duration.ZERO,
+				() -> Duration.ZERO,
+				Schedulers.parallel());
+
+		StepVerifier.create(cached)
+		            .expectErrorSatisfies(e -> assertThat(e)
+				            .isInstanceOf(ArithmeticException.class)
+				            .hasNoSuppressedExceptions())
+		            .verifyThenAssertThat()
+		            .hasDropped(0)
+		            .hasNotDroppedErrors();
+	}
+
+	@Test
+	public void emptyTtlGeneratorFailure() {
+		Mono<Integer> cached = new MonoCacheTime<>(Mono.empty(),
+				Duration::ofSeconds,
+				t -> Duration.ofSeconds(10),
+				() -> { throw new IllegalStateException("boom"); },
+				Schedulers.parallel());
+
+		StepVerifier.create(cached)
+		            .expectErrorSatisfies(e -> assertThat(e)
+				            .isInstanceOf(IllegalStateException.class)
+				            .hasMessage("boom")
+				            .hasNoSuppressedExceptions())
+		            .verifyThenAssertThat()
+		            .hasNotDroppedElements()
+		            .hasNotDroppedErrors();
+	}
+
+	@Test
+	public void errorTtlGeneratorFailure() {
+		Throwable exception = new IllegalArgumentException("foo");
+		Mono<Integer> cached = new MonoCacheTime<>(Mono.error(exception),
+				Duration::ofSeconds,
+				t -> { throw new IllegalStateException("boom"); },
+				() -> Duration.ZERO,
+				Schedulers.parallel());
+
+		StepVerifier.create(cached)
+		            .expectErrorSatisfies(e -> assertThat(e)
+				            .isInstanceOf(IllegalStateException.class)
+				            .hasMessage("boom")
+				            .hasSuppressedException(exception))
+		            .verifyThenAssertThat()
+		            .hasNotDroppedElements()
+		            .hasDroppedErrorWithMessage("foo");
+	}
+
+	@Test
+	public void nextTtlGeneratorTransientFailure() {
+		AtomicInteger count = new AtomicInteger();
+
+		Mono<Integer> cached = new MonoCacheTime<>(Mono.fromCallable(count::incrementAndGet),
+				v -> {
+					if (v == 1) throw new IllegalStateException("transient");
+					return Duration.ofMillis(100 * v);
+				},
+				t -> Duration.ZERO,
+				() -> Duration.ZERO,
+				Schedulers.parallel());
+
+		StepVerifier.create(cached)
+		            .expectErrorSatisfies(e -> assertThat(e)
+				            .isInstanceOf(IllegalStateException.class)
+				            .hasMessage("transient")
+				            .hasNoSuppressedExceptions())
+		            .verifyThenAssertThat()
+		            .hasDropped(1)
+		            .hasNotDroppedErrors();
+
+		StepVerifier.create(cached)
+		            .expectNext(2)
+		            .expectComplete()
+		            .verifyThenAssertThat()
+		            .hasNotDroppedErrors()
+		            .hasNotDroppedElements();
+
+		assertThat(cached.block())
+				.as("cached after cache miss")
+				.isEqualTo(2);
+
+		assertThat(count).as("source invocations")
+		                 .hasValue(2);
+	}
+
+	@Test
+	public void emptyTtlGeneratorTransientFailure() {
+		AtomicInteger count = new AtomicInteger();
+
+		Mono<Integer> cached = new MonoCacheTime<>(Mono.empty(),
+				v -> Duration.ofSeconds(10),
+				t -> Duration.ofSeconds(10),
+				() -> {
+					if (count.incrementAndGet() == 1) throw new IllegalStateException("transient");
+					return Duration.ofMillis(100);
+				},
+				Schedulers.parallel());
+
+		StepVerifier.create(cached)
+		            .expectErrorSatisfies(e -> assertThat(e)
+				            .isInstanceOf(IllegalStateException.class)
+				            .hasMessage("transient")
+				            .hasNoSuppressedExceptions())
+		            .verifyThenAssertThat()
+		            .hasNotDroppedElements()
+		            .hasNotDroppedErrors();
+
+		StepVerifier.create(cached)
+		            .expectComplete()
+		            .verifyThenAssertThat()
+		            .hasNotDroppedErrors()
+		            .hasNotDroppedElements();
+
+		assertThat(cached.block())
+				.as("cached after cache miss")
+				.isNull();
+
+		assertThat(count).as("source invocations")
+		                 .hasValue(2);
+	}
+
+	@Test
+	public void errorTtlGeneratorTransientFailure() {
+		Throwable exception = new IllegalArgumentException("foo");
+		AtomicInteger count = new AtomicInteger();
+
+		Mono<Integer> cached = new MonoCacheTime<>(Mono.error(exception),
+				v -> Duration.ofSeconds(10),
+				t -> {
+					if (count.incrementAndGet() == 1) throw new IllegalStateException("transient");
+					return Duration.ofMillis(100);
+				},
+				() -> Duration.ZERO,
+				Schedulers.parallel());
+
+		StepVerifier.create(cached)
+		            .expectErrorSatisfies(e -> assertThat(e)
+				            .isInstanceOf(IllegalStateException.class)
+				            .hasMessage("transient")
+				            .hasSuppressedException(exception))
+		            .verifyThenAssertThat()
+		            .hasNotDroppedElements()
+		            .hasDroppedErrorWithMessage("foo");
+
+		StepVerifier.create(cached)
+		            .expectErrorSatisfies(e -> assertThat(e)
+				            .isInstanceOf(IllegalArgumentException.class)
+				            .hasMessage("foo"))
+		            .verifyThenAssertThat()
+		            .hasNotDroppedErrors()
+		            .hasNotDroppedElements();
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.as("cached after cache miss")
+				.isThrownBy(cached::block);
+
+		assertThat(count).as("source invocations")
+		                 .hasValue(2);
+	}
 
 	@Override
 	protected List<Scenario<String, String>> scenarios_operatorSuccess() {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
@@ -21,19 +21,16 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
 
 import org.junit.Test;
 import reactor.core.Disposable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.RaceTestUtils;
 import reactor.test.StepVerifier;
-import reactor.test.StepVerifierOptions;
 import reactor.test.publisher.MonoOperatorTest;
 import reactor.test.publisher.TestPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
@@ -244,10 +241,10 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 		Mono<Integer> cached = new MonoCacheTime<>(Mono.fromCallable(count::incrementAndGet),
 				v -> {
 					if (v == 1) throw new IllegalStateException("transient");
-					return Duration.ofMillis(100 * v);
+					return Duration.ofMillis(200 * v);
 				},
-				t -> Duration.ZERO,
-				() -> Duration.ZERO,
+				t -> Duration.ofSeconds(10),
+				() -> Duration.ofSeconds(10),
 				Schedulers.parallel());
 
 		StepVerifier.create(cached)
@@ -321,7 +318,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 					if (count.incrementAndGet() == 1) throw new IllegalStateException("transient");
 					return Duration.ofMillis(100);
 				},
-				() -> Duration.ZERO,
+				() -> Duration.ofSeconds(10),
 				Schedulers.parallel());
 
 		StepVerifier.create(cached)


### PR DESCRIPTION
this is advanced work in progress, but the semantics are still up for discussion. (edit: I also need to have a look at the failing tests, which didn't fail locally)