### PR TITLE
Rework `FluxProcessor`

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/BalancedFluxProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/BalancedFluxProcessor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.reactivestreams.Processor;
+import org.reactivestreams.Subscriber;
+import reactor.core.Disposable;
+
+/**
+ * A simple {@link Disposable} symmetric {@link Processor} (taking the same type as what
+ * it outputs), with {@link Flux} like semantics (0-N elements).
+ *
+ * @author Simon Baslé
+ */
+public interface BalancedFluxProcessor<T>
+		extends Processor<T, T>, Disposable {
+
+	/**
+	 * Return true if this {@link BalancedFluxProcessor} supports multithread producing
+	 *
+	 * @return true if this {@link BalancedFluxProcessor} supports multithread producing
+	 */
+	boolean isSerialized();
+
+	/**
+	 * Create a {@link FluxSink} that safely gates multi-threaded producer
+	 * {@link Subscriber#onNext(Object)}. This processor will be subscribed to
+	 * said {@link FluxSink}, and any previous subscribers will be unsubscribed.
+	 *
+	 * <p> The returned {@link FluxSink} will not apply any
+	 * {@link FluxSink.OverflowStrategy} and overflowing {@link FluxSink#next(Object)}
+	 * will behave in two possible ways depending on the Processor:
+	 * <ul>
+	 * <li> an unbounded processor will handle the overflow itself by dropping or
+	 * buffering </li>
+	 * <li> a bounded processor will block/spin</li>
+	 * </ul>
+	 *
+	 * @return a serializing {@link FluxSink}
+	 */
+	FluxSink<T> sink();
+
+	/**
+	 * Create a {@link FluxSink} that safely gates multi-threaded producer
+	 * {@link Subscriber#onNext(Object)}. This processor will be subscribed to
+	 * said {@link FluxSink}, and any previous subscribers will be unsubscribed.
+	 *
+	 * <p> The returned {@link FluxSink} will deal with overflowing {@link FluxSink#next(Object)}
+	 * according to the selected {@link reactor.core.publisher.FluxSink.OverflowStrategy}.
+	 *
+	 * @param strategy the overflow strategy, see {@link FluxSink.OverflowStrategy}
+	 * for the available strategies
+	 * @return a serializing {@link FluxSink}
+	 */
+	FluxSink<T> sink(FluxSink.OverflowStrategy strategy);
+
+	/**
+	 * Expose a {@link Flux} API on top of the {@link BalancedFluxProcessor}'s output,
+	 * allowing composition of operators on it.
+	 *
+	 * @implNote most implementations will already implement {@link Flux} and thus can
+	 * return themselves.
+	 *
+	 * @return a {@link Flux} API on top of the {@link Processor}'s output
+	 */
+	Flux<T> asFlux();
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/BalancedMonoProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/BalancedMonoProcessor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.reactivestreams.Processor;
+import org.reactivestreams.Subscriber;
+import reactor.core.Disposable;
+import reactor.util.annotation.Nullable;
+
+/**
+ * A simple {@link Disposable} symmetric {@link Processor} (taking the same type as what
+ * it outputs), with {@link Mono} like semantics (0-1 elements).
+ *
+ * @author Simon Baslé
+ */
+public interface BalancedMonoProcessor<T> extends Processor<T, T>, Disposable {
+
+	/**
+	 * Return the produced {@link Throwable} error if any or null
+	 *
+	 * @return the produced {@link Throwable} error if any or null
+	 */
+	@Nullable
+	Throwable getError();
+
+	/**
+	 * Indicates whether this {@link BalancedMonoProcessor} has been interrupted via cancellation.
+	 *
+	 * @return {@code true} if this {@link BalancedMonoProcessor} is cancelled, {@code false}
+	 * otherwise.
+	 */
+	boolean isCancelled();
+
+	/**
+	 * Indicates whether this {@link BalancedMonoProcessor} has been completed with an error.
+	 *
+	 * @return {@code true} if this {@link BalancedMonoProcessor} was completed with an error, {@code false} otherwise.
+	 */
+	boolean isError();
+
+	/**
+	 * Indicates whether this {@link BalancedMonoProcessor} has been successfully completed a value.
+	 *
+	 * @return {@code true} if this {@link BalancedMonoProcessor} is successful, {@code false} otherwise.
+	 */
+	boolean isSuccess();
+
+	/**
+	 * Indicates whether this {@link BalancedMonoProcessor} has been terminated by the
+	 * source producer with a success or an error.
+	 *
+	 * @return {@code true} if this {@link BalancedMonoProcessor} is successful, {@code false} otherwise.
+	 */
+	boolean isTerminated();
+
+	/**
+	 * Return the number of active {@link Subscriber} or {@literal -1} if untracked.
+	 *
+	 * @return the number of active {@link Subscriber} or {@literal -1} if untracked
+	 */
+	long downstreamCount();
+
+	/**
+	 * Return true if any {@link Subscriber} is actively subscribed
+	 *
+	 * @return true if any {@link Subscriber} is actively subscribed
+	 */
+	boolean hasDownstreams();
+
+	/**
+	 * Return true if this {@link BalancedMonoProcessor} supports multithread producing
+	 *
+	 * @return true if this {@link BalancedMonoProcessor} supports multithread producing
+	 */
+	boolean isSerialized();
+
+
+	/**
+	 * Expose a {@link Mono} API on top of the {@link BalancedMonoProcessor}'s output,
+	 * allowing composition of operators on it.
+	 *
+	 * @implNote most implementations will already implement {@link Mono} and thus can
+	 * return themselves.
+	 *
+	 * @return a {@link Mono} API on top of the {@link Processor}'s output
+	 */
+	Mono<T> asMono();
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
@@ -41,8 +41,11 @@ import reactor.util.annotation.Nullable;
  * A terminated DirectProcessor will emit the terminal signal to late subscribers.
  *
  * @param <T> the input and output value type
+ * @deprecated instantiate through {@link Processors#direct()} and use as a {@link BalancedFluxProcessor}
  */
-public final class DirectProcessor<T> extends FluxProcessor<T, T> {
+@Deprecated
+public final class DirectProcessor<T> extends FluxProcessor<T, T>
+		implements BalancedFluxProcessor<T> {
 
 	/**
 	 * Create a new {@link DirectProcessor}
@@ -51,6 +54,7 @@ public final class DirectProcessor<T> extends FluxProcessor<T, T> {
 	 *
 	 * @return a fresh processor
 	 */
+	@Deprecated
 	public static <E> DirectProcessor<E> create() {
 		return new DirectProcessor<>();
 	}
@@ -73,6 +77,11 @@ public final class DirectProcessor<T> extends FluxProcessor<T, T> {
 	Throwable error;
 
 	DirectProcessor() {
+	}
+
+	@Override
+	public Flux<T> asFlux() {
+		return this;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -51,8 +51,11 @@ import static reactor.core.publisher.FluxPublish.PublishSubscriber.TERMINATED;
  * @param <T> the input and output value type
  *
  * @author Stephane Maldini
+ * @deprecated instantiate through {@link Processors#emitter()} and use as a {@link BalancedFluxProcessor}
  */
-public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
+@Deprecated
+public final class EmitterProcessor<T> extends FluxProcessor<T, T>
+		implements BalancedFluxProcessor<T> {
 
 	/**
 	 * Create a new {@link EmitterProcessor} using {@link Queues#SMALL_BUFFER_SIZE}
@@ -62,6 +65,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	 *
 	 * @return a fresh processor
 	 */
+	@Deprecated
 	public static <E> EmitterProcessor<E> create() {
 		return create(Queues.SMALL_BUFFER_SIZE, true);
 	}
@@ -75,6 +79,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	 *
 	 * @return a fresh processor
 	 */
+	@Deprecated
 	public static <E> EmitterProcessor<E> create(boolean autoCancel) {
 		return create(Queues.SMALL_BUFFER_SIZE, autoCancel);
 	}
@@ -87,6 +92,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	 *
 	 * @return a fresh processor
 	 */
+	@Deprecated
 	public static <E> EmitterProcessor<E> create(int bufferSize) {
 		return create(bufferSize, true);
 	}
@@ -100,6 +106,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	 *
 	 * @return a fresh processor
 	 */
+	@Deprecated
 	public static <E> EmitterProcessor<E> create(int bufferSize, boolean autoCancel) {
 		return new EmitterProcessor<>(autoCancel, bufferSize);
 	}
@@ -151,6 +158,11 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 		this.autoCancel = autoCancel;
 		this.prefetch = prefetch;
 		SUBSCRIBERS.lazySet(this, EMPTY);
+	}
+
+	@Override
+	public Flux<T> asFlux() {
+		return this;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/EventLoopProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EventLoopProcessor.java
@@ -43,9 +43,11 @@ import reactor.util.context.Context;
  * A base processor used by executor backed processors to take care of their ExecutorService
  *
  * @author Stephane Maldini
+ * @deprecated will be simplified into {@link BalancedFluxProcessor} in 3.2.0
  */
+@Deprecated
 abstract class EventLoopProcessor<IN> extends FluxProcessor<IN, IN>
-		implements Runnable {
+		implements Runnable, BalancedFluxProcessor<IN> {
 
 	static <E> Flux<E> coldSource(RingBuffer<Slot<E>> ringBuffer,
 			@Nullable Throwable t,
@@ -246,6 +248,11 @@ abstract class EventLoopProcessor<IN> extends FluxProcessor<IN, IN>
 					strategy,
 					this);
 		}
+	}
+
+	@Override
+	public Flux<IN> asFlux() {
+		return this;
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -38,7 +38,10 @@ import reactor.util.annotation.Nullable;
  *
  * @param <IN> the input value type
  * @param <OUT> the output value type
+ *
+ * @deprecated use {@link BalancedFluxProcessor} unless you really need asymmetric IN and OUT types.
  */
+@Deprecated
 public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 		implements Processor<IN, OUT>, CoreSubscriber<IN>, Scannable, Disposable {
 
@@ -180,8 +183,8 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 
 	/**
 	 * Create a {@link FluxSink} that safely gates multi-threaded producer
-	 * {@link Subscriber#onNext(Object)}. This processor will be subscribed to 
-	 * that {@link FluxSink}, and any previous subscribers will be unsubscribed.
+	 * {@link Subscriber#onNext(Object)}. This processor will be subscribed to
+	 * said {@link FluxSink}, and any previous subscribers will be unsubscribed.
 	 *
 	 * <p> The returned {@link FluxSink} will not apply any
 	 * {@link FluxSink.OverflowStrategy} and overflowing {@link FluxSink#next(Object)}
@@ -200,22 +203,14 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 
 	/**
 	 * Create a {@link FluxSink} that safely gates multi-threaded producer
-	 * {@link Subscriber#onNext(Object)}.  This processor will be subscribed to 
-	 * that {@link FluxSink}, and any previous subscribers will be unsubscribed.
+	 * {@link Subscriber#onNext(Object)}.  This processor will be subscribed to
+	 * said {@link FluxSink}, and any previous subscribers will be unsubscribed.
 	 *
-	 * <p> The returned {@link FluxSink} will not apply any
-	 * {@link FluxSink.OverflowStrategy} and overflowing {@link FluxSink#next(Object)}
-	 * will behave in two possible ways depending on the Processor:
-	 * <ul>
-	 * <li> an unbounded processor will handle the overflow itself by dropping or
-	 * buffering </li>
-	 * <li> a bounded processor will block/spin on IGNORE strategy, or apply the
-	 * strategy behavior</li>
-	 * </ul>
+	 * <p> The returned {@link FluxSink} will deal with overflowing {@link FluxSink#next(Object)}
+	 * according to the selected {@link reactor.core.publisher.FluxSink.OverflowStrategy}.
 	 *
 	 * @param strategy the overflow strategy, see {@link FluxSink.OverflowStrategy}
-	 * for the
-	 * available strategies
+	 * for the available strategies
 	 * @return a serializing {@link FluxSink}
 	 */
 	public final FluxSink<IN> sink(FluxSink.OverflowStrategy strategy) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Processors.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Processors.java
@@ -1,0 +1,647 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.util.Queue;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
+
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Disposable;
+import reactor.core.scheduler.Scheduler;
+import reactor.util.annotation.Nullable;
+import reactor.util.concurrent.Queues;
+import reactor.util.concurrent.WaitStrategy;
+
+/**
+ * Utility class to create various flavors of {@link  BalancedFluxProcessor Flux Processors}.
+ *
+ * @author Simon Baslé
+ */
+public final class Processors {
+
+	/**
+	 * Create a "direct" {@link BalancedFluxProcessor}: it can dispatch signals to zero to many
+	 * {@link Subscriber Subscribers}, but has the limitation of not
+	 * handling backpressure.
+	 * <p>
+	 * As a consequence, a direct Processor signals an {@link IllegalStateException} to its
+	 * subscribers if you push N elements through it but at least one of its subscribers has
+	 * requested less than N.
+	 * <p>
+	 * Once the Processor has terminated (usually through its {@link BalancedFluxProcessor#sink() Sink}
+	 * {@link FluxSink#error(Throwable)} or {@link FluxSink#complete()} methods being called),
+	 * it lets more subscribers subscribe but replays the termination signal to them immediately.
+	 *
+	 * @param <T> the type of the data flowing through the processor
+	 * @return a new direct {@link BalancedFluxProcessor}
+	 */
+	@SuppressWarnings("deprecation")
+	public static final <T> BalancedFluxProcessor<T> direct() {
+		return DirectProcessor.create();
+	}
+
+	/**
+	 * Create a builder for a "unicast" {@link BalancedFluxProcessor}, which can deal with
+	 * backpressure using an internal buffer, but <strong>can have at most one
+	 * {@link Subscriber}</strong>.
+	 * <p>
+	 * A unicast Processor can be fine tuned through its builder. For instance, by default
+	 * it is unbounded: if you push any amount of data through it while its
+	 * {@link Subscriber} has not yet requested data, it will buffer
+	 * all of the data, which can be changed by providing a {@link Queue} through the
+	 * {@link UnicastProcessorBuilder#queue(Queue)} method.
+	 *
+	 * @param <T>
+	 * @return a builder to create a new unicast {@link BalancedFluxProcessor}
+	 */
+	public static final <T> UnicastProcessorBuilder<T> unicast() {
+		return new UnicastProcessorBuilder<>();
+	}
+
+	/**
+	 * Create a builder for an "emitter" {@link BalancedFluxProcessor}, which is capable
+	 * of emitting to several {@link Subscriber Subscribers} while honoring backpressure
+	 * for each of its subscribers. It can also subscribe to a {@link Publisher} and relay
+	 * its signals synchronously.
+	 *
+	 * <p>
+	 * Initially, when it has no {@link Subscriber}, an emitter Processor can still accept
+	 * a few data pushes up to a configurable {@link EmitterProcessorBuilder#bufferSize(int) bufferSize}.
+	 * After that point, if no {@link Subscriber} has come in and consumed the data,
+	 * calls to {@link BalancedFluxProcessor#onNext(Object) onNext} block until the processor
+	 * is drained (which can only happen concurrently by then).
+	 *
+	 * <p>
+	 * Thus, the first {@link Subscriber} to subscribe receives up to {@code bufferSize}
+	 * elements upon subscribing. However, after that, the processor stops replaying signals
+	 * to additional subscribers. These subsequent subscribers instead only receive the
+	 * signals pushed through the processor after they have subscribed. The internal buffer
+	 * is still used for backpressure purposes.
+	 *
+	 * <p>
+	 * By default, if all of the emitter Processor's subscribers are cancelled (which
+	 * basically means they have all un-subscribed), it will clear its internal buffer and
+	 * stop accepting new subscribers. This can be deactivated by using the
+	 * {@link EmitterProcessorBuilder#noAutoCancel()} method in the builder.
+	 *
+	 * @param <T>
+	 * @return a builder to create a new emitter {@link BalancedFluxProcessor}
+	 */
+	public static final <T> EmitterProcessorBuilder<T> emitter() {
+		return new EmitterProcessorBuilder<>();
+	}
+
+	/**
+	 * Create a builder for a "replay" {@link BalancedFluxProcessor}, which caches
+	 * elements that are either pushed directly through its {@link BalancedFluxProcessor#sink() sink}
+	 * or elements from an upstream {@link Publisher}, and replays them to late
+	 * {@link Subscriber Subscribers}.
+	 *
+	 * <p>
+	 * Depending on the methods called on the builder, it can create a replay Processor in
+	 * multiple configurations:
+	 * <ul>
+	 *     <li>
+	 *         Caching an unbounded history (no builder configuration and direct call to
+	 *         {@link ReplayProcessorBuilder#build()}, or call to {@link ReplayProcessorBuilder#historySize(int, boolean)}
+	 *         with {@code true}).
+	 *     </li>
+	 *     <li>
+	 *         Caching a bounded history ({@link ReplayProcessorBuilder#historySize(int)}).
+	 *     </li>
+	 *     <li>
+	 *         Caching time-based replay windows, by only specifying a TTL
+	 *         ({@link ReplayProcessorBuilder#maxAge(Duration)}).
+	 *     </li>
+	 *     <li>
+	 *         Caching combination of history size and time window, by specifying both
+	 *         TTL ({@link ReplayProcessorBuilder#maxAge(Duration)}) and history size
+	 *         ({@link ReplayProcessorBuilder#historySize(int)}).
+	 *     </li>
+	 * </ul>
+	 *
+	 * @param <T>
+	 * @return a builder to create a new replay {@link BalancedFluxProcessor}
+	 */
+	public static final <T> ReplayProcessorBuilder<T> replay() {
+		return new ReplayProcessorBuilder<>();
+	}
+
+	/**
+	 * Create a new "replay" {@link BalancedFluxProcessor} (see {@link #replay()}) that
+	 * caches the last element it has pushed, replaying it to late {@link Subscriber subscribers}.
+	 *
+	 * @param <T>
+	 * @return a new replay {@link BalancedFluxProcessor} that caches its last pushed element
+	 */
+	public static final <T> BalancedFluxProcessor<T> cacheLast() {
+		return ReplayProcessor.cacheLast();
+	}
+
+	/**
+	 * Create a new "replay" {@link BalancedFluxProcessor} (see {@link #replay()}) that
+	 * caches the last element it has pushed, replaying it to late {@link Subscriber subscribers}.
+	 * If a {@link Subscriber} comes in <strong>before</strong> any value has been pushed,
+	 * then the {@code defaultValue} is emitted instead.
+	 *
+	 * @param <T>
+	 * @return a new replay {@link BalancedFluxProcessor} that caches its last pushed element
+	 */
+	public static final <T> BalancedFluxProcessor<T> cacheLastOrDefault(T defaultValue) {
+		return ReplayProcessor.cacheLastOrDefault(defaultValue);
+	}
+
+	/**
+	 * Create a builder for a "fan out" {@link BalancedFluxProcessor}, which is an
+	 * <strong>asynchronous</strong> processor optionally capable of relaying elements from multiple
+	 * upstream {@link Publisher Publishers} when created in the shared configuration (see the {@link
+	 * FanOutProcessorBuilder#share(boolean)} option of the builder).
+	 *
+	 * <p>
+	 * Note that the share option is mandatory if you intend to concurrently call the Processor's
+	 * {@link BalancedFluxProcessor#onNext(Object)}, {@link BalancedFluxProcessor#onComplete()}, or
+	 * {@link BalancedFluxProcessor#onError(Throwable)} methods directly or from a concurrent upstream
+	 * {@link Publisher}.
+	 *
+	 * <p>
+	 * Otherwise, such concurrent calls are illegal, as the processor is then fully compliant with
+	 * the Reactive Streams specification.
+	 *
+	 * <p>
+	 * A fan out processor is capable of fanning out to multiple {@link Subscriber Subscribers},
+	 * with the added overhead of establishing resources to keep track of each {@link Subscriber}
+	 * until an {@link BalancedFluxProcessor#onError(Throwable)} or {@link
+	 * BalancedFluxProcessor#onComplete()} signal is pushed through the processor or until the
+	 * associated {@link Subscriber} is cancelled.
+	 *
+	 * <p>
+	 * This variant uses a {@link Thread}-per-{@link Subscriber} model.
+	 *
+	 * <p>
+	 * The maximum number of downstream subscribers for this processor is driven by the {@link
+	 * FanOutProcessorBuilder#executor(ExecutorService) executor} builder option. Provide a bounded
+	 * {@link ExecutorService} to limit it to a specific number.
+	 *
+	 * <p>
+	 * There is also an {@link FanOutProcessorBuilder#autoCancel(boolean) autoCancel} builder
+	 * option: If set to {@code true} (the default), it results in the source {@link Publisher
+	 * Publisher(s)} being cancelled when all subscribers are cancelled.
+	 *
+	 * @param <T>
+	 * @return a builder to create a new fan out {@link BalancedFluxProcessor}
+	 */
+	@SuppressWarnings("deprecation")
+	public static final <T> FanOutProcessorBuilder<T> fanOut() {
+		return new TopicProcessor.Builder<>();
+	}
+
+	/**
+	 * Create a builder for a "fan out" {@link BalancedFluxProcessor} with relaxed
+	 * Reactive Streams compliance. This is an <strong>asynchronous</strong> processor
+	 * optionally capable of relaying elements from multiple upstream {@link Publisher Publishers}
+	 * when created in the shared configuration (see the {@link FanOutProcessorBuilder#share(boolean)}
+	 * option of the builder).
+	 *
+	 * <p>
+	 * Note that the share option is mandatory if you intend to concurrently call the Processor's
+	 * {@link BalancedFluxProcessor#onNext(Object)}, {@link BalancedFluxProcessor#onComplete()}, or
+	 * {@link BalancedFluxProcessor#onError(Throwable)} methods directly or from a concurrent upstream
+	 * {@link Publisher}. Otherwise, such concurrent calls are illegal.
+	 *
+	 * <p>
+	 * A fan out processor is capable of fanning out to multiple {@link Subscriber Subscribers},
+	 * with the added overhead of establishing resources to keep track of each {@link Subscriber}
+	 * until an {@link BalancedFluxProcessor#onError(Throwable)} or {@link
+	 * BalancedFluxProcessor#onComplete()} signal is pushed through the processor or until the
+	 * associated {@link Subscriber} is cancelled.
+	 *
+	 * <p>
+	 * This variant uses a RingBuffer and doesn't have the overhead of keeping track of
+	 * each {@link Subscriber} in its own Thread, so it scales better. As a trade-off,
+	 * its compliance with the Reactive Streams specification is slightly
+	 * relaxed, and its distribution pattern is to add up requests from all {@link Subscriber Subscribers}
+	 * together and to relay signals to only one {@link Subscriber}, picked in a kind of
+	 * round-robin fashion.
+	 *
+	 * <p>
+	 * The maximum number of downstream subscribers for this processor is driven by the {@link
+	 * FanOutProcessorBuilder#executor(ExecutorService) executor} builder option. Provide a bounded
+	 * {@link ExecutorService} to limit it to a specific number.
+	 *
+	 * <p>
+	 * There is also an {@link FanOutProcessorBuilder#autoCancel(boolean) autoCancel} builder
+	 * option: If set to {@code true} (the default), it results in the source {@link Publisher
+	 * Publisher(s)} being cancelled when all subscribers are cancelled.
+	 *
+	 * @param <T>
+	 * @return a builder to create a new round-robin fan out {@link BalancedFluxProcessor}
+	 */
+	@Deprecated
+	public static final <T> FanOutProcessorBuilder<T> relaxedFanOut() {
+		return new WorkQueueProcessor.Builder<>();
+	}
+
+  /**
+   * Create a "first" {@link BalancedMonoProcessor}, which can attach to a {@link Publisher} source
+   * of which it will propagate only the first incoming {@link Subscriber#onNext(Object) onNext}
+   * signal, and cancel the source subscription (unless it is a {@link Mono}). It will then
+   * replay that signal to new {@link Subscriber Subscribers}.
+   *
+   * <p>
+   * If no {@link MonoFirstProcessorBuilder#attachToSource(Publisher) source} is initially
+   * provided, the processor will wait for a source {@link Subscriber#onSubscribe(Subscription)}.
+   *
+   * <p>
+   * Manual usage by pushing events through the {@link MonoSink} is naturally limited to at most
+   * one call to {@link MonoSink#success(Object)}.
+   *
+   * @param <T>
+   * @return a builder to create a new "first" {@link BalancedMonoProcessor}
+   */
+  public static final <T> MonoFirstProcessorBuilder<T> first() {
+		return new MonoFirstProcessorBuilder<>();
+	}
+
+	//=== BUILDERS to replace factory method only processors ===
+
+	/**
+	 * A builder for the {@link #unicast()} flavor of {@link BalancedFluxProcessor}.
+	 *
+	 * @param <T>
+	 */
+	public static final class UnicastProcessorBuilder<T> {
+
+		private Queue<T> queue;
+		private Consumer<? super T> onOverflow;
+		private Disposable endcallback;
+
+		/**
+		 * By default, a unicast Processor is unbounded. This can be changed by using this
+		 * method to provide a custom {@link Queue} implementation for the internal buffering.
+		 * If that queue is bounded, the processor could reject the push of a value when the
+		 * buffer is full and not enough requests from downstream have been received.
+		 * <p>
+		 * In that bounded case, one can also set a callback to be invoked on each rejected
+		 * element, allowing for cleanup of these rejected elements (see {@link #onOverflow(Consumer)}).
+		 *
+		 * @param q the {@link Queue} to be used for internal buffering
+		 * @return the builder
+		 */
+		public UnicastProcessorBuilder<T> queue(Queue<T> q) {
+			this.queue = q;
+			return this;
+		}
+
+		/**
+		 * Set a callback that will be executed by the Processor on any terminating signal.
+		 *
+		 * @param e the callback
+		 * @return the builder
+		 */
+		public UnicastProcessorBuilder<T> endCallback(Disposable e) {
+			this.endcallback = e;
+			return this;
+		}
+
+		/**
+		 * When a bounded {@link #queue(Queue)} has been provided, set up a callback to
+		 * be executed on every element rejected by the {@link Queue} once it is already
+		 * full.
+		 *
+		 * @param c the cleanup consumer for overflowing elements in a bounded queue
+		 * @return the builder
+		 */
+		public UnicastProcessorBuilder<T> onOverflow(Consumer<? super T> c) {
+			this.onOverflow = c;
+			return this;
+		}
+
+		/**
+		 * Build the unicast {@link BalancedFluxProcessor} according to the builder's
+		 * configuration.
+		 *
+		 * @return a new unicast {@link BalancedFluxProcessor Processor}
+		 */
+		public BalancedFluxProcessor<T> build() {
+			if (queue != null && endcallback != null && onOverflow != null) {
+				return UnicastProcessor.create(queue, onOverflow, endcallback);
+			}
+			else if (queue != null && endcallback != null) {
+				return UnicastProcessor.create(queue, endcallback);
+			}
+			else if (queue != null && onOverflow == null) {
+				return UnicastProcessor.create(queue);
+			}
+			else {
+				return UnicastProcessor.create();
+			}
+		}
+	}
+
+	/**
+	 * A builder for the {@link #emitter()} flavor of {@link BalancedFluxProcessor}.
+	 *
+	 * @param <T>
+	 */
+	public static final class EmitterProcessorBuilder<T> {
+
+		private int bufferSize = -1;
+		private boolean autoCancel = true;
+
+		/**
+		 * The replay capacity of the emitter Processor, which defines how many elements
+		 * it will retain while it has no current {@link Subscriber}. Once that size is
+		 * reached, if there still is no {@link Subscriber} the emitter processor will
+		 * block its calls to {@link Processor#onNext(Object)} until it is drained (which
+		 * can only happen concurrently by then).
+		 * <p>
+		 * The first {@link Subscriber} to subscribe receives all of these elements, and
+		 * further subscribers only see new incoming data after that.
+		 *
+		 * @param bufferSize the size of the initial no-subscriber bounded buffer
+		 * @return the builder
+		 */
+		public EmitterProcessorBuilder<T> bufferSize(int bufferSize) {
+			this.bufferSize = bufferSize;
+			return this;
+		}
+
+		/**
+		 * By default, if all of its {@link Subscriber Subscribers} are cancelled (which
+		 * basically means they have all un-subscribed), the emitter Processor will clear
+		 * its internal buffer and stop accepting new subscribers. This method changes
+		 * that so that the emitter processor keeps on running.
+		 *
+		 * @return the builder
+		 */
+		public EmitterProcessorBuilder<T> noAutoCancel() {
+			this.autoCancel = false;
+			return this;
+		}
+
+		/**
+		 * Build the emitter {@link BalancedFluxProcessor} according to the builder's
+		 * configuration.
+		 *
+		 * @return a new emitter {@link BalancedFluxProcessor}
+		 */
+		public BalancedFluxProcessor<T> build() {
+			if (bufferSize != -1 && !autoCancel) {
+				return EmitterProcessor.create(bufferSize, false);
+			}
+			else if (bufferSize != -1) {
+				return EmitterProcessor.create(bufferSize);
+			}
+			else if (!autoCancel) {
+				return EmitterProcessor.create(false);
+			}
+			else {
+				return EmitterProcessor.create();
+			}
+		}
+	}
+
+	/**
+	 * A builder for the {@link #replay()} flavor of {@link BalancedFluxProcessor}.
+	 *
+	 * @param <T>
+	 */
+	public static final class ReplayProcessorBuilder<T> {
+
+		private int       size = -1;
+		private Duration  maxAge = null;
+		private Scheduler scheduler = null;
+		private boolean   unbounded = true;
+
+		/**
+		 * Set the history capacity to a specific bounded size.
+		 *
+		 * @param size the history buffer capacity
+		 * @return the builder, with a bounded capacity
+		 */
+		public ReplayProcessorBuilder<T> historySize(int size) {
+			this.size = size;
+			this.unbounded = false;
+			return this;
+		}
+
+		/**
+		 * Set the history capacity to a specific initial size but allow to still mark
+		 * it as unbounded (which is ignored if combined with time-oriented bounds).
+		 *
+		 * @param size the history buffer capacity
+		 * @param unbounded true if the buffer is to be unbounded and the size to be
+		 * interpreted as a hint, false to keep it bounded
+		 * @return the builder, with an optionally unbounded capacity
+		 */
+		public ReplayProcessorBuilder<T> historySize(int size, boolean unbounded) {
+			this.size = size;
+			this.unbounded = unbounded;
+			return this;
+		}
+
+		/**
+		 * Set a time bound to the history.
+		 *
+		 * @param maxAge the maximum {@link Duration} for which an element is retained and
+		 * replayed
+		 * @return the builder
+		 * @see #maxAge(Duration, Scheduler)
+		 */
+		public ReplayProcessorBuilder<T> maxAge(Duration maxAge) {
+			this.maxAge = maxAge;
+			return this;
+		}
+
+		/**
+		 * Set a time bound for the history, measuring time using the provided
+		 * {@link Scheduler}.
+		 *
+		 * @param maxAge the maximum {@link Duration} for which an element is retained and
+		 * replayed
+		 * @param ttlScheduler the {@link Scheduler} to be used to enforce the TTL
+		 * @return the builder
+		 */
+		public ReplayProcessorBuilder<T> maxAge(Duration maxAge, Scheduler ttlScheduler) {
+			this.maxAge = maxAge;
+			this.scheduler = ttlScheduler;
+			return this;
+		}
+
+		/**
+		 * Build the replay {@link BalancedFluxProcessor} according to the builder's configuration.
+		 *
+		 * @return a new replay {@link BalancedFluxProcessor}
+		 */
+		public BalancedFluxProcessor<T> build() {
+			//replay size and timeout
+			if (size != -1 && maxAge != null) {
+				if (scheduler != null) {
+					return ReplayProcessor.createSizeAndTimeout(size, maxAge, scheduler);
+				}
+				return ReplayProcessor.createSizeAndTimeout(size, maxAge);
+			}
+
+			if (size != -1) {
+				if (unbounded) {
+					return ReplayProcessor.create(size, true);
+				}
+				return ReplayProcessor.create(size);
+			}
+
+			if (maxAge != null) {
+				if (scheduler != null) {
+					return ReplayProcessor.createTimeout(maxAge, scheduler);
+				}
+				return ReplayProcessor.createTimeout(maxAge);
+			}
+
+			return ReplayProcessor.create();
+		}
+	}
+
+	/**
+	 * A builder for the {@link #fanOut()} flavor of {@link BalancedFluxProcessor}.
+	 *
+	 * @param <T>
+	 */
+	public interface FanOutProcessorBuilder<T> {
+
+		/**
+		 * Configures name for this builder. Name is reset to default if the provided
+		 * <code>name</code> is null.
+		 *
+		 * @param name Use a new cached ExecutorService and assign this name to the created threads
+		 *             if {@link #executor(ExecutorService)} is not configured.
+		 * @return builder with provided name
+		 */
+		FanOutProcessorBuilder<T> name(@Nullable String name);
+
+		/**
+		 * Configures buffer size for this builder. Default value is {@link Queues#SMALL_BUFFER_SIZE}.
+		 * @param bufferSize the internal buffer size to hold signals, must be a power of 2
+		 * @return builder with provided buffer size
+		 */
+		FanOutProcessorBuilder bufferSize(int bufferSize);
+
+		/**
+		 * Configures wait strategy for this builder. Default value is {@link WaitStrategy#liteBlocking()}.
+		 * Wait strategy is push to default if the provided <code>waitStrategy</code> is null.
+		 * @param waitStrategy A WaitStrategy to use instead of the default smart blocking wait strategy.
+		 * @return builder with provided wait strategy
+		 */
+		FanOutProcessorBuilder waitStrategy(@Nullable WaitStrategy waitStrategy);
+
+		/**
+		 * Configures auto-cancel for this builder. Default value is true.
+		 * @param autoCancel automatically cancel
+		 * @return builder with provided auto-cancel
+		 */
+		FanOutProcessorBuilder autoCancel(boolean autoCancel);
+
+		/**
+		 * Configures an {@link ExecutorService} to execute as many event-loop consuming the
+		 * ringbuffer as subscribers. Name configured using {@link #name(String)} will be ignored
+		 * if executor is push.
+		 * @param executor A provided ExecutorService to manage threading infrastructure
+		 * @return builder with provided executor
+		 */
+		FanOutProcessorBuilder executor(@Nullable ExecutorService executor);
+
+		/**
+		 * Configures an additional {@link ExecutorService} that is used internally
+		 * on each subscription.
+		 * @param requestTaskExecutor internal request executor
+		 * @return builder with provided internal request executor
+		 */
+		FanOutProcessorBuilder requestTaskExecutor(
+				@Nullable ExecutorService requestTaskExecutor);
+
+		/**
+		 * Configures sharing state for this builder. A shared Processor authorizes
+		 * concurrent onNext calls and is suited for multi-threaded publisher that
+		 * will fan-in data.
+		 * @param share true to support concurrent onNext calls
+		 * @return builder with specified sharing
+		 */
+		FanOutProcessorBuilder share(boolean share);
+
+		/**
+		 * Creates a new fanout {@link BalancedFluxProcessor} according to the builder's
+		 * configuration.
+		 *
+		 * @return a new fanout {@link BalancedFluxProcessor}
+		 */
+		BalancedFluxProcessor<T> build();
+	}
+
+	/**
+	 * A builder for the {@link #first()} flavor of {@link BalancedMonoProcessor}.
+	 *
+	 * @param <T>
+	 */
+	public static final class MonoFirstProcessorBuilder<T> {
+
+		private Publisher<? extends  T> source;
+		private WaitStrategy waitStrategy;
+
+		/**
+		 * Attach the resulting {@link BalancedMonoProcessor} to a source.
+		 *
+		 * @param source the source for the Processor, a {@link Publisher}
+		 * @return the builder
+		 */
+		public MonoFirstProcessorBuilder<T> attachToSource(Publisher<? extends T> source) {
+			this.source = source;
+			return this;
+		}
+
+		/**
+		 * Set a {@link WaitStrategy} to be used by the processor.
+		 *
+		 * @param waitStrategy the {@link WaitStrategy}
+		 * @return the builder
+		 */
+		public MonoFirstProcessorBuilder<T> waitStrategy(WaitStrategy waitStrategy) {
+			this.waitStrategy = waitStrategy;
+			return this;
+		}
+
+		/**
+		 * Build the last-{@link BalancedMonoProcessor} according to the builder's configuration.
+		 *
+		 * @return a new "last" {@link BalancedMonoProcessor}
+		 */
+		public BalancedMonoProcessor<T> build() {
+			if (source != null && waitStrategy != null) {
+				return new MonoProcessor<>(source, waitStrategy);
+			}
+			if (source != null) {
+				return new MonoProcessor<>(source);
+			}
+			if (waitStrategy != null) {
+				return MonoProcessor.create(waitStrategy);
+			}
+			return MonoProcessor.create();
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -44,9 +44,11 @@ import static reactor.core.publisher.FluxReplay.ReplaySubscriber.TERMINATED;
  * <p>
  *
  * @param <T> the value type
+ * @deprecated instantiate through {@link Processors#replay()} or {@link Processors#cacheLast()} and use as a {@link BalancedFluxProcessor}
  */
+@Deprecated
 public final class ReplayProcessor<T> extends FluxProcessor<T, T>
-		implements Fuseable {
+		implements Fuseable, BalancedFluxProcessor<T> {
 
 	/**
 	 * Create a {@link ReplayProcessor} that caches the last element it has pushed,
@@ -61,6 +63,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * @return a new {@link ReplayProcessor} that replays its last pushed element to each new
 	 * {@link Subscriber}
 	 */
+	@Deprecated
 	public static <T> ReplayProcessor<T> cacheLast() {
 		return cacheLastOrDefault(null);
 	}
@@ -81,6 +84,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * @return a new {@link ReplayProcessor} that replays its last pushed element to each new
 	 * {@link Subscriber}, or a default one if nothing was pushed yet
 	 */
+	@Deprecated
 	public static <T> ReplayProcessor<T> cacheLastOrDefault(@Nullable T value) {
 		ReplayProcessor<T> b = create(1);
 		if (value != null) {
@@ -98,6 +102,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * @return a new {@link ReplayProcessor} that replays the whole history to each new
 	 * {@link Subscriber}.
 	 */
+	@Deprecated
 	public static <E> ReplayProcessor<E> create() {
 		return create(Queues.SMALL_BUFFER_SIZE, true);
 	}
@@ -112,6 +117,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * @return a new {@link ReplayProcessor} that replays a limited history to each new
 	 * {@link Subscriber}.
 	 */
+	@Deprecated
 	public static <E> ReplayProcessor<E> create(int historySize) {
 		return create(historySize, false);
 	}
@@ -127,6 +133,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * @return a new {@link ReplayProcessor} that replays the whole history to each new
 	 * {@link Subscriber} if configured as unbounded, a limited history otherwise.
 	 */
+	@Deprecated
 	public static <E> ReplayProcessor<E> create(int historySize, boolean unbounded) {
 		FluxReplay.ReplayBuffer<E> buffer;
 		if (unbounded) {
@@ -169,6 +176,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 *
 	 * @return a new {@link ReplayProcessor} that replays elements based on their age.
 	 */
+	@Deprecated
 	public static <T> ReplayProcessor<T> createTimeout(Duration maxAge) {
 		return createTimeout(maxAge, Schedulers.parallel());
 	}
@@ -204,6 +212,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 *
 	 * @return a new {@link ReplayProcessor} that replays elements based on their age.
 	 */
+	@Deprecated
 	public static <T> ReplayProcessor<T> createTimeout(Duration maxAge, Scheduler scheduler) {
 		return createSizeAndTimeout(Integer.MAX_VALUE, maxAge, scheduler);
 	}
@@ -242,6 +251,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * @return a new {@link ReplayProcessor} that replay up to {@code size} elements, but
 	 * will evict them from its history based on their age.
 	 */
+	@Deprecated
 	public static <T> ReplayProcessor<T> createSizeAndTimeout(int size, Duration maxAge) {
 		return createSizeAndTimeout(size, maxAge, Schedulers.parallel());
 	}
@@ -280,6 +290,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * @return a new {@link ReplayProcessor} that replay up to {@code size} elements, but
 	 * will evict them from its history based on their age.
 	 */
+	@Deprecated
 	public static <T> ReplayProcessor<T> createSizeAndTimeout(int size,
 			Duration maxAge,
 			Scheduler scheduler) {
@@ -306,6 +317,11 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	ReplayProcessor(FluxReplay.ReplayBuffer<T> buffer) {
 		this.buffer = buffer;
 		SUBSCRIBERS.lazySet(this, EMPTY);
+	}
+
+	@Override
+	public Flux<T> asFlux() {
+		return this;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
@@ -66,7 +66,9 @@ import reactor.util.concurrent.WaitStrategy;
  * @param <E> Type of dispatched signal
  * @author Stephane Maldini
  * @author Anatoly Kadyshev
+ * @deprecated instantiate through {@link Processors#fanOut()} and use as a {@link BalancedFluxProcessor}
  */
+@Deprecated
 public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 
 	/**
@@ -77,8 +79,10 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * {@code TopicProcessor<String> processor = TopicProcessor.<String>builder().build()}
 	 *
 	 * @param <T> Type of dispatched signal
+	 * @deprecated will be superseded by {@link reactor.core.publisher.Processors.FanOutProcessorBuilder} in 3.2.0
 	 */
-	public final static class Builder<T> {
+	@Deprecated
+	public final static class Builder<T> implements Processors.FanOutProcessorBuilder<T> {
 
 		String name;
 		ExecutorService executor;
@@ -220,6 +224,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * Create a new {@link TopicProcessor} {@link Builder} with default properties.
 	 * @return new TopicProcessor builder
 	 */
+	@Deprecated
 	public static <E> Builder<E> builder()  {
 		return new Builder<>();
 	}
@@ -231,6 +236,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
 	 */
+	@Deprecated
 	public static <E> TopicProcessor<E> create() {
 		return TopicProcessor.<E>builder().build();
 	}
@@ -245,6 +251,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * @param <E> Type of processed signals
 	 * @return the fresh TopicProcessor instance
 	 */
+	@Deprecated
 	public static <E> TopicProcessor<E> create(String name, int bufferSize) {
 		return TopicProcessor.<E>builder().name(name).bufferSize(bufferSize).build();
 	}
@@ -264,6 +271,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
 	 */
+	@Deprecated
 	public static <E> TopicProcessor<E> share(String name, int bufferSize) {
 		return TopicProcessor.<E>builder().share(true).name(name).bufferSize(bufferSize).build();
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -28,7 +28,6 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
-import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
@@ -41,10 +40,13 @@ import reactor.util.context.Context;
  * The implementation keeps the order of signals.
  *
  * @param <T> the input and output type
+ * @deprecated instantiate through {@link Processors#unicast()} builder and use as a {@link BalancedFluxProcessor}
  */
+@Deprecated
 public final class UnicastProcessor<T>
 		extends FluxProcessor<T, T>
-		implements Fuseable.QueueSubscription<T>, Fuseable, InnerOperator<T, T> {
+		implements Fuseable.QueueSubscription<T>, Fuseable, InnerOperator<T, T>,
+		           BalancedFluxProcessor<T> {
 
 	/**
 	 * Create a new {@link UnicastProcessor} that will buffer on an internal queue in an
@@ -53,6 +55,7 @@ public final class UnicastProcessor<T>
 	 * @param <E> the relayed type
 	 * @return a unicast {@link FluxProcessor}
 	 */
+	@Deprecated
 	public static <E> UnicastProcessor<E> create() {
 		return new UnicastProcessor<>(Queues.<E>unbounded().get());
 	}
@@ -65,6 +68,7 @@ public final class UnicastProcessor<T>
 	 * @param <E> the relayed type
 	 * @return a unicast {@link FluxProcessor}
 	 */
+	@Deprecated
 	public static <E> UnicastProcessor<E> create(Queue<E> queue) {
 		return new UnicastProcessor<>(queue);
 	}
@@ -78,6 +82,7 @@ public final class UnicastProcessor<T>
 	 * @param <E> the relayed type
 	 * @return a unicast {@link FluxProcessor}
 	 */
+	@Deprecated
 	public static <E> UnicastProcessor<E> create(Queue<E> queue, Disposable endcallback) {
 		return new UnicastProcessor<>(queue, endcallback);
 	}
@@ -94,6 +99,7 @@ public final class UnicastProcessor<T>
 	 *
 	 * @return a unicast {@link FluxProcessor}
 	 */
+	@Deprecated
 	public static <E> UnicastProcessor<E> create(Queue<E> queue,
 			Consumer<? super E> onOverflow,
 			Disposable endcallback) {
@@ -150,6 +156,11 @@ public final class UnicastProcessor<T>
 		this.queue = Objects.requireNonNull(queue, "queue");
 		this.onOverflow = Objects.requireNonNull(onOverflow, "onOverflow");
 		this.onTerminate = Objects.requireNonNull(onTerminate, "onTerminate");
+	}
+
+	@Override
+	public Flux<T> asFlux() {
+		return this;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
@@ -63,7 +63,9 @@ import reactor.util.concurrent.WaitStrategy;
  *
  * @param <E> Type of dispatched signal
  * @author Stephane Maldini
+ * @deprecated prefer the {@link Processors#fanOut()} variant, will be removed in 3.2.0.
  */
+@Deprecated
 public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 
 	/**
@@ -74,8 +76,10 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * {@code WorkQueueProcessor<String> processor = WorkQueueProcessor.<String>builder().build()}
 	 *
 	 * @param <T> Type of dispatched signal
+	 * @deprecated will be replaced by {@link Processors#fanOut()} in 3.2.0
 	 */
-	public final static class Builder<T> {
+	@Deprecated
+	public final static class Builder<T> implements Processors.FanOutProcessorBuilder<T> {
 
 		String name;
 		ExecutorService executor;
@@ -92,12 +96,10 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 		}
 
 		/**
-		 * Configures name for this builder. Default value is WorkQueueProcessor.
-		 * Name is push to default if the provided <code>name</code> is null.
-		 * @param name Use a new cached ExecutorService and assign this name to the created threads
-		 *             if {@link #executor(ExecutorService)} is not configured.
-		 * @return builder with provided name
+		 * {@inheritDoc}
+		 * Default name is "WorkQueueProcessor".
 		 */
+		@Override
 		public Builder<T> name(@Nullable String name) {
 			if (executor != null)
 				throw new IllegalArgumentException("Executor service is configured, name will not be used.");
@@ -105,11 +107,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 			return this;
 		}
 
-		/**
-		 * Configures buffer size for this builder. Default value is {@link Queues#SMALL_BUFFER_SIZE}.
-		 * @param bufferSize the internal buffer size to hold signals, must be a power of 2
-		 * @return builder with provided buffer size
-		 */
+		@Override
 		public Builder<T> bufferSize(int bufferSize) {
 			if (!Queues.isPowerOfTwo(bufferSize)) {
 				throw new IllegalArgumentException("bufferSize must be a power of 2 : " + bufferSize);
@@ -123,67 +121,38 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 			return this;
 		}
 
-		/**
-		 * Configures wait strategy for this builder. Default value is {@link WaitStrategy#liteBlocking()}.
-		 * Wait strategy is push to default if the provided <code>waitStrategy</code> is null.
-		 * @param waitStrategy A RingBuffer WaitStrategy to use instead of the default smart blocking wait strategy.
-		 * @return builder with provided wait strategy
-		 */
+		@Override
 		public Builder<T> waitStrategy(@Nullable WaitStrategy waitStrategy) {
 			this.waitStrategy = waitStrategy;
 			return this;
 		}
 
-		/**
-		 * Configures auto-cancel for this builder. Default value is true.
-		 * @param autoCancel automatically cancel
-		 * @return builder with provided auto-cancel
-		 */
+		@Override
 		public Builder<T> autoCancel(boolean autoCancel) {
 			this.autoCancel = autoCancel;
 			return this;
 		}
 
-		/**
-		 * Configures an {@link ExecutorService} to execute as many event-loop consuming the
-		 * ringbuffer as subscribers. Name configured using {@link #name(String)} will be ignored
-		 * if executor is push.
-		 * @param executor A provided ExecutorService to manage threading infrastructure
-		 * @return builder with provided executor
-		 */
+		@Override
 		public Builder<T> executor(@Nullable ExecutorService executor) {
 			this.executor = executor;
 			return this;
 		}
 
-		/**
-		 * Configures an additional {@link ExecutorService} that is used internally
-		 * on each subscription.
-		 * @param requestTaskExecutor internal request executor
-		 * @return builder with provided internal request executor
-		 */
-		public Builder<T> requestTaskExecutor(@Nullable ExecutorService requestTaskExecutor) {
+		@Override
+		public Builder<T> requestTaskExecutor(
+				@Nullable ExecutorService requestTaskExecutor) {
 			this.requestTaskExecutor = requestTaskExecutor;
 			return this;
 		}
 
-		/**
-		 * Configures sharing state for this builder. A shared Processor authorizes
-		 * concurrent onNext calls and is suited for multi-threaded publisher that
-		 * will fan-in data.
-		 * @param share true to support concurrent onNext calls
-		 * @return builder with specified sharing
-		 */
+		@Override
 		public Builder<T> share(boolean share) {
 			this.share = share;
 			return this;
 		}
 
-		/**
-		 * Creates a new {@link WorkQueueProcessor} using the properties
-		 * of this builder.
-		 * @return a fresh processor
-		 */
+		@Override
 		public WorkQueueProcessor<T>  build() {
 			String name = this.name != null ? this.name : WorkQueueProcessor.class.getSimpleName();
 			WaitStrategy waitStrategy = this.waitStrategy != null ? this.waitStrategy : WaitStrategy.liteBlocking();
@@ -205,6 +174,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * Create a new {@link WorkQueueProcessor} {@link Builder} with default properties.
 	 * @return new WorkQueueProcessor builder
 	 */
+	@Deprecated
 	public final static <T> Builder<T> builder() {
 		return new Builder<>();
 	}
@@ -216,6 +186,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
 	 */
+	@Deprecated
 	public static <E> WorkQueueProcessor<E> create() {
 		return WorkQueueProcessor.<E>builder().build();
 	}
@@ -230,6 +201,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
 	 */
+	@Deprecated
 	public static <E> WorkQueueProcessor<E> create(String name, int bufferSize) {
 		return WorkQueueProcessor.<E>builder().name(name).bufferSize(bufferSize).build();
 	}
@@ -246,6 +218,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
 	 */
+	@Deprecated
 	public static <E> WorkQueueProcessor<E> share(String name, int bufferSize) {
 		return WorkQueueProcessor.<E>builder().share(true).name(name).bufferSize(bufferSize).build();
 	}

--- a/src/docs/asciidoc/advancedFeatures.adoc
+++ b/src/docs/asciidoc/advancedFeatures.adoc
@@ -167,7 +167,7 @@ Compare the first example to the second example, shown in the following code:
 
 [source,java]
 ----
-UnicastProcessor<String> hotSource = UnicastProcessor.create();
+BalancedFluxProcessor<String> hotSource = Processors.unicast().build();
 
 Flux<String> hotFlux = hotSource.publish()
                                 .autoConnect()

--- a/src/docs/asciidoc/faq.adoc
+++ b/src/docs/asciidoc/faq.adoc
@@ -187,7 +187,7 @@ chain or for different subscribers.
 
 [source,java]
 ----
-EmitterProcessor<Integer> processor = EmitterProcessor.create();
+BalancedFluxProcessor<Integer> processor = Processors.emitter().build();
 processor.publishOn(scheduler1)
          .map(i -> transform(i))
          .publishOn(scheduler2)

--- a/src/docs/asciidoc/processors.adoc
+++ b/src/docs/asciidoc/processors.adoc
@@ -1,9 +1,13 @@
 Processors are a special kind of `Publisher` that are also a `Subscriber`. That means
-that you can `subscribe` to a `Processor` (generally, they implement `Flux`), but you can
-also call methods to manually inject data into the sequence or terminate it.
+that you can `subscribe` to a `Processor`, but you can also call methods to manually inject
+data into the sequence or terminate it.
 
-There are several kinds of Processors, each with a few particular semantics, but before
-you start looking into these, you need to ask yourself the following question:
+Reactor offers a basic interface for Processors that have the same input and output types,
+the `BalancedFluxProcessor`, with different flavors exposed on the `Processors` utility
+class.
+
+Each flavor has a few particular semantics, but before you start looking into these, you
+need to ask yourself the following question:
 
 = Do I Need a Processor?
 Most of the time, you should try to avoid using a `Processor`. They are harder to use
@@ -21,17 +25,18 @@ terminate it).
 If, after exploring the above alternatives, you still think you need a `Processor`, read
 the <<processor-overview>> section below to learn about the different implementations.
 
-= Safely Produce from Multiple Threads by Using the `Sink` Facade
-Rather than directly using Reactor `Processors`, it is a good practice to obtain a `Sink`
-for the `Processor` by calling `sink()` once.
+= Safely Produce from Multiple Threads by Using the `FluxSink` Facade
+Rather than directly using Reactor `Processors`, it is a good practice to obtain a `FluxSink`
+for the `Processor` by calling `sink()` **once** (and storing the result in a variable to
+reuse it).
 
-`FluxProcessor` sinks safely gate multi-threaded producers and can be used by
+`BalancedFluxProcessor` sinks safely gate multi-threaded producers and can be used by
 applications that generate data from multiple threads concurrently. For example, a
-thread-safe serialized sink can be created for `UnicastProcessor`:
+thread-safe serialized sink can be created for the `unicast` flavor:
 
 [source,java]
 ----
-UnicastProcessor<Integer> processor = UnicastProcessor.create();
+BalancedFluxProcessor<Integer> processor = Processors.unicast().build();
 FluxSink<Integer> sink = processor.sink(overflowStrategy);
 ----
 
@@ -48,59 +53,77 @@ configuration:
 
 * An unbounded processor handles the overflow itself by dropping or buffering.
 * A bounded processor blocks or "spins" on the `IGNORE` strategy or applies the
-`overflowStrategy` behavior specified for the `sink`.
+`overflowStrategy` behavior specified when creating the `sink`.
 
 
 [[processor-overview]]
 = Overview of Available Processors
 Reactor Core comes with several flavors of `Processor`. Not all processors have the same
-semantics but are roughly split into three categories. The following list briefly
-describes the three kinds of processors:
+semantics but are roughly split into four categories, described below:
 
-* *direct* (`DirectProcessor` and `UnicastProcessor`): These processors can only push
-data through direct user action (calling their `Sink`'s methods directly).
-* *synchronous* (`EmitterProcessor` and `ReplayProcessor`): These processors can push data
+* *simple* (`direct` and `unicast` flavors): These processors have more limitations than the others.
+`direct` doesn't manage backpressure, while `unicast` is limited to a single `Subscriber`.
+Pushing data through direct user action (calling their `FluxSink`'s methods directly) is
+the favored way of using these.
+* *synchronous* (`emitter` and `replay` flavors): These processors are meant to push data
 both through user action and by subscribing to an upstream `Publisher` and synchronously
 draining it.
-* *asynchronous* (`WorkQueueProcessor` and `TopicProcessor`): These processors can push
-data obtained from multiple upstream `Publishers`. They are more robust and are  backed
-by a `RingBuffer` data structure in order to deal with their multiple upstreams.
+* *asynchronous* (`fanOut` flavor): These processors can push data obtained from
+**multiple** upstream `Publishers`. They are more robust but also are a bit more costly
+to instantiate, establishing more resources in order to deal with their multiple upstreams.
+* *mono* (`first` flavor): These processors, when attached to a `Publisher` source, only
+propagate at most one element from the source. Their `sink()` is actually a `MonoSink<T>`,
+which limits the sink interactions to follow the semantics of `Mono` (0-1 elements).
 
-The asynchronous processors are the most complex to instantiate, with a lot of different
-options. Consequently, they expose a `Builder` interface. The simpler processors have
-static factory methods instead.
 
-== DirectProcessor
-A `DirectProcessor` is a processor that can dispatch signals to zero to many
-`Subscribers`. It is the simplest one to instantiate, with a single `create()` static
-factory method. On the other hand, *it has the limitation of not handling backpressure*.
-As a consequence, a `DirectProcessor` signals an `IllegalStateException` to its
+
+== Direct Processor
+[source,java]
+----
+BalancedFluxProcessor<Integer> direct = Processors.direct();
+----
+
+A **direct** `Processor` can dispatch signals to zero to many `Subscribers`, but has the
+limitation of not handling backpressure.
+
+As a consequence, a direct `Processor` signals an `IllegalStateException` to its
 subscribers if you push N elements through it but at least one of its subscribers has
 requested less than N.
 
-Once the `Processor` has terminated (usually through its `Sink` `error(Throwable)` or
-`complete()` methods being called), it lets more subscribers subscribe but replays the
-termination signal to them immediately.
+Once the `Processor` has terminated (usually through its `FluxSink` `error(Throwable)`
+or `complete()` methods being called), it lets more subscribers subscribe but
+replays the termination signal to them immediately.
 
-== UnicastProcessor
-A `UnicastProcessor` can deal with backpressure using an internal buffer. The trade-off
-is that it can have *at most one* `Subscriber`.
+== Unicast Processor
+[source,java]
+----
+UnicastProcessorBuilder<Integer> builder = Processors.unicast();
+BalancedFluxProcessor<Integer> unicast = builder.build();
+----
 
-A `UnicastProcessor` has a few more options, reflected by a few `create` static factory
-methods. For instance, by default it is _unbounded_: if you push any amount of
-data through it while its `Subscriber` has not yet requested data, it will buffer all of
-the data.
+A **unicast** `Processor` can deal with backpressure using an internal buffer.
+The trade-off is that it can have *at most one* `Subscriber`.
+
+Such a `Processor` has a few more options in its builder. For instance, by default it is
+_unbounded_: if you push any amount of data through it while its `Subscriber` has not yet
+requested data, it will buffer all of the data.
 
 This can be changed by providing a custom `Queue` implementation for the internal
-buffering in the `create` factory method. If that queue is bounded, the processor could
-reject the push of a value when the buffer is full and not enough requests from
+buffering through the `queue(Queue)` builder method. If that queue is bounded, the processor
+could reject the push of a value when the buffer is full and not enough requests from
 downstream have been received.
 
 In that _bounded_ case, the processor can also be built with a callback that is invoked
 on each rejected element, allowing for cleanup of these rejected elements.
 
-== EmitterProcessor
-An `EmitterProcessor` is capable of emitting to several subscribers, while honoring
+== Emitter Processor
+[source,java]
+----
+EmitterProcessorBuilder<Integer> builder = Processors.emitter();
+BalancedFluxProcessor<Integer> emitter = builder.build();
+----
+
+An **emitter** `Processor` is capable of emitting to several subscribers, while honoring
 backpressure for each of its subscribers. It can also subscribe to a `Publisher` and
 relay its signals synchronously.
 
@@ -117,36 +140,56 @@ backpressure purposes.
 
 By default, if all of its subscribers are cancelled (which basically means they have all
 un-subscribed), it will clear its internal buffer and stop accepting new subscribers.
-This can be tuned by the `autoCancel` parameter in the `create` static factory methods.
+This can be deactivated by using the `noAutoCancel()` method in the builder.
 
-== ReplayProcessor
-A `ReplayProcessor` caches elements that are either pushed directly through its `Sink`
+== Replay Processor
+[source,java]
+----
+ReplayProcessorBuilder<Integer> builder = Processors.replay();
+BalancedFluxProcessor<Integer> replay = builder.build();
+----
+
+A **replay** `Processor` caches elements that are either pushed directly through its `FluxSink`
 or elements from an upstream `Publisher` and replays them to late subscribers.
 
-It can be created in multiple configurations:
+Depending on the methods called on the builder, it can create a replay Processor in
+multiple configurations:
 
-* Caching a single element (`cacheLast`).
-* Caching a limited history (`create(int)`), unbounded history (`create()`).
-* Caching time-based replay window (`createTimeout(Duration)`).
-* Caching combination of history size and time window
-(`createSizeOrTimeout(int, Duration)`).
+* Caching an unbounded history (no builder configuration and direct call to `build()`, or
+call to `historySize(int, true)`).
+* Caching a bounded history (`historySize(int)`).
+* Caching time-based replay windows, by only specifying a TTL (`maxAge(Duration)`).
+* Caching combination of history size and time window, by specifying both TTL
+(`maxAge(Duration)`) and history size (`historySize(int)`).
 
-== TopicProcessor
-A `TopicProcessor` is an asynchronous processor capable of relaying elements from
+There is also a factory method to produce a replay processor that caches the last pushed
+element: `Processors.cacheLast()`.
+
+== FanOut Processor
+[source,java]
+----
+FanOutProcessorBuilder<Integer> builder = Processors.fanOut();
+BalancedFluxProcessor<Integer> fanOut = builder.build();
+----
+
+A **fan out** `Processor` is an **asynchronous** processor capable of relaying elements from
 multiple upstream `Publishers` when created in the `shared` configuration (see the
-`share(boolean)` option of the `builder()`).
+`share(boolean)` option of the builder).
 
-Note that the share option is mandatory if you intend to concurrently call
-`TopicProcessor`'s `onNext`, `onComplete`, or `onError` methods directly or from a
-concurrent upstream Publisher.
+Note that the share option is mandatory if you intend to concurrently call the Processor's
+`onNext`, `onComplete`, or `onError` methods directly or from a concurrent upstream `Publisher`.
 
 Otherwise, such concurrent calls are illegal, as the processor is then fully compliant
 with the Reactive Streams specification.
 
-A `TopicProcessor` is capable of fanning out to multiple `Subscribers`. It does so by
-associating a `Thread` to each `Subscriber`, which will run until an `onError` or
-`onComplete` signal is pushed through the processor or until the associated `Subscriber`
-is cancelled. The maximum number of downstream subscribers is driven by the `executor`
+A fan out processor is capable of fanning out to multiple `Subscribers`,
+with the added overhead of establishing resources to keep track of each `Subscriber`
+until an `onError(Throwable)` or `onComplete()` signal is pushed through the processor or
+until the associated `Subscriber` is cancelled.
+
+This variant uses a `Thread`-per-`Subscriber` model.
+
+The maximum number of downstream subscribers is driven by the `executor(ExecutorService)`
 builder option. Provide a bounded `ExecutorService` to limit it to a specific number.
 
 The processor is backed by a `RingBuffer` data structure that stores pushed signals. Each
@@ -157,32 +200,16 @@ This processor also has an `autoCancel` builder option: If set to `true` (the de
 it results in the source `Publisher`(s) being cancelled when all subscribers are
 cancelled.
 
-== WorkQueueProcessor
-A `WorkQueueProcessor` is also an asynchronous processor capable of relaying elements
-from multiple upstream `Publishers` when created in the `shared` configuration (it shares
-most of its builder options with `TopicProcessor`).
+== First Processor
+[source,java]
+----
+MonoFirstProcessorBuilder<Integer> builder = Processors.first();
+BalancedMonoProcessor<Integer> first = builder
+    .attachSource(Flux.range(1, 10))
+    .build();
+//will emit `1`
+----
 
-It relaxes its compliance with the Reactive Streams specification, but it acquires the
-benefit of requiring fewer resources than the `TopicProcessor`. It is still based on a
-`RingBuffer` but avoids the overhead of creating one consumer `Thread` per `Subscriber`.
-As a result, it scales better than the `TopicProcessor`.
-
-The trade-off is that its distribution pattern is a little bit different: Requests from
-each subscriber all add up together, and the processor relays signals to only one
-`Subscriber` at a time, in a kind of round-robin distribution rather than fan-out
-pattern.
-
-NOTE: A fair round-robin distribution is not guaranteed.
-
-The `WorkQueueProcessor` mostly has the same builder options as the `TopicProcessor`,
-such as `autoCancel`, `share`, and `waitStrategy`. The maximum number of downstream
-subscribers is also driven by a configurable `ExecutorService` with the `executor`
-option.
-
-WARNING: You should take care not to subscribe too many `Subscribers` to a
-`WorkQueueProcessor`, as doing so *could lock the processor*. If you need to limit the
-number of possible subscribers, prefer doing so by using a `ThreadPoolExecutor` or a
-`ForkJoinPool`. The processor can detect their capacity and throw an exception if you
-subscribe one too many times.
-
-//TODO == MonoProcessor
+A **first** `Processor` is a `BalancedMonoProcessor` that captures the _first_ element
+that is pushed through it (either manually or by an upstream source `Publisher`) and
+replays it to further `Subscribers`.


### PR DESCRIPTION
- wip fix #1169 Deprecate FluxProcessor and concrete implementations

Introduce SimpleFluxProcessor<T> and Processors, which exposes builders
for the various flavors of Flux processors (but all exposed as a minimal
SimpleFluxProcessor API).