### PR TITLE
POC for bug with context lookup in tests

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3257,7 +3257,11 @@ public abstract class Flux<T> implements Publisher<T> {
 
 			return fluxConcatArray.concatAdditionalSourceLast(other);
 		}
-		return concat(this, other);
+
+		@SuppressWarnings("unchecked")
+		Publisher<? extends T>[] sources = new Publisher[]{this, other};
+
+		return onAssembly(new FluxConcatArray<>(false, 0, sources));
 	}
 
 	/**
@@ -5351,7 +5355,17 @@ public abstract class Flux<T> implements Publisher<T> {
 			FluxMerge<T> fluxMerge = (FluxMerge<T>) this;
 			return fluxMerge.mergeAdditionalSource(other, Queues::get);
 		}
-		return merge(this, other);
+
+		@SuppressWarnings("unchecked")
+		Publisher<? extends T>[] publishers = new Publisher[] {this, other};
+
+		return onAssembly(new FluxMerge<>(publishers,
+				false,
+				2,
+				Queues.get(2),
+				Queues.XS_BUFFER_SIZE,
+				Queues.get(Queues.XS_BUFFER_SIZE),
+				true));
 	}
 
 	/**
@@ -7038,7 +7052,11 @@ public abstract class Flux<T> implements Publisher<T> {
 			FluxConcatArray<T> fluxConcatArray = (FluxConcatArray<T>) this;
 			return fluxConcatArray.concatAdditionalSourceFirst(publisher);
 		}
-		return concat(publisher, this);
+
+		@SuppressWarnings("unchecked")
+		Publisher<? extends T>[] sources = new Publisher[]{publisher, this};
+
+		return onAssembly(new FluxConcatArray<>(false, 1, sources));
 	}
 
 	/**
@@ -7622,9 +7640,11 @@ public abstract class Flux<T> implements Publisher<T> {
 			return fluxConcatArray.concatAdditionalIgnoredLast(other);
 		}
 
+
 		@SuppressWarnings("unchecked")
-		Flux<V> concat = (Flux<V>)concat(ignoreElements(), other);
-		return concat;
+		Publisher<? extends V>[] sources = new Publisher[]{ignoreElements(), other};
+
+		return onAssembly(new FluxConcatArray<>(false, 0, sources));
 	}
 
 	/**
@@ -8364,7 +8384,13 @@ public abstract class Flux<T> implements Publisher<T> {
 				return result;
 			}
 		}
-		return zip(this, source2, combinator);
+
+		return onAssembly(new FluxZip<>(this,
+				source2,
+				combinator,
+				Queues.xs(),
+				Queues.XS_BUFFER_SIZE,
+				true));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -179,7 +179,7 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 		return false;
 	}
 
-	static final class FlatMapMain<T, R> extends FlatMapTracker<FlatMapInner<R>>
+	static class FlatMapMain<T, R> extends FlatMapTracker<FlatMapInner<R>>
 			implements InnerOperator<T, R> {
 
 		final boolean                                               delayError;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMerge.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMerge.java
@@ -17,11 +17,18 @@ package reactor.core.publisher;
 
 import java.util.Objects;
 import java.util.Queue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
+import reactor.core.Scannable;
 
 /**
  * Merges a fixed array of Publishers.
@@ -31,9 +38,11 @@ import reactor.core.CoreSubscriber;
 final class FluxMerge<T> extends Flux<T> implements SourceProducer<T> {
 
 	final Publisher<? extends T>[] sources;
-	
+
 	final boolean delayError;
-	
+
+	final boolean isMergeWith;
+
 	final int maxConcurrency;
 	
 	final Supplier<? extends Queue<T>> mainQueueSupplier;
@@ -41,17 +50,29 @@ final class FluxMerge<T> extends Flux<T> implements SourceProducer<T> {
 	final int prefetch;
 	
 	final Supplier<? extends Queue<T>> innerQueueSupplier;
+
+	FluxMerge(Publisher<? extends T>[] sources,
+			boolean delayError, int maxConcurrency,
+			Supplier<? extends Queue<T>> mainQueueSupplier,
+			int prefetch,
+			Supplier<? extends Queue<T>> innerQueueSupplier) {
+
+		this(sources, delayError, maxConcurrency, mainQueueSupplier, prefetch, innerQueueSupplier, false);
+	}
 	
 	FluxMerge(Publisher<? extends T>[] sources,
 			boolean delayError, int maxConcurrency, 
 			Supplier<? extends Queue<T>> mainQueueSupplier, 
-					int prefetch, Supplier<? extends Queue<T>> innerQueueSupplier) {
+			int prefetch,
+			Supplier<? extends Queue<T>> innerQueueSupplier,
+			boolean isMergeWith) {
 		if (prefetch <= 0) {
 			throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
 		}
 		if (maxConcurrency <= 0) {
 			throw new IllegalArgumentException("maxConcurrency > 0 required but it was " + maxConcurrency);
 		}
+		this.isMergeWith = isMergeWith;
 		this.sources = Objects.requireNonNull(sources, "sources");
 		this.delayError = delayError;
 		this.maxConcurrency = maxConcurrency;
@@ -62,9 +83,19 @@ final class FluxMerge<T> extends Flux<T> implements SourceProducer<T> {
 	
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
-		FluxFlatMap.FlatMapMain<Publisher<? extends T>, T> merger = new FluxFlatMap.FlatMapMain<>(
-				actual, identityFunction(), delayError, maxConcurrency, mainQueueSupplier, prefetch,
-				innerQueueSupplier);
+		FluxFlatMap.FlatMapMain<Publisher<? extends T>, T> merger;
+
+		if (isMergeWith) {
+			merger = new FluxMergeWithMain<>(
+					actual, identityFunction(), delayError, maxConcurrency, mainQueueSupplier, prefetch,
+					innerQueueSupplier);
+
+		}
+		else {
+			merger = new FluxFlatMap.FlatMapMain<>(
+					actual, identityFunction(), delayError, maxConcurrency, mainQueueSupplier, prefetch,
+					innerQueueSupplier);
+		}
 		
 		merger.onSubscribe(new FluxArray.ArraySubscription<>(merger, sources));
 	}
@@ -96,7 +127,7 @@ final class FluxMerge<T> extends Flux<T> implements SourceProducer<T> {
 			newMainQueue = mainQueueSupplier;
 		}
 		
-		return new FluxMerge<>(newArray, delayError, mc, newMainQueue, prefetch, innerQueueSupplier);
+		return new FluxMerge<>(newArray, delayError, mc, newMainQueue, prefetch, innerQueueSupplier, isMergeWith);
 	}
 
 	@Override
@@ -107,4 +138,90 @@ final class FluxMerge<T> extends Flux<T> implements SourceProducer<T> {
 		return null;
 	}
 
+	static final class FluxMergeWithMain<T> extends FluxFlatMap.FlatMapMain<Publisher<? extends T>, T> {
+
+		volatile FluxFlatMap.FlatMapInner<T> main;
+
+		static final AtomicReferenceFieldUpdater<FluxMergeWithMain, FluxFlatMap.FlatMapInner> MAIN =
+				AtomicReferenceFieldUpdater.newUpdater(FluxMergeWithMain.class, FluxFlatMap.FlatMapInner.class, "main");
+
+		FluxMergeWithMain(CoreSubscriber<? super T> actual,
+				Function<? super Publisher<? extends T>, ? extends Publisher<? extends T>> mapper,
+				boolean delayError,
+				int maxConcurrency,
+				Supplier<? extends Queue<T>> mainQueueSupplier,
+				int prefetch,
+				Supplier<? extends Queue<T>> innerQueueSupplier) {
+			  super(actual,
+					mapper,
+					delayError,
+					maxConcurrency,
+					mainQueueSupplier,
+					prefetch,
+					innerQueueSupplier);
+		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.ACTUAL) return main;
+
+			return super.scanUnsafe(key);
+		}
+
+		@Override
+		public void onNext(Publisher<? extends T> t) {
+			if (done) {
+				Operators.onNextDropped(t, actual.currentContext());
+				return;
+			}
+
+			Publisher<? extends T> p;
+
+			try {
+				p = Objects.requireNonNull(mapper.apply(t),
+						"The mapper returned a null Publisher");
+			}
+			catch (Throwable e) {
+				Throwable e_ = Operators.onNextError(t, e, actual.currentContext(), s);
+				if (e_ != null) {
+					onError(e_);
+				}
+				else {
+					tryEmitScalar(null);
+				}
+				return;
+			}
+
+			if (p instanceof Callable) {
+				T v;
+				try {
+					v = ((Callable<T>) p).call();
+				}
+				catch (Throwable e) {
+					//does the strategy apply? if so, short-circuit the delayError. In any case, don't cancel
+					Throwable e_ = Operators.onNextPollError(t, e, actual.currentContext());
+					if (e_ == null) {
+						return;
+					}
+					//now if error mode strategy doesn't apply, let delayError play
+					if (!delayError || !Exceptions.addThrowable(ERROR, this, e)) {
+						onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
+					}
+
+					return;
+				}
+				tryEmitScalar(v);
+			}
+			else {
+				FluxFlatMap.FlatMapInner<T> inner = new FluxFlatMap.FlatMapInner<>(this, prefetch);
+				if (add(inner)) {
+					if (main == null) {
+						MAIN.compareAndSet(this, null, inner);
+					}
+
+					p.subscribe(inner);
+				}
+			}
+		}
+	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatArrayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatArrayTest.java
@@ -26,6 +26,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -288,6 +289,50 @@ public class FluxConcatArrayTest {
 
 		test.cancel();
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
+	}
+
+	@Test
+	public void checkContext() {
+		StepVerifier.create(Flux.just(1, 2)
+		                        .subscriberContext(Context.of("a", "b"))
+		                        .concatMap(Flux::just)
+		                        .concatWith(Flux.just(3)))
+		            .expectSubscription()
+		            .expectAccessibleContext()
+		            .contains("a", "b")
+		            .then()
+		            .expectNextCount(3)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void checkContext2() {
+		StepVerifier.create(Flux.just(1, 2)
+		                        .subscriberContext(Context.of("a", "b"))
+		                        .concatMap(Flux::just)
+		                        .startWith(Flux.just(3)))
+		            .expectSubscription()
+		            .expectAccessibleContext()
+		            .contains("a", "b")
+		            .then()
+		            .expectNextCount(3)
+		            .verifyComplete();
+	}
+
+
+
+	@Test
+	public void checkContext3() {
+		StepVerifier.create(Flux.just(1, 2)
+		                        .subscriberContext(Context.of("a", "b"))
+		                        .concatMap(Flux::just)
+		                        .thenMany(Flux.just(3)))
+		            .expectSubscription()
+		            .expectAccessibleContext()
+		            .contains("a", "b")
+		            .then()
+		            .expectNextCount(1)
+		            .verifyComplete();
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeWithTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeWithTest.java
@@ -17,7 +17,14 @@ package reactor.core.publisher;
 
 import org.junit.Test;
 
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Scannable;
+import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.util.context.Context;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxMergeWithTest {
 
@@ -98,5 +105,19 @@ public class FluxMergeWithTest {
 		ts.assertValues(1, 2, 3)
 		.assertNoError()
 		.assertComplete();
+	}
+
+	@Test
+	public void scanForActualShouldReturnFirst() {
+		StepVerifier.create(Flux.just(1, 2)
+		    .subscriberContext(Context.of("a", "b"))
+		    .flatMap(Flux::just)
+		    .mergeWith(Flux.just(3)))
+		            .expectSubscription()
+		            .expectAccessibleContext()
+		            .contains("a", "b")
+		            .then()
+		            .expectNextCount(3)
+		            .verifyComplete();
 	}
 }


### PR DESCRIPTION
# Problem 

take a look at following code sample:

``` java
Flux<String> flux = Mono
    .subscriberContext()
    .flatMap(c -> Flux.just(c.get("a"), c.get("b")))
    .subscriberContext("a", "1")
    .concatWith(Mono.subscriberContext()
                   .map(c -> c.get("b")))
    .subscriberContext("b", "2");

StepVerifier.create(flux)
            .expectSubscription()
            .expectAccessibleContext()
		    .contains("a", "1")
		    .contains("b", "2")
		    .then()
            .expectNext("1", "2", "2")
            .verifyCompleted();
```

Regarding the flow, that test should be passed. 
**However**, it will not.

First of all because effectively, underlying code will be rewritten as in the  following code snippet: 

``` java
Flux<String> flux = Flux.concat(
     Mono.subscriberContext()
         .flatMap(c -> Flux.just(c.get("a"), c.get("b")))
         .subscriberContext("a", "1"),
     Mono.subscriberContext()
         .map(c -> c.get("b"))
)
    .subscriberContext("b", "2");
```

Despite the fact that context will be available, verification of its availability is impossible because of internal impl of `.concatWith` operator (the same for `.mergeWith`, `.startWith`, `.thenMany`, `.zipWith`). From the logical perspective, with mentioned operators, the head or top source is `Mono
    .subscriberContext()
    .flatMap(c -> Flux.just(c.get("a"), c.get("b")))`, but, because of internal implementation of those operators, the information is loast, hence we cant verify the presence of expected context which is confusing.


# Current solution

I have rewritten a bit internals of mentioned operators and for now looking for your (@smaldini, @simonbasle) comments on the overall idea **(I will clean up the code right after the discussion, for now, it is JUST POC)**