### PR TITLE
Add hook to process discarded elements (filtered, dropped, backpressure queue clear, etc...)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,7 +182,7 @@ configure(subprojects) { p ->
 	include '**/*Spec.*'
   }
 
-  //all test tasks will show FAILED/PASSED for each test method,
+  //all test tasks will show FAILED for each test method,
   // common exclusions, no scanning
   p.tasks.withType(Test).all {
 	testLogging {
@@ -317,7 +317,8 @@ project('reactor-core') {
 	options.stylesheetFile = file("$rootDir/src/api/stylesheet.css")
 	options.links(rootProject.ext.javadocLinks )
 	options.tags = [ "apiNote:a:API Note:", "implSpec:a:Implementation Requirements:",
-					 "implNote:a:Implementation Note:", "reactor.errorMode:m:Error Mode Support" ]
+					 "implNote:a:Implementation Note:", "reactor.errorMode:m:Error Mode Support",
+					 "reactor.discard:m:onDiscard Support"]
 
 	// In Java 9, javadoc generator will complain if it finds invalid class files in the classpath
 	// And Kotlin produces such classes, plus kotlin plugin puts them in the main sourceSet

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -121,6 +121,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/combinelatest.png"
 	 * alt="">
 	 *
+	 * @reactor.discard This operator is NOT suited for types that need guaranteed discard of unpropagated elements, as
+	 * it doesn't track which elements have been used by the combinator and which haven't. Furthermore, elements can and
+	 * will be passed to the combinator multiple times.
+	 *
 	 * @param sources The {@link Publisher} sources to combine values from
 	 * @param combinator The aggregate function that will receive the latest value from each upstream and return the value
 	 * to signal downstream
@@ -140,6 +144,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/combinelatest.png"
 	 * alt="">
+	 *
+	 * @reactor.discard This operator is NOT suited for types that need guaranteed discard of unpropagated elements, as
+	 * it doesn't track which elements have been used by the combinator and which haven't. Furthermore, elements can and
+	 * will be passed to the combinator multiple times.
 	 *
 	 * @param sources The {@link Publisher} sources to combine values from
 	 * @param prefetch The demand sent to each combined source {@link Publisher}
@@ -178,6 +186,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/combinelatest.png"
 	 * alt="">
 	 *
+	 * @reactor.discard This operator is NOT suited for types that need guaranteed discard of unpropagated elements, as
+	 * it doesn't track which elements have been used by the combinator and which haven't. Furthermore, elements can and
+	 * will be passed to the combinator multiple times.
+	 *
 	 * @param source1 The first {@link Publisher} source to combine values from
 	 * @param source2 The second {@link Publisher} source to combine values from
 	 * @param combinator The aggregate function that will receive the latest value from each upstream and return the value
@@ -201,6 +213,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/combinelatest.png"
 	 * alt="">
+	 *
+	 * @reactor.discard This operator is NOT suited for types that need guaranteed discard of unpropagated elements, as
+	 * it doesn't track which elements have been used by the combinator and which haven't. Furthermore, elements can and
+	 * will be passed to the combinator multiple times.
 	 *
 	 * @param source1 The first {@link Publisher} source to combine values from
 	 * @param source2 The second {@link Publisher} source to combine values from
@@ -227,6 +243,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/combinelatest.png"
 	 * alt="">
+	 *
+	 * @reactor.discard This operator is NOT suited for types that need guaranteed discard of unpropagated elements, as
+	 * it doesn't track which elements have been used by the combinator and which haven't. Furthermore, elements can and
+	 * will be passed to the combinator multiple times.
 	 *
 	 * @param source1 The first {@link Publisher} source to combine values from
 	 * @param source2 The second {@link Publisher} source to combine values from
@@ -256,6 +276,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/combinelatest.png"
 	 * alt="">
+	 *
+	 * @reactor.discard This operator is NOT suited for types that need guaranteed discard of unpropagated elements, as
+	 * it doesn't track which elements have been used by the combinator and which haven't. Furthermore, elements can and
+	 * will be passed to the combinator multiple times.
 	 *
 	 * @param source1 The first {@link Publisher} source to combine values from
 	 * @param source2 The second {@link Publisher} source to combine values from
@@ -288,6 +312,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/combinelatest.png"
 	 * alt="">
+	 *
+	 * @reactor.discard This operator is NOT suited for types that need guaranteed discard of unpropagated elements, as
+	 * it doesn't track which elements have been used by the combinator and which haven't. Furthermore, elements can and
+	 * will be passed to the combinator multiple times.
 	 *
 	 * @param source1 The first {@link Publisher} source to combine values from
 	 * @param source2 The second {@link Publisher} source to combine values from
@@ -325,6 +353,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/combinelatest.png"
 	 * alt="">
 	 *
+	 * @reactor.discard This operator is NOT suited for types that need guaranteed discard of unpropagated elements, as
+	 * it doesn't track which elements have been used by the combinator and which haven't. Furthermore, elements can and
+	 * will be passed to the combinator multiple times.
+	 *
 	 * @param sources The list of {@link Publisher} sources to combine values from
 	 * @param combinator The aggregate function that will receive the latest value from each upstream and return the value
 	 * to signal downstream
@@ -345,6 +377,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/combinelatest.png"
 	 * alt="">
+	 *
+	 * @reactor.discard This operator is NOT suited for types that need guaranteed discard of unpropagated elements, as
+	 * it doesn't track which elements have been used by the combinator and which haven't. Furthermore, elements can and
+	 * will be passed to the combinator multiple times.
 	 *
 	 * @param sources The list of {@link Publisher} sources to combine values from
 	 * @param prefetch demand produced to each combined source {@link Publisher}
@@ -409,6 +445,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/concatinner.png" alt="">
 	 * <p>
+	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation.
+	 *
 	 * @param sources The {@link Publisher} of {@link Publisher} to concatenate
 	 * @param <T> The type of values in both source and output sequences
 	 *
@@ -429,6 +468,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/concatinner.png" alt="">
 	 * <p>
+	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation.
+	 *
 	 * @param sources The {@link Publisher} of {@link Publisher} to concatenate
 	 * @param prefetch the inner source request size
 	 * @param <T> The type of values in both source and output sequences
@@ -474,6 +516,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/concatinner.png" alt="">
 	 * <p>
+	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation.
+	 *
 	 * @param sources The {@link Publisher} of {@link Publisher} to concatenate
 	 * @param <T> The type of values in both source and output sequences
 	 *
@@ -494,6 +539,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/concatinner.png" alt="">
 	 * <p>
+	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation.
+	 *
 	 * @param sources The {@link Publisher} of {@link Publisher} to concatenate
 	 * @param prefetch the inner source request size
 	 * @param <T> The type of values in both source and output sequences
@@ -521,6 +569,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/concatinner.png" alt="">
 	 * <p>
+	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation.
+	 *
 	 * @param sources The {@link Publisher} of {@link Publisher} to concatenate
 	 * @param delayUntilEnd delay error until all sources have been consumed instead of
 	 * after the current source
@@ -548,6 +599,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/concat.png" alt="">
 	 * <p>
+	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation.
+	 *
 	 * @param sources The {@link Publisher} of {@link Publisher} to concat
 	 * @param <T> The type of values in both source and output sequences
 	 *
@@ -587,6 +641,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * });
 	 * </code></pre>
 	 *
+	 * @reactor.discard The {@link FluxSink} exposed by this operator buffers in case of
+	 * overflow. The buffer is discarded when the main sequence is cancelled.
+	 *
 	 * @param <T> The type of values in the sequence
 	 * @param emitter Consume the {@link FluxSink} provided per-subscriber by Reactor to generate signals.
 	 * @return a {@link Flux}
@@ -623,6 +680,11 @@ public abstract class Flux<T> implements Publisher<T> {
      *     });
      * }, FluxSink.OverflowStrategy.LATEST);
      * </code></pre>
+	 *
+	 * @reactor.discard The {@link FluxSink} exposed by this operator discards elements
+	 * as relevant to the chosen {@link OverflowStrategy}. For example, the {@link OverflowStrategy#DROP}
+	 * discards each items as they are being dropped, while {@link OverflowStrategy#BUFFER}
+	 * will discard the buffer upon cancellation.
      *
 	 * @param <T> The type of values in the sequence
 	 * @param backpressure the backpressure mode, see {@link OverflowStrategy} for the
@@ -663,6 +725,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * }, FluxSink.OverflowStrategy.LATEST);
 	 * </code></pre>
 	 *
+	 * @reactor.discard The {@link FluxSink} exposed by this operator buffers in case of
+	 * overflow. The buffer is discarded when the main sequence is cancelled.
+	 *
 	 * @param <T> The type of values in the sequence
 	 * @param emitter Consume the {@link FluxSink} provided per-subscriber by Reactor to generate signals.
 	 * @return a {@link Flux}
@@ -699,6 +764,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *	 });
 	 * }, FluxSink.OverflowStrategy.LATEST);
 	 * </code></pre>
+	 *
+	 * @reactor.discard The {@link FluxSink} exposed by this operator discards elements
+	 * as relevant to the chosen {@link OverflowStrategy}. For example, the {@link OverflowStrategy#DROP}
+	 * discards each items as they are being dropped, while {@link OverflowStrategy#BUFFER}
+	 * will discard the buffer upon cancellation.
 	 *
 	 * @param <T> The type of values in the sequence
 	 * @param backpressure the backpressure mode, see {@link OverflowStrategy} for the
@@ -891,6 +961,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/fromiterable.png" alt="">
 	 * <p>
+	 *
 	 * @param it the {@link Iterable} to read data from
 	 * @param <T> The type of values in the source {@link Iterable} and resulting Flux
 	 *
@@ -2309,6 +2380,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/buffer.png"
 	 * alt="">
 	 *
+	 * @reactor.discard This operator discards the buffer upon cancellation or error triggered by a data signal.
+	 *
 	 * @return a buffered {@link Flux} of at most one {@link List}
 	 * @see #collectList() for an alternative collecting algorithm returning {@link Mono}
 	 */
@@ -2323,6 +2396,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/buffersize.png"
 	 * alt="">
+	 *
+	 * @reactor.discard This operator discards the currently open buffer upon cancellation or error triggered by a data signal.
 	 *
 	 * @param maxSize the maximum collected size
 	 *
@@ -2339,6 +2414,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/buffersize.png"
 	 * alt="">
+	 *
+	 * @reactor.discard This operator discards the currently open buffer upon cancellation or error triggered by a data signal,
+	 * as well as latest unbuffered element if the bufferSupplier fails.
 	 *
 	 * @param maxSize the maximum collected size
 	 * @param bufferSupplier a {@link Supplier} of the concrete {@link Collection} to use for each buffer
@@ -2371,6 +2449,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/buffersize.png"
 	 * alt="">
 	 *
+	 * @reactor.discard This operator discards elements in between buffers (in the case of
+	 * dropping buffers). It also discards the currently open buffer upon cancellation or error triggered by a data signal.
+	 * Note however that overlapping buffer variant DOES NOT discard, as this might result in an element
+	 * being discarded from an early buffer while it is still valid in a more recent buffer.
+	 *
 	 * @param skip the number of items to count before creating a new buffer
 	 * @param maxSize the max collected size
 	 *
@@ -2401,6 +2484,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/buffersize.png"
 	 * alt="">
 	 *
+	 * @reactor.discard This operator discards elements in between buffers (in the case of
+	 * dropping buffers). It also discards the currently open buffer upon cancellation or error triggered by a data signal.
+	 * Note however that overlapping buffer variant DOES NOT discard, as this might result in an element
+	 * being discarded from an early buffer while it is still valid in a more recent buffer.
+	 *
 	 * @param skip the number of items to count before creating a new buffer
 	 * @param maxSize the max collected size
 	 * @param bufferSupplier a {@link Supplier} of the concrete {@link Collection} to use for each buffer
@@ -2421,6 +2509,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/bufferboundary.png"
 	 * alt="">
 	 *
+	 * @reactor.discard This operator discards the currently open buffer upon cancellation or error triggered by a data signal.
+	 *
 	 * @param other the companion {@link Publisher} whose signals trigger new buffers
 	 *
 	 * @return a microbatched {@link Flux} of {@link List} delimited by signals from a {@link Publisher}
@@ -2436,6 +2526,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/bufferboundary.png"
 	 * alt="">
+	 *
+	 * @reactor.discard This operator discards the currently open buffer upon cancellation or error triggered by a data signal,
+	 * and the last received element when the bufferSupplier fails.
 	 *
 	 * @param other the companion {@link Publisher} whose signals trigger new buffers
 	 * @param bufferSupplier a {@link Supplier} of the concrete {@link Collection} to use for each buffer
@@ -2453,6 +2546,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/buffertimespan.png"
 	 * alt="">
+	 *
+	 * @reactor.discard This operator discards the currently open buffer upon cancellation or error triggered by a data signal.
 	 *
 	 * @param timespan the duration from buffer creation until a buffer is closed and emitted
 	 *
@@ -2482,6 +2577,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/buffertimespan.png"
 	 * alt="">
 	 *
+	 * @reactor.discard This operator discards the currently open buffer upon cancellation or error triggered by a data signal.
+	 * It DOES NOT provide strong guarantees in the case of overlapping buffers, as elements
+	 * might get discarded too early (from the first of two overlapping buffers for instance).
+	 *
 	 * @param timespan the duration from buffer creation until a buffer is closed and emitted
 	 * @param timeshift the interval at which to create a new buffer
 	 *
@@ -2497,6 +2596,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/buffertimespan.png"
 	 * alt="">
+	 *
+	 * @reactor.discard This operator discards the currently open buffer upon cancellation or error triggered by a data signal.
 	 *
 	 * @param timespan the duration from buffer creation until a buffer is closed and emitted
 	 * @param timer a time-capable {@link Scheduler} instance to run on
@@ -2528,6 +2629,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/buffertimespan.png"
 	 * alt="">
 	 *
+	 * @reactor.discard This operator discards the currently open buffer upon cancellation or error triggered by a data signal.
+	 * It DOES NOT provide strong guarantees in the case of overlapping buffers, as elements
+	 * might get discarded too early (from the first of two overlapping buffers for instance).
+	 *
 	 * @param timespan the duration from buffer creation until a buffer is closed and emitted
 	 * @param timeshift the interval at which to create a new buffer
 	 * @param timer a time-capable {@link Scheduler} instance to run on
@@ -2550,6 +2655,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/buffertimespansize.png"
 	 * alt="">
 	 *
+	 * @reactor.discard This operator discards the currently open buffer upon cancellation or error triggered by a data signal.
+	 *
 	 * @param maxSize the max collected size
 	 * @param timespan the timeout enforcing the release of a partial buffer
 	 *
@@ -2566,6 +2673,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/buffertimespansize.png"
 	 * alt="">
+	 *
+	 * @reactor.discard This operator discards the currently open buffer upon cancellation or error triggered by a data signal.
 	 *
 	 * @param maxSize the max collected size
 	 * @param timespan the timeout enforcing the release of a partial buffer
@@ -2586,6 +2695,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/buffertimespansize.png"
 	 * alt="">
 	 *
+	 * @reactor.discard This operator discards the currently open buffer upon cancellation or error triggered by a data signal.
+	 *
 	 * @param maxSize the max collected size
 	 * @param timespan the timeout enforcing the release of a partial buffer
 	 * @param timer a time-capable {@link Scheduler} instance to run on
@@ -2603,6 +2714,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/buffertimespansize.png"
 	 * alt="">
+	 *
+	 * @reactor.discard This operator discards the currently open buffer upon cancellation or error triggered by a data signal.
 	 *
 	 * @param maxSize the max collected size
 	 * @param timespan the timeout enforcing the release of a partial buffer
@@ -2629,6 +2742,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * emitted. However, such a "partial" buffer isn't emitted in case of onError
 	 * termination.
 	 *
+	 * @reactor.discard This operator discards the currently open buffer upon cancellation or error triggered by a data signal.
+	 *
 	 * @param predicate a predicate that triggers the next buffer when it becomes true.
 	 * @return a microbatched {@link Flux} of {@link List}
 	 */
@@ -2651,6 +2766,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * On completion, if the latest buffer is non-empty and has not been closed it is
 	 * emitted. However, such a "partial" buffer isn't emitted in case of onError
 	 * termination.
+	 *
+	 * @reactor.discard This operator discards the currently open buffer upon cancellation or error triggered by a data signal.
 	 *
 	 * @param predicate a predicate that triggers the next buffer when it becomes true.
 	 * @param cutBefore set to true to include the triggering element in the new buffer rather than the old.
@@ -2675,6 +2792,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * On completion, if the latest buffer is non-empty and has not been closed it is
 	 * emitted. However, such a "partial" buffer isn't emitted in case of onError
 	 * termination.
+	 *
+	 * @reactor.discard This operator discards the currently open buffer upon cancellation or error triggered by a data signal,
+	 * as well as the buffer-triggering element.
 	 *
 	 * @param predicate a predicate that triggers the next buffer when it becomes false.
 	 * @return a microbatched {@link Flux} of {@link List}
@@ -2703,6 +2823,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/bufferboundary.png"
 	 * alt="">
+	 *
+	 * @reactor.discard This operator discards the currently open buffer upon cancellation or error triggered by a data signal.
+	 * It DOES NOT provide strong guarantees in the case of overlapping buffers, as elements
+	 * might get discarded too early (from the first of two overlapping buffers for instance).
 	 *
 	 * @param bucketOpening a companion {@link Publisher} to subscribe for buffer creation signals.
 	 * @param closeSelector a factory that, given a buffer opening signal, returns a companion
@@ -2737,6 +2861,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/bufferboundary.png"
 	 * alt="">
+	 *
+	 * @reactor.discard This operator discards the currently open buffer upon cancellation or error triggered by a data signal.
+	 * It DOES NOT provide strong guarantees in the case of overlapping buffers, as elements
+	 * might get discarded too early (from the first of two overlapping buffers for instance).
 	 *
 	 * @param bucketOpening a companion {@link Publisher} to subscribe for buffer creation signals.
 	 * @param closeSelector a factory that, given a buffer opening signal, returns a companion
@@ -3279,6 +3407,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/concatmap.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation.
+	 *
 	 * @param mapper the function to transform this sequence of T into concatenated sequences of V
 	 * @param <V> the produced concatenated type
 	 *
@@ -3312,6 +3442,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/concatmap.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation.
 	 *
 	 * @param mapper the function to transform this sequence of T into concatenated sequences of V
 	 * @param prefetch the inner source produced demand
@@ -3350,6 +3482,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/concatmap.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation.
 	 *
 	 * @param mapper the function to transform this sequence of T into concatenated sequences of V
 	 * @param <V> the produced concatenated type
@@ -3387,6 +3520,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/concatmap.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation.
 	 *
 	 * @param mapper the function to transform this sequence of T into concatenated sequences of V
 	 * @param prefetch the inner source produced demand
@@ -3426,6 +3560,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/concatmap.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation.
 	 *
 	 * @param mapper the function to transform this sequence of T into concatenated sequences of V
 	 * @param delayUntilEnd delay error until all sources have been consumed instead of
@@ -3455,6 +3590,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * Thus {@code flatMapIterable} and {@code concatMapIterable} are equivalent offered as a discoverability
 	 * improvement for users that explore the API with the concat vs flatMap expectation.
 	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation.
+	 *
 	 * @param mapper the {@link Function} to transform input sequence into N {@link Iterable}
 	 * @param <R> the merged output sequence type
 	 *
@@ -3475,6 +3612,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * no notion of eager vs lazy inner subscription. The content of the Iterables are all played sequentially.
 	 * Thus {@code flatMapIterable} and {@code concatMapIterable} are equivalent offered as a discoverability
 	 * improvement for users that explore the API with the concat vs flatMap expectation.
+	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation.
 	 *
 	 * @param mapper the {@link Function} to transform input sequence into N {@link Iterable}
 	 * @param prefetch the maximum in-flight elements from each inner {@link Iterable} sequence
@@ -3724,6 +3863,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/distinct.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements that don't match the distinct predicate,
+	 * but you should use the version with a cleanup if you need discarding of keys
+	 * categorized by the operator as "seen". See {@link #distinct(Function, Supplier, BiPredicate, Consumer)}.
+	 *
 	 * @return a filtering {@link Flux} only emitting distinct values
 	 */
 	public final Flux<T> distinct() {
@@ -3737,6 +3880,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/distinctk.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements that don't match the distinct predicate,
+	 * but you should use the version with a cleanup if you need discarding of keys
+	 * categorized by the operator as "seen". See {@link #distinct(Function, Supplier, BiPredicate, Consumer)}.
 	 *
 	 * @param keySelector function to compute comparison key for each element
 	 * @param <V> the type of the key extracted from each value in this sequence
@@ -3755,6 +3902,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/distinctk.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements that don't match the distinct predicate,
+	 * but you should use the version with a cleanup if you need discarding of keys
+	 * categorized by the operator as "seen". See {@link #distinct(Function, Supplier, BiPredicate, Consumer)}.
 	 *
 	 * @param keySelector function to compute comparison key for each element
 	 * @param distinctCollectionSupplier supplier of the {@link Collection} used for distinct
@@ -3781,6 +3932,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/distinctk.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements that don't match the distinct predicate,
+	 * but you should use the {@code cleanup} as well if you need discarding of keys
+	 * categorized by the operator as "seen".
 	 *
 	 * @param keySelector function to compute comparison key for each element
 	 * @param distinctStoreSupplier supplier of the arbitrary store object used in distinct
@@ -3814,10 +3969,15 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/distinctuntilchanged.png" alt="">
 	 * <p>
-	 * The values themselves are recorded into a {@link HashSet} for distinct detection.
+	 * The last distinct value seen is retained for further comparison, which is done
+	 * on the values themselves using {@link Object#equals(Object) the equals method}.
 	 * Use {@code distinctUntilChanged(Object::hashcode)} if you want a more lightweight approach that
 	 * doesn't retain all the objects, but is more susceptible to falsely considering two
 	 * elements as distinct due to a hashcode collision.
+	 *
+	 * @reactor.discard Although this operator discards elements that are considered as "already seen",
+	 * it is not recommended for cases where discarding is needed as the operator doesn't
+	 * discard the "key" (in this context, the distinct instance that was last seen).
 	 *
 	 * @return a filtering {@link Flux} with only one occurrence in a row of each element
 	 * (yet elements can repeat in the overall sequence)
@@ -3833,7 +3993,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/distinctuntilchangedk.png" alt="">
-
+	 *
+	 * @reactor.discard This operator discards elements that are considered as "already seen".
+	 * The keys themselves are not discarded.
 	 *
 	 * @param keySelector function to compute comparison key for each element
 	 * @param <V> the type of the key extracted from each value in this sequence
@@ -3852,6 +4014,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/distinctuntilchangedk.png"
 	 * alt="">
+	 *
+	 * @reactor.discard This operator discards elements that are considered as "already seen"
+	 * (for which the {@code keyComparator} returns {@literal true}). The keys themselves
+	 * are not discarded.
 	 *
 	 * @param keySelector function to compute comparison key for each element
 	 * @param keyComparator predicate used to compare keys.
@@ -4132,6 +4298,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/elementat.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements that appear before the requested index.
+	 *
 	 * @param index zero-based index of the only item to emit
 	 *
 	 * @return a {@link Mono} of the item at the specified zero-based index
@@ -4146,6 +4314,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/elementatd.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements that appear before the requested index.
 	 *
 	 * @param index zero-based index of the only item to emit
 	 * @param defaultValue a default value to emit if the sequence is shorter
@@ -4324,6 +4494,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * considered as if the predicate returned false: they cause the source value to be
 	 * dropped and a new element ({@code request(1)}) being requested from upstream.
 	 *
+	 * @reactor.discard This operator discards elements that do not match the filter. It
+	 * also discards elements internally queued for backpressure upon cancellation or error triggered by a data signal.
+	 *
 	 * @return a new {@link Flux} containing only values that pass the predicate test
 	 */
 	public final Flux<T> filter(Predicate<? super T> p) {
@@ -4343,6 +4516,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * is a {@link Mono}, test will be cancelled after receiving that first value. Test
 	 * publishers are generated and subscribed to in sequence.
 	 *
+	 * @reactor.discard This operator discards elements that do not match the filter. It
+	 * also discards elements internally queued for backpressure upon cancellation or error triggered by a data signal.
+	 *
 	 * @param asyncPredicate the function generating a {@link Publisher} of {@link Boolean}
 	 * for each value, to filter the Flux with
 	 * @return a filtered {@link Flux}
@@ -4360,6 +4536,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * Note that only the first value of the test publisher is considered, and unless it
 	 * is a {@link Mono}, test will be cancelled after receiving that first value. Test
 	 * publishers are generated and subscribed to in sequence.
+	 *
+	 * @reactor.discard This operator discards elements that do not match the filter. It
+	 * also discards elements internally queued for backpressure upon cancellation or error triggered by a data signal.
 	 *
 	 * @param asyncPredicate the function generating a {@link Publisher} of {@link Boolean}
 	 * for each value, to filter the Flux with
@@ -4393,6 +4572,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/flatmap.png" alt="">
 	 * <p>
+	 *
+	 * @reactor.discard This operator discards elements internally queued for backpressure upon cancellation or error triggered by a data signal.
+	 *
 	 * @param mapper the {@link Function} to transform input sequence into N sequences {@link Publisher}
 	 * @param <R> the merged output sequence type
 	 *
@@ -4431,6 +4613,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/flatmapc.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements internally queued for backpressure upon cancellation or error triggered by a data signal.
 	 *
 	 * @param mapper the {@link Function} to transform input sequence into N sequences {@link Publisher}
 	 * @param concurrency the maximum number of in-flight inner sequences
@@ -4475,6 +4659,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/flatmapc.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements internally queued for backpressure upon cancellation or error triggered by a data signal.
+	 *
 	 * @param mapper the {@link Function} to transform input sequence into N sequences {@link Publisher}
 	 * @param concurrency the maximum number of in-flight inner sequences
 	 * @param prefetch the maximum in-flight elements from each inner {@link Publisher} sequence
@@ -4517,6 +4703,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/flatmapc.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements internally queued for backpressure upon cancellation or error triggered by a data signal.
+	 *
 	 * @param mapper the {@link Function} to transform input sequence into N sequences {@link Publisher}
 	 * @param concurrency the maximum number of in-flight inner sequences
 	 * @param prefetch the maximum in-flight elements from each inner {@link Publisher} sequence
@@ -4557,6 +4745,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/flatmaps.png" alt="">
 	 * <p>
+	 *
 	 * @param mapperOnNext the {@link Function} to call on next data and returning a sequence to merge.
 	 * Use {@literal null} to ignore (provided at least one other mapper is specified).
 	 * @param mapperOnError the {@link Function} to call on error signal and returning a sequence to merge.
@@ -4592,6 +4781,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * Thus {@code flatMapIterable} and {@code concatMapIterable} are equivalent offered as a discoverability
 	 * improvement for users that explore the API with the concat vs flatMap expectation.
 	 *
+	 * @reactor.discard This operator discards elements internally queued for backpressure upon cancellation or error triggered by a data signal.
+	 *
 	 * @param mapper the {@link Function} to transform input sequence into N {@link Iterable}
 	 * @param <R> the merged output sequence type
 	 *
@@ -4613,6 +4804,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * no notion of eager vs lazy inner subscription. The content of the Iterables are all played sequentially.
 	 * Thus {@code flatMapIterable} and {@code concatMapIterable} are equivalent offered as a discoverability
 	 * improvement for users that explore the API with the concat vs flatMap expectation.
+	 *
+	 * @reactor.discard This operator discards elements internally queued for backpressure upon cancellation or error triggered by a data signal.
 	 *
 	 * @param mapper the {@link Function} to transform input sequence into N {@link Iterable}
 	 * @param prefetch the maximum in-flight elements from each inner {@link Iterable} sequence
@@ -5062,6 +5255,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/ignoreelements.png" alt="">
 	 * <p>
 	 *
+	 * @reactor.discard This operator discards the upstream's elements.
+	 *
 	 * @return a new empty {@link Mono} representing the completion of this {@link Flux}.
 	 */
 	public final Mono<T> ignoreElements() {
@@ -5113,6 +5308,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/last.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements before the last.
+	 *
 	 * @return a {@link Mono} with the last value in this {@link Flux}
 	 */
     public final Mono<T> last() {
@@ -5135,6 +5332,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/last.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements before the last.
+	 *
 	 * @param defaultValue  a single fallback item if this {@link Flux} is empty
 	 * @return a {@link Mono} with the last value in this {@link Flux}
 	 */
@@ -5551,6 +5751,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/onbackpressurebuffer.png" alt="">
 	 *
+	 * @reactor.discard This operator discards the buffered overflow elements upon cancellation or error triggered by a data signal.
+	 *
 	 * @return a backpressured {@link Flux} that buffers with unbounded capacity
 	 *
 	 */
@@ -5566,6 +5768,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/onbackpressurebuffer.png" alt="">
+	 *
+	 * @reactor.discard This operator discards the buffered overflow elements upon cancellation or error triggered by a data signal,
+	 * as well as elements that are rejected by the buffer due to {@code maxSize}.
 	 *
 	 * @param maxSize maximum buffer backlog size before immediate error
 	 *
@@ -5584,6 +5789,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/onbackpressurebuffer.png" alt="">
+	 *
+	 * @reactor.discard This operator discards the buffered overflow elements upon cancellation or error triggered by a data signal,
+	 * as well as elements that are rejected by the buffer due to {@code maxSize} (even though
+	 * they are passed to the {@code onOverflow} {@link Consumer} first).
 	 *
 	 * @param maxSize maximum buffer backlog size before overflow callback is called
 	 * @param onOverflow callback to invoke on overflow
@@ -5606,6 +5815,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/onbackpressurebuffer.png" alt="">
+	 *
+	 * @reactor.discard This operator discards the buffered overflow elements upon cancellation or error triggered by a data signal,
+	 * as well as elements that are rejected by the buffer due to {@code maxSize} (even though
+	 * they are passed to the {@code bufferOverflowStrategy} first).
+	 *
 	 *
 	 * @param maxSize maximum buffer backlog size before overflow strategy is applied
 	 * @param bufferOverflowStrategy strategy to apply to overflowing elements
@@ -5637,6 +5851,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/onbackpressurebuffer.png" alt="">
 	 *
+	 * @reactor.discard This operator discards the buffered overflow elements upon cancellation or error triggered by a data signal,
+	 * as well as elements that are rejected by the buffer due to {@code maxSize} (even though
+	 * they are passed to the {@code onOverflow} {@link Consumer} AND the {@code bufferOverflowStrategy} first).
+	 *
 	 * @param maxSize maximum buffer backlog size before overflow callback is called
 	 * @param onBufferOverflow callback to invoke on overflow
 	 * @param bufferOverflowStrategy strategy to apply to overflowing elements
@@ -5665,6 +5883,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/onbackpressurebuffer.png" alt="">
 	 *
+	 * @reactor.discard This operator discards its internal buffer of elements that overflow,
+	 * after having applied the {@code onBufferEviction} handler.
+	 *
 	 * @param ttl maximum {@link Duration} for which an element is kept in the backlog
 	 * @param maxSize maximum buffer backlog size before overflow callback is called
 	 * @param onBufferEviction callback to invoke once TTL is reached or on overflow
@@ -5688,6 +5909,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/onbackpressurebuffer.png" alt="">
 	 *
+	 * @reactor.discard This operator discards its internal buffer of elements that overflow,
+	 * after having applied the {@code onBufferEviction} handler.
+	 *
 	 * @param ttl maximum {@link Duration} for which an element is kept in the backlog
 	 * @param maxSize maximum buffer backlog size before overflow callback is called
 	 * @param onBufferEviction callback to invoke once TTL is reached or on overflow
@@ -5709,6 +5933,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/onbackpressuredrop.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements that it drops.
+	 *
 	 * @return a backpressured {@link Flux} that drops overflowing elements
 	 */
 	public final Flux<T> onBackpressureDrop() {
@@ -5722,6 +5948,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/onbackpressuredropc.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements that it drops after having passed
+	 * them to the provided {@code onDropped} handler.
 	 *
 	 * @param onDropped the Consumer called when an value gets dropped due to lack of downstream requests
 	 * @return a backpressured {@link Flux} that drops overflowing elements
@@ -5738,6 +5967,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/onbackpressureerror.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements that it drops, after having propagated
+	 * the error.
+	 *
 	 * @return a backpressured {@link Flux} that errors on overflowing elements
 	 */
 	public final Flux<T> onBackpressureError() {
@@ -5750,6 +5982,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/onbackpressurelatest.png" alt="">
+	 *
+	 * @reactor.discard Each time a new element comes in (the new "latest"), this operator
+	 * discards the previously retained element.
 	 *
 	 * @return a backpressured {@link Flux} that will only keep a reference to the last observed item
 	 */
@@ -6232,6 +6467,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * {@code flux.publishOn(Schedulers.single()).subscribe() }
 	 * </pre></blockquote>
 	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation or error triggered by a data signal.
+	 *
 	 * @param scheduler a {@link Scheduler} providing the {@link Worker} where to publish
 	 *
 	 * @return a {@link Flux} producing asynchronously on a given {@link Scheduler}
@@ -6253,6 +6490,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <blockquote><pre>
 	 * {@code flux.publishOn(Schedulers.single()).subscribe() }
 	 * </pre></blockquote>
+	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation or error triggered by a data signal.
 	 *
 	 * @param scheduler a {@link Scheduler} providing the {@link Worker} where to publish
 	 * @param prefetch the asynchronous boundary capacity
@@ -6276,6 +6515,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <blockquote><pre>
 	 * {@code flux.publishOn(Schedulers.single()).subscribe() }
 	 * </pre></blockquote>
+	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation or error triggered by a data signal.
 	 *
 	 * @param scheduler a {@link Scheduler} providing the {@link Worker} where to publish
 	 * @param delayError should the buffer be consumed before forwarding any error
@@ -6822,6 +7063,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/sampletimespan.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements that are not part of the sampling.
+	 *
 	 * @param timespan the duration of the window after which to emit the latest observed item
 	 *
 	 * @return a {@link Flux} sampled to the last item seen over each periodic window
@@ -6846,6 +7089,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/sample.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements that are not part of the sampling.
+	 *
 	 * @param sampler the sampler companion {@link Publisher}
 	 *
 	 * @param <U> the type of the sampler sequence
@@ -6863,6 +7108,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/samplefirsttimespan.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements that are not part of the sampling.
+	 *
 	 * @param timespan the duration during which to skip values after each sample
 	 *
 	 * @return a {@link Flux} sampled to the first item of each duration-based window
@@ -6877,6 +7124,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/samplefirst.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements that are not part of the sampling.
 	 *
 	 * @param samplerFactory supply a companion sampler {@link Publisher} which signals the end of the skip window
 	 * @param <U> the companion reified type
@@ -6896,6 +7145,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/sampletimeout.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements that are not part of the sampling.
 	 *
 	 * @param throttlerFactory supply a companion sampler {@link Publisher} which signals
 	 * the end of the window during which no new emission should occur. If it is the case,
@@ -6920,6 +7171,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/sampletimeoutm.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements that are not part of the sampling.
 	 *
 	 * @param throttlerFactory supply a companion sampler {@link Publisher} which signals
 	 * the end of the window during which no new emission should occur. If it is the case,
@@ -7135,6 +7388,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/skip.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements that are skipped.
+	 *
 	 * @param skipped the number of elements to drop
 	 *
 	 * @return a dropping {@link Flux} with the specified number of elements skipped at
@@ -7155,6 +7410,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/skiptime.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements that are skipped.
+	 *
 	 * @param timespan the initial time window during which to drop elements
 	 *
 	 * @return a {@link Flux} dropping at the beginning until the end of the given duration
@@ -7169,6 +7426,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/skiptime.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements that are skipped.
 	 *
 	 * @param timespan the initial time window during which to drop elements
 	 * @param timer a time-capable {@link Scheduler} instance to measure the time window on
@@ -7190,6 +7449,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/skiplast.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements that are skipped.
+	 *
 	 * @param n the number of elements to drop before completion
 	 *
 	 * @return a {@link Flux} dropping the specified number of elements at the end of the
@@ -7210,6 +7471,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/skipuntil.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements that are skipped.
+	 *
 	 * @param untilPredicate the {@link Predicate} evaluated to stop skipping.
 	 *
 	 * @return a {@link Flux} dropping until the {@link Predicate} matches
@@ -7225,6 +7488,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/skipuntil.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements that are skipped.
+	 *
 	 * @param other the companion {@link Publisher} to coordinate with to stop skipping
 	 *
 	 * @return a {@link Flux} dropping until the other {@link Publisher} emits
@@ -7239,6 +7504,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/skipwhile.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements that are skipped.
 	 *
 	 * @param skipPredicate the {@link Predicate} that causes skipping while evaluating to true.
 	 *
@@ -7845,6 +8112,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/ignorethen.png" alt="">
 	 * <p>
+	 *
+	 * @reactor.discard This operator discards elements from the source.
+	 *
 	 * @return a new {@link Mono} representing the termination of this {@link Flux}
 	 */
 	public final Mono<Void> then() {
@@ -7863,6 +8133,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/ignorethen1.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements from the source.
+	 *
 	 * @param other a {@link Mono} to emit from after termination
 	 * @param <V> the element type of the supplied Mono
 	 *
@@ -7880,6 +8152,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.2.0.M2/src/docs/marble/thenempty.png"
 	 * alt="">
 	 *
+	 * @reactor.discard This operator discards elements from the source.
+	 *
 	 * @param other a {@link Publisher} to wait for after this Flux's termination
 	 * @return a new {@link Mono} completing when both publishers have completed in
 	 * sequence
@@ -7895,6 +8169,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * {@code Publisher<V>} that will emit elements from the provided {@link Publisher}.
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.2.0.M2/src/docs/marble/thenmany.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements from the source.
 	 *
 	 * @param other a {@link Publisher} to emit from after termination
 	 * @param <V> the element type of the supplied Publisher
@@ -8221,6 +8497,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/windowsize.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure
+	 * upon cancellation or error triggered by a data signal.
+	 *
 	 * @param maxSize the maximum number of items to emit in the window before closing it
 	 *
 	 * @return a {@link Flux} of {@link Flux} windows based on element count
@@ -8246,6 +8525,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/windowsize.png" alt="">
 	 *
+	 * @reactor.discard The overlapping variant DOES NOT discard elements, as they might be part of another still valid window.
+	 * The exact window and dropping window variants bot discard elements they internally queued for backpressure
+	 * upon cancellation or error triggered by a data signal. The dropping window variant also discards elements in between windows.
+	 *
 	 * @param maxSize the maximum number of items to emit in the window before closing it
 	 * @param skip the number of items to count before opening and emitting a new window
 	 *
@@ -8266,6 +8549,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/windowboundary.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure
+	 * upon cancellation or error triggered by a data signal.
+	 *
 	 * @param boundary a {@link Publisher} to emit any item for a split signal and complete to terminate
 	 *
 	 * @return a {@link Flux} of {@link Flux} windows delimited by a given {@link Publisher}
@@ -8282,6 +8568,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/windowtimespan.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure
+	 * upon cancellation or error triggered by a data signal.
 	 *
 	 * @param timespan the {@link Duration} to delimit {@link Flux} windows
 	 *
@@ -8311,6 +8600,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/windowsize.png" alt="">
 	 *
+	 * @reactor.discard The overlapping variant DOES NOT discard elements, as they might be part of another still valid window.
+	 * The exact window and dropping window variants bot discard elements they internally queued for backpressure
+	 * upon cancellation or error triggered by a data signal. The dropping window variant also discards elements in between windows.
+	 *
 	 * @param timespan the maximum {@link Flux} window {@link Duration}
 	 * @param timeshift the period of time at which to create new {@link Flux} windows
 	 *
@@ -8328,6 +8621,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/windowtimespan.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure
+	 * upon cancellation or error triggered by a data signal.
 	 *
 	 * @param timespan the {@link Duration} to delimit {@link Flux} windows
 	 * @param timer a time-capable {@link Scheduler} instance to run on
@@ -8358,6 +8654,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/windowsize.png" alt="">
 	 *
+	 * @reactor.discard The overlapping variant DOES NOT discard elements, as they might be part of another still valid window.
+	 * The exact window and dropping window variants bot discard elements they internally queued for backpressure
+	 * upon cancellation or error triggered by a data signal. The dropping window variant also discards elements in between windows.
+	 *
 	 * @param timespan the maximum {@link Flux} window {@link Duration}
 	 * @param timeshift the period of time at which to create new {@link Flux} windows
 	 * @param timer a time-capable {@link Scheduler} instance to run on
@@ -8382,6 +8682,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/windowsizetimeout.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure
+	 * upon cancellation or error triggered by a data signal.
+	 *
 	 * @param maxSize the maximum number of items to emit in the window before closing it
 	 * @param timespan the maximum {@link Duration} since the window was opened before closing it
 	 *
@@ -8400,6 +8703,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/windowsizetimeout.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure
+	 * upon cancellation or error triggered by a data signal.
 	 *
 	 * @param maxSize the maximum number of items to emit in the window before closing it
 	 * @param timespan the maximum {@link Duration} since the window was opened before closing it
@@ -8423,6 +8729,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/windowuntil.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure
+	 * upon cancellation or error triggered by a data signal.
 	 *
 	 * @param boundaryTrigger a predicate that triggers the next window when it becomes true.
 	 * @return a {@link Flux} of {@link Flux} windows, bounded depending
@@ -8450,6 +8759,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * expose empty windows, as the separators are emitted into the windows they close.
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/windowuntilcutafter.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure
+	 * upon cancellation or error triggered by a data signal.
 	 *
 	 * @param boundaryTrigger a predicate that triggers the next window when it becomes true.
 	 * @param cutBefore set to true to include the triggering element in the new window rather than the old.
@@ -8480,6 +8792,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/windowuntilcutafter.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure
+	 * upon cancellation or error triggered by a data signal.
+	 *
 	 * @param boundaryTrigger a predicate that triggers the next window when it becomes true.
 	 * @param cutBefore set to true to include the triggering element in the new window rather than the old.
 	 * @param prefetch the request size to use for this {@link Flux}.
@@ -8508,6 +8823,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/windowwhile.png" alt="">
 	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure
+	 * upon cancellation or error triggered by a data signal, as well as the triggering element(s) (that doesn't match
+	 * the predicate).
+	 *
 	 * @param inclusionPredicate a predicate that triggers the next window when it becomes false.
 	 * @return a {@link Flux} of {@link Flux} windows, each containing
 	 * subsequent elements that all passed a predicate.
@@ -8528,6 +8847,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * to be emitted.
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/windowwhile.png" alt="">
+	 *
+	 * @reactor.discard This operator discards elements it internally queued for backpressure
+	 * upon cancellation or error triggered by a data signal, as well as the triggering element(s) (that doesn't match
+	 * the predicate).
 	 *
 	 * @param inclusionPredicate a predicate that triggers the next window when it becomes false.
 	 * @param prefetch the request size to use for this {@link Flux}.
@@ -8559,6 +8882,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * When Open signal is exactly coordinated with Close signal : exact windows
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/windowboundary.png" alt="">
+	 *
+	 * @reactor.discard This operator DOES NOT discard elements.
 	 *
 	 * @param bucketOpening a {@link Publisher} that opens a new window when it emits any item
 	 * @param closeSelector a {@link Function} given an opening signal and returning a {@link Publisher} that

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 					"The bufferSupplier returned a null buffer");
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
+			Operators.error(actual, Operators.onOperatorError(e,  actual.currentContext()));
 			return;
 		}
 
@@ -90,6 +90,7 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 
 		final Supplier<C>           bufferSupplier;
 		final CoreSubscriber<? super C> actual;
+		final Context ctx;
 
 		final BufferBoundaryOther<U> other;
 
@@ -112,6 +113,7 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 				C buffer,
 				Supplier<C> bufferSupplier) {
 			this.actual = actual;
+			this.ctx =  actual.currentContext();
 			this.buffer = buffer;
 			this.bufferSupplier = bufferSupplier;
 			this.other = new BufferBoundaryOther<>(this);
@@ -147,6 +149,7 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 		@Override
 		public void cancel() {
 			Operators.terminate(S, this);
+			Operators.onDiscardMultiple(buffer, this.ctx);
 			other.cancel();
 		}
 
@@ -167,21 +170,24 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 				}
 			}
 
-			Operators.onNextDropped(t, actual.currentContext());
+			Operators.onNextDropped(t, this.ctx);
 		}
 
 		@Override
 		public void onError(Throwable t) {
 			if(Operators.terminate(S, this)) {
+				C b;
 				synchronized (this) {
+					b = buffer;
 					buffer = null;
 				}
 
 				other.cancel();
 				actual.onError(t);
+				Operators.onDiscardMultiple(b, this.ctx);
 				return;
 			}
-			Operators.onErrorDropped(t, actual.currentContext());
+			Operators.onErrorDropped(t, this.ctx);
 		}
 
 		@Override
@@ -197,7 +203,7 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 				if (!b.isEmpty()) {
 					if (emit(b)) {
 						actual.onComplete();
-					}
+					} //failed emit will discard buffer's elements
 				}
 				else {
 					actual.onComplete();
@@ -220,7 +226,7 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 				if (b != null && !b.isEmpty()) {
 					if (emit(b)) {
 						actual.onComplete();
-					}
+					} //failed emit will discard buffer content
 				}
 				else {
 					actual.onComplete();
@@ -231,7 +237,9 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 		void otherError(Throwable t){
 			Subscription s = S.getAndSet(this, Operators.cancelledSubscription());
 			if(s != Operators.cancelledSubscription()) {
+				C b;
 				synchronized (this) {
+					b = buffer;
 					buffer = null;
 				}
 
@@ -240,9 +248,10 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 				}
 
 				actual.onError(t);
+				Operators.onDiscardMultiple(b, this.ctx);
 				return;
 			}
-			Operators.onErrorDropped(t, actual.currentContext());
+			Operators.onErrorDropped(t, this.ctx);
 		}
 
 		void otherNext() {
@@ -253,7 +262,7 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 						"The bufferSupplier returned a null buffer");
 			}
 			catch (Throwable e) {
-				otherError(Operators.onOperatorError(other, e, actual.currentContext()));
+				otherError(Operators.onOperatorError(other, e, this.ctx));
 				return;
 			}
 
@@ -281,8 +290,8 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 			}
 			else {
 				actual.onError(Operators.onOperatorError(this, Exceptions
-						.failWithOverflow(), b, actual.currentContext()));
-
+						.failWithOverflow(), b, this.ctx));
+				Operators.onDiscardMultiple(b, this.ctx);
 				return false;
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -125,6 +125,7 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 			implements FluxConcatMapSupport<T, R> {
 
 		final CoreSubscriber<? super R> actual;
+		final Context ctx;
 
 		final ConcatMapInner<R> inner;
 
@@ -171,6 +172,7 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 				Function<? super T, ? extends Publisher<? extends R>> mapper,
 				Supplier<? extends Queue<T>> queueSupplier, int prefetch) {
 			this.actual = actual;
+			this.ctx = actual.currentContext();
 			this.mapper = mapper;
 			this.queueSupplier = queueSupplier;
 			this.prefetch = prefetch;
@@ -235,7 +237,8 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 			}
 			else if (!queue.offer(t)) {
 				onError(Operators.onOperatorError(s, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t,
-						actual.currentContext()));
+						this.ctx));
+				Operators.onDiscard(t, this.ctx);
 			}
 			else {
 				drain();
@@ -251,11 +254,12 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 					t = Exceptions.terminate(ERROR, this);
 					if (t != TERMINATED) {
 						actual.onError(t);
+						Operators.onDiscardQueueWithClear(queue, this.ctx, null);
 					}
 				}
 			}
 			else {
-				Operators.onErrorDropped(t, actual.currentContext());
+				Operators.onErrorDropped(t, this.ctx);
 			}
 		}
 
@@ -300,7 +304,7 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 					}
 				}
 				else {
-					Operators.onErrorDropped(e, actual.currentContext());
+					Operators.onErrorDropped(e, this.ctx);
 				}
 			}
 			else {
@@ -326,6 +330,7 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 
 				inner.cancel();
 				s.cancel();
+				Operators.onDiscardQueueWithClear(queue, this.ctx, null);
 			}
 		}
 
@@ -345,8 +350,7 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 							v = queue.poll();
 						}
 						catch (Throwable e) {
-							actual.onError(Operators.onOperatorError(s, e,
-									actual.currentContext()));
+							actual.onError(Operators.onOperatorError(s, e, this.ctx));
 							return;
 						}
 
@@ -365,10 +369,11 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 								"The mapper returned a null Publisher");
 							}
 							catch (Throwable e) {
-								Throwable e_ = Operators.onNextError(v, e, actual.currentContext(), s);
+								Operators.onDiscard(v, this.ctx);
+								Throwable e_ = Operators.onNextError(v, e, this.ctx, s);
 								if (e_ != null) {
 									actual.onError(Operators.onOperatorError(s, e, v,
-																			 actual.currentContext()));
+											this.ctx));
 									return;
 								}
 								else {
@@ -397,10 +402,10 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 									vr = callable.call();
 								}
 								catch (Throwable e) {
-									Throwable e_ = Operators.onNextError(v, e, actual.currentContext(), s);
+									Throwable e_ = Operators.onNextError(v, e, this.ctx, s);
 									if (e_ != null) {
 										actual.onError(Operators.onOperatorError(s, e, v,
-																				 actual.currentContext()));
+												this.ctx));
 										return;
 									}
 									else {
@@ -469,7 +474,7 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 
 		@Override
 		public void cancel() {
-
+			Operators.onDiscard(value, actual.currentContext());
 		}
 	}
 
@@ -477,6 +482,7 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 			implements FluxConcatMapSupport<T, R> {
 
 		final CoreSubscriber<? super R> actual;
+		final Context ctx;
 
 		final ConcatMapInner<R> inner;
 
@@ -521,6 +527,7 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 				Supplier<? extends Queue<T>> queueSupplier,
 				int prefetch, boolean veryEnd) {
 			this.actual = actual;
+			this.ctx = actual.currentContext();
 			this.mapper = mapper;
 			this.queueSupplier = queueSupplier;
 			this.prefetch = prefetch;
@@ -594,7 +601,8 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 			}
 			else if (!queue.offer(t)) {
 				onError(Operators.onOperatorError(s, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t,
-						actual.currentContext()));
+						this.ctx));
+				Operators.onDiscard(t, this.ctx);
 			}
 			else {
 				drain();
@@ -608,7 +616,7 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 				drain();
 			}
 			else {
-				Operators.onErrorDropped(t, actual.currentContext());
+				Operators.onErrorDropped(t, this.ctx);
 			}
 		}
 
@@ -642,7 +650,7 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 					drain();
 				}
 				else {
-					Operators.onErrorDropped(e, actual.currentContext());
+					Operators.onErrorDropped(e, this.ctx);
 				}
 			}
 			else {
@@ -662,12 +670,12 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 
 				inner.cancel();
 				s.cancel();
+				Operators.onDiscardQueueWithClear(queue, this.ctx, null);
 			}
 		}
 
 		void drain() {
 			if (WIP.getAndIncrement(this) == 0) {
-
 				for (; ; ) {
 					if (cancelled) {
 						return;
@@ -694,8 +702,7 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 							v = queue.poll();
 						}
 						catch (Throwable e) {
-							actual.onError(Operators.onOperatorError(s, e,
-									actual.currentContext()));
+							actual.onError(Operators.onOperatorError(s, e, this.ctx));
 							return;
 						}
 
@@ -720,10 +727,11 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 										"The mapper returned a null Publisher");
 							}
 							catch (Throwable e) {
-								Throwable e_ = Operators.onNextError(v, e, actual.currentContext(), s);
+								Operators.onDiscard(v, this.ctx);
+								Throwable e_ = Operators.onNextError(v, e, this.ctx, s);
 								if (e_ != null) {
 									actual.onError(Operators.onOperatorError(s, e, v,
-																			 actual.currentContext()));
+											this.ctx));
 									return;
 								}
 								else {
@@ -753,7 +761,8 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 								}
 								catch (Throwable e) {
 									//does the strategy apply? if so, short-circuit the delayError. In any case, don't cancel
-									Throwable e_ = Operators.onNextPollError(v, e, actual.currentContext());
+									Throwable e_ = Operators.onNextPollError(v, e,
+											this.ctx);
 									if (e_ == null) {
 										continue;
 									}
@@ -762,7 +771,8 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 										continue;
 									}
 									else {
-										actual.onError(Operators.onOperatorError(s, e, v, actual.currentContext()));
+										actual.onError(Operators.onOperatorError(s, e, v,
+												this.ctx));
 										return;
 									}
 								}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDetach.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDetach.java
@@ -20,6 +20,7 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * Detaches the both the child Subscriber and the Subscription on
@@ -49,6 +50,11 @@ final class FluxDetach<T> extends FluxOperator<T, T> {
 
 		DetachSubscriber(CoreSubscriber<? super T> actual) {
 			this.actual = actual;
+		}
+
+		@Override
+		public Context currentContext() {
+			return actual == null ? Context.empty() : actual.currentContext();
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * Filters out values that make a filter function return false.
@@ -56,6 +57,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 			           ConditionalSubscriber<T> {
 
 		final CoreSubscriber<? super T> actual;
+		final Context                   ctx;
 
 		final Predicate<? super T> predicate;
 
@@ -68,6 +70,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 		FilterFuseableSubscriber(CoreSubscriber<? super T> actual,
 				Predicate<? super T> predicate) {
 			this.actual = actual;
+			this.ctx = actual.currentContext();
 			this.predicate = predicate;
 		}
 
@@ -87,7 +90,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t, actual.currentContext());
+					Operators.onNextDropped(t, this.ctx);
 					return;
 				}
 				boolean b;
@@ -96,13 +99,14 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 					b = predicate.test(t);
 				}
 				catch (Throwable e) {
-					Throwable e_ = Operators.onNextError(t, e, actual.currentContext(), s);
+					Throwable e_ = Operators.onNextError(t, e, this.ctx, s);
 					if (e_ != null) {
 						onError(e_);
 					}
 					else {
 						s.request(1);
 					}
+					Operators.onDiscard(t, this.ctx);
 					return;
 				}
 				if (b) {
@@ -110,6 +114,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 				}
 				else {
 					s.request(1);
+					Operators.onDiscard(t, this.ctx);
 				}
 			}
 		}
@@ -117,7 +122,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onNextDropped(t, this.ctx);
 				return false;
 			}
 
@@ -127,23 +132,25 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 				b = predicate.test(t);
 			}
 			catch (Throwable e) {
-				Throwable e_ = Operators.onNextError(t, e, actual.currentContext(), s);
+				Throwable e_ = Operators.onNextError(t, e, this.ctx, s);
 				if (e_ != null) {
 					onError(e_);
 				}
+				Operators.onDiscard(t, this.ctx);
 				return false;
 			}
 			if (b) {
 				actual.onNext(t);
 				return true;
 			}
+			Operators.onDiscard(t, this.ctx);
 			return false;
 		}
 
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t, actual.currentContext());
+				Operators.onErrorDropped(t, this.ctx);
 				return;
 			}
 			done = true;
@@ -198,10 +205,12 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 							}
 							return v;
 						}
+						Operators.onDiscard(v, this.ctx);
 						dropped++;
 					}
 					catch (Throwable e) {
 						RuntimeException e_ = Operators.onNextPollError(v, e, currentContext());
+						Operators.onDiscard(v, this.ctx);
 						if (e_ != null) {
 							throw e_;
 						}
@@ -217,9 +226,11 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 						if (v == null || predicate.test(v)) {
 							return v;
 						}
+						Operators.onDiscard(v, this.ctx);
 					}
 					catch (Throwable e) {
 						RuntimeException e_ = Operators.onNextPollError(v, e, currentContext());
+						Operators.onDiscard(v, this.ctx);
 						if (e_ != null) {
 							throw e_;
 						}
@@ -263,6 +274,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 			           QueueSubscription<T> {
 
 		final ConditionalSubscriber<? super T> actual;
+		final Context ctx;
 
 		final Predicate<? super T> predicate;
 
@@ -275,6 +287,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 		FilterFuseableConditionalSubscriber(ConditionalSubscriber<? super T> actual,
 				Predicate<? super T> predicate) {
 			this.actual = actual;
+			this.ctx = actual.currentContext();
 			this.predicate = predicate;
 		}
 
@@ -295,7 +308,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t, actual.currentContext());
+					Operators.onNextDropped(t, this.ctx);
 					return;
 				}
 				boolean b;
@@ -304,13 +317,14 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 					b = predicate.test(t);
 				}
 				catch (Throwable e) {
-					Throwable e_ = Operators.onNextError(t, e, actual.currentContext(), s);
+					Throwable e_ = Operators.onNextError(t, e, this.ctx, s);
 					if (e_ != null) {
 						onError(e_);
 					}
 					else {
 						s.request(1);
 					}
+					Operators.onDiscard(t, this.ctx);
 					return;
 				}
 				if (b) {
@@ -318,6 +332,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 				}
 				else {
 					s.request(1);
+					Operators.onDiscard(t, this.ctx);
 				}
 			}
 		}
@@ -325,7 +340,7 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onNextDropped(t, this.ctx);
 				return false;
 			}
 
@@ -335,19 +350,26 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 				b = predicate.test(t);
 			}
 			catch (Throwable e) {
-				Throwable e_ = Operators.onNextError(t, e, actual.currentContext(), s);
+				Throwable e_ = Operators.onNextError(t, e, this.ctx, s);
 				if (e_ != null) {
 					onError(e_);
 				}
+				Operators.onDiscard(t, this.ctx);
 				return false;
 			}
-			return b && actual.tryOnNext(t);
+			if (b) {
+				return actual.tryOnNext(t);
+			}
+			else {
+				Operators.onDiscard(t, this.ctx);
+				return false;
+			}
 		}
 
 		@Override
 		public void onError(Throwable t) {
 			if (done) {
-				Operators.onErrorDropped(t, actual.currentContext());
+				Operators.onErrorDropped(t, this.ctx);
 				return;
 			}
 			done = true;
@@ -401,10 +423,12 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 							}
 							return v;
 						}
+						Operators.onDiscard(v, this.ctx);
 						dropped++;
 					}
 					catch (Throwable e) {
-						RuntimeException e_ = Operators.onNextPollError(v, e, currentContext());
+						RuntimeException e_ = Operators.onNextPollError(v, e, this.ctx);
+						Operators.onDiscard(v, this.ctx);
 						if (e_ != null) {
 							throw e_;
 						}
@@ -420,9 +444,11 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 						if (v == null || predicate.test(v)) {
 							return v;
 						}
+						Operators.onDiscard(v, this.ctx);
 					}
 					catch (Throwable e) {
-						RuntimeException e_ = Operators.onNextPollError(v, e, currentContext());
+						RuntimeException e_ = Operators.onNextPollError(v, e, this.ctx);
+						Operators.onDiscard(v, this.ctx);
 						if (e_ != null) {
 							throw e_;
 						}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
@@ -273,7 +273,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 			worker.dispose();
 
 			if (WIP.getAndIncrement(this) == 0) {
-				queue.clear();
+				Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
 			}
 		}
 
@@ -289,7 +289,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 				worker.schedule(this);
 			}
 			catch (RejectedExecutionException ree) {
-				queue.clear();
+				Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
 				actual.onError(Operators.onRejectedExecution(ree, subscription, suppressed, dataSignal,
 						actual.currentContext()));
 			}
@@ -320,6 +320,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 					}
 
 					if (cancelled) {
+						Operators.onDiscardQueueWithClear(q, actual.currentContext(), null);
 						return;
 					}
 					if (v == null) {
@@ -333,6 +334,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 				}
 
 				if (cancelled) {
+					Operators.onDiscardQueueWithClear(q, actual.currentContext(), null);
 					return;
 				}
 
@@ -377,7 +379,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 					catch (Throwable ex) {
 						Exceptions.throwIfFatal(ex);
 						s.cancel();
-						q.clear();
+						Operators.onDiscardQueueWithClear(q, actual.currentContext(), null);
 
 						doError(a, Operators.onOperatorError(ex, actual.currentContext()));
 						return;
@@ -429,6 +431,8 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 			for (; ; ) {
 
 				if (cancelled) {
+					Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
+
 					return;
 				}
 
@@ -483,7 +487,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 
 		boolean checkTerminated(boolean d, boolean empty, Subscriber<?> a) {
 			if (cancelled) {
-				queue.clear();
+				Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
 				return true;
 			}
 			if (d) {
@@ -502,7 +506,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 				else {
 					Throwable e = error;
 					if (e != null) {
-						queue.clear();
+						Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
 						doError(a, e);
 						return true;
 					}
@@ -539,7 +543,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 
 		@Override
 		public void clear() {
-			queue.clear();
+			Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
 		}
 
 		@Override
@@ -739,7 +743,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 			worker.dispose();
 
 			if (WIP.getAndIncrement(this) == 0) {
-				queue.clear();
+				Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
 			}
 		}
 
@@ -755,7 +759,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 				worker.schedule(this);
 			}
 			catch (RejectedExecutionException ree) {
-				queue.clear();
+				Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
 				actual.onError(Operators.onRejectedExecution(ree, subscription, suppressed, dataSignal,
 						actual.currentContext()));
 			}
@@ -785,6 +789,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 					}
 
 					if (cancelled) {
+						Operators.onDiscardQueueWithClear(q, actual.currentContext(), null);
 						return;
 					}
 					if (v == null) {
@@ -798,6 +803,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 				}
 
 				if (cancelled) {
+					Operators.onDiscardQueueWithClear(q, actual.currentContext(), null);
 					return;
 				}
 
@@ -842,7 +848,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 					catch (Throwable ex) {
 						Exceptions.throwIfFatal(ex);
 						s.cancel();
-						q.clear();
+						Operators.onDiscardQueueWithClear(q, actual.currentContext(), null);
 
 						doError(a, Operators.onOperatorError(ex, actual.currentContext()));
 						return;
@@ -895,6 +901,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 			for (; ; ) {
 
 				if (cancelled) {
+					Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
 					return;
 				}
 
@@ -970,7 +977,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 
 		boolean checkTerminated(boolean d, boolean empty, Subscriber<?> a) {
 			if (cancelled) {
-				queue.clear();
+				Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
 				return true;
 			}
 			if (d) {
@@ -989,7 +996,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 				else {
 					Throwable e = error;
 					if (e != null) {
-						queue.clear();
+						Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
 						doError(a, e);
 						return true;
 					}
@@ -1005,7 +1012,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 
 		@Override
 		public void clear() {
-			queue.clear();
+			Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSampleFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSampleFirst.java
@@ -68,7 +68,8 @@ final class FluxSampleFirst<T, U> extends FluxOperator<T, T> {
 	static final class SampleFirstMain<T, U> implements InnerOperator<T, T> {
 
 		final Function<? super T, ? extends Publisher<U>> throttler;
-		final CoreSubscriber<? super T>                       actual;
+		final CoreSubscriber<? super T>                   actual;
+		final Context                                     ctx;
 
 		volatile boolean gate;
 
@@ -107,6 +108,7 @@ final class FluxSampleFirst<T, U> extends FluxOperator<T, T> {
 		SampleFirstMain(CoreSubscriber<? super T> actual,
 				Function<? super T, ? extends Publisher<U>> throttler) {
 			this.actual = actual;
+			this.ctx = actual.currentContext();
 			this.throttler = throttler;
 		}
 
@@ -175,7 +177,7 @@ final class FluxSampleFirst<T, U> extends FluxOperator<T, T> {
 				}
 				catch (Throwable e) {
 					Operators.terminate(S, this);
-					error(Operators.onOperatorError(null, e, t, actual.currentContext()));
+					error(Operators.onOperatorError(null, e, t, ctx));
 					return;
 				}
 
@@ -184,6 +186,9 @@ final class FluxSampleFirst<T, U> extends FluxOperator<T, T> {
 				if (Operators.replace(OTHER, this, other)) {
 					p.subscribe(other);
 				}
+			}
+			else {
+				Operators.onDiscard(t, ctx);
 			}
 		}
 
@@ -204,7 +209,7 @@ final class FluxSampleFirst<T, U> extends FluxOperator<T, T> {
 				}
 			}
 			else {
-				Operators.onErrorDropped(e, actual.currentContext());
+				Operators.onErrorDropped(e, ctx);
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSkip.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSkip.java
@@ -19,6 +19,7 @@ package reactor.core.publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * Skips the first N elements from a reactive stream.
@@ -50,6 +51,7 @@ final class FluxSkip<T> extends FluxOperator<T, T> {
 			implements InnerOperator<T, T> {
 
 		final CoreSubscriber<? super T> actual;
+		final Context ctx;
 
 		long remaining;
 
@@ -57,6 +59,7 @@ final class FluxSkip<T> extends FluxOperator<T, T> {
 
 		SkipSubscriber(CoreSubscriber<? super T> actual, long n) {
 			this.actual = actual;
+			this.ctx = actual.currentContext();
 			this.remaining = n;
 		}
 
@@ -77,6 +80,7 @@ final class FluxSkip<T> extends FluxOperator<T, T> {
 				actual.onNext(t);
 			}
 			else {
+				Operators.onDiscard(t, ctx);
 				remaining = r - 1;
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSkipLast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSkipLast.java
@@ -75,20 +75,22 @@ final class FluxSkipLast<T> extends FluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (size() == n) {
-				actual.onNext(poll());
+				actual.onNext(pollFirst());
 			}
-			offer(t);
+			offerLast(t);
 
 		}
 
 		@Override
 		public void onError(Throwable t) {
 			actual.onError(t);
+			Operators.onDiscardQueueWithClear(this, actual.currentContext(), null);
 		}
 
 		@Override
 		public void onComplete() {
 			actual.onComplete();
+			Operators.onDiscardQueueWithClear(this, actual.currentContext(), null);
 		}
 
 
@@ -115,6 +117,7 @@ final class FluxSkipLast<T> extends FluxOperator<T, T> {
 		@Override
 		public void cancel() {
 			s.cancel();
+			Operators.onDiscardQueueWithClear(this, actual.currentContext(), null);
 		}
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSkipUntilOther.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSkipUntilOther.java
@@ -124,6 +124,7 @@ final class FluxSkipUntilOther<T, U> extends FluxOperator<T, T> {
 			implements InnerOperator<T, T> {
 
 		final CoreSubscriber<? super T> actual;
+		final Context ctx;
 
 		volatile Subscription       main;
 
@@ -146,6 +147,7 @@ final class FluxSkipUntilOther<T, U> extends FluxOperator<T, T> {
 
 		SkipUntilMainSubscriber(CoreSubscriber<? super T> actual) {
 			this.actual = Operators.serialize(actual);
+			this.ctx = actual.currentContext();
 		}
 
 		@Override
@@ -206,6 +208,7 @@ final class FluxSkipUntilOther<T, U> extends FluxOperator<T, T> {
 				actual.onNext(t);
 			}
 			else {
+				Operators.onDiscard(t, ctx);
 				main.request(1);
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -486,6 +486,9 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/ignoreelements.png" alt="">
 	 * <p>
+	 *
+	 * @reactor.discard This operator discards the element from the source.
+	 *
 	 * @param source the {@link Publisher} to ignore
 	 * @param <T> the source type of the ignored data
 	 *
@@ -2364,6 +2367,10 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/filter1.png" alt="">
 	 * <p>
+	 *
+	 * @reactor.discard This operator discards the element if it does not match the filter. It
+	 * also discards upon cancellation or error triggered by a data signal.
+	 *
 	 * @param tester the predicate to evaluate
 	 *
 	 * @return a filtered {@link Mono}
@@ -2383,6 +2390,9 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * <p>
 	 * Note that only the first value of the test publisher is considered, and unless it
 	 * is a {@link Mono}, test will be cancelled after receiving that first value.
+	 *
+	 * @reactor.discard This operator discards the element if it does not match the filter. It
+	 * also discards upon cancellation or error triggered by a data signal.
 	 *
 	 * @param asyncPredicate the function generating a {@link Publisher} of {@link Boolean}
 	 * to filter the Mono with
@@ -2542,6 +2552,8 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/ignoreelement.png" alt="">
 	 * <p>
+	 *
+	 * @reactor.discard This operator discards the source element.
 	 *
 	 * @return a new empty {@link Mono} representing the completion of this {@link Mono}.
 	 */
@@ -3734,6 +3746,9 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/ignorethen.png" alt="">
 	 * <p>
+	 *
+	 * @reactor.discard This operator discards the element from the source.
+	 *
 	 * @return a {@link Mono} ignoring its payload (actively dropping)
 	 */
 	public final Mono<Void> then() {
@@ -3749,6 +3764,8 @@ public abstract class Mono<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/ignorethen1.png" alt="">
+	 *
+	 * @reactor.discard This operator discards the element from the source.
 	 *
 	 * @param other a {@link Mono} to emit from after termination
 	 * @param <V> the element type of the supplied Mono
@@ -3769,6 +3786,8 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.2.0.M2/src/docs/marble/thenreturn1.png"
 	 * alt="">
 	 *
+	 * @reactor.discard This operator discards the element from the source.
+	 *
 	 * @param value a value to emit after termination
 	 * @param <V> the element type of the supplied value
 	 *
@@ -3786,6 +3805,8 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.2.0.M2/src/docs/marble/thenempty.png"
 	 * alt="">
 	 *
+	 * @reactor.discard This operator discards the element from the source.
+	 *
 	 * @param other a {@link Publisher} to wait for after this Mono's termination
 	 * @return a new {@link Mono} completing when both publishers have completed in
 	 * sequence
@@ -3802,6 +3823,8 @@ public abstract class Mono<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.2.0.M2/src/docs/marble/thenmany.png" alt="">
+	 *
+	 * @reactor.discard This operator discards the element from the source.
 	 *
 	 * @param other a {@link Publisher} to emit from after termination
 	 * @param <V> the element type of the supplied Publisher

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoElementAt.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoElementAt.java
@@ -125,6 +125,7 @@ final class MonoElementAt<T> extends MonoFromFluxOperator<T, T>
 				return;
 			}
 			index = i - 1;
+			Operators.onDiscard(t, actual.currentContext()); //FIXME cache currentcontext
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFilterWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFilterWhen.java
@@ -119,6 +119,7 @@ class MonoFilterWhen<T> extends MonoOperator<T, T> {
 			catch (Throwable ex) {
 				Exceptions.throwIfFatal(ex);
 				super.onError(ex);
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 
@@ -131,6 +132,7 @@ class MonoFilterWhen<T> extends MonoOperator<T, T> {
 				catch (Throwable ex) {
 					Exceptions.throwIfFatal(ex);
 					super.onError(ex);
+					Operators.onDiscard(t, actual.currentContext());
 					return;
 				}
 
@@ -139,6 +141,7 @@ class MonoFilterWhen<T> extends MonoOperator<T, T> {
 				}
 				else {
 					actual.onComplete();
+					Operators.onDiscard(t, actual.currentContext());
 				}
 			}
 			else {
@@ -191,6 +194,7 @@ class MonoFilterWhen<T> extends MonoOperator<T, T> {
 			}
 			else {
 				super.onComplete();
+				Operators.onDiscard(value, actual.currentContext());
 			}
 		}
 
@@ -199,6 +203,7 @@ class MonoFilterWhen<T> extends MonoOperator<T, T> {
 			//always propagate that error directly, as it means that the source Mono
 			//was at least valued rather than in error.
 			super.onError(ex);
+			Operators.onDiscard(value, actual.currentContext());
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoIgnoreElements.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoIgnoreElements.java
@@ -68,6 +68,7 @@ final class MonoIgnoreElements<T> extends MonoFromFluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			// deliberately ignored
+			Operators.onDiscard(t, actual.currentContext()); //FIXME cache context
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoIgnoreThen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoIgnoreThen.java
@@ -227,6 +227,7 @@ final class MonoIgnoreThen<T> extends Mono<T> implements Fuseable, Scannable {
         @Override
         public void onNext(Object t) {
             // ignored
+            Operators.onDiscard(t, currentContext()); //FIXME cache Context
         }
         
         @Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTakeLastOne.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTakeLastOne.java
@@ -85,7 +85,9 @@ final class MonoTakeLastOne<T> extends MonoFromFluxOperator<T, T>
 
 		@Override
 		public void onNext(T t) {
+			T old = value;
 			value = t;
+			Operators.onDiscard(old, actual.currentContext()); //FIXME cache context
 		}
 
 		@Override

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
@@ -17,7 +17,6 @@
 package reactor.core.publisher;
 
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,6 +33,7 @@ import java.util.logging.Level;
 import org.assertj.core.api.Condition;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -408,11 +408,10 @@ public class FluxBufferWhenTest {
 
 	@Test
 	public void scanWhenCloseSubscriber() {
-		//noinspection ConstantConditions
+		CoreSubscriber<Object> actual = new LambdaSubscriber<>(null, null, null, null);
+
 		BufferWhenMainSubscriber<String, Integer, Long, List<String>> main =
-				new BufferWhenMainSubscriber<>(null,
-						ArrayList::new, Queues.small(), Mono.just(1),
-						u -> Mono.just(1L));
+				new BufferWhenMainSubscriber<>(actual, ArrayList::new, Queues.small(), Mono.just(1), u -> Mono.just(1L));
 
 		FluxBufferWhen.BufferWhenCloseSubscriber test = new FluxBufferWhen.BufferWhenCloseSubscriber<>(main, 5);
 
@@ -432,9 +431,10 @@ public class FluxBufferWhenTest {
 
 	@Test
 	public void scanWhenOpenSubscriber() {
-		//noinspection ConstantConditions
+		CoreSubscriber<Object> actual = new LambdaSubscriber<>(null, null, null, null);
+
 		BufferWhenMainSubscriber<String, Integer, Long, List<String>> main = new BufferWhenMainSubscriber<>(
-				null, ArrayList::new, Queues.small(), Mono.just(1), u -> Mono.just(1L));
+				actual, ArrayList::new, Queues.small(), Mono.just(1), u -> Mono.just(1L));
 
 		FluxBufferWhen.BufferWhenOpenSubscriber test = new FluxBufferWhen.BufferWhenOpenSubscriber<>(main);
 
@@ -706,5 +706,195 @@ public class FluxBufferWhenTest {
 				(m1, m2) -> m1.queue.isEmpty());
 
 		assertThat(queue.isEmpty()).isTrue();
+	}
+
+	@Test
+	public void discardOnCancel() {
+		StepVerifier.create(Flux.just(1, 2, 3)
+		                        .concatWith(Mono.never())
+		                        .bufferWhen(Flux.just(1), u -> Mono.never()))
+				.thenAwait(Duration.ofMillis(100))
+				.thenCancel()
+				.verifyThenAssertThat()
+				.hasDiscardedExactly(1, 2, 3);
+	}
+
+	@Test
+	public void discardOnCancelPostQueueing() {
+		List<Object> discarded = new ArrayList<>();
+
+		CoreSubscriber<List<Integer>> actual = new LambdaSubscriber<>(null, null, null, null);
+		FluxBufferWhen.BufferWhenMainSubscriber<Integer, Integer, Integer, List<Integer>> operator =
+				new FluxBufferWhen.BufferWhenMainSubscriber<Integer, Integer, Integer, List<Integer>>(actual,
+						ArrayList::new,
+						Queues.small(),
+						Flux.just(1), i -> Flux.never());
+		operator.onSubscribe(new Operators.EmptySubscription());
+
+		Hooks.onDiscard(discarded::add);
+		try {
+			operator.buffers.put(0L, Arrays.asList(4, 5));
+			operator.queue.offer(Arrays.asList(1, 2, 3));
+			operator.cancel();
+		}
+		finally {
+			Hooks.resetOnDiscard();
+		}
+
+		assertThat(discarded).containsExactly(1, 2, 3, 4, 5);
+	}
+
+	@Test
+	public void discardOnNextWhenNoBuffers() {
+		StepVerifier.create(Flux.just(1, 2, 3)
+		                        //buffer don't open in time
+		                        .bufferWhen(Mono.delay(Duration.ofSeconds(2)), u -> Mono.never()))
+		            .expectComplete()
+		            .verifyThenAssertThat()
+		            .hasDiscardedExactly(1, 2, 3);
+	}
+
+	@Test
+	public void discardOnError() {
+		StepVerifier.create(Flux.just(1, 2, 3)
+		                        .concatWith(Mono.error(new IllegalStateException("boom")))
+		                        .bufferWhen(Mono.delay(Duration.ofSeconds(2)), u -> Mono.never()))
+		            .expectErrorMessage("boom")
+		            .verifyThenAssertThat()
+		            .hasDiscardedExactly(1, 2, 3);
+	}
+
+	@Test
+	public void discardOnDrainCancelled() {
+		List<Object> discarded = new ArrayList<>();
+
+		CoreSubscriber<List<Integer>> actual = new LambdaSubscriber<>(null, null, null, null);
+		FluxBufferWhen.BufferWhenMainSubscriber<Integer, Integer, Integer, List<Integer>> operator =
+				new FluxBufferWhen.BufferWhenMainSubscriber<Integer, Integer, Integer, List<Integer>>(actual,
+						ArrayList::new,
+						Queues.small(),
+						Flux.just(1), i -> Flux.never());
+		operator.onSubscribe(new Operators.EmptySubscription());
+		operator.request(1);
+
+		Hooks.onDiscard(discarded::add);
+		try {
+			operator.buffers.put(0L, Arrays.asList(4, 5));
+			operator.queue.offer(Arrays.asList(1, 2, 3));
+			operator.cancelled = true;
+			operator.drain();
+		}
+		finally {
+			Hooks.resetOnDiscard();
+		}
+
+		//drain only deals with queue, other method calling drain should deal with the open buffers (notably cancel)
+		assertThat(discarded).containsExactly(1, 2, 3);
+	}
+
+	@Test
+	public void discardOnDrainDoneWithErrors() {
+		List<Object> discarded = new ArrayList<>();
+
+		CoreSubscriber<List<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+		FluxBufferWhen.BufferWhenMainSubscriber<Integer, Integer, Integer, List<Integer>> operator =
+				new FluxBufferWhen.BufferWhenMainSubscriber<Integer, Integer, Integer, List<Integer>>(actual,
+						ArrayList::new,
+						Queues.small(),
+						Flux.just(1), i -> Flux.never());
+		operator.onSubscribe(new Operators.EmptySubscription());
+		operator.request(1);
+
+		Hooks.onDiscard(discarded::add);
+		try {
+			operator.buffers.put(0L, Arrays.asList(4, 5));
+			operator.queue.offer(Arrays.asList(1, 2, 3));
+			operator.onError(new IllegalStateException("boom")); //triggers the drain
+		}
+		finally {
+			Hooks.resetOnDiscard();
+		}
+
+		assertThat(discarded).containsExactly(1, 2, 3, 4, 5);
+	}
+
+	@Test
+	public void discardOnDrainEmittedAllCancelled() {
+		List<Object> discarded = new ArrayList<>();
+
+		CoreSubscriber<List<Integer>> actual = new LambdaSubscriber<>(null, null, null, null);
+		FluxBufferWhen.BufferWhenMainSubscriber<Integer, Integer, Integer, List<Integer>> operator =
+				new FluxBufferWhen.BufferWhenMainSubscriber<Integer, Integer, Integer, List<Integer>>(actual,
+						ArrayList::new,
+						Queues.small(),
+						Flux.just(1), i -> Flux.never());
+		operator.onSubscribe(new Operators.EmptySubscription());
+
+		Hooks.onDiscard(discarded::add);
+		try {
+			operator.buffers.put(0L, Arrays.asList(4, 5));
+			operator.queue.offer(Arrays.asList(1, 2, 3));
+			operator.cancelled = true;
+			operator.drain();
+		}
+		finally {
+			Hooks.resetOnDiscard();
+		}
+
+		//drain only deals with queue, other method calling drain should deal with the open buffers (notably cancel)
+		assertThat(discarded).containsExactly(1, 2, 3);
+	}
+
+	@Test
+	public void discardOnDrainEmittedAllWithErrors() {
+		List<Object> discarded = new ArrayList<>();
+
+		CoreSubscriber<List<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+		FluxBufferWhen.BufferWhenMainSubscriber<Integer, Integer, Integer, List<Integer>> operator =
+				new FluxBufferWhen.BufferWhenMainSubscriber<Integer, Integer, Integer, List<Integer>>(actual,
+						ArrayList::new,
+						Queues.small(),
+						Flux.just(1), i -> Flux.never());
+		operator.onSubscribe(new Operators.EmptySubscription());
+
+		Hooks.onDiscard(discarded::add);
+		try {
+			operator.buffers.put(0L, Arrays.asList(4, 5));
+			operator.queue.offer(Arrays.asList(1, 2, 3));
+			operator.onError(new IllegalStateException("boom"));
+		}
+		finally {
+			Hooks.resetOnDiscard();
+		}
+
+		assertThat(discarded).containsExactly(1, 2, 3, 4, 5);
+	}
+
+	@Test
+	public void discardOnOpenError() {
+		StepVerifier.withVirtualTime(() -> Flux.interval(Duration.ZERO, Duration.ofMillis(100)) // 0, 1, 2
+		                                       .map(Long::intValue)
+		                                       .take(3)
+		                                       .bufferWhen(Flux.interval(Duration.ZERO, Duration.ofMillis(100)),
+				                                       u -> (u == 2) ? null : Mono.never()))
+		            .thenAwait(Duration.ofSeconds(2))
+		            .expectErrorMessage("The bufferClose returned a null Publisher")
+		            .verifyThenAssertThat()
+		            .hasDiscardedExactly(0, 1, 1);
+	}
+
+	@Test
+	public void discardOnBoundaryError() {
+		StepVerifier.withVirtualTime(() -> Flux.interval(Duration.ZERO, Duration.ofMillis(100)) // 0, 1, 2
+		                                       .map(Long::intValue)
+		                                       .take(3)
+		                                       .bufferWhen(Flux.interval(Duration.ZERO, Duration.ofMillis(100)),
+				                                       u -> (u == 2) ? Mono.error(new IllegalStateException("boom"))
+						                                       : Mono.never()))
+		            .thenAwait(Duration.ofSeconds(2))
+		            .expectErrorMessage("boom")
+		            .verifyThenAssertThat()
+		            .hasDiscardedExactly(0, 1, 1);
+
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
@@ -59,6 +59,7 @@ public class HooksTest {
 //		Hooks.resetOnOperatorDebug(); //superseded by resetOnEachOperator
 		Hooks.resetOnEachOperator();
 		Hooks.resetOnLastOperator();
+		Hooks.resetOnDiscard();
 	}
 
 	void simpleFlux(){

--- a/reactor-core/src/test/java/reactor/core/publisher/HooksTestStaticInit.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/HooksTestStaticInit.java
@@ -50,6 +50,7 @@ public class HooksTestStaticInit {
 //		Hooks.resetOnOperatorDebug(); //superseded by resetOnEachOperator
 		Hooks.resetOnEachOperator();
 		Hooks.resetOnLastOperator();
+		Hooks.resetOnDiscard();
 	}
 
 	@Test

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -1035,6 +1035,43 @@ public interface StepVerifier {
 		Assertions hasDroppedExactly(Object... values);
 
 		/**
+		 * Assert that the tested publisher has discarded at least one element to the
+		 * {@link Hooks#onDiscard(Consumer)} hook.
+		 * <p>
+		 * Unlike {@link #hasDroppedElements()}, the discard hook can be invoked as part
+		 * of normal operations, eg. when an element doesn't match a filter.
+		 */
+		Assertions hasDiscardedElements();
+
+		/**
+		 * Assert that the tested publisher has not discarded any element to the
+		 * {@link Hooks#onDiscard(Consumer)} hook.
+		 * <p>
+		 * Unlike {@link #hasDroppedElements()}, the discard hook can be invoked as part
+		 * of normal operations, eg. when an element doesn't match a filter.
+		 */
+		Assertions hasNotDiscardedElements();
+
+		/**
+		 * Assert that the tested publisher has discarded at least all of the provided
+		 * elements to the {@link Hooks#onDiscard(Consumer)} hook, in any order.
+		 * <p>
+		 * Unlike {@link #hasDroppedElements()}, the discard hook can be invoked as part
+		 * of normal operations, eg. when an element doesn't match a filter.
+		 */
+		Assertions hasDiscarded(Object... values);
+
+		/**
+		 * Assert that the tested publisher has discarded all of the provided elements to
+		 * the {@link Hooks#onDiscard(Consumer)} hook, in any order, and that no
+		 * other elements were dropped.
+		 * <p>
+		 * Unlike {@link #hasDroppedElements()}, the discard hook can be invoked as part
+		 * of normal operations, eg. when an element doesn't match a filter.
+		 */
+		Assertions hasDiscardedExactly(Object... values);
+
+		/**
 		 * Assert that the tested publisher has dropped at least one error to the
 		 * {@link Hooks#onErrorDropped(Consumer)} hook.
 		 */

--- a/reactor-test/src/test/java/reactor/test/StepVerifierAssertionsTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierAssertionsTests.java
@@ -124,6 +124,77 @@ public class StepVerifierAssertionsTests {
 	}
 
 	@Test
+	public void assertDiscardedElementsAllPass() {
+		StepVerifier.create(Flux.just(1, 2, 3).filter(i -> i == 2))
+		            .expectNext(2)
+		            .expectComplete()
+		            .verifyThenAssertThat()
+		            .hasDiscardedElements()
+		            .hasDiscardedExactly(1, 3)
+		            .hasDiscarded(1);
+	}
+
+	@Test
+	public void assertNotDiscardedElementsFailureOneDiscarded() {
+		try {
+			StepVerifier.create(Flux.just(1, 2).filter(i -> i == 2))
+			            .expectNext(2)
+			            .expectComplete()
+			            .verifyThenAssertThat()
+			            .hasNotDiscardedElements();
+			fail("expected an AssertionError");
+		}
+		catch (AssertionError ae) {
+			assertThat(ae).hasMessage("Expected no discarded elements, found <[1]>.");
+		}
+	}
+
+	@Test
+	public void assertDiscardedElementsFailureNoDiscarded() {
+		try {
+			StepVerifier.create(Mono.empty())
+			            .expectComplete()
+			            .verifyThenAssertThat()
+			            .hasNotDiscardedElements()
+			            .hasDiscardedElements();
+			fail("expected an AssertionError");
+		}
+		catch (AssertionError ae) {
+			assertThat(ae).hasMessage("Expected discarded elements, none found.");
+		}
+	}
+
+	@Test
+	public void assertDiscardedElementsFailureOneExtra() {
+		try {
+			StepVerifier.create(Flux.just(1, 2, 3).filter(i -> i == 2))
+			            .expectNext(2)
+			            .expectComplete()
+			            .verifyThenAssertThat()
+			            .hasDiscarded(4);
+			fail("expected an AssertionError");
+		}
+		catch (AssertionError ae) {
+			assertThat(ae).hasMessage("Expected discarded elements to contain <[4]>, was <[1, 3]>.");
+		}
+	}
+
+	@Test
+	public void assertDiscardedElementsFailureOneMissing() {
+		try {
+			StepVerifier.create(Flux.just(1, 2, 3).filter(i -> i == 2))
+			            .expectNext(2)
+			            .expectComplete()
+			            .verifyThenAssertThat()
+			            .hasDiscardedExactly(1);
+			fail("expected an AssertionError");
+		}
+		catch (AssertionError ae) {
+			assertThat(ae).hasMessage("Expected discarded elements to contain exactly <[1]>, was <[1, 3]>.");
+		}
+	}
+
+	@Test
 	public void assertDroppedErrorAllPass() {
 		Throwable err1 = new IllegalStateException("boom1");
 		Throwable err2 = new IllegalStateException("boom2");

--- a/src/docs/asciidoc/advancedFeatures.adoc
+++ b/src/docs/asciidoc/advancedFeatures.adoc
@@ -12,6 +12,7 @@ This chapter covers advanced features and concepts of Reactor, including the fol
 * <<hooks>>
 * <<context>>
 * <<null-safety>>
+* <<cleanup>>
 
 [[advanced-mutualizing-operator-usage]]
 == Mutualizing Operator Usage
@@ -974,6 +975,72 @@ public void contextForLibraryReactivePut() {
 	            .verifyComplete();
 }
 ----
+
+[[cleanup]]
+== Dealing with Objects that need cleanup
+In very specific cases, your application may deal with types that necessitate some form of cleanup once they're not in use anymore.
+This is an advanced scenario, for example when you have _reference counted_ objects or when you're dealing with _off heap_ objects.
+Netty's `ByteBuf` is a prime example of both.
+
+In order to ensure proper cleanup of such objects, you need to accommodate for it in all of the following hooks (see <<hooks>>):
+
+ * The `onDiscard` hook
+ * The `onOperatorError` hook
+ * The `onNextDropped` hook
+ * Operator-specific handlers
+
+This is needed because each hook is made with a specific subset of cleanup in mind, and users might want ie. to implement specific error handling logic in addition to cleanup logic within `onOperatorError`.
+
+Note that some operators are less adapted to dealing with objects that need cleanup.
+For example, `bufferWhen` can introduce overlapping buffers, and that means that the hooks above might see a first buffer as being discarded and cleanup an element in it that is in a second buffer _which is still valid_.
+
+IMPORTANT: For the purpose of cleaning up, **all these hooks MUST be IDEMPOTENT**.
+They might on some occasions get applied several times to the same object.
+The hooks are also dealing with instances that can be any `Object`, and it is up to the user's implementation to distinguish between which instances need cleanup and which don't.
+
+
+=== The `onDiscard` hook
+
+This hook has been specifically put in place for cleanup of objects that would otherwise never be exposed to user code.
+It is intended as a cleanup hook for flows that operate under normal circumstances (ie. not malformed sources that push too many items, which is covered by `onNextDropped`).
+
+Obvious cases include operators that filter elements from upstream.
+These elements never reach the next operator (or final subscriber), but this is part of the normal path of execution.
+As such, they are passed to the `onDiscard` hook.
+For example:
+
+ * `filter`: items that don't match the filter are considered "discarded"
+ * `skip`: items skipped are discarded
+ * `buffer(maxSize, skip)` with `maxSize < skip`: "dropping buffer", items in between buffers are discarded
+ * ...
+
+But `onDiscard` is not limited to filtering operators, and is also used by operators that internally queue data for backpressure purposes.
+More specifically, most of the time this is important during cancellation: an operator that prefetches data from its source and later drains to its subscriber upon demand could have un-emitted data when it gets cancelled.
+Such operators use the `onDiscard` hook during cancellation to clear up their internal backpressure `Queue`.
+
+=== The `onOperatorError` hook
+
+The `onOperatorError` hook is intended to modify errors in a transverse manner (similar to an AOP catch-and-rethrow).
+
+When the error happens during the processing of an `onNext` signal, the element that was being emitted is passed to `onOperatorError`.
+
+If that type of element needs cleanup you need to implement it in the `onOperatorError` hook, possibly on top of error-rewriting code.
+
+=== The `onNextDropped` hook
+
+With malformed `Publisher`s, there could be cases where an operator receives an element when it expected none (typically, after having received the `onError` or `onComplete` signals).
+In such cases, the unexpected element is "dropped", passed to the `onNextDropped` hook.
+If you have types that need cleanup, you must detect these in the `onNextDropped` hook and implement cleanup code there as well.
+
+=== Operator-specific handlers
+
+Some operators that deal with buffers and/or collect values as part of their operations have specific handlers for cases where collected data isn't propagated downstream.
+If you use such operators with the type(s) that need cleanup, you need to perform cleanup in these handlers.
+
+For example, `distinct` has such a callback that is invoked when the operator terminates (or is cancelled) in order to clear the collection it uses to judge if an element is distinct or not.
+By default, the collection is a `HashSet` and the cleanup callback is simply a `Hashet::clear`.
+But if you deal with reference counted objects, you might want to change that to a more involved handler that would `release` each element in the set before `clear()`ing it.
+
 
 [[null-safety]]
 == Null-safety


### PR DESCRIPTION
Work in progress on #999. This also partially covers #1011 as it becomes more efficient to cache the context.

@smaldini First commit is the projected low-level API (the local hook will need a higher level api like the error strategy).

I think the second commit gives a good idea of the recurring patterns we'll encounter while implementing this.
Do you see other cases/patterns? Something that I have overlooked in these 4 operators?