### PR TITLE
fix #1204 Lift properly maintain GroupedFlux/ConnectableFlux interface

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableLift.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+import reactor.core.Scannable;
+import reactor.util.annotation.Nullable;
+
+/**
+ * @author Simon Baslé
+ */
+final class ConnectableLift<I, O> extends ConnectableFlux<O> implements Scannable {
+
+	final BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
+			lifter;
+
+	final ConnectableFlux<I> source;
+
+	ConnectableLift(ConnectableFlux<I> p,
+			BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+		this.source = Objects.requireNonNull(p, "source");
+		this.lifter = lifter;
+	}
+
+	@Override
+	public int getPrefetch() {
+		return source.getPrefetch();
+	}
+
+	@Override
+	public void connect(Consumer<? super Disposable> cancelSupport) {
+		this.source.connect();
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PREFETCH) return source.getPrefetch();
+		if (key == Attr.PARENT) return source;
+		return null;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super O> actual) {
+		CoreSubscriber<? super I> input =
+				lifter.apply(Scannable.from(source), actual);
+
+		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
+
+		source.subscribe(input);
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/GroupedLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/GroupedLift.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Scannable;
+import reactor.util.annotation.Nullable;
+
+/**
+ * @author Simon Baslé
+ */
+final class GroupedLift<K, I, O> extends GroupedFlux<K, O> implements Scannable {
+
+	final BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
+			lifter;
+
+	final GroupedFlux<K, I> source;
+
+	GroupedLift(GroupedFlux<K, I> p,
+			BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+		this.source = Objects.requireNonNull(p, "source");
+		this.lifter = lifter;
+	}
+
+	@Override
+	public int getPrefetch() {
+		return source.getPrefetch();
+	}
+
+	@Override
+	public K key() {
+		return source.key();
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PARENT) {
+			return source;
+		}
+		if (key == Attr.PREFETCH) {
+			return getPrefetch();
+		}
+
+		return null;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super O> actual) {
+		CoreSubscriber<? super I> input =
+				lifter.apply(Scannable.from(source), actual);
+
+		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
+
+		source.subscribe(input);
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -1851,6 +1851,12 @@ public abstract class Operators {
 			if (publisher instanceof ParallelFlux) {
 				return new ParallelLift<>((ParallelFlux<I>)publisher, lifter);
 			}
+			if (publisher instanceof ConnectableFlux) {
+				return new ConnectableLift<>((ConnectableFlux<I>) publisher, lifter);
+			}
+			if (publisher instanceof GroupedFlux) {
+				return new GroupedLift<>((GroupedFlux<?, I>) publisher, lifter);
+			}
 
 			return new FluxLift<>(publisher, lifter);
 		}

--- a/reactor-core/src/test/java/reactor/core/publisher/LiftFunctionTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/LiftFunctionTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LiftFunctionTest {
+
+	@Test
+	public void liftMono() {
+		Mono<Integer> source = Mono.just(1)
+		                           .hide();
+
+		Operators.LiftFunction<Integer, Integer> liftFunction =
+				new Operators.LiftFunction<>(null, (s, actual) -> actual);
+		Publisher<Integer> liftOperator = liftFunction.apply(source);
+
+		assertThat(liftOperator)
+				.isInstanceOf(Mono.class)
+				.isExactlyInstanceOf(MonoLift.class);
+	}
+
+	@Test
+	public void liftFlux() {
+		Flux<Integer> source = Flux.just(1)
+		                           .hide();
+
+		Operators.LiftFunction<Integer, Integer> liftFunction =
+				new Operators.LiftFunction<>(null, (s, actual) -> actual);
+		Publisher<Integer> liftOperator = liftFunction.apply(source);
+
+		assertThat(liftOperator)
+				.isInstanceOf(Flux.class)
+				.isExactlyInstanceOf(FluxLift.class);
+	}
+
+	@Test
+	public void liftParallelFlux() {
+		ParallelFlux<Integer> source = Flux.just(1)
+		                                   .parallel(2)
+		                                   .hide();
+
+		Operators.LiftFunction<Integer, Integer> liftFunction =
+				new Operators.LiftFunction<>(null, (s, actual) -> actual);
+		Publisher<Integer> liftOperator = liftFunction.apply(source);
+
+		assertThat(liftOperator)
+				.isInstanceOf(ParallelFlux.class)
+				.isExactlyInstanceOf(ParallelLift.class);
+	}
+
+	@Test
+	public void liftConnectableFlux() {
+		ConnectableFlux<Integer> source = Flux.just(1)
+		                                      .publish(); //TODO hide if ConnectableFlux gets a hide function
+
+		Operators.LiftFunction<Integer, Integer> liftFunction =
+				new Operators.LiftFunction<>(null, (s, actual) -> actual);
+		Publisher<Integer> liftOperator = liftFunction.apply(source);
+
+		assertThat(liftOperator)
+				.isInstanceOf(ConnectableFlux.class)
+				.isExactlyInstanceOf(ConnectableLift.class);
+	}
+
+	@Test
+	public void liftGroupedFlux() {
+		Flux<GroupedFlux<String, Integer>> sourceGroups = Flux
+				.just(1)
+				.groupBy(i -> "" + i);
+
+		Operators.LiftFunction<Integer, Integer> liftFunction =
+				new Operators.LiftFunction<>(null, (s, actual) -> actual);
+
+		sourceGroups.map(g -> liftFunction.apply(g)) //TODO hide if GroupedFlux gets a proper hide() function
+		            .doOnNext(liftOperator -> assertThat(liftOperator)
+				            .isInstanceOf(GroupedFlux.class)
+				            .isExactlyInstanceOf(GroupedLift.class))
+		            .blockLast();
+	}
+}


### PR DESCRIPTION
This commit prevents potential ClassCastExceptions when lifting either a
GroupedFlux or a ConnectableFlux, by instantiating dedicated operators
similarly to what is done for ParallelFlux for example.