### PR TITLE
Add Flux and Mono zips for Tuple7 and Tuple8.

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -67,6 +67,8 @@ import reactor.util.function.Tuple3;
 import reactor.util.function.Tuple4;
 import reactor.util.function.Tuple5;
 import reactor.util.function.Tuple6;
+import reactor.util.function.Tuple7;
+import reactor.util.function.Tuple8;
 import reactor.util.function.Tuples;
 
 /**
@@ -1795,6 +1797,81 @@ public abstract class Flux<T> implements Publisher<T> {
 			Publisher<? extends T5> source5,
 			Publisher<? extends T6> source6) {
 		return zip(Tuples.fn6(), source1, source2, source3, source4, source5, source6);
+	}
+
+	/**
+	 * Zip seven sources together, that is to say wait for all the sources to emit one
+	 * element and combine these elements once into a {@link Tuple7}.
+	 * The operator will continue doing so until any of the sources completes.
+	 * Errors will immediately be forwarded.
+	 * This "Step-Merge" processing is especially useful in Scatter-Gather scenarios.
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/zipt.png" alt="">
+	 * <p>
+	 * @param source1 The first upstream {@link Publisher} to subscribe to.
+	 * @param source2 The second upstream {@link Publisher} to subscribe to.
+	 * @param source3 The third upstream {@link Publisher} to subscribe to.
+	 * @param source4 The fourth upstream {@link Publisher} to subscribe to.
+	 * @param source5 The fifth upstream {@link Publisher} to subscribe to.
+	 * @param source6 The sixth upstream {@link Publisher} to subscribe to.
+	 * @param source7 The seventh upstream {@link Publisher} to subscribe to.
+	 * @param <T1> type of the value from source1
+	 * @param <T2> type of the value from source2
+	 * @param <T3> type of the value from source3
+	 * @param <T4> type of the value from source4
+	 * @param <T5> type of the value from source5
+	 * @param <T6> type of the value from source6
+	 * @param <T7> type of the value from source7
+	 *
+	 * @return a zipped {@link Flux}
+	 */
+	public static <T1, T2, T3, T4, T5, T6, T7> Flux<Tuple7<T1, T2, T3, T4, T5, T6, T7>> zip(Publisher<? extends T1> source1,
+			Publisher<? extends T2> source2,
+			Publisher<? extends T3> source3,
+			Publisher<? extends T4> source4,
+			Publisher<? extends T5> source5,
+			Publisher<? extends T6> source6,
+			Publisher<? extends T7> source7) {
+		return zip(Tuples.fn7(), source1, source2, source3, source4, source5, source6, source7);
+	}
+
+	/**
+	 * Zip eight sources together, that is to say wait for all the sources to emit one
+	 * element and combine these elements once into a {@link Tuple8}.
+	 * The operator will continue doing so until any of the sources completes.
+	 * Errors will immediately be forwarded.
+	 * This "Step-Merge" processing is especially useful in Scatter-Gather scenarios.
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/zipt.png" alt="">
+	 * <p>
+	 * @param source1 The first upstream {@link Publisher} to subscribe to.
+	 * @param source2 The second upstream {@link Publisher} to subscribe to.
+	 * @param source3 The third upstream {@link Publisher} to subscribe to.
+	 * @param source4 The fourth upstream {@link Publisher} to subscribe to.
+	 * @param source5 The fifth upstream {@link Publisher} to subscribe to.
+	 * @param source6 The sixth upstream {@link Publisher} to subscribe to.
+	 * @param source7 The seventh upstream {@link Publisher} to subscribe to.
+	 * @param source8 The eight upstream {@link Publisher} to subscribe to.
+	 * @param <T1> type of the value from source1
+	 * @param <T2> type of the value from source2
+	 * @param <T3> type of the value from source3
+	 * @param <T4> type of the value from source4
+	 * @param <T5> type of the value from source5
+	 * @param <T6> type of the value from source6
+	 * @param <T7> type of the value from source7
+	 * @param <T8> type of the value from source8
+	 *
+	 * @return a zipped {@link Flux}
+	 */
+	public static <T1, T2, T3, T4, T5, T6, T7, T8> Flux<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> zip(Publisher<? extends T1> source1,
+			Publisher<? extends T2> source2,
+			Publisher<? extends T3> source3,
+			Publisher<? extends T4> source4,
+			Publisher<? extends T5> source5,
+			Publisher<? extends T6> source6,
+			Publisher<? extends T7> source7,
+			Publisher<? extends T8> source8) {
+		return zip(Tuples.fn8(), source1, source2, source3, source4, source5, source6, source7, source8);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -57,6 +57,8 @@ import reactor.util.function.Tuple3;
 import reactor.util.function.Tuple4;
 import reactor.util.function.Tuple5;
 import reactor.util.function.Tuple6;
+import reactor.util.function.Tuple7;
+import reactor.util.function.Tuple8;
 import reactor.util.function.Tuples;
 
 /**
@@ -928,6 +930,83 @@ public abstract class Mono<T> implements Publisher<T> {
 	}
 
 	/**
+	 * Merge given monos into a new {@literal Mono} that will be fulfilled when all of the given {@literal Monos}
+	 * have produced an item, aggregating their values into a {@link Tuple7}.
+	 * An error or <strong>empty</strong> completion of any source will cause other sources
+	 * to be cancelled and the resulting Mono to immediately error or complete, respectively.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/whent.png" alt="">
+	 * <p>
+	 * @param p1 The first upstream {@link Publisher} to subscribe to.
+	 * @param p2 The second upstream {@link Publisher} to subscribe to.
+	 * @param p3 The third upstream {@link Publisher} to subscribe to.
+	 * @param p4 The fourth upstream {@link Publisher} to subscribe to.
+	 * @param p5 The fifth upstream {@link Publisher} to subscribe to.
+	 * @param p6 The sixth upstream {@link Publisher} to subscribe to.
+	 * @param p7 The seventh upstream {@link Publisher} to subscribe to.
+	 * @param <T1> type of the value from source1
+	 * @param <T2> type of the value from source2
+	 * @param <T3> type of the value from source3
+	 * @param <T4> type of the value from source4
+	 * @param <T5> type of the value from source5
+	 * @param <T6> type of the value from source6
+	 * @param <T7> type of the value from source7
+	 *
+	 * @return a {@link Mono}.
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public static <T1, T2, T3, T4, T5, T6, T7> Mono<Tuple7<T1, T2, T3, T4, T5, T6, T7>> zip(Mono<? extends T1> p1,
+			Mono<? extends T2> p2,
+			Mono<? extends T3> p3,
+			Mono<? extends T4> p4,
+			Mono<? extends T5> p5,
+			Mono<? extends T6> p6,
+			Mono<? extends T7> p7) {
+		return onAssembly(new MonoZip(false, a -> Tuples.fromArray((Object[])a), p1, p2, p3, p4, p5, p6, p7));
+	}
+
+	/**
+	 * Merge given monos into a new {@literal Mono} that will be fulfilled when all of the given {@literal Monos}
+	 * have produced an item, aggregating their values into a {@link Tuple8}.
+	 * An error or <strong>empty</strong> completion of any source will cause other sources
+	 * to be cancelled and the resulting Mono to immediately error or complete, respectively.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/whent.png" alt="">
+	 * <p>
+	 * @param p1 The first upstream {@link Publisher} to subscribe to.
+	 * @param p2 The second upstream {@link Publisher} to subscribe to.
+	 * @param p3 The third upstream {@link Publisher} to subscribe to.
+	 * @param p4 The fourth upstream {@link Publisher} to subscribe to.
+	 * @param p5 The fifth upstream {@link Publisher} to subscribe to.
+	 * @param p6 The sixth upstream {@link Publisher} to subscribe to.
+	 * @param p7 The seventh upstream {@link Publisher} to subscribe to.
+	 * @param p8 The eight upstream {@link Publisher} to subscribe to.
+	 * @param <T1> type of the value from source1
+	 * @param <T2> type of the value from source2
+	 * @param <T3> type of the value from source3
+	 * @param <T4> type of the value from source4
+	 * @param <T5> type of the value from source5
+	 * @param <T6> type of the value from source6
+	 * @param <T7> type of the value from source7
+	 * @param <T8> type of the value from source8
+	 *
+	 * @return a {@link Mono}.
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public static <T1, T2, T3, T4, T5, T6, T7, T8> Mono<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> zip(Mono<? extends T1> p1,
+			Mono<? extends T2> p2,
+			Mono<? extends T3> p3,
+			Mono<? extends T4> p4,
+			Mono<? extends T5> p5,
+			Mono<? extends T6> p6,
+			Mono<? extends T7> p7,
+			Mono<? extends T8> p8) {
+		return onAssembly(new MonoZip(false, a -> Tuples.fromArray((Object[])a), p1, p2, p3, p4, p5, p6, p7, p8));
+	}
+
+	/**
 	 * Aggregate given monos into a new {@literal Mono} that will be fulfilled when all of the given {@literal
 	 * Monos} have produced an item, aggregating their values according to the provided combinator function.
 	 * An error or <strong>empty</strong> completion of any source will cause other sources
@@ -1112,6 +1191,85 @@ public abstract class Mono<T> implements Publisher<T> {
 			Mono<? extends T5> p5,
 			Mono<? extends T6> p6) {
 		return onAssembly(new MonoZip(true, a -> Tuples.fromArray((Object[])a), p1, p2, p3, p4, p5, p6));
+	}
+
+	/**
+	 * Merge given monos into a new {@literal Mono} that will be fulfilled when all of the given {@literal Monos}
+	 * have produced an item, aggregating their values into a {@link Tuple7} and delaying errors.
+	 * If a Mono source completes without value, all other sources are run to completion then
+	 * the resulting {@link Mono} completes empty.
+	 * If several Monos error, their exceptions are combined (as suppressed exceptions on a root exception).
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/whent.png" alt="">
+	 * <p>
+	 * @param p1 The first upstream {@link Publisher} to subscribe to.
+	 * @param p2 The second upstream {@link Publisher} to subscribe to.
+	 * @param p3 The third upstream {@link Publisher} to subscribe to.
+	 * @param p4 The fourth upstream {@link Publisher} to subscribe to.
+	 * @param p5 The fifth upstream {@link Publisher} to subscribe to.
+	 * @param p6 The sixth upstream {@link Publisher} to subscribe to.
+	 * @param p7 The seventh upstream {@link Publisher} to subscribe to.
+	 * @param <T1> type of the value from source1
+	 * @param <T2> type of the value from source2
+	 * @param <T3> type of the value from source3
+	 * @param <T4> type of the value from source4
+	 * @param <T5> type of the value from source5
+	 * @param <T6> type of the value from source6
+	 * @param <T7> type of the value from source7
+	 *
+	 * @return a {@link Mono}.
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public static <T1, T2, T3, T4, T5, T6, T7> Mono<Tuple7<T1, T2, T3, T4, T5, T6, T7>> zipDelayError(Mono<? extends T1> p1,
+			Mono<? extends T2> p2,
+			Mono<? extends T3> p3,
+			Mono<? extends T4> p4,
+			Mono<? extends T5> p5,
+			Mono<? extends T6> p6,
+			Mono<? extends T7> p7) {
+		return onAssembly(new MonoZip(true, a -> Tuples.fromArray((Object[])a), p1, p2, p3, p4, p5, p6, p7));
+	}
+
+	/**
+	 * Merge given monos into a new {@literal Mono} that will be fulfilled when all of the given {@literal Monos}
+	 * have produced an item, aggregating their values into a {@link Tuple8} and delaying errors.
+	 * If a Mono source completes without value, all other sources are run to completion then
+	 * the resulting {@link Mono} completes empty.
+	 * If several Monos error, their exceptions are combined (as suppressed exceptions on a root exception).
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/whent.png" alt="">
+	 * <p>
+	 * @param p1 The first upstream {@link Publisher} to subscribe to.
+	 * @param p2 The second upstream {@link Publisher} to subscribe to.
+	 * @param p3 The third upstream {@link Publisher} to subscribe to.
+	 * @param p4 The fourth upstream {@link Publisher} to subscribe to.
+	 * @param p5 The fifth upstream {@link Publisher} to subscribe to.
+	 * @param p6 The sixth upstream {@link Publisher} to subscribe to.
+	 * @param p7 The seventh upstream {@link Publisher} to subscribe to.
+	 * @param p8 The eight upstream {@link Publisher} to subscribe to.
+	 * @param <T1> type of the value from source1
+	 * @param <T2> type of the value from source2
+	 * @param <T3> type of the value from source3
+	 * @param <T4> type of the value from source4
+	 * @param <T5> type of the value from source5
+	 * @param <T6> type of the value from source6
+	 * @param <T7> type of the value from source7
+	 * @param <T8> type of the value from source8
+	 *
+	 * @return a {@link Mono}.
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public static <T1, T2, T3, T4, T5, T6, T7, T8> Mono<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> zipDelayError(Mono<? extends T1> p1,
+			Mono<? extends T2> p2,
+			Mono<? extends T3> p3,
+			Mono<? extends T4> p4,
+			Mono<? extends T5> p5,
+			Mono<? extends T6> p6,
+			Mono<? extends T7> p7,
+			Mono<? extends T8> p8) {
+		return onAssembly(new MonoZip(true, a -> Tuples.fromArray((Object[])a), p1, p2, p3, p4, p5, p6, p7, p8));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -780,8 +780,8 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * <p>
 	 * @param p1 The first upstream {@link Publisher} to subscribe to.
 	 * @param p2 The second upstream {@link Publisher} to subscribe to.
-	 * @param <T1> type of the value from source1
-	 * @param <T2> type of the value from source2
+	 * @param <T1> type of the value from p1
+	 * @param <T2> type of the value from p2
 	 *
 	 * @return a {@link Mono}.
 	 */
@@ -802,8 +802,8 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param p2 The second upstream {@link Publisher} to subscribe to.
 	 * @param combinator a {@link BiFunction} combinator function when both sources
 	 * complete
-	 * @param <T1> type of the value from source1
-	 * @param <T2> type of the value from source2
+	 * @param <T1> type of the value from p1
+	 * @param <T2> type of the value from p2
 	 * @param <O> output value
 	 *
 	 * @return a {@link Mono}.
@@ -825,9 +825,9 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param p1 The first upstream {@link Publisher} to subscribe to.
 	 * @param p2 The second upstream {@link Publisher} to subscribe to.
 	 * @param p3 The third upstream {@link Publisher} to subscribe to.
-	 * @param <T1> type of the value from source1
-	 * @param <T2> type of the value from source2
-	 * @param <T3> type of the value from source3
+	 * @param <T1> type of the value from p1
+	 * @param <T2> type of the value from p2
+	 * @param <T3> type of the value from p3
 	 *
 	 * @return a {@link Mono}.
 	 */
@@ -849,10 +849,10 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param p2 The second upstream {@link Publisher} to subscribe to.
 	 * @param p3 The third upstream {@link Publisher} to subscribe to.
 	 * @param p4 The fourth upstream {@link Publisher} to subscribe to.
-	 * @param <T1> type of the value from source1
-	 * @param <T2> type of the value from source2
-	 * @param <T3> type of the value from source3
-	 * @param <T4> type of the value from source4
+	 * @param <T1> type of the value from p1
+	 * @param <T2> type of the value from p2
+	 * @param <T3> type of the value from p3
+	 * @param <T4> type of the value from p4
 	 *
 	 * @return a {@link Mono}.
 	 */
@@ -878,11 +878,11 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param p3 The third upstream {@link Publisher} to subscribe to.
 	 * @param p4 The fourth upstream {@link Publisher} to subscribe to.
 	 * @param p5 The fifth upstream {@link Publisher} to subscribe to.
-	 * @param <T1> type of the value from source1
-	 * @param <T2> type of the value from source2
-	 * @param <T3> type of the value from source3
-	 * @param <T4> type of the value from source4
-	 * @param <T5> type of the value from source5
+	 * @param <T1> type of the value from p1
+	 * @param <T2> type of the value from p2
+	 * @param <T3> type of the value from p3
+	 * @param <T4> type of the value from p4
+	 * @param <T5> type of the value from p5
 	 *
 	 * @return a {@link Mono}.
 	 */
@@ -910,12 +910,12 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param p4 The fourth upstream {@link Publisher} to subscribe to.
 	 * @param p5 The fifth upstream {@link Publisher} to subscribe to.
 	 * @param p6 The sixth upstream {@link Publisher} to subscribe to.
-	 * @param <T1> type of the value from source1
-	 * @param <T2> type of the value from source2
-	 * @param <T3> type of the value from source3
-	 * @param <T4> type of the value from source4
-	 * @param <T5> type of the value from source5
-	 * @param <T6> type of the value from source6
+	 * @param <T1> type of the value from p1
+	 * @param <T2> type of the value from p2
+	 * @param <T3> type of the value from p3
+	 * @param <T4> type of the value from p4
+	 * @param <T5> type of the value from p5
+	 * @param <T6> type of the value from p6
 	 *
 	 * @return a {@link Mono}.
 	 */
@@ -945,13 +945,13 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param p5 The fifth upstream {@link Publisher} to subscribe to.
 	 * @param p6 The sixth upstream {@link Publisher} to subscribe to.
 	 * @param p7 The seventh upstream {@link Publisher} to subscribe to.
-	 * @param <T1> type of the value from source1
-	 * @param <T2> type of the value from source2
-	 * @param <T3> type of the value from source3
-	 * @param <T4> type of the value from source4
-	 * @param <T5> type of the value from source5
-	 * @param <T6> type of the value from source6
-	 * @param <T7> type of the value from source7
+	 * @param <T1> type of the value from p1
+	 * @param <T2> type of the value from p2
+	 * @param <T3> type of the value from p3
+	 * @param <T4> type of the value from p4
+	 * @param <T5> type of the value from p5
+	 * @param <T6> type of the value from p6
+	 * @param <T7> type of the value from p7
 	 *
 	 * @return a {@link Mono}.
 	 */
@@ -983,14 +983,14 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param p6 The sixth upstream {@link Publisher} to subscribe to.
 	 * @param p7 The seventh upstream {@link Publisher} to subscribe to.
 	 * @param p8 The eight upstream {@link Publisher} to subscribe to.
-	 * @param <T1> type of the value from source1
-	 * @param <T2> type of the value from source2
-	 * @param <T3> type of the value from source3
-	 * @param <T4> type of the value from source4
-	 * @param <T5> type of the value from source5
-	 * @param <T6> type of the value from source6
-	 * @param <T7> type of the value from source7
-	 * @param <T8> type of the value from source8
+	 * @param <T1> type of the value from p1
+	 * @param <T2> type of the value from p2
+	 * @param <T3> type of the value from p3
+	 * @param <T4> type of the value from p4
+	 * @param <T5> type of the value from p5
+	 * @param <T6> type of the value from p6
+	 * @param <T7> type of the value from p7
+	 * @param <T8> type of the value from p8
 	 *
 	 * @return a {@link Mono}.
 	 */
@@ -1064,8 +1064,8 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * <p>
 	 * @param p1 The first upstream {@link Publisher} to subscribe to.
 	 * @param p2 The second upstream {@link Publisher} to subscribe to.
-	 * @param <T1> type of the value from source1
-	 * @param <T2> type of the value from source2
+	 * @param <T1> type of the value from p1
+	 * @param <T2> type of the value from p2
 	 *
 	 * @return a {@link Mono}.
 	 */
@@ -1087,9 +1087,9 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param p1 The first upstream {@link Publisher} to subscribe to.
 	 * @param p2 The second upstream {@link Publisher} to subscribe to.
 	 * @param p3 The third upstream {@link Publisher} to subscribe to.
-	 * @param <T1> type of the value from source1
-	 * @param <T2> type of the value from source2
-	 * @param <T3> type of the value from source3
+	 * @param <T1> type of the value from p1
+	 * @param <T2> type of the value from p2
+	 * @param <T3> type of the value from p3
 	 *
 	 * @return a {@link Mono}.
 	 */
@@ -1112,10 +1112,10 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param p2 The second upstream {@link Publisher} to subscribe to.
 	 * @param p3 The third upstream {@link Publisher} to subscribe to.
 	 * @param p4 The fourth upstream {@link Publisher} to subscribe to.
-	 * @param <T1> type of the value from source1
-	 * @param <T2> type of the value from source2
-	 * @param <T3> type of the value from source3
-	 * @param <T4> type of the value from source4
+	 * @param <T1> type of the value from p1
+	 * @param <T2> type of the value from p2
+	 * @param <T3> type of the value from p3
+	 * @param <T4> type of the value from p4
 	 *
 	 * @return a {@link Mono}.
 	 */
@@ -1141,11 +1141,11 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param p3 The third upstream {@link Publisher} to subscribe to.
 	 * @param p4 The fourth upstream {@link Publisher} to subscribe to.
 	 * @param p5 The fifth upstream {@link Publisher} to subscribe to.
-	 * @param <T1> type of the value from source1
-	 * @param <T2> type of the value from source2
-	 * @param <T3> type of the value from source3
-	 * @param <T4> type of the value from source4
-	 * @param <T5> type of the value from source5
+	 * @param <T1> type of the value from p1
+	 * @param <T2> type of the value from p2
+	 * @param <T3> type of the value from p3
+	 * @param <T4> type of the value from p4
+	 * @param <T5> type of the value from p5
 	 *
 	 * @return a {@link Mono}.
 	 */
@@ -1174,12 +1174,12 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param p4 The fourth upstream {@link Publisher} to subscribe to.
 	 * @param p5 The fifth upstream {@link Publisher} to subscribe to.
 	 * @param p6 The sixth upstream {@link Publisher} to subscribe to.
-	 * @param <T1> type of the value from source1
-	 * @param <T2> type of the value from source2
-	 * @param <T3> type of the value from source3
-	 * @param <T4> type of the value from source4
-	 * @param <T5> type of the value from source5
-	 * @param <T6> type of the value from source6
+	 * @param <T1> type of the value from p1
+	 * @param <T2> type of the value from p2
+	 * @param <T3> type of the value from p3
+	 * @param <T4> type of the value from p4
+	 * @param <T5> type of the value from p5
+	 * @param <T6> type of the value from p6
 	 *
 	 * @return a {@link Mono}.
 	 */
@@ -1210,13 +1210,13 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param p5 The fifth upstream {@link Publisher} to subscribe to.
 	 * @param p6 The sixth upstream {@link Publisher} to subscribe to.
 	 * @param p7 The seventh upstream {@link Publisher} to subscribe to.
-	 * @param <T1> type of the value from source1
-	 * @param <T2> type of the value from source2
-	 * @param <T3> type of the value from source3
-	 * @param <T4> type of the value from source4
-	 * @param <T5> type of the value from source5
-	 * @param <T6> type of the value from source6
-	 * @param <T7> type of the value from source7
+	 * @param <T1> type of the value from p1
+	 * @param <T2> type of the value from p2
+	 * @param <T3> type of the value from p3
+	 * @param <T4> type of the value from p4
+	 * @param <T5> type of the value from p5
+	 * @param <T6> type of the value from p6
+	 * @param <T7> type of the value from p7
 	 *
 	 * @return a {@link Mono}.
 	 */
@@ -1249,14 +1249,14 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param p6 The sixth upstream {@link Publisher} to subscribe to.
 	 * @param p7 The seventh upstream {@link Publisher} to subscribe to.
 	 * @param p8 The eight upstream {@link Publisher} to subscribe to.
-	 * @param <T1> type of the value from source1
-	 * @param <T2> type of the value from source2
-	 * @param <T3> type of the value from source3
-	 * @param <T4> type of the value from source4
-	 * @param <T5> type of the value from source5
-	 * @param <T6> type of the value from source6
-	 * @param <T7> type of the value from source7
-	 * @param <T8> type of the value from source8
+	 * @param <T1> type of the value from p1
+	 * @param <T2> type of the value from p2
+	 * @param <T3> type of the value from p3
+	 * @param <T4> type of the value from p4
+	 * @param <T5> type of the value from p5
+	 * @param <T6> type of the value from p6
+	 * @param <T7> type of the value from p7
+	 * @param <T8> type of the value from p8
 	 *
 	 * @return a {@link Mono}.
 	 */

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -565,6 +565,35 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	@SuppressWarnings("unchecked")
+	public void zip7() {
+		StepVerifier.create(Flux.zip(Flux.just(1),
+				Flux.just(2),
+				Flux.just(3),
+				Flux.just(4),
+				Flux.just(5),
+				Flux.just(6),
+				Flux.just(7)))
+		            .expectNext(Tuples.of(1, 2, 3, 4, 5, 6, 7))
+		            .verifyComplete();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void zip8() {
+		StepVerifier.create(Flux.zip(Flux.just(1),
+				Flux.just(2),
+				Flux.just(3),
+				Flux.just(4),
+				Flux.just(5),
+				Flux.just(6),
+				Flux.just(7),
+				Flux.just(8)))
+		            .expectNext(Tuples.of(1, 2, 3, 4, 5, 6, 7, 8))
+		            .verifyComplete();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
 	public void createZipWithPrefetch() {
 		Flux<Integer>[] list = new Flux[]{Flux.just(1), Flux.just(2)};
 		Flux<Integer> f = Flux.zip(obj -> 0, 123, list);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoZipTest.java
@@ -277,27 +277,19 @@ public class MonoZipTest {
 
 	@Test
 	public void whenMonoJust7() {
-		MonoProcessor<Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer>> mp =
-				MonoProcessor.create();
 		StepVerifier.create(Mono.zip(Mono.just(1),
 				Mono.just(2),
 				Mono.just(3),
 				Mono.just(4),
 				Mono.just(5),
 				Mono.just(6),
-				Mono.just(7))
-		                        .subscribeWith(mp))
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+				Mono.just(7)))
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4 && v.getT5() == 5 && v.getT6() == 6 && v.getT7() == 7).isTrue())
 		            .verifyComplete();
 	}
 
 	@Test
 	public void whenMonoJust8() {
-		MonoProcessor<Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>> mp =
-				MonoProcessor.create();
 		StepVerifier.create(Mono.zip(Mono.just(1),
 				Mono.just(2),
 				Mono.just(3),
@@ -305,11 +297,7 @@ public class MonoZipTest {
 				Mono.just(5),
 				Mono.just(6),
 				Mono.just(7),
-				Mono.just(8))
-		                        .subscribeWith(mp))
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+				Mono.just(8)))
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4 && v.getT5() == 5 && v.getT6() == 6 && v.getT7() == 7 && v.getT8() == 8).isTrue())
 		            .verifyComplete();
 	}
@@ -424,19 +412,13 @@ public class MonoZipTest {
 				Mono.just(4),
 				Mono.just(5),
 				Mono.just(6),
-				Mono.just(7))
-		                        .subscribeWith(mp))
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+				Mono.just(7)))
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4 && v.getT5() == 5 && v.getT6() == 6 && v.getT7() == 7).isTrue())
 		            .verifyComplete();
 	}
 
 	@Test
 	public void whenDelayMonoJust8() {
-		MonoProcessor<Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>> mp =
-				MonoProcessor.create();
 		StepVerifier.create(Mono.zipDelayError(Mono.just(1),
 				Mono.just(2),
 				Mono.just(3),
@@ -444,11 +426,7 @@ public class MonoZipTest {
 				Mono.just(5),
 				Mono.just(6),
 				Mono.just(7),
-				Mono.just(8))
-		                        .subscribeWith(mp))
-		            .then(() -> assertThat(mp.isError()).isFalse())
-		            .then(() -> assertThat(mp.isSuccess()).isTrue())
-		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+				Mono.just(8)))
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4 && v.getT5() == 5 && v.getT6() == 6 && v.getT7() == 7 && v.getT8() == 8).isTrue())
 		            .verifyComplete();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoZipTest.java
@@ -33,6 +33,8 @@ import reactor.util.function.Tuple3;
 import reactor.util.function.Tuple4;
 import reactor.util.function.Tuple5;
 import reactor.util.function.Tuple6;
+import reactor.util.function.Tuple7;
+import reactor.util.function.Tuple8;
 import reactor.util.function.Tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -274,6 +276,45 @@ public class MonoZipTest {
 	}
 
 	@Test
+	public void whenMonoJust7() {
+		MonoProcessor<Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer>> mp =
+				MonoProcessor.create();
+		StepVerifier.create(Mono.zip(Mono.just(1),
+				Mono.just(2),
+				Mono.just(3),
+				Mono.just(4),
+				Mono.just(5),
+				Mono.just(6),
+				Mono.just(7))
+		                        .subscribeWith(mp))
+		            .then(() -> assertThat(mp.isError()).isFalse())
+		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4 && v.getT5() == 5 && v.getT6() == 6 && v.getT7() == 7).isTrue())
+		            .verifyComplete();
+	}
+
+	@Test
+	public void whenMonoJust8() {
+		MonoProcessor<Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>> mp =
+				MonoProcessor.create();
+		StepVerifier.create(Mono.zip(Mono.just(1),
+				Mono.just(2),
+				Mono.just(3),
+				Mono.just(4),
+				Mono.just(5),
+				Mono.just(6),
+				Mono.just(7),
+				Mono.just(8))
+		                        .subscribeWith(mp))
+		            .then(() -> assertThat(mp.isError()).isFalse())
+		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4 && v.getT5() == 5 && v.getT6() == 6 && v.getT7() == 7 && v.getT8() == 8).isTrue())
+		            .verifyComplete();
+	}
+
+	@Test
 	public void whenMonoError() {
 		MonoProcessor<Tuple2<Integer, Integer>> mp = MonoProcessor.create();
 		StepVerifier.create(Mono.zip(Mono.<Integer>error(new Exception("test1")),
@@ -370,6 +411,45 @@ public class MonoZipTest {
 		            .then(() -> assertThat(mp.isSuccess()).isTrue())
 		            .then(() -> assertThat(mp.isTerminated()).isTrue())
 		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4 && v.getT5() == 5 && v.getT6() == 6).isTrue())
+		            .verifyComplete();
+	}
+
+	@Test
+	public void whenDelayMonoJust7() {
+		MonoProcessor<Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer>> mp =
+				MonoProcessor.create();
+		StepVerifier.create(Mono.zipDelayError(Mono.just(1),
+				Mono.just(2),
+				Mono.just(3),
+				Mono.just(4),
+				Mono.just(5),
+				Mono.just(6),
+				Mono.just(7))
+		                        .subscribeWith(mp))
+		            .then(() -> assertThat(mp.isError()).isFalse())
+		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4 && v.getT5() == 5 && v.getT6() == 6 && v.getT7() == 7).isTrue())
+		            .verifyComplete();
+	}
+
+	@Test
+	public void whenDelayMonoJust8() {
+		MonoProcessor<Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>> mp =
+				MonoProcessor.create();
+		StepVerifier.create(Mono.zipDelayError(Mono.just(1),
+				Mono.just(2),
+				Mono.just(3),
+				Mono.just(4),
+				Mono.just(5),
+				Mono.just(6),
+				Mono.just(7),
+				Mono.just(8))
+		                        .subscribeWith(mp))
+		            .then(() -> assertThat(mp.isError()).isFalse())
+		            .then(() -> assertThat(mp.isSuccess()).isTrue())
+		            .then(() -> assertThat(mp.isTerminated()).isTrue())
+		            .assertNext(v -> assertThat(v.getT1() == 1 && v.getT2() == 2 && v.getT3() == 3 && v.getT4() == 4 && v.getT5() == 5 && v.getT6() == 6 && v.getT7() == 7 && v.getT8() == 8).isTrue())
 		            .verifyComplete();
 	}
 


### PR DESCRIPTION
This PR adds `zip` methods for 7 and 8 items resulting in a `Tuple7` or `Tuple8`. This is especially nice for Kotlin, since then we can use the already existing `component7()` and `component8()` extension functions when combining streams. 

Currently in a codebase I'm working on, we have a `Mono.zip()` combining 11 items. There is no `Tuple9+` yet. I'm wondering if it's a good idea to add these or if adding these extra `Tuple` type would hurt maintainability. Depending on your opinion, I could add these in another PR.