### PR TITLE
Improve tests in build: less verbosity, fix compiler warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -382,8 +382,6 @@ project('reactor-core') {
 	}
   }
 
-  sourceSets.test.resources.srcDirs = ["src/test/resources", "src/test/java"]
-
   if (!JavaVersion.current().isJava9Compatible()) {
 	test {
 	  jvmArgs = ["-Xbootclasspath/p:" + configurations.jsr166backport.asPath]

--- a/build.gradle
+++ b/build.gradle
@@ -181,9 +181,10 @@ configure(subprojects) { p ->
   // common exclusions, no scanning
   p.tasks.withType(Test).all {
 	testLogging {
-	  events "passed", "failed"
+	  events "FAILED"
 	  showExceptions true
-	  exceptionFormat "full"
+	  exceptionFormat "FULL"
+	  stackTraceFilters "ENTRY_POINT"
 	  maxGranularity 3
 	}
 	systemProperty("java.awt.headless", "true")

--- a/build.gradle
+++ b/build.gradle
@@ -174,7 +174,6 @@ configure(subprojects) { p ->
 	include '**/*Tests.*'
 	include '**/*Test.*'
 	include '**/*Spec.*'
-
   }
 
   //all test tasks will show FAILED/PASSED for each test method,
@@ -194,6 +193,17 @@ configure(subprojects) { p ->
 	scanForTestClasses = false
 	exclude '**/*Abstract*.*'
 	exclude '**/*OperatorTest*.*'
+
+	//allow re-run of failed tests only without special test tasks failing
+	// because the filter is too restrictive
+	filter.setFailOnNoMatchingTests(false)
+
+	//display intermediate results for special test tasks
+	afterSuite { desc, result ->
+	  if (!desc.parent) { // will match the outermost suite
+		println('\n' + "${desc} Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)")
+	  }
+	}
   }
 
   // now that kotlin-gradle-plugin 1.1.60 is out with fix for https://youtrack.jetbrains.com/issue/KT-17564

--- a/reactor-core/src/main/java/reactor/core/Scannable.java
+++ b/reactor-core/src/main/java/reactor/core/Scannable.java
@@ -226,8 +226,8 @@ public interface Scannable {
 				return null;
 			}
 			if (safeConverter == null) {
-				//noinspection unchecked
-				return (T) o;
+				@SuppressWarnings("unchecked") T t = (T) o;
+				return t;
 			}
 			return safeConverter.apply(o);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -4905,8 +4905,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return an indexed {@link Flux} with each source value combined with its 0-based index.
 	 */
 	public final Flux<Tuple2<Long, T>> index() {
-		//noinspection unchecked
-		return index(TUPLE2_BIFUNCTION);
+		return index(tuple2Function());
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxIndexFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxIndexFuseable.java
@@ -94,8 +94,9 @@ final class FluxIndexFuseable<T, I> extends FluxOperator<T, I>
 		@Override
 		public void onSubscribe(Subscription s) {
 			if (Operators.validate(this.s, s)) {
-				//noinspection unchecked
-				this.s = (QueueSubscription<T>) s;
+				@SuppressWarnings("unchecked")
+				QueueSubscription<T> qs = (QueueSubscription<T>) s;
+				this.s = qs;
 
 				actual.onSubscribe(this);
 			}
@@ -239,8 +240,9 @@ final class FluxIndexFuseable<T, I> extends FluxOperator<T, I>
 		@Override
 		public void onSubscribe(Subscription s) {
 			if (Operators.validate(this.s, s)) {
-				//noinspection unchecked
-				this.s = (QueueSubscription<T>) s;
+				@SuppressWarnings("unchecked")
+				QueueSubscription<T> qs = (QueueSubscription<T>) s;
+				this.s = qs;
 				actual.onSubscribe(this);
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMergeOrdered.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMergeOrdered.java
@@ -148,8 +148,12 @@ final class FluxMergeOrdered<T> extends Flux<T> implements Scannable {
 				Comparator<? super T> comparator, int prefetch, int n) {
 			this.actual = actual;
 			this.comparator = comparator;
-			//noinspection unchecked
-			this.subscribers = new MergeOrderedInnerSubscriber[n];
+
+			@SuppressWarnings("unchecked")
+			MergeOrderedInnerSubscriber<T>[] mergeOrderedInnerSub =
+					new MergeOrderedInnerSubscriber[n];
+			this.subscribers = mergeOrderedInnerSub;
+
 			for (int i = 0; i < n; i++) {
 				this.subscribers[i] = new MergeOrderedInnerSubscriber<>(this, prefetch);
 			}
@@ -276,8 +280,9 @@ final class FluxMergeOrdered<T> extends Flux<T> implements Scannable {
 						if (o != DONE) {
 							boolean smaller;
 							try {
-								//noinspection unchecked
-								smaller = min == null || comparator.compare(min, (T) o) > 0;
+								@SuppressWarnings("unchecked")
+								T t = (T) o;
+								smaller = min == null || comparator.compare(min, t) > 0;
 							} catch (Throwable ex) {
 								Exceptions.addThrowable(ERROR, this, ex);
 								cancel();
@@ -285,8 +290,9 @@ final class FluxMergeOrdered<T> extends Flux<T> implements Scannable {
 								return;
 							}
 							if (smaller) {
-								//noinspection unchecked
-								min = (T) o;
+								@SuppressWarnings("unchecked")
+								T t = (T) o;
+								min = t;
 								minIndex = i;
 							}
 						}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
@@ -301,8 +301,9 @@ final class FluxWindowWhen<T, U, V> extends FluxOperator<T, Flux<T>> {
 					}
 
 					for (UnicastProcessor<T> w : ws) {
-						//noinspection unchecked
-						w.onNext((T) o);
+						@SuppressWarnings("unchecked")
+						T t = (T) o;
+						w.onNext(t);
 					}
 				}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
@@ -51,14 +51,16 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
 		super(source);
 		this.ttl = ttl;
 		this.clock = clock;
-		//noinspection unchecked
-		this.state = (Signal<T>) EMPTY;
+		@SuppressWarnings("unchecked")
+		Signal<T> emptyState = (Signal<T>) EMPTY;
+		this.state = emptyState;
 	}
 
 	public void run() {
 		LOGGER.debug("expired {}", state);
-		//noinspection unchecked
-		state = (Signal<T>) EMPTY;
+		@SuppressWarnings("unchecked")
+		Signal<T> emptyState = (Signal<T>) EMPTY;
+		state = emptyState;
 	}
 
 	@Override
@@ -115,9 +117,9 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
 		static final AtomicReferenceFieldUpdater<CoordinatorSubscriber, Operators.MonoSubscriber[]> SUBSCRIBERS =
 				AtomicReferenceFieldUpdater.newUpdater(CoordinatorSubscriber.class, Operators.MonoSubscriber[].class, "subscribers");
 
+		@SuppressWarnings("unchecked")
 		CoordinatorSubscriber(MonoCacheTime<T> main) {
 			this.main = main;
-			//noinspection unchecked
 			this.subscribers = EMPTY;
 		}
 
@@ -173,7 +175,7 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
 					return false;
 				}
 				int n = a.length;
-				//noinspection unchecked
+				@SuppressWarnings("unchecked")
 				Operators.MonoSubscriber<T, T>[] b = new Operators.MonoSubscriber[n + 1];
 				System.arraycopy(a, 0, b, 0, n);
 				b[n] = toAdd;
@@ -229,12 +231,12 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
 			}
 		}
 
+		@SuppressWarnings("unchecked")
 		private void signalCached(Signal<T> signal) {
 			if (STATE.compareAndSet(main, this, signal)) {
 				main.clock.schedule(main, main.ttl.toMillis(), TimeUnit.MILLISECONDS);
 			}
 
-			//noinspection unchecked
 			for (Operators.MonoSubscriber<T, T> inner : SUBSCRIBERS.getAndSet(this, TERMINATED)) {
 				if (signal.isOnNext()) {
 					inner.complete(signal.get());

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -556,7 +556,7 @@ public final class MonoProcessor<O> extends Mono<O>
 		return out;
 	}
 
-	@SuppressWarnings("rawtypes")
+	@SuppressWarnings({"rawtypes", "unchecked"})
     final static class NoopProcessor extends FluxProcessor {
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/OnNextFailureStrategy.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/OnNextFailureStrategy.java
@@ -240,11 +240,11 @@ interface OnNextFailureStrategy extends BiFunction<Throwable, Object, Throwable>
 		private final BiFunction<? super Throwable, Object, ? extends Throwable> delegateProcessor;
 		private final BiPredicate<? super Throwable, Object> delegatePredicate;
 
+		@SuppressWarnings("unchecked")
 		public LambdaOnNextErrorStrategy(
 				BiFunction<? super Throwable, Object, ? extends Throwable> delegateProcessor) {
 			this.delegateProcessor = delegateProcessor;
 			if (delegateProcessor instanceof BiPredicate) {
-				//noinspection unchecked
 				this.delegatePredicate = (BiPredicate<? super Throwable, Object>) delegateProcessor;
 			}
 			else {

--- a/reactor-core/src/main/java/reactor/core/publisher/Signal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Signal.java
@@ -44,7 +44,7 @@ public interface Signal<T> extends Supplier<T>, Consumer<Subscriber<? super T>> 
 	 *
 	 * @return an {@code OnCompleted} variety of {@code Signal}
 	 */
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"deprecation", "unchecked"})
 	static <T> Signal<T> complete() {
 		return (Signal<T>) ImmutableSignal.ON_COMPLETE;
 	}
@@ -58,9 +58,9 @@ public interface Signal<T> extends Supplier<T>, Consumer<Subscriber<? super T>> 
 	 *
 	 * @return an {@code OnCompleted} variety of {@code Signal}
 	 */
+	@SuppressWarnings({"deprecation", "unchecked"})
 	static <T> Signal<T> complete(Context context) {
 		if (context.isEmpty()) {
-			//noinspection unchecked
 			return (Signal<T>) ImmutableSignal.ON_COMPLETE;
 		}
 		return new ImmutableSignal<>(context, SignalType.ON_COMPLETE, null, null, null);
@@ -158,6 +158,7 @@ public interface Signal<T> extends Supplier<T>, Consumer<Subscriber<? super T>> 
 	 * @param o the object to check
 	 * @return true if object represents the completion signal
 	 */
+	@SuppressWarnings("deprecation")
 	static boolean isComplete(Object o) {
 		return o == ImmutableSignal.ON_COMPLETE ||
 				(o instanceof Signal && ((Signal) o).getType() == SignalType.ON_COMPLETE);

--- a/reactor-core/src/test/java/reactor/core/ScannableTest.java
+++ b/reactor-core/src/test/java/reactor/core/ScannableTest.java
@@ -18,6 +18,7 @@ package reactor.core;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.assertj.core.api.Condition;
 import org.junit.Test;
@@ -206,10 +207,12 @@ public class ScannableTest {
 		                               .tag("2", "Two")
 		                               .hide();
 
-		assertThat(Scannable.from(tagged1).tags())
+		final Stream<Tuple2<String, String>> scannedTags1 = Scannable.from(tagged1).tags();
+		assertThat(scannedTags1.iterator())
 				.containsExactlyInAnyOrder(Tuples.of("1", "One"));
 
-		assertThat(Scannable.from(tagged2).tags())
+		final Stream<Tuple2<String, String>> scannedTags2 = Scannable.from(tagged2).tags();
+		assertThat(scannedTags2.iterator())
 				.containsExactlyInAnyOrder(Tuples.of("1", "One"), Tuples.of( "2", "Two"));
 	}
 
@@ -225,10 +228,12 @@ public class ScannableTest {
 		                               .tag("2", "Two")
 		                               .hide();
 
-		assertThat(Scannable.from(tagged1).tags())
+		final Stream<Tuple2<String, String>> scannedTags1 = Scannable.from(tagged1).tags();
+		assertThat(scannedTags1.iterator())
 				.containsExactlyInAnyOrder(Tuples.of("1", "One"));
 
-		assertThat(Scannable.from(tagged2).tags())
+		final Stream<Tuple2<String, String>> scannedTags2 = Scannable.from(tagged2).tags();
+		assertThat(scannedTags2.iterator())
 				.containsExactlyInAnyOrder(Tuples.of("1", "One"), Tuples.of( "2", "Two"));
 	}
 
@@ -239,7 +244,8 @@ public class ScannableTest {
 				    .tag("1", "One")
 				    .tag("2", "Two");
 
-		assertThat(Scannable.from(tagged1).tags())
+		final Stream<Tuple2<String, String>> scannedTags = Scannable.from(tagged1).tags();
+		assertThat(scannedTags.iterator())
 				.containsExactlyInAnyOrder(Tuples.of("1", "One"), Tuples.of( "2", "Two"));
 	}
 
@@ -251,7 +257,8 @@ public class ScannableTest {
 				    .tag("1", "One")
 				    .tag("2", "Two");
 
-		assertThat(Scannable.from(tagged1).tags())
+		final Stream<Tuple2<String, String>> scannedTags = Scannable.from(tagged1).tags();
+		assertThat(scannedTags.iterator())
 				.containsExactlyInAnyOrder(Tuples.of("1", "One"), Tuples.of( "2", "Two"));
 	}
 
@@ -337,10 +344,12 @@ public class ScannableTest {
 		                               .tag("2", "Two")
 		                               .hide();
 
-		assertThat(Scannable.from(tagged1).tags())
+		final Stream<Tuple2<String, String>> scannedTags1 = Scannable.from(tagged1).tags();
+		assertThat(scannedTags1.iterator())
 				.containsExactlyInAnyOrder(Tuples.of("1", "One"));
 
-		assertThat(Scannable.from(tagged2).tags())
+		final Stream<Tuple2<String, String>> scannedTags2 = Scannable.from(tagged2).tags();
+		assertThat(scannedTags2.iterator())
 				.containsExactlyInAnyOrder(Tuples.of("1", "One"), Tuples.of( "2", "Two"));
 	}
 
@@ -356,10 +365,12 @@ public class ScannableTest {
 		                               .tag("2", "Two")
 		                               .hide();
 
-		assertThat(Scannable.from(tagged1).tags())
+		final Stream<Tuple2<String, String>> scannedTags1 = Scannable.from(tagged1).tags();
+		assertThat(scannedTags1.iterator())
 				.containsExactlyInAnyOrder(Tuples.of("1", "One"));
 
-		assertThat(Scannable.from(tagged2).tags())
+		final Stream<Tuple2<String, String>> scannedTags2 = Scannable.from(tagged2).tags();
+		assertThat(scannedTags2.iterator())
 				.containsExactlyInAnyOrder(Tuples.of("1", "One"), Tuples.of( "2", "Two"));
 	}
 
@@ -370,7 +381,8 @@ public class ScannableTest {
 				    .tag("1", "One")
 				    .tag("2", "Two");
 
-		assertThat(Scannable.from(tagged1).tags())
+		final Stream<Tuple2<String, String>> scannedTags = Scannable.from(tagged1).tags();
+		assertThat(scannedTags.iterator())
 				.containsExactlyInAnyOrder(Tuples.of("1", "One"), Tuples.of( "2", "Two"));
 	}
 
@@ -382,7 +394,8 @@ public class ScannableTest {
 				    .tag("1", "One")
 				    .tag("2", "Two");
 
-		assertThat(Scannable.from(tagged1).tags())
+		final Stream<Tuple2<String, String>> scannedTags = Scannable.from(tagged1).tags();
+		assertThat(scannedTags.iterator())
 				.containsExactlyInAnyOrder(Tuples.of("1", "One"), Tuples.of( "2", "Two"));
 	}
 
@@ -436,10 +449,11 @@ public class ScannableTest {
 		                               .tag("2", "Two")
 		                               .hide();
 
-		assertThat(Scannable.from(tagged1).tags())
-				.containsExactlyInAnyOrder(Tuples.of("1", "One"));
+		Stream<Tuple2<String, String>> scannedTags1 = Scannable.from(tagged1).tags();
+		assertThat(scannedTags1.iterator()).containsExactlyInAnyOrder(Tuples.of("1", "One"));
 
-		assertThat(Scannable.from(tagged2).tags())
+		Stream<Tuple2<String, String>> scannedTags2 = Scannable.from(tagged2).tags();
+		assertThat(scannedTags2.iterator())
 				.containsExactlyInAnyOrder(Tuples.of("1", "One"), Tuples.of( "2", "Two"));
 	}
 
@@ -450,7 +464,8 @@ public class ScannableTest {
 				    .tag("1", "One")
 				    .tag("2", "Two");
 
-		assertThat(Scannable.from(tagged1).tags())
+		final Stream<Tuple2<String, String>> scannedTags = Scannable.from(tagged1).tags();
+		assertThat(scannedTags.iterator())
 				.containsExactlyInAnyOrder(Tuples.of("1", "One"), Tuples.of( "2", "Two"));
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/EventLoopProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EventLoopProcessorTest.java
@@ -143,6 +143,7 @@ public class EventLoopProcessorTest {
 				e.printStackTrace();
 			}
 		});
+		@SuppressWarnings("deprecation")
 		boolean shutResult = test.awaitAndShutdown(1000, TimeUnit.NANOSECONDS);
 		assertThat(test.executor)
 				.isNotNull()
@@ -172,6 +173,7 @@ public class EventLoopProcessorTest {
 				.when(executor).awaitTermination(anyLong(), any());
 		EventLoopProcessor<String> interruptingProcessor = initProcessor(executor);
 
+		@SuppressWarnings("deprecation")
 		boolean result = interruptingProcessor.awaitAndShutdown(100, TimeUnit.MILLISECONDS);
 
 		assertThat(Thread.currentThread().isInterrupted()).as("interrupted").isTrue();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatArrayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatArrayTest.java
@@ -261,7 +261,8 @@ public class FluxConcatArrayTest {
 
 	@Test
 	public void scanOperator() {
-		FluxConcatArray s = new FluxConcatArray<>(true);
+		@SuppressWarnings("unchecked") //vararg of Publisher<String>
+		FluxConcatArray<String> s = new FluxConcatArray<>(true, Flux.empty());
 		assertThat(s.scan(Scannable.Attr.DELAY_ERROR)).as("delayError").isTrue();
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctTest.java
@@ -415,6 +415,7 @@ public class FluxDistinctTest extends FluxOperatorTest<String, String> {
 	public void distinctPredicateThrowsConditional() {
 		IllegalStateException error = new IllegalStateException("forced failure");
 
+		@SuppressWarnings("unchecked")
 		Fuseable.ConditionalSubscriber<Integer> actualConditional = Mockito.mock(Fuseable.ConditionalSubscriber.class);
 		when(actualConditional.currentContext()).thenReturn(Context.empty());
 		when(actualConditional.tryOnNext(anyInt())).thenReturn(false);
@@ -436,6 +437,7 @@ public class FluxDistinctTest extends FluxOperatorTest<String, String> {
 	public void distinctPredicateThrowsConditionalOnNext() {
 		IllegalStateException error = new IllegalStateException("forced failure");
 
+		@SuppressWarnings("unchecked")
 		Fuseable.ConditionalSubscriber<Integer> actualConditional = Mockito.mock(Fuseable.ConditionalSubscriber.class);
 		when(actualConditional.currentContext()).thenReturn(Context.empty());
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxJustTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxJustTest.java
@@ -90,7 +90,7 @@ public class FluxJustTest {
 
     @Test
     public void scanOperator() {
-    	FluxJust s = new FluxJust("foo");
+    	FluxJust<String> s = new FluxJust<>("foo");
     	assertThat(s.scan(Scannable.Attr.BUFFERED)).isEqualTo(1);
     }
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
@@ -290,6 +290,8 @@ public class FluxMergeOrderedTest {
 	public void scanOperator() {
 		Flux<Integer> source1 = Flux.just(1).map(Function.identity()); //scannable
 		Flux<Integer> source2 = Flux.just(2);
+
+		@SuppressWarnings("unchecked") //safe varargs
 		Scannable fmo = new FluxMergeOrdered<>(123, Queues.small(), Comparator.naturalOrder(), source1, source2);
 
 		assertThat(fmo.scan(Scannable.Attr.PARENT)).isSameAs(source1);
@@ -364,7 +366,11 @@ public class FluxMergeOrderedTest {
 				new FluxMergeOrdered.MergeOrderedMainProducer<>(actual, Comparator.naturalOrder(), 123, 4);
 
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> test.subscribe(new Publisher[3]))
+				.isThrownBy(() -> {
+					@SuppressWarnings("unchecked")
+					final Publisher<Integer>[] sources = new Publisher[3];
+					test.subscribe(sources);
+				})
 				.withMessage("must subscribe with 4 sources");
 	}
 
@@ -405,6 +411,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void normal1() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.just(1), Flux.just(2))
@@ -414,6 +421,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void normal2() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.just(1, 3, 5, 7), Flux.just(2, 4, 6, 8))
@@ -423,6 +431,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void normal3() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.just(1, 3, 5, 7), Flux.just(2, 4, 6))
@@ -432,6 +441,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void normal4() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.just(1, 3, 5, 7), Flux.just(1, 3, 5, 7))
@@ -441,6 +451,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void normal1Hidden() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.just(1).hide(), Flux.just(2).hide())
@@ -450,6 +461,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void normal2Hidden() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.just(1, 3, 5, 7).hide(), Flux.just(2, 4, 6, 8).hide())
@@ -459,6 +471,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void normal3Hidden() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.just(1, 3, 5, 7).hide(), Flux.just(2, 4, 6).hide())
@@ -468,6 +481,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void normal4Hidden() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.just(1, 3, 5, 7).hide(), Flux.just(1, 3, 5, 7).hide())
@@ -477,6 +491,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void backpressure1() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.just(1, 3, 5, 7), Flux.just(2, 4, 6, 8))
@@ -487,6 +502,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void backpressure2() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.just(1), Flux.just(2))
@@ -497,6 +513,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void backpressure3() {
 		new FluxMergeOrdered<>(1, Queues.small(), Comparator.naturalOrder(),
 				Flux.just(1, 3, 5, 7), Flux.just(2, 4, 6, 8))
@@ -507,6 +524,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void take() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.just(1, 3, 5, 7), Flux.just(2, 4, 6, 8))
@@ -517,6 +535,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void firstErrorsDelayed() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.error(new IOException("boom")),
@@ -527,6 +546,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void firstErrorsBackpressuredDelayed() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.error(new IOException("boom")),
@@ -538,6 +558,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void secondErrorsDelayed() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.just(1, 3, 5, 7),
@@ -549,6 +570,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void secondErrorsBackpressuredDelayed() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.just(1, 3, 5, 7),
@@ -584,6 +606,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void fusedThrowsInDrainLoopDelayed() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.just(1).map(v -> { throw new IllegalArgumentException("boom"); }),
@@ -594,6 +617,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void fusedThrowsInPostEmissionCheckDelayed() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.just(1).map(v -> { throw new IllegalArgumentException("boom"); }),
@@ -605,6 +629,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void nullSecond() {
 		FluxMergeOrdered<Integer> test = new FluxMergeOrdered<>(2, Queues.small(),
 				Comparator.naturalOrder(),
@@ -615,6 +640,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void nullFirst() {
 		FluxMergeOrdered<Integer> test = new FluxMergeOrdered<>(2, Queues.small(),
 				Comparator.naturalOrder(),
@@ -625,6 +651,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void comparatorThrows() {
 		new FluxMergeOrdered<>(2, Queues.small(),
 				(a, b) -> { throw new IllegalArgumentException("boom"); },
@@ -634,6 +661,7 @@ public class FluxMergeOrderedTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked") //safe varargs
 	public void naturalOrder() {
 		new FluxMergeOrdered<>(2, Queues.small(), Comparator.naturalOrder(),
 				Flux.just(1), Flux.just(2))

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
@@ -264,6 +264,7 @@ public class FluxMergeOrderedTest {
 	@Test
 	public void mergeAdditionalSource() {
 		Comparator<Integer> originalComparator = Comparator.naturalOrder();
+		@SuppressWarnings("unchecked")
 		FluxMergeOrdered<Integer> fmo = new FluxMergeOrdered<>(2,
 				Queues.small(),
 				originalComparator,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxNameFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxNameFuseableTest.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.junit.Test;
 import reactor.core.Scannable;
@@ -45,7 +46,9 @@ public class FluxNameFuseableTest {
 		assertThat(test.scan(Scannable.Attr.NAME)).isEqualTo("foo");
 
 		//noinspection unchecked
-		assertThat(test.scan(Scannable.Attr.TAGS)).containsExactlyInAnyOrder(tag1, tag2);
+		final Stream<Tuple2<String, String>> scannedTags = test.scan(Scannable.Attr.TAGS);
+		assertThat(scannedTags).isNotNull();
+		assertThat(scannedTags.iterator()).containsExactlyInAnyOrder(tag1, tag2);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxNameTest.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.junit.Test;
 import reactor.core.Scannable;
@@ -44,8 +45,9 @@ public class FluxNameTest {
 
 		assertThat(test.scan(Scannable.Attr.NAME)).isEqualTo("foo");
 
-		//noinspection unchecked
-		assertThat(test.scan(Scannable.Attr.TAGS)).containsExactlyInAnyOrder(tag1, tag2);
+		final Stream<Tuple2<String, String>> scannedTags = test.scan(Scannable.Attr.TAGS);
+		assertThat(scannedTags).isNotNull();
+		assertThat(scannedTags.iterator()).containsExactlyInAnyOrder(tag1, tag2);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferTimeoutTest.java
@@ -311,7 +311,7 @@ public class FluxOnBackpressureBufferTimeoutTest implements Consumer<Object> {
 	@Test
 	public void scanSubscriber() {
 		CoreSubscriber<String> actual = new LambdaSubscriber<>(null, null, null, null);
-		BackpressureBufferTimeoutSubscriber test = new BackpressureBufferTimeoutSubscriber<>(actual, Duration.ofSeconds(1), Schedulers.immediate(), 123, v -> {});
+		BackpressureBufferTimeoutSubscriber<String> test = new BackpressureBufferTimeoutSubscriber<>(actual, Duration.ofSeconds(1), Schedulers.immediate(), 123, v -> {});
 		Subscription s = Operators.emptySubscription();
 		test.onSubscribe(s);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxStreamTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxStreamTest.java
@@ -36,7 +36,7 @@ public class FluxStreamTest {
 	@SuppressWarnings("ConstantConditions")
 	@Test(expected = NullPointerException.class)
 	public void nullStream() {
-		Flux.fromStream((Stream) null);
+		Flux.fromStream((Stream<?>) null);
 	}
 
 	@SuppressWarnings("ConstantConditions")

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
@@ -128,9 +128,9 @@ public class FluxWindowWhenTest {
 		System.gc();
 		Thread.sleep(500);
 
-		assertThat(windows.get())
+		assertThat(windows.get().size())
 				.as("no window retained")
-				.isEmpty();
+				.isZero();
 		assertThat(finalized.longValue())
 				.as("final GC collects all")
 				.isEqualTo(created.longValue());

--- a/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
@@ -610,8 +610,10 @@ public class HooksTest {
 		AtomicReference<Publisher> hook = new AtomicReference<>();
 		AtomicReference<Object> hook2 = new AtomicReference<>();
 		Hooks.onEachOperator(h -> {
-			hook.set(TestPublisher.create().flux());
-			return hook.get();
+			Flux<Object> publisher = TestPublisher.create()
+			                                      .flux();
+			hook.set(publisher);
+			return publisher;
 		});
 		Hooks.onEachOperator(h -> {
 			hook2.set(h);
@@ -627,8 +629,9 @@ public class HooksTest {
 		hook2.set(null);
 
 		Hooks.onLastOperator(h -> {
-			hook.set(TestPublisher.create().flux());
-			return hook.get();
+			final Flux<Object> publisher = TestPublisher.create().flux();
+			hook.set(publisher);
+			return publisher;
 		});
 		Hooks.onLastOperator(h -> {
 			hook2.set(h);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNameFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNameFuseableTest.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.junit.Test;
 import reactor.core.Scannable;
@@ -44,8 +45,9 @@ public class MonoNameFuseableTest {
 
 		assertThat(test.scan(Scannable.Attr.NAME)).isEqualTo("foo");
 
-		//noinspection unchecked
-		assertThat(test.scan(Scannable.Attr.TAGS)).containsExactlyInAnyOrder(tag1, tag2);
+		final Stream<Tuple2<String, String>> scannedTags = test.scan(Scannable.Attr.TAGS);
+		assertThat(scannedTags).isNotNull();
+		assertThat(scannedTags.iterator()).containsExactlyInAnyOrder(tag1, tag2);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNameTest.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.junit.Test;
 import reactor.core.Scannable;
@@ -44,8 +45,9 @@ public class MonoNameTest {
 
 		assertThat(test.scan(Scannable.Attr.NAME)).isEqualTo("foo");
 
-		//noinspection unchecked
-		assertThat(test.scan(Scannable.Attr.TAGS)).containsExactlyInAnyOrder(tag1, tag2);
+		final Stream<Tuple2<String, String>> scannedTags = test.scan(Scannable.Attr.TAGS);
+		assertThat(scannedTags).isNotNull();
+		assertThat(scannedTags.iterator()).containsExactlyInAnyOrder(tag1, tag2);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/OnNextFailureStrategyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnNextFailureStrategyTest.java
@@ -771,6 +771,7 @@ public class OnNextFailureStrategyTest {
 
 	@Test
 	public void errorStrategyConfiguredInFlatMapDoesNotLeak() {
+		@SuppressWarnings("divzero")
 		Flux<Integer> test = Flux.just(0, 1, 2)
 				.map(i -> i / 0)
 				.flatMap(i -> Flux.just(i).errorStrategyContinue());

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxNameTest.java
@@ -17,7 +17,9 @@
 package reactor.core.publisher;
 
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.junit.Test;
 import reactor.core.Scannable;
@@ -56,8 +58,9 @@ public class ParallelFluxNameTest {
 
 		assertThat(test.scan(Scannable.Attr.NAME)).isEqualTo("foo");
 
-		//noinspection unchecked
-		assertThat(test.scan(Scannable.Attr.TAGS)).containsExactlyInAnyOrder(tag1, tag2);
+		final Stream<Tuple2<String, String>> scannedTags = test.scan(Scannable.Attr.TAGS);
+		assertThat(scannedTags).isNotNull();
+		assertThat(scannedTags.iterator()).containsExactlyInAnyOrder(tag1, tag2);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelReduceSeedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelReduceSeedTest.java
@@ -259,7 +259,10 @@ public class ParallelReduceSeedTest extends ParallelOperatorTest<String, String>
 		ParallelReduceSeed.ParallelReduceSeedSubscriber<Integer, String> test = new ParallelReduceSeed.ParallelReduceSeedSubscriber<>(
 				subscriber, "", (s, i) -> s + i);
 
-		source.subscribe(new CoreSubscriber[] { test });
+		@SuppressWarnings("unchecked")
+		final CoreSubscriber<Integer>[] testSubscribers = new CoreSubscriber[1];
+		testSubscribers[0] = test;
+		source.subscribe(testSubscribers);
 
 		assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelSourceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelSourceTest.java
@@ -45,6 +45,7 @@ public class ParallelSourceTest {
 
 	@Test
 	public void scanMainSubscriber() {
+		@SuppressWarnings("unchecked")
 		CoreSubscriber<String>[] subs = new CoreSubscriber[1];
 		subs[0] = new LambdaSubscriber<>(null, e -> {}, null, null);
 		ParallelSource.ParallelSourceMain<String> test = new ParallelSource.ParallelSourceMain<>(
@@ -75,6 +76,7 @@ public class ParallelSourceTest {
 
 	@Test
 	public void scanInnerSubscriber() {
+		@SuppressWarnings("unchecked")
 		CoreSubscriber<String>[] subs = new CoreSubscriber[2];
 		subs[0] = new LambdaSubscriber<>(null, e -> {}, null, null);
 		subs[1] = new LambdaSubscriber<>(null, e -> {}, null, null);

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -1108,7 +1108,7 @@ public class SchedulersTest {
 		}
 
 		@Override
-		public void close() throws Exception {
+		public void close() {
 			shutdown();
 		}
 	}

--- a/reactor-core/src/test/java/reactor/core/scheduler/WorkerTaskTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/WorkerTaskTest.java
@@ -19,6 +19,7 @@ package reactor.core.scheduler;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -295,10 +296,10 @@ public class WorkerTaskTest {
 		final WorkerTask run = new WorkerTask(() -> {}, null);
 
 		run.run();
-		assertThat(WorkerTask.FUTURE.get(run)).isEqualTo(WorkerTask.FINISHED);
+		assertThat((Future<?>) WorkerTask.FUTURE.get(run)).isEqualTo(WorkerTask.FINISHED);
 
 		run.dispose();
-		assertThat(WorkerTask.FUTURE.get(run)).isEqualTo(WorkerTask.FINISHED);
+		assertThat((Future<?>) WorkerTask.FUTURE.get(run)).isEqualTo(WorkerTask.FINISHED);
 	}
 
 	@Test
@@ -307,11 +308,11 @@ public class WorkerTaskTest {
 		WorkerTask.THREAD.set(run, Thread.currentThread());
 
 		run.dispose();
-		assertThat(WorkerTask.FUTURE.get(run)).isEqualTo(WorkerTask.SYNC_CANCELLED);
+		assertThat((Future<?>) WorkerTask.FUTURE.get(run)).isEqualTo(WorkerTask.SYNC_CANCELLED);
 		run.dispose();
-		assertThat(WorkerTask.FUTURE.get(run)).isEqualTo(WorkerTask.SYNC_CANCELLED);
+		assertThat((Future<?>) WorkerTask.FUTURE.get(run)).isEqualTo(WorkerTask.SYNC_CANCELLED);
 		run.run();
-		assertThat(WorkerTask.FUTURE.get(run)).isEqualTo(WorkerTask.SYNC_CANCELLED);
+		assertThat((Future<?>) WorkerTask.FUTURE.get(run)).isEqualTo(WorkerTask.SYNC_CANCELLED);
 	}
 
 	@Test
@@ -319,11 +320,16 @@ public class WorkerTaskTest {
 		final WorkerTask run = new WorkerTask(() -> {}, null);
 
 		run.dispose();
-		assertThat(WorkerTask.FUTURE.get(run)).isEqualTo(WorkerTask.ASYNC_CANCELLED);
+		assertThat((Future<?>) WorkerTask.FUTURE.get(run))
+				.isEqualTo(WorkerTask.ASYNC_CANCELLED);
+
 		run.dispose();
-		assertThat(WorkerTask.FUTURE.get(run)).isEqualTo(WorkerTask.ASYNC_CANCELLED);
+		assertThat((Future<?>) WorkerTask.FUTURE.get(run))
+				.isEqualTo(WorkerTask.ASYNC_CANCELLED);
+
 		run.run();
-		assertThat(WorkerTask.FUTURE.get(run)).isEqualTo(WorkerTask.ASYNC_CANCELLED);
+		assertThat((Future<?>) WorkerTask.FUTURE.get(run))
+				.isEqualTo(WorkerTask.ASYNC_CANCELLED);
 	}
 
 

--- a/reactor-core/src/test/java/reactor/test/publisher/OperatorScenario.java
+++ b/reactor-core/src/test/java/reactor/test/publisher/OperatorScenario.java
@@ -48,10 +48,11 @@ public class OperatorScenario<I, PI extends Publisher<? extends I>, O, PO extend
 	int              producing                            = -1;
 	int              demand                               = -1;
 	IntFunction<? extends I> producingMapper;
-	Consumer<? super O>[]          receivers      = null;
-	O[]                            receiverValues = null;
-	String                         description    = null;
-	Consumer<StepVerifier.Step<O>> verifier       = null;
+
+	@Nullable Consumer<? super O>[]          receivers      = null;
+	@Nullable O[]                            receiverValues = null;
+	@Nullable String                         description    = null;
+	@Nullable Consumer<StepVerifier.Step<O>> verifier       = null;
 
 	OperatorScenario(@Nullable Function<PI, ? extends PO> body, @Nullable Exception stack) {
 		this.body = body;
@@ -138,6 +139,7 @@ public class OperatorScenario<I, PI extends Publisher<? extends I>, O, PO extend
 		return this;
 	}
 
+	@SuppressWarnings("unchecked")
 	public OperatorScenario<I, PI, O, PO> receive(Consumer<? super O>... receivers) {
 		this.receivers = Objects.requireNonNull(receivers, "receivers");
 		if (this.demand != 0 && this.demand < receivers.length) {
@@ -162,6 +164,7 @@ public class OperatorScenario<I, PI extends Publisher<? extends I>, O, PO extend
 		return receiveValues(receivers);
 	}
 
+	@SuppressWarnings("unchecked")
 	public OperatorScenario<I, PI, O, PO> receiveValues(O... receivers) {
 		this.receiverValues = Objects.requireNonNull(receivers, "receivers");
 		if (this.demand != 0 && this.demand < receivers.length) {

--- a/reactor-core/src/test/java/reactor/test/publisher/ParallelOperatorTest.java
+++ b/reactor-core/src/test/java/reactor/test/publisher/ParallelOperatorTest.java
@@ -231,14 +231,13 @@ public abstract class ParallelOperatorTest<I, O>
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	protected ParallelFlux<I> sourceScalar(OperatorScenario<I, ParallelFlux<I>, O, ParallelFlux<O>> scenario) {
 		if(scenario.producerCount() == 0){
-			return (ParallelFlux<I>)Flux.empty()
-			                            .parallel(4);
+			return Flux.<I>empty()
+					.parallel(4);
 		}
-		return (ParallelFlux<I>)Flux.just(scenario.producingMapper.apply(0))
-		                            .parallel(4);
+		return Flux.<I>just(scenario.producingMapper.apply(0))
+				.parallel(4);
 	}
 
 	@Override

--- a/reactor-core/src/test/java/reactor/util/context/Context1Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context1Test.java
@@ -72,8 +72,8 @@ public class Context1Test {
 	}
 
 	@Test
-	public void get() throws Exception {
-		assertThat((Object) c.get(1)).isEqualTo("A"); //TODO meh, necessary cast to Object
+	public void get() {
+		assertThat((String) c.get(1)).isEqualTo("A");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/context/Context2Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context2Test.java
@@ -93,10 +93,9 @@ public class Context2Test {
 	}
 
 	@Test
-	public void get() throws Exception {
-		//TODO meh, necessary cast to Object
-		assertThat((Object) c.get(1)).isEqualTo("A");
-		assertThat((Object) c.get(2)).isEqualTo("B");
+	public void get() {
+		assertThat((String) c.get(1)).isEqualTo("A");
+		assertThat((String) c.get(2)).isEqualTo("B");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/context/Context3Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context3Test.java
@@ -116,11 +116,10 @@ public class Context3Test {
 	}
 
 	@Test
-	public void get() throws Exception {
-		//TODO meh, necessary cast to Object
-		assertThat((Object) c.get(1)).isEqualTo("A");
-		assertThat((Object) c.get(2)).isEqualTo("B");
-		assertThat((Object) c.get(3)).isEqualTo("C");
+	public void get() {
+		assertThat((String) c.get(1)).isEqualTo("A");
+		assertThat((String) c.get(2)).isEqualTo("B");
+		assertThat((String) c.get(3)).isEqualTo("C");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/context/Context4Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context4Test.java
@@ -141,12 +141,11 @@ public class Context4Test {
 	}
 
 	@Test
-	public void get() throws Exception {
-		//TODO meh, necessary cast to Object
-		assertThat((Object) c.get(1)).isEqualTo("A");
-		assertThat((Object) c.get(2)).isEqualTo("B");
-		assertThat((Object) c.get(3)).isEqualTo("C");
-		assertThat((Object) c.get(4)).isEqualTo("D");
+	public void get() {
+		assertThat((String) c.get(1)).isEqualTo("A");
+		assertThat((String) c.get(2)).isEqualTo("B");
+		assertThat((String) c.get(3)).isEqualTo("C");
+		assertThat((String) c.get(4)).isEqualTo("D");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/context/Context5Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context5Test.java
@@ -170,13 +170,12 @@ public class Context5Test {
 	}
 
 	@Test
-	public void get() throws Exception {
-		//TODO meh, necessary cast to Object
-		assertThat((Object) c.get(1)).isEqualTo("A");
-		assertThat((Object) c.get(2)).isEqualTo("B");
-		assertThat((Object) c.get(3)).isEqualTo("C");
-		assertThat((Object) c.get(4)).isEqualTo("D");
-		assertThat((Object) c.get(5)).isEqualTo("E");
+	public void get() {
+		assertThat((String) c.get(1)).isEqualTo("A");
+		assertThat((String) c.get(2)).isEqualTo("B");
+		assertThat((String) c.get(3)).isEqualTo("C");
+		assertThat((String) c.get(4)).isEqualTo("D");
+		assertThat((String) c.get(5)).isEqualTo("E");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/context/ContextNTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextNTest.java
@@ -227,13 +227,13 @@ public class ContextNTest {
 	}
 
 	@Test
-	public void get() throws Exception {
-		assertThat((Object) c.get(1)).isEqualTo("A");
-		assertThat((Object) c.get(2)).isEqualTo("B");
-		assertThat((Object) c.get(3)).isEqualTo("C");
-		assertThat((Object) c.get(4)).isEqualTo("D");
-		assertThat((Object) c.get(5)).isEqualTo("E");
-		assertThat((Object) c.get(6)).isEqualTo("F");
+	public void get() {
+		assertThat((String) c.get(1)).isEqualTo("A");
+		assertThat((String) c.get(2)).isEqualTo("B");
+		assertThat((String) c.get(3)).isEqualTo("C");
+		assertThat((String) c.get(4)).isEqualTo("D");
+		assertThat((String) c.get(5)).isEqualTo("E");
+		assertThat((String) c.get(6)).isEqualTo("F");
 	}
 
 	@Test

--- a/reactor-core/src/test/kotlin/reactor/core/publisher/MonoExtensionsTests.kt
+++ b/reactor-core/src/test/kotlin/reactor/core/publisher/MonoExtensionsTests.kt
@@ -139,6 +139,7 @@ class MonoExtensionsTests {
 
     @Test
     fun nullableLambdaToEmptyMonoWithMap() {
+        @Suppress("USELESS_CAST")
         val callable = { null as String? }
         val verifier = StepVerifier.create(callable.toMono().map { it.toUpperCase() })
             .expectComplete()

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -694,6 +694,7 @@ public interface StepVerifier {
 		 *
 		 * @see Subscriber#onNext(Object)
 		 */
+		@SuppressWarnings("unchecked")
 		Step<T> expectNext(T... ts);
 
 		/**


### PR DESCRIPTION
@smaldini to be rebase-merged.

 - [test] Fix compiler warnings during compileTestJava phase
 - [test] Allow re-run of failed tests (empty test suite due to filters)
 - [test] Make test logs less verbose by only displaying details of FAILED
 - [test} Fix compiler warnings during compileJava phase
 - [test] Remove seemingly useless test.resources srcDir declaration