### PR TITLE
fix #1205 Have lift alternative that exposes the raw Publisher

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableLift.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
+import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Scannable;
@@ -30,13 +31,13 @@ import reactor.util.annotation.Nullable;
  */
 final class ConnectableLift<I, O> extends ConnectableFlux<O> implements Scannable {
 
-	final BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
 			lifter;
 
 	final ConnectableFlux<I> source;
 
 	ConnectableLift(ConnectableFlux<I> p,
-			BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
 		this.source = Objects.requireNonNull(p, "source");
 		this.lifter = lifter;
 	}
@@ -62,7 +63,7 @@ final class ConnectableLift<I, O> extends ConnectableFlux<O> implements Scannabl
 	@Override
 	public void subscribe(CoreSubscriber<? super O> actual) {
 		CoreSubscriber<? super I> input =
-				lifter.apply(Scannable.from(source), actual);
+				lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableLiftFuseable.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
+import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Fuseable;
@@ -32,13 +33,13 @@ import reactor.util.annotation.Nullable;
 final class ConnectableLiftFuseable<I, O> extends ConnectableFlux<O>
 		implements Scannable, Fuseable {
 
-	final BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
 			lifter;
 
 	final ConnectableFlux<I> source;
 
 	ConnectableLiftFuseable(ConnectableFlux<I> p,
-			BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
 		this.source = Objects.requireNonNull(p, "source");
 		this.lifter = lifter;
 	}
@@ -64,7 +65,7 @@ final class ConnectableLiftFuseable<I, O> extends ConnectableFlux<O>
 	@Override
 	public void subscribe(CoreSubscriber<? super O> actual) {
 		CoreSubscriber<? super I> input =
-				lifter.apply(Scannable.from(source), actual);
+				lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxLift.java
@@ -27,11 +27,11 @@ import reactor.core.Scannable;
  */
 final class FluxLift<I, O> extends FluxOperator<I, O> {
 
-	final BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
 			lifter;
 
 	FluxLift(Publisher<I> p,
-			BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
 		super(Flux.from(p));
 		this.lifter = lifter;
 	}
@@ -39,7 +39,7 @@ final class FluxLift<I, O> extends FluxOperator<I, O> {
 	@Override
 	public void subscribe(CoreSubscriber<? super O> actual) {
 		CoreSubscriber<? super I> input =
-				lifter.apply(Scannable.from(source), actual);
+				lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxLiftFuseable.java
@@ -45,11 +45,11 @@ import reactor.core.Scannable;
 final class FluxLiftFuseable<I, O> extends FluxOperator<I, O>
 		implements Fuseable {
 
-	final BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
 			lifter;
 
 	FluxLiftFuseable(Publisher<I> p,
-			BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
 		super(Flux.from(p));
 		this.lifter = lifter;
 	}
@@ -57,7 +57,7 @@ final class FluxLiftFuseable<I, O> extends FluxOperator<I, O>
 	@Override
 	public void subscribe(CoreSubscriber<? super O> actual) {
 		CoreSubscriber<? super I> input =
-				lifter.apply(Scannable.from(source), actual);
+				lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/GroupedLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/GroupedLift.java
@@ -19,6 +19,7 @@ package reactor.core.publisher;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
+import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
@@ -28,13 +29,13 @@ import reactor.util.annotation.Nullable;
  */
 final class GroupedLift<K, I, O> extends GroupedFlux<K, O> implements Scannable {
 
-	final BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
 			lifter;
 
 	final GroupedFlux<K, I> source;
 
 	GroupedLift(GroupedFlux<K, I> p,
-			BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
 		this.source = Objects.requireNonNull(p, "source");
 		this.lifter = lifter;
 	}
@@ -65,7 +66,7 @@ final class GroupedLift<K, I, O> extends GroupedFlux<K, O> implements Scannable 
 	@Override
 	public void subscribe(CoreSubscriber<? super O> actual) {
 		CoreSubscriber<? super I> input =
-				lifter.apply(Scannable.from(source), actual);
+				lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/GroupedLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/GroupedLiftFuseable.java
@@ -19,6 +19,7 @@ package reactor.core.publisher;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
+import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
@@ -30,13 +31,13 @@ import reactor.util.annotation.Nullable;
 final class GroupedLiftFuseable<K, I, O> extends GroupedFlux<K, O>
 		implements Scannable, Fuseable {
 
-	final BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
 			lifter;
 
 	final GroupedFlux<K, I> source;
 
 	GroupedLiftFuseable(GroupedFlux<K, I> p,
-			BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
 		this.source = Objects.requireNonNull(p, "source");
 		this.lifter = lifter;
 	}
@@ -67,7 +68,7 @@ final class GroupedLiftFuseable<K, I, O> extends GroupedFlux<K, O>
 	@Override
 	public void subscribe(CoreSubscriber<? super O> actual) {
 		CoreSubscriber<? super I> input =
-				lifter.apply(Scannable.from(source), actual);
+				lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoLift.java
@@ -20,18 +20,17 @@ import java.util.function.BiFunction;
 
 import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
-import reactor.core.Scannable;
 
 /**
  * @author Stephane Maldini
  */
 final class MonoLift<I, O> extends MonoOperator<I, O> {
 
-	final BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
 			lifter;
 
 	MonoLift(Publisher<I> p,
-			BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
 		super(Mono.from(p));
 		this.lifter = lifter;
 	}
@@ -39,7 +38,7 @@ final class MonoLift<I, O> extends MonoOperator<I, O> {
 	@Override
 	public void subscribe(CoreSubscriber<? super O> actual) {
 		CoreSubscriber<? super I> input =
-				lifter.apply(Scannable.from(source), actual);
+				lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoLiftFuseable.java
@@ -31,19 +31,18 @@ import reactor.core.Scannable;
 final class MonoLiftFuseable<I, O> extends MonoOperator<I, O>
 		implements Fuseable {
 
-	final BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
 			lifter;
 
 	MonoLiftFuseable(Publisher<I> p,
-			BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
 		super(Mono.from(p));
 		this.lifter = lifter;
 	}
 
 	@Override
 	public void subscribe(CoreSubscriber<? super O> actual) {
-		CoreSubscriber<? super I> input =
-				lifter.apply(Scannable.from(source), actual);
+		CoreSubscriber<? super I> input = lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -190,7 +190,7 @@ public abstract class Operators {
 	 * convenience of introspection. You should however avoid instanceof checks or any
 	 * other processing that depends on identity of the {@link Publisher}, as it might
 	 * get hidden if {@link Scannable#isScanAvailable()} returns {@code false}.
-	 * Use {@link #liftRaw(BiFunction)} instead for that kind of use case.
+	 * Use {@link #liftPublisher(BiFunction)} instead for that kind of use case.
 	 *
 	 * @param lifter the bifunction taking {@link Scannable} from the enclosing
 	 * publisher (assuming it is compatible) and consuming {@link CoreSubscriber}.
@@ -201,7 +201,7 @@ public abstract class Operators {
 	 * @param <O> the output type
 	 *
 	 * @return a new {@link Function}
-	 * @see #liftRaw(BiFunction)
+	 * @see #liftPublisher(BiFunction)
 	 */
 	public static <I, O> Function<? super Publisher<I>, ? extends Publisher<O>> lift(BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
 		return LiftFunction.liftScannable(null, lifter);
@@ -218,7 +218,7 @@ public abstract class Operators {
 	 * convenience of introspection. You should however avoid instanceof checks or any
 	 * other processing that depends on identity of the {@link Publisher}, as it might
 	 * get hidden if {@link Scannable#isScanAvailable()} returns {@code false}.
-	 * Use {@link #liftRaw(Predicate, BiFunction)} instead for that kind of use case.
+	 * Use {@link #liftPublisher(Predicate, BiFunction)} instead for that kind of use case.
 	 *
 	 * <p>
 	 *     The function will be invoked only if the passed {@link Predicate} matches.
@@ -235,7 +235,7 @@ public abstract class Operators {
 	 * @param <O> the input and output type
 	 *
 	 * @return a new {@link Function}
-	 * @see #liftRaw(Predicate, BiFunction)
+	 * @see #liftPublisher(Predicate, BiFunction)
 	 */
 	public static <O> Function<? super Publisher<O>, ? extends Publisher<O>> lift(
 			Predicate<Scannable> filter,
@@ -248,7 +248,9 @@ public abstract class Operators {
 	 * {@link CoreSubscriber} decoration. The function is compatible with
 	 * {@link Flux#transform(Function)}, {@link Mono#transform(Function)},
 	 * {@link Hooks#onEachOperator(Function)} and {@link Hooks#onLastOperator(Function)},
-	 * and works with the raw {@link Publisher} as input.
+	 * and works with the raw {@link Publisher} as input, which is useful if you need to
+	 * detect the precise type of the source (eg. instanceof checks to detect Mono, Flux,
+	 * true Scannable, etc...).
 	 *
 	 * @param lifter the bifunction taking the raw {@link Publisher} and
 	 * {@link CoreSubscriber}. The publisher can be double-checked (including with
@@ -260,7 +262,7 @@ public abstract class Operators {
 	 *
 	 * @return a new {@link Function}
 	 */
-	public static <I, O> Function<? super Publisher<I>, ? extends Publisher<O>> liftRaw(
+	public static <I, O> Function<? super Publisher<I>, ? extends Publisher<O>> liftPublisher(
 			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
 		return LiftFunction.liftPublisher(null, lifter);
 	}
@@ -270,7 +272,9 @@ public abstract class Operators {
 	 * {@link CoreSubscriber} decoration. The function is compatible with
 	 * {@link Flux#transform(Function)}, {@link Mono#transform(Function)},
 	 * {@link Hooks#onEachOperator(Function)} and {@link Hooks#onLastOperator(Function)},
-	 * and works with the raw {@link Publisher} as input.
+	 * and works with the raw {@link Publisher} as input, which is useful if you need to
+	 * 	 * detect the precise type of the source (eg. instanceof checks to detect Mono, Flux,
+	 * 	 * true Scannable, etc...).
 	 *
 	 * <p>
 	 *     The function will be invoked only if the passed {@link Predicate} matches.
@@ -288,7 +292,7 @@ public abstract class Operators {
 	 *
 	 * @return a new {@link Function}
 	 */
-	public static <O> Function<? super Publisher<O>, ? extends Publisher<O>> liftRaw(
+	public static <O> Function<? super Publisher<O>, ? extends Publisher<O>> liftPublisher(
 			Predicate<Publisher> filter,
 			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super O>> lifter) {
 		return LiftFunction.liftPublisher(filter, lifter);

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -183,27 +183,42 @@ public abstract class Operators {
 	 * Create a function that can be used to support a custom operator via
 	 * {@link CoreSubscriber} decoration. The function is compatible with
 	 * {@link Flux#transform(Function)}, {@link Mono#transform(Function)},
-	 * {@link Hooks#onEachOperator(Function)} and {@link Hooks#onLastOperator(Function)}
+	 * {@link Hooks#onEachOperator(Function)} and {@link Hooks#onLastOperator(Function)},
+	 * but requires that the original {@link Publisher} be {@link Scannable}.
+	 * <p>
+	 * This variant attempts to expose the {@link Publisher} as a {@link Scannable} for
+	 * convenience of introspection. You should however avoid instanceof checks or any
+	 * other processing that depends on identity of the {@link Publisher}, as it might
+	 * get hidden if {@link Scannable#isScanAvailable()} returns {@code false}.
+	 * Use {@link #liftRaw(BiFunction)} instead for that kind of use case.
 	 *
 	 * @param lifter the bifunction taking {@link Scannable} from the enclosing
-	 * publisher and consuming {@link CoreSubscriber}. It must return a receiving
-	 * {@link CoreSubscriber} that will immediately subscribe to the applied
-	 * {@link Publisher}.
+	 * publisher (assuming it is compatible) and consuming {@link CoreSubscriber}.
+	 * It must return a receiving {@link CoreSubscriber} that will immediately subscribe
+	 * to the applied {@link Publisher}.
 	 *
 	 * @param <I> the input type
 	 * @param <O> the output type
 	 *
 	 * @return a new {@link Function}
+	 * @see #liftRaw(BiFunction)
 	 */
 	public static <I, O> Function<? super Publisher<I>, ? extends Publisher<O>> lift(BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
-		return new LiftFunction<>(null, lifter);
+		return LiftFunction.liftScannable(null, lifter);
 	}
 
 	/**
 	 * Create a function that can be used to support a custom operator via
 	 * {@link CoreSubscriber} decoration. The function is compatible with
 	 * {@link Flux#transform(Function)}, {@link Mono#transform(Function)},
-	 * {@link Hooks#onEachOperator(Function)} and {@link Hooks#onLastOperator(Function)}
+	 * {@link Hooks#onEachOperator(Function)} and {@link Hooks#onLastOperator(Function)},
+	 * but requires that the original {@link Publisher} be {@link Scannable}.
+	 * <p>
+	 * This variant attempts to expose the {@link Publisher} as a {@link Scannable} for
+	 * convenience of introspection. You should however avoid instanceof checks or any
+	 * other processing that depends on identity of the {@link Publisher}, as it might
+	 * get hidden if {@link Scannable#isScanAvailable()} returns {@code false}.
+	 * Use {@link #liftRaw(Predicate, BiFunction)} instead for that kind of use case.
 	 *
 	 * <p>
 	 *     The function will be invoked only if the passed {@link Predicate} matches.
@@ -211,20 +226,72 @@ public abstract class Operators {
 	 *     unmatched predicate will return the applied {@link Publisher}.
 	 *
 	 * @param filter the predicate to match taking {@link Scannable} from the applied
-	 * publisher to operate on
+	 * publisher to operate on. Assumes original is scan-compatible.
 	 * @param lifter the bifunction taking {@link Scannable} from the enclosing
 	 * publisher and consuming {@link CoreSubscriber}. It must return a receiving
 	 * {@link CoreSubscriber} that will immediately subscribe to the applied
-	 * {@link Publisher}.
+	 * {@link Publisher}. Assumes the original is scan-compatible.
+	 *
+	 * @param <O> the input and output type
+	 *
+	 * @return a new {@link Function}
+	 * @see #liftRaw(Predicate, BiFunction)
+	 */
+	public static <O> Function<? super Publisher<O>, ? extends Publisher<O>> lift(
+			Predicate<Scannable> filter,
+			BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super O>> lifter) {
+		return LiftFunction.liftScannable(filter, lifter);
+	}
+
+	/**
+	 * Create a function that can be used to support a custom operator via
+	 * {@link CoreSubscriber} decoration. The function is compatible with
+	 * {@link Flux#transform(Function)}, {@link Mono#transform(Function)},
+	 * {@link Hooks#onEachOperator(Function)} and {@link Hooks#onLastOperator(Function)},
+	 * and works with the raw {@link Publisher} as input.
+	 *
+	 * @param lifter the bifunction taking the raw {@link Publisher} and
+	 * {@link CoreSubscriber}. The publisher can be double-checked (including with
+	 * {@code instanceof}, and the function must return a receiving {@link CoreSubscriber}
+	 * that will immediately subscribe to the {@link Publisher}.
+	 *
+	 * @param <I> the input type
+	 * @param <O> the output type
+	 *
+	 * @return a new {@link Function}
+	 */
+	public static <I, O> Function<? super Publisher<I>, ? extends Publisher<O>> liftRaw(
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+		return LiftFunction.liftPublisher(null, lifter);
+	}
+
+	/**
+	 * Create a function that can be used to support a custom operator via
+	 * {@link CoreSubscriber} decoration. The function is compatible with
+	 * {@link Flux#transform(Function)}, {@link Mono#transform(Function)},
+	 * {@link Hooks#onEachOperator(Function)} and {@link Hooks#onLastOperator(Function)},
+	 * and works with the raw {@link Publisher} as input.
+	 *
+	 * <p>
+	 *     The function will be invoked only if the passed {@link Predicate} matches.
+	 *     Therefore the transformed type O must be the same than the input type since
+	 *     unmatched predicate will return the applied {@link Publisher}.
+	 *
+	 * @param filter the {@link Predicate} that the raw {@link Publisher} must pass for
+	 * the transformation to occur
+	 * @param lifter the {@link BiFunction} taking the raw {@link Publisher} and
+	 * {@link CoreSubscriber}. The publisher can be double-checked (including with
+	 * {@code instanceof}, and the function must return a receiving {@link CoreSubscriber}
+	 * that will immediately subscribe to the {@link Publisher}.
 	 *
 	 * @param <O> the input and output type
 	 *
 	 * @return a new {@link Function}
 	 */
-	public static <O> Function<? super Publisher<O>, ? extends Publisher<O>> lift(
-			Predicate<Scannable> filter,
-			BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super O>> lifter) {
-		return new LiftFunction<>(filter, lifter);
+	public static <O> Function<? super Publisher<O>, ? extends Publisher<O>> liftRaw(
+			Predicate<Publisher> filter,
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super O>> lifter) {
+		return LiftFunction.liftPublisher(filter, lifter);
 	}
 
 	/**
@@ -1830,14 +1897,35 @@ public abstract class Operators {
 	final static class LiftFunction<I, O>
 			implements Function<Publisher<I>, Publisher<O>> {
 
-		final Predicate<Scannable> filter;
+		final Predicate<Publisher> filter;
 
-		final BiFunction<Scannable, ? super CoreSubscriber<? super O>,
+		final BiFunction<Publisher, ? super CoreSubscriber<? super O>,
 				? extends CoreSubscriber<? super I>> lifter;
 
-		LiftFunction(@Nullable Predicate<Scannable> filter,
-				BiFunction<Scannable, ? super CoreSubscriber<? super O>,
-				? extends CoreSubscriber<? super I>> lifter) {
+		static final <I, O> LiftFunction<I, O> liftScannable(
+				@Nullable Predicate<Scannable> filter,
+				BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+			Objects.requireNonNull(lifter, "lifter");
+
+			Predicate<Publisher> effectiveFilter =  null;
+			if (filter != null) {
+				effectiveFilter = pub -> filter.test(Scannable.from(pub));
+			}
+
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
+					effectiveLifter = (pub, sub) -> lifter.apply(Scannable.from(pub), sub);
+
+			return new LiftFunction<>(effectiveFilter, effectiveLifter);
+		}
+
+		static final <I, O> LiftFunction<I, O> liftPublisher(
+				@Nullable Predicate<Publisher> filter,
+				BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+			return new LiftFunction<>(filter, Objects.requireNonNull(lifter, "lifter"));
+		}
+
+		private LiftFunction(@Nullable Predicate<Publisher> filter,
+				BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
 			this.filter = filter;
 			this.lifter = Objects.requireNonNull(lifter, "lifter");
 		}
@@ -1845,7 +1933,7 @@ public abstract class Operators {
 		@Override
 		@SuppressWarnings("unchecked")
 		public Publisher<O> apply(Publisher<I> publisher) {
-			if (filter != null && !filter.test(Scannable.from(publisher))) {
+			if (filter != null && !filter.test(publisher)) {
 				return (Publisher<O>)publisher;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelLift.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
+import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
@@ -27,13 +28,13 @@ import reactor.util.annotation.Nullable;
  */
 final class ParallelLift<I, O> extends ParallelFlux<O> implements Scannable {
 
-	final BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
 			lifter;
 
 	final ParallelFlux<I> source;
 
 	ParallelLift(ParallelFlux<I> p,
-			BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
 		this.source = Objects.requireNonNull(p, "source");
 		this.lifter = lifter;
 	}
@@ -69,7 +70,7 @@ final class ParallelLift<I, O> extends ParallelFlux<O> implements Scannable {
 		int i = 0;
 		while (i < subscribers.length) {
 			subscribers[i++] =
-					Objects.requireNonNull(lifter.apply(Scannable.from(source), s[i-1]),
+					Objects.requireNonNull(lifter.apply(source, s[i-1]),
 							"Lifted subscriber MUST NOT be null");
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelLiftFuseable.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
+import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
@@ -30,13 +31,13 @@ import reactor.util.annotation.Nullable;
 final class ParallelLiftFuseable<I, O> extends ParallelFlux<O>
 		implements Scannable, Fuseable {
 
-	final BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
 			lifter;
 
 	final ParallelFlux<I> source;
 
 	ParallelLiftFuseable(ParallelFlux<I> p,
-			BiFunction<Scannable, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
 		this.source = Objects.requireNonNull(p, "source");
 		this.lifter = lifter;
 	}
@@ -73,7 +74,7 @@ final class ParallelLiftFuseable<I, O> extends ParallelFlux<O>
 		while (i < subscribers.length) {
 			CoreSubscriber<? super O> actual = s[i - 1];
 			CoreSubscriber<? super I> converted =
-					Objects.requireNonNull(lifter.apply(Scannable.from(source), actual),
+					Objects.requireNonNull(lifter.apply(source, actual),
 							"Lifted subscriber MUST NOT be null");
 
 			Objects.requireNonNull(converted, "Lifted subscriber MUST NOT be null");

--- a/reactor-core/src/test/java/reactor/core/publisher/LiftFunctionTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/LiftFunctionTest.java
@@ -106,7 +106,7 @@ public class LiftFunctionTest {
 		Mono<Integer> source = Mono.just(1);
 
 		Operators.LiftFunction<Integer, Integer> liftFunction =
-				new Operators.LiftFunction<>(null, (s, actual) -> actual);
+				Operators.LiftFunction.liftScannable(null, (s, actual) -> actual);
 		Publisher<Integer> liftOperator = liftFunction.apply(source);
 
 		assertThat(liftOperator)
@@ -120,7 +120,7 @@ public class LiftFunctionTest {
 		Flux<Integer> source = Flux.just(1);
 
 		Operators.LiftFunction<Integer, Integer> liftFunction =
-				new Operators.LiftFunction<>(null, (s, actual) -> actual);
+				Operators.LiftFunction.liftScannable(null, (s, actual) -> actual);
 		Publisher<Integer> liftOperator = liftFunction.apply(source);
 
 		assertThat(liftOperator)
@@ -153,7 +153,7 @@ public class LiftFunctionTest {
 		                                      .replay(2);
 
 		Operators.LiftFunction<Integer, Integer> liftFunction =
-				new Operators.LiftFunction<>(null, (s, actual) -> actual);
+				Operators.LiftFunction.liftScannable(null, (s, actual) -> actual);
 		Publisher<Integer> liftOperator = liftFunction.apply(source);
 
 		assertThat(liftOperator)
@@ -169,7 +169,7 @@ public class LiftFunctionTest {
 				.groupBy(i -> "" + i);
 
 		Operators.LiftFunction<Integer, Integer> liftFunction =
-				new Operators.LiftFunction<>(null, (s, actual) -> actual);
+				Operators.LiftFunction.liftScannable(null, (s, actual) -> actual);
 
 		sourceGroups.map(g -> liftFunction.apply(g))
 		            .doOnNext(liftOperator -> assertThat(liftOperator)

--- a/reactor-core/src/test/java/reactor/core/publisher/LiftFunctionTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/LiftFunctionTest.java
@@ -33,7 +33,7 @@ public class LiftFunctionTest {
 		                           .hide();
 
 		Operators.LiftFunction<Integer, Integer> liftFunction =
-				new Operators.LiftFunction<>(null, (s, actual) -> actual);
+				Operators.LiftFunction.liftScannable(null, (s, actual) -> actual);
 		Publisher<Integer> liftOperator = liftFunction.apply(source);
 
 		assertThat(liftOperator)
@@ -47,7 +47,7 @@ public class LiftFunctionTest {
 		                           .hide();
 
 		Operators.LiftFunction<Integer, Integer> liftFunction =
-				new Operators.LiftFunction<>(null, (s, actual) -> actual);
+				Operators.LiftFunction.liftScannable(null, (s, actual) -> actual);
 		Publisher<Integer> liftOperator = liftFunction.apply(source);
 
 		assertThat(liftOperator)
@@ -62,7 +62,7 @@ public class LiftFunctionTest {
 		                                   .hide();
 
 		Operators.LiftFunction<Integer, Integer> liftFunction =
-				new Operators.LiftFunction<>(null, (s, actual) -> actual);
+				Operators.LiftFunction.liftScannable(null, (s, actual) -> actual);
 		Publisher<Integer> liftOperator = liftFunction.apply(source);
 
 		assertThat(liftOperator)
@@ -76,7 +76,7 @@ public class LiftFunctionTest {
 		                                      .publish(); //TODO hide if ConnectableFlux gets a hide function
 
 		Operators.LiftFunction<Integer, Integer> liftFunction =
-				new Operators.LiftFunction<>(null, (s, actual) -> actual);
+				Operators.LiftFunction.liftScannable(null, (s, actual) -> actual);
 		Publisher<Integer> liftOperator = liftFunction.apply(source);
 
 		assertThat(liftOperator)
@@ -92,7 +92,7 @@ public class LiftFunctionTest {
 				.groupBy(i -> "" + i);
 
 		Operators.LiftFunction<Integer, Integer> liftFunction =
-				new Operators.LiftFunction<>(null, (s, actual) -> actual);
+				Operators.LiftFunction.liftScannable(null, (s, actual) -> actual);
 
 		sourceGroups.map(g -> liftFunction.apply(g)) //TODO hide if GroupedFlux gets a proper hide() function
 		            .doOnNext(liftOperator -> assertThat(liftOperator)

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
@@ -22,18 +22,14 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
-import org.assertj.core.internal.Predicates;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
@@ -565,7 +561,7 @@ public class OperatorsTest {
 	}
 
 	@Test
-	public void liftVsLiftRaw() {
+	public void liftVsLiftPublisher() {
 		Publisher<Object> notScannable = new Flux<Object>() {
 			@Override
 			public void subscribe(CoreSubscriber<? super Object> actual) { }
@@ -582,14 +578,14 @@ public class OperatorsTest {
 				});
 
 		@SuppressWarnings("unchecked")
-		Function<Publisher<Object>, Publisher<Object>> liftRaw = (Function<Publisher<Object>, Publisher<Object>>)
-				Operators.liftRaw((pub, sub) -> {
+		Function<Publisher<Object>, Publisher<Object>> liftPublisher = (Function<Publisher<Object>, Publisher<Object>>)
+				Operators.liftPublisher((pub, sub) -> {
 					rawRef.set(pub);
 					return sub;
 				});
 
 		Publisher<Object> lifted = lift.apply(notScannable);
-		Publisher<Object> liftedRaw = liftRaw.apply(notScannable);
+		Publisher<Object> liftedRaw = liftPublisher.apply(notScannable);
 
 		assertThat(scannableRef).hasValue(null);
 		assertThat(rawRef).hasValue(null);
@@ -631,7 +627,7 @@ public class OperatorsTest {
 
 		@SuppressWarnings("unchecked")
 		Function<Publisher<Object>, Publisher<Object>> liftRaw = (Function<Publisher<Object>, Publisher<Object>>)
-				Operators.liftRaw(pub -> {
+				Operators.liftPublisher(pub -> {
 							rawFilterRef.set(pub);
 							return true;
 						},


### PR DESCRIPTION
By default LiftFunction will work on the Publisher, and can adapt to
user-provided functions that work with Scannable.

Exposed as Operators.liftRaw for backwards compatibility.