### PR TITLE
fix issue with generified BiConsumer

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3979,9 +3979,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * @return a {@link Flux} that attempts to continue processing on errors.
 	 */
-	public final Flux<T> errorStrategyContinue(BiConsumer<Throwable, ? super T> errorConsumer) {
+	public final Flux<T> errorStrategyContinue(BiConsumer<Throwable, Object> errorConsumer) {
 		//this cast is ok as only T values will be propagated in this sequence
-		@SuppressWarnings("unchecked") BiConsumer<Throwable, Object> genericConsumer = (BiConsumer<Throwable, Object>) errorConsumer;
+		BiConsumer<Throwable, Object> genericConsumer = (BiConsumer<Throwable, Object>) errorConsumer;
 		return subscriberContext(Context.of(
 				OnNextFailureStrategy.KEY_ON_NEXT_ERROR_STRATEGY,
 				OnNextFailureStrategy.resume(genericConsumer)
@@ -4000,8 +4000,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * @return a {@link Flux} that attempts to continue processing on some errors.
 	 */
-	public final <E extends Throwable> Flux<T> errorStrategyContinue(Class<E> type,
-																	 BiConsumer<Throwable, ? super T> errorConsumer) {
+	public final <E extends Throwable> Flux<T> errorStrategyContinue(Class<E> type, BiConsumer<Throwable, Object> errorConsumer) {
 		return errorStrategyContinue(type::isInstance, errorConsumer);
 	}
 
@@ -4018,12 +4017,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a {@link Flux} that attempts to continue processing on some errors.
 	 */
 	public final <E extends Throwable> Flux<T> errorStrategyContinue(Predicate<E> errorPredicate,
-																	 BiConsumer<Throwable, ? super T> errorConsumer) {
+																	 BiConsumer<Throwable, Object> errorConsumer) {
 		//this cast is ok as only T values will be propagated in this sequence
 		@SuppressWarnings("unchecked")
 		Predicate<Throwable> genericPredicate = (Predicate<Throwable>) errorPredicate;
-		@SuppressWarnings("unchecked")
-		BiConsumer<Throwable, Object> genericErrorConsumer = (BiConsumer<Throwable, Object>) errorConsumer;
+		BiConsumer<Throwable, Object> genericErrorConsumer = errorConsumer;
 		return subscriberContext(Context.of(
 				OnNextFailureStrategy.KEY_ON_NEXT_ERROR_STRATEGY,
 				OnNextFailureStrategy.resumeIf(genericPredicate, genericErrorConsumer)


### PR DESCRIPTION
# Problem 

Local continues strategy a bit speculatively assume that given element will be exactly as the given from upstream generic type. For example, let's consider following example

```
Flux.just("0", "1", "2", "asdfghc3")
	.map(Integer::parseInt)  // BiHandler will be handled with NumberFormatException and String value
	.filter(l -> l < 3)
	.map(l -> 10 / l) // <- seems like we have to fail there and exceptuin should be handled fine
	.errorStrategyContinue((t, v) -> { });
                               ^
                               |
                            Integer
```

In that example, error strategy takes value type `Integer` for the object, on which `Throwable` has been thrown. In turn, that type is derived from the upstream operator, which is the result of Mapping. However, the mapping may be a mapping from one type to another, as it was depicted in the first `.map(Integer::parseInt)`. Hence, when we get an error as the result of unsuccessful mapping, instead of Integer we will get String, which in turn cause `ClassCastException` on the step of invocation of `BiConsumer`.