### PR TITLE
fix #437 Add simplified implementation for Mono.publish(Function)

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
@@ -99,7 +99,7 @@ final class FluxPublishMulticast<T, R> extends FluxOperator<T, R> implements Fus
 	}
 
 	static final class FluxPublishMulticaster<T> extends Flux<T>
-			implements InnerConsumer<T> {
+			implements InnerConsumer<T>, PublishMulticasterParent {
 
 		final int limit;
 
@@ -606,8 +606,9 @@ final class FluxPublishMulticast<T, R> extends FluxOperator<T, R> implements Fus
 			}
 		}
 
+		@Override
 		@SuppressWarnings("unchecked")
-		void terminate() {
+		public void terminate() {
 			Operators.terminate(S, this);
 			if (WIP.getAndIncrement(this) == 0) {
 				if (connected) {
@@ -677,17 +678,23 @@ final class FluxPublishMulticast<T, R> extends FluxOperator<T, R> implements Fus
 		}
 	}
 
+	interface PublishMulticasterParent {
+
+		void terminate();
+
+	}
+
 	static final class CancelMulticaster<T>
 			implements InnerOperator<T, T>, QueueSubscription<T> {
 
 		final CoreSubscriber<? super T> actual;
 
-		final FluxPublishMulticaster<?> parent;
+		final PublishMulticasterParent parent;
 
 		Subscription s;
 
 		CancelMulticaster(CoreSubscriber<? super T> actual,
-				FluxPublishMulticaster<?> parent) {
+				PublishMulticasterParent parent) {
 			this.actual = actual;
 			this.parent = parent;
 		}
@@ -778,12 +785,12 @@ final class FluxPublishMulticast<T, R> extends FluxOperator<T, R> implements Fus
 
 		final CoreSubscriber<? super T> actual;
 
-		final FluxPublishMulticaster<?> parent;
+		final PublishMulticasterParent parent;
 
 		QueueSubscription<T> s;
 
 		CancelFuseableMulticaster(CoreSubscriber<? super T> actual,
-				FluxPublishMulticaster<?> parent) {
+				PublishMulticasterParent parent) {
 			this.actual = actual;
 			this.parent = parent;
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPublishMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPublishMulticast.java
@@ -17,14 +17,19 @@
 package reactor.core.publisher;
 
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
+import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
-import reactor.core.Fuseable;
-import reactor.util.concurrent.Queues;
+import reactor.core.Scannable;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
- * Shares a sequence for the duration of a function that may transform it and
+ * Shares a {@link Mono} for the duration of a function that may transform it and
  * consume it as many times as necessary without causing multiple subscriptions
  * to the upstream.
  *
@@ -33,7 +38,7 @@ import reactor.util.concurrent.Queues;
  *
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
-final class MonoPublishMulticast<T, R> extends MonoOperator<T, R> implements Fuseable {
+final class MonoPublishMulticast<T, R> extends MonoOperator<T, R> {
 
 	final Function<? super Mono<T>, ? extends Mono<? extends R>> transform;
 
@@ -45,13 +50,9 @@ final class MonoPublishMulticast<T, R> extends MonoOperator<T, R> implements Fus
 
 	@Override
 	public void subscribe(CoreSubscriber<? super R> actual) {
-
-		FluxPublishMulticast.FluxPublishMulticaster<T> multicast =
-				new FluxPublishMulticast.FluxPublishMulticaster<>(Integer.MAX_VALUE,
-						Queues.one(), actual.currentContext());
+		MonoPublishMulticaster<T> multicast = new MonoPublishMulticaster<>(actual.currentContext());
 
 		Mono<? extends R> out;
-
 		try {
 			out = Objects.requireNonNull(transform.apply(fromDirect(multicast)),
 					"The transform returned a null Mono");
@@ -61,14 +62,382 @@ final class MonoPublishMulticast<T, R> extends MonoOperator<T, R> implements Fus
 			return;
 		}
 
-		if (out instanceof Fuseable) {
-			out.subscribe(new FluxPublishMulticast.CancelFuseableMulticaster<>(actual, multicast));
-		}
-		else {
-			out.subscribe(new FluxPublishMulticast.CancelMulticaster<>(actual, multicast));
+		out.subscribe(new CancelMulticaster<>(actual, multicast));
+		source.subscribe(multicast);
+	}
+
+	static final class MonoPublishMulticaster<T> extends Mono<T>
+			implements InnerConsumer<T> {
+
+		volatile     Subscription s;
+		static final AtomicReferenceFieldUpdater<MonoPublishMulticaster, Subscription> S =
+				AtomicReferenceFieldUpdater.newUpdater(MonoPublishMulticaster.class,
+						Subscription.class,
+						"s");
+
+		volatile     int wip;
+		static final AtomicIntegerFieldUpdater<MonoPublishMulticaster> WIP =
+				AtomicIntegerFieldUpdater.newUpdater(MonoPublishMulticaster.class, "wip");
+
+		volatile PublishMulticastInner<T>[] subscribers;
+		@SuppressWarnings("rawtypes")
+		static final AtomicReferenceFieldUpdater<MonoPublishMulticaster, PublishMulticastInner[]> SUBSCRIBERS =
+				AtomicReferenceFieldUpdater.newUpdater(MonoPublishMulticaster.class, PublishMulticastInner[].class, "subscribers");
+
+		@SuppressWarnings("rawtypes")
+		static final PublishMulticastInner[] EMPTY = new PublishMulticastInner[0];
+
+		@SuppressWarnings("rawtypes")
+		static final PublishMulticastInner[] TERMINATED = new PublishMulticastInner[0];
+
+		volatile boolean done;
+
+		@Nullable
+		T         value;
+		Throwable error;
+
+		volatile boolean connected;
+
+		final Context context;
+
+		@SuppressWarnings("unchecked")
+		MonoPublishMulticaster(Context ctx) {
+			SUBSCRIBERS.lazySet(this, EMPTY);
+			this.context = ctx;
 		}
 
-		source.subscribe(multicast);
+		@Override
+		@Nullable
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) {
+				return s;
+			}
+			if (key == Attr.ERROR) {
+				return error;
+			}
+			if (key == Attr.CANCELLED) {
+				return s == Operators.cancelledSubscription();
+			}
+			if (key == Attr.TERMINATED) {
+				return done;
+			}
+			if (key == Attr.PREFETCH) {
+				return 1;
+			}
+			if (key == Attr.BUFFERED) {
+				return value != null ? 1 : 0;
+			}
+
+			return null;
+		}
+
+		@Override
+		public Stream<? extends Scannable> inners() {
+			return Stream.of(subscribers);
+		}
+
+		@Override
+		public Context currentContext() {
+			return context;
+		}
+
+		@Override
+		public void subscribe(CoreSubscriber<? super T> actual) {
+			PublishMulticastInner<T> pcs = new PublishMulticastInner<>(this, actual);
+			actual.onSubscribe(pcs);
+
+			if (add(pcs)) {
+				if (pcs.cancelled == 1) {
+					remove(pcs);
+					return;
+				}
+				drain();
+			}
+			else {
+				Throwable ex = error;
+				if (ex != null) {
+					actual.onError(ex);
+				}
+				else {
+					actual.onComplete();
+				}
+			}
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.setOnce(S, this, s)) {
+				connected = true;
+				s.request(Long.MAX_VALUE);
+			}
+		}
+
+		@Override
+		public void onNext(T t) {
+			if (done) {
+				Operators.onNextDropped(t, context);
+				return;
+			}
+
+			value = t;
+			done = true;
+			drain();
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			if (done) {
+				Operators.onErrorDropped(t, context);
+				return;
+			}
+			error = t;
+			done = true;
+			drain();
+		}
+
+		@Override
+		public void onComplete() {
+			done = true;
+			drain();
+		}
+
+		void drain() {
+			if (WIP.getAndIncrement(this) != 0) {
+				return;
+			}
+
+			int missed = 1;
+
+			for (; ; ) {
+				if (connected) {
+					if (s == Operators.cancelledSubscription()) {
+						value = null;
+						return;
+					}
+
+					final T v = value;
+
+					PublishMulticastInner<T>[] a = subscribers;
+					int n = a.length;
+
+					if (n != 0) {
+						if (s == Operators.cancelledSubscription()) {
+							value = null;
+							return;
+						}
+
+						if (v == null) {
+							//noinspection unchecked
+							a = SUBSCRIBERS.getAndSet(this, TERMINATED);
+							n = a.length;
+							for (int i = 0; i < n; i++) {
+								a[i].actual.onComplete();
+							}
+							return;
+						}
+						else {
+							//noinspection unchecked
+							a = SUBSCRIBERS.getAndSet(this, TERMINATED);
+							n = a.length;
+							for (int i = 0; i < n; i++) {
+								a[i].actual.onNext(v);
+								a[i].actual.onComplete();
+							}
+							value = null;
+							return;
+						}
+					}
+				}
+
+				missed = WIP.addAndGet(this, -missed);
+				if (missed == 0) {
+					break;
+				}
+			}
+		}
+
+		boolean add(PublishMulticastInner<T> s) {
+			for (; ; ) {
+				PublishMulticastInner<T>[] a = subscribers;
+
+				if (a == TERMINATED) {
+					return false;
+				}
+
+				int n = a.length;
+
+				@SuppressWarnings("unchecked")
+				PublishMulticastInner<T>[] b = new PublishMulticastInner[n + 1];
+				System.arraycopy(a, 0, b, 0, n);
+				b[n] = s;
+				if (SUBSCRIBERS.compareAndSet(this, a, b)) {
+					return true;
+				}
+			}
+		}
+
+		@SuppressWarnings("unchecked")
+		void remove(PublishMulticastInner<T> s) {
+			for (; ; ) {
+				PublishMulticastInner<T>[] a = subscribers;
+
+				if (a == TERMINATED || a == EMPTY) {
+					return;
+				}
+
+				int n = a.length;
+				int j = -1;
+
+				for (int i = 0; i < n; i++) {
+					if (a[i] == s) {
+						j = i;
+						break;
+					}
+				}
+
+				if (j < 0) {
+					return;
+				}
+
+				PublishMulticastInner<T>[] b;
+				if (n == 1) {
+					b = EMPTY;
+				}
+				else {
+					b = new PublishMulticastInner[n - 1];
+					System.arraycopy(a, 0, b, 0, j);
+					System.arraycopy(a, j + 1, b, j, n - j - 1);
+				}
+				if (SUBSCRIBERS.compareAndSet(this, a, b)) {
+					return;
+				}
+			}
+		}
+
+		void terminate() {
+			Operators.terminate(S, this);
+			if (WIP.getAndIncrement(this) == 0) {
+				if (connected) {
+					value = null;
+				}
+			}
+		}
+	}
+
+	static final class PublishMulticastInner<T> implements InnerProducer<T> {
+
+		final MonoPublishMulticaster<T> parent;
+
+		final CoreSubscriber<? super T> actual;
+
+		volatile int cancelled;
+		static final AtomicIntegerFieldUpdater<PublishMulticastInner> CANCELLED = AtomicIntegerFieldUpdater.newUpdater(PublishMulticastInner.class, "cancelled");
+
+		PublishMulticastInner(MonoPublishMulticaster<T> parent,
+				CoreSubscriber<? super T> actual) {
+			this.parent = parent;
+			this.actual = actual;
+		}
+
+		@Override
+		@Nullable
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) {
+				return parent;
+			}
+			if (key == Attr.CANCELLED) {
+				return cancelled == 1;
+			}
+
+			return InnerProducer.super.scanUnsafe(key);
+		}
+
+		@Override
+		public CoreSubscriber<? super T> actual() {
+			return actual;
+		}
+
+		@Override
+		public void request(long n) {
+			if (Operators.validate(n)) {
+				parent.drain();
+			}
+		}
+
+		@Override
+		public void cancel() {
+			if (CANCELLED.compareAndSet(this, 0, 1)) {
+				parent.remove(this);
+				parent.drain();
+			}
+		}
+	}
+
+	static final class CancelMulticaster<T>
+			implements InnerOperator<T, T> {
+
+		final CoreSubscriber<? super T> actual;
+
+		final MonoPublishMulticaster<?> parent;
+
+		Subscription s;
+
+		CancelMulticaster(CoreSubscriber<? super T> actual,
+				MonoPublishMulticaster<?> parent) {
+			this.actual = actual;
+			this.parent = parent;
+		}
+
+		@Override
+		public CoreSubscriber<? super T> actual() {
+			return actual;
+		}
+
+		@Override
+		@Nullable
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) {
+				return s;
+			}
+
+			return InnerOperator.super.scanUnsafe(key);
+		}
+
+		@Override
+		public void request(long n) {
+			s.request(n);
+		}
+
+		@Override
+		public void cancel() {
+			s.cancel();
+			parent.terminate();
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.validate(this.s, s)) {
+				this.s = s;
+				actual.onSubscribe(this);
+			}
+		}
+
+		@Override
+		public void onNext(T t) {
+			actual.onNext(t);
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			actual.onError(t);
+			parent.terminate();
+		}
+
+		@Override
+		public void onComplete() {
+			actual.onComplete();
+			parent.terminate();
+		}
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPublishMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPublishMulticastTest.java
@@ -17,13 +17,24 @@
 package reactor.core.publisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.extractProperty;
+import static org.assertj.core.api.Fail.fail;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.util.concurrent.Queues;
+import reactor.util.context.Context;
 
 public class MonoPublishMulticastTest {
 
@@ -86,6 +97,34 @@ public class MonoPublishMulticastTest {
 		Assert.assertFalse("Still subscribed?", sp.isCancelled());
 	}
 
+	@Test
+	public void nullFunction() {
+		assertThatNullPointerException()
+				.isThrownBy(() -> Mono.just("Foo")
+				                      .publish(null))
+				.withMessage("transform");
+	}
+
+	@Test
+	public void npeFunction() {
+		StepVerifier.create(Mono.just("Foo")
+		                        .publish(m -> null))
+		            .expectErrorSatisfies(e -> assertThat(e)
+				            .isInstanceOf(NullPointerException.class)
+				            .hasMessage("The transform returned a null Mono"))
+		            .verify();
+	}
+
+	@Test
+	public void failingFunction() {
+		RuntimeException expected = new IllegalStateException("boom");
+		StepVerifier.create(Mono.just("Foo")
+		                        .publish(m -> {
+			                        throw expected;
+		                        }))
+		            .expectErrorSatisfies(e -> assertThat(e).isSameAs(expected))
+		            .verify();
+	}
 
     @Test
     public void syncCancelBeforeComplete() {
@@ -96,5 +135,63 @@ public class MonoPublishMulticastTest {
     public void normalCancelBeforeComplete() {
         assertThat(Mono.just(Mono.just(1).hide().publish(v -> v)).flatMapMany(v -> v).blockLast()).isEqualTo(1);
     }
+
+	@Test
+	public void scanMulticaster() {
+		MonoPublishMulticast.MonoPublishMulticaster<Integer> test =
+				new MonoPublishMulticast.MonoPublishMulticaster<>(Context.empty());
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(1);
+		assertThat(test.scan(Scannable.Attr.BUFFERED)).isEqualTo(0);
+		test.value = 1;
+		assertThat(test.scan(Scannable.Attr.BUFFERED)).isEqualTo(1);
+
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.Attr.ERROR)).isNull();
+		test.error = new IllegalArgumentException("boom");
+		assertThat(test.scan(Scannable.Attr.ERROR)).isSameAs(test.error);
+		test.onComplete();
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
+
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+		test.terminate();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
+	}
+
+	@Test
+	public void scanMulticastInner() {
+		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+		MonoPublishMulticast.MonoPublishMulticaster<Integer> parent =
+				new MonoPublishMulticast.MonoPublishMulticaster<>(Context.empty());
+		MonoPublishMulticast.PublishMulticastInner<Integer> test =
+				new MonoPublishMulticast.PublishMulticastInner<>(parent, actual);
+
+		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
+		test.request(789);
+		//does not track request in the Mono version
+		assertThat(test.scan(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(0);
+
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+		test.cancel();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
+	}
+
+	@Test
+	public void scanCancelMulticaster() {
+		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+		MonoPublishMulticast.MonoPublishMulticaster<Integer> parent =
+				new MonoPublishMulticast.MonoPublishMulticaster<>(Context.empty());
+		MonoPublishMulticast.CancelMulticaster<Integer> test =
+				new MonoPublishMulticast.CancelMulticaster<>(actual, parent);
+		Subscription sub = Operators.emptySubscription();
+		test.onSubscribe(sub);
+
+		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(sub);
+		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
+	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPublishMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPublishMulticastTest.java
@@ -180,18 +180,4 @@ public class MonoPublishMulticastTest {
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
 	}
 
-	@Test
-	public void scanCancelMulticaster() {
-		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
-		MonoPublishMulticast.MonoPublishMulticaster<Integer> parent =
-				new MonoPublishMulticast.MonoPublishMulticaster<>(Context.empty());
-		MonoPublishMulticast.CancelMulticaster<Integer> test =
-				new MonoPublishMulticast.CancelMulticaster<>(actual, parent);
-		Subscription sub = Operators.emptySubscription();
-		test.onSubscribe(sub);
-
-		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(sub);
-		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
-	}
-
 }


### PR DESCRIPTION
The implementation doesn't use a queue nor inner request tracking,
instead simply storing the value in a T volatile field.

As a consequence though, it is not Fuseable.