### PR TITLE
fix #402 Add terminateHandler to handle that can modify terminal events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ ext {
   // Testing
   assertJVersion = '3.9.0'
   mockitoVersion = '2.10.0'
+  jUnitParamsVersion = '1.1.1'
 
   javadocLinks = ["https://docs.oracle.com/javase/8/docs/api/",
 				  "https://docs.oracle.com/javaee/6/api/",
@@ -265,6 +266,7 @@ project('reactor-core') {
 			"org.testng:testng:6.8.5",
 			"org.assertj:assertj-core:$assertJVersion",
 			"org.mockito:mockito-core:$mockitoVersion",
+			"pl.pragmatists:JUnitParams:$jUnitParamsVersion",
 			"org.openjdk.jol:jol-core:0.9"
 
 	if ("$compatibleVersion" != "SKIP") {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGenerate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGenerate.java
@@ -148,19 +148,19 @@ final class FluxGenerate<T, S> extends Flux<T> implements Fuseable, Scannable {
 		}
 
 		@Override
-		public void next(T t) {
+		public SynchronousSink<T> next(T t) {
 			if (terminate) {
 				Operators.onNextDropped(t, actual.currentContext());
-				return;
+				return this;
 			}
 			if (hasValue) {
 				error(new IllegalStateException("More than one call to onNext"));
-				return;
+				return this;
 			}
 			//noinspection ConstantConditions
 			if (t == null) {
 				error(new NullPointerException("The generator produced a null value"));
-				return;
+				return this;
 			}
 			hasValue = true;
 			if (outputFused) {
@@ -168,12 +168,13 @@ final class FluxGenerate<T, S> extends Flux<T> implements Fuseable, Scannable {
 			} else {
 				actual.onNext(t);
 			}
+			return this;
 		}
 
 		@Override
-		public void error(Throwable e) {
+		public SynchronousSink<T> error(Throwable e) {
 			if (terminate) {
-				return;
+				return this;
 			}
 			terminate = true;
 			if (outputFused) {
@@ -181,17 +182,19 @@ final class FluxGenerate<T, S> extends Flux<T> implements Fuseable, Scannable {
 			} else {
 				actual.onError(e);
 			}
+			return this;
 		}
 
 		@Override
-		public void complete() {
+		public SynchronousSink<T> complete() {
 			if (terminate) {
-				return;
+				return this;
 			}
 			terminate = true;
 			if (!outputFused) {
 				actual.onComplete();
 			}
+			return this;
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
@@ -208,24 +208,26 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 		}
 
 		@Override
-		public void complete() {
+		public SynchronousSink<R> complete() {
 			if (stop) {
 				throw new IllegalStateException("Cannot complete after a complete or error");
 			}
 			stop = true;
+			return this;
 		}
 
 		@Override
-		public void error(Throwable e) {
+		public SynchronousSink<R> error(Throwable e) {
 			if (stop) {
 				throw new IllegalStateException("Cannot error after a complete or error");
 			}
 			error = Objects.requireNonNull(e, "error");
 			stop = true;
+			return this;
 		}
 
 		@Override
-		public void next(R o) {
+		public SynchronousSink<R> next(R o) {
 			if(data != null){
 				throw new IllegalStateException("Cannot emit more than one data");
 			}
@@ -233,6 +235,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 				throw new IllegalStateException("Cannot emit after a complete or error");
 			}
 			data = Objects.requireNonNull(o, "data");
+			return this;
 		}
 
 		@Override
@@ -423,24 +426,26 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 		}
 
 		@Override
-		public void complete() {
+		public SynchronousSink<R> complete() {
 			if (stop) {
 				throw new IllegalStateException("Cannot complete after a complete or error");
 			}
 			stop = true;
+			return this;
 		}
 
 		@Override
-		public void error(Throwable e) {
+		public SynchronousSink<R> error(Throwable e) {
 			if (stop) {
 				throw new IllegalStateException("Cannot error after a complete or error");
 			}
 			error = Objects.requireNonNull(e, "error");
 			stop = true;
+			return this;
 		}
 
 		@Override
-		public void next(R o) {
+		public SynchronousSink<R> next(R o) {
 			if(data != null){
 				throw new IllegalStateException("Cannot emit more than one data");
 			}
@@ -448,6 +453,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 				throw new IllegalStateException("Cannot emit after a complete or error");
 			}
 			data = Objects.requireNonNull(o, "data");
+			return this;
 		}
 		
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
@@ -16,6 +16,7 @@
 package reactor.core.publisher;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import org.reactivestreams.Subscription;
@@ -33,11 +34,26 @@ import reactor.util.context.Context;
  */
 final class FluxHandle<T, R> extends FluxOperator<T, R> {
 
-	final BiConsumer<? super T, SynchronousSink<R>> handler;
+	static final byte STOP_NOT_STOPPED = 0;
+	static final byte STOP_WILL_TERMINATE = 1;
+	static final byte STOP_INTERMEDIATE = 2;
+	static final byte STOP_TERMINATE = 3;
 
-	FluxHandle(Flux<? extends T> source, BiConsumer<? super T, SynchronousSink<R>> handler) {
+	final BiConsumer<? super T, SynchronousSink<R>>           handler;
+	@Nullable
+	final BiConsumer<Optional<Throwable>, SynchronousSink<R>> terminateHandler;
+
+	/**
+	 * @param source the source
+	 * @param handler the handler function
+	 * @param terminateHandler the optional terminate function that can optionally change
+	 * 	 * the terminate signal)
+	 */
+	FluxHandle(Flux<? extends T> source, BiConsumer<? super T, SynchronousSink<R>> handler,
+			@Nullable BiConsumer<Optional<Throwable>, SynchronousSink<R>> terminateHandler) {
 		super(source);
 		this.handler = Objects.requireNonNull(handler, "handler");
+		this.terminateHandler = terminateHandler;
 	}
 
 	@Override
@@ -45,10 +61,10 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 	public void subscribe(CoreSubscriber<? super R> actual) {
 		if (actual instanceof Fuseable.ConditionalSubscriber) {
 			Fuseable.ConditionalSubscriber<? super R> cs = (Fuseable.ConditionalSubscriber<? super R>) actual;
-			source.subscribe(new HandleConditionalSubscriber<>(cs, handler));
+			source.subscribe(new HandleConditionalSubscriber<>(cs, handler, terminateHandler));
 			return;
 		}
-		source.subscribe(new HandleSubscriber<>(actual, handler));
+		source.subscribe(new HandleSubscriber<>(actual, handler, terminateHandler));
 	}
 
 	static final class HandleSubscriber<T, R>
@@ -58,18 +74,22 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 
 		final CoreSubscriber<? super R>                 actual;
 		final BiConsumer<? super T, SynchronousSink<R>> handler;
+		@Nullable
+		final BiConsumer<Optional<Throwable>, SynchronousSink<R>> terminateHandler;
 
 		boolean done;
-		boolean stop;
-		Throwable error;
-		R data;
+		byte stop;
+		@Nullable Throwable error;
+		@Nullable R data;
 
 		Subscription s;
 
 		HandleSubscriber(CoreSubscriber<? super R> actual,
-				BiConsumer<? super T, SynchronousSink<R>> handler) {
+				BiConsumer<? super T, SynchronousSink<R>> handler,
+				@Nullable BiConsumer<Optional<Throwable>, SynchronousSink<R>> terminateHandler) {
 			this.actual = actual;
 			this.handler = handler;
+			this.terminateHandler = terminateHandler;
 		}
 
 		@Override
@@ -112,7 +132,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 			if (v != null) {
 				actual.onNext(v);
 			}
-			if(stop){
+			if(stop == STOP_INTERMEDIATE){
 				if(error != null){
 					Throwable e_ = Operators.onNextError(t, error, actual.currentContext(), s);
 					if (e_ != null) {
@@ -135,7 +155,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 
 		private void reset() {
 			done = false;
-			stop = false;
+			stop = STOP_NOT_STOPPED;
 			error = null;
 		}
 
@@ -165,7 +185,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 			if (v != null) {
 				actual.onNext(v);
 			}
-			if(stop){
+			if(stop == STOP_INTERMEDIATE){
 				if(error != null){
 					Throwable e_ = Operators.onNextError(t, error, actual.currentContext(), s);
 					if (e_ != null) {
@@ -191,8 +211,20 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
-
 			done = true;
+
+			if (stop == STOP_NOT_STOPPED) {
+				if (terminateHandler != null) {
+					stop = STOP_WILL_TERMINATE;
+					terminateHandler.accept(Optional.of(t), this); //might do complete or error
+					if (stop == STOP_TERMINATE) {
+						return;
+					}
+				}
+				//we have either a null or no-op terminateHandler
+				//we'll default to the original signal
+				stop = STOP_TERMINATE; //for scanUnsafe's benefit
+			}
 
 			actual.onError(t);
 		}
@@ -204,25 +236,51 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 			}
 			done = true;
 
+			if (stop == STOP_NOT_STOPPED) {
+				if (terminateHandler != null) {
+					stop = STOP_WILL_TERMINATE;
+					terminateHandler.accept(Optional.empty(), this); //might do complete or error
+					if (stop == STOP_TERMINATE) {
+						return;
+					}
+				}
+				//we have either a null or no-op terminateHandler
+				//we'll default to the original signal
+				stop = STOP_TERMINATE; //for scanUnsafe's benefit
+			}
+
 			actual.onComplete();
 		}
 
 		@Override
 		public SynchronousSink<R> complete() {
-			if (stop) {
+			if (stop > STOP_WILL_TERMINATE) {
 				throw new IllegalStateException("Cannot complete after a complete or error");
 			}
-			stop = true;
+			else if (stop == STOP_WILL_TERMINATE) {
+				stop = STOP_TERMINATE;
+				actual.onComplete();
+			}
+			else {
+				stop = STOP_INTERMEDIATE;
+			}
 			return this;
 		}
 
 		@Override
 		public SynchronousSink<R> error(Throwable e) {
-			if (stop) {
+			if (stop > STOP_WILL_TERMINATE) {
 				throw new IllegalStateException("Cannot error after a complete or error");
 			}
-			error = Objects.requireNonNull(e, "error");
-			stop = true;
+			else if (stop == STOP_WILL_TERMINATE) {
+				stop = STOP_TERMINATE;
+				// store error for scanUnsafe's benefit
+				error = Objects.requireNonNull(e, "error in terminateHandler");
+				actual.onError(error);			}
+			else {
+				stop = STOP_INTERMEDIATE;
+				error = Objects.requireNonNull(e, "error");
+			}
 			return this;
 		}
 
@@ -231,8 +289,11 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 			if(data != null){
 				throw new IllegalStateException("Cannot emit more than one data");
 			}
-			if (stop) {
+			if (stop > STOP_WILL_TERMINATE) {
 				throw new IllegalStateException("Cannot emit after a complete or error");
+			}
+			if (stop == STOP_WILL_TERMINATE) {
+				throw new IllegalStateException("Cannot emit in terminateHandler");
 			}
 			data = Objects.requireNonNull(o, "data");
 			return this;
@@ -242,7 +303,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 		@Nullable
 		public Object scanUnsafe(Attr key) {
 			if (key == Attr.PARENT) return s;
-			if (key == Attr.TERMINATED) return done;
+			if (key == Attr.TERMINATED) return done && (stop > STOP_WILL_TERMINATE);
 			if (key == Attr.ERROR) return error;
 
 			return InnerOperator.super.scanUnsafe(key);
@@ -269,17 +330,21 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 			           SynchronousSink<R> {
 		final Fuseable.ConditionalSubscriber<? super R> actual;
 		final BiConsumer<? super T, SynchronousSink<R>> handler;
+		@Nullable
+		final BiConsumer<Optional<Throwable>, SynchronousSink<R>> terminateHandler;
 
 		boolean done;
-		boolean stop;
-		Throwable error;
-		R data;
+		byte stop;
+		@Nullable Throwable error;
+		@Nullable R data;
 
 		Subscription s;
 
-		HandleConditionalSubscriber(Fuseable.ConditionalSubscriber<? super R> actual, BiConsumer<? super T, SynchronousSink<R>> handler) {
+		HandleConditionalSubscriber(Fuseable.ConditionalSubscriber<? super R> actual, BiConsumer<? super T, SynchronousSink<R>> handler,
+				@Nullable BiConsumer<Optional<Throwable>, SynchronousSink<R>> terminateHandler) {
 			this.actual = actual;
 			this.handler = handler;
+			this.terminateHandler = terminateHandler;
 		}
 
 		@Override
@@ -322,7 +387,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 			if (v != null) {
 				actual.onNext(v);
 			}
-			if(stop){
+			if(stop > STOP_NOT_STOPPED){
 				done = true; //set done because we go through `actual` directly
 				if(error != null){
 					Throwable e_ = Operators.onNextError(t, error, actual.currentContext(), s);
@@ -346,7 +411,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 
 		private void reset() {
 			done = false;
-			stop = false;
+			stop = STOP_NOT_STOPPED;
 			error = null;
 		}
 
@@ -377,7 +442,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 			if (v != null) {
 				emit = actual.tryOnNext(v);
 			}
-			if(stop){
+			if(stop > STOP_NOT_STOPPED){
 				done = true; //set done because we go through `actual` directly
 				if(error != null){
 					Throwable e_ = Operators.onNextError(t, error, actual.currentContext(), s);
@@ -404,8 +469,20 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
-
 			done = true;
+
+			if (stop == STOP_NOT_STOPPED) {
+				if (terminateHandler != null) {
+					stop = STOP_WILL_TERMINATE;
+					terminateHandler.accept(Optional.of(t), this); //might do complete or error
+					if (stop == STOP_TERMINATE) {
+						return;
+					}
+				}
+				//we have either a null or no-op terminateHandler
+				//we'll default to the original signal
+				stop = STOP_TERMINATE; //for scanUnsafe's benefit
+			}
 
 			actual.onError(t);
 		}
@@ -417,6 +494,19 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 			}
 			done = true;
 
+			if (stop == STOP_NOT_STOPPED) {
+				if (terminateHandler != null) {
+					stop = STOP_WILL_TERMINATE;
+					terminateHandler.accept(Optional.empty(), this); //might do complete or error
+					if (stop == STOP_TERMINATE) {
+						return;
+					}
+				}
+				//we have either a null or no-op terminateHandler
+				//we'll default to the original signal
+				stop = STOP_TERMINATE; //for scanUnsafe's benefit
+			}
+
 			actual.onComplete();
 		}
 
@@ -427,20 +517,34 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 
 		@Override
 		public SynchronousSink<R> complete() {
-			if (stop) {
+			if (stop > STOP_WILL_TERMINATE) {
 				throw new IllegalStateException("Cannot complete after a complete or error");
 			}
-			stop = true;
+			else if (stop == STOP_WILL_TERMINATE) {
+				stop = STOP_TERMINATE;
+				actual.onComplete();
+			}
+			else {
+				stop = STOP_INTERMEDIATE;
+			}
 			return this;
 		}
 
 		@Override
 		public SynchronousSink<R> error(Throwable e) {
-			if (stop) {
+			if (stop > STOP_WILL_TERMINATE) {
 				throw new IllegalStateException("Cannot error after a complete or error");
 			}
-			error = Objects.requireNonNull(e, "error");
-			stop = true;
+			else if (stop == STOP_WILL_TERMINATE) {
+				stop = STOP_TERMINATE;
+				// store error for scanUnsafe's benefit
+				error = Objects.requireNonNull(e, "error in terminateHandler");
+				actual.onError(error);
+			}
+			else {
+				stop = STOP_INTERMEDIATE;
+				error = Objects.requireNonNull(e, "error");
+			}
 			return this;
 		}
 
@@ -449,8 +553,11 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 			if(data != null){
 				throw new IllegalStateException("Cannot emit more than one data");
 			}
-			if (stop) {
+			if (stop > STOP_WILL_TERMINATE) {
 				throw new IllegalStateException("Cannot emit after a complete or error");
+			}
+			if (stop == STOP_WILL_TERMINATE) {
+				throw new IllegalStateException("Cannot emit in terminateHandler");
 			}
 			data = Objects.requireNonNull(o, "data");
 			return this;
@@ -470,7 +577,7 @@ final class FluxHandle<T, R> extends FluxOperator<T, R> {
 		@Nullable
 		public Object scanUnsafe(Attr key) {
 			if (key == Attr.PARENT) return s;
-			if (key == Attr.TERMINATED) return done;
+			if (key == Attr.TERMINATED) return done && (stop > STOP_WILL_TERMINATE);
 			if (key == Attr.ERROR) return error;
 
 			return InnerOperator.super.scanUnsafe(key);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
@@ -389,24 +389,26 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 		}
 
 		@Override
-		public void complete() {
+		public SynchronousSink<R> complete() {
 			if (stop) {
 				throw new IllegalStateException("Cannot complete after a complete or error");
 			}
 			stop = true;
+			return this;
 		}
 
 		@Override
-		public void error(Throwable e) {
+		public SynchronousSink<R> error(Throwable e) {
 			if (stop) {
 				throw new IllegalStateException("Cannot error after a complete or error");
 			}
 			error = Objects.requireNonNull(e, "error");
 			stop = true;
+			return this;
 		}
 
 		@Override
-		public void next(R o) {
+		public SynchronousSink<R> next(R o) {
 			if (data != null) {
 				throw new IllegalStateException("Cannot emit more than one data");
 			}
@@ -414,6 +416,7 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 				throw new IllegalStateException("Cannot emit after a complete or error");
 			}
 			data = Objects.requireNonNull(o, "data");
+			return this;
 		}
 	}
 
@@ -585,24 +588,26 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 		}
 
 		@Override
-		public void complete() {
+		public SynchronousSink<R> complete() {
 			if (stop) {
 				throw new IllegalStateException("Cannot complete after a complete or error");
 			}
 			stop = true;
+			return this;
 		}
 
 		@Override
-		public void error(Throwable e) {
+		public SynchronousSink<R> error(Throwable e) {
 			if (stop) {
 				throw new IllegalStateException("Cannot error after a complete or error");
 			}
 			error = Objects.requireNonNull(e, "error");
 			stop = true;
+			return this;
 		}
 
 		@Override
-		public void next(R o) {
+		public SynchronousSink<R> next(R o) {
 			if (data != null) {
 				throw new IllegalStateException("Cannot emit more than one data");
 			}
@@ -610,6 +615,7 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 				throw new IllegalStateException("Cannot emit after a complete or error");
 			}
 			data = Objects.requireNonNull(o, "data");
+			return this;
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -2187,7 +2187,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Handle the items emitted by this {@link Mono} by calling a biconsumer with the
+	 * Handle the items emitted by this {@link Mono} by calling a {@link BiConsumer} with the
 	 * output sink for each onNext. At most one {@link SynchronousSink#next(Object)}
 	 * call must be performed and/or 0 or 1 {@link SynchronousSink#error(Throwable)} or
 	 * {@link SynchronousSink#complete()}.
@@ -2199,9 +2199,37 @@ public abstract class Mono<T> implements Publisher<T> {
 	 */
 	public final <R> Mono<R> handle(BiConsumer<? super T, SynchronousSink<R>> handler) {
 		if (this instanceof Fuseable) {
-			return onAssembly(new MonoHandleFuseable<>(this, handler));
+			return onAssembly(new MonoHandleFuseable<>(this, handler, null));
 		}
-		return onAssembly(new MonoHandle<>(this, handler));
+		return onAssembly(new MonoHandle<>(this, handler, null));
+	}
+
+	/**
+	 * Handle the items emitted by this {@link Mono} by calling {@link BiConsumer} with the
+	 * output sink for each onNext. At most one {@link SynchronousSink#next(Object)}
+	 * call must be performed and/or 0 or 1 {@link SynchronousSink#error(Throwable)} or
+	 * {@link SynchronousSink#complete()}.
+	 * <p>
+	 * Additionally, a second {@link BiConsumer} is provided to react to the terminal
+	 * signal. An {@link Optional} is exposed that represents which terminal signal (valued
+	 * with a {@link Throwable} for {@code onError} or empty for {@code onComplete}). The
+	 * {@link SynchronousSink sink} can then be used to optionally change the completion
+	 * signal (the {@link SynchronousSink#next(Object) sink's next()} method is disallowed).
+	 * A {@code terminateHandler} that doesn't use the sink at all will result in the
+	 * original terminal signal to be propagated.
+	 *
+	 * @param <R> the transformed type
+	 *
+	 * @param handler the handling {@link BiConsumer}
+	 * @param terminateHandler the terminal {@link BiConsumer}
+	 * @return a transformed {@link Mono}
+	 */
+	public final <R> Mono<R> handle(BiConsumer<? super T, SynchronousSink<R>> handler,
+			BiConsumer<Optional<Throwable>, SynchronousSink<R>> terminateHandler) {
+		if (this instanceof Fuseable) {
+			return onAssembly(new MonoHandleFuseable<>(this, handler, terminateHandler));
+		}
+		return onAssembly(new MonoHandle<>(this, handler, terminateHandler));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/SynchronousSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SynchronousSink.java
@@ -39,7 +39,7 @@ public interface SynchronousSink<T> {
 	/**
 	 * @see Subscriber#onComplete()
 	 */
-	void complete();
+	SynchronousSink<T> complete();
 
 	/**
 	 * Return the current subscriber {@link Context}.
@@ -58,7 +58,7 @@ public interface SynchronousSink<T> {
 	 *
 	 * @see Subscriber#onError(Throwable)
 	 */
-	void error(Throwable e);
+	SynchronousSink<T> error(Throwable e);
 
 	/**
 	 * Try emitting, might throw an unchecked exception.
@@ -68,5 +68,5 @@ public interface SynchronousSink<T> {
 	 * @throws RuntimeException in case of unchecked error during the emission
 	 * @see Subscriber#onNext(Object)
 	 */
-	void next(T t);
+	SynchronousSink<T> next(T t);
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoHandleTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoHandleTest.java
@@ -15,11 +15,20 @@
  */
 package reactor.core.publisher;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
+@RunWith(JUnitParamsRunner.class)
 public class MonoHandleTest {
 
 	@Test
@@ -51,6 +60,163 @@ public class MonoHandleTest {
 		    .assertValueCount(0)
 		    .assertNoError()
 		    .assertComplete();
+	}
+
+
+	private static final String sourceErrorMessage = "boomSource";
+	private static final String sourceData = "foo";
+
+	private Object[] sourcesError() {
+		return new Object[] {
+				new Object[] { Mono.error(new IllegalStateException(sourceErrorMessage))
+						.hide() },
+				new Object[] { Mono.error(new IllegalStateException(sourceErrorMessage))
+				                   .hide().filter(i -> true) },
+				new Object[] { Mono.error(new IllegalStateException(sourceErrorMessage)) },
+				new Object[] { Mono.error(new IllegalStateException(sourceErrorMessage))
+						.filter(i -> true) }
+		};
+	}
+
+	private Object[] sourcesComplete() {
+		return new Object[] {
+				new Object[] { Mono.just(sourceData).hide() },
+				new Object[] { Mono.just(sourceData).hide().filter(i -> true) },
+				new Object[] { Mono.just(sourceData) },
+				new Object[] { Mono.just(sourceData).filter(i -> true) }
+		};
+	}
+
+	@Test
+	@Parameters(method = "sourcesError")
+	public void sourceErrorHandleNotInvoked(Mono<String> source) {
+		//the source errors so the handler is never invoked
+		AtomicBoolean handlerInvoked = new AtomicBoolean();
+		Mono<String> test = source.handle((t, sink) -> handlerInvoked.set(true));
+
+		StepVerifier.create(test)
+		            .expectErrorMessage(sourceErrorMessage)
+		            .verify();
+
+		Assertions.assertThat(handlerInvoked)
+		          .as("handler shouldn't be invoked")
+		          .isFalse();
+	}
+
+	@Test
+	@Parameters(method = "sourcesComplete")
+	public void sourceCompleteHandleError(Mono<String> source) {
+		//the source completes but handle calls sink.error during data event
+		RuntimeException sinkException = new IllegalStateException("boom2");
+		Mono<String> test = source.handle((t, sink) -> {
+			sink.next(t);
+			sink.error(sinkException);
+		});
+
+		StepVerifier.create(test)
+		            .expectNext(sourceData)
+		            .expectErrorMessage("boom2")
+		            .verify();
+	}
+
+	@Test
+	@Parameters(method = "sourcesComplete")
+	public void sourceCompleteHandleComplete(Mono<String> source) {
+		//the source completes but handle calls sink.error during data event
+		Mono<String> test = source.handle((t, sink) -> {
+			sink.next(t);
+			sink.complete();
+		});
+
+		StepVerifier.create(test)
+		            .expectNext(sourceData)
+		            .expectComplete()
+		            .verify();
+	}
+
+	@Test
+	@Parameters(method = "sourcesError")
+	public void sourceErrorHandleTerminateComplete(Mono<String> source) {
+		//the source errors and no terminal sink method is called during data event, terminate callback calls sink.complete
+		Mono<String> test = source.handle((t, sink) -> sink.next(t),
+				(opt, sink) -> sink.complete());
+
+		StepVerifier.create(test)
+		            .expectComplete()
+		            .verify();
+	}
+
+	@Test
+	@Parameters(method = "sourcesError")
+	public void sourceErrorHandleTerminateError(Mono<String> source) {
+		//the source errors and no terminal sink method is called during data event, terminate callback calls sink.error
+		RuntimeException sinkException = new IllegalStateException("boom2");
+		Mono<String> test = source.handle((t, sink) -> sink.next(t),
+				(opt, sink) -> sink.error(sinkException));
+
+		StepVerifier.create(test)
+		            .expectErrorMessage("boom2")
+		            .verify();
+	}
+
+	@Test
+	@Parameters(method = "sourcesComplete")
+	public void sourceCompleteHandleTerminateComplete(Mono<String> source) {
+		//the source completes and no terminal sink method is called during data event, terminate callback calls sink.complete
+		Mono<String> test = source.handle((t, sink) -> sink.next(t),
+				(opt, sink) -> sink.complete());
+
+		StepVerifier.create(test)
+		            .expectNext(sourceData)
+		            .expectComplete()
+		            .verify();
+	}
+
+	@Test
+	@Parameters(method = "sourcesComplete")
+	public void sourceCompleteHandleTerminateError(Mono<String> source) {
+		//the source completes and no terminal sink method is called during data event, terminate callback calls sink.error
+		RuntimeException sinkException = new IllegalStateException("boom2");
+		Mono<String> test = source.handle((t, sink) -> sink.next(t),
+				(opt, sink) -> sink.error(sinkException));
+
+		StepVerifier.create(test)
+		            .expectNext(sourceData)
+		            .expectErrorMessage("boom2")
+		            .verify();
+	}
+
+	@Test
+	@Parameters(method = "sourcesComplete")
+	public void sourceCompleteHandleTerminateNoOp(Mono<String> source) {
+		StepVerifier.create(source.handle((t, sink) -> sink.next(t),
+				(opt, sink) -> {}))
+		            .expectNext(sourceData)
+		            .verifyComplete();
+	}
+
+	@Test
+	@Parameters(method = "sourcesError")
+	public void sourceErrorHandleTerminateNoOp(Mono<String> source) {
+		StepVerifier.create(source.handle((t, sink) -> sink.next(t),
+				(opt, sink) -> {}))
+		            .verifyErrorMessage(sourceErrorMessage);
+	}
+
+	@Test
+	@Parameters(method = "sourcesComplete")
+	public void sourceCompleteHandleTerminateNextRejected(Mono<String> source) {
+		Mono<Object> test = source.handle((t, sink) -> sink.next(t), (opt, sink) -> sink.next("last"));
+		assertThatIllegalStateException().isThrownBy(test::subscribe)
+		                                 .withMessage("Cannot emit in terminateHandler");
+	}
+
+	@Test
+	@Parameters(method = "sourcesError")
+	public void sourceErrorHandleTerminateNextRejected(Mono<String> source) {
+		Mono<Object> test = source.handle((t, sink) -> sink.next(t), (opt, sink) -> sink.next("last"));
+		assertThatIllegalStateException().isThrownBy(test::subscribe)
+		                                 .withMessage("Cannot emit in terminateHandler");
 	}
 
 }


### PR DESCRIPTION
@smaldini I didn't authorize `next()` calls in the `terminateHandler`, but it could be made to work, except probably for `Mono` (unless we manage to check that it is an empty `Mono`, not a valued one nor an erroring one, and that `error()` and `next()` are mutually excluded).