### PR TITLE
fix #1130 Add meaningful toString to FluxSink/MonoSink implementations

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
@@ -284,6 +284,11 @@ final class FluxCreate<T> extends Flux<T> {
 
 			return sink.scanUnsafe(key);
 		}
+
+		@Override
+		public String toString() {
+			return sink.toString();
+		}
 	}
 
 	/**
@@ -359,6 +364,11 @@ final class FluxCreate<T> extends Flux<T> {
 		public FluxSink<T> onDispose(Disposable d) {
 			sink.onDispose(d);
 			return this;
+		}
+
+		@Override
+		public String toString() {
+			return serializedSink != null ? serializedSink.toString() : baseSink.toString();
 		}
 	}
 
@@ -550,6 +560,11 @@ final class FluxCreate<T> extends Flux<T> {
 
 			return InnerProducer.super.scanUnsafe(key);
 		}
+
+		@Override
+		public String toString() {
+			return "FluxSink";
+		}
 	}
 
 	static final class IgnoreSink<T> extends BaseSink<T> {
@@ -575,6 +590,10 @@ final class FluxCreate<T> extends Flux<T> {
 			}
 		}
 
+		@Override
+		public String toString() {
+			return "FluxSink(" + OverflowStrategy.IGNORE + ")";
+		}
 	}
 
 	static abstract class NoOverflowBaseAsyncSink<T> extends BaseSink<T> {
@@ -614,6 +633,11 @@ final class FluxCreate<T> extends Flux<T> {
 			// nothing to do
 		}
 
+		@Override
+		public String toString() {
+			return "FluxSink(" + OverflowStrategy.DROP + ")";
+		}
+
 	}
 
 	static final class ErrorAsyncSink<T> extends NoOverflowBaseAsyncSink<T> {
@@ -625,6 +649,12 @@ final class FluxCreate<T> extends Flux<T> {
 		@Override
 		void onOverflow() {
 			error(Exceptions.failWithOverflow());
+		}
+
+
+		@Override
+		public String toString() {
+			return "FluxSink(" + OverflowStrategy.ERROR + ")";
 		}
 
 	}
@@ -771,6 +801,11 @@ final class FluxCreate<T> extends Flux<T> {
 
 			return super.scanUnsafe(key);
 		}
+
+		@Override
+		public String toString() {
+			return "FluxSink(" + OverflowStrategy.BUFFER + ")";
+		}
 	}
 
 	static final class LatestAsyncSink<T> extends BaseSink<T> {
@@ -914,6 +949,11 @@ final class FluxCreate<T> extends Flux<T> {
 			}
 
 			return super.scanUnsafe(key);
+		}
+
+		@Override
+		public String toString() {
+			return "FluxSink(" + OverflowStrategy.LATEST + ")";
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
@@ -368,7 +368,7 @@ final class FluxCreate<T> extends Flux<T> {
 
 		@Override
 		public String toString() {
-			return serializedSink != null ? serializedSink.toString() : baseSink.toString();
+			return baseSink.toString();
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
@@ -273,5 +273,9 @@ final class MonoCreate<T> extends Mono<T> {
 			}
 		}
 
+		@Override
+		public String toString() {
+			return "MonoSink";
+		}
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCreateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCreateTest.java
@@ -1211,7 +1211,6 @@ public class FluxCreateTest {
 
 	}
 
-
 	@Test
 	public void contextTest() {
 		StepVerifier.create(Flux.create(s -> IntStream.range(0, 10).forEach(i -> s.next(s
@@ -1235,6 +1234,91 @@ public class FluxCreateTest {
 		                        .subscriberContext(ctx -> ctx.put(AtomicInteger.class,
 				                        new AtomicInteger())))
 		            .expectNext(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void bufferSinkToString() {
+		StepVerifier.create(Flux.create(sink -> {
+			sink.next(sink.toString());
+			if (sink instanceof  SerializedSink) {
+				sink.next(((SerializedSink) sink).sink.toString());
+				sink.complete();
+			}
+			else {
+				sink.error(new IllegalArgumentException("expected SerializedSink"));
+			}
+		}, OverflowStrategy.BUFFER))
+		            .expectNext("FluxSink(BUFFER)")
+		            .expectNext("FluxSink(BUFFER)")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void dropSinkToString() {
+		StepVerifier.create(Flux.create(sink -> {
+			sink.next(sink.toString());
+			if (sink instanceof  SerializedSink) {
+				sink.next(((SerializedSink) sink).sink.toString());
+				sink.complete();
+			}
+			else {
+				sink.error(new IllegalArgumentException("expected SerializedSink"));
+			}
+		}, OverflowStrategy.DROP))
+		            .expectNext("FluxSink(DROP)")
+		            .expectNext("FluxSink(DROP)")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void ignoreSinkToString() {
+		StepVerifier.create(Flux.create(sink -> {
+			sink.next(sink.toString());
+			if (sink instanceof  SerializedSink) {
+				sink.next(((SerializedSink) sink).sink.toString());
+				sink.complete();
+			}
+			else {
+				sink.error(new IllegalArgumentException("expected SerializedSink"));
+			}
+		}, OverflowStrategy.IGNORE))
+		            .expectNext("FluxSink(IGNORE)")
+		            .expectNext("FluxSink(IGNORE)")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void errorSinkToString() {
+		StepVerifier.create(Flux.create(sink -> {
+			sink.next(sink.toString());
+			if (sink instanceof  SerializedSink) {
+				sink.next(((SerializedSink) sink).sink.toString());
+				sink.complete();
+			}
+			else {
+				sink.error(new IllegalArgumentException("expected SerializedSink"));
+			}
+		}, OverflowStrategy.ERROR))
+		            .expectNext("FluxSink(ERROR)")
+		            .expectNext("FluxSink(ERROR)")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void latestSinkToString() {
+		StepVerifier.create(Flux.create(sink -> {
+			sink.next(sink.toString());
+			if (sink instanceof  SerializedSink) {
+				sink.next(((SerializedSink) sink).sink.toString());
+				sink.complete();
+			}
+			else {
+				sink.error(new IllegalArgumentException("expected SerializedSink"));
+			}
+		}, OverflowStrategy.LATEST))
+		            .expectNext("FluxSink(LATEST)")
+		            .expectNext("FluxSink(LATEST)")
 		            .verifyComplete();
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCreateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCreateTest.java
@@ -308,5 +308,12 @@ public class MonoCreateTest {
 		            .expectNext(1)
 		            .verifyComplete();
 	}
+
+	@Test
+	public void sinkToString() {
+		StepVerifier.create(Mono.create(sink -> sink.success(sink.toString())))
+		            .expectNext("MonoSink")
+		            .verifyComplete();
+	}
 }
 


### PR DESCRIPTION
Base FluxSink variants in the form of `FluxSink(OverflowStrategy)`,
decorator sinks like SerializedSink defer to wrapped.