### PR TITLE
fix #1158 Flux.take(0) now eagerly cancels on subscription

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTake.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTake.java
@@ -89,10 +89,14 @@ final class FluxTake<T> extends FluxOperator<T, T> {
 		@Override
 		public void onSubscribe(Subscription s) {
 			if (Operators.validate(this.s, s)) {
-				this.s = s;
-				actual.onSubscribe(this);
-				if (n == 0 && wip == 0) {
-					request(Long.MAX_VALUE);
+				if (n == 0) {
+					s.cancel();
+					done = true;
+					Operators.complete(actual);
+				}
+				else {
+					this.s = s;
+					actual.onSubscribe(this);
 				}
 			}
 		}
@@ -206,10 +210,14 @@ final class FluxTake<T> extends FluxOperator<T, T> {
 		@Override
 		public void onSubscribe(Subscription s) {
 			if (Operators.validate(this.s, s)) {
-				this.s = s;
-				actual.onSubscribe(this);
-				if (n == 0 && wip == 0) {
-					request(Long.MAX_VALUE);
+				if (n == 0) {
+					s.cancel();
+					done = true;
+					Operators.complete(actual);
+				}
+				else {
+					this.s = s;
+					actual.onSubscribe(this);
 				}
 			}
 		}
@@ -353,13 +361,14 @@ final class FluxTake<T> extends FluxOperator<T, T> {
 		@Override
 		public void onSubscribe(Subscription s) {
 			if (Operators.validate(this.qs, s)) {
-				this.qs = (QueueSubscription<T>) s;
-				actual.onSubscribe(this);
-
-				if (inputMode != Fuseable.SYNC) {
-					if (n == 0 && wip == 0) {
-						request(Long.MAX_VALUE);
-					}
+				if (n == 0) {
+					s.cancel();
+					done = true;
+					Operators.complete(actual);
+				}
+				else {
+					this.qs = (QueueSubscription<T>) s;
+					actual.onSubscribe(this);
 				}
 			}
 		}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
@@ -16,6 +16,8 @@
 
 package reactor.core.publisher;
 
+import java.time.Duration;
+
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -26,6 +28,7 @@ import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.test.MockUtils;
 import reactor.test.StepVerifier;
+import reactor.test.publisher.PublisherProbe;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 
@@ -99,6 +102,27 @@ public class FluxTakeTest {
 		ts.assertNoValues()
 		  .assertComplete()
 		  .assertNoError();
+	}
+
+	@Test
+	public void takeNever() {
+		StepVerifier.create(
+				Flux.never().take(1))
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofSeconds(1))
+		            .thenCancel()
+		            .verify();
+	}
+
+	@Test
+	public void takeNeverZero() {
+		PublisherProbe<Object> probe = PublisherProbe.of(Flux.never());
+		StepVerifier.create(probe.flux().take(0))
+		            .expectSubscription()
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(1));
+
+		probe.assertWasCancelled();
 	}
 
 	@Test
@@ -539,14 +563,15 @@ public class FluxTakeTest {
 	}
 
 	@Test
-	public void takeZeroLongMaxWhenNoRequest() {
+	public void takeZeroCancelsWhenNoRequest() {
 		TestPublisher<Integer> ts = TestPublisher.create();
 		StepVerifier.create(ts.flux()
 		                      .take(0), 0)
 		            .thenAwait()
-		            .then(() -> ts.assertMinRequested(Long.MAX_VALUE))
-		            .then(() -> ts.complete())
 		            .verifyComplete();
+
+		ts.assertWasNotRequested();
+		ts.assertWasCancelled();
 	}
 
 	@Test
@@ -555,9 +580,10 @@ public class FluxTakeTest {
 		StepVerifier.create(ts.flux()
 		                      .take(0), 3)
 		            .thenAwait()
-		            .then(() -> ts.assertMinRequested(3))
-		            .then(() -> ts.complete())
 		            .verifyComplete();
+
+		ts.assertWasNotRequested();
+		ts.assertWasCancelled();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
@@ -575,7 +575,7 @@ public class FluxTakeTest {
 	}
 
 	@Test
-	public void takeZeroPassRequestWhenActive() {
+	public void takeZeroIgnoresRequestAndCancels() {
 		TestPublisher<Integer> ts = TestPublisher.create();
 		StepVerifier.create(ts.flux()
 		                      .take(0), 3)
@@ -587,27 +587,29 @@ public class FluxTakeTest {
 	}
 
 	@Test
-	public void takeConditionalZeroLongMaxWhenNoRequest() {
+	public void takeConditionalZeroCancelsWhenNoRequest() {
 		TestPublisher<Integer> ts = TestPublisher.create();
 		StepVerifier.create(ts.flux()
 		                      .take(0)
 		                      .filter(d -> true), 0)
 		            .thenAwait()
-		            .then(() -> ts.assertMinRequested(Long.MAX_VALUE))
-		            .then(() -> ts.complete())
 		            .verifyComplete();
+
+		ts.assertWasNotRequested();
+		ts.assertWasCancelled();
 	}
 
 	@Test
-	public void takeConditionalZeroPassRequestWhenActive() {
+	public void takeConditionalZeroIgnoresRequestAndCancels() {
 		TestPublisher<Integer> ts = TestPublisher.create();
 		StepVerifier.create(ts.flux()
 		                      .take(0)
 		                      .filter(d -> true), 3)
 		            .thenAwait()
-		            .then(() -> ts.assertMinRequested(3))
-		            .then(() -> ts.complete())
 		            .verifyComplete();
+
+		ts.assertWasNotRequested();
+		ts.assertWasCancelled();
 	}
 
 	@Test


### PR DESCRIPTION
This covers the case of a `never()` source (no emission and no
completion) for n = 0, which would previously be handled with a
`request(MAX)` (which would hang in that specific case).