### PR TITLE
Unexpected behavior for Flux.interval when scheduled interval does not supported

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/InstantPeriodicWorkerTask.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/InstantPeriodicWorkerTask.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.scheduler;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import reactor.core.Disposable;
+import reactor.util.annotation.Nullable;
+
+/**
+ * A runnable task for {@link Scheduler} Workers that can run periodically
+ **/
+final class InstantPeriodicWorkerTask implements Disposable, Callable<Void> {
+
+	final Runnable task;
+
+	final ExecutorService executor;
+
+	static final Composite DISPOSED = new EmptyCompositeDisposable();
+
+	static final Future<Void> CANCELLED = new FutureTask<>(() -> null);
+
+	volatile Future<?>                                                          rest;
+	static final AtomicReferenceFieldUpdater<InstantPeriodicWorkerTask, Future> REST =
+			AtomicReferenceFieldUpdater.newUpdater(InstantPeriodicWorkerTask.class, Future.class, "rest");
+
+	volatile Future<?>                                                          first;
+	static final AtomicReferenceFieldUpdater<InstantPeriodicWorkerTask, Future> FIRST =
+			AtomicReferenceFieldUpdater.newUpdater(InstantPeriodicWorkerTask.class, Future.class, "first");
+
+	volatile Composite                                                             parent;
+	static final AtomicReferenceFieldUpdater<InstantPeriodicWorkerTask, Composite> PARENT =
+			AtomicReferenceFieldUpdater.newUpdater(InstantPeriodicWorkerTask.class, Composite.class, "parent");
+
+	Thread thread;
+
+	InstantPeriodicWorkerTask(Runnable task, ExecutorService executor, Composite parent) {
+		this.task = task;
+		this.executor = executor;
+		PARENT.lazySet(this, parent);
+	}
+
+	@Override
+	@Nullable
+	public Void call() {
+		thread = Thread.currentThread();
+		try {
+			try {
+				task.run();
+				setRest(executor.submit(this));
+			}
+			catch (Throwable ex) {
+				Schedulers.handleError(ex);
+			}
+		}
+		finally {
+			thread = null;
+		}
+		return null;
+	}
+
+	void setRest(Future<?> f) {
+		for (;;) {
+			Future o = rest;
+			if (o == CANCELLED) {
+				f.cancel(thread != Thread.currentThread());
+				return;
+			}
+			if (REST.compareAndSet(this, o, f)) {
+				return;
+			}
+		}
+	}
+
+	void setFirst(Future<?> f) {
+		for (;;) {
+			Future o = first;
+			if (o == CANCELLED) {
+				f.cancel(thread != Thread.currentThread());
+				return;
+			}
+			if (FIRST.compareAndSet(this, o, f)) {
+				return;
+			}
+		}
+	}
+
+	@Override
+	public boolean isDisposed() {
+		return rest == CANCELLED;
+	}
+
+	@Override
+	public void dispose() {
+		for (;;) {
+			Future f = first;
+			if (f == CANCELLED) {
+				break;
+			}
+			if (FIRST.compareAndSet(this, f, CANCELLED)) {
+				if (f != null) {
+					f.cancel(thread != Thread.currentThread());
+				}
+				break;
+			}
+		}
+
+		for (;;) {
+			Future f = rest;
+			if (f == CANCELLED) {
+				break;
+			}
+			if (REST.compareAndSet(this, f, CANCELLED)) {
+				if (f != null) {
+					f.cancel(thread != Thread.currentThread());
+				}
+				break;
+			}
+		}
+
+		for (;;) {
+			Composite o = parent;
+			if (o == DISPOSED || o == null) {
+				return;
+			}
+			if (PARENT.compareAndSet(this, o, DISPOSED)) {
+				o.remove(this);
+				return;
+			}
+		}
+	}
+
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxIntervalTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxIntervalTest.java
@@ -179,4 +179,15 @@ public class FluxIntervalTest {
 		            .expectNextCount(6)
 		            .verifyErrorMessage("Could not emit tick 32 due to lack of requests (interval doesn't support small downstream requests that replenish slower than the ticks)");
     }
+
+    @Test
+	public void shouldBeAbleToScheduleIntervalsWithLowGranularity() {
+		StepVerifier.create(Flux.interval(Duration.ofNanos(1)))
+		            .expectSubscription()
+		            .expectNext(0L)
+		            .expectNext(1L)
+		            .expectNext(2L)
+		            .thenCancel()
+		            .verify();
+    }
 }

--- a/reactor-core/src/test/java/reactor/core/scheduler/InstantPeriodicWorkerTaskTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/InstantPeriodicWorkerTaskTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.scheduler;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+
+import org.junit.Test;
+import reactor.core.Disposable;
+import reactor.core.Disposables;
+import reactor.test.util.RaceTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class InstantPeriodicWorkerTaskTest {
+    private static final RuntimeException exception = new RuntimeException();
+    private static final Runnable errorRunnable = () -> { throw exception; };
+    private static final Runnable emptyRunnable = () -> { };
+
+    @Test
+    public void taskCrash() {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        Disposable.Composite composit = Disposables.composite();
+        List<Throwable> throwables = prepareErrorHook();
+
+        try {
+            InstantPeriodicWorkerTask task = new InstantPeriodicWorkerTask(errorRunnable, exec, composit);
+
+            assertThat(task.call()).isNull();
+            assertThat(throwables).containsOnly(exception);
+        }
+        finally {
+            exec.shutdownNow();
+            Schedulers.resetOnHandleError();
+        }
+    }
+
+    @Test
+    public void dispose() {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        Disposable.Composite composit = Disposables.composite();
+
+        try {
+            InstantPeriodicWorkerTask task = new InstantPeriodicWorkerTask(errorRunnable, exec, composit);
+
+            assertThat(task.isDisposed()).isFalse();
+
+            task.dispose();
+
+            assertThat(task.isDisposed()).isTrue();
+
+            task.dispose();
+
+            assertThat(task.isDisposed()).isTrue();
+        }
+        finally {
+            exec.shutdownNow();
+            Schedulers.resetOnHandleError();
+        }
+    }
+
+    @Test
+    public void dispose2() {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        Disposable.Composite composit = Disposables.composite();
+
+        try {
+            InstantPeriodicWorkerTask task = new InstantPeriodicWorkerTask(errorRunnable, exec, composit);
+
+            task.setFirst(new FutureTask<Void>(emptyRunnable, null));
+            task.setRest(new FutureTask<Void>(emptyRunnable, null));
+
+            assertThat(task.isDisposed()).isFalse();
+
+            task.dispose();
+
+            assertThat(task.isDisposed()).isTrue();
+
+            task.dispose();
+
+            assertThat(task.isDisposed()).isTrue();
+        }
+        finally {
+            exec.shutdownNow();
+            Schedulers.resetOnHandleError();
+        }
+    }
+
+    @Test
+    public void dispose2CurrentThread() {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        Disposable.Composite composit = Disposables.composite();
+
+        try {
+            InstantPeriodicWorkerTask task = new InstantPeriodicWorkerTask(errorRunnable, exec, composit);
+            task.thread = Thread.currentThread();
+
+            task.setFirst(new FutureTask<Void>(emptyRunnable, null));
+            task.setRest(new FutureTask<Void>(emptyRunnable, null));
+
+            assertThat(task.isDisposed()).isFalse();
+
+            task.dispose();
+
+            assertThat(task.isDisposed()).isTrue();
+            assertThat(composit.size()).isEqualTo(0);
+
+            task.dispose();
+
+            assertThat(task.isDisposed()).isTrue();
+            assertThat(composit.size()).isEqualTo(0);
+        }
+        finally {
+            exec.shutdownNow();
+            Schedulers.resetOnHandleError();
+        }
+    }
+
+    @Test
+    public void dispose3() {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        Disposable.Composite composit = Disposables.composite();
+
+        try {
+            InstantPeriodicWorkerTask task = new InstantPeriodicWorkerTask(errorRunnable, exec, composit);
+
+            task.dispose();
+
+            FutureTask<Void> f1 = new FutureTask<Void>(emptyRunnable, null);
+            task.setFirst(f1);
+
+            assertThat(f1.isCancelled()).isTrue();
+
+            FutureTask<Void> f2 = new FutureTask<Void>(emptyRunnable, null);
+            task.setRest(f2);
+
+            assertThat(f2.isCancelled()).isTrue();
+        }
+        finally {
+            exec.shutdownNow();
+            Schedulers.resetOnHandleError();
+        }
+    }
+
+    @Test
+    public void disposeOnCurrentThread() {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        Disposable.Composite composit = Disposables.composite();
+
+        try {
+            InstantPeriodicWorkerTask task = new InstantPeriodicWorkerTask(errorRunnable, exec, composit);
+
+            task.thread = Thread.currentThread();
+
+            task.dispose();
+
+            FutureTask<Void> f1 = new FutureTask<Void>(emptyRunnable, null);
+            task.setFirst(f1);
+
+            assertThat(f1.isCancelled()).isTrue();
+
+            FutureTask<Void> f2 = new FutureTask<Void>(emptyRunnable, null);
+            task.setRest(f2);
+
+            assertThat(f2.isCancelled()).isTrue();
+        }
+        finally {
+            exec.shutdownNow();
+            Schedulers.resetOnHandleError();
+        }
+    }
+
+    @Test
+    public void firstCancelRace() {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        Disposable.Composite composit = Disposables.composite();
+
+        try {
+            for (int i = 0; i < 10000; i++) {
+                final InstantPeriodicWorkerTask task = new InstantPeriodicWorkerTask(errorRunnable, exec, composit);
+
+                final FutureTask<Void>
+		                f1 = new FutureTask<Void>(emptyRunnable, null);
+                Runnable r1 = () -> task.setFirst(f1);
+                Runnable r2 = task::dispose;
+
+                RaceTestUtils.race(r1, r2);
+
+                assertTrue(f1.isCancelled());
+                assertTrue(task.isDisposed());
+            }
+        }
+        finally {
+            exec.shutdownNow();
+            Schedulers.resetOnHandleError();
+        }
+    }
+
+    @Test
+    public void restCancelRace() {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        Disposable.Composite composit = Disposables.composite();
+
+        try {
+            for (int i = 0; i < 10000; i++) {
+                final InstantPeriodicWorkerTask task = new InstantPeriodicWorkerTask(errorRunnable, exec, composit);
+
+                final FutureTask<Void> f1 = new FutureTask<Void>(emptyRunnable, null);
+                Runnable r1 = () -> task.setRest(f1);
+                Runnable r2 = task::dispose;
+
+                RaceTestUtils.race(r1, r2);
+
+                assertTrue(f1.isCancelled());
+                assertTrue(task.isDisposed());
+            }
+        }
+        finally {
+            exec.shutdownNow();
+            Schedulers.resetOnHandleError();
+        }
+    }
+
+    private static List<Throwable> prepareErrorHook() {
+        List<Throwable> errorsCollector = new CopyOnWriteArrayList<>();
+        Schedulers.onHandleError((t, e) -> errorsCollector.add(e));
+        return errorsCollector;
+    }
+}


### PR DESCRIPTION
Got an issue with Flux.interval when granularity of interval is nanoseconds, thus that time is rounded to zero milliseconds, hence default `java.util.concurrent.ScheduledExecutorService#scheduleAtFixedRate` does not support zero time according to documentation 

>  * @throws IllegalArgumentException if period less than or equal to zero
     */
    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command,
                                                  long initialDelay,
                                                  long period,
                                                  TimeUnit unit);

Due to the current implementation, we handle only `RejectedTaskException`, which means that error will be propagated to `FluxInterval` which also catches only `RejectedTaskException`
```
@Override
	public void subscribe(CoreSubscriber<? super Long> actual) {
		Worker w = timedScheduler.createWorker();

		IntervalRunnable r = new IntervalRunnable(actual, w);

		actual.onSubscribe(r);

		try {
			w.schedulePeriodically(r, initialDelay, period, unit);
		}
		catch (RejectedExecutionException ree) {
			if (!r.cancelled) {
				actual.onError(Operators.onRejectedExecution(ree, r, null, null,
						actual.currentContext()));
			}
		}
	}
```

Hence `IllegalArgumentException` causes violation of RS.