### PR TITLE
fix #1169 Deprecate old processors, add new Processors API

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Scannable.java
+++ b/reactor-core/src/main/java/reactor/core/Scannable.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.reactivestreams.Subscriber;
+import reactor.core.publisher.Processors;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Scheduler.Worker;
 import reactor.util.annotation.Nullable;
@@ -138,7 +139,7 @@ public interface Scannable {
 		 * {@literal Integer.MIN_VALUE}, which serves as a signal that this attribute
 		 * should be used instead. Defaults to {@literal null}.
 		 * <p>
-		 * {@code Flux.flatMap}, {@code Flux.filterWhen}, {@link reactor.core.publisher.TopicProcessor},
+		 * {@code Flux.flatMap}, {@code Flux.filterWhen}, {@link Processors#fanOut()},
 		 * and {@code Flux.window} (with overlap) are known to use this attribute.
 		 */
 		public static final Attr<Long> LARGE_BUFFERED = new Attr<>(null);

--- a/reactor-core/src/main/java/reactor/core/Scannable.java
+++ b/reactor-core/src/main/java/reactor/core/Scannable.java
@@ -139,7 +139,7 @@ public interface Scannable {
 		 * {@literal Integer.MIN_VALUE}, which serves as a signal that this attribute
 		 * should be used instead. Defaults to {@literal null}.
 		 * <p>
-		 * {@code Flux.flatMap}, {@code Flux.filterWhen}, {@link Processors#fanOut()},
+		 * {@code Flux.flatMap}, {@code Flux.filterWhen}, {@link Processors#asyncEmitter()},
 		 * and {@code Flux.window} (with overlap) are known to use this attribute.
 		 */
 		public static final Attr<Long> LARGE_BUFFERED = new Attr<>(null);

--- a/reactor-core/src/main/java/reactor/core/publisher/DelegateProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DelegateProcessor.java
@@ -76,6 +76,11 @@ final class DelegateProcessor<IN, OUT> extends FluxProcessor<IN, OUT> {
 	}
 
 	@Override
+	public long getAvailableCapacity() {
+		return getBufferSize();
+	}
+
+	@Override
 	@SuppressWarnings("unchecked")
 	public boolean isSerialized() {
 		return upstream instanceof SerializedSubscriber ||

--- a/reactor-core/src/main/java/reactor/core/publisher/DelegateProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DelegateProcessor.java
@@ -30,6 +30,7 @@ import reactor.util.context.Context;
 /**
  * @author Stephane Maldini
  */
+@SuppressWarnings("deprecation")
 final class DelegateProcessor<IN, OUT> extends FluxProcessor<IN, OUT> {
 
 	final Publisher<OUT> downstream;

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
@@ -77,7 +77,9 @@ import reactor.util.annotation.Nullable;
  * </p>
  *
  * @param <T> the input and output value type
+ * @deprecated instantiate through {@link Processors#direct()} and use as a {@link ProcessorSink}
  */
+@Deprecated
 public final class DirectProcessor<T> extends FluxProcessor<T, T> {
 
 	/**
@@ -87,6 +89,7 @@ public final class DirectProcessor<T> extends FluxProcessor<T, T> {
 	 *
 	 * @return a fresh processor
 	 */
+	@Deprecated
 	public static <E> DirectProcessor<E> create() {
 		return new DirectProcessor<>();
 	}
@@ -126,6 +129,7 @@ public final class DirectProcessor<T> extends FluxProcessor<T, T> {
 			s.cancel();
 		}
 	}
+
 
 	@Override
 	public void onNext(T t) {
@@ -279,6 +283,15 @@ public final class DirectProcessor<T> extends FluxProcessor<T, T> {
 			return error;
 		}
 		return null;
+	}
+
+	@Override
+	public long getAvailableCapacity() {
+		long cap = 0L;
+		for (DirectInner inner : subscribers) {
+			cap = Math.max(inner.requested, cap);
+		}
+		return cap;
 	}
 
 	static final class DirectInner<T> implements InnerProducer<T> {

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
@@ -284,16 +284,6 @@ public final class DirectProcessor<T> extends FluxProcessor<T, T> implements Flu
 	}
 
 	@Override
-	public Processor<T, T> asProcessor() {
-		return this;
-	}
-
-	@Override
-	public CoreSubscriber<T> asCoreSubscriber() {
-		return this;
-	}
-
-	@Override
 	@Nullable
 	public Throwable getError() {
 		if (subscribers == TERMINATED) {

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.stream.Stream;
 
+import org.reactivestreams.Processor;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
@@ -77,10 +78,11 @@ import reactor.util.annotation.Nullable;
  * </p>
  *
  * @param <T> the input and output value type
- * @deprecated instantiate through {@link Processors#direct()} and use as a {@link ProcessorSink}
+ * @deprecated instantiate through {@link Processors#directSink()} or {@link Processors#direct()}
+ * depending on whether you want to manually push data or push through a source. Will be removed in 3.3.
  */
 @Deprecated
-public final class DirectProcessor<T> extends FluxProcessor<T, T> {
+public final class DirectProcessor<T> extends FluxProcessor<T, T> implements FluxProcessorFacade<T> {
 
 	/**
 	 * Create a new {@link DirectProcessor}
@@ -274,6 +276,26 @@ public final class DirectProcessor<T> extends FluxProcessor<T, T> {
 	public boolean hasDownstreams() {
 		DirectInner<T>[] s = subscribers;
 		return s != EMPTY && s != TERMINATED;
+	}
+
+	@Override
+	public Flux<T> asFlux() {
+		return this;
+	}
+
+	@Override
+	public Processor<T, T> asProcessor() {
+		return this;
+	}
+
+	@Override
+	public CoreSubscriber<T> asCoreSubscriber() {
+		return this;
+	}
+
+	@Override
+	public Scannable asScannable() {
+		return this;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
@@ -294,11 +294,6 @@ public final class DirectProcessor<T> extends FluxProcessor<T, T> implements Flu
 	}
 
 	@Override
-	public Scannable asScannable() {
-		return this;
-	}
-
-	@Override
 	@Nullable
 	public Throwable getError() {
 		if (subscribers == TERMINATED) {

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.locks.LockSupport;
 import java.util.stream.Stream;
 
+import org.reactivestreams.Processor;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -51,10 +52,11 @@ import static reactor.core.publisher.FluxPublish.PublishSubscriber.TERMINATED;
  * @param <T> the input and output value type
  *
  * @author Stephane Maldini
- * @deprecated instantiate through {@link Processors#emitter()} and use as a {@link ProcessorSink}
+ * @deprecated instantiate through {@link Processors#emitter()} and use as a {@link ProcessorFacade}
  */
 @Deprecated
-public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
+public final class EmitterProcessor<T> extends FluxProcessor<T, T>
+		implements FluxProcessorFacade<T> {
 
 	/**
 	 * Create a new {@link EmitterProcessor} using {@link Queues#SMALL_BUFFER_SIZE}
@@ -115,6 +117,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 	final boolean autoCancel;
 
 	volatile Subscription s;
+
 	@SuppressWarnings("rawtypes")
 	static final AtomicReferenceFieldUpdater<EmitterProcessor, Subscription> S =
 			AtomicReferenceFieldUpdater.newUpdater(EmitterProcessor.class,
@@ -294,6 +297,26 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 		}
 		done = true;
 		drain();
+	}
+
+	@Override
+	public Flux<T> asFlux() {
+		return this;
+	}
+
+	@Override
+	public Processor<T, T> asProcessor() {
+		return this;
+	}
+
+	@Override
+	public CoreSubscriber<T> asCoreSubscriber() {
+		return this;
+	}
+
+	@Override
+	public Scannable asScannable() {
+		return this;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -305,16 +305,6 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T>
 	}
 
 	@Override
-	public Processor<T, T> asProcessor() {
-		return this;
-	}
-
-	@Override
-	public CoreSubscriber<T> asCoreSubscriber() {
-		return this;
-	}
-
-	@Override
 	@Nullable
 	public Throwable getError() {
 		return error;

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.locks.LockSupport;
 import java.util.stream.Stream;
 
-import org.reactivestreams.Processor;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -52,7 +51,7 @@ import static reactor.core.publisher.FluxPublish.PublishSubscriber.TERMINATED;
  * @param <T> the input and output value type
  *
  * @author Stephane Maldini
- * @deprecated instantiate through {@link Processors#emitter()} and use as a {@link ProcessorFacade}
+ * @deprecated instantiate through {@link Processors#emitter()} and use as a {@link FluxProcessorFacade}, will be removed from public API in 3.3
  */
 @Deprecated
 public final class EmitterProcessor<T> extends FluxProcessor<T, T>

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -315,11 +315,6 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T>
 	}
 
 	@Override
-	public Scannable asScannable() {
-		return this;
-	}
-
-	@Override
 	@Nullable
 	public Throwable getError() {
 		return error;

--- a/reactor-core/src/main/java/reactor/core/publisher/EventLoopProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EventLoopProcessor.java
@@ -45,7 +45,7 @@ import reactor.util.context.Context;
  * A base processor used by executor backed processors to take care of their ExecutorService
  *
  * @author Stephane Maldini
- * @deprecated will be simplified into {@link ProcessorFacade} in 3.2.0
+ * @deprecated will be simplified into {@link FluxProcessorFacade} in 3.2.0, will be removed from public API in 3.3
  */
 @Deprecated
 abstract class EventLoopProcessor<IN> extends FluxProcessor<IN, IN>

--- a/reactor-core/src/main/java/reactor/core/publisher/EventLoopProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EventLoopProcessor.java
@@ -31,7 +31,9 @@ import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import org.reactivestreams.Processor;
 import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
@@ -43,11 +45,11 @@ import reactor.util.context.Context;
  * A base processor used by executor backed processors to take care of their ExecutorService
  *
  * @author Stephane Maldini
- * @deprecated will be simplified into {@link ProcessorSink} in 3.2.0
+ * @deprecated will be simplified into {@link ProcessorFacade} in 3.2.0
  */
 @Deprecated
 abstract class EventLoopProcessor<IN> extends FluxProcessor<IN, IN>
-		implements Runnable {
+		implements Runnable, FluxProcessorFacade<IN> {
 
 	static <E> Flux<E> coldSource(RingBuffer<Slot<E>> ringBuffer,
 			@Nullable Throwable t,
@@ -394,6 +396,26 @@ abstract class EventLoopProcessor<IN> extends FluxProcessor<IN, IN>
 	@Override
 	final public long getAvailableCapacity() {
 		return ringBuffer.bufferSize() - ringBuffer.getPending();
+	}
+
+	@Override
+	public CoreSubscriber<IN> asCoreSubscriber() {
+		return this;
+	}
+
+	@Override
+	public Flux<IN> asFlux() {
+		return this;
+	}
+
+	@Override
+	public Processor<IN, IN> asProcessor() {
+		return this;
+	}
+
+	@Override
+	public Scannable asScannable() {
+		return this;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/EventLoopProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EventLoopProcessor.java
@@ -399,17 +399,7 @@ abstract class EventLoopProcessor<IN> extends FluxProcessor<IN, IN>
 	}
 
 	@Override
-	public CoreSubscriber<IN> asCoreSubscriber() {
-		return this;
-	}
-
-	@Override
 	public Flux<IN> asFlux() {
-		return this;
-	}
-
-	@Override
-	public Processor<IN, IN> asProcessor() {
 		return this;
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/EventLoopProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EventLoopProcessor.java
@@ -414,11 +414,6 @@ abstract class EventLoopProcessor<IN> extends FluxProcessor<IN, IN>
 	}
 
 	@Override
-	public Scannable asScannable() {
-		return this;
-	}
-
-	@Override
 	@Nullable
 	final public Throwable getError() {
 		return error;

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -7500,26 +7500,6 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Subscribe the given {@link FluxProcessorFacade} to this {@link Flux} and return said
-	 * {@link FluxProcessorFacade}.
-	 *
-	 * <blockquote><pre>
-	 * {@code flux.subscribeWith(Processors.unicast()).asFlux().subscribe() }
-	 * </pre></blockquote>
-	 *
-	 * If you need more control over backpressure and the request, use a {@link BaseSubscriber}.
-	 *
-	 * @param processorFacade the {@link FluxProcessorFacade} to subscribe with and return
-	 * @param <E> the reified type from the input/output subscriber
-	 *
-	 * @return the passed {@link FluxProcessorFacade}
-	 */
-	public final <E extends FluxProcessorFacade<? super T>> E subscribeWith(E processorFacade) {
-		subscribe(processorFacade.asProcessor());
-		return processorFacade;
-	}
-
-	/**
 	 * Switch to an alternative {@link Publisher} if this sequence is completed without any data.
 	 * <p>
 	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/switchifempty.png" alt="">

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -1564,7 +1564,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param mergedPublishers The {@link Publisher} of {@link Publisher} to switch on and mirror.
 	 * @param <T> the produced type
 	 *
-	 * @return a {@link FluxProcessor} accepting publishers and producing T
+	 * @return a {@link Flux} that mirrors data from incoming Publishers
 	 */
 	public static <T> Flux<T> switchOnNext(Publisher<? extends Publisher<? extends T>> mergedPublishers) {
 		return switchOnNext(mergedPublishers, Queues.XS_BUFFER_SIZE);
@@ -1585,7 +1585,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param prefetch the inner source request size
 	 * @param <T> the produced type
 	 *
-	 * @return a {@link FluxProcessor} accepting publishers and producing T
+	 * @return a {@link Flux} that mirrors data from incoming Publishers
 	 */
 	public static <T> Flux<T> switchOnNext(Publisher<? extends Publisher<? extends T>> mergedPublishers, int prefetch) {
 		return onAssembly(new FluxSwitchMap<>(from(mergedPublishers),
@@ -6088,7 +6088,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a new {@link Mono}
 	 */
 	public final Mono<T> publishNext() {
-		return Mono.onAssembly(new MonoProcessor<>(this));
+		return Mono.onAssembly(Processors.first(this).build().asMono());
 	}
 
 	/**
@@ -7481,10 +7481,10 @@ public abstract class Flux<T> implements Publisher<T> {
 
 	/**
 	 * Subscribe the given {@link Subscriber} to this {@link Flux} and return said
-	 * {@link Subscriber} (eg. a {@link FluxProcessor}).
+	 * {@link Subscriber}.
 	 *
 	 * <blockquote><pre>
-	 * {@code flux.subscribeWith(WorkQueueProcessor.create()).subscribe() }
+	 * {@code flux.subscribeWith(new MySubscriberWithApi()).callApi() }
 	 * </pre></blockquote>
 	 *
 	 * If you need more control over backpressure and the request, use a {@link BaseSubscriber}.
@@ -7497,6 +7497,26 @@ public abstract class Flux<T> implements Publisher<T> {
 	public final <E extends Subscriber<? super T>> E subscribeWith(E subscriber) {
 		subscribe(subscriber);
 		return subscriber;
+	}
+
+	/**
+	 * Subscribe the given {@link ProcessorSink} to this {@link Flux} and return said
+	 * {@link ProcessorSink}.
+	 *
+	 * <blockquote><pre>
+	 * {@code flux.subscribeWith(Processors.unicast()).asFlux().subscribe() }
+	 * </pre></blockquote>
+	 *
+	 * If you need more control over backpressure and the request, use a {@link BaseSubscriber}.
+	 *
+	 * @param processorSink the {@link ProcessorSink} to subscribe with and return
+	 * @param <E> the reified type from the input/output subscriber
+	 *
+	 * @return the passed {@link ProcessorSink}
+	 */
+	public final <E extends ProcessorSink<? super T>> E subscribeWith(E processorSink) {
+		subscribe(processorSink.asProcessor());
+		return processorSink;
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -6088,7 +6088,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a new {@link Mono}
 	 */
 	public final Mono<T> publishNext() {
-		return Mono.onAssembly(Processors.first(this).build().asMono());
+		return Mono.onAssembly(Processors.firstFrom(this).asMono());
 	}
 
 	/**
@@ -7500,8 +7500,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Subscribe the given {@link ProcessorSink} to this {@link Flux} and return said
-	 * {@link ProcessorSink}.
+	 * Subscribe the given {@link FluxProcessorFacade} to this {@link Flux} and return said
+	 * {@link FluxProcessorFacade}.
 	 *
 	 * <blockquote><pre>
 	 * {@code flux.subscribeWith(Processors.unicast()).asFlux().subscribe() }
@@ -7509,14 +7509,14 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * If you need more control over backpressure and the request, use a {@link BaseSubscriber}.
 	 *
-	 * @param processorSink the {@link ProcessorSink} to subscribe with and return
+	 * @param processorFacade the {@link FluxProcessorFacade} to subscribe with and return
 	 * @param <E> the reified type from the input/output subscriber
 	 *
-	 * @return the passed {@link ProcessorSink}
+	 * @return the passed {@link FluxProcessorFacade}
 	 */
-	public final <E extends ProcessorSink<? super T>> E subscribeWith(E processorSink) {
-		subscribe(processorSink.asProcessor());
-		return processorSink;
+	public final <E extends FluxProcessorFacade<? super T>> E subscribeWith(E processorFacade) {
+		subscribe(processorFacade.asProcessor());
+		return processorFacade;
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGroupJoin.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGroupJoin.java
@@ -206,7 +206,7 @@ final class FluxGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R>
 		@Override
 		public Stream<? extends Scannable> inners() {
 			return Stream.concat(
-					lefts.values().stream().map(FluxProcessorFacade::asScannable),
+					lefts.values().stream().map(Scannable::from),
 					Scannable.from(cancellations).inners()
 			);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -39,7 +39,7 @@ import reactor.util.annotation.Nullable;
  * @param <IN> the input value type
  * @param <OUT> the output value type
  *
- * @deprecated use {@link ProcessorSink} unless you really need asymmetric IN and OUT types.
+ * @deprecated use {@link ProcessorFacade} unless you really need asymmetric IN and OUT types.
  */
 @Deprecated
 public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -38,9 +38,14 @@ import reactor.util.annotation.Nullable;
  *
  * @param <IN> the input value type
  * @param <OUT> the output value type
+ *
+ * @deprecated use {@link ProcessorSink} unless you really need asymmetric IN and OUT types.
  */
+@Deprecated
 public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 		implements Processor<IN, OUT>, CoreSubscriber<IN>, Scannable, Disposable {
+
+	boolean disposed = false;
 
 	/**
 	 * Build a {@link FluxProcessor} whose data are emitted by the most recent emitted {@link Publisher}.
@@ -75,9 +80,66 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 		return new DelegateProcessor<>(downstream, upstream);
 	}
 
+	/**
+	 * Return the processor buffer capacity if any or {@link Integer#MAX_VALUE}
+	 *
+	 * @return processor buffer capacity if any or {@link Integer#MAX_VALUE}
+	 */
+	public int getBufferSize() {
+		return Integer.MAX_VALUE;
+	}
+
+
+	@Override
+	public Stream<? extends Scannable> inners() {
+		return Stream.empty();
+	}
+
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.TERMINATED) return isTerminated();
+		if (key == Attr.ERROR) return getError();
+		if (key == Attr.CAPACITY) return getBufferSize();
+
+		return null;
+	}
+
+	/**
+	 * Create a {@link FluxProcessor} that safely gates multi-threaded producer
+	 * {@link Subscriber#onNext(Object)}.
+	 *
+	 * @return a serializing {@link FluxProcessor}
+	 */
+	public final FluxProcessor<IN, OUT> serialize() {
+		return new DelegateProcessor<>(this, Operators.serialize(this));
+	}
+
+	/**
+	 * Returns serialization strategy. If true, {@link FluxProcessor#sink()} will always
+	 * be serialized. Otherwise sink is serialized only if {@link FluxSink#onRequest(java.util.function.LongConsumer)}
+	 * is invoked.
+	 * @return true to serialize any sink, false to delay serialization till onRequest
+	 */
+	protected boolean serializeAlways() {
+		return true;
+	}
+
+
+	//== shared API with ProcessorSink ==
+
+	public abstract long getAvailableCapacity();
+
 	@Override
 	public void dispose() {
+		this.disposed = true;
 		onError(new CancellationException("Disposed"));
+	}
+
+	@Override
+	public boolean isDisposed() {
+		return disposed;
 	}
 
 	/**
@@ -87,15 +149,6 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 	 */
 	public long downstreamCount(){
 		return inners().count();
-	}
-
-	/**
-	 * Return the processor buffer capacity if any or {@link Integer#MAX_VALUE}
-	 *
-	 * @return processor buffer capacity if any or {@link Integer#MAX_VALUE}
-	 */
-	public int getBufferSize() {
-		return Integer.MAX_VALUE;
 	}
 
 	/**
@@ -135,11 +188,6 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 		return isTerminated() && getError() != null;
 	}
 
-	@Override
-	public Stream<? extends Scannable> inners() {
-		return Stream.empty();
-	}
-
 	/**
 	 * Has this upstream finished or "completed" / "failed" ?
 	 *
@@ -158,30 +206,10 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 		return false;
 	}
 
-	@Override
-	@Nullable
-	public Object scanUnsafe(Attr key) {
-		if (key == Attr.TERMINATED) return isTerminated();
-		if (key == Attr.ERROR) return getError();
-		if (key == Attr.CAPACITY) return getBufferSize();
-
-		return null;
-	}
-
-	/**
-	 * Create a {@link FluxProcessor} that safely gates multi-threaded producer
-	 * {@link Subscriber#onNext(Object)}.
-	 *
-	 * @return a serializing {@link FluxProcessor}
-	 */
-	public final FluxProcessor<IN, OUT> serialize() {
-		return new DelegateProcessor<>(this, Operators.serialize(this));
-	}
-
 	/**
 	 * Create a {@link FluxSink} that safely gates multi-threaded producer
-	 * {@link Subscriber#onNext(Object)}. This processor will be subscribed to 
-	 * that {@link FluxSink}, and any previous subscribers will be unsubscribed.
+	 * {@link Subscriber#onNext(Object)}. This processor will be subscribed to
+	 * said {@link FluxSink}, and any previous subscribers will be unsubscribed.
 	 *
 	 * <p> The returned {@link FluxSink} will not apply any
 	 * {@link FluxSink.OverflowStrategy} and overflowing {@link FluxSink#next(Object)}
@@ -200,22 +228,14 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 
 	/**
 	 * Create a {@link FluxSink} that safely gates multi-threaded producer
-	 * {@link Subscriber#onNext(Object)}.  This processor will be subscribed to 
-	 * that {@link FluxSink}, and any previous subscribers will be unsubscribed.
+	 * {@link Subscriber#onNext(Object)}.  This processor will be subscribed to
+	 * said {@link FluxSink}, and any previous subscribers will be unsubscribed.
 	 *
-	 * <p> The returned {@link FluxSink} will not apply any
-	 * {@link FluxSink.OverflowStrategy} and overflowing {@link FluxSink#next(Object)}
-	 * will behave in two possible ways depending on the Processor:
-	 * <ul>
-	 * <li> an unbounded processor will handle the overflow itself by dropping or
-	 * buffering </li>
-	 * <li> a bounded processor will block/spin on IGNORE strategy, or apply the
-	 * strategy behavior</li>
-	 * </ul>
+	 * <p> The returned {@link FluxSink} will deal with overflowing {@link FluxSink#next(Object)}
+	 * according to the selected {@link reactor.core.publisher.FluxSink.OverflowStrategy}.
 	 *
 	 * @param strategy the overflow strategy, see {@link FluxSink.OverflowStrategy}
-	 * for the
-	 * available strategies
+	 * for the available strategies
 	 * @return a serializing {@link FluxSink}
 	 */
 	public final FluxSink<IN> sink(FluxSink.OverflowStrategy strategy) {
@@ -237,13 +257,5 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 			return new FluxCreate.SerializeOnRequestSink<>(s);
 	}
 
-	/**
-	 * Returns serialization strategy. If true, {@link FluxProcessor#sink()} will always
-	 * be serialized. Otherwise sink is serialized only if {@link FluxSink#onRequest(java.util.function.LongConsumer)}
-	 * is invoked.
-	 * @return true to serialize any sink, false to delay serialization till onRequest
-	 */
-	protected boolean serializeAlways() {
-		return true;
-	}
+	//==end of shared API with ProcessorSink ==
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -39,7 +39,7 @@ import reactor.util.annotation.Nullable;
  * @param <IN> the input value type
  * @param <OUT> the output value type
  *
- * @deprecated use {@link ProcessorFacade} unless you really need asymmetric IN and OUT types.
+ * @deprecated Discouraged, use {@link FluxProcessorFacade} and/or {@link FluxProcessorSink} unless you really need asymmetric IN and OUT types.
  */
 @Deprecated
 public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessorFacade.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessorFacade.java
@@ -16,14 +16,14 @@
 
 package reactor.core.publisher;
 
-import java.util.function.Consumer;
-
-import reactor.core.Disposable;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import reactor.core.CoreSubscriber;
 
 /**
  * @author Simon Baslé
  */
-public interface FluxProcessorSink<T> extends ProcessorFacade<T>, FluxSink<T> {
+public interface FluxProcessorFacade<T> extends ProcessorFacade<T> {
 
 	/**
 	 * Expose a Reactor {@link Flux} API on top of the {@link FluxProcessorSink}'s output,
@@ -37,22 +37,22 @@ public interface FluxProcessorSink<T> extends ProcessorFacade<T>, FluxSink<T> {
 	Flux<T> asFlux();
 
 	/**
-	 * Terminate with the given exception
-	 * <p>
-	 * Calling this method multiple times or after the other terminating methods is
-	 * an unsupported operation. It will discard the exception through the
-	 * {@link Hooks#onErrorDropped(Consumer)} hook (which by default throws the exception
-	 * wrapped via {@link reactor.core.Exceptions#bubble(Throwable)}). This is to avoid
-	 * complete and silent swallowing of the exception.
+	 * Return a view of this {@link FluxProcessorFacade} that is a
+	 * {@link Processor Processor&lt;T, T&gt;}, suitable for subscribing to a source
+	 * {@link Publisher}.
 	 *
-	 * @param e the exception to complete with
+	 * @return the {@link Processor} backing this {@link ProcessorFacade}
 	 */
-	@Override
-	void error(Throwable e);
+	Processor<T, T> asProcessor();
 
 	/**
-	 * @return the {@link OverflowStrategy} that was used when instantiating this {@link FluxProcessorSink}
+	 * Return a view of this {@link FluxProcessorFacade} that is a {@link CoreSubscriber},
+	 * suitable for subscribing to a source {@link Publisher}.
+	 *
+	 * @implSpec if the backing {@link Processor} doesn't come from Reactor, this method
+	 * should return it wrapped in a {@link CoreSubscriber} adapter.
+	 * @return the {@link CoreSubscriber} backing this {@link ProcessorFacade}
 	 */
-	OverflowStrategy getOverflowStrategy();
+	CoreSubscriber<T> asCoreSubscriber();
 
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessorFacade.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessorFacade.java
@@ -20,6 +20,9 @@ import org.reactivestreams.Processor;
 import reactor.core.CoreSubscriber;
 
 /**
+ * A simple {@link Processor} that has the same type for input and output, and exposes a
+ * view of itself as a {@link Flux}.
+ *
  * @author Simon Baslé
  */
 public interface FluxProcessorFacade<T> extends ProcessorFacade<T>, CoreSubscriber<T>, Processor<T, T> {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessorFacade.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessorFacade.java
@@ -17,13 +17,12 @@
 package reactor.core.publisher;
 
 import org.reactivestreams.Processor;
-import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
 
 /**
  * @author Simon Baslé
  */
-public interface FluxProcessorFacade<T> extends ProcessorFacade<T> {
+public interface FluxProcessorFacade<T> extends ProcessorFacade<T>, CoreSubscriber<T>, Processor<T, T> {
 
 	/**
 	 * Expose a Reactor {@link Flux} API on top of the {@link FluxProcessorSink}'s output,
@@ -35,24 +34,5 @@ public interface FluxProcessorFacade<T> extends ProcessorFacade<T> {
 	 * @return a full reactive {@link Flux} API on top of the {@link FluxProcessorSink}'s output
 	 */
 	Flux<T> asFlux();
-
-	/**
-	 * Return a view of this {@link FluxProcessorFacade} that is a
-	 * {@link Processor Processor&lt;T, T&gt;}, suitable for subscribing to a source
-	 * {@link Publisher}.
-	 *
-	 * @return the {@link Processor} backing this {@link ProcessorFacade}
-	 */
-	Processor<T, T> asProcessor();
-
-	/**
-	 * Return a view of this {@link FluxProcessorFacade} that is a {@link CoreSubscriber},
-	 * suitable for subscribing to a source {@link Publisher}.
-	 *
-	 * @implSpec if the backing {@link Processor} doesn't come from Reactor, this method
-	 * should return it wrapped in a {@link CoreSubscriber} adapter.
-	 * @return the {@link CoreSubscriber} backing this {@link ProcessorFacade}
-	 */
-	CoreSubscriber<T> asCoreSubscriber();
 
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessorSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessorSink.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import reactor.core.Disposable;
+
+/**
+ * @author Simon Baslé
+ */
+public interface FluxProcessorSink<T> extends Disposable, ProcessorSink<T>, FluxSink<T> {
+
+	/**
+	 * Expose a Reactor {@link Flux} API on top of the {@link FluxProcessorSink}'s output,
+	 * allowing composition of operators on it.
+	 *
+	 * @implNote most implementations will already implement {@link Flux}
+	 * and thus can return themselves.
+	 *
+	 * @return a full reactive {@link Flux} API on top of the {@link FluxProcessorSink}'s output
+	 */
+	Flux<T> asFlux();
+
+	/**
+	 * @return the {@link OverflowStrategy} that was used when instantiating this {@link FluxProcessorSink}
+	 */
+	OverflowStrategy getOverflowStrategy();
+
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessorSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessorSink.java
@@ -18,9 +18,11 @@ package reactor.core.publisher;
 
 import java.util.function.Consumer;
 
-import reactor.core.Disposable;
-
 /**
+ * A standalone {@link FluxSink}, similar to a {@link FluxProcessorFacade} except tailored
+ * for manual triggering of events rather than {@link org.reactivestreams.Processor}-like
+ * subscribe-and-emit use.
+ *
  * @author Simon Baslé
  */
 public interface FluxProcessorSink<T> extends ProcessorFacade<T>, FluxSink<T> {
@@ -51,7 +53,7 @@ public interface FluxProcessorSink<T> extends ProcessorFacade<T>, FluxSink<T> {
 	void error(Throwable e);
 
 	/**
-	 * @return the {@link OverflowStrategy} that was used when instantiating this {@link FluxProcessorSink}
+	 * @return the {@link FluxSink.OverflowStrategy} that was used when instantiating this {@link FluxProcessorSink}
 	 */
 	OverflowStrategy getOverflowStrategy();
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
@@ -55,7 +55,7 @@ final class FluxRepeatWhen<T> extends FluxOperator<T, T> {
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
 		RepeatWhenOtherSubscriber other = new RepeatWhenOtherSubscriber();
-		Subscriber<Long> signaller = Operators.serialize(other.completionSignal.asCoreSubscriber());
+		Subscriber<Long> signaller = Operators.serialize(other.completionSignal);
 
 		signaller.onSubscribe(Operators.emptySubscription());
 
@@ -194,12 +194,14 @@ final class FluxRepeatWhen<T> extends FluxOperator<T, T> {
 
 	}
 
+	//use of DirectProcessor internally instead of facade, to avoid going through builder in critical path
+	@SuppressWarnings("deprecation")
 	static final class RepeatWhenOtherSubscriber extends Flux<Long>
 			implements InnerConsumer<Object> {
 
 		RepeatWhenMainSubscriber<?> main;
 
-		final FluxProcessorFacade<Long> completionSignal = Processors.direct();
+		final DirectProcessor<Long> completionSignal = new DirectProcessor<>();
 
 		@Override
 		public Context currentContext() {
@@ -237,7 +239,7 @@ final class FluxRepeatWhen<T> extends FluxOperator<T, T> {
 
 		@Override
 		public void subscribe(CoreSubscriber<? super Long> actual) {
-			completionSignal.asProcessor().subscribe(actual);
+			completionSignal.subscribe(actual);
 		}
 
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
@@ -199,7 +199,7 @@ final class FluxRepeatWhen<T> extends FluxOperator<T, T> {
 
 		RepeatWhenMainSubscriber<?> main;
 
-		final FluxProcessorSink<Long> completionSignal = Processors.direct();
+		final FluxProcessorFacade<Long> completionSignal = Processors.direct();
 
 		@Override
 		public Context currentContext() {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
@@ -55,7 +55,7 @@ final class FluxRepeatWhen<T> extends FluxOperator<T, T> {
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
 		RepeatWhenOtherSubscriber other = new RepeatWhenOtherSubscriber();
-		Subscriber<Long> signaller = Operators.serialize(other.completionSignal);
+		Subscriber<Long> signaller = Operators.serialize(other.completionSignal.asCoreSubscriber());
 
 		signaller.onSubscribe(Operators.emptySubscription());
 
@@ -199,7 +199,7 @@ final class FluxRepeatWhen<T> extends FluxOperator<T, T> {
 
 		RepeatWhenMainSubscriber<?> main;
 
-		final DirectProcessor<Long> completionSignal = new DirectProcessor<>();
+		final FluxProcessorSink<Long> completionSignal = Processors.direct();
 
 		@Override
 		public Context currentContext() {
@@ -237,7 +237,7 @@ final class FluxRepeatWhen<T> extends FluxOperator<T, T> {
 
 		@Override
 		public void subscribe(CoreSubscriber<? super Long> actual) {
-			completionSignal.subscribe(actual);
+			completionSignal.asProcessor().subscribe(actual);
 		}
 
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRetryWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRetryWhen.java
@@ -55,7 +55,7 @@ final class FluxRetryWhen<T> extends FluxOperator<T, T> {
 			Flux<Throwable>, ?
 			extends Publisher<?>> whenSourceFactory, Publisher<? extends T> source) {
 		RetryWhenOtherSubscriber other = new RetryWhenOtherSubscriber();
-		Subscriber<Throwable> signaller = Operators.serialize(other.completionSignal);
+		Subscriber<Throwable> signaller = Operators.serialize(other.completionSignal.asCoreSubscriber());
 
 		signaller.onSubscribe(Operators.emptySubscription());
 
@@ -202,7 +202,7 @@ final class FluxRetryWhen<T> extends FluxOperator<T, T> {
 	implements InnerConsumer<Object> {
 		RetryWhenMainSubscriber<?> main;
 
-		final DirectProcessor<Throwable> completionSignal = new DirectProcessor<>();
+		final FluxProcessorSink<Throwable> completionSignal = Processors.direct();
 
 		@Override
 		public Context currentContext() {
@@ -240,7 +240,7 @@ final class FluxRetryWhen<T> extends FluxOperator<T, T> {
 
 		@Override
 		public void subscribe(CoreSubscriber<? super Throwable> actual) {
-			completionSignal.subscribe(actual);
+			completionSignal.asProcessor().subscribe(actual);
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRetryWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRetryWhen.java
@@ -202,7 +202,7 @@ final class FluxRetryWhen<T> extends FluxOperator<T, T> {
 	implements InnerConsumer<Object> {
 		RetryWhenMainSubscriber<?> main;
 
-		final FluxProcessorSink<Throwable> completionSignal = Processors.direct();
+		final FluxProcessorFacade<Throwable> completionSignal = Processors.direct();
 
 		@Override
 		public Context currentContext() {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindow.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindow.java
@@ -255,7 +255,7 @@ final class FluxWindow<T> extends FluxOperator<T, Flux<T>> {
 		@Override
 		public Stream<? extends Scannable> inners() {
 			FluxProcessorFacade<T> w = window;
-			return w == null ? Stream.empty() : Stream.of(w.asScannable());
+			return w == null ? Stream.empty() : Stream.of(Scannable.from(w));
 		}
 	}
 
@@ -442,7 +442,7 @@ final class FluxWindow<T> extends FluxOperator<T, Flux<T>> {
 		@Override
 		public Stream<? extends Scannable> inners() {
 			FluxProcessorFacade<T> w = window;
-			return w == null ? Stream.empty() : Stream.of(w.asScannable());
+			return w == null ? Stream.empty() : Stream.of(Scannable.from(w));
 		}
 	}
 
@@ -743,7 +743,7 @@ final class FluxWindow<T> extends FluxOperator<T, Flux<T>> {
 			return Stream.of(toArray())
 			             .filter(Objects::nonNull)
 			             .map(o -> ((FluxProcessorFacade) o))
-			             .map(FluxProcessorFacade::asScannable);
+			             .map(Scannable::from);
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindow.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindow.java
@@ -254,7 +254,8 @@ final class FluxWindow<T> extends FluxOperator<T, Flux<T>> {
 
 		@Override
 		public Stream<? extends Scannable> inners() {
-			return Stream.of(window.asScannable());
+			FluxProcessorSink<T> w = window;
+			return w == null ? Stream.empty() : Stream.of(w.asScannable());
 		}
 	}
 
@@ -438,7 +439,8 @@ final class FluxWindow<T> extends FluxOperator<T, Flux<T>> {
 
 		@Override
 		public Stream<? extends Scannable> inners() {
-			return Stream.of(window.asScannable());
+			FluxProcessorSink<T> w = window;
+			return w == null ? Stream.empty() : Stream.of(w.asScannable());
 		}
 	}
 
@@ -735,7 +737,9 @@ final class FluxWindow<T> extends FluxOperator<T, Flux<T>> {
 		@Override
 		public Stream<? extends Scannable> inners() {
 			return Stream.of(toArray())
-			             .map(Scannable::from);
+			             .filter(Objects::nonNull)
+			             .map(o -> ((FluxProcessorSink) o))
+			             .map(FluxProcessorSink::asScannable);
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
@@ -155,7 +155,7 @@ final class FluxWindowBoundary<T, U> extends FluxOperator<T, Flux<T>> {
 
 		@Override
 		public Stream<? extends Scannable> inners() {
-			return Stream.of(boundary, window.asScannable());
+			return Stream.of(boundary, Scannable.from(window));
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
@@ -129,7 +129,7 @@ final class FluxWindowTimeout<T> extends FluxOperator<T, Flux<T>> {
 		@Override
 		public Stream<? extends Scannable> inners() {
 			FluxProcessorFacade<T> w = window;
-			return w == null ? Stream.empty() : Stream.of(w.asScannable());
+			return w == null ? Stream.empty() : Stream.of(Scannable.from(w));
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
@@ -100,7 +100,7 @@ final class FluxWindowTimeout<T> extends FluxOperator<T, Flux<T>> {
 
 		Subscription s;
 
-		FluxProcessorSink<T> window;
+		FluxProcessorFacade<T> window;
 
 		volatile boolean terminated;
 
@@ -128,7 +128,7 @@ final class FluxWindowTimeout<T> extends FluxOperator<T, Flux<T>> {
 
 		@Override
 		public Stream<? extends Scannable> inners() {
-			FluxProcessorSink<T> w = window;
+			FluxProcessorFacade<T> w = window;
 			return w == null ? Stream.empty() : Stream.of(w.asScannable());
 		}
 
@@ -157,7 +157,7 @@ final class FluxWindowTimeout<T> extends FluxOperator<T, Flux<T>> {
 					return;
 				}
 
-				FluxProcessorSink<T> w = Processors.unicast();
+				FluxProcessorFacade<T> w = Processors.unicast();
 				window = w;
 
 				long r = requested;
@@ -197,7 +197,7 @@ final class FluxWindowTimeout<T> extends FluxOperator<T, Flux<T>> {
 			}
 
 			if (WIP.get(this) == 0 && WIP.compareAndSet(this, 0, 1)) {
-				FluxProcessorSink<T> w = window;
+				FluxProcessorFacade<T> w = window;
 				w.asProcessor().onNext(t);
 
 				int c = count + 1;
@@ -295,7 +295,7 @@ final class FluxWindowTimeout<T> extends FluxOperator<T, Flux<T>> {
 		void drainLoop() {
 			final Queue<Object> q = queue;
 			final Subscriber<? super Flux<T>> a = actual;
-			FluxProcessorSink<T> w = window;
+			FluxProcessorFacade<T> w = window;
 
 			int missed = 1;
 			for (; ; ) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
@@ -101,7 +101,7 @@ final class FluxWindowWhen<T, U, V> extends FluxOperator<T, Flux<T>> {
 		static final AtomicReferenceFieldUpdater<WindowWhenMainSubscriber, Disposable> BOUNDARY =
 				AtomicReferenceFieldUpdater.newUpdater(WindowWhenMainSubscriber.class, Disposable.class, "boundary");
 
-		final List<FluxProcessorSink<T>> windows;
+		final List<FluxProcessorFacade<T>> windows;
 
 		volatile long openWindowCount;
 		static final AtomicLongFieldUpdater<WindowWhenMainSubscriber> OPEN_WINDOW_COUNT =
@@ -134,7 +134,7 @@ final class FluxWindowWhen<T, U, V> extends FluxOperator<T, Flux<T>> {
 				return;
 			}
 			if (fastEnter()) {
-				for (FluxProcessorSink<T> w : windows) {
+				for (FluxProcessorFacade<T> w : windows) {
 					w.asProcessor().onNext(t);
 				}
 				if (leave(-1) == 0) {
@@ -209,7 +209,7 @@ final class FluxWindowWhen<T, U, V> extends FluxOperator<T, Flux<T>> {
 		void drainLoop() {
 			final Queue<Object> q = queue;
 			final Subscriber<? super Flux<T>> a = actual;
-			final List<FluxProcessorSink<T>> ws = this.windows;
+			final List<FluxProcessorFacade<T>> ws = this.windows;
 			int missed = 1;
 
 			for (;;) {
@@ -225,12 +225,12 @@ final class FluxWindowWhen<T, U, V> extends FluxOperator<T, Flux<T>> {
 						Throwable e = error;
 						if (e != null) {
 							actual.onError(e);
-							for (FluxProcessorSink<T> w : ws) {
+							for (FluxProcessorFacade<T> w : ws) {
 								w.asProcessor().onError(e);
 							}
 						} else {
 							actual.onComplete();
-							for (FluxProcessorSink<T> w : ws) {
+							for (FluxProcessorFacade<T> w : ws) {
 								w.asProcessor().onComplete();
 							}
 						}
@@ -246,7 +246,7 @@ final class FluxWindowWhen<T, U, V> extends FluxOperator<T, Flux<T>> {
 						@SuppressWarnings("unchecked")
 						WindowOperation<T, U> wo = (WindowOperation<T, U>) o;
 
-						FluxProcessorSink<T> w = wo.w;
+						FluxProcessorFacade<T> w = wo.w;
 						if (w != null) {
 							if (ws.remove(wo.w)) {
 								wo.w.asProcessor().onComplete();
@@ -264,7 +264,7 @@ final class FluxWindowWhen<T, U, V> extends FluxOperator<T, Flux<T>> {
 						}
 
 
-						w = Processors.unicast(processorQueueSupplier.get()).build();
+						w = UnicastProcessor.create(processorQueueSupplier.get());
 
 						long r = requested();
 						if (r != 0L) {
@@ -300,7 +300,7 @@ final class FluxWindowWhen<T, U, V> extends FluxOperator<T, Flux<T>> {
 						continue;
 					}
 
-					for (FluxProcessorSink<T> w : ws) {
+					for (FluxProcessorFacade<T> w : ws) {
 						@SuppressWarnings("unchecked")
 						T t = (T) o;
 						w.asProcessor().onNext(t);
@@ -331,9 +331,9 @@ final class FluxWindowWhen<T, U, V> extends FluxOperator<T, Flux<T>> {
 	}
 
 	static final class WindowOperation<T, U> {
-		final FluxProcessorSink<T> w;
+		final FluxProcessorFacade<T> w;
 		final U open;
-		WindowOperation(@Nullable FluxProcessorSink<T> w, @Nullable U open) {
+		WindowOperation(@Nullable FluxProcessorFacade<T> w, @Nullable U open) {
 			this.w = w;
 			this.open = open;
 		}
@@ -407,11 +407,11 @@ final class FluxWindowWhen<T, U, V> extends FluxOperator<T, Flux<T>> {
 				AtomicReferenceFieldUpdater.newUpdater(WindowWhenCloseSubscriber.class, Subscription.class, "subscription");
 
 		final WindowWhenMainSubscriber<T, ?, V> parent;
-		final FluxProcessorSink<T>               w;
+		final FluxProcessorFacade<T>               w;
 
 		boolean done;
 
-		WindowWhenCloseSubscriber(WindowWhenMainSubscriber<T, ?, V> parent, FluxProcessorSink<T> w) {
+		WindowWhenCloseSubscriber(WindowWhenMainSubscriber<T, ?, V> parent, FluxProcessorFacade<T> w) {
 			this.parent = parent;
 			this.w = w;
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1485,7 +1485,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @return a replaying {@link Mono}
 	 */
 	public final Mono<T> cache() {
-		return onAssembly(Processors.first(this).build().asMono());
+		return onAssembly(Processors.firstFrom(this).asMono());
 	}
 
 	/**
@@ -3571,17 +3571,17 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Subscribe the given {@link MonoProcessorSink} to this {@link Mono} and return said
-	 * {@link MonoProcessorSink}.
+	 * Subscribe the given {@link MonoProcessorFacade} to this {@link Mono} and return said
+	 * {@link MonoProcessorFacade}.
 	 *
-	 * @param processorSink the {@link MonoProcessorSink} to subscribe with
+	 * @param processorFacade the {@link MonoProcessorFacade} to subscribe with
 	 * @param <E> the reified type of the {@link Subscriber} for chaining
 	 *
-	 * @return the passed {@link MonoProcessorSink} after subscribing it to this {@link Mono}
+	 * @return the passed {@link MonoProcessorFacade} after subscribing it to this {@link Mono}
 	 */
-	public final <E extends MonoProcessorSink<? super T>> E subscribeWith(E processorSink) {
-		subscribe(processorSink.asProcessor());
-		return processorSink;
+	public final <E extends MonoProcessorFacade<? super T>> E subscribeWith(E processorFacade) {
+		subscribe(processorFacade.asProcessor());
+		return processorFacade;
 	}
 
 	/**
@@ -3941,6 +3941,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @return a {@link MonoProcessorSink} to use to either retrieve value or dispose the underlying {@link Subscription}
 	 */
 	@SuppressWarnings("deprecation")
+	//FIXME
 	public final MonoProcessorSink<T> toProcessorSink() {
 		MonoProcessor<T> mp;
 		if (this instanceof MonoProcessor) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -3571,20 +3571,6 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Subscribe the given {@link MonoProcessorFacade} to this {@link Mono} and return said
-	 * {@link MonoProcessorFacade}.
-	 *
-	 * @param processorFacade the {@link MonoProcessorFacade} to subscribe with
-	 * @param <E> the reified type of the {@link Subscriber} for chaining
-	 *
-	 * @return the passed {@link MonoProcessorFacade} after subscribing it to this {@link Mono}
-	 */
-	public final <E extends MonoProcessorFacade<? super T>> E subscribeWith(E processorFacade) {
-		subscribe(processorFacade.asProcessor());
-		return processorFacade;
-	}
-
-	/**
 	 * Fallback to an alternative {@link Mono} if this mono is completed without data
 	 *
 	 * <p>

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -547,11 +547,6 @@ public final class MonoProcessor<O> extends Mono<O>
 	}
 
 	@Override
-	public Scannable asScannable() {
-		return this;
-	}
-
-	@Override
 	@Nullable
 	public final Throwable getError() {
 		return isTerminated() ? error : null;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -537,16 +537,6 @@ public final class MonoProcessor<O> extends Mono<O>
 	}
 
 	@Override
-	public Processor<O, O> asProcessor() {
-		return this;
-	}
-
-	@Override
-	public CoreSubscriber<O> asCoreSubscriber() {
-		return this;
-	}
-
-	@Override
 	@Nullable
 	public final Throwable getError() {
 		return isTerminated() ? error : null;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -47,7 +47,7 @@ import reactor.util.context.Context;
  * @param <O> the type of the value that will be made available
  *
  * @author Stephane Maldini
- * @deprecated instantiate through {@link Processors#first} and use as a {@link ProcessorFacade}
+ * @deprecated instantiate through {@link Processors#first} and use as a {@link MonoProcessorFacade}, will be removed from public API in 3.3
  */
 @Deprecated
 public final class MonoProcessor<O> extends Mono<O>

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -553,7 +553,7 @@ public final class MonoProcessor<O> extends Mono<O>
 	 * Indicates whether this {@code MonoProcessor} has been successfully completed a value.
 	 *
 	 * @return {@code true} if this {@code MonoProcessor} is successful, {@code false} otherwise.
-	 * @deprecated use {@link MonoProcessorSink#isComplete()} instead
+	 * @deprecated use {@link Processors#first()}'s {@link MonoProcessorSink#isComplete()} instead
 	 */
 	public final boolean isSuccess() {
 		return isTerminated() && error == null;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoProcessorFacade.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoProcessorFacade.java
@@ -20,6 +20,9 @@ import org.reactivestreams.Processor;
 import reactor.core.CoreSubscriber;
 
 /**
+ * A simple {@link Processor} that has the same type for input and output, and exposes a
+ * view of itself as a {@link Mono}.
+ *
  * @author Simon Baslé
  */
 public interface MonoProcessorFacade<T> extends ProcessorFacade<T>, CoreSubscriber<T>, Processor<T, T> {
@@ -39,7 +42,7 @@ public interface MonoProcessorFacade<T> extends ProcessorFacade<T>, CoreSubscrib
 	 * Indicates whether this {@link MonoProcessorFacade} has completed with or without a value,
 	 * whereas {@link #isValued()} indicates it completed with a value.
 	 *
-	 * @return {@code true} if this {@link ProcessorFacade} is completed, but without value, {@code false} otherwise.
+	 * @return {@code true} if this {@link MonoProcessorFacade} is completed, but without value, {@code false} otherwise.
 	 */
 	@Override
 	boolean isComplete();
@@ -48,7 +51,7 @@ public interface MonoProcessorFacade<T> extends ProcessorFacade<T>, CoreSubscrib
 	 * Indicates whether this {@link MonoProcessorFacade} has completed with a value,
 	 * whereas {@link #isComplete()} indicates it completed, but could be without a value.
 	 *
-	 * @return {@code true} if this {@link ProcessorFacade} is completed with value, {@code false} otherwise.
+	 * @return {@code true} if this {@link MonoProcessorFacade} is completed with value, {@code false} otherwise.
 	 */
 	boolean isValued();
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoProcessorFacade.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoProcessorFacade.java
@@ -17,13 +17,12 @@
 package reactor.core.publisher;
 
 import org.reactivestreams.Processor;
-import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
 
 /**
  * @author Simon Baslé
  */
-public interface MonoProcessorFacade<T> extends ProcessorFacade<T> {
+public interface MonoProcessorFacade<T> extends ProcessorFacade<T>, CoreSubscriber<T>, Processor<T, T> {
 
 	/**
 	 * Expose a Reactor {@link Mono} API on top of the {@link MonoProcessorFacade}'s output,
@@ -35,26 +34,6 @@ public interface MonoProcessorFacade<T> extends ProcessorFacade<T> {
 	 * @return a full reactive {@link Mono} API on top of the {@link MonoProcessorFacade}'s output
 	 */
 	Mono<T> asMono();
-
-	/**
-	 * Return a view of this {@link MonoProcessorFacade} that is a
-	 * {@link Processor Processor&lt;T, T&gt;}, suitable for subscribing to a source
-	 * {@link Publisher}.
-	 *
-	 * @return the {@link Processor} backing this {@link MonoProcessorFacade}
-	 */
-	Processor<T, T> asProcessor();
-
-	/**
-	 * Return a view of this {@link MonoProcessorFacade} that is a {@link CoreSubscriber},
-   * suitable for subscribing to a source {@link Publisher}.
-	 *
-	 * @implSpec if the backing {@link Processor} doesn't come from Reactor, this method
-	 * should return it wrapped in a {@link CoreSubscriber} adapter.
-	 * @return the {@link CoreSubscriber} backing this {@link MonoProcessorFacade}
-	 */
-	CoreSubscriber<T> asCoreSubscriber();
-
 
 	/**
 	 * Indicates whether this {@link MonoProcessorFacade} has completed with or without a value,

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoProcessorFacade.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoProcessorFacade.java
@@ -14,42 +14,50 @@
  * limitations under the License.
  */
 
-/*
- * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package reactor.core.publisher;
+
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import reactor.core.CoreSubscriber;
 
 /**
  * @author Simon Baslé
  */
-public interface MonoProcessorSink<T> extends ProcessorFacade<T>, MonoSink<T> {
+public interface MonoProcessorFacade<T> extends ProcessorFacade<T> {
 
 	/**
-	 * Expose a Reactor {@link Mono} API on top of the {@link MonoProcessorSink}'s output,
+	 * Expose a Reactor {@link Mono} API on top of the {@link MonoProcessorFacade}'s output,
 	 * allowing composition of operators on it.
 	 *
 	 * @implNote most implementations will already implement {@link Mono}
 	 * and thus can return themselves.
 	 *
-	 * @return a full reactive {@link Mono} API on top of the {@link MonoProcessorSink}'s output
+	 * @return a full reactive {@link Mono} API on top of the {@link MonoProcessorFacade}'s output
 	 */
 	Mono<T> asMono();
 
 	/**
-	 * Indicates whether this {@link MonoProcessorSink} has completed with or without a value,
+	 * Return a view of this {@link MonoProcessorFacade} that is a
+	 * {@link Processor Processor&lt;T, T&gt;}, suitable for subscribing to a source
+	 * {@link Publisher}.
+	 *
+	 * @return the {@link Processor} backing this {@link MonoProcessorFacade}
+	 */
+	Processor<T, T> asProcessor();
+
+	/**
+	 * Return a view of this {@link MonoProcessorFacade} that is a {@link CoreSubscriber},
+   * suitable for subscribing to a source {@link Publisher}.
+	 *
+	 * @implSpec if the backing {@link Processor} doesn't come from Reactor, this method
+	 * should return it wrapped in a {@link CoreSubscriber} adapter.
+	 * @return the {@link CoreSubscriber} backing this {@link MonoProcessorFacade}
+	 */
+	CoreSubscriber<T> asCoreSubscriber();
+
+
+	/**
+	 * Indicates whether this {@link MonoProcessorFacade} has completed with or without a value,
 	 * whereas {@link #isValued()} indicates it completed with a value.
 	 *
 	 * @return {@code true} if this {@link ProcessorFacade} is completed, but without value, {@code false} otherwise.
@@ -58,7 +66,7 @@ public interface MonoProcessorSink<T> extends ProcessorFacade<T>, MonoSink<T> {
 	boolean isComplete();
 
 	/**
-	 * Indicates whether this {@link MonoProcessorSink} has completed with a value,
+	 * Indicates whether this {@link MonoProcessorFacade} has completed with a value,
 	 * whereas {@link #isComplete()} indicates it completed, but could be without a value.
 	 *
 	 * @return {@code true} if this {@link ProcessorFacade} is completed with value, {@code false} otherwise.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoProcessorSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoProcessorSink.java
@@ -33,6 +33,10 @@
 package reactor.core.publisher;
 
 /**
+ * A standalone {@link MonoSink}, similar to {@link MonoProcessorFacade} except tailored
+ * for manual triggering of events rather than {@link org.reactivestreams.Processor}-like
+ * subscribe-and-emit use.
+ *
  * @author Simon Baslé
  */
 public interface MonoProcessorSink<T> extends ProcessorFacade<T>, MonoSink<T> {
@@ -52,7 +56,7 @@ public interface MonoProcessorSink<T> extends ProcessorFacade<T>, MonoSink<T> {
 	 * Indicates whether this {@link MonoProcessorSink} has completed with or without a value,
 	 * whereas {@link #isValued()} indicates it completed with a value.
 	 *
-	 * @return {@code true} if this {@link ProcessorFacade} is completed, but without value, {@code false} otherwise.
+	 * @return {@code true} if this {@link MonoProcessorSink} is completed, but without value, {@code false} otherwise.
 	 */
 	@Override
 	boolean isComplete();
@@ -61,7 +65,7 @@ public interface MonoProcessorSink<T> extends ProcessorFacade<T>, MonoSink<T> {
 	 * Indicates whether this {@link MonoProcessorSink} has completed with a value,
 	 * whereas {@link #isComplete()} indicates it completed, but could be without a value.
 	 *
-	 * @return {@code true} if this {@link ProcessorFacade} is completed with value, {@code false} otherwise.
+	 * @return {@code true} if this {@link MonoProcessorSink} is completed with value, {@code false} otherwise.
 	 */
 	boolean isValued();
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoProcessorSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoProcessorSink.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import reactor.core.Disposable;
+
+/**
+ * @author Simon Baslé
+ */
+public interface MonoProcessorSink<T> extends Disposable, ProcessorSink<T>, MonoSink<T> {
+
+	/**
+	 * Expose a Reactor {@link Mono} API on top of the {@link MonoProcessorSink}'s output,
+	 * allowing composition of operators on it.
+	 *
+	 * @implNote most implementations will already implement {@link Mono}
+	 * and thus can return themselves.
+	 *
+	 * @return a full reactive {@link Mono} API on top of the {@link MonoProcessorSink}'s output
+	 */
+	Mono<T> asMono();
+
+	/**
+	 * Indicates whether this {@link MonoProcessorSink} has completed with or without a value,
+	 * whereas {@link #isValued()} indicates it completed with a value.
+	 *
+	 * @return {@code true} if this {@link ProcessorSink} is completed, but without value, {@code false} otherwise.
+	 */
+	@Override
+	boolean isComplete();
+
+	/**
+	 * Indicates whether this {@link MonoProcessorSink} has completed with a value,
+	 * whereas {@link #isComplete()} indicates it completed, but could be without a value.
+	 *
+	 * @return {@code true} if this {@link ProcessorSink} is completed with value, {@code false} otherwise.
+	 */
+	boolean isValued();
+
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoRepeatWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoRepeatWhen.java
@@ -50,7 +50,7 @@ final class MonoRepeatWhen<T> extends FluxFromMonoOperator<T, T> {
 	public void subscribe(CoreSubscriber<? super T> actual) {
 		FluxRepeatWhen.RepeatWhenOtherSubscriber other =
 				new FluxRepeatWhen.RepeatWhenOtherSubscriber();
-		Subscriber<Long> signaller = Operators.serialize(other.completionSignal);
+		Subscriber<Long> signaller = Operators.serialize(other.completionSignal.asCoreSubscriber());
 
 		signaller.onSubscribe(Operators.emptySubscription());
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoRepeatWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoRepeatWhen.java
@@ -50,7 +50,7 @@ final class MonoRepeatWhen<T> extends FluxFromMonoOperator<T, T> {
 	public void subscribe(CoreSubscriber<? super T> actual) {
 		FluxRepeatWhen.RepeatWhenOtherSubscriber other =
 				new FluxRepeatWhen.RepeatWhenOtherSubscriber();
-		Subscriber<Long> signaller = Operators.serialize(other.completionSignal.asCoreSubscriber());
+		Subscriber<Long> signaller = Operators.serialize(other.completionSignal);
 
 		signaller.onSubscribe(Operators.emptySubscription());
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ProcessorFacade.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ProcessorFacade.java
@@ -84,7 +84,7 @@ public interface ProcessorFacade<T> extends Disposable {
 
 	/**
 	 * For asynchronous {@link ProcessorFacade}, which maintain heavy resources
-	 * (such as {@link Processors#fanOut()}), this method attempts to forcibly shutdown
+	 * (such as {@link Processors#asyncEmitter()}), this method attempts to forcibly shutdown
 	 * these resources, unlike {@link #dispose()} which would let the {@link ProcessorFacade}
 	 * tear down the resources gracefully.
 	 * <p>
@@ -102,7 +102,7 @@ public interface ProcessorFacade<T> extends Disposable {
 	}
 
 	/**
-	 * For {@link ProcessorFacade} that maintain heavy resources (such as {@link Processors#fanOut()}),
+	 * For {@link ProcessorFacade} that maintain heavy resources (such as {@link Processors#asyncEmitter()}),
 	 * this method attempts to shutdown these resources gracefully within the given {@link Duration}.
 	 * Unlike {@link #dispose()}, this <strong>blocks</strong> for the given {@link Duration}.
 	 *

--- a/reactor-core/src/main/java/reactor/core/publisher/ProcessorFacade.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ProcessorFacade.java
@@ -29,47 +29,48 @@ import reactor.util.annotation.Nullable;
 /**
  * @author Simon Baslé
  */
-public interface ProcessorSink<T> extends Disposable {
+public interface ProcessorFacade<T> extends Disposable {
+//	/**
+//	 * Terminate with the given exception
+//	 * <p>
+//	 * Calling this method multiple times or after the other terminating methods is
+//	 * an unsupported operation. It will discard the exception through the
+//	 * {@link Hooks#onErrorDropped(Consumer)} hook (which by default throws the exception
+//	 * wrapped via {@link reactor.core.Exceptions#bubble(Throwable)}). This is to avoid
+//	 * complete and silent swallowing of the exception.
+//	 *
+//	 * @param e the exception to complete with
+//	 */
+//	void error(Throwable e);
+//
+//	/**
+//	 * Return a view of this {@link ProcessorFacade} that is a
+//	 * {@link Processor Processor&lt;T, T&gt;}, suitable for subscribing to a source
+//	 * {@link Publisher}.
+//	 *
+//	 * @return the {@link Processor} backing this {@link ProcessorFacade}
+//	 */
+//	Processor<T, T> asProcessor();
+//
+//	/**
+//	 * Return a view of this {@link ProcessorFacade} that is a {@link CoreSubscriber},
+//   * suitable for subscribing to a source {@link Publisher}.
+//	 *
+//	 * @implSpec if the backing {@link Processor} doesn't come from Reactor, this method
+//	 * should return it wrapped in a {@link CoreSubscriber} adapter.
+//	 * @return the {@link CoreSubscriber} backing this {@link ProcessorFacade}
+//	 */
+//	CoreSubscriber<T> asCoreSubscriber();
 
 	/**
-	 * Return a view of this {@link ProcessorSink} that is a
-	 * {@link Processor Processor&lt;T, T&gt;}.
-	 *
-	 * @return the {@link Processor} backing this {@link ProcessorSink}
-	 */
-	Processor<T, T> asProcessor();
-
-	/**
-	 * Return a view of this {@link ProcessorSink} that is a {@link CoreSubscriber}, or
-	 *
-	 * @implSpec if the backing {@link Processor} doesn't come from Reactor, this method
-	 * should return it wrapped in a {@link CoreSubscriber} adapter.
-	 * @return the {@link CoreSubscriber} backing this {@link ProcessorSink}
-	 */
-	CoreSubscriber<T> asCoreSubscriber();
-
-	/**
-	 * Return a view of this {@link ProcessorSink} that is {@link Scannable}.
+	 * Return a view of this {@link ProcessorFacade} that is {@link Scannable}.
 	 * <p>
 	 * Possibly return an unscannable instance if no backing element is Scannable
 	 * (see {@link Scannable#isScanAvailable()}).
 	 *
-	 * @return the {@link Scannable} backing this {@link ProcessorSink}
+	 * @return the {@link Scannable} backing this {@link ProcessorFacade}
 	 */
 	Scannable asScannable();
-
-	/**
-	 * Terminate with the give exception
-	 * <p>
-	 * Calling this method multiple times or after the other terminating methods is
-	 * an unsupported operation. It will discard the exception through the
-	 * {@link Hooks#onErrorDropped(Consumer)} hook (which by default throws the exception
-	 * wrapped via {@link reactor.core.Exceptions#bubble(Throwable)}). This is to avoid
-	 * complete and silent swallowing of the exception.
-	 *
-	 * @param e the exception to complete with
-	 */
-	void error(Throwable e);
 
 	/**
 	 * Return the produced {@link Throwable} error if any or null
@@ -98,43 +99,43 @@ public interface ProcessorSink<T> extends Disposable {
 	}
 
 	/**
-	 * Indicates whether this {@link ProcessorSink} has been terminated by the
+	 * Indicates whether this {@link ProcessorFacade} has been terminated by the
 	 * source producer with a success or an error.
 	 *
-	 * @return {@code true} if this {@link ProcessorSink} is successful, {@code false} otherwise.
+	 * @return {@code true} if this {@link ProcessorFacade} is successful, {@code false} otherwise.
 	 */
 	boolean isTerminated();
 
 	/**
-	 * Forcibly terminate the {@link ProcessorSink}, preventing it to be reused and
+	 * Forcibly terminate the {@link ProcessorFacade}, preventing it to be reused and
 	 * resubscribed.
 	 */
 	@Override
 	void dispose();
 
 	/**
-	 * Indicates whether this {@link ProcessorSink} has been terminated by calling its
+	 * Indicates whether this {@link ProcessorFacade} has been terminated by calling its
 	 * {@link #dispose()} method.
 	 *
-	 * @return true if the {@link ProcessorSink} has been terminated.
+	 * @return true if the {@link ProcessorFacade} has been terminated.
 	 */
 	@Override
 	boolean isDisposed();
 
 
 	/**
-	 * For asynchronous {@link ProcessorSink}, which maintain heavy resources
+	 * For asynchronous {@link ProcessorFacade}, which maintain heavy resources
 	 * (such as {@link Processors#fanOut()}), this method attempts to forcibly shutdown
-	 * these resources, unlike {@link #dispose()} which would let the {@link ProcessorSink}
+	 * these resources, unlike {@link #dispose()} which would let the {@link ProcessorFacade}
 	 * tear down the resources gracefully.
 	 * <p>
-	 * Since for asynchronous {@link ProcessorSink} there could be undistributed values at
+	 * Since for asynchronous {@link ProcessorFacade} there could be undistributed values at
 	 * this point, said values are returned as a {@link Flux}.
 	 * <p>
 	 * For other implementations, this is equivalent to calling {@link #dispose()} and
 	 * returns an {@link Flux#empty() empty Flux}.
 	 *
-	 * @return a {@link Flux} of the undistributed values for async {@link ProcessorSink Broadcasters}
+	 * @return a {@link Flux} of the undistributed values for async {@link ProcessorFacade Broadcasters}
 	 */
 	default Flux<T> forceDispose() {
 		dispose();
@@ -142,7 +143,7 @@ public interface ProcessorSink<T> extends Disposable {
 	}
 
 	/**
-	 * For {@link ProcessorSink} that maintain heavy resources (such as {@link Processors#fanOut()}),
+	 * For {@link ProcessorFacade} that maintain heavy resources (such as {@link Processors#fanOut()}),
 	 * this method attempts to shutdown these resources gracefully within the given {@link Duration}.
 	 * Unlike {@link #dispose()}, this <strong>blocks</strong> for the given {@link Duration}.
 	 *
@@ -183,9 +184,9 @@ public interface ProcessorSink<T> extends Disposable {
 	}
 
 	/**
-	 * Return true if this {@link ProcessorSink} supports multithread producing
+	 * Return true if this {@link ProcessorFacade} supports multithread producing
 	 *
-	 * @return true if this {@link ProcessorSink} supports multithread producing
+	 * @return true if this {@link ProcessorFacade} supports multithread producing
 	 */
 	boolean isSerialized();
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ProcessorFacade.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ProcessorFacade.java
@@ -30,47 +30,6 @@ import reactor.util.annotation.Nullable;
  * @author Simon Baslé
  */
 public interface ProcessorFacade<T> extends Disposable {
-//	/**
-//	 * Terminate with the given exception
-//	 * <p>
-//	 * Calling this method multiple times or after the other terminating methods is
-//	 * an unsupported operation. It will discard the exception through the
-//	 * {@link Hooks#onErrorDropped(Consumer)} hook (which by default throws the exception
-//	 * wrapped via {@link reactor.core.Exceptions#bubble(Throwable)}). This is to avoid
-//	 * complete and silent swallowing of the exception.
-//	 *
-//	 * @param e the exception to complete with
-//	 */
-//	void error(Throwable e);
-//
-//	/**
-//	 * Return a view of this {@link ProcessorFacade} that is a
-//	 * {@link Processor Processor&lt;T, T&gt;}, suitable for subscribing to a source
-//	 * {@link Publisher}.
-//	 *
-//	 * @return the {@link Processor} backing this {@link ProcessorFacade}
-//	 */
-//	Processor<T, T> asProcessor();
-//
-//	/**
-//	 * Return a view of this {@link ProcessorFacade} that is a {@link CoreSubscriber},
-//   * suitable for subscribing to a source {@link Publisher}.
-//	 *
-//	 * @implSpec if the backing {@link Processor} doesn't come from Reactor, this method
-//	 * should return it wrapped in a {@link CoreSubscriber} adapter.
-//	 * @return the {@link CoreSubscriber} backing this {@link ProcessorFacade}
-//	 */
-//	CoreSubscriber<T> asCoreSubscriber();
-
-	/**
-	 * Return a view of this {@link ProcessorFacade} that is {@link Scannable}.
-	 * <p>
-	 * Possibly return an unscannable instance if no backing element is Scannable
-	 * (see {@link Scannable#isScanAvailable()}).
-	 *
-	 * @return the {@link Scannable} backing this {@link ProcessorFacade}
-	 */
-	Scannable asScannable();
 
 	/**
 	 * Return the produced {@link Throwable} error if any or null

--- a/reactor-core/src/main/java/reactor/core/publisher/ProcessorFacade.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ProcessorFacade.java
@@ -27,6 +27,8 @@ import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
 
 /**
+ * Common introspection API for Reactor simpler processors.
+ *
  * @author Simon Baslé
  */
 public interface ProcessorFacade<T> extends Disposable {

--- a/reactor-core/src/main/java/reactor/core/publisher/ProcessorSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ProcessorSink.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+
+import org.reactivestreams.Processor;
+import org.reactivestreams.Subscriber;
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+import reactor.core.Scannable;
+import reactor.util.annotation.Nullable;
+
+/**
+ * @author Simon Baslé
+ */
+public interface ProcessorSink<T> extends Disposable {
+
+	/**
+	 * Return a view of this {@link ProcessorSink} that is a
+	 * {@link Processor Processor&lt;T, T&gt;}.
+	 *
+	 * @return the {@link Processor} backing this {@link ProcessorSink}
+	 */
+	Processor<T, T> asProcessor();
+
+	/**
+	 * Return a view of this {@link ProcessorSink} that is a {@link CoreSubscriber}, or
+	 *
+	 * @implSpec if the backing {@link Processor} doesn't come from Reactor, this method
+	 * should return it wrapped in a {@link CoreSubscriber} adapter.
+	 * @return the {@link CoreSubscriber} backing this {@link ProcessorSink}
+	 */
+	CoreSubscriber<T> asCoreSubscriber();
+
+	/**
+	 * Return a view of this {@link ProcessorSink} that is {@link Scannable}.
+	 * <p>
+	 * Possibly return an unscannable instance if no backing element is Scannable
+	 * (see {@link Scannable#isScanAvailable()}).
+	 *
+	 * @return the {@link Scannable} backing this {@link ProcessorSink}
+	 */
+	Scannable asScannable();
+
+	/**
+	 * Terminate with the give exception
+	 * <p>
+	 * Calling this method multiple times or after the other terminating methods is
+	 * an unsupported operation. It will discard the exception through the
+	 * {@link Hooks#onErrorDropped(Consumer)} hook (which by default throws the exception
+	 * wrapped via {@link reactor.core.Exceptions#bubble(Throwable)}). This is to avoid
+	 * complete and silent swallowing of the exception.
+	 *
+	 * @param e the exception to complete with
+	 */
+	void error(Throwable e);
+
+	/**
+	 * Return the produced {@link Throwable} error if any or null
+	 *
+	 * @return the produced {@link Throwable} error if any or null
+	 */
+	@Nullable
+	Throwable getError();
+
+	/**
+	 * Return true if terminated with onComplete
+	 *
+	 * @return true if terminated with onComplete
+	 */
+	default boolean isComplete() {
+		return isTerminated() && getError() == null;
+	}
+
+	/**
+	 * Return true if terminated with onError
+	 *
+	 * @return true if terminated with onError
+	 */
+	default boolean isError() {
+		return isTerminated() && getError() != null;
+	}
+
+	/**
+	 * Indicates whether this {@link ProcessorSink} has been terminated by the
+	 * source producer with a success or an error.
+	 *
+	 * @return {@code true} if this {@link ProcessorSink} is successful, {@code false} otherwise.
+	 */
+	boolean isTerminated();
+
+	/**
+	 * Forcibly terminate the {@link ProcessorSink}, preventing it to be reused and
+	 * resubscribed.
+	 */
+	@Override
+	void dispose();
+
+	/**
+	 * Indicates whether this {@link ProcessorSink} has been terminated by calling its
+	 * {@link #dispose()} method.
+	 *
+	 * @return true if the {@link ProcessorSink} has been terminated.
+	 */
+	@Override
+	boolean isDisposed();
+
+
+	/**
+	 * For asynchronous {@link ProcessorSink}, which maintain heavy resources
+	 * (such as {@link Processors#fanOut()}), this method attempts to forcibly shutdown
+	 * these resources, unlike {@link #dispose()} which would let the {@link ProcessorSink}
+	 * tear down the resources gracefully.
+	 * <p>
+	 * Since for asynchronous {@link ProcessorSink} there could be undistributed values at
+	 * this point, said values are returned as a {@link Flux}.
+	 * <p>
+	 * For other implementations, this is equivalent to calling {@link #dispose()} and
+	 * returns an {@link Flux#empty() empty Flux}.
+	 *
+	 * @return a {@link Flux} of the undistributed values for async {@link ProcessorSink Broadcasters}
+	 */
+	default Flux<T> forceDispose() {
+		dispose();
+		return Flux.empty();
+	}
+
+	/**
+	 * For {@link ProcessorSink} that maintain heavy resources (such as {@link Processors#fanOut()}),
+	 * this method attempts to shutdown these resources gracefully within the given {@link Duration}.
+	 * Unlike {@link #dispose()}, this <strong>blocks</strong> for the given {@link Duration}.
+	 *
+	 * <p>
+	 * For other implementations, this is equivalent to calling {@link #dispose()}, returning
+	 * the result of {@link #isDisposed()} immediately.
+	 *
+	 * @param timeout the timeout value as a {@link java.time.Duration}. Note this is
+	 * converted to a {@link Long} * of nanoseconds (which amounts to roughly 292 years
+	 * maximum timeout).
+	 * @return if the underlying executor terminated and false if the timeout elapsed before
+	 * termination
+	 */
+	default boolean disposeAndAwait(Duration timeout) {
+		dispose();
+		return isDisposed();
+	}
+
+	/**
+	 * @return a snapshot number of available onNext before starving the resource
+	 */
+	long getAvailableCapacity();
+
+	/**
+	 * Return the number of active {@link Subscriber} or {@literal -1} if untracked.
+	 *
+	 * @return the number of active {@link Subscriber} or {@literal -1} if untracked
+	 */
+	long downstreamCount();
+
+	/**
+	 * Return true if any {@link Subscriber} is actively subscribed
+	 *
+	 * @return true if any {@link Subscriber} is actively subscribed
+	 */
+	default boolean hasDownstreams() {
+		return downstreamCount() != 0L;
+	}
+
+	/**
+	 * Return true if this {@link ProcessorSink} supports multithread producing
+	 *
+	 * @return true if this {@link ProcessorSink} supports multithread producing
+	 */
+	boolean isSerialized();
+
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/Processors.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Processors.java
@@ -24,12 +24,10 @@ import java.util.function.Consumer;
 import java.util.function.LongConsumer;
 import java.util.stream.Stream;
 
-import com.sun.webkit.EventLoop;
 import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Scannable;
 import reactor.core.publisher.FluxSink.OverflowStrategy;
@@ -47,7 +45,7 @@ import reactor.util.context.Context;
 public final class Processors {
 
 	/**
-	 * Create a "direct" {@link FluxProcessorFacade}: when used {@link FluxProcessorFacade#asProcessor() as a Processor}
+	 * Create a "direct" {@link FluxProcessorFacade}: when used as a {@link Processor}
 	 * it is suitable for transferring data from a {@link Publisher} source and can
 	 * dispatch signals to zero to many {@link Subscriber Subscribers}, but has the
 	 * limitation of not handling backpressure.
@@ -91,7 +89,7 @@ public final class Processors {
 
 
 	/**
-	 * Create an unbounded "unicast" {@link FluxProcessorFacade}: when used {@link FluxProcessorFacade#asProcessor() as a Processor}
+	 * Create an unbounded "unicast" {@link FluxProcessorFacade}: when used as a {@link Processor}
 	 * it is suitable for transferring data from a {@link Publisher} source and can
 	 * deal with backpressure using an internal buffer, but <strong>can have at most one
 	 * {@link Subscriber}</strong>.
@@ -151,11 +149,10 @@ public final class Processors {
 
 
 	/**
-	 * Create a new "emitter" {@link FluxProcessorFacade}: when used
-	 * {@link FluxProcessorFacade#asProcessor() as a Processor} it is suitable for
-	 * transferring data from a {@link Publisher} source and relay its signals synchronously.
-	 * It can emit to several {@link Subscriber Subscribers} while honoring backpressure
-	 * for each of them.
+	 * Create a new "emitter" {@link FluxProcessorFacade}: when used as a {@link Processor}
+	 * it is suitable for transferring data from a {@link Publisher} source and relay its
+	 * signals synchronously. It can emit to several {@link Subscriber Subscribers} while
+	 * honoring backpressure for each of them.
 	 *
 	 * <p>
 	 * Initially, when it has no {@link Subscriber}, this emitter Processor can still accept
@@ -1075,7 +1072,7 @@ public final class Processors {
 		 * Configures sharing state for this builder. A shared fanout processor authorizes
 		 * is suited for multi-threaded publisher that will fan-in data.
 		 *
-		 * @param share true to support concurrent sources on the {@link FluxProcessorFacade#asProcessor Processor}
+		 * @param share true to support concurrent sources on the {@link Processor}
 		 * @return builder with specified sharing
 		 */
 		public AsyncEmitterProcessorBuilder share(boolean share) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Processors.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Processors.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.LongConsumer;
+import java.util.stream.Stream;
 
 import com.sun.webkit.EventLoop;
 import org.reactivestreams.Processor;
@@ -1157,7 +1158,7 @@ public final class Processors {
 
 	//=== Adapter Classes from FluxProcessor to FluxProcessorSink ===
 
-	static class FluxProcessorSinkAdapter<T> implements FluxProcessorSink<T> {
+	static class FluxProcessorSinkAdapter<T> implements FluxProcessorSink<T>, Scannable {
 
 		@SuppressWarnings("deprecation")
 		final FluxProcessor<T, T> processor;
@@ -1170,11 +1171,6 @@ public final class Processors {
 			this.processor = processor;
 			this.overflowStrategy = overflowStrategy == null ? OverflowStrategy.IGNORE : overflowStrategy;
 			this.sink = processor.sink(this.overflowStrategy);
-		}
-
-		@Override
-		public Scannable asScannable() {
-			return processor;
 		}
 
 		@Override
@@ -1277,6 +1273,43 @@ public final class Processors {
 			return processor.isSerialized();
 		}
 
+		//==delegates to processor as Scannable ==
+
+		@Override
+		@Nullable
+		public Object scanUnsafe(Scannable.Attr key) {
+			return processor.scanUnsafe(key);
+		}
+
+		@Override
+		public boolean isScanAvailable() {
+			return processor.isScanAvailable();
+		}
+
+		@Override
+		public String stepName() {
+			return processor.stepName();
+		}
+
+		@Override
+		public String operatorName() {
+			return processor.operatorName();
+		}
+
+		@Override
+		public Stream<? extends Scannable> parents() {
+			return processor.parents();
+		}
+
+		@Override
+		public Stream<? extends Scannable> actuals() {
+			return processor.actuals();
+		}
+
+		@Override
+		public Stream<? extends Scannable> inners() {
+			return processor.inners();
+		}
 	}
 
 	static final class AsyncFluxProcessorSinkAdapter<T> extends FluxProcessorSinkAdapter<T> {
@@ -1300,7 +1333,7 @@ public final class Processors {
 		}
 	}
 
-	static class MonoFirstProcessorSinkAdapter<T> implements MonoProcessorSink<T> {
+	static class MonoFirstProcessorSinkAdapter<T> implements MonoProcessorSink<T>, Scannable {
 
 		@SuppressWarnings("deprecation")
 		final MonoProcessor<T> processor;
@@ -1314,11 +1347,6 @@ public final class Processors {
 
 		@Override
 		public Mono<T> asMono() {
-			return processor;
-		}
-
-		@Override
-		public Scannable asScannable() {
 			return processor;
 		}
 
@@ -1418,6 +1446,44 @@ public final class Processors {
 		@Override
 		public boolean hasDownstreams() {
 			return processor.hasDownstreams();
+		}
+
+		//==delegates to processor as Scannable ==
+
+		@Override
+		@Nullable
+		public Object scanUnsafe(Scannable.Attr key) {
+			return processor.scanUnsafe(key);
+		}
+
+		@Override
+		public boolean isScanAvailable() {
+			return processor.isScanAvailable();
+		}
+
+		@Override
+		public String stepName() {
+			return processor.stepName();
+		}
+
+		@Override
+		public String operatorName() {
+			return processor.operatorName();
+		}
+
+		@Override
+		public Stream<? extends Scannable> parents() {
+			return processor.parents();
+		}
+
+		@Override
+		public Stream<? extends Scannable> actuals() {
+			return processor.actuals();
+		}
+
+		@Override
+		public Stream<? extends Scannable> inners() {
+			return processor.inners();
 		}
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/Processors.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Processors.java
@@ -1,0 +1,1270 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.util.Queue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.LongConsumer;
+
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+import reactor.core.Scannable;
+import reactor.core.publisher.FluxSink.OverflowStrategy;
+import reactor.core.scheduler.Scheduler;
+import reactor.util.annotation.Nullable;
+import reactor.util.concurrent.Queues;
+import reactor.util.concurrent.WaitStrategy;
+import reactor.util.context.Context;
+
+/**
+ * Utility class to create various flavors of {@link  ProcessorSink Flux Processors}.
+ *
+ * @author Simon Baslé
+ */
+public final class Processors {
+
+	/**
+	 * Create a "direct" {@link ProcessorSink}: it can dispatch signals to zero to many
+	 * {@link Subscriber Subscribers}, but has the limitation of not
+	 * handling backpressure.
+	 * <p>
+	 * As a consequence, a direct Processor signals an {@link IllegalStateException} to its
+	 * subscribers if you push N elements through it but at least one of its subscribers has
+	 * requested less than N.
+	 * <p>
+	 * Once the Processor has terminated (usually through its {@link FluxSink#error(Throwable)}
+	 * or {@link FluxSink#complete()} methods being called), it lets more subscribers
+	 * subscribe but replays the termination signal to them immediately.
+	 *
+	 * @param <T> the type of the data flowing through the processor
+	 * @return a new direct {@link ProcessorSink}
+	 */
+	@SuppressWarnings("deprecation")
+	public static final <T> FluxProcessorSink<T> direct() {
+		return new FluxProcessorSinkAdapter<>(new DirectProcessor<>(), null);
+	}
+
+	/**
+	 * Create an unbounded "unicast" {@link ProcessorSink}, which can deal with
+	 * backpressure using an internal buffer, but <strong>can have at most one
+	 * {@link Subscriber}</strong>.
+	 * <p>
+	 * The returned unicast Processor is unbounded: if you push any amount of data through
+	 * it while its {@link Subscriber} has not yet requested data, it will buffer
+	 * all of the data. Use the builder variant to provide a {@link Queue} through the
+	 * {@link #unicast(Queue)} method, which returns a builder that allows further
+	 * configuration.
+	 *
+	 * @param <T>
+	 * @return a new unicast {@link ProcessorSink}
+	 */
+	@SuppressWarnings("deprecation")
+	public static final <T> FluxProcessorSink<T> unicast() {
+		return new FluxProcessorSinkAdapter<>(UnicastProcessor.create(), null);
+	}
+
+	/**
+	 * Create a builder for a "unicast" {@link ProcessorSink}, which can deal with
+	 * backpressure using an internal buffer, but <strong>can have at most one
+	 * {@link Subscriber}</strong>.
+	 * <p>
+	 * This unicast Processor can be fine tuned through its builder, but it requires at
+	 * least a {@link Queue}. If said queue is unbounded and if you push any amount of
+	 * data through the processor while its {@link Subscriber} has not yet requested data,
+	 * it will buffer all of the data. You can avoid that by providing a bounded {@link Queue}
+	 * instead.
+	 *
+	 * @param queue the {@link Queue} to back the processor, making it bounded or unbounded
+	 * @param <T>
+	 * @return a builder to create a new unicast {@link ProcessorSink}
+	 */
+	public static final <T> UnicastProcessorBuilder<T> unicast(Queue<T> queue) {
+		return new UnicastProcessorBuilder<>(queue);
+	}
+
+	/**
+	 * Create a new "emitter" {@link ProcessorSink}, which is capable
+	 * of emitting to several {@link Subscriber Subscribers} while honoring backpressure
+	 * for each of its subscribers. It can also subscribe to a {@link Publisher} and relay
+	 * its signals synchronously.
+	 *
+	 * <p>
+	 * Initially, when it has no {@link Subscriber}, this emitter Processor can still accept
+	 * a few data pushes up to {@link Queues#SMALL_BUFFER_SIZE}.
+	 * After that point, if no {@link Subscriber} has come in and consumed the data,
+	 * calls to {@link FluxProcessorSink#next(Object) onNext} block until the processor
+	 * is drained (which can only happen concurrently by then).
+	 *
+	 * <p>
+	 * Thus, the first {@link Subscriber} to subscribe receives up to {@code bufferSize}
+	 * elements upon subscribing. However, after that, the processor stops replaying signals
+	 * to additional subscribers. These subsequent subscribers instead only receive the
+	 * signals pushed through the processor after they have subscribed. The internal buffer
+	 * is still used for backpressure purposes.
+	 *
+	 * <p>
+	 * The returned emitter Processor is {@code auto-cancelling}, which means that when
+	 * all the Processor's subscribers are cancelled (ie. they have all un-subscribed),
+	 * it will clear its internal buffer and stop accepting new subscribers. This can be
+	 * tuned by creating a processor through the builder method, {@link #emitter(int)}.
+	 *
+	 * @return a new auto-cancelling emitter {@link ProcessorSink}
+	 */
+	public static final <T> FluxProcessorSink<T> emitter() {
+		return new EmitterProcessorBuilder(-1).build();
+	}
+
+	/**
+	 * Create a builder for an "emitter" {@link ProcessorSink}, which is capable
+	 * of emitting to several {@link Subscriber Subscribers} while honoring backpressure
+	 * for each of its subscribers. It can also subscribe to a {@link Publisher} and relay
+	 * its signals synchronously.
+	 *
+	 * <p>
+	 * Initially, when it has no {@link Subscriber}, an emitter Processor can still accept
+	 * a few data pushes up to a configurable {@code bufferSize}.
+	 * After that point, if no {@link Subscriber} has come in and consumed the data,
+	 * calls to {@link FluxProcessorSink#next(Object)} block until the processor
+	 * is drained (which can only happen concurrently by then).
+	 *
+	 * <p>
+	 * Thus, the first {@link Subscriber} to subscribe receives up to {@code bufferSize}
+	 * elements upon subscribing. However, after that, the processor stops replaying signals
+	 * to additional subscribers. These subsequent subscribers instead only receive the
+	 * signals pushed through the processor after they have subscribed. The internal buffer
+	 * is still used for backpressure purposes.
+	 *
+	 * <p>
+	 * By default, if all of the emitter Processor's subscribers are cancelled (which
+	 * basically means they have all un-subscribed), it will clear its internal buffer and
+	 * stop accepting new subscribers. This can be deactivated by using the
+	 * {@link EmitterProcessorBuilder#noAutoCancel()} method in the builder.
+	 *
+	 * @param bufferSize the size of the initial replay buffer (must be positive)
+	 * @return a builder to create a new emitter {@link ProcessorSink}
+	 */
+	public static final EmitterProcessorBuilder emitter(int bufferSize) {
+		if (bufferSize < 0) {
+			throw new IllegalArgumentException("bufferSize must be positive");
+		}
+		return new EmitterProcessorBuilder(bufferSize);
+	}
+
+	/**
+	 * Create a new unbounded "replay" {@link ProcessorSink}, which caches
+	 * elements that are either pushed directly through it or elements from an upstream
+	 * {@link Publisher}, and replays them to late {@link Subscriber Subscribers}.
+	 *
+	 * <p>
+	 * Replay Processors can be created in multiple configurations (this method creates
+	 * an unbounded variant):
+	 * <ul>
+	 *     <li>
+	 *         Caching an unbounded history (call to this method, or the {@link #replay(int) size variant}
+	 *         of the replay builder with a call to its {@link ReplayProcessorBuilder#unbounded()}
+	 *         method).
+	 *     </li>
+	 *     <li>
+	 *         Caching a bounded history ({@link #replay(int)}).
+	 *     </li>
+	 *     <li>
+	 *         Caching time-based replay windows (by only specifying a TTL in the time-oriented
+	 *         builder {@link #replay(Duration)}).
+	 *     </li>
+	 *     <li>
+	 *         Caching combination of history size and time window (by using the time-oriented
+	 *         builder {@link #replay(Duration)} and configuring a size on it via its
+	 *         {@link ReplayTimeProcessorBuilder#historySize(int)} method).
+	 *     </li>
+	 * </ul>
+	 *
+	 * @return a builder to create a new replay {@link ProcessorSink}
+	 */
+	@SuppressWarnings("deprecation")
+	public static final <T> FluxProcessorSink<T> replay() {
+		return new FluxProcessorSinkAdapter<>(ReplayProcessor.create(), null);
+	}
+
+	/**
+	 * Create a builder for a "replay" {@link ProcessorSink}, which caches
+	 * elements that are either pushed directly through it or elements from an upstream
+	 * {@link Publisher}, and replays them to late {@link Subscriber Subscribers}.
+	 *
+	 * <p>
+	 * Replay Processors can be created in multiple configurations (this builder allows to
+	 * create all time-oriented variants):
+	 * <ul>
+	 *     <li>
+	 *         Caching an unbounded history (call to {@link #replay()}, or the
+	 *         {@link #replay(int) size variant} of the replay builder with a call to its
+	 *         {@link ReplayProcessorBuilder#unbounded()} method).
+	 *     </li>
+	 *     <li>
+	 *         Caching a bounded history ({@link #replay(int)}).
+	 *     </li>
+	 *     <li>
+	 *         Caching time-based replay windows (by only specifying a TTL in this builder).
+	 *     </li>
+	 *     <li>
+	 *         Caching combination of history size and time window (by using this builder
+	 *         to configure a size via the {@link ReplayTimeProcessorBuilder#historySize(int)}
+	 *         method).
+	 *     </li>
+	 * </ul>
+	 *
+	 * @return a builder to create a new replay {@link ProcessorSink}
+	 */
+	public static final ReplayTimeProcessorBuilder replay(Duration maxAge) {
+		return new ReplayTimeProcessorBuilder(maxAge);
+	}
+
+	/**
+	 * Create a builder for a "replay" {@link ProcessorSink}, which caches
+	 * elements that are either pushed directly through it or elements from an upstream
+	 * {@link Publisher}, and replays them to late {@link Subscriber Subscribers}.
+	 *
+	 * <p>
+	 * Replay Processors can be created in multiple configurations (this builder exclusively
+	 * creates purely size-oriented variants):
+	 * <ul>
+	 *     <li>
+	 *         Caching an unbounded history (call to {@link #replay()} or this builder
+	 *         with a call to its {@link ReplayProcessorBuilder#unbounded()} method).
+	 *     </li>
+	 *     <li>
+	 *         Caching a bounded history (this builder).
+	 *     </li>
+	 *     <li>
+	 *         Caching time-based replay windows (by only specifying a TTL in the time-oriented
+	 *         builder {@link #replay(Duration)}).
+	 *     </li>
+	 *     <li>
+	 *         Caching combination of history size and time window (by using the time-oriented
+	 *         builder {@link #replay(Duration)} and configuring a size on it via its
+	 *         {@link ReplayTimeProcessorBuilder#historySize(int)} method).
+	 *     </li>
+	 * </ul>
+	 *
+	 * @return a builder to create a new replay {@link ProcessorSink}
+	 */
+	public static final ReplayProcessorBuilder replay(int historySize) {
+		return new ReplayProcessorBuilder(historySize);
+	}
+
+	/**
+	 * Create a new "replay" {@link ProcessorSink} (see {@link #replay()}) that
+	 * caches the last element it has pushed, replaying it to late {@link Subscriber subscribers}.
+	 *
+	 * @param <T>
+	 * @return a new replay {@link ProcessorSink} that caches its last pushed element
+	 */
+	@SuppressWarnings("deprecation")
+	public static final <T> FluxProcessorSink<T> cacheLast() {
+		return new FluxProcessorSinkAdapter<>(ReplayProcessor.cacheLast(), null);
+	}
+
+	/**
+	 * Create a new "replay" {@link ProcessorSink} (see {@link #replay()}) that
+	 * caches the last element it has pushed, replaying it to late {@link Subscriber subscribers}.
+	 * If a {@link Subscriber} comes in <strong>before</strong> any value has been pushed,
+	 * then the {@code defaultValue} is emitted instead.
+	 *
+	 * @param <T>
+	 * @return a new replay {@link ProcessorSink} that caches its last pushed element
+	 */
+	@SuppressWarnings("deprecation")
+	public static final <T> FluxProcessorSink<T> cacheLastOrDefault(T defaultValue) {
+		return new FluxProcessorSinkAdapter<>(ReplayProcessor.cacheLastOrDefault(defaultValue), null);
+	}
+
+	/**
+	 * Create a builder for a "fan out" {@link ProcessorSink}, which is an
+	 * <strong>asynchronous</strong> processor optionally capable of relaying elements from multiple
+	 * upstream {@link Publisher Publishers} when created in the shared configuration (see the {@link
+	 * FanOutProcessorBuilder#share(boolean)} option of the builder).
+	 *
+	 * <p>
+	 * Note that the share option is mandatory if you intend to concurrently call the
+	 * {@link FluxProcessorSink#next(Object)}, {@link FluxProcessorSink#complete()} or
+	 * {@link FluxProcessorSink#error(Throwable)} methods directly or from a concurrent upstream
+	 * {@link Publisher}.
+	 *
+	 * <p>
+	 * Otherwise, such concurrent calls are illegal, as the processor is then fully compliant with
+	 * the Reactive Streams specification.
+	 *
+	 * <p>
+	 * A fan out processor is capable of fanning out to multiple {@link Subscriber Subscribers},
+	 * with the added overhead of establishing resources to keep track of each {@link Subscriber}
+	 * until an {@link ProcessorSink#error(Throwable)} or {@link FluxProcessorSink#complete()}
+	 * signal is pushed through the processor or until the associated {@link Subscriber} is cancelled.
+	 *
+	 * <p>
+	 * This variant uses a {@link Thread}-per-{@link Subscriber} model.
+	 *
+	 * <p>
+	 * The maximum number of downstream subscribers for this processor is driven by the {@link
+	 * FanOutProcessorBuilder#executor(ExecutorService) executor} builder option. Provide a bounded
+	 * {@link ExecutorService} to limit it to a specific number.
+	 *
+	 * <p>
+	 * There is also an {@link FanOutProcessorBuilder#autoCancel(boolean) autoCancel} builder
+	 * option: Set it to {@code false} to avoid cancelling the source {@link Publisher Publisher(s)}
+	 * when all subscribers are cancelled.
+	 *
+	 * @return a builder to create a new fan out {@link ProcessorSink}
+	 */
+	public static final FanOutProcessorBuilder fanOut() {
+		return new FanOutProcessorBuilder();
+	}
+
+	/**
+	 * Create a builder for a "fan out" {@link ProcessorSink} with relaxed
+	 * Reactive Streams compliance. This is an <strong>asynchronous</strong> processor
+	 * optionally capable of relaying elements from multiple upstream {@link Publisher Publishers}
+	 * when created in the shared configuration (see the {@link FanOutProcessorBuilder#share(boolean)}
+	 * option of the builder).
+	 *
+	 * <p>
+	 * Note that the share option is mandatory if you intend to concurrently call the Processor's
+	 * {@link FluxProcessorSink#next(Object)}, {@link FluxProcessorSink#complete()} ()}, or
+	 * {@link FluxProcessorSink#error(Throwable)} methods directly or from a concurrent upstream
+	 * {@link Publisher}. Otherwise, such concurrent calls are illegal.
+	 *
+	 * <p>
+	 * A fan out processor is capable of fanning out to multiple {@link Subscriber Subscribers},
+	 * with the added overhead of establishing resources to keep track of each {@link Subscriber}
+	 * until an {@link FluxProcessorSink#error(Throwable)} or {@link
+	 * FluxProcessorSink#complete()} signal is pushed through the processor or until the
+	 * associated {@link Subscriber} is cancelled.
+	 *
+	 * <p>
+	 * This variant uses a RingBuffer and doesn't have the overhead of keeping track of
+	 * each {@link Subscriber} in its own Thread, so it scales better. As a trade-off,
+	 * its compliance with the Reactive Streams specification is slightly
+	 * relaxed, and its distribution pattern is to add up requests from all {@link Subscriber Subscribers}
+	 * together and to relay signals to only one {@link Subscriber}, picked in a kind of
+	 * round-robin fashion.
+	 *
+	 * <p>
+	 * The maximum number of downstream subscribers for this processor is driven by the {@link
+	 * FanOutProcessorBuilder#executor(ExecutorService) executor} builder option. Provide a bounded
+	 * {@link ExecutorService} to limit it to a specific number.
+	 *
+	 * <p>
+	 * There is also an {@link FanOutProcessorBuilder#autoCancel(boolean) autoCancel} builder
+	 * option: If set to {@code true} (the default), it results in the source {@link Publisher
+	 * Publisher(s)} being cancelled when all subscribers are cancelled.
+	 *
+	 * @return a builder to create a new round-robin fan out {@link ProcessorSink}
+	 */
+	@Deprecated
+	public static final FanOutProcessorBuilder relaxedFanOut() {
+		return new FanOutProcessorBuilder(true);
+	}
+
+	/**
+	 * Create a "first" {@link ProcessorSink}, which will wait for a source
+	 * {@link Subscriber#onSubscribe(Subscription)}. It will then propagate only the first
+	 * incoming {@link Subscriber#onNext(Object) onNext} signal, and cancel the source
+	 * subscription (unless it is a {@link Mono}). The processor will replay that signal
+	 * to new {@link Subscriber Subscribers}.
+	 *
+	 * <p>
+	 * Manual usage by pushing events through the {@link MonoSink} is naturally limited to at most
+	 * one call to {@link MonoSink#success(Object)}.
+	 *
+	 * @param <T> the type of the processor
+	 * @return a new "first" {@link ProcessorSink} that is detached
+	 */
+	@SuppressWarnings("deprecation")
+	public static final <T> ProcessorSink<T> first() {
+		return new MonoFirstProcessorSinkAdapter<>(new MonoProcessor<>(null));
+	}
+
+	/**
+	 * Create a "first" {@link ProcessorSink}, which will wait for a source
+	 * {@link Subscriber#onSubscribe(Subscription)}. It will then propagate only the first
+	 * incoming {@link Subscriber#onNext(Object) onNext} signal, and cancel the source
+	 * subscription (unless it is a {@link Mono}). The processor will replay that signal
+	 * to new {@link Subscriber Subscribers}.
+	 *
+	 * <p>
+	 * Manual usage by pushing events through the {@link MonoSink} is naturally limited to at most
+	 * one call to {@link MonoSink#success(Object)}.
+	 *
+	 * @param waitStrategy the {@link WaitStrategy} to use in blocking methods of the processor
+	 * @param <T> the type of the processor
+	 * @return a new "first" {@link ProcessorSink} that is detached
+	 */
+	@SuppressWarnings("deprecation")
+	public static final <T> ProcessorSink<T> first(WaitStrategy waitStrategy) {
+		return new MonoFirstProcessorSinkAdapter<>(new MonoProcessor<>(null, waitStrategy));
+	}
+
+	/**
+	 * Create a builder for a "first" {@link ProcessorSink} that is attached to a
+	 * {@link Publisher} source, of which it will propagate only the first incoming
+	 * {@link Subscriber#onNext(Object) onNext} signal. Once this is done, the processor
+	 * cancels the source subscription (unless it is a {@link Mono}). It will then
+	 * replay that signal to new {@link Subscriber Subscribers}.
+	 *
+	 * <p>
+	 * Manual usage by pushing events through the {@link MonoSink} is naturally limited to at most
+	 * one call to {@link MonoSink#success(Object)}.
+	 *
+	 * @param source the source to attach to
+	 * @param <T> the type of the source, which drives the type of the processor
+	 * @return a builder to create a new "first" {@link ProcessorSink} attached to a source
+	 */
+	public static final <T> MonoFirstProcessorBuilder<T> first(Publisher<? extends T> source) {
+		return new MonoFirstProcessorBuilder<>(source);
+	}
+
+	//=== BUILDERS to replace factory method only processors ===
+
+	/**
+	 * A builder for the {@link #unicast()} flavor of {@link ProcessorSink}.
+	 *
+	 * @param <T>
+	 */
+	public static final class UnicastProcessorBuilder<T> {
+
+		private final Queue<T> queue;
+		private Disposable endcallback;
+		private OverflowStrategy overflowStrategy;
+		private Consumer<? super T> onOverflow;
+
+		/**
+		 * A unicast Processor created through {@link Processors#unicast()} is unbounded.
+		 * This can be changed by using this builder, which also allows further configuration.
+		 * <p>
+		 * Provide a custom {@link Queue} implementation for the internal buffering.
+		 * If that queue is bounded, the processor could reject the push of a value when the
+		 * buffer is full and not enough requests from downstream have been received.
+		 * <p>
+		 * In that bounded case, one can also set a callback to be invoked on each rejected
+		 * element, allowing for cleanup of these rejected elements (see {@link #onOverflow(Consumer)}).
+		 *
+		 * @param q the {@link Queue} to be used for internal buffering
+		 */
+		UnicastProcessorBuilder(Queue<T> q) {
+			this.queue = q;
+		}
+
+		/**
+		 * Set a callback that will be executed by the Processor on any terminating signal.
+		 *
+		 * @param e the callback
+		 * @return the builder
+		 */
+		public UnicastProcessorBuilder<T> endCallback(Disposable e) {
+			this.endcallback = e;
+			return this;
+		}
+
+		/**
+		 * Set an {@link OverflowStrategy} to use when creating the {@link FluxSink}
+		 * backing this {@link FluxProcessorSink}.
+		 *
+		 * @param overflowStrategy the strategy to use on sink methods
+		 * @return the builder
+		 */
+		public UnicastProcessorBuilder<T> withOverflowStrategy(OverflowStrategy overflowStrategy) {
+			this.overflowStrategy = overflowStrategy;
+			return this;
+		}
+
+		/**
+		 * When a bounded {@link #UnicastProcessorBuilder(Queue) queue} has been provided,
+		 * set up a callback to be executed on every element rejected by the {@link Queue}
+		 * once it is already full.
+		 *
+		 * @param c the cleanup consumer for overflowing elements in a bounded queue
+		 * @return the builder
+		 */
+		public UnicastProcessorBuilder<T> onOverflow(Consumer<? super T> c) {
+			this.onOverflow = c;
+			return this;
+		}
+
+		/**
+		 * Build the unicast {@link FluxProcessorSink} according to the builder's
+		 * configuration.
+		 *
+		 * @return a new unicast {@link FluxProcessorSink Processor}
+		 */
+		@SuppressWarnings("deprecation")
+		public FluxProcessorSink<T> build() {
+			UnicastProcessor<T> processor;
+			if (endcallback != null && onOverflow != null) {
+				processor = new UnicastProcessor<>(queue, onOverflow, endcallback);
+			}
+			else if (endcallback != null) {
+				processor = new UnicastProcessor<>(queue, endcallback);
+			}
+			else if (onOverflow == null) {
+				processor = new UnicastProcessor<>(queue);
+			}
+			else {
+				processor = new UnicastProcessor<>(queue, onOverflow);
+			}
+
+			return new FluxProcessorSinkAdapter<>(processor, overflowStrategy);
+		}
+	}
+
+	/**
+	 * A builder for the {@link #emitter()} flavor of {@link ProcessorSink}.
+	 */
+	public static final class EmitterProcessorBuilder {
+
+		private final int bufferSize;
+		private boolean autoCancel = true;
+		private OverflowStrategy overflowStrategy;
+
+		/**
+		 * Initialize the builder with the replay capacity of the emitter Processor,
+		 * which defines how many elements it will retain while it has no current
+		 * {@link Subscriber}. Once that size is reached, if there still is no
+		 * {@link Subscriber} the emitter processor will block its calls to
+		 * {@link Processor#onNext(Object)} until it is drained (which can only happen
+		 * concurrently by then).
+		 * <p>
+		 * The first {@link Subscriber} to subscribe receives all of these elements, and
+		 * further subscribers only see new incoming data after that.
+		 *
+		 * @param bufferSize the size of the initial no-subscriber bounded buffer
+		 */
+		EmitterProcessorBuilder(int bufferSize) {
+			this.bufferSize = bufferSize;
+		}
+
+		/**
+		 * By default, if all of its {@link Subscriber Subscribers} are cancelled (which
+		 * basically means they have all un-subscribed), the emitter Processor will clear
+		 * its internal buffer and stop accepting new subscribers. This method changes
+		 * that so that the emitter processor keeps on running.
+		 *
+		 * @return the builder
+		 */
+		public EmitterProcessorBuilder noAutoCancel() {
+			this.autoCancel = false;
+			return this;
+		}
+
+		/**
+		 * Set an {@link OverflowStrategy} to use when creating the {@link FluxSink}
+		 * backing this {@link FluxProcessorSink}.
+		 *
+		 * @param overflowStrategy the strategy to use on sink methods
+		 * @return the builder
+		 */
+		public EmitterProcessorBuilder withOverflowStrategy(OverflowStrategy overflowStrategy) {
+			this.overflowStrategy = overflowStrategy;
+			return this;
+		}
+
+		/**
+		 * Build the emitter {@link ProcessorSink} according to the builder's
+		 * configuration.
+		 *
+		 * @return a new emitter {@link ProcessorSink}
+		 */
+		@SuppressWarnings("deprecation")
+		public <T> FluxProcessorSink<T> build() {
+			EmitterProcessor<T> processor;
+			if (bufferSize >= 0 && !autoCancel) {
+				processor = new EmitterProcessor<>(false, bufferSize);
+			}
+			else if (bufferSize >= 0) {
+				processor = new EmitterProcessor<>(true, bufferSize);
+			}
+			else if (!autoCancel) {
+				processor = new EmitterProcessor<>(false, Queues.SMALL_BUFFER_SIZE);
+			}
+			else {
+				processor = new EmitterProcessor<>(true, Queues.SMALL_BUFFER_SIZE);
+			}
+
+			return new FluxProcessorSinkAdapter<>(processor, overflowStrategy);
+		}
+	}
+
+	/**
+	 * A builder for the size-configured {@link #replay()} flavor of {@link ProcessorSink}.
+	 */
+	public static final class ReplayProcessorBuilder {
+
+		private final int       size;
+		private boolean         unbounded;
+		private OverflowStrategy overflowStrategy;
+
+		/**
+		 * Set the history capacity to a specific bounded size.
+		 *
+		 * @param size the history buffer capacity
+		 * @return the builder, with a bounded capacity
+		 */
+		public ReplayProcessorBuilder(int size) {
+			this.size = size;
+			this.unbounded = false;
+		}
+
+		/**
+		 * Despite the history capacity being set to a specific initial size, mark the
+		 * processor as unbounded: the size will be considered as a hint instead of an
+		 * hard limit.
+		 *
+		 * @return the builder, with an unbounded capacity
+		 */
+		public ReplayProcessorBuilder unbounded() {
+			this.unbounded = true;
+			return this;
+		}
+
+		/**
+		 * Set an {@link OverflowStrategy} to use when creating the {@link FluxSink}
+		 * backing this {@link FluxProcessorSink}.
+		 *
+		 * @param overflowStrategy the strategy to use on sink methods
+		 * @return the builder
+		 */
+		public ReplayProcessorBuilder withOverflowStrategy(OverflowStrategy overflowStrategy) {
+			this.overflowStrategy = overflowStrategy;
+			return this;
+		}
+
+		/**
+		 * Build the replay {@link ProcessorSink} according to the builder's configuration.
+		 *
+		 * @return a new replay {@link ProcessorSink}
+		 */
+		@SuppressWarnings("deprecation")
+		public <T> FluxProcessorSink<T> build() {
+			ReplayProcessor<T> processor;
+			if (size < 0) {
+				processor = ReplayProcessor.create();
+			}
+			else if (unbounded) {
+				processor = ReplayProcessor.create(size, true);
+			}
+			else {
+				processor = ReplayProcessor.create(size);
+			}
+
+			return new FluxProcessorSinkAdapter<>(processor, overflowStrategy);
+		}
+	}
+
+	/**
+	 * A builder for the time-oriented {@link #replay()} flavors of {@link ProcessorSink}.
+	 * This can also be used to build a time + size oriented replay processor.
+	 */
+	public static final class ReplayTimeProcessorBuilder {
+
+		private final Duration  maxAge;
+		private int       size = -1;
+		private Scheduler scheduler = null;
+		private OverflowStrategy overflowStrategy;
+
+		public ReplayTimeProcessorBuilder(Duration maxAge) {
+			this.maxAge = maxAge;
+		}
+
+		/**
+		 * Set the history capacity to a specific bounded size.
+		 *
+		 * @param size the history buffer capacity
+		 * @return the builder, with a bounded capacity
+		 */
+		public ReplayTimeProcessorBuilder historySize(int size) {
+			this.size = size;
+			return this;
+		}
+
+		/**
+		 * Set the {@link Scheduler} to use for measuring time.
+		 *
+		 * @param ttlScheduler the {@link Scheduler} to be used to enforce the TTL
+		 * @return the builder
+		 */
+		public ReplayTimeProcessorBuilder scheduler(Scheduler ttlScheduler) {
+			this.scheduler = ttlScheduler;
+			return this;
+		}
+
+		/**
+		 * Set an {@link OverflowStrategy} to use when creating the {@link FluxSink}
+		 * backing this {@link FluxProcessorSink}.
+		 *
+		 * @param overflowStrategy the strategy to use on sink methods
+		 * @return the builder
+		 */
+		public ReplayTimeProcessorBuilder withOverflowStrategy(OverflowStrategy overflowStrategy) {
+			this.overflowStrategy = overflowStrategy;
+			return this;
+		}
+
+		/**
+		 * Build the replay {@link ProcessorSink} according to the builder's configuration.
+		 *
+		 * @return a new replay {@link ProcessorSink}
+		 */
+		@SuppressWarnings("deprecation")
+		public <T> ProcessorSink<T> build() {
+			//replay size and timeout
+			ReplayProcessor<T> processor;
+			if (size != -1) {
+				if (scheduler != null) {
+					processor = ReplayProcessor.createSizeAndTimeout(size, maxAge, scheduler);
+				}
+				else {
+					processor = ReplayProcessor.createSizeAndTimeout(size, maxAge);
+				}
+			}
+			else if (scheduler != null) {
+				processor = ReplayProcessor.createTimeout(maxAge, scheduler);
+			}
+			else {
+				processor = ReplayProcessor.createTimeout(maxAge);
+			}
+
+			return new FluxProcessorSinkAdapter<>(processor, overflowStrategy);
+		}
+	}
+
+	/**
+	 * A builder for the {@link #fanOut()} flavor of {@link ProcessorSink}.
+	 */
+	public static final class FanOutProcessorBuilder {
+
+		boolean useWorkQueueProcessor;
+
+		@Nullable
+		String name;
+		@Nullable
+		ExecutorService executor;
+		@Nullable
+		ExecutorService requestTaskExecutor;
+		int bufferSize;
+		@Nullable
+		WaitStrategy waitStrategy;
+		boolean share;
+		boolean autoCancel;
+		@Nullable
+		OverflowStrategy overflowStrategy;
+
+		FanOutProcessorBuilder() {
+			this(false);
+		}
+
+		FanOutProcessorBuilder(boolean useWorkQueueProcessor) {
+			this.bufferSize = Queues.SMALL_BUFFER_SIZE;
+			this.autoCancel = true;
+			this.share = false;
+			this.useWorkQueueProcessor = useWorkQueueProcessor;
+		}
+
+		/**
+		 * Configures name for this builder, if {@link #executor(ExecutorService)} is not configured.
+		 * Default value is {@code "fanOut"}.
+		 * Name is reset to default if the provided {@code name} is null.
+		 *
+		 * @param name Use a new cached ExecutorService and assign this name to the created threads.
+		 * @return builder with provided name
+		 */
+		public FanOutProcessorBuilder name(@Nullable String name) {
+			if (executor != null)
+				throw new IllegalArgumentException("Executor service is configured, name cannot be set.");
+			this.name = name;
+			return this;
+		}
+
+		/**
+		 * Configures buffer size for this builder. Default value is {@link Queues#SMALL_BUFFER_SIZE}.
+		 *
+		 * @param bufferSize the internal buffer size to hold signals, must be a power of 2.
+		 * @return builder with provided buffer size
+		 */
+		public FanOutProcessorBuilder bufferSize(int bufferSize) {
+			if (!Queues.isPowerOfTwo(bufferSize)) {
+				throw new IllegalArgumentException("bufferSize must be a power of 2 : " + bufferSize);
+			}
+
+			if (bufferSize < 1){
+				throw new IllegalArgumentException("bufferSize must be strictly positive, was: " + bufferSize);
+			}
+			this.bufferSize = bufferSize;
+			return this;
+		}
+
+		/**
+		 * Configures wait strategy for this builder. Default value is {@link WaitStrategy#phasedOffLiteLock(long, long, TimeUnit)}.
+		 * Wait strategy is reset to default if the provided {@code waitStrategy} is null.
+		 *
+		 * @param waitStrategy A RingBuffer {@link WaitStrategy} to use instead of the default blocking wait strategy.
+		 * @return builder with provided wait strategy
+		 */
+		public FanOutProcessorBuilder waitStrategy(@Nullable WaitStrategy waitStrategy) {
+			this.waitStrategy = waitStrategy;
+			return this;
+		}
+
+		/**
+		 * Configures auto-cancel for this builder. Default value is {@code true}.
+		 *
+		 * @param autoCancel true to automatically cancel when all subscribers have cancelled.
+		 * @return builder with provided auto-cancel
+		 */
+		public FanOutProcessorBuilder autoCancel(boolean autoCancel) {
+			this.autoCancel = autoCancel;
+			return this;
+		}
+
+		/**
+		 * Configures an {@link ExecutorService} that will be used to back the thread-per-subscriber
+		 * model of this fan out processor. The threads are named according to the executor's
+		 * naming policy, which overrides name configuration made through {@link #name(String)}.
+		 *
+		 * @param executor A provided ExecutorService to manage threading infrastructure
+		 * @return builder with provided executor
+		 */
+		public FanOutProcessorBuilder executor(@Nullable ExecutorService executor) {
+			this.executor = executor;
+			return this;
+		}
+
+
+		/**
+		 * Configures an additional {@link ExecutorService} that is used internally
+		 * on each subscription to perform the request.
+		 *
+		 * @param requestTaskExecutor internal request executor
+		 * @return builder with provided internal request executor
+		 */
+		public FanOutProcessorBuilder requestTaskExecutor(@Nullable ExecutorService requestTaskExecutor) {
+			this.requestTaskExecutor = requestTaskExecutor;
+			return this;
+		}
+
+		/**
+		 * Configures sharing state for this builder. A shared fanout processor authorizes
+		 * is suited for multi-threaded publisher that will fan-in data.
+		 *
+		 * @param share true to support concurrent sources on the {@link ProcessorSink#asProcessor Processor}
+		 * @return builder with specified sharing
+		 */
+		public FanOutProcessorBuilder share(boolean share) {
+			this.share = share;
+			return this;
+		}
+
+		/**
+		 * Set an {@link OverflowStrategy} to use when creating the {@link FluxSink}
+		 * backing this {@link FluxProcessorSink}.
+		 *
+		 * @param overflowStrategy the strategy to use on sink methods
+		 * @return the builder
+		 */
+		public FanOutProcessorBuilder withOverflowStrategy(OverflowStrategy overflowStrategy) {
+			this.overflowStrategy = overflowStrategy;
+			return this;
+		}
+
+		/**
+		 * Creates a new fanout {@link ProcessorSink} according to the builder's
+		 * configuration.
+		 *
+		 * @return a new fanout {@link ProcessorSink}
+		 */
+		@SuppressWarnings("deprecation")
+		public <T> FluxProcessorSink<T>  build() {
+			this.name = this.name != null ? this.name : "fanOut";
+			this.waitStrategy = this.waitStrategy != null ? this.waitStrategy : WaitStrategy.phasedOffLiteLock(200, 100, TimeUnit.MILLISECONDS);
+			EventLoopProcessor.EventLoopFactory threadFactory = this.executor != null
+					? null
+					: new EventLoopProcessor.EventLoopFactory(name, autoCancel);
+
+			String requestTaskExecutorName = threadFactory != null
+					? threadFactory.get()
+					: "fanOutRequest";
+
+			ExecutorService requestTaskExecutor = this.requestTaskExecutor != null
+					? this.requestTaskExecutor
+					: EventLoopProcessor.defaultRequestTaskExecutor(requestTaskExecutorName);
+
+			EventLoopProcessor<T> processor;
+			if (useWorkQueueProcessor) {
+				processor = new WorkQueueProcessor<>(
+						threadFactory,
+						executor,
+						requestTaskExecutor,
+						bufferSize,
+						waitStrategy,
+						share,
+						autoCancel);
+			}
+			else {
+				processor = new TopicProcessor<>(
+						threadFactory,
+						executor,
+						requestTaskExecutor,
+						bufferSize,
+						waitStrategy,
+						share,
+						autoCancel,
+						null);
+			}
+
+			return new AsyncFluxProcessorSinkAdapter<>(processor, overflowStrategy);
+		}
+	}
+
+	/**
+	 * A builder for the {@link #first()} flavor of {@link ProcessorSink},
+	 * directly attached to a {@link Publisher} source.
+	 *
+	 * @param <T>
+	 */
+	public static final class MonoFirstProcessorBuilder<T> {
+
+		private final Publisher<? extends T> source;
+
+		public MonoFirstProcessorBuilder(Publisher<? extends T> source) {
+			this.source = source;
+		}
+
+		/**
+		 * Create the processor with a {@link WaitStrategy} and attach it to the source.
+		 *
+		 * @param waitStrategy the {@link WaitStrategy} to use for blocking methods of the processor
+		 * @return a new "first" {@link ProcessorSink} with a wait strategy, that
+		 * is attached to a source
+		 */
+		public ProcessorSink<T> withWaitStrategy(WaitStrategy waitStrategy) {
+			@SuppressWarnings("deprecation")
+			MonoProcessor<T> processor = new MonoProcessor<>(this.source, waitStrategy);
+			return new MonoFirstProcessorSinkAdapter<>(processor);
+		}
+
+		/**
+		 * Create the {@link ProcessorSink} by immediately attaching it to the
+		 * {@link Publisher} source.
+		 *
+		 * @return a new first {@link ProcessorSink} that is attached to a source
+		 */
+		public MonoProcessorSink<T> build() {
+			@SuppressWarnings("deprecation")
+			MonoProcessor<T> processor = new MonoProcessor<>(source);
+			return new MonoFirstProcessorSinkAdapter<>(processor);
+		}
+	}
+
+	//=== Adapter Classes from FluxProcessor to FluxProcessorSink ===
+
+	static class FluxProcessorSinkAdapter<T> implements FluxProcessorSink<T> {
+
+		@SuppressWarnings("deprecation")
+		final FluxProcessor<T, T> processor;
+		final FluxSink<T> sink;
+		final OverflowStrategy overflowStrategy;
+
+		@SuppressWarnings("deprecation")
+		public FluxProcessorSinkAdapter(FluxProcessor<T,T> processor,
+				@Nullable OverflowStrategy overflowStrategy) {
+			this.processor = processor;
+			this.overflowStrategy = overflowStrategy == null ? OverflowStrategy.IGNORE : overflowStrategy;
+			this.sink = processor.sink(this.overflowStrategy);
+		}
+
+		@Override
+		public Processor<T, T> asProcessor() {
+			return processor;
+		}
+
+		@Override
+		public CoreSubscriber<T> asCoreSubscriber() {
+			return processor;
+		}
+
+		@Override
+		public Scannable asScannable() {
+			return processor;
+		}
+
+		@Override
+		public Flux<T> asFlux() {
+			return processor;
+		}
+
+		@Override
+		public OverflowStrategy getOverflowStrategy() {
+			return this.overflowStrategy;
+		}
+
+		// == delegates to FluxSink ==
+
+		@Override
+		public void complete() {
+			sink.complete();
+		}
+
+		@Override
+		public Context currentContext() {
+			return sink.currentContext();
+		}
+
+		@Override
+		public void error(Throwable e) {
+			sink.error(e);
+		}
+
+		@Override
+		public FluxSink<T> next(T t) {
+			return sink.next(t);
+		}
+
+		@Override
+		public long requestedFromDownstream() {
+			return sink.requestedFromDownstream();
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return sink.isCancelled();
+		}
+
+		@Override
+		public FluxSink<T> onRequest(LongConsumer consumer) {
+			return sink.onRequest(consumer);
+		}
+
+		@Override
+		public FluxSink<T> onCancel(Disposable d) {
+			return sink.onCancel(d);
+		}
+
+		@Override
+		public FluxSink<T> onDispose(Disposable d) {
+			return sink.onDispose(d);
+		}
+
+		//== delegates to FluxProcessor / processor
+
+		@Override
+		public void dispose() {
+			processor.dispose();
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return processor.isDisposed();
+		}
+
+		@Override
+		public long getAvailableCapacity() {
+			return processor.getAvailableCapacity();
+		}
+
+		@Override
+		public long downstreamCount() {
+			return processor.downstreamCount();
+		}
+
+		@Override
+		@Nullable
+		public Throwable getError() {
+			return processor.getError();
+		}
+
+		@Override
+		public boolean hasDownstreams() {
+			return processor.hasDownstreams();
+		}
+
+		@Override
+		public boolean isTerminated() {
+			return processor.isTerminated();
+		}
+
+		@Override
+		public boolean isSerialized() {
+			return processor.isSerialized();
+		}
+
+	}
+
+	static final class AsyncFluxProcessorSinkAdapter<T> extends FluxProcessorSinkAdapter<T> {
+
+		@SuppressWarnings("deprecation")
+		public AsyncFluxProcessorSinkAdapter(EventLoopProcessor<T> processor,
+				@Nullable OverflowStrategy overflowStrategy) {
+			super(processor, overflowStrategy);
+		}
+
+		@Override
+		@SuppressWarnings("deprecation")
+		public Flux<T> forceDispose() {
+			return ((EventLoopProcessor<T>) processor).forceShutdown();
+		}
+
+		@Override
+		@SuppressWarnings("deprecation")
+		public boolean disposeAndAwait(Duration timeout) {
+			return ((EventLoopProcessor<T>) processor).awaitAndShutdown(timeout);
+		}
+	}
+
+	static class MonoFirstProcessorSinkAdapter<T> implements MonoProcessorSink<T> {
+
+		@SuppressWarnings("deprecation")
+		final MonoProcessor<T> processor;
+		final MonoSink<T> sink;
+
+		@SuppressWarnings("deprecation")
+		public MonoFirstProcessorSinkAdapter(MonoProcessor<T> processor) {
+			this.processor = processor;
+			this.sink = new MonoCreate.DefaultMonoSink<>(processor);
+		}
+
+		@Override
+		public Mono<T> asMono() {
+			return processor;
+		}
+
+		@Override
+		public Processor<T, T> asProcessor() {
+			return processor;
+		}
+
+		@Override
+		public CoreSubscriber<T> asCoreSubscriber() {
+			return processor;
+		}
+
+		@Override
+		public Scannable asScannable() {
+			return processor;
+		}
+
+		@Override
+		public long getAvailableCapacity() {
+			if (isTerminated()) {
+				return 0L;
+			}
+			return 1L;
+		}
+
+		@Override
+		public boolean isSerialized() {
+			return false;
+		}
+
+		//== delegates to sink ==
+
+		@Override
+		public Context currentContext() {
+			return sink.currentContext();
+		}
+
+		@Override
+		public void success() {
+			sink.success();
+		}
+
+		@Override
+		public void success(T value) {
+			sink.success(value);
+		}
+
+		@Override
+		public void error(Throwable e) {
+			sink.error(e);
+		}
+
+		@Override
+		public MonoSink<T> onRequest(LongConsumer consumer) {
+			return sink.onRequest(consumer);
+		}
+
+		@Override
+		public MonoSink<T> onCancel(Disposable d) {
+			return sink.onCancel(d);
+		}
+
+		@Override
+		public MonoSink<T> onDispose(Disposable d) {
+			return sink.onDispose(d);
+		}
+
+		//==delegates to processor ==
+
+		@Override
+		@SuppressWarnings("deprecation")
+		public boolean isComplete() {
+			return processor.isSuccess();
+		}
+
+		@Override
+		public boolean isValued() {
+			return processor.isValued();
+		}
+
+		@Override
+		public boolean isTerminated() {
+			return processor.isTerminated();
+		}
+
+		@Override
+		public Throwable getError() {
+			return processor.getError();
+		}
+
+		@Override
+		public boolean isError() {
+			return processor.isError();
+		}
+
+		@Override
+		public void dispose() {
+			processor.dispose();
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return processor.isDisposed();
+		}
+
+		@Override
+		public long downstreamCount() {
+			return processor.downstreamCount();
+		}
+
+		@Override
+		public boolean hasDownstreams() {
+			return processor.hasDownstreams();
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/Processors.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Processors.java
@@ -425,7 +425,7 @@ public final class Processors {
 	 * Create a builder for a "fan out" {@link ProcessorFacade}, which is an
 	 * <strong>asynchronous</strong> processor optionally capable of relaying elements from multiple
 	 * upstream {@link Publisher Publishers} when created in the shared configuration (see the {@link
-	 * FanOutProcessorBuilder#share(boolean)} option of the builder).
+	 * AsyncEmitterProcessorBuilder#share(boolean)} option of the builder).
 	 *
 	 * <p>
 	 * Note that the share option is mandatory if you intend to concurrently call the
@@ -449,25 +449,25 @@ public final class Processors {
 	 *
 	 * <p>
 	 * The maximum number of downstream subscribers for this processor is driven by the {@link
-	 * FanOutProcessorBuilder#executor(ExecutorService) executor} builder option. Provide a bounded
+	 * AsyncEmitterProcessorBuilder#executor(ExecutorService) executor} builder option. Provide a bounded
 	 * {@link ExecutorService} to limit it to a specific number.
 	 *
 	 * <p>
-	 * There is also an {@link FanOutProcessorBuilder#autoCancel(boolean) autoCancel} builder
+	 * There is also an {@link AsyncEmitterProcessorBuilder#autoCancel(boolean) autoCancel} builder
 	 * option: Set it to {@code false} to avoid cancelling the source {@link Publisher Publisher(s)}
 	 * when all subscribers are cancelled.
 	 *
 	 * @return a builder to create a new fan out {@link ProcessorFacade}
 	 */
-	public static final FanOutProcessorBuilder fanOut() {
-		return new FanOutProcessorBuilder();
+	public static final AsyncEmitterProcessorBuilder asyncEmitter() {
+		return new AsyncEmitterProcessorBuilder();
 	}
 
 	/**
 	 * Create a builder for a "fan out" {@link ProcessorFacade} with relaxed
 	 * Reactive Streams compliance. This is an <strong>asynchronous</strong> processor
 	 * optionally capable of relaying elements from multiple upstream {@link Publisher Publishers}
-	 * when created in the shared configuration (see the {@link FanOutProcessorBuilder#share(boolean)}
+	 * when created in the shared configuration (see the {@link AsyncEmitterProcessorBuilder#share(boolean)}
 	 * option of the builder).
 	 *
 	 * <p>
@@ -494,19 +494,19 @@ public final class Processors {
 	 *
 	 * <p>
 	 * The maximum number of downstream subscribers for this processor is driven by the {@link
-	 * FanOutProcessorBuilder#executor(ExecutorService) executor} builder option. Provide a bounded
+	 * AsyncEmitterProcessorBuilder#executor(ExecutorService) executor} builder option. Provide a bounded
 	 * {@link ExecutorService} to limit it to a specific number.
 	 *
 	 * <p>
-	 * There is also an {@link FanOutProcessorBuilder#autoCancel(boolean) autoCancel} builder
+	 * There is also an {@link AsyncEmitterProcessorBuilder#autoCancel(boolean) autoCancel} builder
 	 * option: If set to {@code true} (the default), it results in the source {@link Publisher
 	 * Publisher(s)} being cancelled when all subscribers are cancelled.
 	 *
 	 * @return a builder to create a new round-robin fan out {@link ProcessorFacade}
 	 */
 	@Deprecated
-	public static final FanOutProcessorBuilder relaxedFanOut() {
-		return new FanOutProcessorBuilder(true);
+	public static final AsyncEmitterProcessorBuilder relaxedFanOut() {
+		return new AsyncEmitterProcessorBuilder(true);
 	}
 
 
@@ -960,9 +960,9 @@ public final class Processors {
 	}
 
 	/**
-	 * A builder for the {@link #fanOut()} flavor of {@link ProcessorFacade}.
+	 * A builder for the {@link #asyncEmitter()} flavor of {@link ProcessorFacade}.
 	 */
-	public static final class FanOutProcessorBuilder {
+	public static final class AsyncEmitterProcessorBuilder {
 
 		boolean useWorkQueueProcessor;
 
@@ -978,11 +978,11 @@ public final class Processors {
 		boolean share;
 		boolean autoCancel;
 
-		FanOutProcessorBuilder() {
+		AsyncEmitterProcessorBuilder() {
 			this(false);
 		}
 
-		FanOutProcessorBuilder(boolean useWorkQueueProcessor) {
+		AsyncEmitterProcessorBuilder(boolean useWorkQueueProcessor) {
 			this.bufferSize = Queues.SMALL_BUFFER_SIZE;
 			this.autoCancel = true;
 			this.share = false;
@@ -991,13 +991,13 @@ public final class Processors {
 
 		/**
 		 * Configures name for this builder, if {@link #executor(ExecutorService)} is not configured.
-		 * Default value is {@code "fanOut"}.
+		 * Default value is {@code "asyncEmitter"}.
 		 * Name is reset to default if the provided {@code name} is null.
 		 *
 		 * @param name Use a new cached ExecutorService and assign this name to the created threads.
 		 * @return builder with provided name
 		 */
-		public FanOutProcessorBuilder name(@Nullable String name) {
+		public AsyncEmitterProcessorBuilder name(@Nullable String name) {
 			if (executor != null)
 				throw new IllegalArgumentException("Executor service is configured, name cannot be set.");
 			this.name = name;
@@ -1010,7 +1010,7 @@ public final class Processors {
 		 * @param bufferSize the internal buffer size to hold signals, must be a power of 2.
 		 * @return builder with provided buffer size
 		 */
-		public FanOutProcessorBuilder bufferSize(int bufferSize) {
+		public AsyncEmitterProcessorBuilder bufferSize(int bufferSize) {
 			if (!Queues.isPowerOfTwo(bufferSize)) {
 				throw new IllegalArgumentException("bufferSize must be a power of 2 : " + bufferSize);
 			}
@@ -1029,7 +1029,7 @@ public final class Processors {
 		 * @param waitStrategy A RingBuffer {@link WaitStrategy} to use instead of the default blocking wait strategy.
 		 * @return builder with provided wait strategy
 		 */
-		public FanOutProcessorBuilder waitStrategy(@Nullable WaitStrategy waitStrategy) {
+		public AsyncEmitterProcessorBuilder waitStrategy(@Nullable WaitStrategy waitStrategy) {
 			this.waitStrategy = waitStrategy;
 			return this;
 		}
@@ -1040,7 +1040,7 @@ public final class Processors {
 		 * @param autoCancel true to automatically cancel when all subscribers have cancelled.
 		 * @return builder with provided auto-cancel
 		 */
-		public FanOutProcessorBuilder autoCancel(boolean autoCancel) {
+		public AsyncEmitterProcessorBuilder autoCancel(boolean autoCancel) {
 			this.autoCancel = autoCancel;
 			return this;
 		}
@@ -1053,7 +1053,7 @@ public final class Processors {
 		 * @param executor A provided ExecutorService to manage threading infrastructure
 		 * @return builder with provided executor
 		 */
-		public FanOutProcessorBuilder executor(@Nullable ExecutorService executor) {
+		public AsyncEmitterProcessorBuilder executor(@Nullable ExecutorService executor) {
 			this.executor = executor;
 			return this;
 		}
@@ -1066,7 +1066,7 @@ public final class Processors {
 		 * @param requestTaskExecutor internal request executor
 		 * @return builder with provided internal request executor
 		 */
-		public FanOutProcessorBuilder requestTaskExecutor(@Nullable ExecutorService requestTaskExecutor) {
+		public AsyncEmitterProcessorBuilder requestTaskExecutor(@Nullable ExecutorService requestTaskExecutor) {
 			this.requestTaskExecutor = requestTaskExecutor;
 			return this;
 		}
@@ -1078,14 +1078,14 @@ public final class Processors {
 		 * @param share true to support concurrent sources on the {@link FluxProcessorFacade#asProcessor Processor}
 		 * @return builder with specified sharing
 		 */
-		public FanOutProcessorBuilder share(boolean share) {
+		public AsyncEmitterProcessorBuilder share(boolean share) {
 			this.share = share;
 			return this;
 		}
 
 		@SuppressWarnings("deprecation")
 		private <T> EventLoopProcessor<T> buildFluxProcessor() {
-			this.name = this.name != null ? this.name : "fanOut";
+			this.name = this.name != null ? this.name : "asyncEmitter";
 			this.waitStrategy = this.waitStrategy != null ? this.waitStrategy : WaitStrategy.phasedOffLiteLock(200, 100, TimeUnit.MILLISECONDS);
 			EventLoopProcessor.EventLoopFactory threadFactory = this.executor != null
 					? null
@@ -1093,7 +1093,7 @@ public final class Processors {
 
 			String requestTaskExecutorName = threadFactory != null
 					? threadFactory.get()
-					: "fanOutRequest";
+					: "asyncEmitterRequest";
 
 			ExecutorService requestTaskExecutor = this.requestTaskExecutor != null
 					? this.requestTaskExecutor

--- a/reactor-core/src/main/java/reactor/core/publisher/Processors.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Processors.java
@@ -522,10 +522,9 @@ public final class Processors {
 	 */
 	@SuppressWarnings("deprecation")
 	public static final <T> MonoProcessorFacade<T> firstFrom(Publisher<T> source) {
-		MonoProcessor<T> processor = new MonoProcessor<>(source);
-		processor.connect();
-		return processor;
+		return new MonoProcessor<>(source);
 	}
+
 	/**
 	 * Create a "first" {@link MonoProcessorFacade}, which will wait for a source
 	 * {@link Subscriber#onSubscribe(Subscription)}. It will then propagate only the first

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -45,7 +45,9 @@ import static reactor.core.publisher.FluxReplay.ReplaySubscriber.TERMINATED;
  * <p>
  *
  * @param <T> the value type
+ * @deprecated instantiate through {@link Processors#replay()} or {@link Processors#cacheLast()} and use as a {@link ProcessorSink}
  */
+@Deprecated
 public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 		implements Fuseable {
 
@@ -62,6 +64,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * @return a new {@link ReplayProcessor} that replays its last pushed element to each new
 	 * {@link Subscriber}
 	 */
+	@Deprecated
 	public static <T> ReplayProcessor<T> cacheLast() {
 		return cacheLastOrDefault(null);
 	}
@@ -82,6 +85,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * @return a new {@link ReplayProcessor} that replays its last pushed element to each new
 	 * {@link Subscriber}, or a default one if nothing was pushed yet
 	 */
+	@Deprecated
 	public static <T> ReplayProcessor<T> cacheLastOrDefault(@Nullable T value) {
 		ReplayProcessor<T> b = create(1);
 		if (value != null) {
@@ -99,6 +103,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * @return a new {@link ReplayProcessor} that replays the whole history to each new
 	 * {@link Subscriber}.
 	 */
+	@Deprecated
 	public static <E> ReplayProcessor<E> create() {
 		return create(Queues.SMALL_BUFFER_SIZE, true);
 	}
@@ -113,6 +118,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * @return a new {@link ReplayProcessor} that replays a limited history to each new
 	 * {@link Subscriber}.
 	 */
+	@Deprecated
 	public static <E> ReplayProcessor<E> create(int historySize) {
 		return create(historySize, false);
 	}
@@ -128,6 +134,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * @return a new {@link ReplayProcessor} that replays the whole history to each new
 	 * {@link Subscriber} if configured as unbounded, a limited history otherwise.
 	 */
+	@Deprecated
 	public static <E> ReplayProcessor<E> create(int historySize, boolean unbounded) {
 		FluxReplay.ReplayBuffer<E> buffer;
 		if (unbounded) {
@@ -170,6 +177,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 *
 	 * @return a new {@link ReplayProcessor} that replays elements based on their age.
 	 */
+	@Deprecated
 	public static <T> ReplayProcessor<T> createTimeout(Duration maxAge) {
 		return createTimeout(maxAge, Schedulers.parallel());
 	}
@@ -205,6 +213,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 *
 	 * @return a new {@link ReplayProcessor} that replays elements based on their age.
 	 */
+	@Deprecated
 	public static <T> ReplayProcessor<T> createTimeout(Duration maxAge, Scheduler scheduler) {
 		return createSizeAndTimeout(Integer.MAX_VALUE, maxAge, scheduler);
 	}
@@ -243,6 +252,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * @return a new {@link ReplayProcessor} that replay up to {@code size} elements, but
 	 * will evict them from its history based on their age.
 	 */
+	@Deprecated
 	public static <T> ReplayProcessor<T> createSizeAndTimeout(int size, Duration maxAge) {
 		return createSizeAndTimeout(size, maxAge, Schedulers.parallel());
 	}
@@ -281,6 +291,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * @return a new {@link ReplayProcessor} that replay up to {@code size} elements, but
 	 * will evict them from its history based on their age.
 	 */
+	@Deprecated
 	public static <T> ReplayProcessor<T> createSizeAndTimeout(int size,
 			Duration maxAge,
 			Scheduler scheduler) {
@@ -354,6 +365,11 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	@Override
 	public boolean isTerminated() {
 		return buffer.isDone();
+	}
+
+	@Override
+	public long getAvailableCapacity() {
+		return buffer.capacity() - buffer.size();
 	}
 
 	boolean add(FluxReplay.ReplaySubscription<T> rs) {

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -343,16 +343,6 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	}
 
 	@Override
-	public Processor<T, T> asProcessor() {
-		return this;
-	}
-
-	@Override
-	public CoreSubscriber<T> asCoreSubscriber() {
-		return this;
-	}
-
-	@Override
 	@Nullable
 	public Throwable getError() {
 		return buffer.getError();

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.stream.Stream;
 
+import org.reactivestreams.Processor;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -45,11 +46,11 @@ import static reactor.core.publisher.FluxReplay.ReplaySubscriber.TERMINATED;
  * <p>
  *
  * @param <T> the value type
- * @deprecated instantiate through {@link Processors#replay()} or {@link Processors#cacheLast()} and use as a {@link ProcessorSink}
+ * @deprecated instantiate through {@link Processors#replay()} or {@link Processors#cacheLast()} and use as a {@link ProcessorFacade}
  */
 @Deprecated
 public final class ReplayProcessor<T> extends FluxProcessor<T, T>
-		implements Fuseable {
+		implements Fuseable, FluxProcessorFacade<T> {
 
 	/**
 	 * Create a {@link ReplayProcessor} that caches the last element it has pushed,
@@ -309,6 +310,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	Subscription subscription;
 
 	volatile FluxReplay.ReplaySubscription<T>[] subscribers;
+
 	@SuppressWarnings("rawtypes")
 	static final AtomicReferenceFieldUpdater<ReplayProcessor, FluxReplay.ReplaySubscription[]>
 			SUBSCRIBERS = AtomicReferenceFieldUpdater.newUpdater(ReplayProcessor.class,
@@ -333,6 +335,26 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 			}
 		}
 		buffer.replay(rs);
+	}
+
+	@Override
+	public Flux<T> asFlux() {
+		return this;
+	}
+
+	@Override
+	public Processor<T, T> asProcessor() {
+		return this;
+	}
+
+	@Override
+	public CoreSubscriber<T> asCoreSubscriber() {
+		return this;
+	}
+
+	@Override
+	public Scannable asScannable() {
+		return this;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -353,11 +353,6 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	}
 
 	@Override
-	public Scannable asScannable() {
-		return this;
-	}
-
-	@Override
 	@Nullable
 	public Throwable getError() {
 		return buffer.getError();

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -46,7 +46,8 @@ import static reactor.core.publisher.FluxReplay.ReplaySubscriber.TERMINATED;
  * <p>
  *
  * @param <T> the value type
- * @deprecated instantiate through {@link Processors#replay()} or {@link Processors#cacheLast()} and use as a {@link ProcessorFacade}
+ * @deprecated instantiate through {@link Processors#replay()} or {@link Processors#cacheLast()}
+ * and use as a {@link FluxProcessorFacade}, will be removed from public API in 3.3
  */
 @Deprecated
 public final class ReplayProcessor<T> extends FluxProcessor<T, T>

--- a/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
@@ -353,6 +353,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 
 	@Override
 	@Deprecated
+	@SuppressWarnings("deprecation")
 	public Flux<E> drain() {
 		return coldSource(ringBuffer, null, error, minimum);
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
@@ -67,7 +67,8 @@ import reactor.util.concurrent.WaitStrategy;
  * @param <E> Type of dispatched signal
  * @author Stephane Maldini
  * @author Anatoly Kadyshev
- * @deprecated instantiate through {@link Processors#asyncEmitter()} and use as a {@link ProcessorFacade}
+ * @deprecated instantiate through {@link Processors#asyncEmitter()} and use as a
+ * {@link FluxProcessorFacade}, will be removed from public API in 3.3
  */
 @Deprecated
 public final class TopicProcessor<E> extends EventLoopProcessor<E>  {

--- a/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
@@ -66,7 +66,9 @@ import reactor.util.concurrent.WaitStrategy;
  * @param <E> Type of dispatched signal
  * @author Stephane Maldini
  * @author Anatoly Kadyshev
+ * @deprecated instantiate through {@link Processors#fanOut()} and use as a {@link ProcessorSink}
  */
+@Deprecated
 public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 
 	/**
@@ -77,7 +79,9 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * {@code TopicProcessor<String> processor = TopicProcessor.<String>builder().build()}
 	 *
 	 * @param <T> Type of dispatched signal
+	 * @deprecated will be superseded by {@link reactor.core.publisher.Processors.FanOutProcessorBuilder} in 3.2.0
 	 */
+	@Deprecated
 	public final static class Builder<T> {
 
 		String name;
@@ -220,6 +224,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * Create a new {@link TopicProcessor} {@link Builder} with default properties.
 	 * @return new TopicProcessor builder
 	 */
+	@Deprecated
 	public static <E> Builder<E> builder()  {
 		return new Builder<>();
 	}
@@ -231,6 +236,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
 	 */
+	@Deprecated
 	public static <E> TopicProcessor<E> create() {
 		return TopicProcessor.<E>builder().build();
 	}
@@ -245,6 +251,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * @param <E> Type of processed signals
 	 * @return the fresh TopicProcessor instance
 	 */
+	@Deprecated
 	public static <E> TopicProcessor<E> create(String name, int bufferSize) {
 		return TopicProcessor.<E>builder().name(name).bufferSize(bufferSize).build();
 	}
@@ -264,6 +271,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
 	 */
+	@Deprecated
 	public static <E> TopicProcessor<E> share(String name, int bufferSize) {
 		return TopicProcessor.<E>builder().share(true).name(name).bufferSize(bufferSize).build();
 	}
@@ -344,6 +352,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	}
 
 	@Override
+	@Deprecated
 	public Flux<E> drain() {
 		return coldSource(ringBuffer, null, error, minimum);
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Supplier;
 
+import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -66,7 +67,7 @@ import reactor.util.concurrent.WaitStrategy;
  * @param <E> Type of dispatched signal
  * @author Stephane Maldini
  * @author Anatoly Kadyshev
- * @deprecated instantiate through {@link Processors#fanOut()} and use as a {@link ProcessorSink}
+ * @deprecated instantiate through {@link Processors#fanOut()} and use as a {@link ProcessorFacade}
  */
 @Deprecated
 public final class TopicProcessor<E> extends EventLoopProcessor<E>  {

--- a/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
@@ -67,7 +67,7 @@ import reactor.util.concurrent.WaitStrategy;
  * @param <E> Type of dispatched signal
  * @author Stephane Maldini
  * @author Anatoly Kadyshev
- * @deprecated instantiate through {@link Processors#fanOut()} and use as a {@link ProcessorFacade}
+ * @deprecated instantiate through {@link Processors#asyncEmitter()} and use as a {@link ProcessorFacade}
  */
 @Deprecated
 public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
@@ -80,7 +80,7 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * {@code TopicProcessor<String> processor = TopicProcessor.<String>builder().build()}
 	 *
 	 * @param <T> Type of dispatched signal
-	 * @deprecated will be superseded by {@link reactor.core.publisher.Processors.FanOutProcessorBuilder} in 3.2.0
+	 * @deprecated will be superseded by {@link reactor.core.publisher.Processors.AsyncEmitterProcessorBuilder} in 3.2.0
 	 */
 	@Deprecated
 	public final static class Builder<T> {

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -28,7 +28,6 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
-import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
@@ -84,7 +83,9 @@ import reactor.util.context.Context;
  * </p>
  *
  * @param <T> the input and output type
+ * @deprecated instantiate through {@link Processors#unicast()} builder and use as a {@link ProcessorSink}
  */
+@Deprecated
 public final class UnicastProcessor<T>
 		extends FluxProcessor<T, T>
 		implements Fuseable.QueueSubscription<T>, Fuseable, InnerOperator<T, T> {
@@ -96,6 +97,7 @@ public final class UnicastProcessor<T>
 	 * @param <E> the relayed type
 	 * @return a unicast {@link FluxProcessor}
 	 */
+	@Deprecated
 	public static <E> UnicastProcessor<E> create() {
 		return new UnicastProcessor<>(Queues.<E>unbounded().get());
 	}
@@ -108,6 +110,7 @@ public final class UnicastProcessor<T>
 	 * @param <E> the relayed type
 	 * @return a unicast {@link FluxProcessor}
 	 */
+	@Deprecated
 	public static <E> UnicastProcessor<E> create(Queue<E> queue) {
 		return new UnicastProcessor<>(queue);
 	}
@@ -121,6 +124,7 @@ public final class UnicastProcessor<T>
 	 * @param <E> the relayed type
 	 * @return a unicast {@link FluxProcessor}
 	 */
+	@Deprecated
 	public static <E> UnicastProcessor<E> create(Queue<E> queue, Disposable endcallback) {
 		return new UnicastProcessor<>(queue, endcallback);
 	}
@@ -137,6 +141,7 @@ public final class UnicastProcessor<T>
 	 *
 	 * @return a unicast {@link FluxProcessor}
 	 */
+	@Deprecated
 	public static <E> UnicastProcessor<E> create(Queue<E> queue,
 			Consumer<? super E> onOverflow,
 			Disposable endcallback) {
@@ -187,6 +192,13 @@ public final class UnicastProcessor<T>
 		this.onOverflow = null;
 	}
 
+	UnicastProcessor(Queue<T> queue,
+			Consumer<? super T> onOverflow) {
+		this.queue = Objects.requireNonNull(queue, "queue");
+		this.onOverflow = Objects.requireNonNull(onOverflow, "onOverflow");
+		this.onTerminate = null;
+	}
+
 	public UnicastProcessor(Queue<T> queue,
 			Consumer<? super T> onOverflow,
 			Disposable onTerminate) {
@@ -195,9 +207,22 @@ public final class UnicastProcessor<T>
 		this.onTerminate = Objects.requireNonNull(onTerminate, "onTerminate");
 	}
 
+	/**
+	 * @deprecated use {@link ProcessorSink#getAvailableCapacity()} instead
+	 */
 	@Override
+	@Deprecated
 	public int getBufferSize() {
 		return Queues.capacity(this.queue);
+	}
+
+	@Override
+	public long getAvailableCapacity() {
+		int cap = Queues.capacity(this.queue);
+		if (cap < 0) {
+			return Long.MAX_VALUE;
+		}
+		return cap;
 	}
 
 	@Override
@@ -488,8 +513,13 @@ public final class UnicastProcessor<T>
 	}
 
 	@Override
+	public void dispose() {
+		cancel();
+	}
+
+	@Override
 	public boolean isDisposed() {
-		return cancelled || done;
+		return cancelled;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -22,12 +22,14 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
 
+import org.reactivestreams.Processor;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
+import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
@@ -83,12 +85,12 @@ import reactor.util.context.Context;
  * </p>
  *
  * @param <T> the input and output type
- * @deprecated instantiate through {@link Processors#unicast()} builder and use as a {@link ProcessorSink}
+ * @deprecated instantiate through {@link Processors#unicast()} builder and use as a {@link ProcessorFacade}
  */
 @Deprecated
 public final class UnicastProcessor<T>
 		extends FluxProcessor<T, T>
-		implements Fuseable.QueueSubscription<T>, Fuseable, InnerOperator<T, T> {
+		implements Fuseable.QueueSubscription<T>, Fuseable, InnerOperator<T, T>, FluxProcessorFacade<T> {
 
 	/**
 	 * Create a new {@link UnicastProcessor} that will buffer on an internal queue in an
@@ -152,6 +154,7 @@ public final class UnicastProcessor<T>
 	final Consumer<? super T> onOverflow;
 
 	volatile Disposable onTerminate;
+
 	@SuppressWarnings("rawtypes")
 	static final AtomicReferenceFieldUpdater<UnicastProcessor, Disposable> ON_TERMINATE =
 			AtomicReferenceFieldUpdater.newUpdater(UnicastProcessor.class, Disposable.class, "onTerminate");
@@ -208,7 +211,7 @@ public final class UnicastProcessor<T>
 	}
 
 	/**
-	 * @deprecated use {@link ProcessorSink#getAvailableCapacity()} instead
+	 * @deprecated use {@link ProcessorFacade#getAvailableCapacity()} instead
 	 */
 	@Override
 	@Deprecated
@@ -525,6 +528,26 @@ public final class UnicastProcessor<T>
 	@Override
 	public boolean isTerminated() {
 		return done;
+	}
+
+	@Override
+	public Flux<T> asFlux() {
+		return this;
+	}
+
+	@Override
+	public Processor<T, T> asProcessor() {
+		return this;
+	}
+
+	@Override
+	public CoreSubscriber<T> asCoreSubscriber() {
+		return this;
+	}
+
+	@Override
+	public Scannable asScannable() {
+		return this;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -85,7 +85,8 @@ import reactor.util.context.Context;
  * </p>
  *
  * @param <T> the input and output type
- * @deprecated instantiate through {@link Processors#unicast()} builder and use as a {@link ProcessorFacade}
+ * @deprecated instantiate through {@link Processors#unicast()} builder and use as a
+ * {@link FluxProcessorFacade}, will be removed from public API in 3.3
  */
 @Deprecated
 public final class UnicastProcessor<T>

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -546,11 +546,6 @@ public final class UnicastProcessor<T>
 	}
 
 	@Override
-	public Scannable asScannable() {
-		return this;
-	}
-
-	@Override
 	@Nullable
 	public Throwable getError() {
 		return error;

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -536,16 +536,6 @@ public final class UnicastProcessor<T>
 	}
 
 	@Override
-	public Processor<T, T> asProcessor() {
-		return this;
-	}
-
-	@Override
-	public CoreSubscriber<T> asCoreSubscriber() {
-		return this;
-	}
-
-	@Override
 	@Nullable
 	public Throwable getError() {
 		return error;

--- a/reactor-core/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
@@ -63,7 +63,9 @@ import reactor.util.concurrent.WaitStrategy;
  *
  * @param <E> Type of dispatched signal
  * @author Stephane Maldini
+ * @deprecated prefer the {@link Processors#fanOut()} variant, will be removed in 3.2.0.
  */
+@Deprecated
 public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 
 	/**
@@ -74,7 +76,9 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * {@code WorkQueueProcessor<String> processor = WorkQueueProcessor.<String>builder().build()}
 	 *
 	 * @param <T> Type of dispatched signal
+	 * @deprecated will be replaced by {@link Processors#fanOut()} in 3.2.0
 	 */
+	@Deprecated
 	public final static class Builder<T> {
 
 		String name;
@@ -162,7 +166,8 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 		 * @param requestTaskExecutor internal request executor
 		 * @return builder with provided internal request executor
 		 */
-		public Builder<T> requestTaskExecutor(@Nullable ExecutorService requestTaskExecutor) {
+		public Builder<T> requestTaskExecutor(
+				@Nullable ExecutorService requestTaskExecutor) {
 			this.requestTaskExecutor = requestTaskExecutor;
 			return this;
 		}
@@ -205,6 +210,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * Create a new {@link WorkQueueProcessor} {@link Builder} with default properties.
 	 * @return new WorkQueueProcessor builder
 	 */
+	@Deprecated
 	public final static <T> Builder<T> builder() {
 		return new Builder<>();
 	}
@@ -216,6 +222,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
 	 */
+	@Deprecated
 	public static <E> WorkQueueProcessor<E> create() {
 		return WorkQueueProcessor.<E>builder().build();
 	}
@@ -230,6 +237,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
 	 */
+	@Deprecated
 	public static <E> WorkQueueProcessor<E> create(String name, int bufferSize) {
 		return WorkQueueProcessor.<E>builder().name(name).bufferSize(bufferSize).build();
 	}
@@ -246,6 +254,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * @param <E> Type of processed signals
 	 * @return a fresh processor
 	 */
+	@Deprecated
 	public static <E> WorkQueueProcessor<E> share(String name, int bufferSize) {
 		return WorkQueueProcessor.<E>builder().share(true).name(name).bufferSize(bufferSize).build();
 	}
@@ -356,6 +365,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	}
 
 	@Override
+	@Deprecated
 	public Flux<E> drain() {
 		return TopicProcessor.coldSource(ringBuffer, null, error, workSequence);
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
@@ -366,6 +366,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 
 	@Override
 	@Deprecated
+	@SuppressWarnings("deprecation")
 	public Flux<E> drain() {
 		return TopicProcessor.coldSource(ringBuffer, null, error, workSequence);
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
@@ -63,7 +63,7 @@ import reactor.util.concurrent.WaitStrategy;
  *
  * @param <E> Type of dispatched signal
  * @author Stephane Maldini
- * @deprecated prefer the {@link Processors#fanOut()} variant, will be removed in 3.2.0.
+ * @deprecated prefer the {@link Processors#asyncEmitter()} variant, will be removed in 3.2.0.
  */
 @Deprecated
 public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
@@ -76,7 +76,7 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * {@code WorkQueueProcessor<String> processor = WorkQueueProcessor.<String>builder().build()}
 	 *
 	 * @param <T> Type of dispatched signal
-	 * @deprecated will be replaced by {@link Processors#fanOut()} in 3.2.0
+	 * @deprecated will be replaced by {@link Processors#asyncEmitter()} in 3.2.0
 	 */
 	@Deprecated
 	public final static class Builder<T> {

--- a/reactor-core/src/main/java/reactor/core/publisher/package-info.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/package-info.java
@@ -35,7 +35,7 @@
  *         {@link reactor.core.publisher.Processors#unicast()} and
  *         {@link reactor.core.publisher.Processors#direct()}</li>
  *         <li>A dedicated parallel pub-sub event buffering broadcaster :
- *         {@link reactor.core.publisher.Processors#fanOut()}</li>
+ *         {@link reactor.core.publisher.Processors#asyncEmitter()}</li>
  *         <li>A dedicated parallel work queue distribution for slow consumers :
  *         {@link reactor.core.publisher.Processors#relaxedFanOut()}</li>
  * </ul>

--- a/reactor-core/src/main/java/reactor/core/publisher/package-info.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/package-info.java
@@ -26,19 +26,18 @@
  * A typed one-element at most sequence {@link org.reactivestreams.Publisher} with core reactive extensions.
  *
  * <h2>Processors</h2>
- * The following
- * {@link org.reactivestreams.Processor} extending {@link reactor.core.publisher.FluxProcessor} are available:
+ * The following {@link reactor.core.publisher.FluxProcessorSink} are available, which can
+ * be converted to {@link org.reactivestreams.Processor}:
  * <ul>
- *         <li>A synchronous/non-opinionated pub-sub replaying capable event emitter :
- *         {@link reactor.core.publisher.EmitterProcessor},
- *         {@link reactor.core.publisher.ReplayProcessor},
- *         {@link reactor.core.publisher.UnicastProcessor} and
- *         {@link reactor.core.publisher.DirectProcessor}</li>
+ *         <li>Synchronous/non-opinionated pub-sub replaying capable event emitter :
+ *         {@link reactor.core.publisher.Processors#emitter()},
+ *         {@link reactor.core.publisher.Processors#replay()},
+ *         {@link reactor.core.publisher.Processors#unicast()} and
+ *         {@link reactor.core.publisher.Processors#direct()}</li>
  *         <li>A dedicated parallel pub-sub event buffering broadcaster :
- *         {@link reactor.core.publisher.TopicProcessor}</li>
+ *         {@link reactor.core.publisher.Processors#fanOut()}</li>
  *         <li>A dedicated parallel work queue distribution for slow consumers :
- *         {@link reactor.core.publisher.WorkQueueProcessor}</li>
- *         <li>{@link reactor.core.publisher.FluxProcessor} itself offers factories to build arbitrary {@link org.reactivestreams.Processor}</li>
+ *         {@link reactor.core.publisher.Processors#relaxedFanOut()}</li>
  * </ul>
  * <p>
  **

--- a/reactor-core/src/test/java/reactor/core/publisher/DirectProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/DirectProcessorTest.java
@@ -17,7 +17,9 @@ package reactor.core.publisher;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.reactivestreams.Processor;
 import org.reactivestreams.Subscriber;
+import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
@@ -53,8 +55,8 @@ public class DirectProcessorTest {
 	    DirectProcessor<Object> processor = DirectProcessor.create();
 
 	    assertThat(processor)
-			    .isSameAs(processor.asCoreSubscriber())
-			    .isSameAs(processor.asProcessor())
+			    .isInstanceOf(CoreSubscriber.class)
+			    .isInstanceOf(Processor.class)
 			    .isSameAs(Scannable.from(processor))
 			    .isSameAs(processor.asFlux());
     }

--- a/reactor-core/src/test/java/reactor/core/publisher/DirectProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/DirectProcessorTest.java
@@ -55,7 +55,7 @@ public class DirectProcessorTest {
 	    assertThat(processor)
 			    .isSameAs(processor.asCoreSubscriber())
 			    .isSameAs(processor.asProcessor())
-			    .isSameAs(processor.asScannable())
+			    .isSameAs(Scannable.from(processor))
 			    .isSameAs(processor.asFlux());
     }
 

--- a/reactor-core/src/test/java/reactor/core/publisher/DirectProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/DirectProcessorTest.java
@@ -25,6 +25,7 @@ import reactor.test.subscriber.AssertSubscriber;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+@SuppressWarnings("deprecation")
 public class DirectProcessorTest {
 
     @Test(expected = NullPointerException.class)

--- a/reactor-core/src/test/java/reactor/core/publisher/DirectProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/DirectProcessorTest.java
@@ -49,6 +49,17 @@ public class DirectProcessorTest {
     }
 
     @Test
+    public void fluxProcessorFacadeViewsAreSame() {
+	    DirectProcessor<Object> processor = DirectProcessor.create();
+
+	    assertThat(processor)
+			    .isSameAs(processor.asCoreSubscriber())
+			    .isSameAs(processor.asProcessor())
+			    .isSameAs(processor.asScannable())
+			    .isSameAs(processor.asFlux());
+    }
+
+    @Test
     public void normal() {
         DirectProcessor<Integer> tp = DirectProcessor.create();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -60,8 +60,8 @@ public class EmitterProcessorTest {
 		EmitterProcessor<Object> processor = EmitterProcessor.create();
 
 		assertThat(processor)
-				.isSameAs(processor.asCoreSubscriber())
-				.isSameAs(processor.asProcessor())
+				.isInstanceOf(CoreSubscriber.class)
+				.isInstanceOf(Processor.class)
 				.isSameAs(Scannable.from(processor))
 				.isSameAs(processor.asFlux());
 	}
@@ -734,14 +734,14 @@ public class EmitterProcessorTest {
 	@Test
 	public void cancelIsDisposed() {
 		FluxProcessorFacade<Integer> processor = Processors.emitter();
-		assertThat(processor.asProcessor()).isExactlyInstanceOf(EmitterProcessor.class);
+		assertThat(processor).isExactlyInstanceOf(EmitterProcessor.class);
 
 		assertThat(processor.isDisposed()).as("not yet disposed").isFalse();
 
 		processor.dispose();
 
 		assertThat(processor.isDisposed()).as("disposed").isTrue();
-		assertThat(((EmitterProcessor) processor.asProcessor()).isCancelled())
+		assertThat(((EmitterProcessor) processor).isCancelled())
 				.as("isCancelled")
 				.isTrue();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -52,6 +52,7 @@ import static reactor.core.Scannable.Attr;
 /**
  * @author Stephane Maldini
  */
+@SuppressWarnings("deprecation")
 public class EmitterProcessorTest {
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -62,7 +62,7 @@ public class EmitterProcessorTest {
 		assertThat(processor)
 				.isSameAs(processor.asCoreSubscriber())
 				.isSameAs(processor.asProcessor())
-				.isSameAs(processor.asScannable())
+				.isSameAs(Scannable.from(processor))
 				.isSameAs(processor.asFlux());
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
-import java.util.stream.Stream;
 
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -718,6 +717,21 @@ public class EmitterProcessorTest {
 		boolean autoCancel = false;
 		EmitterProcessor<Integer> processor = EmitterProcessor.create(bufferSize, autoCancel);
 		assertProcessor(processor, bufferSize, autoCancel);
+	}
+
+	@Test
+	public void cancelIsDisposed() {
+		ProcessorSink<Integer> processor = Processors.emitter();
+		assertThat(processor.asProcessor()).isExactlyInstanceOf(EmitterProcessor.class);
+
+		assertThat(processor.isDisposed()).as("not yet disposed").isFalse();
+
+		processor.dispose();
+
+		assertThat(processor.isDisposed()).as("disposed").isTrue();
+		assertThat(((EmitterProcessor) processor.asProcessor()).isCancelled())
+				.as("isCancelled")
+				.isTrue();
 	}
 
 	public void assertProcessor(EmitterProcessor<Integer> processor,

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -56,6 +56,17 @@ import static reactor.core.Scannable.Attr;
 public class EmitterProcessorTest {
 
 	@Test
+	public void fluxProcessorFacadeViewsAreSame() {
+		EmitterProcessor<Object> processor = EmitterProcessor.create();
+
+		assertThat(processor)
+				.isSameAs(processor.asCoreSubscriber())
+				.isSameAs(processor.asProcessor())
+				.isSameAs(processor.asScannable())
+				.isSameAs(processor.asFlux());
+	}
+
+	@Test
 	public void testColdIdentityProcessor() throws InterruptedException {
 		final int elements = 10;
 		CountDownLatch latch = new CountDownLatch(elements + 1);
@@ -722,7 +733,7 @@ public class EmitterProcessorTest {
 
 	@Test
 	public void cancelIsDisposed() {
-		ProcessorSink<Integer> processor = Processors.emitter();
+		FluxProcessorFacade<Integer> processor = Processors.emitter();
 		assertThat(processor.asProcessor()).isExactlyInstanceOf(EmitterProcessor.class);
 
 		assertThat(processor.isDisposed()).as("not yet disposed").isFalse();

--- a/reactor-core/src/test/java/reactor/core/publisher/EventLoopProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EventLoopProcessorTest.java
@@ -37,6 +37,7 @@ import static reactor.core.Scannable.Attr.TERMINATED;
 import static reactor.core.Scannable.Attr.PARENT;
 import static reactor.core.Scannable.Attr.ERROR;
 
+@SuppressWarnings("deprecation")
 public class EventLoopProcessorTest {
 
 	EventLoopProcessor<String> test;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxAutoConnectTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxAutoConnectTest.java
@@ -42,11 +42,13 @@ public class FluxAutoConnectTest {
 	
 	@Test
 	public void connectImmediately() {
-		EmitterProcessor<Integer> e = EmitterProcessor.create();
+		FluxProcessorSink<Integer> e = Processors.emitter();
 
 		AtomicReference<Disposable> cancel = new AtomicReference<>();
 		
-		e.publish().autoConnect(0, cancel::set);
+		e.asFlux()
+		 .publish()
+		 .autoConnect(0, cancel::set);
 		
 		Assert.assertNotNull(cancel.get());
 		Assert.assertTrue("sp has no subscribers?", e.downstreamCount() != 0);
@@ -57,11 +59,13 @@ public class FluxAutoConnectTest {
 
 	@Test
 	public void connectAfterMany() {
-		EmitterProcessor<Integer> e = EmitterProcessor.create();
+		FluxProcessorSink<Integer> e = Processors.emitter();
 
 		AtomicReference<Disposable> cancel = new AtomicReference<>();
 		
-		Flux<Integer> p = e.publish().autoConnect(2, cancel::set);
+		Flux<Integer> p = e.asFlux()
+		                   .publish()
+		                   .autoConnect(2, cancel::set);
 		
 		Assert.assertNull(cancel.get());
 		Assert.assertFalse("sp has subscribers?", e.downstreamCount() != 0);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxAutoConnectTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxAutoConnectTest.java
@@ -42,7 +42,7 @@ public class FluxAutoConnectTest {
 	
 	@Test
 	public void connectImmediately() {
-		FluxProcessorSink<Integer> e = Processors.emitter();
+		FluxProcessorSink<Integer> e = Processors.emitterSink();
 
 		AtomicReference<Disposable> cancel = new AtomicReference<>();
 		
@@ -59,7 +59,7 @@ public class FluxAutoConnectTest {
 
 	@Test
 	public void connectAfterMany() {
-		FluxProcessorSink<Integer> e = Processors.emitter();
+		FluxProcessorSink<Integer> e = Processors.emitterSink();
 
 		AtomicReference<Disposable> cancel = new AtomicReference<>();
 		

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
@@ -73,8 +73,8 @@ public class FluxBufferBoundaryTest
 	public void normal() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
 
 		sp1.asFlux().buffer(sp2.asFlux())
 		   .subscribe(ts);
@@ -124,8 +124,8 @@ public class FluxBufferBoundaryTest
 	public void mainError() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
 
 		sp1.asFlux().buffer(sp2.asFlux())
 		   .subscribe(ts);
@@ -170,8 +170,8 @@ public class FluxBufferBoundaryTest
 	public void otherError() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
 
 		sp1.asFlux().buffer(sp2.asFlux())
 		   .subscribe(ts);
@@ -216,8 +216,8 @@ public class FluxBufferBoundaryTest
 	public void bufferSupplierThrows() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
 
 		sp1.asFlux().buffer(sp2.asFlux(), (Supplier<List<Integer>>) () -> {
 			throw new RuntimeException("forced failure");
@@ -237,8 +237,8 @@ public class FluxBufferBoundaryTest
 	public void bufferSupplierThrowsLater() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
 
 		int count[] = {1};
 
@@ -268,8 +268,8 @@ public class FluxBufferBoundaryTest
 	public void bufferSupplierReturnsNUll() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
 
 		sp1.asFlux().buffer(sp2.asFlux(), (Supplier<List<Integer>>) () -> null)
 		   .subscribe(ts);
@@ -319,10 +319,10 @@ public class FluxBufferBoundaryTest
 	@Test
 	public void bufferWillAcumulateMultipleListsOfValues() {
 		//given: "a source and a collected flux"
-		FluxProcessorSink<Integer> numbers = Processors.emitter();
+		FluxProcessorSink<Integer> numbers = Processors.emitterSink();
 
 		//non overlapping buffers
-		FluxProcessorSink<Integer> boundaryFlux = Processors.emitter();
+		FluxProcessorSink<Integer> boundaryFlux = Processors.emitterSink();
 
 		MonoProcessor<List<List<Integer>>> res = numbers.asFlux()
 		                                                .buffer(boundaryFlux.asFlux())

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
@@ -73,47 +73,47 @@ public class FluxBufferBoundaryTest
 	public void normal() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
 
-		sp1.buffer(sp2)
+		sp1.asFlux().buffer(sp2.asFlux())
 		   .subscribe(ts);
 
 		ts.assertNoValues()
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp1.onNext(1);
-		sp1.onNext(2);
+		sp1.next(1);
+		sp1.next(2);
 
 		ts.assertNoValues()
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp2.onNext(1);
+		sp2.next(1);
 
 		ts.assertValues(Arrays.asList(1, 2))
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp2.onNext(2);
+		sp2.next(2);
 
 		ts.assertValues(Arrays.asList(1, 2))
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp1.onNext(3);
-		sp1.onNext(4);
+		sp1.next(3);
+		sp1.next(4);
 
-		sp2.onComplete();
+		sp2.complete();
 
 		ts.assertValues(Arrays.asList(1, 2), Arrays.asList(3, 4))
 		  .assertNoError()
 		  .assertComplete();
 
-		sp1.onNext(5);
-		sp1.onNext(6);
-		sp1.onComplete();
+		sp1.next(5);
+		sp1.next(6);
+		sp1.complete();
 
 		ts.assertValues(Arrays.asList(1, 2), Arrays.asList(3, 4))
 		  .assertNoError()
@@ -124,41 +124,41 @@ public class FluxBufferBoundaryTest
 	public void mainError() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
 
-		sp1.buffer(sp2)
+		sp1.asFlux().buffer(sp2.asFlux())
 		   .subscribe(ts);
 
 		ts.assertNoValues()
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp1.onNext(1);
-		sp1.onNext(2);
+		sp1.next(1);
+		sp1.next(2);
 
 		ts.assertNoValues()
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp2.onNext(1);
+		sp2.next(1);
 
 		ts.assertValues(Arrays.asList(1, 2))
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp1.onError(new RuntimeException("forced failure"));
+		sp1.error(new RuntimeException("forced failure"));
 
 		Assert.assertFalse("sp2 has subscribers?", sp2.hasDownstreams());
 
-		sp2.onNext(2);
+		sp2.next(2);
 
 		ts.assertValues(Arrays.asList(1, 2))
 		  .assertError(RuntimeException.class)
 		  .assertErrorMessage("forced failure")
 		  .assertNotComplete();
 
-		sp2.onComplete();
+		sp2.complete();
 
 		ts.assertValues(Arrays.asList(1, 2))
 		  .assertError(RuntimeException.class)
@@ -170,32 +170,32 @@ public class FluxBufferBoundaryTest
 	public void otherError() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
 
-		sp1.buffer(sp2)
+		sp1.asFlux().buffer(sp2.asFlux())
 		   .subscribe(ts);
 
 		ts.assertNoValues()
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp1.onNext(1);
-		sp1.onNext(2);
+		sp1.next(1);
+		sp1.next(2);
 
 		ts.assertNoValues()
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp2.onNext(1);
+		sp2.next(1);
 
 		ts.assertValues(Arrays.asList(1, 2))
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp1.onNext(3);
+		sp1.next(3);
 
-		sp2.onError(new RuntimeException("forced failure"));
+		sp2.error(new RuntimeException("forced failure"));
 
 		Assert.assertFalse("sp1 has subscribers?", sp1.hasDownstreams());
 
@@ -204,7 +204,7 @@ public class FluxBufferBoundaryTest
 		  .assertErrorMessage("forced failure")
 		  .assertNotComplete();
 
-		sp2.onComplete();
+		sp2.complete();
 
 		ts.assertValues(Arrays.asList(1, 2))
 		  .assertError(RuntimeException.class)
@@ -216,10 +216,10 @@ public class FluxBufferBoundaryTest
 	public void bufferSupplierThrows() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
 
-		sp1.buffer(sp2, (Supplier<List<Integer>>) () -> {
+		sp1.asFlux().buffer(sp2.asFlux(), (Supplier<List<Integer>>) () -> {
 			throw new RuntimeException("forced failure");
 		})
 		   .subscribe(ts);
@@ -237,12 +237,12 @@ public class FluxBufferBoundaryTest
 	public void bufferSupplierThrowsLater() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
 
 		int count[] = {1};
 
-		sp1.buffer(sp2, (Supplier<List<Integer>>) () -> {
+		sp1.asFlux().buffer(sp2.asFlux(), (Supplier<List<Integer>>) () -> {
 			if (count[0]-- > 0) {
 				return new ArrayList<>();
 			}
@@ -250,10 +250,10 @@ public class FluxBufferBoundaryTest
 		})
 		   .subscribe(ts);
 
-		sp1.onNext(1);
-		sp1.onNext(2);
+		sp1.next(1);
+		sp1.next(2);
 
-		sp2.onNext(1);
+		sp2.next(1);
 
 		Assert.assertFalse("sp1 has subscribers?", sp1.hasDownstreams());
 		Assert.assertFalse("sp2 has subscribers?", sp2.hasDownstreams());
@@ -268,10 +268,10 @@ public class FluxBufferBoundaryTest
 	public void bufferSupplierReturnsNUll() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
 
-		sp1.buffer(sp2, (Supplier<List<Integer>>) () -> null)
+		sp1.asFlux().buffer(sp2.asFlux(), (Supplier<List<Integer>>) () -> null)
 		   .subscribe(ts);
 
 		Assert.assertFalse("sp1 has subscribers?", sp1.hasDownstreams());
@@ -319,24 +319,25 @@ public class FluxBufferBoundaryTest
 	@Test
 	public void bufferWillAcumulateMultipleListsOfValues() {
 		//given: "a source and a collected flux"
-		EmitterProcessor<Integer> numbers = EmitterProcessor.create();
+		FluxProcessorSink<Integer> numbers = Processors.emitter();
 
 		//non overlapping buffers
-		EmitterProcessor<Integer> boundaryFlux = EmitterProcessor.create();
+		FluxProcessorSink<Integer> boundaryFlux = Processors.emitter();
 
-		MonoProcessor<List<List<Integer>>> res = numbers.buffer(boundaryFlux)
-		                                       .buffer()
-		                                       .publishNext()
-		                                       .toProcessor();
+		MonoProcessor<List<List<Integer>>> res = numbers.asFlux()
+		                                                .buffer(boundaryFlux.asFlux())
+		                                                .buffer()
+		                                                .publishNext()
+		                                                .toProcessor();
 		res.subscribe();
 
-		numbers.onNext(1);
-		numbers.onNext(2);
-		numbers.onNext(3);
-		boundaryFlux.onNext(1);
-		numbers.onNext(5);
-		numbers.onNext(6);
-		numbers.onComplete();
+		numbers.next(1);
+		numbers.next(2);
+		numbers.next(3);
+		boundaryFlux.next(1);
+		numbers.next(5);
+		numbers.next(6);
+		numbers.complete();
 
 		//"the collected lists are available"
 		assertThat(res.block()).containsExactly(Arrays.asList(1, 2, 3), Arrays.asList(5, 6));

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
@@ -42,28 +42,28 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalUntil() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
-				sp1, i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL);
+				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL);
 
 		StepVerifier.create(bufferUntil)
 				.expectSubscription()
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(1))
-				.then(() -> sp1.onNext(2))
+				.then(() -> sp1.next(1))
+				.then(() -> sp1.next(2))
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(3))
+				.then(() -> sp1.next(3))
 				.expectNext(Arrays.asList(1, 2, 3))
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(4))
-				.then(() -> sp1.onNext(5))
+				.then(() -> sp1.next(4))
+				.then(() -> sp1.next(5))
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(6))
+				.then(() -> sp1.next(6))
 				.expectNext(Arrays.asList(4, 5, 6))
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(7))
-				.then(() -> sp1.onNext(8))
-				.then(sp1::onComplete)
+				.then(() -> sp1.next(7))
+				.then(() -> sp1.next(8))
+				.then(sp1::complete)
 				.expectNext(Arrays.asList(7, 8))
 				.expectComplete()
 				.verify();
@@ -106,18 +106,18 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void mainErrorUntil() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
-				sp1, i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL);
+				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL);
 
 		StepVerifier.create(bufferUntil)
 		            .expectSubscription()
-		            .then(() -> sp1.onNext(1))
-		            .then(() -> sp1.onNext(2))
-		            .then(() -> sp1.onNext(3))
+		            .then(() -> sp1.next(1))
+		            .then(() -> sp1.next(2))
+		            .then(() -> sp1.next(3))
 		            .expectNext(Arrays.asList(1, 2, 3))
-		            .then(() -> sp1.onNext(4))
-		            .then(() -> sp1.onError(new RuntimeException("forced failure")))
+		            .then(() -> sp1.next(4))
+		            .then(() -> sp1.error(new RuntimeException("forced failure")))
 		            .expectErrorMessage("forced failure")
 		            .verify();
 		assertFalse(sp1.hasDownstreams());
@@ -126,9 +126,9 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void predicateErrorUntil() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
-				sp1,
+				sp1.asFlux(),
 				i -> {
 					if (i == 5) throw new IllegalStateException("predicate failure");
 					return i % 3 == 0;
@@ -136,12 +136,12 @@ public class FluxBufferPredicateTest {
 
 		StepVerifier.create(bufferUntil)
 					.expectSubscription()
-					.then(() -> sp1.onNext(1))
-					.then(() -> sp1.onNext(2))
-					.then(() -> sp1.onNext(3))
+					.then(() -> sp1.next(1))
+					.then(() -> sp1.next(2))
+					.then(() -> sp1.next(3))
 					.expectNext(Arrays.asList(1, 2, 3))
-					.then(() -> sp1.onNext(4))
-					.then(() -> sp1.onNext(5))
+					.then(() -> sp1.next(4))
+					.then(() -> sp1.next(5))
 					.expectErrorMessage("predicate failure")
 					.verify();
 		assertFalse(sp1.hasDownstreams());
@@ -149,28 +149,28 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalUntilOther() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther = new FluxBufferPredicate<>(
-				sp1, i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE);
+				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE);
 
 		StepVerifier.create(bufferUntilOther)
 				.expectSubscription()
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(1))
-				.then(() -> sp1.onNext(2))
+				.then(() -> sp1.next(1))
+				.then(() -> sp1.next(2))
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(3))
+				.then(() -> sp1.next(3))
 				.expectNext(Arrays.asList(1, 2))
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(4))
-				.then(() -> sp1.onNext(5))
+				.then(() -> sp1.next(4))
+				.then(() -> sp1.next(5))
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(6))
+				.then(() -> sp1.next(6))
 				.expectNext(Arrays.asList(3, 4, 5))
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(7))
-				.then(() -> sp1.onNext(8))
-				.then(sp1::onComplete)
+				.then(() -> sp1.next(7))
+				.then(() -> sp1.next(8))
+				.then(sp1::complete)
 				.expectNext(Arrays.asList(6, 7, 8))
 				.expectComplete()
 				.verify();
@@ -180,19 +180,19 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void mainErrorUntilOther() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther =
-				new FluxBufferPredicate<>(sp1, i -> i % 3 == 0, Flux.listSupplier(),
+				new FluxBufferPredicate<>(sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(),
 						FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE);
 
 		StepVerifier.create(bufferUntilOther)
 		            .expectSubscription()
-		            .then(() -> sp1.onNext(1))
-		            .then(() -> sp1.onNext(2))
-		            .then(() -> sp1.onNext(3))
+		            .then(() -> sp1.next(1))
+		            .then(() -> sp1.next(2))
+		            .then(() -> sp1.next(3))
 		            .expectNext(Arrays.asList(1, 2))
-		            .then(() -> sp1.onNext(4))
-		            .then(() -> sp1.onError(new RuntimeException("forced failure")))
+		            .then(() -> sp1.next(4))
+		            .then(() -> sp1.error(new RuntimeException("forced failure")))
 		            .expectErrorMessage("forced failure")
 		            .verify();
 		assertFalse(sp1.hasDownstreams());
@@ -201,9 +201,9 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void predicateErrorUntilOther() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther =
-				new FluxBufferPredicate<>(sp1,
+				new FluxBufferPredicate<>(sp1.asFlux(),
 				i -> {
 					if (i == 5) throw new IllegalStateException("predicate failure");
 					return i % 3 == 0;
@@ -211,12 +211,12 @@ public class FluxBufferPredicateTest {
 
 		StepVerifier.create(bufferUntilOther)
 					.expectSubscription()
-					.then(() -> sp1.onNext(1))
-					.then(() -> sp1.onNext(2))
-					.then(() -> sp1.onNext(3))
+					.then(() -> sp1.next(1))
+					.then(() -> sp1.next(2))
+					.then(() -> sp1.next(3))
 					.expectNext(Arrays.asList(1, 2))
-					.then(() -> sp1.onNext(4))
-					.then(() -> sp1.onNext(5))
+					.then(() -> sp1.next(4))
+					.then(() -> sp1.next(5))
 					.expectErrorMessage("predicate failure")
 					.verify();
 		assertFalse(sp1.hasDownstreams());
@@ -225,29 +225,29 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalWhile() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
-				sp1, i -> i % 3 != 0, Flux.listSupplier(),
+				sp1.asFlux(), i -> i % 3 != 0, Flux.listSupplier(),
 				FluxBufferPredicate.Mode.WHILE);
 
 		StepVerifier.create(bufferWhile)
 				.expectSubscription()
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(1))
-				.then(() -> sp1.onNext(2))
+				.then(() -> sp1.next(1))
+				.then(() -> sp1.next(2))
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(3))
+				.then(() -> sp1.next(3))
 				.expectNext(Arrays.asList(1, 2))
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(4))
-				.then(() -> sp1.onNext(5))
+				.then(() -> sp1.next(4))
+				.then(() -> sp1.next(5))
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(6))
+				.then(() -> sp1.next(6))
 				.expectNext(Arrays.asList(4, 5))
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(7))
-				.then(() -> sp1.onNext(8))
-				.then(sp1::onComplete)
+				.then(() -> sp1.next(7))
+				.then(() -> sp1.next(8))
+				.then(sp1::complete)
 				.expectNext(Arrays.asList(7, 8))
 				.expectComplete()
 				.verify();
@@ -257,28 +257,28 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalWhileDoesntInitiallyMatch() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
-				sp1, i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
+				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
 
 		StepVerifier.create(bufferWhile)
 				.expectSubscription()
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(1))
-				.then(() -> sp1.onNext(2))
-				.then(() -> sp1.onNext(3))
+				.then(() -> sp1.next(1))
+				.then(() -> sp1.next(2))
+				.then(() -> sp1.next(3))
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(4))
+				.then(() -> sp1.next(4))
 				.expectNext(Arrays.asList(3)) //emission of 4 triggers the buffer emit
-				.then(() -> sp1.onNext(5))
-				.then(() -> sp1.onNext(6))
+				.then(() -> sp1.next(5))
+				.then(() -> sp1.next(6))
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(() -> sp1.onNext(7)) // emission of 7 triggers the buffer emit
+				.then(() -> sp1.next(7)) // emission of 7 triggers the buffer emit
 				.expectNext(Arrays.asList(6))
-				.then(() -> sp1.onNext(8))
-				.then(() -> sp1.onNext(9))
+				.then(() -> sp1.next(8))
+				.then(() -> sp1.next(9))
 				.expectNoEvent(Duration.ofMillis(10))
-				.then(sp1::onComplete) // completion triggers the buffer emit
+				.then(sp1::complete) // completion triggers the buffer emit
 			    .expectNext(Collections.singletonList(9))
 				.expectComplete()
 				.verify(Duration.ofSeconds(1));
@@ -288,24 +288,24 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalWhileDoesntMatch() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
-				sp1, i -> i > 4, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
+				sp1.asFlux(), i -> i > 4, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
 
 		StepVerifier.create(bufferWhile)
 		            .expectSubscription()
 		            .expectNoEvent(Duration.ofMillis(10))
-		            .then(() -> sp1.onNext(1))
-		            .then(() -> sp1.onNext(2))
-		            .then(() -> sp1.onNext(3))
-		            .then(() -> sp1.onNext(4))
+		            .then(() -> sp1.next(1))
+		            .then(() -> sp1.next(2))
+		            .then(() -> sp1.next(3))
+		            .then(() -> sp1.next(4))
 		            .expectNoEvent(Duration.ofMillis(10))
-		            .then(() -> sp1.onNext(1))
-		            .then(() -> sp1.onNext(2))
-		            .then(() -> sp1.onNext(3))
-		            .then(() -> sp1.onNext(4))
+		            .then(() -> sp1.next(1))
+		            .then(() -> sp1.next(2))
+		            .then(() -> sp1.next(3))
+		            .then(() -> sp1.next(4))
 		            .expectNoEvent(Duration.ofMillis(10))
-		            .then(sp1::onComplete)
+		            .then(sp1::complete)
 		            .expectComplete()
 		            .verify(Duration.ofSeconds(1));
 		assertFalse(sp1.hasDownstreams());
@@ -314,18 +314,18 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void mainErrorWhile() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
-				sp1, i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
+				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
 
 		StepVerifier.create(bufferWhile)
 		            .expectSubscription()
-		            .then(() -> sp1.onNext(1))
-		            .then(() -> sp1.onNext(2))
-		            .then(() -> sp1.onNext(3))
-		            .then(() -> sp1.onNext(4))
+		            .then(() -> sp1.next(1))
+		            .then(() -> sp1.next(2))
+		            .then(() -> sp1.next(3))
+		            .then(() -> sp1.next(4))
 		            .expectNext(Arrays.asList(3))
-		            .then(() -> sp1.onError(new RuntimeException("forced failure")))
+		            .then(() -> sp1.error(new RuntimeException("forced failure")))
 		            .expectErrorMessage("forced failure")
 		            .verify(Duration.ofMillis(100));
 		assertFalse(sp1.hasDownstreams());
@@ -334,9 +334,9 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void predicateErrorWhile() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
-				sp1,
+				sp1.asFlux(),
 				i -> {
 					if (i == 3) return true;
 					if (i == 5) throw new IllegalStateException("predicate failure");
@@ -345,12 +345,12 @@ public class FluxBufferPredicateTest {
 
 		StepVerifier.create(bufferWhile)
 					.expectSubscription()
-					.then(() -> sp1.onNext(1)) //ignored
-					.then(() -> sp1.onNext(2)) //ignored
-					.then(() -> sp1.onNext(3)) //buffered
-					.then(() -> sp1.onNext(4)) //ignored, emits buffer
+					.then(() -> sp1.next(1)) //ignored
+					.then(() -> sp1.next(2)) //ignored
+					.then(() -> sp1.next(3)) //buffered
+					.then(() -> sp1.next(4)) //ignored, emits buffer
 					.expectNext(Arrays.asList(3))
-					.then(() -> sp1.onNext(5)) //fails
+					.then(() -> sp1.next(5)) //fails
 					.expectErrorMessage("predicate failure")
 					.verify(Duration.ofMillis(100));
 		assertFalse(sp1.hasDownstreams());
@@ -359,9 +359,9 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void bufferSupplierThrows() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
-				sp1, i -> i % 3 == 0,
+				sp1.asFlux(), i -> i % 3 == 0,
 				() -> { throw new RuntimeException("supplier failure"); },
 				FluxBufferPredicate.Mode.UNTIL);
 
@@ -374,10 +374,10 @@ public class FluxBufferPredicateTest {
 
 	@Test
 	public void bufferSupplierThrowsLater() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		int count[] = {1};
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
-				sp1, i -> i % 3 == 0,
+				sp1.asFlux(), i -> i % 3 == 0,
 				() -> {
 					if (count[0]-- > 0) {
 						return new ArrayList<>();
@@ -389,26 +389,26 @@ public class FluxBufferPredicateTest {
 		Assert.assertFalse("sp1 has subscribers?", sp1.hasDownstreams());
 
 		StepVerifier.create(bufferUntil)
-		            .then(() -> sp1.onNext(1))
-		            .then(() -> sp1.onNext(2))
+		            .then(() -> sp1.next(1))
+		            .then(() -> sp1.next(2))
 		            .expectNoEvent(Duration.ofMillis(10))
-		            .then(() -> sp1.onNext(3))
+		            .then(() -> sp1.next(3))
 		            .expectErrorMessage("supplier failure")
 		            .verify();
 	}
 
 	@Test
 	public void bufferSupplierReturnsNull() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
-				sp1, i -> i % 3 == 0,
+				sp1.asFlux(), i -> i % 3 == 0,
 				() -> null,
 				FluxBufferPredicate.Mode.UNTIL);
 
 		Assert.assertFalse("sp1 has subscribers?", sp1.hasDownstreams());
 
 		StepVerifier.create(bufferUntil)
-		            .then(() -> sp1.onNext(1))
+		            .then(() -> sp1.next(1))
 		            .expectErrorMatches(t -> t instanceof NullPointerException &&
 		                "The bufferSupplier returned a null initial buffer".equals(t.getMessage()))
 		            .verify();
@@ -418,7 +418,7 @@ public class FluxBufferPredicateTest {
 	@SuppressWarnings("unchecked")
 	public void multipleTriggersOfEmptyBufferKeepInitialBuffer() {
 		//this is best demonstrated with bufferWhile:
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		LongAdder bufferCount = new LongAdder();
 		Supplier<List<Integer>> bufferSupplier = () -> {
 			bufferCount.increment();
@@ -427,20 +427,20 @@ public class FluxBufferPredicateTest {
 
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new
 				FluxBufferPredicate<>(
-				sp1, i -> i >= 10,
+				sp1.asFlux(), i -> i >= 10,
 				bufferSupplier,
 				FluxBufferPredicate.Mode.WHILE);
 
 		StepVerifier.create(bufferWhile)
 		            .then(() -> assertThat(bufferCount.intValue(), is(1)))
-		            .then(() -> sp1.onNext(1))
-		            .then(() -> sp1.onNext(2))
-		            .then(() -> sp1.onNext(3))
+		            .then(() -> sp1.next(1))
+		            .then(() -> sp1.next(2))
+		            .then(() -> sp1.next(3))
 		            .then(() -> assertThat(bufferCount.intValue(), is(1)))
 		            .expectNoEvent(Duration.ofMillis(10))
-		            .then(() -> sp1.onNext(10))
-		            .then(() -> sp1.onNext(11))
-		            .then(sp1::onComplete)
+		            .then(() -> sp1.next(10))
+		            .then(() -> sp1.next(11))
+		            .then(sp1::complete)
 		            .expectNext(Arrays.asList(10, 11))
 		            .then(() -> assertThat(bufferCount.intValue(), is(1)))
 		            .expectComplete()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
@@ -42,7 +42,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalUntil() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL);
 
@@ -106,7 +106,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void mainErrorUntil() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL);
 
@@ -126,7 +126,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void predicateErrorUntil() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(),
 				i -> {
@@ -149,7 +149,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalUntilOther() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE);
 
@@ -180,7 +180,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void mainErrorUntilOther() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther =
 				new FluxBufferPredicate<>(sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(),
 						FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE);
@@ -201,7 +201,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void predicateErrorUntilOther() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther =
 				new FluxBufferPredicate<>(sp1.asFlux(),
 				i -> {
@@ -225,7 +225,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalWhile() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 != 0, Flux.listSupplier(),
 				FluxBufferPredicate.Mode.WHILE);
@@ -257,7 +257,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalWhileDoesntInitiallyMatch() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
 
@@ -288,7 +288,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalWhileDoesntMatch() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i > 4, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
 
@@ -314,7 +314,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void mainErrorWhile() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
 
@@ -334,7 +334,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void predicateErrorWhile() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
 				sp1.asFlux(),
 				i -> {
@@ -359,7 +359,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void bufferSupplierThrows() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0,
 				() -> { throw new RuntimeException("supplier failure"); },
@@ -374,7 +374,7 @@ public class FluxBufferPredicateTest {
 
 	@Test
 	public void bufferSupplierThrowsLater() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		int count[] = {1};
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0,
@@ -399,7 +399,7 @@ public class FluxBufferPredicateTest {
 
 	@Test
 	public void bufferSupplierReturnsNull() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0,
 				() -> null,
@@ -418,7 +418,7 @@ public class FluxBufferPredicateTest {
 	@SuppressWarnings("unchecked")
 	public void multipleTriggersOfEmptyBufferKeepInitialBuffer() {
 		//this is best demonstrated with bufferWhile:
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		LongAdder bufferCount = new LongAdder();
 		Supplier<List<Integer>> bufferSupplier = () -> {
 			bufferCount.increment();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
@@ -111,7 +111,7 @@ public class FluxBufferWhenTest {
 		}
 
 		final CountDownLatch latch = new CountDownLatch(1);
-		final FluxProcessorSink<Wrapper> processor = Processors.unicast();
+		final FluxProcessorSink<Wrapper> processor = Processors.unicastSink();
 
 		Flux<Integer> emitter = Flux.range(1, 200)
 		                            .delayElements(Duration.ofMillis(25))
@@ -157,10 +157,10 @@ public class FluxBufferWhenTest {
 	public void normal() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
-		FluxProcessorSink<Integer> sp3 = Processors.direct();
-		FluxProcessorSink<Integer> sp4 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
+		FluxProcessorSink<Integer> sp3 = Processors.directSink();
+		FluxProcessorSink<Integer> sp4 = Processors.directSink();
 
 		sp1.asFlux()
 		   .bufferWhen(sp2.asFlux(), v -> v == 1 ? sp3.asFlux() : sp4.asFlux())
@@ -215,9 +215,9 @@ public class FluxBufferWhenTest {
 	public void startCompletes() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> source = Processors.direct();
-		FluxProcessorSink<Integer> open = Processors.direct();
-		FluxProcessorSink<Integer> close = Processors.direct();
+		FluxProcessorSink<Integer> source = Processors.directSink();
+		FluxProcessorSink<Integer> open = Processors.directSink();
+		FluxProcessorSink<Integer> close = Processors.directSink();
 
 		source.asFlux()
 		      .bufferWhen(open.asFlux(), v -> close.asFlux())
@@ -258,11 +258,11 @@ public class FluxBufferWhenTest {
 	@Test
 	public void bufferWillAcumulateMultipleListsOfValuesOverlap() {
 		//given: "a source and a collected flux"
-		FluxProcessorSink<Integer> numbers = Processors.emitter();
-		FluxProcessorSink<Integer> bucketOpening = Processors.emitter();
+		FluxProcessorSink<Integer> numbers = Processors.emitterSink();
+		FluxProcessorSink<Integer> bucketOpening = Processors.emitterSink();
 
 		//"overlapping buffers"
-		FluxProcessorSink<Integer> boundaryFlux = Processors.emitter();
+		FluxProcessorSink<Integer> boundaryFlux = Processors.emitterSink();
 
 		MonoProcessor<List<List<Integer>>> res = numbers.asFlux()
 		                                                .bufferWhen(bucketOpening.asFlux(), u -> boundaryFlux.asFlux())

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCombineLatestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCombineLatestTest.java
@@ -157,26 +157,26 @@ public class FluxCombineLatestTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void fused() {
-		DirectProcessor<Integer> dp1 = DirectProcessor.create();
-		DirectProcessor<Integer> dp2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> dp1 = Processors.direct();
+		FluxProcessorSink<Integer> dp2 = Processors.direct();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		ts.requestedFusionMode(Fuseable.ANY);
 
-		Flux.combineLatest(dp1, dp2, (a, b) -> a + b)
+		Flux.combineLatest(dp1.asFlux(), dp2.asFlux(), (a, b) -> a + b)
 		    .subscribe(ts);
 
-		dp1.onNext(1);
-		dp1.onNext(2);
+		dp1.next(1);
+		dp1.next(2);
 
-		dp2.onNext(10);
-		dp2.onNext(20);
-		dp2.onNext(30);
+		dp2.next(10);
+		dp2.next(20);
+		dp2.next(30);
 
-		dp1.onNext(3);
+		dp1.next(3);
 
-		dp1.onComplete();
-		dp2.onComplete();
+		dp1.complete();
+		dp2.complete();
 
 		ts.assertFuseableSource()
 		  .assertFusionMode(Fuseable.ASYNC)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCombineLatestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCombineLatestTest.java
@@ -157,8 +157,8 @@ public class FluxCombineLatestTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void fused() {
-		FluxProcessorSink<Integer> dp1 = Processors.direct();
-		FluxProcessorSink<Integer> dp2 = Processors.direct();
+		FluxProcessorSink<Integer> dp1 = Processors.directSink();
+		FluxProcessorSink<Integer> dp2 = Processors.directSink();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		ts.requestedFusionMode(Fuseable.ANY);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
@@ -277,32 +277,32 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void singleSubscriberOnly() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> source = DirectProcessor.create();
+		FluxProcessorSink<Integer> source = Processors.direct();
 
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
-		source.concatMap(v -> v == 1 ? source1 : source2)
+		source.asFlux().concatMap(v -> v == 1 ? source1.asFlux() : source2.asFlux())
 		      .subscribe(ts);
 
 		ts.assertNoValues()
 		  .assertNoError()
 		  .assertNotComplete();
 
-		source.onNext(1);
-		source.onNext(2);
+		source.next(1);
+		source.next(2);
 
 		Assert.assertTrue("source1 no subscribers?", source1.hasDownstreams());
 		Assert.assertFalse("source2 has subscribers?", source2.hasDownstreams());
 
-		source1.onNext(1);
-		source2.onNext(10);
+		source1.next(1);
+		source2.next(10);
 
-		source1.onComplete();
-		source.onComplete();
+		source1.complete();
+		source.complete();
 
-		source2.onNext(2);
-		source2.onComplete();
+		source2.next(2);
+		source2.complete();
 
 		ts.assertValues(1, 2)
 		  .assertNoError()
@@ -313,32 +313,32 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void singleSubscriberOnlyBoundary() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> source = DirectProcessor.create();
+		FluxProcessorSink<Integer> source = Processors.direct();
 
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
-		source.concatMapDelayError(v -> v == 1 ? source1 : source2)
+		source.asFlux().concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux())
 		      .subscribe(ts);
 
 		ts.assertNoValues()
 		  .assertNoError()
 		  .assertNotComplete();
 
-		source.onNext(1);
+		source.next(1);
 
 		Assert.assertTrue("source1 no subscribers?", source1.hasDownstreams());
 		Assert.assertFalse("source2 has subscribers?", source2.hasDownstreams());
 
-		source1.onNext(1);
-		source2.onNext(10);
+		source1.next(1);
+		source2.next(10);
 
-		source1.onComplete();
-		source.onNext(2);
-		source.onComplete();
+		source1.complete();
+		source.next(2);
+		source.complete();
 
-		source2.onNext(2);
-		source2.onComplete();
+		source2.next(2);
+		source2.complete();
 
 		ts.assertValues(1, 2)
 		  .assertNoError()
@@ -352,26 +352,26 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void mainErrorsImmediate() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> source = DirectProcessor.create();
+		FluxProcessorSink<Integer> source = Processors.direct();
 
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
-		source.concatMap(v -> v == 1 ? source1 : source2)
+		source.asFlux().concatMap(v -> v == 1 ? source1.asFlux() : source2.asFlux())
 		      .subscribe(ts);
 
 		ts.assertNoValues()
 		  .assertNoError()
 		  .assertNotComplete();
 
-		source.onNext(1);
+		source.next(1);
 
 		Assert.assertTrue("source1 no subscribers?", source1.hasDownstreams());
 		Assert.assertFalse("source2 has subscribers?", source2.hasDownstreams());
 
-		source1.onNext(1);
+		source1.next(1);
 
-		source.onError(new RuntimeException("forced failure"));
+		source.error(new RuntimeException("forced failure"));
 
 		ts.assertValues(1)
 		  .assertError(RuntimeException.class)
@@ -386,33 +386,33 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void mainErrorsBoundary() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> source = DirectProcessor.create();
+		FluxProcessorSink<Integer> source = Processors.direct();
 
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
-		source.concatMapDelayError(v -> v == 1 ? source1 : source2)
+		source.asFlux().concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux())
 		      .subscribe(ts);
 
 		ts.assertNoValues()
 		  .assertNoError()
 		  .assertNotComplete();
 
-		source.onNext(1);
+		source.next(1);
 
 		Assert.assertTrue("source1 no subscribers?", source1.hasDownstreams());
 		Assert.assertFalse("source2 has subscribers?", source2.hasDownstreams());
 
-		source1.onNext(1);
+		source1.next(1);
 
-		source.onError(new RuntimeException("forced failure"));
+		source.error(new RuntimeException("forced failure"));
 
 		ts.assertValues(1)
 		  .assertNoError()
 		  .assertNotComplete();
 
-		source1.onNext(2);
-		source1.onComplete();
+		source1.next(2);
+		source1.complete();
 
 		ts.assertValues(1, 2)
 		  .assertError(RuntimeException.class)
@@ -427,26 +427,26 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void innerErrorsImmediate() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> source = DirectProcessor.create();
+		FluxProcessorSink<Integer> source = Processors.direct();
 
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
-		source.concatMap(v -> v == 1 ? source1 : source2)
+		source.asFlux().concatMap(v -> v == 1 ? source1.asFlux() : source2.asFlux())
 		      .subscribe(ts);
 
 		ts.assertNoValues()
 		  .assertNoError()
 		  .assertNotComplete();
 
-		source.onNext(1);
+		source.next(1);
 
 		Assert.assertTrue("source1 no subscribers?", source1.hasDownstreams());
 		Assert.assertFalse("source2 has subscribers?", source2.hasDownstreams());
 
-		source1.onNext(1);
+		source1.next(1);
 
-		source1.onError(new RuntimeException("forced failure"));
+		source1.error(new RuntimeException("forced failure"));
 
 		ts.assertValues(1)
 		  .assertError(RuntimeException.class)
@@ -461,27 +461,27 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void innerErrorsBoundary() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> source = DirectProcessor.create();
+		FluxProcessorSink<Integer> source = Processors.direct();
 
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		//gh-1101: default changed from BOUNDARY to END
-		source.concatMapDelayError(v -> v == 1 ? source1 : source2, false, Queues.XS_BUFFER_SIZE)
+		source.asFlux().concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux(), false, Queues.XS_BUFFER_SIZE)
 		      .subscribe(ts);
 
 		ts.assertNoValues()
 		  .assertNoError()
 		  .assertNotComplete();
 
-		source.onNext(1);
+		source.next(1);
 
 		Assert.assertTrue("source1 no subscribers?", source1.hasDownstreams());
 		Assert.assertFalse("source2 has subscribers?", source2.hasDownstreams());
 
-		source1.onNext(1);
+		source1.next(1);
 
-		source1.onError(new RuntimeException("forced failure"));
+		source1.error(new RuntimeException("forced failure"));
 
 		ts.assertValues(1)
 		  .assertError(RuntimeException.class)
@@ -496,35 +496,35 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void innerErrorsEnd() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> source = DirectProcessor.create();
+		FluxProcessorSink<Integer> source = Processors.direct();
 
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
-		source.concatMapDelayError(v -> v == 1 ? source1 : source2, true, 32)
+		source.asFlux().concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux(), true, 32)
 		      .subscribe(ts);
 
 		ts.assertNoValues()
 		  .assertNoError()
 		  .assertNotComplete();
 
-		source.onNext(1);
+		source.next(1);
 
 		Assert.assertTrue("source1 no subscribers?", source1.hasDownstreams());
 		Assert.assertFalse("source2 has subscribers?", source2.hasDownstreams());
 
-		source1.onNext(1);
+		source1.next(1);
 
-		source1.onError(new RuntimeException("forced failure"));
+		source1.error(new RuntimeException("forced failure"));
 
-		source.onNext(2);
+		source.next(2);
 
 		Assert.assertTrue("source2 no subscribers?", source2.hasDownstreams());
 
-		source2.onNext(2);
-		source2.onComplete();
+		source2.next(2);
+		source2.complete();
 
-		source.onComplete();
+		source.complete();
 
 		ts.assertValues(1, 2)
 		  .assertError(RuntimeException.class)
@@ -568,12 +568,12 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void asyncFusionMapToNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		UnicastProcessor<Integer> up = UnicastProcessor.create(Queues.<Integer>get(2).get());
-		up.onNext(1);
-		up.onNext(2);
-		up.onComplete();
+		FluxProcessorSink<Integer> up = Processors.unicast(Queues.<Integer>get(2).get()).build();
+		up.next(1);
+		up.next(2);
+		up.complete();
 
-		up.map(v -> v == 2 ? null : v)
+		up.asFlux().map(v -> v == 2 ? null : v)
 		  .concatMap(Flux::just)
 		  .subscribe(ts);
 
@@ -586,13 +586,13 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void asyncFusionMapToNullFilter() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		UnicastProcessor<Integer> up =
-				UnicastProcessor.create(Queues.<Integer>get(2).get());
-		up.onNext(1);
-		up.onNext(2);
-		up.onComplete();
+		FluxProcessorSink<Integer> up =
+				Processors.unicast(Queues.<Integer>get(2).get()).build();
+		up.next(1);
+		up.next(2);
+		up.complete();
 
-		up.map(v -> v == 2 ? null : v)
+		up.asFlux().map(v -> v == 2 ? null : v)
 		  .filter(v -> true)
 		  .concatMap(Flux::just)
 		  .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
@@ -277,10 +277,10 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void singleSubscriberOnly() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> source = Processors.direct();
+		FluxProcessorSink<Integer> source = Processors.directSink();
 
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		source.asFlux().concatMap(v -> v == 1 ? source1.asFlux() : source2.asFlux())
 		      .subscribe(ts);
@@ -313,10 +313,10 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void singleSubscriberOnlyBoundary() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> source = Processors.direct();
+		FluxProcessorSink<Integer> source = Processors.directSink();
 
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		source.asFlux().concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux())
 		      .subscribe(ts);
@@ -352,10 +352,10 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void mainErrorsImmediate() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> source = Processors.direct();
+		FluxProcessorSink<Integer> source = Processors.directSink();
 
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		source.asFlux().concatMap(v -> v == 1 ? source1.asFlux() : source2.asFlux())
 		      .subscribe(ts);
@@ -386,10 +386,10 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void mainErrorsBoundary() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> source = Processors.direct();
+		FluxProcessorSink<Integer> source = Processors.directSink();
 
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		source.asFlux().concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux())
 		      .subscribe(ts);
@@ -427,10 +427,10 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void innerErrorsImmediate() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> source = Processors.direct();
+		FluxProcessorSink<Integer> source = Processors.directSink();
 
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		source.asFlux().concatMap(v -> v == 1 ? source1.asFlux() : source2.asFlux())
 		      .subscribe(ts);
@@ -461,10 +461,10 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void innerErrorsBoundary() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> source = Processors.direct();
+		FluxProcessorSink<Integer> source = Processors.directSink();
 
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		//gh-1101: default changed from BOUNDARY to END
 		source.asFlux().concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux(), false, Queues.XS_BUFFER_SIZE)
@@ -496,10 +496,10 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void innerErrorsEnd() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> source = Processors.direct();
+		FluxProcessorSink<Integer> source = Processors.directSink();
 
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		source.asFlux().concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux(), true, 32)
 		      .subscribe(ts);
@@ -568,7 +568,8 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 	public void asyncFusionMapToNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> up = Processors.unicast(Queues.<Integer>get(2).get()).build();
+		FluxProcessorSink<Integer> up = Processors.unicast(Queues.<Integer>get(2).get())
+		                                          .buildSink();
 		up.next(1);
 		up.next(2);
 		up.complete();
@@ -587,7 +588,8 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		FluxProcessorSink<Integer> up =
-				Processors.unicast(Queues.<Integer>get(2).get()).build();
+				Processors.unicast(Queues.<Integer>get(2).get())
+				          .buildSink();
 		up.next(1);
 		up.next(2);
 		up.complete();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
@@ -219,16 +219,17 @@ public class FluxDistinctUntilChangedTest extends FluxOperatorTest<String, Strin
 
 	@Test
 	public void allDistinctConditional() {
-		DirectProcessor<Integer> dp = new DirectProcessor<>();
+		FluxProcessorSink<Integer> dp = Processors.direct();
 
-		AssertSubscriber<Integer> ts = dp.distinctUntilChanged()
+		AssertSubscriber<Integer> ts = dp.asFlux()
+		                                 .distinctUntilChanged()
 		                                 .filter(v -> true)
 		                                 .subscribeWith(AssertSubscriber.create());
 
-		dp.onNext(1);
-		dp.onNext(2);
-		dp.onNext(3);
-		dp.onComplete();
+		dp.next(1);
+		dp.next(2);
+		dp.next(3);
+		dp.complete();
 
 		ts.assertValues(1, 2, 3).assertComplete();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
@@ -219,7 +219,7 @@ public class FluxDistinctUntilChangedTest extends FluxOperatorTest<String, Strin
 
 	@Test
 	public void allDistinctConditional() {
-		FluxProcessorSink<Integer> dp = Processors.direct();
+		FluxProcessorSink<Integer> dp = Processors.directSink();
 
 		AssertSubscriber<Integer> ts = dp.asFlux()
 		                                 .distinctUntilChanged()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDoFinallyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDoFinallyTest.java
@@ -138,7 +138,7 @@ public class FluxDoFinallyTest implements Consumer<SignalType> {
 
 	@Test
 	public void asyncFused() {
-		FluxProcessorSink<Integer> up = Processors.unicast();
+		FluxProcessorSink<Integer> up = Processors.unicastSink();
 		up.next(1);
 		up.next(2);
 		up.next(3);
@@ -158,7 +158,7 @@ public class FluxDoFinallyTest implements Consumer<SignalType> {
 
 	@Test
 	public void asyncFusedThreadBarrier() {
-		FluxProcessorSink<Integer> up = Processors.unicast();
+		FluxProcessorSink<Integer> up = Processors.unicastSink();
 		up.next(1);
 		up.next(2);
 		up.next(3);
@@ -280,7 +280,7 @@ public class FluxDoFinallyTest implements Consumer<SignalType> {
 
 	@Test
 	public void asyncFusedConditional() {
-		FluxProcessorSink<Integer> up = Processors.unicast();
+		FluxProcessorSink<Integer> up = Processors.unicastSink();
 		up.next(1);
 		up.next(2);
 		up.next(3);
@@ -301,7 +301,7 @@ public class FluxDoFinallyTest implements Consumer<SignalType> {
 
 	@Test
 	public void asyncFusedThreadBarrierConditional() {
-		FluxProcessorSink<Integer> up = Processors.unicast();
+		FluxProcessorSink<Integer> up = Processors.unicastSink();
 		up.next(1);
 		up.next(2);
 		up.next(3);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDoFinallyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDoFinallyTest.java
@@ -138,15 +138,15 @@ public class FluxDoFinallyTest implements Consumer<SignalType> {
 
 	@Test
 	public void asyncFused() {
-		UnicastProcessor<Integer> up = UnicastProcessor.create();
-		up.onNext(1);
-		up.onNext(2);
-		up.onNext(3);
-		up.onNext(4);
-		up.onNext(5);
-		up.onComplete();
+		FluxProcessorSink<Integer> up = Processors.unicast();
+		up.next(1);
+		up.next(2);
+		up.next(3);
+		up.next(4);
+		up.next(5);
+		up.complete();
 
-		StepVerifier.create(up.doFinally(this))
+		StepVerifier.create(up.asFlux().doFinally(this))
 		            .expectFusion(ASYNC)
 		            .expectNext(1, 2, 3, 4, 5)
 		            .expectComplete()
@@ -158,15 +158,15 @@ public class FluxDoFinallyTest implements Consumer<SignalType> {
 
 	@Test
 	public void asyncFusedThreadBarrier() {
-		UnicastProcessor<Integer> up = UnicastProcessor.create();
-		up.onNext(1);
-		up.onNext(2);
-		up.onNext(3);
-		up.onNext(4);
-		up.onNext(5);
-		up.onComplete();
+		FluxProcessorSink<Integer> up = Processors.unicast();
+		up.next(1);
+		up.next(2);
+		up.next(3);
+		up.next(4);
+		up.next(5);
+		up.complete();
 
-		StepVerifier.create(up.doFinally(this))
+		StepVerifier.create(up.asFlux().doFinally(this))
 		            .expectFusion(ASYNC | THREAD_BARRIER, NONE)
 		            .expectNext(1, 2, 3, 4, 5)
 		            .expectComplete()
@@ -280,15 +280,15 @@ public class FluxDoFinallyTest implements Consumer<SignalType> {
 
 	@Test
 	public void asyncFusedConditional() {
-		UnicastProcessor<Integer> up = UnicastProcessor.create();
-		up.onNext(1);
-		up.onNext(2);
-		up.onNext(3);
-		up.onNext(4);
-		up.onNext(5);
-		up.onComplete();
+		FluxProcessorSink<Integer> up = Processors.unicast();
+		up.next(1);
+		up.next(2);
+		up.next(3);
+		up.next(4);
+		up.next(5);
+		up.complete();
 
-		StepVerifier.create(up.doFinally(this)
+		StepVerifier.create(up.asFlux().doFinally(this)
 		                      .filter(i -> true))
 		            .expectFusion(ASYNC)
 		            .expectNext(1, 2, 3, 4, 5)
@@ -301,15 +301,15 @@ public class FluxDoFinallyTest implements Consumer<SignalType> {
 
 	@Test
 	public void asyncFusedThreadBarrierConditional() {
-		UnicastProcessor<Integer> up = UnicastProcessor.create();
-		up.onNext(1);
-		up.onNext(2);
-		up.onNext(3);
-		up.onNext(4);
-		up.onNext(5);
-		up.onComplete();
+		FluxProcessorSink<Integer> up = Processors.unicast();
+		up.next(1);
+		up.next(2);
+		up.next(3);
+		up.next(4);
+		up.next(5);
+		up.complete();
 
-		StepVerifier.create(up.doFinally(this)
+		StepVerifier.create(up.asFlux().doFinally(this)
 		                      .filter(i -> true))
 		            .expectFusion(ASYNC | THREAD_BARRIER, NONE)
 		            .expectNext(1, 2, 3, 4, 5)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
@@ -253,7 +253,7 @@ public class FluxFilterWhenTest {
 
 	@Test
 	public void cancel() {
-		final FluxProcessorSink<Boolean> pp = Processors.emitter();
+		final FluxProcessorSink<Boolean> pp = Processors.emitterSink();
 
 		StepVerifier.create(Flux.range(1, 5)
 		                        .filterWhen(v -> pp.asFlux(), 16))

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
@@ -253,10 +253,10 @@ public class FluxFilterWhenTest {
 
 	@Test
 	public void cancel() {
-		final EmitterProcessor<Boolean> pp = EmitterProcessor.create();
+		final FluxProcessorSink<Boolean> pp = Processors.emitter();
 
 		StepVerifier.create(Flux.range(1, 5)
-		                        .filterWhen(v -> pp, 16))
+		                        .filterWhen(v -> pp.asFlux(), 16))
 		            .thenCancel();
 
 		assertThat(pp.hasDownstreams()).isFalse();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -616,7 +616,7 @@ public class FluxFlatMapTest {
 		StepVerifier.create(up.asFlux().flatMap(Flux::just))
 		            .then(() -> {
 			            up.next(1);
-			            CoreSubscriber<? super Integer> a = ((InnerOperator<Integer, Integer>) up).actual();
+			            CoreSubscriber<? super Integer> a = ProcessorsTestUtils.unicastActual(up);
 			            up.complete();
 			            a.onNext(2);
 		            })

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -331,8 +331,8 @@ public class FluxFlatMapTest {
 
 		Flux<Integer> source = Flux.range(1, 2).doOnNext(v -> emission.getAndIncrement());
 
-		FluxProcessorSink<Integer> source1 = Processors.emitter();
-		FluxProcessorSink<Integer> source2 = Processors.emitter();
+		FluxProcessorSink<Integer> source1 = Processors.emitterSink();
+		FluxProcessorSink<Integer> source2 = Processors.emitterSink();
 
 		source.flatMap(v -> v == 1 ? source1.asFlux() : source2.asFlux(), 1, 32).subscribe(ts);
 
@@ -366,8 +366,8 @@ public class FluxFlatMapTest {
 
 		Flux<Integer> source = Flux.range(1, 1000).doOnNext(v -> emission.getAndIncrement());
 
-		FluxProcessorSink<Integer> source1 = Processors.emitter();
-		FluxProcessorSink<Integer> source2 = Processors.emitter();
+		FluxProcessorSink<Integer> source1 = Processors.emitterSink();
+		FluxProcessorSink<Integer> source2 = Processors.emitterSink();
 
 		source.flatMap(v -> v == 1 ? source1.asFlux() : source2.asFlux(), Integer.MAX_VALUE, 32).subscribe(ts);
 
@@ -608,7 +608,7 @@ public class FluxFlatMapTest {
 
 	@Test //FIXME use Violation.NO_CLEANUP_ON_TERMINATE
 	public void failNextOnTerminated() {
-		FluxProcessorSink<Integer> up = Processors.unicast();
+		FluxProcessorSink<Integer> up = Processors.unicastSink();
 
 		Hooks.onNextDropped(c -> {
 			assertThat(c).isEqualTo(2);
@@ -1029,7 +1029,7 @@ public class FluxFlatMapTest {
 
 		fmm.onSubscribe(Operators.emptySubscription());
 
-		FluxProcessorSink<Integer> ps = Processors.emitter();
+		FluxProcessorSink<Integer> ps = Processors.emitterSink();
 
 		fmm.onNext(ps.asFlux());
 
@@ -1155,7 +1155,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void asyncInnerFusion() {
-		FluxProcessorSink<Integer> up = Processors.unicast();
+		FluxProcessorSink<Integer> up = Processors.unicastSink();
 		StepVerifier.create(Flux.just(1)
 		                        .hide()
 		                        .flatMap(f -> up.asFlux(), 1))
@@ -1170,7 +1170,7 @@ public class FluxFlatMapTest {
 
 	@Test
 	public void failAsyncInnerFusion() {
-		FluxProcessorSink<Integer> up = Processors.unicast();
+		FluxProcessorSink<Integer> up = Processors.unicastSink();
 		StepVerifier.create(Flux.just(1)
 		                        .hide()
 		                        .flatMap(f -> up.asFlux(), 1))

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxGroupJoinTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxGroupJoinTest.java
@@ -45,25 +45,25 @@ public class FluxGroupJoinTest {
 	@Test
 	public void behaveAsJoin() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		Flux<Integer> m =
-				source1.groupJoin(source2, just(Flux.never()), just(Flux.never()), add2)
+				source1.asFlux().groupJoin(source2.asFlux(), just(Flux.never()), just(Flux.never()), add2)
 				       .flatMap(t -> t);
 
 		m.subscribe(ts);
 
-		source1.onNext(1);
-		source1.onNext(2);
-		source1.onNext(4);
+		source1.next(1);
+		source1.next(2);
+		source1.next(4);
 
-		source2.onNext(16);
-		source2.onNext(32);
-		source2.onNext(64);
+		source2.next(16);
+		source2.next(32);
+		source2.next(64);
 
-		source1.onComplete();
-		source2.onComplete();
+		source1.complete();
+		source2.complete();
 
 		ts.assertValues(17, 18, 20, 33, 34, 36, 65, 66, 68)
 		  .assertComplete()
@@ -137,16 +137,16 @@ public class FluxGroupJoinTest {
 	@Test
 	public void leftThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		Flux<Flux<Integer>> m =
-				source1.groupJoin(source2, just(Flux.never()), just(Flux.never()), add2);
+				source1.asFlux().groupJoin(source2.asFlux(), just(Flux.never()), just(Flux.never()), add2);
 
 		m.subscribe(ts);
 
-		source2.onNext(1);
-		source1.onError(new RuntimeException("Forced failure"));
+		source2.next(1);
+		source1.error(new RuntimeException("Forced failure"));
 
 		ts.assertErrorMessage("Forced failure")
 		  .assertNotComplete()
@@ -156,16 +156,16 @@ public class FluxGroupJoinTest {
 	@Test
 	public void rightThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		Flux<Flux<Integer>> m =
-				source1.groupJoin(source2, just(Flux.never()), just(Flux.never()), add2);
+				source1.asFlux().groupJoin(source2.asFlux(), just(Flux.never()), just(Flux.never()), add2);
 
 		m.subscribe(ts);
 
-		source1.onNext(1);
-		source2.onError(new RuntimeException("Forced failure"));
+		source1.next(1);
+		source2.error(new RuntimeException("Forced failure"));
 
 		ts.assertErrorMessage("Forced failure")
 		  .assertNotComplete()
@@ -175,16 +175,16 @@ public class FluxGroupJoinTest {
 	@Test
 	public void leftDurationThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		Flux<Integer> duration1 = Flux.error(new RuntimeException("Forced failure"));
 
 		Flux<Flux<Integer>> m =
-				source1.groupJoin(source2, just(duration1), just(Flux.never()), add2);
+				source1.asFlux().groupJoin(source2.asFlux(), just(duration1), just(Flux.never()), add2);
 		m.subscribe(ts);
 
-		source1.onNext(1);
+		source1.next(1);
 
 		ts.assertErrorMessage("Forced failure")
 		  .assertNotComplete()
@@ -194,16 +194,16 @@ public class FluxGroupJoinTest {
 	@Test
 	public void rightDurationThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		Flux<Integer> duration1 = Flux.error(new RuntimeException("Forced failure"));
 
 		Flux<Flux<Integer>> m =
-				source1.groupJoin(source2, just(Flux.never()), just(duration1), add2);
+				source1.asFlux().groupJoin(source2.asFlux(), just(Flux.never()), just(duration1), add2);
 		m.subscribe(ts);
 
-		source2.onNext(1);
+		source2.next(1);
 
 		ts.assertErrorMessage("Forced failure")
 		  .assertNotComplete()
@@ -213,18 +213,18 @@ public class FluxGroupJoinTest {
 	@Test
 	public void leftDurationSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		Function<Integer, Flux<Integer>> fail = t1 -> {
 			throw new RuntimeException("Forced failure");
 		};
 
 		Flux<Flux<Integer>> m =
-				source1.groupJoin(source2, fail, just(Flux.never()), add2);
+				source1.asFlux().groupJoin(source2.asFlux(), fail, just(Flux.never()), add2);
 		m.subscribe(ts);
 
-		source1.onNext(1);
+		source1.next(1);
 
 		ts.assertErrorMessage("Forced failure")
 		  .assertNotComplete()
@@ -234,18 +234,18 @@ public class FluxGroupJoinTest {
 	@Test
 	public void rightDurationSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		Function<Integer, Flux<Integer>> fail = t1 -> {
 			throw new RuntimeException("Forced failure");
 		};
 
 		Flux<Flux<Integer>> m =
-				source1.groupJoin(source2, just(Flux.never()), fail, add2);
+				source1.asFlux().groupJoin(source2.asFlux(), just(Flux.never()), fail, add2);
 		m.subscribe(ts);
 
-		source2.onNext(1);
+		source2.next(1);
 
 		ts.assertErrorMessage("Forced failure")
 		  .assertNotComplete()
@@ -255,19 +255,19 @@ public class FluxGroupJoinTest {
 	@Test
 	public void resultSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		BiFunction<Integer, Flux<Integer>, Integer> fail = (t1, t2) -> {
 			throw new RuntimeException("Forced failure");
 		};
 
 		Flux<Integer> m =
-				source1.groupJoin(source2, just(Flux.never()), just(Flux.never()), fail);
+				source1.asFlux().groupJoin(source2.asFlux(), just(Flux.never()), just(Flux.never()), fail);
 		m.subscribe(ts);
 
-		source1.onNext(1);
-		source2.onNext(2);
+		source1.next(1);
+		source2.next(2);
 
 		ts.assertErrorMessage("Forced failure")
 		  .assertNotComplete()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxGroupJoinTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxGroupJoinTest.java
@@ -45,8 +45,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void behaveAsJoin() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		Flux<Integer> m =
 				source1.asFlux().groupJoin(source2.asFlux(), just(Flux.never()), just(Flux.never()), add2)
@@ -137,8 +137,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void leftThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		Flux<Flux<Integer>> m =
 				source1.asFlux().groupJoin(source2.asFlux(), just(Flux.never()), just(Flux.never()), add2);
@@ -156,8 +156,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void rightThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		Flux<Flux<Integer>> m =
 				source1.asFlux().groupJoin(source2.asFlux(), just(Flux.never()), just(Flux.never()), add2);
@@ -175,8 +175,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void leftDurationThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		Flux<Integer> duration1 = Flux.error(new RuntimeException("Forced failure"));
 
@@ -194,8 +194,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void rightDurationThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		Flux<Integer> duration1 = Flux.error(new RuntimeException("Forced failure"));
 
@@ -213,8 +213,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void leftDurationSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		Function<Integer, Flux<Integer>> fail = t1 -> {
 			throw new RuntimeException("Forced failure");
@@ -234,8 +234,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void rightDurationSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		Function<Integer, Flux<Integer>> fail = t1 -> {
 			throw new RuntimeException("Forced failure");
@@ -255,8 +255,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void resultSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		BiFunction<Integer, Flux<Integer>, Integer> fail = (t1, t2) -> {
 			throw new RuntimeException("Forced failure");

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxJoinTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxJoinTest.java
@@ -39,8 +39,8 @@ public class FluxJoinTest {
 	public void normal1() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		Flux<Integer> m =
 				source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(Flux.never()), add);
@@ -66,10 +66,10 @@ public class FluxJoinTest {
 	@Test
 	public void normal1WithDuration() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
-		FluxProcessorSink<Integer> duration1 = Processors.direct();
+		FluxProcessorSink<Integer> duration1 = Processors.directSink();
 
 		Flux<Integer> m = source1.asFlux().join(source2.asFlux(), just(duration1.asFlux()), just(Flux.never()), add);
 		m.subscribe(ts);
@@ -95,8 +95,8 @@ public class FluxJoinTest {
 	@Test
 	public void normal2() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		Flux<Integer> m =
 				source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(Flux.never()), add);
@@ -121,8 +121,8 @@ public class FluxJoinTest {
 	@Test
 	public void leftThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		Flux<Integer> m =
 				source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(Flux.never()), add);
@@ -140,8 +140,8 @@ public class FluxJoinTest {
 	@Test
 	public void rightThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		Flux<Integer> m =
 				source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(Flux.never()), add);
@@ -159,8 +159,8 @@ public class FluxJoinTest {
 	@Test
 	public void leftDurationThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		Flux<Integer> duration1 = Flux.error(new RuntimeException("Forced failure"));
 
@@ -177,8 +177,8 @@ public class FluxJoinTest {
 	@Test
 	public void rightDurationThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		Flux<Integer> duration1 = Flux.error(new RuntimeException("Forced failure"));
 
@@ -195,8 +195,8 @@ public class FluxJoinTest {
 	@Test
 	public void leftDurationSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		Function<Integer, Flux<Integer>> fail = t1 -> {
 			throw new RuntimeException("Forced failure");
@@ -215,8 +215,8 @@ public class FluxJoinTest {
 	@Test
 	public void rightDurationSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		Function<Integer, Flux<Integer>> fail = t1 -> {
 			throw new RuntimeException("Forced failure");
@@ -235,8 +235,8 @@ public class FluxJoinTest {
 	@Test
 	public void resultSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		FluxProcessorSink<Integer> source1 = Processors.direct();
-		FluxProcessorSink<Integer> source2 = Processors.direct();
+		FluxProcessorSink<Integer> source1 = Processors.directSink();
+		FluxProcessorSink<Integer> source2 = Processors.directSink();
 
 		BiFunction<Integer, Integer, Integer> fail = (t1, t2) -> {
 			throw new RuntimeException("Forced failure");

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxJoinTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxJoinTest.java
@@ -39,24 +39,24 @@ public class FluxJoinTest {
 	public void normal1() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		Flux<Integer> m =
-				source1.join(source2, just(Flux.never()), just(Flux.never()), add);
+				source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(Flux.never()), add);
 
 		m.subscribe(ts);
 
-		source1.onNext(1);
-		source1.onNext(2);
-		source1.onNext(4);
+		source1.next(1);
+		source1.next(2);
+		source1.next(4);
 
-		source2.onNext(16);
-		source2.onNext(32);
-		source2.onNext(64);
+		source2.next(16);
+		source2.next(32);
+		source2.next(64);
 
-		source1.onComplete();
-		source2.onComplete();
+		source1.complete();
+		source2.complete();
 
 		ts.assertValues(17, 18, 20, 33, 34, 36, 65, 66, 68)
 		  .assertComplete()
@@ -66,25 +66,25 @@ public class FluxJoinTest {
 	@Test
 	public void normal1WithDuration() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
-		DirectProcessor<Integer> duration1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> duration1 = Processors.direct();
 
-		Flux<Integer> m = source1.join(source2, just(duration1), just(Flux.never()), add);
+		Flux<Integer> m = source1.asFlux().join(source2.asFlux(), just(duration1.asFlux()), just(Flux.never()), add);
 		m.subscribe(ts);
 
-		source1.onNext(1);
-		source1.onNext(2);
-		source2.onNext(16);
+		source1.next(1);
+		source1.next(2);
+		source2.next(16);
 
-		duration1.onNext(1);
+		duration1.next(1);
 
-		source1.onNext(4);
-		source1.onNext(8);
+		source1.next(4);
+		source1.next(8);
 
-		source1.onComplete();
-		source2.onComplete();
+		source1.complete();
+		source2.complete();
 
 		ts.assertValues(17, 18, 20, 24)
 		  .assertComplete()
@@ -95,23 +95,23 @@ public class FluxJoinTest {
 	@Test
 	public void normal2() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		Flux<Integer> m =
-				source1.join(source2, just(Flux.never()), just(Flux.never()), add);
+				source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(Flux.never()), add);
 
 		m.subscribe(ts);
 
-		source1.onNext(1);
-		source1.onNext(2);
-		source1.onComplete();
+		source1.next(1);
+		source1.next(2);
+		source1.complete();
 
-		source2.onNext(16);
-		source2.onNext(32);
-		source2.onNext(64);
+		source2.next(16);
+		source2.next(32);
+		source2.next(64);
 
-		source2.onComplete();
+		source2.complete();
 
 		ts.assertValues(17, 18, 33, 34, 65, 66)
 		  .assertComplete()
@@ -121,16 +121,16 @@ public class FluxJoinTest {
 	@Test
 	public void leftThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		Flux<Integer> m =
-				source1.join(source2, just(Flux.never()), just(Flux.never()), add);
+				source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(Flux.never()), add);
 
 		m.subscribe(ts);
 
-		source2.onNext(1);
-		source1.onError(new RuntimeException("Forced failure"));
+		source2.next(1);
+		source1.error(new RuntimeException("Forced failure"));
 
 		ts.assertErrorMessage("Forced failure")
 		  .assertNotComplete()
@@ -140,16 +140,16 @@ public class FluxJoinTest {
 	@Test
 	public void rightThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		Flux<Integer> m =
-				source1.join(source2, just(Flux.never()), just(Flux.never()), add);
+				source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(Flux.never()), add);
 
 		m.subscribe(ts);
 
-		source1.onNext(1);
-		source2.onError(new RuntimeException("Forced failure"));
+		source1.next(1);
+		source2.error(new RuntimeException("Forced failure"));
 
 		ts.assertErrorMessage("Forced failure")
 		  .assertNotComplete()
@@ -159,15 +159,15 @@ public class FluxJoinTest {
 	@Test
 	public void leftDurationThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		Flux<Integer> duration1 = Flux.error(new RuntimeException("Forced failure"));
 
-		Flux<Integer> m = source1.join(source2, just(duration1), just(Flux.never()), add);
+		Flux<Integer> m = source1.asFlux().join(source2.asFlux(), just(duration1), just(Flux.never()), add);
 		m.subscribe(ts);
 
-		source1.onNext(1);
+		source1.next(1);
 
 		ts.assertErrorMessage("Forced failure")
 		  .assertNotComplete()
@@ -177,15 +177,15 @@ public class FluxJoinTest {
 	@Test
 	public void rightDurationThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		Flux<Integer> duration1 = Flux.error(new RuntimeException("Forced failure"));
 
-		Flux<Integer> m = source1.join(source2, just(Flux.never()), just(duration1), add);
+		Flux<Integer> m = source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(duration1), add);
 		m.subscribe(ts);
 
-		source2.onNext(1);
+		source2.next(1);
 
 		ts.assertErrorMessage("Forced failure")
 		  .assertNotComplete()
@@ -195,17 +195,17 @@ public class FluxJoinTest {
 	@Test
 	public void leftDurationSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		Function<Integer, Flux<Integer>> fail = t1 -> {
 			throw new RuntimeException("Forced failure");
 		};
 
-		Flux<Integer> m = source1.join(source2, fail, just(Flux.never()), add);
+		Flux<Integer> m = source1.asFlux().join(source2.asFlux(), fail, just(Flux.never()), add);
 		m.subscribe(ts);
 
-		source1.onNext(1);
+		source1.next(1);
 
 		ts.assertErrorMessage("Forced failure")
 		  .assertNotComplete()
@@ -215,17 +215,17 @@ public class FluxJoinTest {
 	@Test
 	public void rightDurationSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		Function<Integer, Flux<Integer>> fail = t1 -> {
 			throw new RuntimeException("Forced failure");
 		};
 
-		Flux<Integer> m = source1.join(source2, just(Flux.never()), fail, add);
+		Flux<Integer> m = source1.asFlux().join(source2.asFlux(), just(Flux.never()), fail, add);
 		m.subscribe(ts);
 
-		source2.onNext(1);
+		source2.next(1);
 
 		ts.assertErrorMessage("Forced failure")
 		  .assertNotComplete()
@@ -235,19 +235,19 @@ public class FluxJoinTest {
 	@Test
 	public void resultSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		DirectProcessor<Integer> source1 = DirectProcessor.create();
-		DirectProcessor<Integer> source2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> source1 = Processors.direct();
+		FluxProcessorSink<Integer> source2 = Processors.direct();
 
 		BiFunction<Integer, Integer, Integer> fail = (t1, t2) -> {
 			throw new RuntimeException("Forced failure");
 		};
 
 		Flux<Integer> m =
-				source1.join(source2, just(Flux.never()), just(Flux.never()), fail);
+				source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(Flux.never()), fail);
 		m.subscribe(ts);
 
-		source1.onNext(1);
-		source2.onNext(2);
+		source1.next(1);
+		source2.next(2);
 
 		ts.assertErrorMessage("Forced failure")
 		  .assertNotComplete()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
@@ -81,7 +81,8 @@ public class FluxMergeSequentialTest {
 	@Test
 	public void normalFusedAsync() {
 		StepVerifier.create(Flux.range(1, 5)
-		                        .subscribeWith(UnicastProcessor.create())
+		                        .subscribeWith(Processors.unicast())
+		                        .asFlux()
 		                        .flatMapSequential(t -> Flux.range(t, 2)))
 		            .expectNext(1, 2, 2, 3, 3, 4, 4, 5, 5, 6)
 		            .verifyComplete();
@@ -141,8 +142,8 @@ public class FluxMergeSequentialTest {
 
 	@Test
 	public void mainErrorsDelayEnd() {
-		FluxProcessorSink<Integer> main = Processors.direct();
-		final FluxProcessorSink<Integer> inner = Processors.direct();
+		FluxProcessorSink<Integer> main = Processors.directSink();
+		final FluxProcessorSink<Integer> inner = Processors.directSink();
 
 		AssertSubscriber<Integer> ts = main.asFlux()
 		                                   .flatMapSequentialDelayError(t -> inner.asFlux(), 32, 32)
@@ -168,8 +169,8 @@ public class FluxMergeSequentialTest {
 
 	@Test
 	public void mainErrorsImmediate() {
-		FluxProcessorSink<Integer> main = Processors.direct();
-		final FluxProcessorSink<Integer> inner = Processors.direct();
+		FluxProcessorSink<Integer> main = Processors.directSink();
+		final FluxProcessorSink<Integer> inner = Processors.directSink();
 
 		AssertSubscriber<Integer> ts = main.asFlux().flatMapSequential(t -> inner.asFlux())
 		                                   .subscribeWith(AssertSubscriber.create());
@@ -461,7 +462,7 @@ public class FluxMergeSequentialTest {
 
 	@Test
 	public void testReentrantWork() {
-		final FluxProcessorSink<Integer> subject = Processors.direct();
+		final FluxProcessorSink<Integer> subject = Processors.directSink();
 
 		final AtomicBoolean once = new AtomicBoolean();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
@@ -66,7 +66,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void drop() {
-		FluxProcessorSink<String> processor = Processors.direct();
+		FluxProcessorSink<String> processor = Processors.directSink();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, this, DROP_LATEST);
@@ -94,7 +94,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void dropOldest() {
-		FluxProcessorSink<String> processor = Processors.direct();
+		FluxProcessorSink<String> processor = Processors.directSink();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, this, DROP_OLDEST);
@@ -122,7 +122,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void error() {
-		FluxProcessorSink<String> processor = Processors.direct();
+		FluxProcessorSink<String> processor = Processors.directSink();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, this, ERROR);
@@ -150,7 +150,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void dropCallbackError() {
-		FluxProcessorSink<String> processor = Processors.direct();
+		FluxProcessorSink<String> processor = Processors.directSink();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, v -> { throw new IllegalArgumentException("boom"); },
@@ -180,7 +180,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void dropOldestCallbackError() {
-		FluxProcessorSink<String> processor = Processors.direct();
+		FluxProcessorSink<String> processor = Processors.directSink();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, v -> { throw new IllegalArgumentException("boom"); },
@@ -210,7 +210,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void errorCallbackError() {
-		FluxProcessorSink<String> processor = Processors.direct();
+		FluxProcessorSink<String> processor = Processors.directSink();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, v -> { throw new IllegalArgumentException("boom"); },
@@ -240,7 +240,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void noCallbackWithErrorStrategyOnErrorImmediately() {
-		FluxProcessorSink<String> processor = Processors.direct();
+		FluxProcessorSink<String> processor = Processors.directSink();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, null, ERROR);
@@ -268,7 +268,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void noCallbackWithDropStrategyNoError() {
-		FluxProcessorSink<String> processor = Processors.direct();
+		FluxProcessorSink<String> processor = Processors.directSink();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, null, DROP_LATEST);
@@ -296,7 +296,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void noCallbackWithDropOldestStrategyNoError() {
-		FluxProcessorSink<String> processor = Processors.direct();
+		FluxProcessorSink<String> processor = Processors.directSink();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, null, DROP_OLDEST);
@@ -324,7 +324,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void fluxOnBackpressureBufferStrategyNoCallback() {
-		FluxProcessorSink<String> processor = Processors.direct();
+		FluxProcessorSink<String> processor = Processors.directSink();
 
 		StepVerifier.create(processor.asFlux().onBackpressureBuffer(2, DROP_OLDEST), 0)
 		            .thenRequest(1)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
@@ -66,19 +66,19 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void drop() {
-		DirectProcessor<String> processor = DirectProcessor.create();
+		FluxProcessorSink<String> processor = Processors.direct();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
-				processor, 2, this, DROP_LATEST);
+				processor.asFlux(), 2, this, DROP_LATEST);
 
 		StepVerifier.create(flux, 0)
 		            .thenRequest(1)
 		            .then(() -> {
-			            processor.onNext("normal");
-			            processor.onNext("over1");
-			            processor.onNext("over2");
-			            processor.onNext("over3");
-			            processor.onComplete();
+			            processor.next("normal");
+			            processor.next("over1");
+			            processor.next("over2");
+			            processor.next("over3");
+			            processor.complete();
 		            })
 		            .expectNext("normal")
 		            .thenAwait()
@@ -94,19 +94,19 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void dropOldest() {
-		DirectProcessor<String> processor = DirectProcessor.create();
+		FluxProcessorSink<String> processor = Processors.direct();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
-				processor, 2, this, DROP_OLDEST);
+				processor.asFlux(), 2, this, DROP_OLDEST);
 
 		StepVerifier.create(flux, 0)
 		            .thenRequest(1)
 		            .then(() -> {
-			            processor.onNext("normal");
-			            processor.onNext("over1");
-			            processor.onNext("over2");
-			            processor.onNext("over3");
-			            processor.onComplete();
+			            processor.next("normal");
+			            processor.next("over1");
+			            processor.next("over2");
+			            processor.next("over3");
+			            processor.complete();
 		            })
 		            .expectNext("normal")
 		            .thenAwait()
@@ -122,19 +122,19 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void error() {
-		DirectProcessor<String> processor = DirectProcessor.create();
+		FluxProcessorSink<String> processor = Processors.direct();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
-				processor, 2, this, ERROR);
+				processor.asFlux(), 2, this, ERROR);
 
 		StepVerifier.create(flux, 0)
 		            .thenRequest(1)
 		            .then(() -> {
-			            processor.onNext("normal");
-			            processor.onNext("over1");
-			            processor.onNext("over2");
-			            processor.onNext("over3");
-			            processor.onComplete();
+			            processor.next("normal");
+			            processor.next("over1");
+			            processor.next("over2");
+			            processor.next("over3");
+			            processor.complete();
 		            })
 		            .expectNext("normal")
 		            .thenAwait()
@@ -150,20 +150,20 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void dropCallbackError() {
-		DirectProcessor<String> processor = DirectProcessor.create();
+		FluxProcessorSink<String> processor = Processors.direct();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
-				processor, 2, v -> { throw new IllegalArgumentException("boom"); },
+				processor.asFlux(), 2, v -> { throw new IllegalArgumentException("boom"); },
 				DROP_LATEST);
 
 		StepVerifier.create(flux, 0)
 		            .thenRequest(1)
 		            .then(() -> {
-			            processor.onNext("normal");
-			            processor.onNext("over1");
-			            processor.onNext("over2");
-			            processor.onNext("over3");
-			            processor.onComplete();
+			            processor.next("normal");
+			            processor.next("over1");
+			            processor.next("over2");
+			            processor.next("over3");
+			            processor.complete();
 		            })
 		            .expectNext("normal")
 		            .thenAwait()
@@ -180,20 +180,20 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void dropOldestCallbackError() {
-		DirectProcessor<String> processor = DirectProcessor.create();
+		FluxProcessorSink<String> processor = Processors.direct();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
-				processor, 2, v -> { throw new IllegalArgumentException("boom"); },
+				processor.asFlux(), 2, v -> { throw new IllegalArgumentException("boom"); },
 				DROP_OLDEST);
 
 		StepVerifier.create(flux, 0)
 		            .thenRequest(1)
 		            .then(() -> {
-			            processor.onNext("normal");
-			            processor.onNext("over1");
-			            processor.onNext("over2");
-			            processor.onNext("over3");
-			            processor.onComplete();
+			            processor.next("normal");
+			            processor.next("over1");
+			            processor.next("over2");
+			            processor.next("over3");
+			            processor.complete();
 		            })
 		            .expectNext("normal")
 		            .thenAwait()
@@ -210,20 +210,20 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void errorCallbackError() {
-		DirectProcessor<String> processor = DirectProcessor.create();
+		FluxProcessorSink<String> processor = Processors.direct();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
-				processor, 2, v -> { throw new IllegalArgumentException("boom"); },
+				processor.asFlux(), 2, v -> { throw new IllegalArgumentException("boom"); },
 				ERROR);
 
 		StepVerifier.create(flux, 0)
 		            .thenRequest(1)
 		            .then(() -> {
-			            processor.onNext("normal");
-			            processor.onNext("over1");
-			            processor.onNext("over2");
-			            processor.onNext("over3");
-			            processor.onComplete();
+			            processor.next("normal");
+			            processor.next("over1");
+			            processor.next("over2");
+			            processor.next("over3");
+			            processor.complete();
 		            })
 		            .expectNext("normal")
 		            .thenAwait()
@@ -240,19 +240,19 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void noCallbackWithErrorStrategyOnErrorImmediately() {
-		DirectProcessor<String> processor = DirectProcessor.create();
+		FluxProcessorSink<String> processor = Processors.direct();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
-				processor, 2, null, ERROR);
+				processor.asFlux(), 2, null, ERROR);
 
 		StepVerifier.create(flux, 0)
 		            .thenRequest(1)
 		            .then(() -> {
-			            processor.onNext("normal");
-			            processor.onNext("over1");
-			            processor.onNext("over2");
-			            processor.onNext("over3");
-			            processor.onComplete();
+			            processor.next("normal");
+			            processor.next("over1");
+			            processor.next("over2");
+			            processor.next("over3");
+			            processor.complete();
 		            })
 		            .expectNext("normal")
 		            .thenAwait()
@@ -268,19 +268,19 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void noCallbackWithDropStrategyNoError() {
-		DirectProcessor<String> processor = DirectProcessor.create();
+		FluxProcessorSink<String> processor = Processors.direct();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
-				processor, 2, null, DROP_LATEST);
+				processor.asFlux(), 2, null, DROP_LATEST);
 
 		StepVerifier.create(flux, 0)
 		            .thenRequest(1)
 		            .then(() -> {
-			            processor.onNext("normal");
-			            processor.onNext("over1");
-			            processor.onNext("over2");
-			            processor.onNext("over3");
-			            processor.onComplete();
+			            processor.next("normal");
+			            processor.next("over1");
+			            processor.next("over2");
+			            processor.next("over3");
+			            processor.complete();
 		            })
 		            .expectNext("normal")
 		            .thenAwait()
@@ -296,19 +296,19 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void noCallbackWithDropOldestStrategyNoError() {
-		DirectProcessor<String> processor = DirectProcessor.create();
+		FluxProcessorSink<String> processor = Processors.direct();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
-				processor, 2, null, DROP_OLDEST);
+				processor.asFlux(), 2, null, DROP_OLDEST);
 
 		StepVerifier.create(flux, 0)
 		            .thenRequest(1)
 		            .then(() -> {
-			            processor.onNext("normal");
-			            processor.onNext("over1");
-			            processor.onNext("over2");
-			            processor.onNext("over3");
-			            processor.onComplete();
+			            processor.next("normal");
+			            processor.next("over1");
+			            processor.next("over2");
+			            processor.next("over3");
+			            processor.complete();
 		            })
 		            .expectNext("normal")
 		            .thenAwait()
@@ -324,16 +324,16 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void fluxOnBackpressureBufferStrategyNoCallback() {
-		DirectProcessor<String> processor = DirectProcessor.create();
+		FluxProcessorSink<String> processor = Processors.direct();
 
-		StepVerifier.create(processor.onBackpressureBuffer(2, DROP_OLDEST), 0)
+		StepVerifier.create(processor.asFlux().onBackpressureBuffer(2, DROP_OLDEST), 0)
 		            .thenRequest(1)
 		            .then(() -> {
-			            processor.onNext("normal");
-			            processor.onNext("over1");
-			            processor.onNext("over2");
-			            processor.onNext("over3");
-			            processor.onComplete();
+			            processor.next("normal");
+			            processor.next("over1");
+			            processor.next("over2");
+			            processor.next("over3");
+			            processor.complete();
 		            })
 		            .expectNext("normal")
 		            .thenAwait()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureDropTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureDropTest.java
@@ -89,7 +89,7 @@ public class FluxOnBackpressureDropTest {
 
 	@Test
 	public void someDrops() {
-		FluxProcessorSink<Integer> tp = Processors.direct();
+		FluxProcessorSink<Integer> tp = Processors.directSink();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureDropTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureDropTest.java
@@ -89,27 +89,28 @@ public class FluxOnBackpressureDropTest {
 
 	@Test
 	public void someDrops() {
-		DirectProcessor<Integer> tp = DirectProcessor.create();
+		FluxProcessorSink<Integer> tp = Processors.direct();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
 		List<Integer> drops = new ArrayList<>();
 
-		tp.onBackpressureDrop(drops::add)
+		tp.asFlux()
+		  .onBackpressureDrop(drops::add)
 		  .subscribe(ts);
 
-		tp.onNext(1);
+		tp.next(1);
 
 		ts.request(2);
 
-		tp.onNext(2);
-		tp.onNext(3);
-		tp.onNext(4);
+		tp.next(2);
+		tp.next(3);
+		tp.next(4);
 
 		ts.request(1);
 
-		tp.onNext(5);
-		tp.onComplete();
+		tp.next(5);
+		tp.complete();
 
 		ts.assertValues(2, 3, 5)
 		  .assertComplete()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureLatestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureLatestTest.java
@@ -44,19 +44,20 @@ public class FluxOnBackpressureLatestTest {
 
 	@Test
 	public void backpressured() {
-		DirectProcessor<Integer> tp = DirectProcessor.create();
+		FluxProcessorSink<Integer> tp = Processors.direct();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
-		tp.onBackpressureLatest().subscribe(ts);
+		tp.asFlux()
+		  .onBackpressureLatest().subscribe(ts);
 
-		tp.onNext(1);
+		tp.next(1);
 
 		ts.assertNoValues()
 		  .assertNoError()
 		  .assertNotComplete();
 
-		tp.onNext(2);
+		tp.next(2);
 
 		ts.request(1);
 
@@ -64,8 +65,8 @@ public class FluxOnBackpressureLatestTest {
 		  .assertNoError()
 		  .assertNotComplete();
 
-		tp.onNext(3);
-		tp.onNext(4);
+		tp.next(3);
+		tp.next(4);
 
 		ts.request(2);
 
@@ -73,8 +74,8 @@ public class FluxOnBackpressureLatestTest {
 		  .assertNoError()
 		  .assertNotComplete();
 
-		tp.onNext(5);
-		tp.onComplete();
+		tp.next(5);
+		tp.complete();
 
 		ts.assertValues(2, 4, 5)
 		  .assertNoError()
@@ -83,13 +84,14 @@ public class FluxOnBackpressureLatestTest {
 
 	@Test
 	public void error() {
-		DirectProcessor<Integer> tp = DirectProcessor.create();
+		FluxProcessorSink<Integer> tp = Processors.direct();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
-		tp.onBackpressureLatest().subscribe(ts);
+		tp.asFlux()
+		  .onBackpressureLatest().subscribe(ts);
 
-		tp.onError(new RuntimeException("forced failure"));
+		tp.error(new RuntimeException("forced failure"));
 
 		ts.assertNoValues()
 		  .assertNotComplete()
@@ -99,23 +101,24 @@ public class FluxOnBackpressureLatestTest {
 
 	@Test
 	public void backpressureWithDrop() {
-		DirectProcessor<Integer> tp = DirectProcessor.create();
+		FluxProcessorSink<Integer> tp = Processors.direct();
 
 		AssertSubscriber<Integer> ts = new AssertSubscriber<Integer>(0) {
 			@Override
 			public void onNext(Integer t) {
 				super.onNext(t);
 				if (t == 2) {
-					tp.onNext(3);
+					tp.next(3);
 				}
 			}
 		};
 
-		tp.onBackpressureLatest()
+		tp.asFlux()
+		  .onBackpressureLatest()
 		  .subscribe(ts);
 
-		tp.onNext(1);
-		tp.onNext(2);
+		tp.next(1);
+		tp.next(2);
 
 		ts.request(1);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureLatestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureLatestTest.java
@@ -44,7 +44,7 @@ public class FluxOnBackpressureLatestTest {
 
 	@Test
 	public void backpressured() {
-		FluxProcessorSink<Integer> tp = Processors.direct();
+		FluxProcessorSink<Integer> tp = Processors.directSink();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
@@ -84,7 +84,7 @@ public class FluxOnBackpressureLatestTest {
 
 	@Test
 	public void error() {
-		FluxProcessorSink<Integer> tp = Processors.direct();
+		FluxProcessorSink<Integer> tp = Processors.directSink();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
@@ -101,7 +101,7 @@ public class FluxOnBackpressureLatestTest {
 
 	@Test
 	public void backpressureWithDrop() {
-		FluxProcessorSink<Integer> tp = Processors.direct();
+		FluxProcessorSink<Integer> tp = Processors.directSink();
 
 		AssertSubscriber<Integer> ts = new AssertSubscriber<Integer>(0) {
 			@Override

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnErrorResumeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnErrorResumeTest.java
@@ -155,7 +155,7 @@ public class FluxOnErrorResumeTest {
 
 	@Test
 	public void someFirst() {
-		FluxProcessorSink<Integer> tp = Processors.emitter();
+		FluxProcessorSink<Integer> tp = Processors.emitterSink();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -177,7 +177,7 @@ public class FluxOnErrorResumeTest {
 
 	@Test
 	public void someFirstBackpressured() {
-		FluxProcessorSink<Integer> tp = Processors.emitter();
+		FluxProcessorSink<Integer> tp = Processors.emitterSink();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(10);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnErrorResumeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnErrorResumeTest.java
@@ -155,19 +155,20 @@ public class FluxOnErrorResumeTest {
 
 	@Test
 	public void someFirst() {
-		EmitterProcessor<Integer> tp = EmitterProcessor.create();
+		FluxProcessorSink<Integer> tp = Processors.emitter();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		tp.onErrorResume(v -> Flux.range(11, 10))
+		tp.asFlux()
+		  .onErrorResume(v -> Flux.range(11, 10))
 		  .subscribe(ts);
 
-		tp.onNext(1);
-		tp.onNext(2);
-		tp.onNext(3);
-		tp.onNext(4);
-		tp.onNext(5);
-		tp.onError(new RuntimeException("forced failure"));
+		tp.next(1);
+		tp.next(2);
+		tp.next(3);
+		tp.next(4);
+		tp.next(5);
+		tp.error(new RuntimeException("forced failure"));
 
 		ts.assertValues(1, 2, 3, 4, 5, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20)
 		  .assertNoError()
@@ -176,19 +177,20 @@ public class FluxOnErrorResumeTest {
 
 	@Test
 	public void someFirstBackpressured() {
-		EmitterProcessor<Integer> tp = EmitterProcessor.create();
+		FluxProcessorSink<Integer> tp = Processors.emitter();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(10);
 
-		tp.onErrorResume(v -> Flux.range(11, 10))
+		tp.asFlux()
+		  .onErrorResume(v -> Flux.range(11, 10))
 		  .subscribe(ts);
 
-		tp.onNext(1);
-		tp.onNext(2);
-		tp.onNext(3);
-		tp.onNext(4);
-		tp.onNext(5);
-		tp.onError(new RuntimeException("forced failure"));
+		tp.next(1);
+		tp.next(2);
+		tp.next(3);
+		tp.next(4);
+		tp.next(5);
+		tp.error(new RuntimeException("forced failure"));
 
 		ts.assertValues(1, 2, 3, 4, 5, 11, 12, 13, 14, 15)
 		  .assertNotComplete()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
@@ -498,10 +498,11 @@ public class FluxPeekFuseableTest {
 	public void asyncFusionAvailable() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		UnicastProcessor.create(Queues.<Integer>get(2).get())
-		                .doOnNext(v -> {
-		                })
-		                .subscribe(ts);
+		Processors.unicast(Queues.<Integer>get(2).get()).build()
+		          .asFlux()
+		          .doOnNext(v -> {
+		          })
+		          .subscribe(ts);
 
 		Subscription s = ts.upstream();
 		Assert.assertTrue("Non-fuseable upstream" + s,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
@@ -498,7 +498,8 @@ public class FluxPeekFuseableTest {
 	public void asyncFusionAvailable() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Processors.unicast(Queues.<Integer>get(2).get()).build()
+		Processors.unicast(Queues.<Integer>get(2).get())
+		          .buildSink()
 		          .asFlux()
 		          .doOnNext(v -> {
 		          })

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
@@ -736,7 +736,8 @@ public class FluxPeekTest extends FluxOperatorTest<String, String> {
 	public void asyncFusionAvailable() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Processors.unicast(Queues.<Integer>get(2).get()).build()
+		Processors.unicast(Queues.<Integer>get(2).get())
+		          .buildSink()
 		          .asFlux()
 		          .doOnNext(v -> { })
 		          .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
@@ -736,10 +736,10 @@ public class FluxPeekTest extends FluxOperatorTest<String, String> {
 	public void asyncFusionAvailable() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		UnicastProcessor.create(Queues.<Integer>get(2).get())
-		                .doOnNext(v -> {
-		                })
-		                .subscribe(ts);
+		Processors.unicast(Queues.<Integer>get(2).get()).build()
+		          .asFlux()
+		          .doOnNext(v -> { })
+		          .subscribe(ts);
 
 		Subscription s = ts.upstream();
 		Assert.assertTrue("Non-fuseable upstream" + s,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxProcessorTest.java
@@ -32,6 +32,7 @@ import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("deprecation")
 public class FluxProcessorTest {
 
 	@Test(expected = NullPointerException.class)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
@@ -76,7 +76,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
 				scenario(f -> f.publish(p -> Flux.just("test", "test1", "test2")))
 						.fusionMode(Fuseable.SYNC),
 
-				scenario(f -> f.publish(p -> p.subscribeWith(UnicastProcessor.create()), 256))
+				scenario(f -> f.publish(p -> p.subscribeWith(Processors.unicast()).asFlux(), 256))
 						.fusionMode(Fuseable.ASYNC),
 
 
@@ -156,7 +156,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		FluxProcessorSink<Integer> up =
-				Processors.unicast(Queues.<Integer>get(16).get()).build();
+				Processors.unicast(Queues.<Integer>get(16).get()).buildSink();
 
 		up.asFlux()
 		  .publish(o -> zip((Object[] a) -> (Integer) a[0] + (Integer) a[1], o, o.skip(1)))
@@ -178,7 +178,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
 	public void cancelComposes() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp = Processors.emitter();
+		FluxProcessorSink<Integer> sp = Processors.emitterSink();
 
 		sp.asFlux()
 		  .publish(o -> Flux.<Integer>never())
@@ -195,7 +195,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
 	public void cancelComposes2() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp = Processors.emitter();
+		FluxProcessorSink<Integer> sp = Processors.emitterSink();
 
 		sp.asFlux()
 		  .publish(o -> Flux.<Integer>empty())

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
@@ -243,15 +243,16 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	public void normalAsyncFused() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		UnicastProcessor<Integer> up =
-				UnicastProcessor.create(new ConcurrentLinkedQueue<>());
+		FluxProcessorSink<Integer> up =
+				Processors.unicast(new ConcurrentLinkedQueue<Integer>()).build();
 
 		for (int i = 0; i < 1_000_000; i++) {
-			up.onNext(i);
+			up.next(i);
 		}
-		up.onComplete();
+		up.complete();
 
-		up.publishOn(Schedulers.fromExecutorService(exec))
+		up.asFlux()
+		  .publishOn(Schedulers.fromExecutorService(exec))
 		  .subscribe(ts);
 
 		ts.await(Duration.ofSeconds(5));
@@ -263,15 +264,15 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void normalAsyncFusedBackpressured() throws Exception {
-		UnicastProcessor<Integer> up =
-				UnicastProcessor.create(Queues.<Integer>unbounded(1024).get());
+		FluxProcessorSink<Integer> up =
+				Processors.unicast(Queues.<Integer>unbounded(1024).get()).build();
 
 		for (int i = 0; i < 1_000_000; i++) {
-			up.onNext(0);
+			up.next(0);
 		}
-		up.onComplete();
+		up.complete();
 
-		StepVerifier.create(up.publishOn(Schedulers.fromExecutorService(exec)), 0)
+		StepVerifier.create(up.asFlux().publishOn(Schedulers.fromExecutorService(exec)), 0)
 		            .expectSubscription()
 		            .thenRequest(500_000)
 		            .expectNextCount(500_000)
@@ -451,12 +452,12 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 
 	public void diamond() {
 
-		DirectProcessor<Integer> sp = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp = Processors.direct();
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Flux<Integer> fork1 = sp.map(d -> d)
+		Flux<Integer> fork1 = sp.asFlux().map(d -> d)
 		                        .publishOn(Schedulers.fromExecutorService(exec));
-		Flux<Integer> fork2 = sp.map(d -> d)
+		Flux<Integer> fork2 = sp.asFlux().map(d -> d)
 		                        .publishOn(Schedulers.fromExecutorService(exec));
 
 		ts.request(256);
@@ -467,7 +468,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		Flux.range(0, 128)
 		    .hide()
 		    .publishOn(Schedulers.fromExecutorService(ForkJoinPool.commonPool()))
-		    .subscribe(sp);
+		    .subscribe(sp.asProcessor());
 
 		ts.await(Duration.ofSeconds(5))
 		  .assertTerminated()
@@ -694,13 +695,14 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void mappedAsyncSourceWithNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
-		UnicastProcessor<Integer> up =
-				UnicastProcessor.create(Queues.<Integer>get(2).get());
-		up.onNext(1);
-		up.onNext(2);
-		up.onComplete();
+		FluxProcessorSink<Integer> up =
+				Processors.unicast(Queues.<Integer>get(2).get()).build();
+		up.next(1);
+		up.next(2);
+		up.complete();
 
-		up.map(v -> v == 2 ? null : v)
+		up.asFlux()
+		  .map(v -> v == 2 ? null : v)
 		  .publishOn(Schedulers.fromExecutorService(exec))
 		  .subscribe(ts);
 
@@ -714,13 +716,14 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void mappedAsyncSourceWithNullPostFilter() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
-		UnicastProcessor<Integer> up =
-				UnicastProcessor.create(Queues.<Integer>get(2).get());
-		up.onNext(1);
-		up.onNext(2);
-		up.onComplete();
+		FluxProcessorSink<Integer> up =
+				Processors.unicast(Queues.<Integer>get(2).get()).build();
+		up.next(1);
+		up.next(2);
+		up.complete();
 
-		up.map(v -> v == 2 ? null : v)
+		up.asFlux()
+		  .map(v -> v == 2 ? null : v)
 		  .publishOn(Schedulers.fromExecutorService(exec))
 		  .filter(v -> true)
 		  .subscribe(ts);
@@ -796,18 +799,19 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void threadBoundaryPreventsInvalidFusionMap() {
-		UnicastProcessor<Integer> up =
-				UnicastProcessor.create(Queues.<Integer>get(2).get());
+		FluxProcessorSink<Integer> up =
+				Processors.unicast(Queues.<Integer>get(2).get()).build();
 
 		AssertSubscriber<String> ts = AssertSubscriber.create();
 
-		up.map(v -> Thread.currentThread()
+		up.asFlux()
+		  .map(v -> Thread.currentThread()
 		                  .getName())
 		  .publishOn(Schedulers.fromExecutorService(exec))
 		  .subscribe(ts);
 
-		up.onNext(1);
-		up.onComplete();
+		up.next(1);
+		up.complete();
 
 		ts.await(Duration.ofSeconds(5));
 
@@ -819,21 +823,22 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void threadBoundaryPreventsInvalidFusionFilter() {
-		UnicastProcessor<Integer> up =
-				UnicastProcessor.create(Queues.<Integer>get(2).get());
+		FluxProcessorSink<Integer> up =
+				Processors.unicast(Queues.<Integer>get(2).get()).build();
 
 		String s = Thread.currentThread()
 		                 .getName();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		up.filter(v -> s.equals(Thread.currentThread()
+		up.asFlux()
+		  .filter(v -> s.equals(Thread.currentThread()
 		                              .getName()))
 		  .publishOn(Schedulers.fromExecutorService(exec))
 		  .subscribe(ts);
 
-		up.onNext(1);
-		up.onComplete();
+		up.next(1);
+		up.complete();
 
 		ts.await(Duration.ofSeconds(5));
 
@@ -1171,11 +1176,11 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		final ConcurrentHashMap<Object, Long> seenInternal = new ConcurrentHashMap<>();
 		final ConcurrentHashMap<Object, Long> seenConsumer = new ConcurrentHashMap<>();
 
-		EmitterProcessor<Integer> d = EmitterProcessor.create();
-		FluxSink<Integer> s = d.sink();
+		FluxProcessorSink<Integer> d = Processors.emitter();
 
 		/*Disposable c = */
-		d.publishOn(Schedulers.parallel())
+		d.asFlux()
+		 .publishOn(Schedulers.parallel())
 		 .parallel(8)
 		 .groups()
 		 .subscribe(stream -> stream.publishOn(Schedulers.parallel())
@@ -1222,7 +1227,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		                            }));
 
 		for (int i = 0; i < COUNT; i++) {
-			s.next(i);
+			d.next(i);
 		}
 
 		internalLatch.await(5, TimeUnit.SECONDS);
@@ -1237,10 +1242,10 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		CountDownLatch latch = new CountDownLatch(items);
 		Random random = ThreadLocalRandom.current();
 
-		EmitterProcessor<String> d = EmitterProcessor.create();
-		FluxSink<String> s = d.sink();
+		FluxProcessorSink<String> d = Processors.emitter();
 
-		Flux<Integer> tasks = d.publishOn(Schedulers.parallel())
+		Flux<Integer> tasks = d.asFlux()
+		                       .publishOn(Schedulers.parallel())
 		                       .parallel(8)
 		                       .groups()
 		                       .flatMap(stream -> stream.publishOn(Schedulers.parallel())
@@ -1262,7 +1267,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		});
 
 		for (int i = 1; i <= items; i++) {
-			s.next(String.valueOf(i));
+			d.next(String.valueOf(i));
 		}
 		latch.await(15, TimeUnit.SECONDS);
 		assertTrue(latch.getCount() + " of " + items + " items were not counted down",

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
@@ -244,7 +244,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		FluxProcessorSink<Integer> up =
-				Processors.unicast(new ConcurrentLinkedQueue<Integer>()).build();
+				Processors.unicast(new ConcurrentLinkedQueue<Integer>()).buildSink();
 
 		for (int i = 0; i < 1_000_000; i++) {
 			up.next(i);
@@ -265,7 +265,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void normalAsyncFusedBackpressured() throws Exception {
 		FluxProcessorSink<Integer> up =
-				Processors.unicast(Queues.<Integer>unbounded(1024).get()).build();
+				Processors.unicast(Queues.<Integer>unbounded(1024).get()).buildSink();
 
 		for (int i = 0; i < 1_000_000; i++) {
 			up.next(0);
@@ -452,7 +452,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 
 	public void diamond() {
 
-		FluxProcessorSink<Integer> sp = Processors.direct();
+		FluxProcessorFacade<Integer> sp = Processors.direct();
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		Flux<Integer> fork1 = sp.asFlux().map(d -> d)
@@ -696,7 +696,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	public void mappedAsyncSourceWithNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		FluxProcessorSink<Integer> up =
-				Processors.unicast(Queues.<Integer>get(2).get()).build();
+				Processors.unicast(Queues.<Integer>get(2).get()).buildSink();
 		up.next(1);
 		up.next(2);
 		up.complete();
@@ -717,7 +717,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	public void mappedAsyncSourceWithNullPostFilter() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		FluxProcessorSink<Integer> up =
-				Processors.unicast(Queues.<Integer>get(2).get()).build();
+				Processors.unicast(Queues.<Integer>get(2).get()).buildSink();
 		up.next(1);
 		up.next(2);
 		up.complete();
@@ -800,7 +800,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void threadBoundaryPreventsInvalidFusionMap() {
 		FluxProcessorSink<Integer> up =
-				Processors.unicast(Queues.<Integer>get(2).get()).build();
+				Processors.unicast(Queues.<Integer>get(2).get()).buildSink();
 
 		AssertSubscriber<String> ts = AssertSubscriber.create();
 
@@ -824,7 +824,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void threadBoundaryPreventsInvalidFusionFilter() {
 		FluxProcessorSink<Integer> up =
-				Processors.unicast(Queues.<Integer>get(2).get()).build();
+				Processors.unicast(Queues.<Integer>get(2).get()).buildSink();
 
 		String s = Thread.currentThread()
 		                 .getName();
@@ -1176,7 +1176,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		final ConcurrentHashMap<Object, Long> seenInternal = new ConcurrentHashMap<>();
 		final ConcurrentHashMap<Object, Long> seenConsumer = new ConcurrentHashMap<>();
 
-		FluxProcessorSink<Integer> d = Processors.emitter();
+		FluxProcessorSink<Integer> d = Processors.emitterSink();
 
 		/*Disposable c = */
 		d.asFlux()
@@ -1242,7 +1242,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		CountDownLatch latch = new CountDownLatch(items);
 		Random random = ThreadLocalRandom.current();
 
-		FluxProcessorSink<String> d = Processors.emitter();
+		FluxProcessorSink<String> d = Processors.emitterSink();
 
 		Flux<Integer> tasks = d.asFlux()
 		                       .publishOn(Schedulers.parallel())

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
@@ -468,7 +468,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		Flux.range(0, 128)
 		    .hide()
 		    .publishOn(Schedulers.fromExecutorService(ForkJoinPool.commonPool()))
-		    .subscribe(sp.asProcessor());
+		    .subscribe(sp);
 
 		ts.await(Duration.ofSeconds(5))
 		  .assertTerminated()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
@@ -206,7 +206,8 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts1 = AssertSubscriber.create();
 		AssertSubscriber<Integer> ts2 = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> up = Processors.unicast(Queues.<Integer>get(8).get()).build();
+		FluxProcessorSink<Integer> up = Processors.unicast(Queues.<Integer>get(8).get())
+		                                          .buildSink();
 		up.next(1);
 		up.next(2);
 		up.next(3);
@@ -245,7 +246,8 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts1 = AssertSubscriber.create(0);
 		AssertSubscriber<Integer> ts2 = AssertSubscriber.create(0);
 
-		FluxProcessorSink<Integer> up = Processors.unicast(Queues.<Integer>get(8).get()).build();
+		FluxProcessorSink<Integer> up = Processors.unicast(Queues.<Integer>get(8).get())
+		                                          .buildSink();
 		up.next(1);
 		up.next(2);
 		up.next(3);
@@ -393,7 +395,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 	public void disconnect() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> e = Processors.emitter();
+		FluxProcessorSink<Integer> e = Processors.emitterSink();
 
 		ConnectableFlux<Integer> p = e.asFlux().publish();
 
@@ -417,7 +419,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 	public void disconnectBackpressured() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
-		FluxProcessorSink<Integer> e = Processors.emitter();
+		FluxProcessorSink<Integer> e = Processors.emitterSink();
 
 		ConnectableFlux<Integer> p = e.asFlux().publish();
 
@@ -438,7 +440,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 	public void error() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> e = Processors.emitter();
+		FluxProcessorSink<Integer> e = Processors.emitterSink();
 
 		ConnectableFlux<Integer> p = e.asFlux().publish();
 
@@ -474,7 +476,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void retry() {
-		FluxProcessorSink<Integer> dp = Processors.direct();
+		FluxProcessorSink<Integer> dp = Processors.directSink();
 		StepVerifier.create(
 				dp.asFlux()
 				  .publish()
@@ -501,7 +503,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void retryWithPublishOn() {
-		FluxProcessorSink<Integer> dp = Processors.direct();
+		FluxProcessorSink<Integer> dp = Processors.directSink();
 		StepVerifier.create(
 				dp.asFlux()
 				  .publishOn(Schedulers.parallel()).publish()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
@@ -84,7 +84,7 @@ public class FluxRefCountTest {
 
 	@Test
 	public void normal() {
-		FluxProcessorSink<Integer> e = Processors.emitter();
+		FluxProcessorSink<Integer> e = Processors.emitterSink();
 
 		Flux<Integer> p = e.asFlux().publish().refCount();
 
@@ -124,7 +124,7 @@ public class FluxRefCountTest {
 
 	@Test
 	public void normalTwoSubscribers() {
-		FluxProcessorSink<Integer> e = Processors.emitter();
+		FluxProcessorSink<Integer> e = Processors.emitterSink();
 
 		Flux<Integer> p = e.asFlux().publish().refCount(2);
 
@@ -285,7 +285,7 @@ public class FluxRefCountTest {
 
 	@Test
 	public void delayElementShouldNotCancelTwice() throws Exception {
-		FluxProcessorSink<Long> p = Processors.direct();
+		FluxProcessorSink<Long> p = Processors.directSink();
 		AtomicInteger cancellations = new AtomicInteger();
 
 		Flux<Long> publishedFlux = p

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
@@ -84,9 +84,9 @@ public class FluxRefCountTest {
 
 	@Test
 	public void normal() {
-		EmitterProcessor<Integer> e = EmitterProcessor.create();
+		FluxProcessorSink<Integer> e = Processors.emitter();
 
-		Flux<Integer> p = e.publish().refCount();
+		Flux<Integer> p = e.asFlux().publish().refCount();
 
 		Assert.assertFalse("sp has subscribers?", e.downstreamCount() != 0);
 
@@ -100,14 +100,14 @@ public class FluxRefCountTest {
 
 		Assert.assertTrue("sp has no subscribers?", e.downstreamCount() != 0);
 
-		e.onNext(1);
-		e.onNext(2);
+		e.next(1);
+		e.next(2);
 
 		ts1.cancel();
 
 		Assert.assertTrue("sp has no subscribers?", e.downstreamCount() != 0);
 
-		e.onNext(3);
+		e.next(3);
 
 		ts2.cancel();
 
@@ -124,9 +124,9 @@ public class FluxRefCountTest {
 
 	@Test
 	public void normalTwoSubscribers() {
-		EmitterProcessor<Integer> e = EmitterProcessor.create();
+		FluxProcessorSink<Integer> e = Processors.emitter();
 
-		Flux<Integer> p = e.publish().refCount(2);
+		Flux<Integer> p = e.asFlux().publish().refCount(2);
 
 		Assert.assertFalse("sp has subscribers?", e.downstreamCount() != 0);
 
@@ -140,14 +140,14 @@ public class FluxRefCountTest {
 
 		Assert.assertTrue("sp has no subscribers?", e.downstreamCount() != 0);
 
-		e.onNext(1);
-		e.onNext(2);
+		e.next(1);
+		e.next(2);
 
 		ts1.cancel();
 
 		Assert.assertTrue("sp has no subscribers?", e.downstreamCount() != 0);
 
-		e.onNext(3);
+		e.next(3);
 
 		ts2.cancel();
 
@@ -285,13 +285,14 @@ public class FluxRefCountTest {
 
 	@Test
 	public void delayElementShouldNotCancelTwice() throws Exception {
-		DirectProcessor<Long> p = DirectProcessor.create();
+		FluxProcessorSink<Long> p = Processors.direct();
 		AtomicInteger cancellations = new AtomicInteger();
 
 		Flux<Long> publishedFlux = p
-			.publish()
-			.refCount(2)
-			.doOnCancel(() -> cancellations.incrementAndGet());
+				.asFlux()
+				.publish()
+				.refCount(2)
+				.doOnCancel(() -> cancellations.incrementAndGet());
 
 		publishedFlux.any(x -> x > 5)
 			.delayElement(Duration.ofMillis(2))
@@ -300,10 +301,10 @@ public class FluxRefCountTest {
 		CompletableFuture<List<Long>> result = publishedFlux.collectList().toFuture();
 
 		for (long i = 0; i < 10; i++) {
-			p.onNext(i);
+			p.next(i);
 			Thread.sleep(1);
 		}
-		p.onComplete();
+		p.complete();
 
 		assertThat(result.get(10, TimeUnit.MILLISECONDS).size()).isEqualTo(10);
 		assertThat(cancellations.get()).isEqualTo(2);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSampleFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSampleFirstTest.java
@@ -33,38 +33,39 @@ public class FluxSampleFirstTest {
 	public void normal() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
-		DirectProcessor<Integer> sp3 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp3 = Processors.direct();
 
-		sp1.sampleFirst(v -> v == 1 ? sp2 : sp3)
+		sp1.asFlux()
+		   .sampleFirst(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
 		   .subscribe(ts);
 
-		sp1.onNext(1);
+		sp1.next(1);
 
 		ts.assertValues(1)
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp1.onNext(2);
+		sp1.next(2);
 
 		ts.assertValues(1)
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp2.onNext(1);
+		sp2.next(1);
 
 		ts.assertValues(1)
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp1.onNext(3);
+		sp1.next(3);
 
 		ts.assertValues(1, 3)
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp1.onComplete();
+		sp1.complete();
 
 		ts.assertValues(1, 3)
 		  .assertNoError()
@@ -79,15 +80,16 @@ public class FluxSampleFirstTest {
 	public void mainError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
-		DirectProcessor<Integer> sp3 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp3 = Processors.direct();
 
-		sp1.sampleFirst(v -> v == 1 ? sp2 : sp3)
+		sp1.asFlux()
+		   .sampleFirst(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
 		   .subscribe(ts);
 
-		sp1.onNext(1);
-		sp1.onError(new RuntimeException("forced failure"));
+		sp1.next(1);
+		sp1.error(new RuntimeException("forced failure"));
 
 		ts.assertValues(1)
 		  .assertError(RuntimeException.class)
@@ -103,15 +105,16 @@ public class FluxSampleFirstTest {
 	public void throttlerError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
-		DirectProcessor<Integer> sp3 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp3 = Processors.direct();
 
-		sp1.sampleFirst(v -> v == 1 ? sp2 : sp3)
+		sp1.asFlux()
+		   .sampleFirst(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
 		   .subscribe(ts);
 
-		sp1.onNext(1);
-		sp2.onError(new RuntimeException("forced failure"));
+		sp1.next(1);
+		sp2.error(new RuntimeException("forced failure"));
 
 		ts.assertValues(1)
 		  .assertError(RuntimeException.class)
@@ -127,14 +130,15 @@ public class FluxSampleFirstTest {
 	public void throttlerThrows() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 
-		sp1.sampleFirst(v -> {
+		sp1.asFlux()
+		   .sampleFirst(v -> {
 			throw new RuntimeException("forced failure");
 		})
 		   .subscribe(ts);
 
-		sp1.onNext(1);
+		sp1.next(1);
 
 		ts.assertValues(1)
 		  .assertError(RuntimeException.class)
@@ -148,12 +152,13 @@ public class FluxSampleFirstTest {
 	public void throttlerReturnsNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 
-		sp1.sampleFirst(v -> null)
+		sp1.asFlux()
+		   .sampleFirst(v -> null)
 		   .subscribe(ts);
 
-		sp1.onNext(1);
+		sp1.next(1);
 
 		ts.assertValues(1)
 		  .assertError(NullPointerException.class)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSampleFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSampleFirstTest.java
@@ -33,9 +33,9 @@ public class FluxSampleFirstTest {
 	public void normal() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
-		FluxProcessorSink<Integer> sp3 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
+		FluxProcessorSink<Integer> sp3 = Processors.directSink();
 
 		sp1.asFlux()
 		   .sampleFirst(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
@@ -80,9 +80,9 @@ public class FluxSampleFirstTest {
 	public void mainError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
-		FluxProcessorSink<Integer> sp3 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
+		FluxProcessorSink<Integer> sp3 = Processors.directSink();
 
 		sp1.asFlux()
 		   .sampleFirst(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
@@ -105,9 +105,9 @@ public class FluxSampleFirstTest {
 	public void throttlerError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
-		FluxProcessorSink<Integer> sp3 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
+		FluxProcessorSink<Integer> sp3 = Processors.directSink();
 
 		sp1.asFlux()
 		   .sampleFirst(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
@@ -130,7 +130,7 @@ public class FluxSampleFirstTest {
 	public void throttlerThrows() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 
 		sp1.asFlux()
 		   .sampleFirst(v -> {
@@ -152,7 +152,7 @@ public class FluxSampleFirstTest {
 	public void throttlerReturnsNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 
 		sp1.asFlux()
 		   .sampleFirst(v -> null)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTest.java
@@ -42,59 +42,59 @@ public class FluxSampleTest {
 	}
 
 	void sample(boolean complete, boolean which) {
-		DirectProcessor<Integer> main = DirectProcessor.create();
+		FluxProcessorSink<Integer> main = Processors.direct();
 
-		DirectProcessor<String> other = DirectProcessor.create();
+		FluxProcessorSink<String> other = Processors.direct();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		main.sample(other).subscribe(ts);
+		main.asFlux().sample(other.asFlux()).subscribe(ts);
 
 		ts.assertNoValues()
 		  .assertNotComplete()
 		  .assertNoError();
 
-		main.onNext(1);
+		main.next(1);
 
 		ts.assertNoValues()
 		  .assertNotComplete()
 		  .assertNoError();
 
-		other.onNext("first");
+		other.next("first");
 
 		ts.assertValues(1)
 		  .assertNoError()
 		  .assertNotComplete();
 
-		other.onNext("second");
+		other.next("second");
 
 		ts.assertValues(1)
 		  .assertNoError()
 		  .assertNotComplete();
 
-		main.onNext(2);
+		main.next(2);
 
 		ts.assertValues(1)
 		  .assertNoError()
 		  .assertNotComplete();
 
-		other.onNext("third");
+		other.next("third");
 
 		ts.assertValues(1, 2)
 		  .assertNoError()
 		  .assertNotComplete();
 
-		DirectProcessor<?> p = which ? main : other;
+		FluxProcessorSink<?> p = which ? main : other;
 
 		if (complete) {
-			p.onComplete();
+			p.complete();
 
 			ts.assertValues(1, 2)
 			  .assertComplete()
 			  .assertNoError();
 		}
 		else {
-			p.onError(new RuntimeException("forced failure"));
+			p.error(new RuntimeException("forced failure"));
 
 			ts.assertValues(1, 2)
 			  .assertNotComplete()
@@ -128,13 +128,13 @@ public class FluxSampleTest {
 
 	@Test
 	public void subscriberCancels() {
-		DirectProcessor<Integer> main = DirectProcessor.create();
+		FluxProcessorSink<Integer> main = Processors.direct();
 
-		DirectProcessor<String> other = DirectProcessor.create();
+		FluxProcessorSink<String> other = Processors.direct();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		main.sample(other).subscribe(ts);
+		main.asFlux().sample(other.asFlux()).subscribe(ts);
 
 		Assert.assertTrue("Main no subscriber?", main.hasDownstreams());
 		Assert.assertTrue("Other no subscriber?", other.hasDownstreams());
@@ -150,20 +150,20 @@ public class FluxSampleTest {
 	}
 
 	public void completeImmediately(boolean which) {
-		DirectProcessor<Integer> main = DirectProcessor.create();
+		FluxProcessorSink<Integer> main = Processors.direct();
 
-		DirectProcessor<String> other = DirectProcessor.create();
+		FluxProcessorSink<String> other = Processors.direct();
 
 		if (which) {
-			main.onComplete();
+			main.complete();
 		}
 		else {
-			other.onComplete();
+			other.complete();
 		}
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		main.sample(other).subscribe(ts);
+		main.asFlux().sample(other.asFlux()).subscribe(ts);
 
 		Assert.assertFalse("Main subscriber?", main.hasDownstreams());
 		Assert.assertFalse("Other subscriber?", other.hasDownstreams());

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTest.java
@@ -42,9 +42,9 @@ public class FluxSampleTest {
 	}
 
 	void sample(boolean complete, boolean which) {
-		FluxProcessorSink<Integer> main = Processors.direct();
+		FluxProcessorSink<Integer> main = Processors.directSink();
 
-		FluxProcessorSink<String> other = Processors.direct();
+		FluxProcessorSink<String> other = Processors.directSink();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -128,9 +128,9 @@ public class FluxSampleTest {
 
 	@Test
 	public void subscriberCancels() {
-		FluxProcessorSink<Integer> main = Processors.direct();
+		FluxProcessorSink<Integer> main = Processors.directSink();
 
-		FluxProcessorSink<String> other = Processors.direct();
+		FluxProcessorSink<String> other = Processors.directSink();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -150,9 +150,9 @@ public class FluxSampleTest {
 	}
 
 	public void completeImmediately(boolean which) {
-		FluxProcessorSink<Integer> main = Processors.direct();
+		FluxProcessorSink<Integer> main = Processors.directSink();
 
-		FluxProcessorSink<String> other = Processors.direct();
+		FluxProcessorSink<String> other = Processors.directSink();
 
 		if (which) {
 			main.complete();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTimeoutTest.java
@@ -37,9 +37,9 @@ public class FluxSampleTimeoutTest {
 	public void normal() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
-		FluxProcessorSink<Integer> sp3 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
+		FluxProcessorSink<Integer> sp3 = Processors.directSink();
 
 		sp1.asFlux()
 		   .sampleTimeout(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
@@ -78,8 +78,8 @@ public class FluxSampleTimeoutTest {
 	public void mainError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
 
 		sp1.asFlux()
 		   .sampleTimeout(v -> sp2.asFlux())
@@ -101,8 +101,8 @@ public class FluxSampleTimeoutTest {
 	public void throttlerError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
 
 		sp1.asFlux().sampleTimeout(v -> sp2.asFlux())
 		   .subscribe(ts);
@@ -123,7 +123,7 @@ public class FluxSampleTimeoutTest {
 	public void throttlerReturnsNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 
 		sp1.asFlux()
 		   .sampleTimeout(v -> null)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
@@ -34,8 +34,8 @@ public class FluxSwitchMapTest {
 	public void noswitch() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
 
 		sp1.asFlux().switchMap(v -> sp2.asFlux())
 		   .subscribe(ts);
@@ -64,8 +64,8 @@ public class FluxSwitchMapTest {
 	public void noswitchBackpressured() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
 
 		sp1.asFlux().switchMap(v -> sp2.asFlux())
 		   .subscribe(ts);
@@ -106,9 +106,9 @@ public class FluxSwitchMapTest {
 	public void doswitch() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
-		FluxProcessorSink<Integer> sp3 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
+		FluxProcessorSink<Integer> sp3 = Processors.directSink();
 
 		sp1.asFlux().switchMap(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
 		   .subscribe(ts);
@@ -156,8 +156,8 @@ public class FluxSwitchMapTest {
 	public void mainCompletesBefore() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
 
 		sp1.asFlux().switchMap(v -> sp2.asFlux())
 		   .subscribe(ts);
@@ -185,8 +185,8 @@ public class FluxSwitchMapTest {
 	public void mainError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
 
 		sp1.asFlux().switchMap(v -> sp2.asFlux())
 		   .subscribe(ts);
@@ -210,8 +210,8 @@ public class FluxSwitchMapTest {
 	public void innerError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
 
 		sp1.asFlux().switchMap(v -> sp2.asFlux())
 		   .subscribe(ts);
@@ -237,7 +237,7 @@ public class FluxSwitchMapTest {
 	public void mapperThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 
 		sp1.asFlux().switchMap(v -> {
 			throw new RuntimeException("forced failure");
@@ -256,7 +256,7 @@ public class FluxSwitchMapTest {
 	public void mapperReturnsNull() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 
 		sp1.asFlux().switchMap(v -> null)
 		   .subscribe(ts);
@@ -278,7 +278,7 @@ public class FluxSwitchMapTest {
 
 	@Test
 	public void switchOnNextDynamicallyOnNext() {
-		FluxProcessorSink<Flux<Integer>> up = Processors.unicast();
+		FluxProcessorSink<Flux<Integer>> up = Processors.unicastSink();
 		up.next(Flux.range(1, 3));
 		up.next(Flux.range(2, 3).concatWith(Mono.never()));
 		up.next(Flux.range(4, 3));

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
@@ -34,25 +34,25 @@ public class FluxSwitchMapTest {
 	public void noswitch() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
 
-		sp1.switchMap(v -> sp2)
+		sp1.asFlux().switchMap(v -> sp2.asFlux())
 		   .subscribe(ts);
 
-		sp1.onNext(1);
+		sp1.next(1);
 
-		sp2.onNext(10);
-		sp2.onNext(20);
-		sp2.onNext(30);
-		sp2.onNext(40);
-		sp2.onComplete();
+		sp2.next(10);
+		sp2.next(20);
+		sp2.next(30);
+		sp2.next(40);
+		sp2.complete();
 
 		ts.assertValues(10, 20, 30, 40)
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp1.onComplete();
+		sp1.complete();
 
 		ts.assertValues(10, 20, 30, 40)
 		  .assertNoError()
@@ -64,19 +64,19 @@ public class FluxSwitchMapTest {
 	public void noswitchBackpressured() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
 
-		sp1.switchMap(v -> sp2)
+		sp1.asFlux().switchMap(v -> sp2.asFlux())
 		   .subscribe(ts);
 
-		sp1.onNext(1);
+		sp1.next(1);
 
-		sp2.onNext(10);
-		sp2.onNext(20);
-		sp2.onNext(30);
-		sp2.onNext(40);
-		sp2.onComplete();
+		sp2.next(10);
+		sp2.next(20);
+		sp2.next(30);
+		sp2.next(40);
+		sp2.complete();
 
 		ts.assertNoValues()
 		  .assertNoError()
@@ -88,7 +88,7 @@ public class FluxSwitchMapTest {
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp1.onComplete();
+		sp1.complete();
 
 		ts.assertValues(10, 20)
 		  .assertNoError()
@@ -106,34 +106,34 @@ public class FluxSwitchMapTest {
 	public void doswitch() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
-		DirectProcessor<Integer> sp3 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp3 = Processors.direct();
 
-		sp1.switchMap(v -> v == 1 ? sp2 : sp3)
+		sp1.asFlux().switchMap(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
 		   .subscribe(ts);
 
-		sp1.onNext(1);
+		sp1.next(1);
 
-		sp2.onNext(10);
-		sp2.onNext(20);
+		sp2.next(10);
+		sp2.next(20);
 
-		sp1.onNext(2);
+		sp1.next(2);
 
 		Assert.assertFalse("sp2 has subscribers?", sp2.hasDownstreams());
 
-		sp2.onNext(30);
-		sp3.onNext(300);
-		sp2.onNext(40);
-		sp3.onNext(400);
-		sp2.onComplete();
-		sp3.onComplete();
+		sp2.next(30);
+		sp3.next(300);
+		sp2.next(40);
+		sp3.next(400);
+		sp2.complete();
+		sp3.complete();
 
 		ts.assertValues(10, 20, 300, 400)
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp1.onComplete();
+		sp1.complete();
 
 		ts.assertValues(10, 20, 300, 400)
 		  .assertNoError()
@@ -156,24 +156,24 @@ public class FluxSwitchMapTest {
 	public void mainCompletesBefore() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
 
-		sp1.switchMap(v -> sp2)
+		sp1.asFlux().switchMap(v -> sp2.asFlux())
 		   .subscribe(ts);
 
-		sp1.onNext(1);
-		sp1.onComplete();
+		sp1.next(1);
+		sp1.complete();
 
 		ts.assertNoValues()
 		  .assertNoError()
 		  .assertNotComplete();
 
-		sp2.onNext(10);
-		sp2.onNext(20);
-		sp2.onNext(30);
-		sp2.onNext(40);
-		sp2.onComplete();
+		sp2.next(10);
+		sp2.next(20);
+		sp2.next(30);
+		sp2.next(40);
+		sp2.complete();
 
 		ts.assertValues(10, 20, 30, 40)
 		  .assertNoError()
@@ -185,20 +185,20 @@ public class FluxSwitchMapTest {
 	public void mainError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
 
-		sp1.switchMap(v -> sp2)
+		sp1.asFlux().switchMap(v -> sp2.asFlux())
 		   .subscribe(ts);
 
-		sp1.onNext(1);
-		sp1.onError(new RuntimeException("forced failure"));
+		sp1.next(1);
+		sp1.error(new RuntimeException("forced failure"));
 
-		sp2.onNext(10);
-		sp2.onNext(20);
-		sp2.onNext(30);
-		sp2.onNext(40);
-		sp2.onComplete();
+		sp2.next(10);
+		sp2.next(20);
+		sp2.next(30);
+		sp2.next(40);
+		sp2.complete();
 
 		ts.assertNoValues()
 		  .assertError(RuntimeException.class)
@@ -210,19 +210,19 @@ public class FluxSwitchMapTest {
 	public void innerError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
 
-		sp1.switchMap(v -> sp2)
+		sp1.asFlux().switchMap(v -> sp2.asFlux())
 		   .subscribe(ts);
 
-		sp1.onNext(1);
+		sp1.next(1);
 
-		sp2.onNext(10);
-		sp2.onNext(20);
-		sp2.onNext(30);
-		sp2.onNext(40);
-		sp2.onError(new RuntimeException("forced failure"));
+		sp2.next(10);
+		sp2.next(20);
+		sp2.next(30);
+		sp2.next(40);
+		sp2.error(new RuntimeException("forced failure"));
 
 		ts.assertValues(10, 20, 30, 40)
 		  .assertError(RuntimeException.class)
@@ -237,14 +237,14 @@ public class FluxSwitchMapTest {
 	public void mapperThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 
-		sp1.switchMap(v -> {
+		sp1.asFlux().switchMap(v -> {
 			throw new RuntimeException("forced failure");
 		})
 		   .subscribe(ts);
 
-		sp1.onNext(1);
+		sp1.next(1);
 
 		ts.assertNoValues()
 		  .assertError(RuntimeException.class)
@@ -256,12 +256,12 @@ public class FluxSwitchMapTest {
 	public void mapperReturnsNull() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 
-		sp1.switchMap(v -> null)
+		sp1.asFlux().switchMap(v -> null)
 		   .subscribe(ts);
 
-		sp1.onNext(1);
+		sp1.next(1);
 
 		ts.assertNoValues()
 		  .assertError(NullPointerException.class)
@@ -278,12 +278,12 @@ public class FluxSwitchMapTest {
 
 	@Test
 	public void switchOnNextDynamicallyOnNext() {
-		UnicastProcessor<Flux<Integer>> up = UnicastProcessor.create();
-		up.onNext(Flux.range(1, 3));
-		up.onNext(Flux.range(2, 3).concatWith(Mono.never()));
-		up.onNext(Flux.range(4, 3));
-		up.onComplete();
-		StepVerifier.create(Flux.switchOnNext(up))
+		FluxProcessorSink<Flux<Integer>> up = Processors.unicast();
+		up.next(Flux.range(1, 3));
+		up.next(Flux.range(2, 3).concatWith(Mono.never()));
+		up.next(Flux.range(4, 3));
+		up.complete();
+		StepVerifier.create(Flux.switchOnNext(up.asFlux()))
 		            .expectNext(1, 2, 3, 2, 3, 4, 4, 5, 6)
 		            .verifyComplete();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
@@ -300,18 +300,10 @@ public class FluxTakeTest {
 		FluxProcessorSink<Integer> up = Processors.unicast();
 		Hooks.onNextDropped(t -> assertThat(t).isEqualTo(1));
 		StepVerifier.create(up.asFlux().take(2))
-		            .then(() -> unicastActual(up).onComplete())
-		            .then(() -> unicastActual(up).onNext(1))
+		            .then(() -> ProcessorsTestUtils.unicastActual(up).onComplete())
+		            .then(() -> ProcessorsTestUtils.unicastActual(up).onNext(1))
 		            .verifyComplete();
 		Hooks.resetOnNextDropped();
-	}
-
-	//FIXME extract similar methods in test as a utility method
-	private static <T> CoreSubscriber<T> unicastActual(FluxProcessorSink<T> unicast) {
-		assertThat(unicast).isInstanceOf(InnerOperator.class);
-		@SuppressWarnings("unchecked")
-		CoreSubscriber<T> actual = ((InnerOperator) unicast).actual();
-		return actual;
 	}
 
 	@Test
@@ -502,10 +494,10 @@ public class FluxTakeTest {
 			            assertTrackableBeforeOnSubscribe((InnerOperator)s);
 		            })
 		            .then(() -> {
-			            assertTrackableAfterOnSubscribe((InnerOperator) unicastActual(up));
-			            unicastActual(up).onError(new Exception("test"));
-			            assertTrackableAfterOnComplete((InnerOperator) unicastActual(up));
-			            unicastActual(up).onError(new Exception("test2"));
+			            assertTrackableAfterOnSubscribe((InnerOperator) ProcessorsTestUtils.unicastActual(up));
+			            ProcessorsTestUtils.unicastActual(up).onError(new Exception("test"));
+			            assertTrackableAfterOnComplete((InnerOperator) ProcessorsTestUtils.unicastActual(up));
+			            ProcessorsTestUtils.unicastActual(up).onError(new Exception("test2"));
 		            })
 		            .verifyErrorMessage("test");
 
@@ -521,10 +513,10 @@ public class FluxTakeTest {
 			            assertTrackableAfterOnSubscribe((InnerOperator)s);
 		            })
 		            .then(() -> {
-			            assertTrackableAfterOnSubscribe((InnerOperator)unicastActual(up));
-			            unicastActual(up).onComplete();
-			            assertTrackableAfterOnComplete((InnerOperator)unicastActual(up));
-			            unicastActual(up).onComplete();
+			            assertTrackableAfterOnSubscribe((InnerOperator) ProcessorsTestUtils.unicastActual(up));
+			            ProcessorsTestUtils.unicastActual(up).onComplete();
+			            assertTrackableAfterOnComplete((InnerOperator)ProcessorsTestUtils.unicastActual(up));
+			            ProcessorsTestUtils.unicastActual(up).onComplete();
 		            })
 		            .verifyComplete();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
@@ -183,7 +183,7 @@ public class FluxTakeTest {
 
 	@Test
 	public void takeFusedBackpressured() {
-		FluxProcessorSink<String> up = Processors.unicast();
+		FluxProcessorSink<String> up = Processors.unicastSink();
 		StepVerifier.create(up.asFlux().take(3), 0)
 		            .expectFusion()
 		            .then(() -> up.next("test"))
@@ -200,7 +200,7 @@ public class FluxTakeTest {
 
 	@Test
 	public void takeFusedBackpressuredCancelled() {
-		FluxProcessorSink<String> up = Processors.unicast();
+		FluxProcessorSink<String> up = Processors.unicastSink();
 		StepVerifier.create(up.asFlux().take(3).doOnSubscribe(s -> {
 			assertThat(((Fuseable.QueueSubscription)s).size()).isEqualTo(0);
 		}), 0)
@@ -297,7 +297,7 @@ public class FluxTakeTest {
 
 	@Test
 	public void failNextIfTerminatedTakeFused() {
-		FluxProcessorSink<Integer> up = Processors.unicast();
+		FluxProcessorSink<Integer> up = Processors.unicastSink();
 		Hooks.onNextDropped(t -> assertThat(t).isEqualTo(1));
 		StepVerifier.create(up.asFlux().take(2))
 		            .then(() -> ProcessorsTestUtils.unicastActual(up).onComplete())
@@ -373,7 +373,7 @@ public class FluxTakeTest {
 
 	@Test
 	public void takeFusedAsync() {
-		FluxProcessorSink<String> up = Processors.unicast();
+		FluxProcessorSink<String> up = Processors.unicastSink();
 		StepVerifier.create(up.asFlux().take(2))
 		            .expectFusion(Fuseable.ASYNC)
 		            .then(() -> {
@@ -486,7 +486,7 @@ public class FluxTakeTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void failFusedDoubleError() {
-		FluxProcessorSink<Integer> up = Processors.unicast();
+		FluxProcessorSink<Integer> up = Processors.unicastSink();
 		Hooks.onErrorDropped(e -> assertThat(e).hasMessage("test2"));
 		StepVerifier.create(up.asFlux()
 		                        .take(2))
@@ -506,7 +506,7 @@ public class FluxTakeTest {
 
 	@Test
 	public void ignoreFusedDoubleComplete() {
-		FluxProcessorSink<Integer> up = Processors.unicast();
+		FluxProcessorSink<Integer> up = Processors.unicastSink();
 		StepVerifier.create(up.asFlux()
 		                        .take(2).filter(d -> true))
 		            .consumeSubscriptionWith(s -> {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
@@ -98,9 +98,9 @@ public class FluxTimeoutTest {
 
 	@Test
 	public void oldTimeoutHasNoEffect() {
-		FluxProcessorSink<Integer> source = Processors.direct();
+		FluxProcessorSink<Integer> source = Processors.directSink();
 
-		FluxProcessorSink<Integer> tp = Processors.direct();
+		FluxProcessorSink<Integer> tp = Processors.directSink();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -123,9 +123,9 @@ public class FluxTimeoutTest {
 
 	@Test
 	public void oldTimeoutCompleteHasNoEffect() {
-		FluxProcessorSink<Integer> source = Processors.direct();
+		FluxProcessorSink<Integer> source = Processors.directSink();
 
-		FluxProcessorSink<Integer> tp = Processors.direct();
+		FluxProcessorSink<Integer> tp = Processors.directSink();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -148,9 +148,9 @@ public class FluxTimeoutTest {
 
 	@Test
 	public void oldTimeoutErrorHasNoEffect() {
-		FluxProcessorSink<Integer> source = Processors.direct();
+		FluxProcessorSink<Integer> source = Processors.directSink();
 
-		FluxProcessorSink<Integer> tp = Processors.direct();
+		FluxProcessorSink<Integer> tp = Processors.directSink();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -234,9 +234,9 @@ public class FluxTimeoutTest {
 	public void timeoutRequested() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> source = Processors.direct();
+		FluxProcessorSink<Integer> source = Processors.directSink();
 
-		FluxProcessorSink<Integer> tp = Processors.direct();
+		FluxProcessorSink<Integer> tp = Processors.directSink();
 
 		source.asFlux()
 		      .timeout(tp.asFlux(), v -> tp.asFlux())

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
@@ -98,20 +98,21 @@ public class FluxTimeoutTest {
 
 	@Test
 	public void oldTimeoutHasNoEffect() {
-		DirectProcessor<Integer> source = DirectProcessor.create();
+		FluxProcessorSink<Integer> source = Processors.direct();
 
-		DirectProcessor<Integer> tp = DirectProcessor.create();
+		FluxProcessorSink<Integer> tp = Processors.direct();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		source.timeout(tp, v -> Flux.never(), Flux.range(1, 10))
+		source.asFlux()
+		      .timeout(tp.asFlux(), v -> Flux.never(), Flux.range(1, 10))
 		      .subscribe(ts);
 
-		source.onNext(0);
+		source.next(0);
 
-		tp.onNext(1);
+		tp.next(1);
 
-		source.onComplete();
+		source.complete();
 
 		Assert.assertFalse("Timeout has subscribers?", tp.hasDownstreams());
 
@@ -122,20 +123,21 @@ public class FluxTimeoutTest {
 
 	@Test
 	public void oldTimeoutCompleteHasNoEffect() {
-		DirectProcessor<Integer> source = DirectProcessor.create();
+		FluxProcessorSink<Integer> source = Processors.direct();
 
-		DirectProcessor<Integer> tp = DirectProcessor.create();
+		FluxProcessorSink<Integer> tp = Processors.direct();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		source.timeout(tp, v -> Flux.never(), Flux.range(1, 10))
+		source.asFlux()
+		      .timeout(tp.asFlux(), v -> Flux.never(), Flux.range(1, 10))
 		      .subscribe(ts);
 
-		source.onNext(0);
+		source.next(0);
 
-		tp.onComplete();
+		tp.complete();
 
-		source.onComplete();
+		source.complete();
 
 		Assert.assertFalse("Timeout has subscribers?", tp.hasDownstreams());
 
@@ -146,20 +148,21 @@ public class FluxTimeoutTest {
 
 	@Test
 	public void oldTimeoutErrorHasNoEffect() {
-		DirectProcessor<Integer> source = DirectProcessor.create();
+		FluxProcessorSink<Integer> source = Processors.direct();
 
-		DirectProcessor<Integer> tp = DirectProcessor.create();
+		FluxProcessorSink<Integer> tp = Processors.direct();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		source.timeout(tp, v -> Flux.never(), Flux.range(1, 10))
+		source.asFlux()
+		      .timeout(tp.asFlux(), v -> Flux.never(), Flux.range(1, 10))
 		      .subscribe(ts);
 
-		source.onNext(0);
+		source.next(0);
 
-		tp.onError(new RuntimeException("forced failure"));
+		tp.error(new RuntimeException("forced failure"));
 
-		source.onComplete();
+		source.complete();
 
 		Assert.assertFalse("Timeout has subscribers?", tp.hasDownstreams());
 
@@ -231,17 +234,18 @@ public class FluxTimeoutTest {
 	public void timeoutRequested() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> source = DirectProcessor.create();
+		FluxProcessorSink<Integer> source = Processors.direct();
 
-		DirectProcessor<Integer> tp = DirectProcessor.create();
+		FluxProcessorSink<Integer> tp = Processors.direct();
 
-		source.timeout(tp, v -> tp)
+		source.asFlux()
+		      .timeout(tp.asFlux(), v -> tp.asFlux())
 		      .subscribe(ts);
 
-		tp.onNext(1);
+		tp.next(1);
 
-		source.onNext(2);
-		source.onComplete();
+		source.next(2);
+		source.complete();
 
 		ts.assertNoValues()
 		  .assertError(TimeoutException.class)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxUsingTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxUsingTest.java
@@ -262,7 +262,7 @@ public class FluxUsingTest extends FluxOperatorTest<String, String> {
 
 		AtomicInteger cleanup = new AtomicInteger();
 
-		FluxProcessorSink<Integer> tp = Processors.direct();
+		FluxProcessorSink<Integer> tp = Processors.directSink();
 
 		Flux.using(() -> 1, r -> tp.asFlux(), cleanup::set, true)
 		    .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxUsingTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxUsingTest.java
@@ -262,14 +262,14 @@ public class FluxUsingTest extends FluxOperatorTest<String, String> {
 
 		AtomicInteger cleanup = new AtomicInteger();
 
-		DirectProcessor<Integer> tp = DirectProcessor.create();
+		FluxProcessorSink<Integer> tp = Processors.direct();
 
-		Flux.using(() -> 1, r -> tp, cleanup::set, true)
+		Flux.using(() -> 1, r -> tp.asFlux(), cleanup::set, true)
 		    .subscribe(ts);
 
 		Assert.assertTrue("No subscriber?", tp.hasDownstreams());
 
-		tp.onNext(1);
+		tp.next(1);
 
 		ts.assertValues(1)
 		  .assertNotComplete()
@@ -277,7 +277,7 @@ public class FluxUsingTest extends FluxOperatorTest<String, String> {
 
 		ts.cancel();
 
-		tp.onNext(2);
+		tp.next(2);
 
 		ts.assertValues(1)
 		  .assertNotComplete()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
@@ -53,24 +53,25 @@ public class FluxWindowBoundaryTest {
 	public void normal() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
 
-		sp1.window(sp2)
+		sp1.asFlux()
+		   .window(sp2.asFlux())
 		   .subscribe(ts);
 
 		ts.assertValueCount(1);
 
-		sp1.onNext(1);
-		sp1.onNext(2);
-		sp1.onNext(3);
+		sp1.next(1);
+		sp1.next(2);
+		sp1.next(3);
 
-		sp2.onNext(1);
+		sp2.next(1);
 
-		sp1.onNext(4);
-		sp1.onNext(5);
+		sp1.next(4);
+		sp1.next(5);
 
-		sp1.onComplete();
+		sp1.complete();
 
 		ts.assertValueCount(2);
 
@@ -88,24 +89,25 @@ public class FluxWindowBoundaryTest {
 	public void normalOtherCompletes() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
 
-		sp1.window(sp2)
+		sp1.asFlux()
+		   .window(sp2.asFlux())
 		   .subscribe(ts);
 
 		ts.assertValueCount(1);
 
-		sp1.onNext(1);
-		sp1.onNext(2);
-		sp1.onNext(3);
+		sp1.next(1);
+		sp1.next(2);
+		sp1.next(3);
 
-		sp2.onNext(1);
+		sp2.next(1);
 
-		sp1.onNext(4);
-		sp1.onNext(5);
+		sp1.next(4);
+		sp1.next(5);
 
-		sp2.onComplete();
+		sp2.complete();
 
 		ts.assertValueCount(2);
 
@@ -123,24 +125,25 @@ public class FluxWindowBoundaryTest {
 	public void mainError() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
 
-		sp1.window(sp2)
+		sp1.asFlux()
+		   .window(sp2.asFlux())
 		   .subscribe(ts);
 
 		ts.assertValueCount(1);
 
-		sp1.onNext(1);
-		sp1.onNext(2);
-		sp1.onNext(3);
+		sp1.next(1);
+		sp1.next(2);
+		sp1.next(3);
 
-		sp2.onNext(1);
+		sp2.next(1);
 
-		sp1.onNext(4);
-		sp1.onNext(5);
+		sp1.next(4);
+		sp1.next(5);
 
-		sp1.onError(new RuntimeException("forced failure"));
+		sp1.error(new RuntimeException("forced failure"));
 
 		ts.assertValueCount(2);
 
@@ -164,24 +167,25 @@ public class FluxWindowBoundaryTest {
 	public void otherError() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		DirectProcessor<Integer> sp2 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp2 = Processors.direct();
 
-		sp1.window(sp2)
+		sp1.asFlux()
+		   .window(sp2.asFlux())
 		   .subscribe(ts);
 
 		ts.assertValueCount(1);
 
-		sp1.onNext(1);
-		sp1.onNext(2);
-		sp1.onNext(3);
+		sp1.next(1);
+		sp1.next(2);
+		sp1.next(3);
 
-		sp2.onNext(1);
+		sp2.next(1);
 
-		sp1.onNext(4);
-		sp1.onNext(5);
+		sp1.next(4);
+		sp1.next(5);
 
-		sp2.onError(new RuntimeException("forced failure"));
+		sp2.error(new RuntimeException("forced failure"));
 
 		ts.assertValueCount(2);
 
@@ -223,25 +227,26 @@ public class FluxWindowBoundaryTest {
 	@Test
 	public void windowWillAcumulateMultipleListsOfValues() {
 		//given: "a source and a collected flux"
-		EmitterProcessor<Integer> numbers = EmitterProcessor.create();
+		FluxProcessorSink<Integer> numbers = Processors.emitter();
 
 		//non overlapping buffers
-		EmitterProcessor<Integer> boundaryFlux = EmitterProcessor.create();
+		FluxProcessorSink<Integer> boundaryFlux = Processors.emitter();
 
-		MonoProcessor<List<List<Integer>>> res = numbers.window(boundaryFlux)
-		                                       .concatMap(Flux::buffer)
-		                                       .buffer()
-		                                       .publishNext()
-		                                       .toProcessor();
+		MonoProcessor<List<List<Integer>>> res = numbers.asFlux()
+		                                                .window(boundaryFlux.asFlux())
+		                                                .concatMap(Flux::buffer)
+		                                                .buffer()
+		                                                .publishNext()
+		                                                .toProcessor();
 		res.subscribe();
 
-		numbers.onNext(1);
-		numbers.onNext(2);
-		numbers.onNext(3);
-		boundaryFlux.onNext(1);
-		numbers.onNext(5);
-		numbers.onNext(6);
-		numbers.onComplete();
+		numbers.next(1);
+		numbers.next(2);
+		numbers.next(3);
+		boundaryFlux.next(1);
+		numbers.next(5);
+		numbers.next(6);
+		numbers.complete();
 
 		//"the collected lists are available"
 		assertThat(res.block()).containsExactly(Arrays.asList(1, 2, 3), Arrays.asList(5, 6));

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
@@ -53,8 +53,8 @@ public class FluxWindowBoundaryTest {
 	public void normal() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
 
 		sp1.asFlux()
 		   .window(sp2.asFlux())
@@ -89,8 +89,8 @@ public class FluxWindowBoundaryTest {
 	public void normalOtherCompletes() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
 
 		sp1.asFlux()
 		   .window(sp2.asFlux())
@@ -125,8 +125,8 @@ public class FluxWindowBoundaryTest {
 	public void mainError() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
 
 		sp1.asFlux()
 		   .window(sp2.asFlux())
@@ -167,8 +167,8 @@ public class FluxWindowBoundaryTest {
 	public void otherError() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
 
 		sp1.asFlux()
 		   .window(sp2.asFlux())
@@ -227,10 +227,10 @@ public class FluxWindowBoundaryTest {
 	@Test
 	public void windowWillAcumulateMultipleListsOfValues() {
 		//given: "a source and a collected flux"
-		FluxProcessorSink<Integer> numbers = Processors.emitter();
+		FluxProcessorSink<Integer> numbers = Processors.emitterSink();
 
 		//non overlapping buffers
-		FluxProcessorSink<Integer> boundaryFlux = Processors.emitter();
+		FluxProcessorSink<Integer> boundaryFlux = Processors.emitterSink();
 
 		MonoProcessor<List<List<Integer>>> res = numbers.asFlux()
 		                                                .window(boundaryFlux.asFlux())

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
@@ -228,7 +228,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalUntil() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(sp1.asFlux(),
 				Queues.small(),
 				Queues.unbounded(),
@@ -295,7 +295,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void mainErrorUntilIsPropagatedToBothWindowAndMain() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.UNTIL);
@@ -321,7 +321,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void predicateErrorUntil() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> {
@@ -349,7 +349,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalUntilCutBefore() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxWindowPredicate<Integer> windowUntilCutBefore = new FluxWindowPredicate<>(sp1.asFlux(),
 				Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.UNTIL_CUT_BEFORE);
@@ -380,7 +380,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void mainErrorUntilCutBeforeIsPropagatedToBothWindowAndMain() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxWindowPredicate<Integer> windowUntilCutBefore =
 				new FluxWindowPredicate<>(sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 						i -> i % 3 == 0, Mode.UNTIL_CUT_BEFORE);
@@ -407,7 +407,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void predicateErrorUntilCutBefore() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxWindowPredicate<Integer> windowUntilCutBefore =
 				new FluxWindowPredicate<>(sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> {
@@ -441,7 +441,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalWhile() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 != 0, Mode.WHILE);
@@ -472,7 +472,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalWhileDoesntInitiallyMatch() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.WHILE);
@@ -510,7 +510,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalWhileDoesntMatch() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i > 4, Mode.WHILE);
@@ -545,7 +545,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void mainErrorWhileIsPropagatedToBothWindowAndMain() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.WHILE);
@@ -592,7 +592,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void predicateErrorWhile() {
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
@@ -228,8 +228,8 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalUntil() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(sp1,
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(sp1.asFlux(),
 				Queues.small(),
 				Queues.unbounded(),
 				Queues.SMALL_BUFFER_SIZE,
@@ -238,23 +238,23 @@ public class FluxWindowPredicateTest extends
 
 		StepVerifier.create(windowUntil.flatMap(Flux::materialize))
 		            .expectSubscription()
-		            .then(() -> sp1.onNext(1))
+		            .then(() -> sp1.next(1))
 		            .expectNext(Signal.next(1))
-				    .then(() -> sp1.onNext(2))
+				    .then(() -> sp1.next(2))
 		            .expectNext(Signal.next(2))
-				    .then(() -> sp1.onNext(3))
+				    .then(() -> sp1.next(3))
 		            .expectNext(Signal.next(3), Signal.complete())
-				    .then(() -> sp1.onNext(4))
+				    .then(() -> sp1.next(4))
 				    .expectNext(Signal.next(4))
-				    .then(() -> sp1.onNext(5))
+				    .then(() -> sp1.next(5))
 				    .expectNext(Signal.next(5))
-				    .then(() -> sp1.onNext(6))
+				    .then(() -> sp1.next(6))
 				    .expectNext(Signal.next(6), Signal.complete())
-				    .then(() -> sp1.onNext(7))
+				    .then(() -> sp1.next(7))
 				    .expectNext(Signal.next(7))
-				    .then(() -> sp1.onNext(8))
+				    .then(() -> sp1.next(8))
 				    .expectNext(Signal.next(8))
-				    .then(sp1::onComplete)
+				    .then(sp1::complete)
 		            .expectNext(Signal.complete())
 				    .verifyComplete();
 
@@ -295,22 +295,22 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void mainErrorUntilIsPropagatedToBothWindowAndMain() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(
-				sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
+				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.UNTIL);
 
 		StepVerifier.create(windowUntil.flatMap(Flux::materialize))
 		            .expectSubscription()
-		            .then(() -> sp1.onNext(1))
+		            .then(() -> sp1.next(1))
 		            .expectNext(Signal.next(1))
-		            .then(() -> sp1.onNext(2))
+		            .then(() -> sp1.next(2))
 		            .expectNext(Signal.next(2))
-		            .then(() -> sp1.onNext(3))
+		            .then(() -> sp1.next(3))
 		            .expectNext(Signal.next(3), Signal.complete())
-		            .then(() -> sp1.onNext(4))
+		            .then(() -> sp1.next(4))
 		            .expectNext(Signal.next(4))
-		            .then(() -> sp1.onError(new RuntimeException("forced failure")))
+		            .then(() -> sp1.error(new RuntimeException("forced failure")))
 		            //this is the error in the window:
 		            .expectNextMatches(signalErrorMessage("forced failure"))
 		            //this is the error in the main:
@@ -321,9 +321,9 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void predicateErrorUntil() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(
-				sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
+				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> {
 					if (i == 5) throw new IllegalStateException("predicate failure");
 					return i % 3 == 0;
@@ -331,15 +331,15 @@ public class FluxWindowPredicateTest extends
 
 		StepVerifier.create(windowUntil.flatMap(Flux::materialize))
 					.expectSubscription()
-					.then(() -> sp1.onNext(1))
+					.then(() -> sp1.next(1))
 					.expectNext(Signal.next(1))
-					.then(() -> sp1.onNext(2))
+					.then(() -> sp1.next(2))
 					.expectNext(Signal.next(2))
-					.then(() -> sp1.onNext(3))
+					.then(() -> sp1.next(3))
 					.expectNext(Signal.next(3), Signal.complete())
-					.then(() -> sp1.onNext(4))
+					.then(() -> sp1.next(4))
 					.expectNext(Signal.next(4))
-					.then(() -> sp1.onNext(5))
+					.then(() -> sp1.next(5))
 					//error in the window:
 					.expectNextMatches(signalErrorMessage("predicate failure"))
 					.expectErrorMessage("predicate failure")
@@ -349,30 +349,30 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalUntilCutBefore() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
-		FluxWindowPredicate<Integer> windowUntilCutBefore = new FluxWindowPredicate<>(sp1,
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
+		FluxWindowPredicate<Integer> windowUntilCutBefore = new FluxWindowPredicate<>(sp1.asFlux(),
 				Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.UNTIL_CUT_BEFORE);
 
 		StepVerifier.create(windowUntilCutBefore.flatMap(Flux::materialize))
 				.expectSubscription()
-				    .then(() -> sp1.onNext(1))
+				    .then(() -> sp1.next(1))
 				    .expectNext(Signal.next(1))
-				    .then(() -> sp1.onNext(2))
+				    .then(() -> sp1.next(2))
 				    .expectNext(Signal.next(2))
-				    .then(() -> sp1.onNext(3))
+				    .then(() -> sp1.next(3))
 				    .expectNext(Signal.complete(), Signal.next(3))
-				    .then(() -> sp1.onNext(4))
+				    .then(() -> sp1.next(4))
 				    .expectNext(Signal.next(4))
-				    .then(() -> sp1.onNext(5))
+				    .then(() -> sp1.next(5))
 				    .expectNext(Signal.next(5))
-				    .then(() -> sp1.onNext(6))
+				    .then(() -> sp1.next(6))
 				    .expectNext(Signal.complete(), Signal.next(6))
-				    .then(() -> sp1.onNext(7))
+				    .then(() -> sp1.next(7))
 				    .expectNext(Signal.next(7))
-				    .then(() -> sp1.onNext(8))
+				    .then(() -> sp1.next(8))
 				    .expectNext(Signal.next(8))
-				    .then(sp1::onComplete)
+				    .then(sp1::complete)
 				    .expectNext(Signal.complete())
 				    .verifyComplete();
 		assertThat(sp1.hasDownstreams()).isFalse();
@@ -380,23 +380,23 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void mainErrorUntilCutBeforeIsPropagatedToBothWindowAndMain() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxWindowPredicate<Integer> windowUntilCutBefore =
-				new FluxWindowPredicate<>(sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
+				new FluxWindowPredicate<>(sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 						i -> i % 3 == 0, Mode.UNTIL_CUT_BEFORE);
 
 		StepVerifier.create(windowUntilCutBefore.flatMap(Flux::materialize))
 		            .expectSubscription()
-		            .then(() -> sp1.onNext(1))
+		            .then(() -> sp1.next(1))
 		            .expectNext(Signal.next(1))
-		            .then(() -> sp1.onNext(2))
+		            .then(() -> sp1.next(2))
 		            .expectNext(Signal.next(2))
-		            .then(() -> sp1.onNext(3))
+		            .then(() -> sp1.next(3))
 		            .expectNext(Signal.complete())
 		            .expectNext(Signal.next(3))
-		            .then(() -> sp1.onNext(4))
+		            .then(() -> sp1.next(4))
 		            .expectNext(Signal.next(4))
-		            .then(() -> sp1.onError(new RuntimeException("forced failure")))
+		            .then(() -> sp1.error(new RuntimeException("forced failure")))
 		            //this is the error in the window:
 		            .expectNextMatches(signalErrorMessage("forced failure"))
 		            //this is the error in the main:
@@ -407,9 +407,9 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void predicateErrorUntilCutBefore() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxWindowPredicate<Integer> windowUntilCutBefore =
-				new FluxWindowPredicate<>(sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
+				new FluxWindowPredicate<>(sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> {
 					if (i == 5) throw new IllegalStateException("predicate failure");
 					return i % 3 == 0;
@@ -417,15 +417,15 @@ public class FluxWindowPredicateTest extends
 
 		StepVerifier.create(windowUntilCutBefore.flatMap(Flux::materialize))
 					.expectSubscription()
-					.then(() -> sp1.onNext(1))
+					.then(() -> sp1.next(1))
 					.expectNext(Signal.next(1))
-					.then(() -> sp1.onNext(2))
+					.then(() -> sp1.next(2))
 					.expectNext(Signal.next(2))
-					.then(() -> sp1.onNext(3))
+					.then(() -> sp1.next(3))
 					.expectNext(Signal.complete(), Signal.next(3))
-					.then(() -> sp1.onNext(4))
+					.then(() -> sp1.next(4))
 					.expectNext(Signal.next(4))
-					.then(() -> sp1.onNext(5))
+					.then(() -> sp1.next(5))
 					//error in the window:
 					.expectNextMatches(signalErrorMessage("predicate failure"))
 					.expectErrorMessage("predicate failure")
@@ -441,30 +441,30 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalWhile() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
-				sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
+				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 != 0, Mode.WHILE);
 
 		StepVerifier.create(windowWhile.flatMap(Flux::materialize))
 		            .expectSubscription()
-		            .then(() -> sp1.onNext(1))
+		            .then(() -> sp1.next(1))
 		            .expectNext(Signal.next(1))
-		            .then(() -> sp1.onNext(2))
+		            .then(() -> sp1.next(2))
 		            .expectNext(Signal.next(2))
-		            .then(() -> sp1.onNext(3))
+		            .then(() -> sp1.next(3))
 		            .expectNext(Signal.complete())
-		            .then(() -> sp1.onNext(4))
+		            .then(() -> sp1.next(4))
 		            .expectNext(Signal.next(4))
-		            .then(() -> sp1.onNext(5))
+		            .then(() -> sp1.next(5))
 		            .expectNext(Signal.next(5))
-		            .then(() -> sp1.onNext(6))
+		            .then(() -> sp1.next(6))
 		            .expectNext(Signal.complete())
-		            .then(() -> sp1.onNext(7))
+		            .then(() -> sp1.next(7))
 		            .expectNext(Signal.next(7))
-		            .then(() -> sp1.onNext(8))
+		            .then(() -> sp1.next(8))
 		            .expectNext(Signal.next(8))
-		            .then(sp1::onComplete)
+		            .then(sp1::complete)
 		            .expectNext(Signal.complete())
 		            .verifyComplete();
 		assertThat(sp1.hasDownstreams()).isFalse();
@@ -472,36 +472,36 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalWhileDoesntInitiallyMatch() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
-				sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
+				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.WHILE);
 
 		StepVerifier.create(windowWhile.flatMap(Flux::materialize))
 		            .expectSubscription()
 		            .expectNoEvent(Duration.ofMillis(10))
-		            .then(() -> sp1.onNext(1)) //closes initial, open 2nd
+		            .then(() -> sp1.next(1)) //closes initial, open 2nd
 		            .expectNext(Signal.complete())
-		            .then(() -> sp1.onNext(2)) //closes second, open 3rd
+		            .then(() -> sp1.next(2)) //closes second, open 3rd
 		            .expectNext(Signal.complete())
-		            .then(() -> sp1.onNext(3)) //emits 3
+		            .then(() -> sp1.next(3)) //emits 3
 		            .expectNext(Signal.next(3))
 		            .expectNoEvent(Duration.ofMillis(10))
-		            .then(() -> sp1.onNext(4)) //closes 3rd, open 4th
+		            .then(() -> sp1.next(4)) //closes 3rd, open 4th
 		            .expectNext(Signal.complete())
-		            .then(() -> sp1.onNext(5)) //closes 4th, open 5th
+		            .then(() -> sp1.next(5)) //closes 4th, open 5th
 		            .expectNext(Signal.complete())
-		            .then(() -> sp1.onNext(6)) //emits 6
+		            .then(() -> sp1.next(6)) //emits 6
 		            .expectNext(Signal.next(6))
 		            .expectNoEvent(Duration.ofMillis(10))
-		            .then(() -> sp1.onNext(7)) //closes 5th, open 6th
+		            .then(() -> sp1.next(7)) //closes 5th, open 6th
 		            .expectNext(Signal.complete())
-		            .then(() -> sp1.onNext(8)) //closes 6th, open 7th
+		            .then(() -> sp1.next(8)) //closes 6th, open 7th
 		            .expectNext(Signal.complete())
-		            .then(() -> sp1.onNext(9)) //emits 9
+		            .then(() -> sp1.next(9)) //emits 9
 		            .expectNext(Signal.next(9))
 		            .expectNoEvent(Duration.ofMillis(10))
-		            .then(sp1::onComplete) // completion triggers completion of the last window (7th)
+		            .then(sp1::complete) // completion triggers completion of the last window (7th)
 		            .expectNext(Signal.complete())
 		            .expectComplete()
 		            .verify(Duration.ofSeconds(1));
@@ -510,33 +510,33 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalWhileDoesntMatch() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
-				sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
+				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i > 4, Mode.WHILE);
 
 		StepVerifier.create(windowWhile.flatMap(Flux::materialize))
 		            .expectSubscription()
 		            .expectNoEvent(Duration.ofMillis(10))
-		            .then(() -> sp1.onNext(1))
+		            .then(() -> sp1.next(1))
 		            .expectNext(Signal.complete())
-		            .then(() -> sp1.onNext(2))
+		            .then(() -> sp1.next(2))
 		            .expectNext(Signal.complete())
-		            .then(() -> sp1.onNext(3))
+		            .then(() -> sp1.next(3))
 		            .expectNext(Signal.complete())
-		            .then(() -> sp1.onNext(4))
+		            .then(() -> sp1.next(4))
 		            .expectNext(Signal.complete())
 		            .expectNoEvent(Duration.ofMillis(10))
-		            .then(() -> sp1.onNext(1))
+		            .then(() -> sp1.next(1))
 		            .expectNext(Signal.complete())
-		            .then(() -> sp1.onNext(2))
+		            .then(() -> sp1.next(2))
 		            .expectNext(Signal.complete())
-		            .then(() -> sp1.onNext(3))
+		            .then(() -> sp1.next(3))
 		            .expectNext(Signal.complete())
-		            .then(() -> sp1.onNext(4))
+		            .then(() -> sp1.next(4))
 		            .expectNext(Signal.complete()) //closing window opened by 3
 		            .expectNoEvent(Duration.ofMillis(10))
-		            .then(sp1::onComplete)
+		            .then(sp1::complete)
 		            //remainder window, not emitted
 		            .expectComplete()
 		            .verify(Duration.ofSeconds(1));
@@ -545,21 +545,21 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void mainErrorWhileIsPropagatedToBothWindowAndMain() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
-				sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
+				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.WHILE);
 
 		StepVerifier.create(windowWhile.flatMap(Flux::materialize))
 		            .expectSubscription()
-		            .then(() -> sp1.onNext(1))
+		            .then(() -> sp1.next(1))
 		            .expectNext(Signal.complete())
-		            .then(() -> sp1.onNext(2))
+		            .then(() -> sp1.next(2))
 		            .expectNext(Signal.complete())
-		            .then(() -> sp1.onNext(3)) //at this point, new window, need another data to close it
-		            .then(() -> sp1.onNext(4))
+		            .then(() -> sp1.next(3)) //at this point, new window, need another data to close it
+		            .then(() -> sp1.next(4))
 		            .expectNext(Signal.next(3), Signal.complete())
-		            .then(() -> sp1.onError(new RuntimeException("forced failure")))
+		            .then(() -> sp1.error(new RuntimeException("forced failure")))
 		            //this is the error in the main:
 		            .expectErrorMessage("forced failure")
 		            .verify(Duration.ofMillis(100));
@@ -592,9 +592,9 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void predicateErrorWhile() {
-		DirectProcessor<Integer> sp1 = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp1 = Processors.direct();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
-				sp1, Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
+				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> {
 					if (i == 3) return true;
 					if (i == 5) throw new IllegalStateException("predicate failure");
@@ -603,15 +603,15 @@ public class FluxWindowPredicateTest extends
 
 		StepVerifier.create(windowWhile.flatMap(Flux::materialize))
 					.expectSubscription()
-					.then(() -> sp1.onNext(1)) //empty window
+					.then(() -> sp1.next(1)) //empty window
 					.expectNext(Signal.complete())
-					.then(() -> sp1.onNext(2)) //empty window
+					.then(() -> sp1.next(2)) //empty window
 					.expectNext(Signal.complete())
-					.then(() -> sp1.onNext(3)) //window opens
+					.then(() -> sp1.next(3)) //window opens
 					.expectNext(Signal.next(3))
-					.then(() -> sp1.onNext(4)) //previous window closes, new (empty) window
+					.then(() -> sp1.next(4)) //previous window closes, new (empty) window
 					.expectNext(Signal.complete())
-					.then(() -> sp1.onNext(5)) //fails, the empty window receives onError
+					.then(() -> sp1.next(5)) //fails, the empty window receives onError
 					//error in the window:
 					.expectErrorMessage("predicate failure")
 					.verify(Duration.ofMillis(100));

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTest.java
@@ -74,8 +74,8 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 	}
 
 	// javac can't handle these inline and fails with type inference error
-	final Supplier<Queue<Integer>>                    pqs = ConcurrentLinkedQueue::new;
-	final Supplier<Queue<FluxProcessorSink<Integer>>> oqs = ConcurrentLinkedQueue::new;
+	final Supplier<Queue<Integer>>                      pqs = ConcurrentLinkedQueue::new;
+	final Supplier<Queue<FluxProcessorFacade<Integer>>> oqs = ConcurrentLinkedQueue::new;
 
 	@Test(expected = NullPointerException.class)
 	public void source1Null() {
@@ -428,7 +428,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 	public void exactError() {
 		AssertSubscriber<Publisher<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp = Processors.direct();
+		FluxProcessorSink<Integer> sp = Processors.directSink();
 
 		sp.asFlux().window(2, 2)
 		  .subscribe(ts);
@@ -456,7 +456,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 	public void skipError() {
 		AssertSubscriber<Publisher<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp = Processors.direct();
+		FluxProcessorSink<Integer> sp = Processors.directSink();
 
 		sp.asFlux().window(2, 3)
 		  .subscribe(ts);
@@ -484,7 +484,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 	public void skipInGapError() {
 		AssertSubscriber<Publisher<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp = Processors.direct();
+		FluxProcessorSink<Integer> sp = Processors.directSink();
 
 		sp.asFlux().window(1, 3)
 		  .subscribe(ts);
@@ -509,7 +509,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 	public void overlapError() {
 		AssertSubscriber<Publisher<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp = Processors.direct();
+		FluxProcessorSink<Integer> sp = Processors.directSink();
 
 		sp.asFlux().window(2, 1)
 		  .subscribe(ts);
@@ -603,7 +603,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
     public void scanOverlapSubscriber() {
         CoreSubscriber<Flux<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindow.WindowOverlapSubscriber<Integer> test = new FluxWindow.WindowOverlapSubscriber<Integer>(actual,
-        		123, 3, Queues.unbounded(), Queues.<FluxProcessorSink<Integer>>unbounded().get());
+        		123, 3, Queues.unbounded(), Queues.<FluxProcessorFacade<Integer>>unbounded().get());
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
 
@@ -629,7 +629,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
     @Test
     public void scanOverlapSubscriberSmallBuffered() {
 	    @SuppressWarnings("unchecked")
-	    Queue<FluxProcessorSink<Integer>> mockQueue = Mockito.mock(Queue.class);
+	    Queue<FluxProcessorFacade<Integer>> mockQueue = Mockito.mock(Queue.class);
 
         CoreSubscriber<Flux<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindow.WindowOverlapSubscriber<Integer> test = new FluxWindow.WindowOverlapSubscriber<Integer>(actual,
@@ -646,7 +646,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
     @Test
     public void scanOverlapSubscriberLargeBuffered() {
 	    @SuppressWarnings("unchecked")
-	    Queue<FluxProcessorSink<Integer>> mockQueue = Mockito.mock(Queue.class);
+	    Queue<FluxProcessorFacade<Integer>> mockQueue = Mockito.mock(Queue.class);
 
         CoreSubscriber<Flux<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindow.WindowOverlapSubscriber<Integer> test = new FluxWindow.WindowOverlapSubscriber<Integer>(actual,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTest.java
@@ -75,7 +75,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 
 	// javac can't handle these inline and fails with type inference error
 	final Supplier<Queue<Integer>>                      pqs = ConcurrentLinkedQueue::new;
-	final Supplier<Queue<FluxProcessorFacade<Integer>>> oqs = ConcurrentLinkedQueue::new;
+	final Supplier<Queue<UnicastProcessor<Integer>>>    oqs = ConcurrentLinkedQueue::new;
 
 	@Test(expected = NullPointerException.class)
 	public void source1Null() {
@@ -603,7 +603,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
     public void scanOverlapSubscriber() {
         CoreSubscriber<Flux<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindow.WindowOverlapSubscriber<Integer> test = new FluxWindow.WindowOverlapSubscriber<Integer>(actual,
-        		123, 3, Queues.unbounded(), Queues.<FluxProcessorFacade<Integer>>unbounded().get());
+        		123, 3, Queues.unbounded(), Queues.<UnicastProcessor<Integer>>unbounded().get());
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
 
@@ -629,7 +629,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
     @Test
     public void scanOverlapSubscriberSmallBuffered() {
 	    @SuppressWarnings("unchecked")
-	    Queue<FluxProcessorFacade<Integer>> mockQueue = Mockito.mock(Queue.class);
+	    Queue<UnicastProcessor<Integer>> mockQueue = Mockito.mock(Queue.class);
 
         CoreSubscriber<Flux<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindow.WindowOverlapSubscriber<Integer> test = new FluxWindow.WindowOverlapSubscriber<Integer>(actual,
@@ -637,7 +637,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 
         when(mockQueue.size()).thenReturn(Integer.MAX_VALUE - 2);
         //size() is 1
-        test.offer(Processors.unicast());
+        test.offer(UnicastProcessor.create());
 
         assertThat(test.scan(Scannable.Attr.BUFFERED)).isEqualTo(Integer.MAX_VALUE - 1);
         assertThat(test.scan(Scannable.Attr.LARGE_BUFFERED)).isEqualTo(Integer.MAX_VALUE - 1L);
@@ -646,7 +646,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
     @Test
     public void scanOverlapSubscriberLargeBuffered() {
 	    @SuppressWarnings("unchecked")
-	    Queue<FluxProcessorFacade<Integer>> mockQueue = Mockito.mock(Queue.class);
+	    Queue<UnicastProcessor<Integer>> mockQueue = Mockito.mock(Queue.class);
 
         CoreSubscriber<Flux<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxWindow.WindowOverlapSubscriber<Integer> test = new FluxWindow.WindowOverlapSubscriber<Integer>(actual,
@@ -654,11 +654,11 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 
         when(mockQueue.size()).thenReturn(Integer.MAX_VALUE);
         //size() is 5
-        test.offer(Processors.unicast());
-        test.offer(Processors.unicast());
-        test.offer(Processors.unicast());
-        test.offer(Processors.unicast());
-        test.offer(Processors.unicast());
+        test.offer(UnicastProcessor.create());
+        test.offer(UnicastProcessor.create());
+        test.offer(UnicastProcessor.create());
+        test.offer(UnicastProcessor.create());
+        test.offer(UnicastProcessor.create());
 
         assertThat(test.scan(Scannable.Attr.BUFFERED)).isEqualTo(Integer.MIN_VALUE);
         assertThat(test.scan(Scannable.Attr.LARGE_BUFFERED)).isEqualTo(Integer.MAX_VALUE + 5L);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
@@ -86,7 +86,7 @@ public class FluxWindowWhenTest {
 		}
 
 		final CountDownLatch latch = new CountDownLatch(1);
-		final FluxProcessorSink<Wrapper> processor = Processors.unicast();
+		final FluxProcessorSink<Wrapper> processor = Processors.unicastSink();
 
 		Flux<Integer> emitter = Flux.range(1, 400)
 		                            .delayElements(Duration.ofMillis(10))
@@ -141,10 +141,10 @@ public class FluxWindowWhenTest {
 	public void normal() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> sp1 = Processors.direct();
-		FluxProcessorSink<Integer> sp2 = Processors.direct();
-		FluxProcessorSink<Integer> sp3 = Processors.direct();
-		FluxProcessorSink<Integer> sp4 = Processors.direct();
+		FluxProcessorSink<Integer> sp1 = Processors.directSink();
+		FluxProcessorSink<Integer> sp2 = Processors.directSink();
+		FluxProcessorSink<Integer> sp3 = Processors.directSink();
+		FluxProcessorSink<Integer> sp4 = Processors.directSink();
 
 		sp1.asFlux()
 		   .windowWhen(sp2.asFlux(), v -> v == 1 ? sp3.asFlux() : sp4.asFlux())
@@ -185,10 +185,10 @@ public class FluxWindowWhenTest {
 	public void normalStarterEnds() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> source = Processors.direct();
-		FluxProcessorSink<Integer> openSelector = Processors.direct();
-		FluxProcessorSink<Integer> closeSelectorFor1 = Processors.direct();
-		FluxProcessorSink<Integer> closeSelectorForOthers = Processors.direct();
+		FluxProcessorSink<Integer> source = Processors.directSink();
+		FluxProcessorSink<Integer> openSelector = Processors.directSink();
+		FluxProcessorSink<Integer> closeSelectorFor1 = Processors.directSink();
+		FluxProcessorSink<Integer> closeSelectorForOthers = Processors.directSink();
 
 		source.asFlux()
 		      .windowWhen(openSelector.asFlux(), v -> v == 1 ? closeSelectorFor1.asFlux() : closeSelectorForOthers.asFlux())
@@ -230,10 +230,10 @@ public class FluxWindowWhenTest {
 	public void oneWindowOnly() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		FluxProcessorSink<Integer> source = Processors.direct();
-		FluxProcessorSink<Integer> openSelector = Processors.direct();
-		FluxProcessorSink<Integer> closeSelectorFor1 = Processors.direct();
-		FluxProcessorSink<Integer> closeSelectorOthers = Processors.direct();
+		FluxProcessorSink<Integer> source = Processors.directSink();
+		FluxProcessorSink<Integer> openSelector = Processors.directSink();
+		FluxProcessorSink<Integer> closeSelectorFor1 = Processors.directSink();
+		FluxProcessorSink<Integer> closeSelectorOthers = Processors.directSink();
 
 		source.asFlux()
 		      .windowWhen(openSelector.asFlux(), v -> v == 1 ? closeSelectorFor1.asFlux() : closeSelectorOthers.asFlux())
@@ -266,11 +266,11 @@ public class FluxWindowWhenTest {
 	@Test
 	public void windowWillAcumulateMultipleListsOfValuesOverlap() {
 		//given: "a source and a collected flux"
-		FluxProcessorSink<Integer> numbers = Processors.emitter();
-		FluxProcessorSink<Integer> bucketOpening = Processors.emitter();
+		FluxProcessorSink<Integer> numbers = Processors.emitterSink();
+		FluxProcessorSink<Integer> bucketOpening = Processors.emitterSink();
 
 		//"overlapping buffers"
-		FluxProcessorSink<Integer> boundaryFlux = Processors.emitter();
+		FluxProcessorSink<Integer> boundaryFlux = Processors.emitterSink();
 
 		MonoProcessor<List<List<Integer>>> res = numbers.asFlux()
 		                                                .windowWhen(bucketOpening.asFlux(), u -> boundaryFlux.asFlux())

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -746,8 +746,10 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 		});
 		try {
 			StepVerifier.create(Flux.zip(obj -> 0, Flux.just(1), d1.asFlux(), s -> {
-				Stream<? extends Scannable> inners = Scannable.from(d1)
-				                                              .inners();
+				Scannable d1Scannable = Scannable.from(d1.asProcessor());
+				assertThat(d1Scannable.isScanAvailable()).as("d1 actually scannable").isTrue();
+
+				Stream<? extends Scannable> inners = d1Scannable.inners();
 				CoreSubscriber<?> a = ((DirectProcessor.DirectInner) inners.findFirst().get())
 						.actual;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -927,8 +927,7 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 	}
 
 	private static final <T> FluxZip.ZipInner<T> zipInnerFrom(FluxProcessorSink<T> up) {
-		assertThat(up).isInstanceOf(InnerOperator.class);
-		CoreSubscriber actual = ((InnerOperator) up).actual();
+		CoreSubscriber<T> actual = ProcessorsTestUtils.unicastActual(up);
 		assertThat(actual).isInstanceOf(FluxZip.ZipInner.class);
 		return (FluxZip.ZipInner<T>) actual;
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -437,8 +437,8 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 	public void multipleStreamValuesCanBeZipped() {
 //		"Multiple Stream"s values can be zipped"
 //		given: "source composables to merge, buffer and tap"
-		FluxProcessorSink<Integer> source1 = Processors.emitter();
-		FluxProcessorSink<Integer> source2 = Processors.emitter();
+		FluxProcessorSink<Integer> source1 = Processors.emitterSink();
+		FluxProcessorSink<Integer> source2 = Processors.emitterSink();
 		Flux<Integer> zippedFlux = Flux.zip(source1.asFlux(), source2.asFlux(), (t1, t2) -> t1 + t2);
 		AtomicReference<Integer> tap = new AtomicReference<>();
 		zippedFlux.subscribe(it -> tap.set(it));
@@ -741,12 +741,12 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void failDoubleTerminalPublisher() {
-		FluxProcessorSink<Integer> d1 = Processors.direct();
+		FluxProcessorSink<Integer> d1 = Processors.directSink();
 		Hooks.onErrorDropped(e -> {
 		});
 		try {
 			StepVerifier.create(Flux.zip(obj -> 0, Flux.just(1), d1.asFlux(), s -> {
-				Scannable d1Scannable = Scannable.from(d1.asProcessor());
+				Scannable d1Scannable = d1.asScannable();
 				assertThat(d1Scannable.isScanAvailable()).as("d1 actually scannable").isTrue();
 
 				Stream<? extends Scannable> inners = d1Scannable.inners();
@@ -838,7 +838,7 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void backpressuredAsyncFusedCancelled() {
-		FluxProcessorSink<Integer> up = Processors.unicast();
+		FluxProcessorSink<Integer> up = Processors.unicastSink();
 		StepVerifier.create(Flux.zip(obj -> (int) obj[0] + (int) obj[1],
 				1,
 				up.asFlux(),
@@ -855,7 +855,7 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void backpressuredAsyncFusedCancelled2() {
-		FluxProcessorSink<Integer> up = Processors.unicast();
+		FluxProcessorSink<Integer> up = Processors.unicastSink();
 		StepVerifier.create(Flux.zip(obj -> (int) obj[0] + (int) obj[1],
 				1,
 				up.asFlux(),
@@ -875,7 +875,7 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 			assertThat(c).hasMessage("test2");
 		});
 		try {
-			FluxProcessorSink<Integer> up = Processors.unicast();
+			FluxProcessorSink<Integer> up = Processors.unicastSink();
 			StepVerifier.create(Flux.zip(obj -> (int) obj[0] + (int) obj[1],
 					1,
 					up.asFlux(),
@@ -900,7 +900,7 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 		Hooks.onErrorDropped(c -> {
 			assertThat(c).hasMessage("test2");
 		});
-		FluxProcessorSink<Integer> up = Processors.unicast();
+		FluxProcessorSink<Integer> up = Processors.unicastSink();
 		try {
 			StepVerifier.create(Flux.zip(obj -> (int) obj[0] + (int) obj[1], 1,
 					up.asFlux(),
@@ -936,7 +936,7 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void backpressuredAsyncFusedComplete() {
-		FluxProcessorSink<Integer> up = Processors.unicast();
+		FluxProcessorSink<Integer> up = Processors.unicastSink();
 		StepVerifier.create(Flux.zip(obj -> (int) obj[0] + (int) obj[1],
 				1,
 				up.asFlux(),
@@ -1049,7 +1049,7 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void prematureCompleteSourceEmptyDouble() {
-		FluxProcessorSink<Integer> d = Processors.direct();
+		FluxProcessorSink<Integer> d = Processors.directSink();
 		StepVerifier.create(Flux.zip(obj -> 0, d.asFlux(), s -> {
 			Stream<? extends Scannable> inners = d.asScannable()
 			                                      .inners();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -746,7 +746,7 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 		});
 		try {
 			StepVerifier.create(Flux.zip(obj -> 0, Flux.just(1), d1.asFlux(), s -> {
-				Scannable d1Scannable = d1.asScannable();
+				Scannable d1Scannable = Scannable.from(d1);
 				assertThat(d1Scannable.isScanAvailable()).as("d1 actually scannable").isTrue();
 
 				Stream<? extends Scannable> inners = d1Scannable.inners();
@@ -1051,8 +1051,8 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 	public void prematureCompleteSourceEmptyDouble() {
 		FluxProcessorSink<Integer> d = Processors.directSink();
 		StepVerifier.create(Flux.zip(obj -> 0, d.asFlux(), s -> {
-			Stream<? extends Scannable> inners = d.asScannable()
-			                                      .inners();
+			Stream<? extends Scannable> inners = Scannable.from(d)
+			                                              .inners();
 			CoreSubscriber<?> a =
 					((DirectProcessor.DirectInner) inners.findFirst().get())
 							.actual;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFilterTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFilterTest.java
@@ -170,7 +170,9 @@ public class MonoFilterTest {
 	@Test
 	public void filterMono() {
 		MonoProcessor<Integer> mp = MonoProcessor.create();
-		StepVerifier.create(Mono.just(2).filter(s -> s % 2 == 0).subscribeWith(mp))
+		StepVerifier.create(Mono.just(2).filter(s -> s % 2 == 0)
+		                        .subscribeWith((MonoProcessorFacade<Integer>) mp)
+		                        .asMono())
 		            .then(() -> assertThat(mp.isError()).isFalse())
 		            .then(() -> assertThat(mp.isSuccess()).isTrue())
 		            .then(() -> assertThat(mp.peek()).isEqualTo(2))
@@ -183,7 +185,9 @@ public class MonoFilterTest {
 	@Test
 	public void filterMonoNot() {
 		MonoProcessor<Integer> mp = MonoProcessor.create();
-		StepVerifier.create(Mono.just(1).filter(s -> s % 2 == 0).subscribeWith(mp))
+		StepVerifier.create(Mono.just(1).filter(s -> s % 2 == 0)
+		                        .subscribeWith((MonoProcessorFacade<Integer>) mp)
+		                        .asMono())
 		            .then(() -> assertThat(mp.isError()).isFalse())
 		            .then(() -> assertThat(mp.isSuccess()).isTrue())
 		            .then(() -> assertThat(mp.peek()).isNull())

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFilterTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFilterTest.java
@@ -173,10 +173,10 @@ public class MonoFilterTest {
 		StepVerifier.create(Mono.just(2).filter(s -> s % 2 == 0)
 		                        .subscribeWith((MonoProcessorFacade<Integer>) mp)
 		                        .asMono())
-		            .then(() -> assertThat(mp.isError()).isFalse())
+		            .then(() -> assertThat(mp.isError()).as("isError").isFalse())
 		            .then(() -> assertThat(mp.isSuccess()).isTrue())
 		            .then(() -> assertThat(mp.peek()).isEqualTo(2))
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .expectNext(2)
 		            .verifyComplete();
 	}
@@ -188,10 +188,10 @@ public class MonoFilterTest {
 		StepVerifier.create(Mono.just(1).filter(s -> s % 2 == 0)
 		                        .subscribeWith((MonoProcessorFacade<Integer>) mp)
 		                        .asMono())
-		            .then(() -> assertThat(mp.isError()).isFalse())
+		            .then(() -> assertThat(mp.isError()).as("isError").isFalse())
 		            .then(() -> assertThat(mp.isSuccess()).isTrue())
 		            .then(() -> assertThat(mp.peek()).isNull())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .verifyComplete();
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
@@ -247,10 +247,10 @@ public class MonoFilterWhenTest {
 
 	@Test
 	public void cancel() {
-		final EmitterProcessor<Boolean> pp = EmitterProcessor.create();
+		final FluxProcessorSink<Boolean> pp = Processors.emitter();
 
 		StepVerifier.create(Mono.just(1)
-		                        .filterWhen(v -> pp))
+		                        .filterWhen(v -> pp.asFlux()))
 		            .thenCancel();
 
 		assertThat(pp.hasDownstreams()).isFalse();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
@@ -247,7 +247,7 @@ public class MonoFilterWhenTest {
 
 	@Test
 	public void cancel() {
-		final FluxProcessorSink<Boolean> pp = Processors.emitter();
+		final FluxProcessorSink<Boolean> pp = Processors.emitterSink();
 
 		StepVerifier.create(Mono.just(1)
 		                        .filterWhen(v -> pp.asFlux()))

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFirstTest.java
@@ -110,10 +110,10 @@ public class MonoFirstTest {
 		StepVerifier.create(Mono.first(Mono.just(1), Mono.just(2))
 		                        .subscribeWith(mp)
 		                        .asMono())
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isComplete()).isTrue())
-		            .then(() -> assertThat(mp.isValued()).isFalse())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isFalse())
+		            .then(() -> assertThat(mp.isComplete()).as("isComplete").isTrue())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .expectNext(1)
 		            .verifyComplete();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFirstTest.java
@@ -106,11 +106,13 @@ public class MonoFirstTest {
 
 	@Test
 	public void firstMonoJust() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		MonoProcessorFacade<Integer> mp = Processors.first();
 		StepVerifier.create(Mono.first(Mono.just(1), Mono.just(2))
-		                        .subscribeWith(mp))
+		                        .subscribeWith(mp)
+		                        .asMono())
 		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isComplete()).isTrue())
+		            .then(() -> assertThat(mp.isValued()).isFalse())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .expectNext(1)
 		            .verifyComplete();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoOnErrorResumeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoOnErrorResumeTest.java
@@ -201,10 +201,10 @@ public class MonoOnErrorResumeTest {
 				.onErrorMap(TestException.class, e -> new Exception("test"))
 				.subscribeWith(mp)
 				.asMono())
-		            .then(() -> assertThat(mp.isError()).isTrue())
-		            .then(() -> assertThat(mp.isComplete()).isFalse())
-		            .then(() -> assertThat(mp.isValued()).isFalse())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isTrue())
+		            .then(() -> assertThat(mp.isComplete()).as("isComplete").isFalse())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isFalse())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .verifyErrorMessage("test");
 	}
 
@@ -215,10 +215,10 @@ public class MonoOnErrorResumeTest {
 				.onErrorResume(TestException.class, e -> Mono.just(1))
 				.subscribeWith(mp)
 				.asMono())
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isComplete()).isTrue())
-		            .then(() -> assertThat(mp.isValued()).isFalse())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isFalse())
+		            .then(() -> assertThat(mp.isComplete()).as("isComplete").isTrue())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .expectNext(1)
 		            .verifyComplete();
 	}
@@ -230,10 +230,10 @@ public class MonoOnErrorResumeTest {
 				.onErrorResume(RuntimeException.class, e -> Mono.just(1))
 				.subscribeWith(mp)
 				.asMono())
-		            .then(() -> assertThat(mp.isError()).isTrue())
-		            .then(() -> assertThat(mp.isComplete()).isFalse())
-		            .then(() -> assertThat(mp.isValued()).isFalse())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isTrue())
+		            .then(() -> assertThat(mp.isComplete()).as("isComplete").isFalse())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isFalse())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .verifyError(TestException.class);
 	}
 
@@ -244,10 +244,10 @@ public class MonoOnErrorResumeTest {
 				.onErrorReturn(TestException.class, 1)
 				.subscribeWith(mp)
 				.asMono())
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isComplete()).isTrue())
-		            .then(() -> assertThat(mp.isValued()).isFalse())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isFalse())
+		            .then(() -> assertThat(mp.isComplete()).as("isComplete").isTrue())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .expectNext(1)
 		            .verifyComplete();
 	}
@@ -260,10 +260,10 @@ public class MonoOnErrorResumeTest {
 				.onErrorReturn(TestException.class::isInstance, 1)
 				.subscribeWith(mp)
 				.asMono())
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isComplete()).isTrue())
-		            .then(() -> assertThat(mp.isValued()).isFalse())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isFalse())
+		            .then(() -> assertThat(mp.isComplete()).as("isComplete").isTrue())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .expectNext(1)
 		            .verifyComplete();
 	}
@@ -275,10 +275,10 @@ public class MonoOnErrorResumeTest {
 				.onErrorReturn(RuntimeException.class, 1)
 				.subscribeWith(mp)
 				.asMono())
-		            .then(() -> assertThat(mp.isError()).isTrue())
-		            .then(() -> assertThat(mp.isComplete()).isFalse())
-		            .then(() -> assertThat(mp.isValued()).isFalse())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isTrue())
+		            .then(() -> assertThat(mp.isComplete()).as("isComplete").isFalse())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isFalse())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .verifyError(TestException.class);
 	}
 
@@ -289,10 +289,10 @@ public class MonoOnErrorResumeTest {
 				.onErrorReturn(RuntimeException.class::isInstance, 1)
 				.subscribeWith(mp)
 				.asMono())
-		            .then(() -> assertThat(mp.isError()).isTrue())
-		            .then(() -> assertThat(mp.isComplete()).isFalse())
-		            .then(() -> assertThat(mp.isValued()).isFalse())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isTrue())
+		            .then(() -> assertThat(mp.isComplete()).as("isComplete").isFalse())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isFalse())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .verifyError(TestException.class);
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoOnErrorResumeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoOnErrorResumeTest.java
@@ -196,24 +196,28 @@ public class MonoOnErrorResumeTest {
 
 	@Test
 	public void mapError() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		MonoProcessorFacade<Integer> mp = Processors.first();
 		StepVerifier.create(Mono.<Integer>error(new TestException())
 				.onErrorMap(TestException.class, e -> new Exception("test"))
-				.subscribeWith(mp))
+				.subscribeWith(mp)
+				.asMono())
 		            .then(() -> assertThat(mp.isError()).isTrue())
-		            .then(() -> assertThat(mp.isSuccess()).isFalse())
+		            .then(() -> assertThat(mp.isComplete()).isFalse())
+		            .then(() -> assertThat(mp.isValued()).isFalse())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .verifyErrorMessage("test");
 	}
 
 	@Test
 	public void otherwiseErrorFilter() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		MonoProcessorFacade<Integer> mp = Processors.first();
 		StepVerifier.create(Mono.<Integer>error(new TestException())
 				.onErrorResume(TestException.class, e -> Mono.just(1))
-				.subscribeWith(mp))
+				.subscribeWith(mp)
+				.asMono())
 		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isComplete()).isTrue())
+		            .then(() -> assertThat(mp.isValued()).isFalse())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .expectNext(1)
 		            .verifyComplete();
@@ -221,24 +225,28 @@ public class MonoOnErrorResumeTest {
 
 	@Test
 	public void otherwiseErrorUnfilter() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		MonoProcessorFacade<Integer> mp = Processors.first();
 		StepVerifier.create(Mono.<Integer>error(new TestException())
 				.onErrorResume(RuntimeException.class, e -> Mono.just(1))
-				.subscribeWith(mp))
+				.subscribeWith(mp)
+				.asMono())
 		            .then(() -> assertThat(mp.isError()).isTrue())
-		            .then(() -> assertThat(mp.isSuccess()).isFalse())
+		            .then(() -> assertThat(mp.isComplete()).isFalse())
+		            .then(() -> assertThat(mp.isValued()).isFalse())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .verifyError(TestException.class);
 	}
 
 	@Test
 	public void otherwiseReturnErrorFilter() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		MonoProcessorFacade<Integer> mp = Processors.first();
 		StepVerifier.create(Mono.<Integer>error(new TestException())
 				.onErrorReturn(TestException.class, 1)
-				.subscribeWith(mp))
+				.subscribeWith(mp)
+				.asMono())
 		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isComplete()).isTrue())
+		            .then(() -> assertThat(mp.isValued()).isFalse())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .expectNext(1)
 		            .verifyComplete();
@@ -247,12 +255,14 @@ public class MonoOnErrorResumeTest {
 
 	@Test
 	public void otherwiseReturnErrorFilter2() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		MonoProcessorFacade<Integer> mp = Processors.first();
 		StepVerifier.create(Mono.<Integer>error(new TestException())
 				.onErrorReturn(TestException.class::isInstance, 1)
-				.subscribeWith(mp))
+				.subscribeWith(mp)
+				.asMono())
 		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isComplete()).isTrue())
+		            .then(() -> assertThat(mp.isValued()).isFalse())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .expectNext(1)
 		            .verifyComplete();
@@ -260,24 +270,28 @@ public class MonoOnErrorResumeTest {
 
 	@Test
 	public void otherwiseReturnErrorUnfilter() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		MonoProcessorFacade<Integer> mp = Processors.first();
 		StepVerifier.create(Mono.<Integer>error(new TestException())
 				.onErrorReturn(RuntimeException.class, 1)
-				.subscribeWith(mp))
+				.subscribeWith(mp)
+				.asMono())
 		            .then(() -> assertThat(mp.isError()).isTrue())
-		            .then(() -> assertThat(mp.isSuccess()).isFalse())
+		            .then(() -> assertThat(mp.isComplete()).isFalse())
+		            .then(() -> assertThat(mp.isValued()).isFalse())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .verifyError(TestException.class);
 	}
 
 	@Test
 	public void otherwiseReturnErrorUnfilter2() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		MonoProcessorFacade<Integer> mp = Processors.first();
 		StepVerifier.create(Mono.<Integer>error(new TestException())
 				.onErrorReturn(RuntimeException.class::isInstance, 1)
-				.subscribeWith(mp))
+				.subscribeWith(mp)
+				.asMono())
 		            .then(() -> assertThat(mp.isError()).isTrue())
-		            .then(() -> assertThat(mp.isSuccess()).isFalse())
+		            .then(() -> assertThat(mp.isComplete()).isFalse())
+		            .then(() -> assertThat(mp.isValued()).isFalse())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .verifyError(TestException.class);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
@@ -335,7 +335,8 @@ public class MonoProcessorTest {
 
 		StepVerifier.create(mp.<Integer>map(s -> {
 			throw new RuntimeException("test");
-		}).subscribeWith(mp2), 0)
+		}).subscribeWith((MonoProcessorFacade<Integer>) mp2)
+		  .asMono(), 0)
 		            .thenRequest(1)
 		            .then(() -> {
 			            assertThat(mp2.isTerminated()).isTrue();
@@ -368,7 +369,8 @@ public class MonoProcessorTest {
 		MonoProcessor<Tuple2<Integer, Integer>> mp3 = MonoProcessor.create();
 
 		StepVerifier.create(Mono.zip(mp, mp2)
-		                        .subscribeWith(mp3))
+		                        .subscribeWith((MonoProcessorFacade<Tuple2<Integer, Integer>>) mp3)
+		                        .asMono())
 		            .then(() -> assertThat(mp3.isPending()).isTrue())
 		            .then(() -> mp.onNext(1))
 		            .then(() -> assertThat(mp3.isPending()).isTrue())
@@ -392,7 +394,9 @@ public class MonoProcessorTest {
 		MonoProcessor<Integer> mp3 = MonoProcessor.create();
 
 		StepVerifier.create(Mono.zip(d -> (Integer)d[0], mp)
-		                        .subscribeWith(mp3))
+		                        .subscribeWith((MonoProcessorFacade<Integer>) mp3)
+		                        .asMono()
+		)
 		            .then(() -> assertThat(mp3.isPending()).isTrue())
 		            .then(() -> mp.onNext(1))
 		            .then(() -> {
@@ -412,7 +416,8 @@ public class MonoProcessorTest {
 		MonoProcessor<Tuple2<Integer, Integer>> mp3 = MonoProcessor.create();
 
 		StepVerifier.create(Mono.zip(mp, mp2)
-		                        .subscribeWith(mp3))
+		                        .subscribeWith((MonoProcessorFacade<Tuple2<Integer, Integer>>) mp3)
+		                        .asMono())
 		            .then(() -> assertThat(mp3.isPending()).isTrue())
 		            .then(() -> mp.onError(new Exception("test")))
 		            .then(() -> {
@@ -429,7 +434,9 @@ public class MonoProcessorTest {
 	public void filterMonoProcessor() {
 		MonoProcessor<Integer> mp = MonoProcessor.create();
 		MonoProcessor<Integer> mp2 = MonoProcessor.create();
-		StepVerifier.create(mp.filter(s -> s % 2 == 0).subscribeWith(mp2))
+		StepVerifier.create(mp.filter(s -> s % 2 == 0)
+		                      .subscribeWith((MonoProcessorFacade<Integer>) mp2)
+		                      .asMono())
 		            .then(() -> mp.onNext(2))
 		            .then(() -> assertThat(mp2.isError()).isFalse())
 		            .then(() -> assertThat(mp2.isSuccess()).isTrue())
@@ -444,7 +451,9 @@ public class MonoProcessorTest {
 	public void filterMonoProcessorNot() {
 		MonoProcessor<Integer> mp = MonoProcessor.create();
 		MonoProcessor<Integer> mp2 = MonoProcessor.create();
-		StepVerifier.create(mp.filter(s -> s % 2 == 0).subscribeWith(mp2))
+		StepVerifier.create(mp.filter(s -> s % 2 == 0)
+		                      .subscribeWith((MonoProcessorFacade<Integer>) mp2)
+		                      .asMono())
 		            .then(() -> mp.onNext(1))
 		            .then(() -> assertThat(mp2.isError()).isFalse())
 		            .then(() -> assertThat(mp2.isSuccess()).isTrue())
@@ -458,8 +467,8 @@ public class MonoProcessorTest {
 		MonoProcessor<Integer> mp = MonoProcessor.create();
 		MonoProcessor<Integer> mp2 = MonoProcessor.create();
 		StepVerifier.create(mp.filter(s -> {throw new RuntimeException("test"); })
-					.subscribeWith
-						(mp2))
+		                      .subscribeWith((MonoProcessorFacade<Integer>) mp2)
+		                      .asMono())
 		            .then(() -> mp.onNext(2))
 		            .then(() -> assertThat(mp2.isError()).isTrue())
 		            .then(() -> assertThat(mp2.isSuccess()).isFalse())
@@ -476,8 +485,8 @@ public class MonoProcessorTest {
 
 		StepVerifier.create(mp.doOnSuccess(s -> {throw new RuntimeException("test"); })
 		                      .doOnError(ref::set)
-					.subscribeWith
-						(mp2))
+		                      .subscribeWith((MonoProcessorFacade<Integer>) mp2)
+		                      .asMono())
 		            .then(() -> mp.onNext(2))
 		            .then(() -> assertThat(mp2.isError()).isTrue())
 		            .then(() -> assertThat(ref.get()).hasMessage("test"))

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
@@ -36,6 +36,7 @@ import reactor.util.function.Tuple2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+@SuppressWarnings("deprecation")
 public class MonoProcessorTest {
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
@@ -70,12 +70,12 @@ public class MonoTimeoutTest {
 
 		MonoProcessor<Integer> source = MonoProcessor.create();
 
-		DirectProcessor<Integer> tp = DirectProcessor.create();
+		FluxProcessorSink<Integer> tp = Processors.direct();
 
-		source.timeout(tp)
+		source.timeout(tp.asFlux())
 		      .subscribe(ts);
 
-		tp.onNext(1);
+		tp.next(1);
 
 		source.onNext(2);
 		source.onComplete();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
@@ -70,7 +70,7 @@ public class MonoTimeoutTest {
 
 		MonoProcessor<Integer> source = MonoProcessor.create();
 
-		FluxProcessorSink<Integer> tp = Processors.direct();
+		FluxProcessorSink<Integer> tp = Processors.directSink();
 
 		source.timeout(tp.asFlux())
 		      .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoZipTest.java
@@ -202,11 +202,11 @@ public class MonoZipTest {
 
 	@Test
 	public void whenMonoJust() {
-		MonoProcessor<Tuple2<Integer, Integer>> mp = MonoProcessor.create();
+		MonoProcessorFacade<Tuple2<Integer, Integer>> mp = Processors.first();
 		StepVerifier.create(Mono.zip(Mono.just(1), Mono.just(2))
-		                        .subscribeWith(mp))
+		                        .subscribeWith(mp).asMono())
 		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isValued()).isTrue())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2).isTrue())
 		            .verifyComplete();
@@ -214,11 +214,11 @@ public class MonoZipTest {
 
 	@Test
 	public void whenMonoJust3() {
-		MonoProcessor<Tuple3<Integer, Integer, Integer>> mp = MonoProcessor.create();
+		MonoProcessorFacade<Tuple3<Integer, Integer, Integer>> mp = Processors.first();
 		StepVerifier.create(Mono.zip(Mono.just(1), Mono.just(2), Mono.just(3))
-		                        .subscribeWith(mp))
+		                        .subscribeWith(mp).asMono())
 		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isValued()).isTrue())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3).isTrue())
 		            .verifyComplete();
@@ -226,15 +226,15 @@ public class MonoZipTest {
 
 	@Test
 	public void whenMonoJust4() {
-		MonoProcessor<Tuple4<Integer, Integer, Integer, Integer>> mp =
-				MonoProcessor.create();
+		MonoProcessorFacade<Tuple4<Integer, Integer, Integer, Integer>> mp =
+				Processors.first();
 		StepVerifier.create(Mono.zip(Mono.just(1),
 				Mono.just(2),
 				Mono.just(3),
 				Mono.just(4))
-		                        .subscribeWith(mp))
+		                        .subscribeWith(mp).asMono())
 		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isValued()).isTrue())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4).isTrue())
 		            .verifyComplete();
@@ -242,16 +242,16 @@ public class MonoZipTest {
 
 	@Test
 	public void whenMonoJust5() {
-		MonoProcessor<Tuple5<Integer, Integer, Integer, Integer, Integer>> mp =
-				MonoProcessor.create();
+		MonoProcessorFacade<Tuple5<Integer, Integer, Integer, Integer, Integer>> mp =
+				Processors.first();
 		StepVerifier.create(Mono.zip(Mono.just(1),
 				Mono.just(2),
 				Mono.just(3),
 				Mono.just(4),
 				Mono.just(5))
-		                        .subscribeWith(mp))
+		                        .subscribeWith(mp).asMono())
 		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isValued()).isTrue())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4 && v.getT5() == 5).isTrue())
 		            .verifyComplete();
@@ -259,17 +259,17 @@ public class MonoZipTest {
 
 	@Test
 	public void whenMonoJust6() {
-		MonoProcessor<Tuple6<Integer, Integer, Integer, Integer, Integer, Integer>> mp =
-				MonoProcessor.create();
+		MonoProcessorFacade<Tuple6<Integer, Integer, Integer, Integer, Integer, Integer>> mp =
+				Processors.first();
 		StepVerifier.create(Mono.zip(Mono.just(1),
 				Mono.just(2),
 				Mono.just(3),
 				Mono.just(4),
 				Mono.just(5),
 				Mono.just(6))
-		                        .subscribeWith(mp))
+		                        .subscribeWith(mp).asMono())
 		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isValued()).isTrue())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4 && v.getT5() == 5 && v.getT6() == 6).isTrue())
 		            .verifyComplete();
@@ -304,24 +304,25 @@ public class MonoZipTest {
 
 	@Test
 	public void whenMonoError() {
-		MonoProcessor<Tuple2<Integer, Integer>> mp = MonoProcessor.create();
+		MonoProcessorFacade<Tuple2<Integer, Integer>> mp = Processors.first();
 		StepVerifier.create(Mono.zip(Mono.<Integer>error(new Exception("test1")),
 				Mono.<Integer>error(new Exception("test2")))
-		                        .subscribeWith(mp))
+		                        .subscribeWith(mp).asMono())
 		            .then(() -> assertThat(mp.isError()).isTrue())
-		            .then(() -> assertThat(mp.isSuccess()).isFalse())
+		            .then(() -> assertThat(mp.isComplete()).isFalse())
+		            .then(() -> assertThat(mp.isValued()).isFalse())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .verifyErrorSatisfies(e -> assertThat(e).hasMessage("test1"));
 	}
 
 	@Test
 	public void whenMonoCallable() {
-		MonoProcessor<Tuple2<Integer, Integer>> mp = MonoProcessor.create();
+		MonoProcessorFacade<Tuple2<Integer, Integer>> mp = Processors.first();
 		StepVerifier.create(Mono.zip(Mono.fromCallable(() -> 1),
 				Mono.fromCallable(() -> 2))
-		                        .subscribeWith(mp))
+		                        .subscribeWith(mp).asMono())
 		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isValued()).isTrue())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2).isTrue())
 		            .verifyComplete();
@@ -329,11 +330,11 @@ public class MonoZipTest {
 
 	@Test
 	public void whenDelayJustMono() {
-		MonoProcessor<Tuple2<Integer, Integer>> mp = MonoProcessor.create();
+		MonoProcessorFacade<Tuple2<Integer, Integer>> mp = Processors.first();
 		StepVerifier.create(Mono.zipDelayError(Mono.just(1), Mono.just(2))
-		                        .subscribeWith(mp))
+		                        .subscribeWith(mp).asMono())
 		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isValued()).isTrue())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2).isTrue())
 		            .verifyComplete();
@@ -341,11 +342,11 @@ public class MonoZipTest {
 
 	@Test
 	public void whenDelayJustMono3() {
-		MonoProcessor<Tuple3<Integer, Integer, Integer>> mp = MonoProcessor.create();
+		MonoProcessorFacade<Tuple3<Integer, Integer, Integer>> mp = Processors.first();
 		StepVerifier.create(Mono.zipDelayError(Mono.just(1), Mono.just(2), Mono.just(3))
-		                        .subscribeWith(mp))
+		                        .subscribeWith(mp).asMono())
 		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isValued()).isTrue())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3).isTrue())
 		            .verifyComplete();
@@ -353,15 +354,15 @@ public class MonoZipTest {
 
 	@Test
 	public void whenDelayMonoJust4() {
-		MonoProcessor<Tuple4<Integer, Integer, Integer, Integer>> mp =
-				MonoProcessor.create();
+		MonoProcessorFacade<Tuple4<Integer, Integer, Integer, Integer>> mp =
+				Processors.first();
 		StepVerifier.create(Mono.zipDelayError(Mono.just(1),
 				Mono.just(2),
 				Mono.just(3),
 				Mono.just(4))
-		                        .subscribeWith(mp))
+		                        .subscribeWith(mp).asMono())
 		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isValued()).isTrue())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4).isTrue())
 		            .verifyComplete();
@@ -369,16 +370,16 @@ public class MonoZipTest {
 
 	@Test
 	public void whenDelayMonoJust5() {
-		MonoProcessor<Tuple5<Integer, Integer, Integer, Integer, Integer>> mp =
-				MonoProcessor.create();
+		MonoProcessorFacade<Tuple5<Integer, Integer, Integer, Integer, Integer>> mp =
+				Processors.first();
 		StepVerifier.create(Mono.zipDelayError(Mono.just(1),
 				Mono.just(2),
 				Mono.just(3),
 				Mono.just(4),
 				Mono.just(5))
-		                        .subscribeWith(mp))
+		                        .subscribeWith(mp).asMono())
 		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isValued()).isTrue())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4 && v.getT5() == 5).isTrue())
 		            .verifyComplete();
@@ -386,17 +387,19 @@ public class MonoZipTest {
 
 	@Test
 	public void whenDelayMonoJust6() {
-		MonoProcessor<Tuple6<Integer, Integer, Integer, Integer, Integer, Integer>> mp =
-				MonoProcessor.create();
+		MonoProcessorFacade<Tuple6<Integer, Integer, Integer, Integer, Integer, Integer>> mp =
+				Processors.first();
 		StepVerifier.create(Mono.zipDelayError(Mono.just(1),
 				Mono.just(2),
 				Mono.just(3),
 				Mono.just(4),
 				Mono.just(5),
 				Mono.just(6))
-		                        .subscribeWith(mp))
+		                        .subscribeWith(mp)
+		                        .asMono())
 		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isComplete()).isTrue())
+		            .then(() -> assertThat(mp.isValued()).isTrue())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4 && v.getT5() == 5 && v.getT6() == 6).isTrue())
 		            .verifyComplete();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoZipTest.java
@@ -205,9 +205,9 @@ public class MonoZipTest {
 		MonoProcessorFacade<Tuple2<Integer, Integer>> mp = Processors.first();
 		StepVerifier.create(Mono.zip(Mono.just(1), Mono.just(2))
 		                        .subscribeWith(mp).asMono())
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isValued()).isTrue())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isFalse())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2).isTrue())
 		            .verifyComplete();
 	}
@@ -217,9 +217,9 @@ public class MonoZipTest {
 		MonoProcessorFacade<Tuple3<Integer, Integer, Integer>> mp = Processors.first();
 		StepVerifier.create(Mono.zip(Mono.just(1), Mono.just(2), Mono.just(3))
 		                        .subscribeWith(mp).asMono())
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isValued()).isTrue())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isFalse())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3).isTrue())
 		            .verifyComplete();
 	}
@@ -233,9 +233,9 @@ public class MonoZipTest {
 				Mono.just(3),
 				Mono.just(4))
 		                        .subscribeWith(mp).asMono())
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isValued()).isTrue())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isFalse())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4).isTrue())
 		            .verifyComplete();
 	}
@@ -250,9 +250,9 @@ public class MonoZipTest {
 				Mono.just(4),
 				Mono.just(5))
 		                        .subscribeWith(mp).asMono())
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isValued()).isTrue())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isFalse())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4 && v.getT5() == 5).isTrue())
 		            .verifyComplete();
 	}
@@ -268,9 +268,9 @@ public class MonoZipTest {
 				Mono.just(5),
 				Mono.just(6))
 		                        .subscribeWith(mp).asMono())
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isValued()).isTrue())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isFalse())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4 && v.getT5() == 5 && v.getT6() == 6).isTrue())
 		            .verifyComplete();
 	}
@@ -308,10 +308,10 @@ public class MonoZipTest {
 		StepVerifier.create(Mono.zip(Mono.<Integer>error(new Exception("test1")),
 				Mono.<Integer>error(new Exception("test2")))
 		                        .subscribeWith(mp).asMono())
-		            .then(() -> assertThat(mp.isError()).isTrue())
-		            .then(() -> assertThat(mp.isComplete()).isFalse())
-		            .then(() -> assertThat(mp.isValued()).isFalse())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isTrue())
+		            .then(() -> assertThat(mp.isComplete()).as("isComplete").isFalse())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isFalse())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .verifyErrorSatisfies(e -> assertThat(e).hasMessage("test1"));
 	}
 
@@ -321,9 +321,9 @@ public class MonoZipTest {
 		StepVerifier.create(Mono.zip(Mono.fromCallable(() -> 1),
 				Mono.fromCallable(() -> 2))
 		                        .subscribeWith(mp).asMono())
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isValued()).isTrue())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isFalse())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2).isTrue())
 		            .verifyComplete();
 	}
@@ -333,9 +333,9 @@ public class MonoZipTest {
 		MonoProcessorFacade<Tuple2<Integer, Integer>> mp = Processors.first();
 		StepVerifier.create(Mono.zipDelayError(Mono.just(1), Mono.just(2))
 		                        .subscribeWith(mp).asMono())
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isValued()).isTrue())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isFalse())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2).isTrue())
 		            .verifyComplete();
 	}
@@ -345,9 +345,9 @@ public class MonoZipTest {
 		MonoProcessorFacade<Tuple3<Integer, Integer, Integer>> mp = Processors.first();
 		StepVerifier.create(Mono.zipDelayError(Mono.just(1), Mono.just(2), Mono.just(3))
 		                        .subscribeWith(mp).asMono())
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isValued()).isTrue())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isFalse())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3).isTrue())
 		            .verifyComplete();
 	}
@@ -361,9 +361,9 @@ public class MonoZipTest {
 				Mono.just(3),
 				Mono.just(4))
 		                        .subscribeWith(mp).asMono())
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isValued()).isTrue())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isFalse())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4).isTrue())
 		            .verifyComplete();
 	}
@@ -378,9 +378,9 @@ public class MonoZipTest {
 				Mono.just(4),
 				Mono.just(5))
 		                        .subscribeWith(mp).asMono())
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isValued()).isTrue())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isFalse())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4 && v.getT5() == 5).isTrue())
 		            .verifyComplete();
 	}
@@ -397,10 +397,10 @@ public class MonoZipTest {
 				Mono.just(6))
 		                        .subscribeWith(mp)
 		                        .asMono())
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isComplete()).isTrue())
-		            .then(() -> assertThat(mp.isValued()).isTrue())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .then(() -> assertThat(mp.isError()).as("isError").isFalse())
+		            .then(() -> assertThat(mp.isComplete()).as("isComplete").isTrue())
+		            .then(() -> assertThat(mp.isValued()).as("isValued").isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).as("isTerminated").isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4 && v.getT5() == 5 && v.getT6() == 6).isTrue())
 		            .verifyComplete();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/ProcessorsTestUtils.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ProcessorsTestUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import reactor.core.CoreSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Internal utility methods for tests around {@link org.reactivestreams.Processor} and
+ * {@link FluxProcessorSink} APIs.
+ *
+ * @author Simon Baslé
+ */
+public class ProcessorsTestUtils {
+
+	/**
+	 * Method to extract the {@code actual} from a unicast {@link FluxProcessorSink}
+	 * @param unicast the unicast processor
+	 * @param <T> the type of the processor
+	 * @return the actual {@link CoreSubscriber} the unicast processor is attached to
+	 */
+	public static <T> CoreSubscriber<T> unicastActual(FluxProcessorSink<T> unicast) {
+		assertThat(unicast.asProcessor()).isInstanceOf(InnerOperator.class);
+		@SuppressWarnings("unchecked")
+		CoreSubscriber<T> actual = ((InnerOperator) unicast.asProcessor()).actual();
+		return actual;
+	}
+
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/ProcessorsTestUtils.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ProcessorsTestUtils.java
@@ -51,9 +51,9 @@ public class ProcessorsTestUtils {
 	 * @return the actual {@link CoreSubscriber} the unicast processor is attached to
 	 */
 	public static <T> CoreSubscriber<T> unicastActual(FluxProcessorSink<T> unicast) {
-		assertThat(unicast.asProcessor()).isInstanceOf(InnerOperator.class);
+		assertThat(unicast.asFlux()).isInstanceOf(InnerOperator.class);
 		@SuppressWarnings("unchecked")
-		CoreSubscriber<T> actual = ((InnerOperator) unicast.asProcessor()).actual();
+		CoreSubscriber<T> actual = ((InnerOperator) unicast.asFlux()).actual();
 		return actual;
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/ReplayProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ReplayProcessorTest.java
@@ -32,6 +32,7 @@ import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("deprecation")
 public class ReplayProcessorTest {
 
     @Test

--- a/reactor-core/src/test/java/reactor/core/publisher/StrictSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/StrictSubscriberTest.java
@@ -72,9 +72,10 @@ public class StrictSubscriberTest {
 		AtomicBoolean state2 = new AtomicBoolean();
 		AtomicReference<Throwable> e = new AtomicReference<>();
 
-		DirectProcessor<Integer> sp = DirectProcessor.create();
+		FluxProcessorSink<Integer> sp = Processors.direct();
 
-		sp.doOnCancel(() -> state2.set(state1.get()))
+		sp.asFlux()
+		  .doOnCancel(() -> state2.set(state1.get()))
 		  .subscribe(new Subscriber<Integer>() {
 			  @Override
 			  public void onSubscribe(Subscription s) {

--- a/reactor-core/src/test/java/reactor/core/publisher/StrictSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/StrictSubscriberTest.java
@@ -72,7 +72,7 @@ public class StrictSubscriberTest {
 		AtomicBoolean state2 = new AtomicBoolean();
 		AtomicReference<Throwable> e = new AtomicReference<>();
 
-		FluxProcessorSink<Integer> sp = Processors.direct();
+		FluxProcessorSink<Integer> sp = Processors.directSink();
 
 		sp.asFlux()
 		  .doOnCancel(() -> state2.set(state1.get()))

--- a/reactor-core/src/test/java/reactor/core/publisher/TopicProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/TopicProcessorTest.java
@@ -45,6 +45,7 @@ import static org.junit.Assert.*;
 /**
  * @author Stephane Maldini
  */
+@SuppressWarnings("deprecation")
 public class TopicProcessorTest {
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
@@ -24,8 +24,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Consumer;
 
 import org.junit.Test;
-import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
+import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.annotation.Nullable;
@@ -44,7 +44,7 @@ public class UnicastProcessorTest {
 		assertThat(processor)
 				.isSameAs(processor.asCoreSubscriber())
 				.isSameAs(processor.asProcessor())
-				.isSameAs(processor.asScannable())
+				.isSameAs(Scannable.from(processor))
 				.isSameAs(processor.asFlux());
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
@@ -24,6 +24,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Consumer;
 
 import org.junit.Test;
+import org.reactivestreams.Processor;
+import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
@@ -42,8 +44,8 @@ public class UnicastProcessorTest {
 		UnicastProcessor<Object> processor = UnicastProcessor.create();
 
 		assertThat(processor)
-				.isSameAs(processor.asCoreSubscriber())
-				.isSameAs(processor.asProcessor())
+				.isInstanceOf(CoreSubscriber.class)
+				.isInstanceOf(Processor.class)
 				.isSameAs(Scannable.from(processor))
 				.isSameAs(processor.asFlux());
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
@@ -37,6 +37,17 @@ import static org.junit.Assert.assertEquals;
 @SuppressWarnings("deprecation")
 public class UnicastProcessorTest {
 
+	@Test
+	public void fluxProcessorFacadeViewsAreSame() {
+		UnicastProcessor<Object> processor = UnicastProcessor.create();
+
+		assertThat(processor)
+				.isSameAs(processor.asCoreSubscriber())
+				.isSameAs(processor.asProcessor())
+				.isSameAs(processor.asScannable())
+				.isSameAs(processor.asFlux());
+	}
+
     @Test
     public void secondSubscriberRejectedProperly() {
 

--- a/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
@@ -34,6 +34,7 @@ import reactor.util.concurrent.Queues;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
+@SuppressWarnings("deprecation")
 public class UnicastProcessorTest {
 
     @Test

--- a/reactor-core/src/test/java/reactor/core/publisher/WorkQueueProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/WorkQueueProcessorTest.java
@@ -60,6 +60,7 @@ import static reactor.util.concurrent.WaitStrategy.liteBlocking;
 
 /**
  */
+@SuppressWarnings("deprecation")
 public class WorkQueueProcessorTest {
 
 	static final Logger logger = Loggers.getLogger(WorkQueueProcessorTest.class);

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/BurstyWorkQueueProcessorTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/BurstyWorkQueueProcessorTests.java
@@ -47,6 +47,7 @@ public class BurstyWorkQueueProcessorTests {
 	public static final int BURST_SIZE              = 5;
 
 	private LongAccumulator            maxRingBufferPending;
+	@SuppressWarnings("deprecation")
 	private WorkQueueProcessor<Object> processor;
 	private ExecutorService            producerExecutor;
 	private AtomicLong                 droppedCount;
@@ -60,6 +61,7 @@ public class BurstyWorkQueueProcessorTests {
 
 	@Test
 	@Ignore
+	@SuppressWarnings("deprecation")
 	public void test() throws Exception {
 		processor = WorkQueueProcessor.builder().name("test-processor").bufferSize(RINGBUFFER_SIZE).build();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/BurstyWorkQueueProcessorTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/BurstyWorkQueueProcessorTests.java
@@ -26,7 +26,9 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxProcessorFacade;
 import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.MonoProcessorFacade;
 import reactor.core.publisher.SignalType;
 import reactor.core.publisher.WorkQueueProcessor;
 
@@ -63,13 +65,17 @@ public class BurstyWorkQueueProcessorTests {
 	@Ignore
 	@SuppressWarnings("deprecation")
 	public void test() throws Exception {
-		processor = WorkQueueProcessor.builder().name("test-processor").bufferSize(RINGBUFFER_SIZE).build();
+		processor = WorkQueueProcessor.builder()
+		                              .name("test-processor")
+		                              .bufferSize(RINGBUFFER_SIZE)
+		                              .build();
 
 		Flux
 				.create((emitter) -> burstyProducer(emitter, PRODUCED_MESSAGES_COUNT, BURST_SIZE))
 				.onBackpressureDrop(this::incrementDroppedMessagesCounter)
 			//	.log("test", Level.INFO, SignalType.REQUEST)
-				.subscribeWith(processor)
+				.subscribeWith((FluxProcessorFacade<Object>) processor)
+				.asFlux()
 				.map(this::complicatedCalculation)
 				.subscribe(this::logConsumedValue);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/BurstyWorkQueueProcessorTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/BurstyWorkQueueProcessorTests.java
@@ -20,16 +20,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAccumulator;
-import java.util.logging.Level;
 
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.FluxProcessorFacade;
 import reactor.core.publisher.FluxSink;
-import reactor.core.publisher.MonoProcessorFacade;
-import reactor.core.publisher.SignalType;
 import reactor.core.publisher.WorkQueueProcessor;
 
 import static org.testng.Assert.assertEquals;
@@ -74,7 +70,7 @@ public class BurstyWorkQueueProcessorTests {
 				.create((emitter) -> burstyProducer(emitter, PRODUCED_MESSAGES_COUNT, BURST_SIZE))
 				.onBackpressureDrop(this::incrementDroppedMessagesCounter)
 			//	.log("test", Level.INFO, SignalType.REQUEST)
-				.subscribeWith((FluxProcessorFacade<Object>) processor)
+				.subscribeWith(processor)
 				.asFlux()
 				.map(this::complicatedCalculation)
 				.subscribe(this::logConsumedValue);

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
@@ -47,6 +47,7 @@ import reactor.test.subscriber.AssertSubscriber;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+@SuppressWarnings("deprecation")
 public class FluxSpecTests {
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
@@ -33,6 +33,7 @@ import java.util.function.Consumer;
 
 import org.junit.Assert;
 import org.junit.Test;
+import reactor.core.CoreSubscriber;
 import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxProcessor;
@@ -676,8 +677,9 @@ public class FluxSpecTests {
 //		"Stream can be counted"
 //		given: "source composables to count and tap"
 		EmitterProcessor<Integer> source = EmitterProcessor.create();
-		MonoProcessor<Long> tap = source.count()
-		                                .subscribeWith(MonoProcessor.create());
+		MonoProcessor<Long> tap = MonoProcessor.create();
+
+		source.count().subscribe(tap);
 
 //		when: "the sources accept a value"
 		source.onNext(1);
@@ -915,7 +917,9 @@ public class FluxSpecTests {
 //		given: "a composable that will accept 5 values and a reduce function"
 		EmitterProcessor<Integer> source = EmitterProcessor.create();
 		Mono<Integer> reduced = source.reduce(new Reduction());
-		MonoProcessor<Integer> value = reduced.subscribeWith(MonoProcessor.create());
+		MonoProcessor<Integer> value = MonoProcessor.create();
+
+		reduced.subscribe(value);
 
 //		when: "the expected number of values is accepted"
 		source.onNext(1);
@@ -934,8 +938,10 @@ public class FluxSpecTests {
 //		"When a known number of values is being reduced, only the final value is made available"
 //		given: "a composable that will accept 2 values and a reduce function"
 		EmitterProcessor<Integer> source = EmitterProcessor.create();
-		MonoProcessor<Integer> value = source.reduce(new Reduction())
-		                                     .subscribeWith(MonoProcessor.create());
+		MonoProcessor<Integer> value = MonoProcessor.create();
+
+		source.reduce(new Reduction())
+		      .subscribe(value);
 
 //		when: "the first value is accepted"
 		source.onNext(1);

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -64,6 +64,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxProcessor;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
+import reactor.core.publisher.Processors;
 import reactor.core.publisher.ReplayProcessor;
 import reactor.core.publisher.Signal;
 import reactor.core.publisher.SignalType;
@@ -985,7 +986,11 @@ public class FluxTests extends AbstractReactorTest {
 		}).log("points")
 		  .buffer(2)
 		  .map(pairs -> new Point(pairs.get(0), pairs.get(1)))
-		  .subscribeWith(TopicProcessor.<Point>builder().name("tee").bufferSize(32).build());
+		  .subscribeWith(Processors.<Point>fanOut()
+				  .name("tee")
+				  .bufferSize(32)
+				  .buildFacade())
+		  .asFlux();
 
 		Flux<InnerSample> innerSamples = points.log("inner-1")
 		                                          .filter(Point::isInner)

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -986,7 +986,7 @@ public class FluxTests extends AbstractReactorTest {
 		}).log("points")
 		  .buffer(2)
 		  .map(pairs -> new Point(pairs.get(0), pairs.get(1)))
-		  .subscribeWith(Processors.<Point>fanOut()
+		  .subscribeWith(Processors.<Point>asyncEmitter()
 				  .name("tee")
 				  .bufferSize(32)
 				  .buildFacade())

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -83,6 +83,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.junit.Assert.*;
 
+@SuppressWarnings("deprecation")
 public class FluxTests extends AbstractReactorTest {
 
 	static final Logger LOG = Loggers.getLogger(FluxTests.class);

--- a/reactor-core/src/test/java/reactor/core/publisher/tck/FluxWithProcessorVerification.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/tck/FluxWithProcessorVerification.java
@@ -63,7 +63,7 @@ public class FluxWithProcessorVerification extends AbstractProcessorVerification
 						                          otherStream,
 						                          combinator)))
 				 .doOnNext(array -> cumulatedJoin.getAndIncrement())
-				 .subscribeWith(Processors.fanOut()
+				 .subscribeWith(Processors.asyncEmitter()
 				                          .name("fluxion-raw-join")
 				                          .bufferSize(bufferSize)
 				                          .buildFacade())

--- a/reactor-core/src/test/java/reactor/core/publisher/tck/FluxWithProcessorVerification.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/tck/FluxWithProcessorVerification.java
@@ -23,9 +23,7 @@ import java.util.function.BiFunction;
 import org.reactivestreams.Processor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxProcessor;
-import reactor.core.publisher.ProcessorFacade;
 import reactor.core.publisher.Processors;
-import reactor.core.publisher.TopicProcessor;
 import reactor.core.publisher.WorkQueueProcessor;
 
 /**

--- a/reactor-core/src/test/java/reactor/core/publisher/tck/FluxWithProcessorVerification.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/tck/FluxWithProcessorVerification.java
@@ -23,6 +23,8 @@ import java.util.function.BiFunction;
 import org.reactivestreams.Processor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxProcessor;
+import reactor.core.publisher.ProcessorFacade;
+import reactor.core.publisher.Processors;
 import reactor.core.publisher.TopicProcessor;
 import reactor.core.publisher.WorkQueueProcessor;
 
@@ -47,6 +49,7 @@ public class FluxWithProcessorVerification extends AbstractProcessorVerification
 		cumulatedJoin.set(0);
 
 		BiFunction<Long, String, Long> combinator = (t1, t2) -> t1;
+
 		return FluxProcessor.wrap(p,
 				p.groupBy(k -> k % 2 == 0)
 				 .flatMap(stream -> stream.scan((prev, next) -> next)
@@ -60,7 +63,11 @@ public class FluxWithProcessorVerification extends AbstractProcessorVerification
 						                          otherStream,
 						                          combinator)))
 				 .doOnNext(array -> cumulatedJoin.getAndIncrement())
-				 .subscribeWith(TopicProcessor.<Long>builder().name("fluxion-raw-join").bufferSize(bufferSize).build())
+				 .subscribeWith(Processors.fanOut()
+				                          .name("fluxion-raw-join")
+				                          .bufferSize(bufferSize)
+				                          .buildFacade())
+				 .asFlux()
 				 .doOnError(Throwable::printStackTrace));
 	}
 

--- a/reactor-core/src/test/java/reactor/guide/GuideTests.java
+++ b/reactor-core/src/test/java/reactor/guide/GuideTests.java
@@ -202,7 +202,7 @@ public class GuideTests {
 
 	@Test
 	public void advancedHot() {
-		FluxProcessorSink<String> hotSource = Processors.unicast();
+		FluxProcessorSink<String> hotSource = Processors.unicastSink();
 
 		Flux<String> hotFlux = hotSource.asFlux()
 		                                .publish()

--- a/reactor-core/src/test/java/reactor/guide/GuideTests.java
+++ b/reactor-core/src/test/java/reactor/guide/GuideTests.java
@@ -45,13 +45,14 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
+import reactor.core.publisher.FluxProcessorSink;
 import reactor.core.publisher.BaseSubscriber;
 import reactor.core.publisher.ConnectableFlux;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.Processors;
 import reactor.core.publisher.SignalType;
-import reactor.core.publisher.UnicastProcessor;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.PublisherProbe;
@@ -201,23 +202,24 @@ public class GuideTests {
 
 	@Test
 	public void advancedHot() {
-		UnicastProcessor<String> hotSource = UnicastProcessor.create();
+		FluxProcessorSink<String> hotSource = Processors.unicast();
 
-		Flux<String> hotFlux = hotSource.publish()
+		Flux<String> hotFlux = hotSource.asFlux()
+		                                .publish()
 		                                .autoConnect()
 		                                .map(String::toUpperCase);
 
 
 		hotFlux.subscribe(d -> System.out.println("Subscriber 1 to Hot Source: "+d));
 
-		hotSource.onNext("blue");
-		hotSource.onNext("green");
+		hotSource.next("blue");
+		hotSource.next("green");
 
 		hotFlux.subscribe(d -> System.out.println("Subscriber 2 to Hot Source: "+d));
 
-		hotSource.onNext("orange");
-		hotSource.onNext("purple");
-		hotSource.onComplete();
+		hotSource.next("orange");
+		hotSource.next("purple");
+		hotSource.complete();
 	}
 
 	@Test
@@ -985,7 +987,7 @@ public class GuideTests {
 				assertThat(withSuppressed.getSuppressed()).hasSize(1);
 				assertThat(withSuppressed.getSuppressed()[0])
 						.hasMessageStartingWith("\nAssembly trace from producer [reactor.core.publisher.MonoSingle] :")
-						.hasMessageEndingWith("Flux.single ⇢ reactor.guide.GuideTests.scatterAndGather(GuideTests.java:949)\n");
+						.hasMessageEndingWith("Flux.single ⇢ reactor.guide.GuideTests.scatterAndGather(GuideTests.java:951)\n");
 			});
 		}
 	}

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -555,7 +555,7 @@ public class StepVerifierTests {
 
 	@Test
 	public void verifyThenOnCompleteRange() {
-		FluxProcessorSink<Void> p = Processors.direct();
+		FluxProcessorSink<Void> p = Processors.directSink();
 
 		Flux<String> flux = Flux.range(0, 3)
 		                        .map(d -> "t" + d)
@@ -1822,7 +1822,7 @@ public class StepVerifierTests {
 
 	@Test
 	public void takeAsyncFusedBackpressured() {
-		FluxProcessorSink<String> up = Processors.unicast();;
+		FluxProcessorSink<String> up = Processors.unicastSink();
 		StepVerifier.create(up.asFlux().take(3), 0)
 		            .expectFusion()
 		            .then(() -> up.next("test"))
@@ -1837,7 +1837,7 @@ public class StepVerifierTests {
 
 	@Test
 	public void cancelAsyncFusion() {
-		FluxProcessorSink<String> up = Processors.unicast();;
+		FluxProcessorSink<String> up = Processors.unicastSink();
 		StepVerifier.create(up.asFlux().take(3), 0)
 		            .expectFusion()
 		            .then(() -> up.next("test"))
@@ -1908,7 +1908,7 @@ public class StepVerifierTests {
 	@Test
 	public void assertNextWithSubscribeOnDirectProcessor() {
 		Scheduler scheduler = Schedulers.newElastic("test");
-		FluxProcessorSink<Integer> processor = Processors.direct();;
+		FluxProcessorSink<Integer> processor = Processors.directSink();
 		Mono<Integer> doAction = Mono.fromSupplier(() -> 22)
 		                             .doOnNext(processor::next)
 		                             .subscribeOn(scheduler);

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -37,7 +37,9 @@ import org.junit.Test;
 import reactor.core.Fuseable;
 import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxProcessorSink;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.Processors;
 import reactor.core.publisher.UnicastProcessor;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -553,15 +555,15 @@ public class StepVerifierTests {
 
 	@Test
 	public void verifyThenOnCompleteRange() {
-		DirectProcessor<Void> p = DirectProcessor.create();
+		FluxProcessorSink<Void> p = Processors.direct();
 
 		Flux<String> flux = Flux.range(0, 3)
 		                        .map(d -> "t" + d)
-		                        .takeUntilOther(p);
+		                        .takeUntilOther(p.asFlux());
 
 		StepVerifier.create(flux, 2)
 		            .expectNext("t0", "t1")
-		            .then(p::onComplete)
+		            .then(p::complete)
 		            .expectComplete()
 		            .verify();
 
@@ -1820,12 +1822,12 @@ public class StepVerifierTests {
 
 	@Test
 	public void takeAsyncFusedBackpressured() {
-		UnicastProcessor<String> up = UnicastProcessor.create();
-		StepVerifier.create(up.take(3), 0)
+		FluxProcessorSink<String> up = Processors.unicast();;
+		StepVerifier.create(up.asFlux().take(3), 0)
 		            .expectFusion()
-		            .then(() -> up.onNext("test"))
-		            .then(() -> up.onNext("test"))
-		            .then(() -> up.onNext("test"))
+		            .then(() -> up.next("test"))
+		            .then(() -> up.next("test"))
+		            .then(() -> up.next("test"))
 		            .thenRequest(2)
 		            .expectNext("test", "test")
 		            .thenRequest(1)
@@ -1835,12 +1837,12 @@ public class StepVerifierTests {
 
 	@Test
 	public void cancelAsyncFusion() {
-		UnicastProcessor<String> up = UnicastProcessor.create();
-		StepVerifier.create(up.take(3), 0)
+		FluxProcessorSink<String> up = Processors.unicast();;
+		StepVerifier.create(up.asFlux().take(3), 0)
 		            .expectFusion()
-		            .then(() -> up.onNext("test"))
-		            .then(() -> up.onNext("test"))
-		            .then(() -> up.onNext("test"))
+		            .then(() -> up.next("test"))
+		            .then(() -> up.next("test"))
+		            .then(() -> up.next("test"))
 		            .thenRequest(2)
 		            .expectNext("test", "test")
 		            .thenCancel()
@@ -1906,14 +1908,14 @@ public class StepVerifierTests {
 	@Test
 	public void assertNextWithSubscribeOnDirectProcessor() {
 		Scheduler scheduler = Schedulers.newElastic("test");
-		DirectProcessor<Integer> processor = DirectProcessor.create();
+		FluxProcessorSink<Integer> processor = Processors.direct();;
 		Mono<Integer> doAction = Mono.fromSupplier(() -> 22)
-		                             .doOnNext(processor::onNext)
+		                             .doOnNext(processor::next)
 		                             .subscribeOn(scheduler);
 
 		assertThatExceptionOfType(AssertionError.class)
 				.isThrownBy(
-						StepVerifier.create(processor)
+						StepVerifier.create(processor.asFlux())
 						            .then(doAction::subscribe)
 						            .assertNext(v -> assertThat(v).isEqualTo(23))
 						            .thenCancel()

--- a/src/docs/asciidoc/advancedFeatures.adoc
+++ b/src/docs/asciidoc/advancedFeatures.adoc
@@ -167,7 +167,7 @@ Compare the first example to the second example, shown in the following code:
 
 [source,java]
 ----
-FluxProcessorSink<String> hotSource = Processors.unicast();
+FluxProcessorSink<String> hotSource = Processors.unicastSink();
 
 Flux<String> hotFlux = hotSource.asFlux()
                                 .publish()

--- a/src/docs/asciidoc/advancedFeatures.adoc
+++ b/src/docs/asciidoc/advancedFeatures.adoc
@@ -167,23 +167,24 @@ Compare the first example to the second example, shown in the following code:
 
 [source,java]
 ----
-UnicastProcessor<String> hotSource = UnicastProcessor.create();
+FluxProcessorSink<String> hotSource = Processors.unicast();
 
-Flux<String> hotFlux = hotSource.publish()
+Flux<String> hotFlux = hotSource.asFlux()
+                                .publish()
                                 .autoConnect()
                                 .map(String::toUpperCase);
 
 
 hotFlux.subscribe(d -> System.out.println("Subscriber 1 to Hot Source: "+d));
 
-hotSource.onNext("blue");
-hotSource.onNext("green");
+hotSource.next("blue");
+hotSource.next("green");
 
 hotFlux.subscribe(d -> System.out.println("Subscriber 2 to Hot Source: "+d));
 
-hotSource.onNext("orange");
-hotSource.onNext("purple");
-hotSource.onComplete();
+hotSource.next("orange");
+hotSource.next("purple");
+hotSource.complete();
 ----
 
 The second example produces the following output:

--- a/src/docs/asciidoc/faq.adoc
+++ b/src/docs/asciidoc/faq.adoc
@@ -187,7 +187,7 @@ chain or for different subscribers.
 
 [source,java]
 ----
-EmitterProcessor<Integer> processor = EmitterProcessor.create();
+Broadcaster<Integer> processor = Processors.emitter().build();
 processor.publishOn(scheduler1)
          .map(i -> transform(i))
          .publishOn(scheduler2)

--- a/src/docs/asciidoc/processors.adoc
+++ b/src/docs/asciidoc/processors.adoc
@@ -1,9 +1,13 @@
 Processors are a special kind of `Publisher` that are also a `Subscriber`. That means
-that you can `subscribe` to a `Processor` (generally, they implement `Flux`), but you can
-also call methods to manually inject data into the sequence or terminate it.
+that you can `subscribe` to a `Processor`, but you can also call methods to manually inject
+data into the sequence or terminate it.
 
-There are several kinds of Processors, each with a few particular semantics, but before
-you start looking into these, you need to ask yourself the following question:
+Reactor offers a basic interface for Processors that have the same input and output types,
+the `Broadcaster`, with different flavors exposed on the `Processors` utility
+class.
+
+Each flavor has a few particular semantics, but before you start looking into these, you
+need to ask yourself the following question:
 
 = Do I Need a Processor?
 Most of the time, you should try to avoid using a `Processor`. They are harder to use
@@ -21,17 +25,18 @@ terminate it).
 If, after exploring the above alternatives, you still think you need a `Processor`, read
 the <<processor-overview>> section below to learn about the different implementations.
 
-= Safely Produce from Multiple Threads by Using the `Sink` Facade
-Rather than directly using Reactor `Processors`, it is a good practice to obtain a `Sink`
-for the `Processor` by calling `sink()` once.
+= Safely Produce from Multiple Threads by Using the `FluxSink` Facade
+Rather than directly using Reactor `Processors`, it is a good practice to obtain a `FluxSink`
+for the `Processor` by calling `sink()` **once** (and storing the result in a variable to
+reuse it).
 
-`FluxProcessor` sinks safely gate multi-threaded producers and can be used by
+`Broadcaster` sinks safely gate multi-threaded producers and can be used by
 applications that generate data from multiple threads concurrently. For example, a
-thread-safe serialized sink can be created for `UnicastProcessor`:
+thread-safe serialized sink can be created for the `unicast` flavor:
 
 [source,java]
 ----
-UnicastProcessor<Integer> processor = UnicastProcessor.create();
+Broadcaster<Integer> processor = Processors.unicast().build();
 FluxSink<Integer> sink = processor.sink(overflowStrategy);
 ----
 
@@ -48,59 +53,77 @@ configuration:
 
 * An unbounded processor handles the overflow itself by dropping or buffering.
 * A bounded processor blocks or "spins" on the `IGNORE` strategy or applies the
-`overflowStrategy` behavior specified for the `sink`.
+`overflowStrategy` behavior specified when creating the `sink`.
 
 
 [[processor-overview]]
 = Overview of Available Processors
 Reactor Core comes with several flavors of `Processor`. Not all processors have the same
-semantics but are roughly split into three categories. The following list briefly
-describes the three kinds of processors:
+semantics but are roughly split into four categories, described below:
 
-* *direct* (`DirectProcessor` and `UnicastProcessor`): These processors can only push
-data through direct user action (calling their `Sink`'s methods directly).
-* *synchronous* (`EmitterProcessor` and `ReplayProcessor`): These processors can push data
+* *simple* (`direct` and `unicast` flavors): These processors have more limitations than the others.
+`direct` doesn't manage backpressure, while `unicast` is limited to a single `Subscriber`.
+Pushing data through direct user action (calling their `FluxSink`'s methods directly) is
+the favored way of using these.
+* *synchronous* (`emitter` and `replay` flavors): These processors are meant to push data
 both through user action and by subscribing to an upstream `Publisher` and synchronously
 draining it.
-* *asynchronous* (`WorkQueueProcessor` and `TopicProcessor`): These processors can push
-data obtained from multiple upstream `Publishers`. They are more robust and are  backed
-by a `RingBuffer` data structure in order to deal with their multiple upstreams.
+* *asynchronous* (`fanOut` flavor): These processors can push data obtained from
+**multiple** upstream `Publishers`. They are more robust but also are a bit more costly
+to instantiate, establishing more resources in order to deal with their multiple upstreams.
+* *mono* (`first` flavor): These processors, when attached to a `Publisher` source, only
+propagate at most one element from the source. Their `sink()` is actually a `MonoSink<T>`,
+which limits the sink interactions to follow the semantics of `Mono` (0-1 elements).
 
-The asynchronous processors are the most complex to instantiate, with a lot of different
-options. Consequently, they expose a `Builder` interface. The simpler processors have
-static factory methods instead.
 
-== DirectProcessor
-A `DirectProcessor` is a processor that can dispatch signals to zero to many
-`Subscribers`. It is the simplest one to instantiate, with a single `create()` static
-factory method. On the other hand, *it has the limitation of not handling backpressure*.
-As a consequence, a `DirectProcessor` signals an `IllegalStateException` to its
+
+== Direct Processor
+[source,java]
+----
+Broadcaster<Integer> direct = Processors.direct();
+----
+
+A **direct** `Processor` can dispatch signals to zero to many `Subscribers`, but has the
+limitation of not handling backpressure.
+
+As a consequence, a direct `Processor` signals an `IllegalStateException` to its
 subscribers if you push N elements through it but at least one of its subscribers has
 requested less than N.
 
-Once the `Processor` has terminated (usually through its `Sink` `error(Throwable)` or
-`complete()` methods being called), it lets more subscribers subscribe but replays the
-termination signal to them immediately.
+Once the `Processor` has terminated (usually through its `FluxSink` `error(Throwable)`
+or `complete()` methods being called), it lets more subscribers subscribe but
+replays the termination signal to them immediately.
 
-== UnicastProcessor
-A `UnicastProcessor` can deal with backpressure using an internal buffer. The trade-off
-is that it can have *at most one* `Subscriber`.
+== Unicast Processor
+[source,java]
+----
+UnicastProcessorBuilder<Integer> builder = Processors.unicast();
+Broadcaster<Integer> unicast = builder.build();
+----
 
-A `UnicastProcessor` has a few more options, reflected by a few `create` static factory
-methods. For instance, by default it is _unbounded_: if you push any amount of
-data through it while its `Subscriber` has not yet requested data, it will buffer all of
-the data.
+A **unicast** `Processor` can deal with backpressure using an internal buffer.
+The trade-off is that it can have *at most one* `Subscriber`.
+
+Such a `Processor` has a few more options in its builder. For instance, by default it is
+_unbounded_: if you push any amount of data through it while its `Subscriber` has not yet
+requested data, it will buffer all of the data.
 
 This can be changed by providing a custom `Queue` implementation for the internal
-buffering in the `create` factory method. If that queue is bounded, the processor could
-reject the push of a value when the buffer is full and not enough requests from
+buffering through the `queue(Queue)` builder method. If that queue is bounded, the processor
+could reject the push of a value when the buffer is full and not enough requests from
 downstream have been received.
 
 In that _bounded_ case, the processor can also be built with a callback that is invoked
 on each rejected element, allowing for cleanup of these rejected elements.
 
-== EmitterProcessor
-An `EmitterProcessor` is capable of emitting to several subscribers, while honoring
+== Emitter Processor
+[source,java]
+----
+EmitterProcessorBuilder<Integer> builder = Processors.emitter();
+Broadcaster<Integer> emitter = builder.build();
+----
+
+An **emitter** `Processor` is capable of emitting to several subscribers, while honoring
 backpressure for each of its subscribers. It can also subscribe to a `Publisher` and
 relay its signals synchronously.
 
@@ -117,36 +140,56 @@ backpressure purposes.
 
 By default, if all of its subscribers are cancelled (which basically means they have all
 un-subscribed), it will clear its internal buffer and stop accepting new subscribers.
-This can be tuned by the `autoCancel` parameter in the `create` static factory methods.
+This can be deactivated by using the `noAutoCancel()` method in the builder.
 
-== ReplayProcessor
-A `ReplayProcessor` caches elements that are either pushed directly through its `Sink`
+== Replay Processor
+[source,java]
+----
+ReplayProcessorBuilder<Integer> builder = Processors.replay();
+Broadcaster<Integer> replay = builder.build();
+----
+
+A **replay** `Processor` caches elements that are either pushed directly through its `FluxSink`
 or elements from an upstream `Publisher` and replays them to late subscribers.
 
-It can be created in multiple configurations:
+Depending on the methods called on the builder, it can create a replay Processor in
+multiple configurations:
 
-* Caching a single element (`cacheLast`).
-* Caching a limited history (`create(int)`), unbounded history (`create()`).
-* Caching time-based replay window (`createTimeout(Duration)`).
-* Caching combination of history size and time window
-(`createSizeOrTimeout(int, Duration)`).
+* Caching an unbounded history (no builder configuration and direct call to `build()`, or
+call to `historySize(int, true)`).
+* Caching a bounded history (`historySize(int)`).
+* Caching time-based replay windows, by only specifying a TTL (`maxAge(Duration)`).
+* Caching combination of history size and time window, by specifying both TTL
+(`maxAge(Duration)`) and history size (`historySize(int)`).
 
-== TopicProcessor
-A `TopicProcessor` is an asynchronous processor capable of relaying elements from
+There is also a factory method to produce a replay processor that caches the last pushed
+element: `Processors.cacheLast()`.
+
+== FanOut Processor
+[source,java]
+----
+FanOutProcessorBuilder<Integer> builder = Processors.fanOut();
+Broadcaster<Integer> fanOut = builder.build();
+----
+
+A **fan out** `Processor` is an **asynchronous** processor capable of relaying elements from
 multiple upstream `Publishers` when created in the `shared` configuration (see the
-`share(boolean)` option of the `builder()`).
+`share(boolean)` option of the builder).
 
-Note that the share option is mandatory if you intend to concurrently call
-`TopicProcessor`'s `onNext`, `onComplete`, or `onError` methods directly or from a
-concurrent upstream Publisher.
+Note that the share option is mandatory if you intend to concurrently call the Processor's
+`onNext`, `onComplete`, or `onError` methods directly or from a concurrent upstream `Publisher`.
 
 Otherwise, such concurrent calls are illegal, as the processor is then fully compliant
 with the Reactive Streams specification.
 
-A `TopicProcessor` is capable of fanning out to multiple `Subscribers`. It does so by
-associating a `Thread` to each `Subscriber`, which will run until an `onError` or
-`onComplete` signal is pushed through the processor or until the associated `Subscriber`
-is cancelled. The maximum number of downstream subscribers is driven by the `executor`
+A fan out processor is capable of fanning out to multiple `Subscribers`,
+with the added overhead of establishing resources to keep track of each `Subscriber`
+until an `onError(Throwable)` or `onComplete()` signal is pushed through the processor or
+until the associated `Subscriber` is cancelled.
+
+This variant uses a `Thread`-per-`Subscriber` model.
+
+The maximum number of downstream subscribers is driven by the `executor(ExecutorService)`
 builder option. Provide a bounded `ExecutorService` to limit it to a specific number.
 
 The processor is backed by a `RingBuffer` data structure that stores pushed signals. Each
@@ -157,32 +200,16 @@ This processor also has an `autoCancel` builder option: If set to `true` (the de
 it results in the source `Publisher`(s) being cancelled when all subscribers are
 cancelled.
 
-== WorkQueueProcessor
-A `WorkQueueProcessor` is also an asynchronous processor capable of relaying elements
-from multiple upstream `Publishers` when created in the `shared` configuration (it shares
-most of its builder options with `TopicProcessor`).
+== First Processor
+[source,java]
+----
+MonoFirstProcessorBuilder<Integer> builder = Processors.first();
+Broadcaster<Integer> first = builder
+    .attachSource(Flux.range(1, 10))
+    .build();
+//will emit `1`
+----
 
-It relaxes its compliance with the Reactive Streams specification, but it acquires the
-benefit of requiring fewer resources than the `TopicProcessor`. It is still based on a
-`RingBuffer` but avoids the overhead of creating one consumer `Thread` per `Subscriber`.
-As a result, it scales better than the `TopicProcessor`.
-
-The trade-off is that its distribution pattern is a little bit different: Requests from
-each subscriber all add up together, and the processor relays signals to only one
-`Subscriber` at a time, in a kind of round-robin distribution rather than fan-out
-pattern.
-
-NOTE: A fair round-robin distribution is not guaranteed.
-
-The `WorkQueueProcessor` mostly has the same builder options as the `TopicProcessor`,
-such as `autoCancel`, `share`, and `waitStrategy`. The maximum number of downstream
-subscribers is also driven by a configurable `ExecutorService` with the `executor`
-option.
-
-WARNING: You should take care not to subscribe too many `Subscribers` to a
-`WorkQueueProcessor`, as doing so *could lock the processor*. If you need to limit the
-number of possible subscribers, prefer doing so by using a `ThreadPoolExecutor` or a
-`ForkJoinPool`. The processor can detect their capacity and throw an exception if you
-subscribe one too many times.
-
-//TODO == MonoProcessor
+A **first** `Processor` is a `Broadcaster` that captures the _first_ element
+that is pushed through it (either manually or by an upstream source `Publisher`) and
+replays it to further `Subscribers`.

--- a/src/docs/asciidoc/processors.adoc
+++ b/src/docs/asciidoc/processors.adoc
@@ -80,7 +80,7 @@ which limits the sink interactions to follow the semantics of `Mono` (0-1 elemen
 == Direct Processor
 [source,java]
 ----
-Broadcaster<Integer> direct = Processors.direct();
+FluxProcessorSink<Integer> direct = Processors.directSink();
 ----
 
 A **direct** `Processor` can dispatch signals to zero to many `Subscribers`, but has the
@@ -97,8 +97,7 @@ replays the termination signal to them immediately.
 == Unicast Processor
 [source,java]
 ----
-UnicastProcessorBuilder<Integer> builder = Processors.unicast();
-Broadcaster<Integer> unicast = builder.build();
+FluxProcessorSink<Integer> unicast = Processors.unicastSink();
 ----
 
 A **unicast** `Processor` can deal with backpressure using an internal buffer.
@@ -119,8 +118,7 @@ on each rejected element, allowing for cleanup of these rejected elements.
 == Emitter Processor
 [source,java]
 ----
-EmitterProcessorBuilder<Integer> builder = Processors.emitter();
-Broadcaster<Integer> emitter = builder.build();
+FluxProcessorSink<Integer> emitter = Processors.emitterSink();
 ----
 
 An **emitter** `Processor` is capable of emitting to several subscribers, while honoring
@@ -145,8 +143,7 @@ This can be deactivated by using the `noAutoCancel()` method in the builder.
 == Replay Processor
 [source,java]
 ----
-ReplayProcessorBuilder<Integer> builder = Processors.replay();
-Broadcaster<Integer> replay = builder.build();
+FluxProcessorSink<Integer> builder = Processors.replaySink();
 ----
 
 A **replay** `Processor` caches elements that are either pushed directly through its `FluxSink`
@@ -169,7 +166,7 @@ element: `Processors.cacheLast()`.
 [source,java]
 ----
 FanOutProcessorBuilder<Integer> builder = Processors.fanOut();
-Broadcaster<Integer> fanOut = builder.build();
+FluxProcessorSink<Integer> fanOut = builder.buildSink();
 ----
 
 A **fan out** `Processor` is an **asynchronous** processor capable of relaying elements from
@@ -203,10 +200,9 @@ cancelled.
 == First Processor
 [source,java]
 ----
-MonoFirstProcessorBuilder<Integer> builder = Processors.first();
-Broadcaster<Integer> first = builder
-    .attachSource(Flux.range(1, 10))
-    .build();
+MonoProcessorFacade<Integer> first = Processors.firstFrom(
+    Flux.range(1, 10)
+);
 //will emit `1`
 ----
 

--- a/src/docs/asciidoc/processors.adoc
+++ b/src/docs/asciidoc/processors.adoc
@@ -68,7 +68,7 @@ the favored way of using these.
 * *synchronous* (`emitter` and `replay` flavors): These processors are meant to push data
 both through user action and by subscribing to an upstream `Publisher` and synchronously
 draining it.
-* *asynchronous* (`fanOut` flavor): These processors can push data obtained from
+* *asynchronous* (`asyncEmitter` flavor): These processors can push data obtained from
 **multiple** upstream `Publishers`. They are more robust but also are a bit more costly
 to instantiate, establishing more resources in order to deal with their multiple upstreams.
 * *mono* (`first` flavor): These processors, when attached to a `Publisher` source, only
@@ -165,8 +165,8 @@ element: `Processors.cacheLast()`.
 == FanOut Processor
 [source,java]
 ----
-FanOutProcessorBuilder<Integer> builder = Processors.fanOut();
-FluxProcessorSink<Integer> fanOut = builder.buildSink();
+AsyncEmitterProcessorBuilder<Integer> builder = Processors.asyncEmitter();
+FluxProcessorSink<Integer> asyncEmitter = builder.buildSink();
 ----
 
 A **fan out** `Processor` is an **asynchronous** processor capable of relaying elements from


### PR DESCRIPTION
<details>
  <summary>Old initial comment</summary>
  
This PR is expected to be backported into `3.1.x`. It prepares for #1170 by

- discouraging the use of `FluxProcessor` (which leaks APIs from `Flux`, `Scannable`, etc...) by deprecating it
- marking concrete `FluxProcessor` implementations as deprecated **to be removed in 3.2.0** (will actually be made package-private)
- exposes a new simplified `Processor<T, T>` API in `BalancedFluxProcessor<T>` and `BalancedMonoProcessor<T>`. This API hides the `Flux` and `Mono` nature of the concrete processors, but allows the user to reach the larger APIs by way of `asFlux()` and `asMono()` respectively
- exposes all flavors of concrete processors as factory methods (for simplest or most common cases) and builder (for more advanced configurations) in the `Processors` class. All these methods return a `BalancedFluxProcessor` interface rather than a concrete type.
- the currently only flavor of `MonoProcessor` is exposed as `first()`, preparing for a second flavor, "last", to be added in 3.2.0
- there are 2 interfaces because notably the `sink()` method returns a different type of sink for mono vs flux, and there is also a need to distinguish for the `asXXX()` method that opens up the whole reactor API on the processors.

## Questions:
 - should `Mono#toProcessor` be also marked as `deprecated`? In 3.2.0 it won't really go away but during test migrations, there were a lot of use cases where it was used as a `Mono`, so users will need to add calls to `asMono()`... They will also be unable to use the processor as a `Queue` (cases of `peek()` in the test codebase)
 - are there any other "must have" methods to add to `BalancedFluxProcessor`/`BalancedMonoProcessor`?

## Naming:
`Balanced` as in `Processor<IN, OUT>` where `IN` is the same as `OUT`.
Other suggestions welcome. What we thought about so far:

 - `IdentityFluxProcessor`/`IdentityMonoProcessor`
 - `Broadcaster`
</details>