### PR TITLE
Fix #1189 Add cache(Duration, Scheduler) alias

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -2672,7 +2672,26 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a replaying {@link Flux}
 	 */
 	public final Flux<T> cache(Duration ttl) {
-		return replay(Integer.MAX_VALUE, ttl).autoConnect();
+		return cache(ttl, Schedulers.parallel());
+	}
+
+	/**
+	 * Turn this {@link Flux} into a hot source and cache last emitted signals for further
+	 * {@link Subscriber}. Will retain an unbounded history but apply a per-item expiry timeout
+	 * <p>
+	 *   Completion and Error will also be replayed until {@code ttl} triggers in which case
+	 *   the next {@link Subscriber} will start over a new subscription.
+	 * <p>
+	 * <img width="500" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/cache.png"
+	 * alt="">
+	 *
+	 * @param ttl Time-to-live for each cached item and post termination.
+	 * @param timer the {@link Scheduler} on which to measure the duration.
+	 *
+	 * @return a replaying {@link Flux}
+	 */
+	public final Flux<T> cache(Duration ttl, Scheduler timer) {
+		return cache(Integer.MAX_VALUE, ttl, timer);
 	}
 
 	/**
@@ -2692,7 +2711,28 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @return a replaying {@link Flux}
 	 */
 	public final Flux<T> cache(int history, Duration ttl) {
-		return replay(history, ttl).autoConnect();
+		return cache(history, ttl, Schedulers.parallel());
+	}
+
+	/**
+	 * Turn this {@link Flux} into a hot source and cache last emitted signals for further
+	 * {@link Subscriber}. Will retain up to the given history size and apply a per-item expiry
+	 * timeout.
+	 * <p>
+	 *   Completion and Error will also be replayed until {@code ttl} triggers in which case
+	 *   the next {@link Subscriber} will start over a new subscription.
+	 * <p>
+	 * <img width="500" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/cache.png"
+	 * alt="">
+	 *
+	 * @param history number of elements retained in cache
+	 * @param ttl Time-to-live for each cached item and post termination.
+	 * @param timer the {@link Scheduler} on which to measure the duration.
+	 *
+	 * @return a replaying {@link Flux}
+	 */
+	public final Flux<T> cache(int history, Duration ttl, Scheduler timer) {
+		return replay(history, ttl, timer).autoConnect();
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1501,7 +1501,26 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @return a replaying {@link Mono}
 	 */
 	public final Mono<T> cache(Duration ttl) {
-		return onAssembly(new MonoCacheTime<>(this, ttl, Schedulers.parallel()));
+		return cache(ttl, Schedulers.parallel());
+	}
+
+	/**
+	* Turn this {@link Mono} into a hot source and cache last emitted signals for further
+	* {@link Subscriber}, with an expiry timeout.
+	* <p>
+	* Completion and Error will also be replayed until {@code ttl} triggers in which case
+	* the next {@link Subscriber} will start over a new subscription.
+	* <p>
+	* <img width="500" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/cache1.png"
+	* alt="">
+	*
+	 * @param ttl Time-to-live for each cached item and post termination.
+	 * @param timer the {@link Scheduler} on which to measure the duration.
+	 *
+	* @return a replaying {@link Mono}
+	*/
+	public final Mono<T> cache(Duration ttl, Scheduler timer) {
+		return onAssembly(new MonoCacheTime<>(this, ttl, timer));
 	}
 
 	/**

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCacheTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCacheTest.java
@@ -30,119 +30,99 @@ public class FluxCacheTest {
 
 	@Test
 	public void cacheFlux() {
-		try {
-			//delayElements now uses parallel() so VTS must be enabled everywhere
-			VirtualTimeScheduler vts = VirtualTimeScheduler.getOrSet();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 
-			Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-			                                         .delayElements(Duration.ofMillis(1000))
-			                                         .cache()
-			                                         .elapsed();
+		Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
+		                                         .delayElements(Duration.ofMillis(1000)
+				                                         , vts)
+		                                         .cache()
+		                                         .elapsed(vts);
 
-			StepVerifier.create(source)
-			            .then(() -> vts.advanceTimeBy(Duration.ofSeconds(3)))
-			            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 1)
-			            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 2)
-			            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 3)
-			            .verifyComplete();
+		StepVerifier.withVirtualTime(() -> source, () -> vts, Long.MAX_VALUE)
+		            .thenAwait(Duration.ofSeconds(3))
+		            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 1)
+		            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 2)
+		            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 3)
+		            .verifyComplete();
 
-			StepVerifier.create(source)
-			            .then(() -> vts.advanceTimeBy(Duration.ofSeconds(3)))
-			            .expectNextMatches(t -> t.getT1() == 0 && t.getT2() == 1)
-			            .expectNextMatches(t -> t.getT1() == 0 && t.getT2() == 2)
-			            .expectNextMatches(t -> t.getT1() == 0 && t.getT2() == 3)
-			            .verifyComplete();
-		}
-		finally {
-			VirtualTimeScheduler.reset();
-		}
+		StepVerifier.withVirtualTime(() -> source, () -> vts, Long.MAX_VALUE)
+		            .thenAwait(Duration.ofSeconds(3))
+		            .expectNextMatches(t -> t.getT1() == 0 && t.getT2() == 1)
+		            .expectNextMatches(t -> t.getT1() == 0 && t.getT2() == 2)
+		            .expectNextMatches(t -> t.getT1() == 0 && t.getT2() == 3)
+		            .verifyComplete();
 	}
 
 	@Test
 	public void cacheFluxTTL() {
-		try {
-			//delayElements now uses parallel() so VTS must be enabled everywhere
-			VirtualTimeScheduler vts = VirtualTimeScheduler.getOrSet();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 
-			Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-			                                         .delayElements(Duration.ofMillis(1000))
-			                                         .cache(Duration.ofMillis(2000))
-			                                         .elapsed();
+		Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
+		                                         .delayElements(Duration.ofMillis(1000)
+				                                         , vts)
+		                                         .cache(Duration.ofMillis(2000), vts)
+		                                         .elapsed(vts);
 
-			StepVerifier.create(source)
-			            .then(() -> vts.advanceTimeBy(Duration.ofSeconds(3)))
-			            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 1)
-			            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 2)
-			            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 3)
-			            .verifyComplete();
+		StepVerifier.withVirtualTime(() -> source, () -> vts, Long.MAX_VALUE)
+		            .thenAwait(Duration.ofSeconds(3))
+		            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 1)
+		            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 2)
+		            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 3)
+		            .verifyComplete();
 
-			StepVerifier.create(source)
-			            .then(() -> vts.advanceTimeBy(Duration.ofSeconds(3)))
-			            .expectNextMatches(t -> t.getT1() == 0 && t.getT2() == 2)
-			            .expectNextMatches(t -> t.getT1() == 0 && t.getT2() == 3)
-			            .verifyComplete();
-		}
-		finally {
-			VirtualTimeScheduler.reset();
-		}
+		StepVerifier.withVirtualTime(() -> source, () -> vts, Long.MAX_VALUE)
+		            .thenAwait(Duration.ofSeconds(3))
+		            .expectNextMatches(t -> t.getT1() == 0 && t.getT2() == 2)
+		            .expectNextMatches(t -> t.getT1() == 0 && t.getT2() == 3)
+		            .verifyComplete();
 	}
 
 	@Test
 	public void cacheFluxHistoryTTL() {
-		try {
-			//delayElements now uses parallel() so VTS must be enabled everywhere
-			VirtualTimeScheduler vts = VirtualTimeScheduler.getOrSet();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 
-			Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
-			                                         .delayElements(Duration.ofMillis(1000))
-			                                         .cache(2, Duration.ofMillis(2000))
-			                                         .elapsed();
+		Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
+		                                         .delayElements(Duration.ofMillis
+				                                         (1000), vts)
+		                                         .cache(2, Duration.ofMillis(2000), vts)
+		                                         .elapsed(vts);
 
-			StepVerifier.create(source)
-			            .then(() -> vts.advanceTimeBy(Duration.ofSeconds(3)))
-			            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 1)
-			            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 2)
-			            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 3)
-			            .verifyComplete();
+		StepVerifier.withVirtualTime(() -> source, () -> vts, Long.MAX_VALUE)
+		            .thenAwait(Duration.ofSeconds(3))
+		            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 1)
+		            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 2)
+		            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 3)
+		            .verifyComplete();
 
-			StepVerifier.create(source)
-			            .then(() -> vts.advanceTimeBy(Duration.ofSeconds(3)))
-			            .expectNextMatches(t -> t.getT1() == 0 && t.getT2() == 2)
-			            .expectNextMatches(t -> t.getT1() == 0 && t.getT2() == 3)
-			            .verifyComplete();
-		}
-		finally {
-			VirtualTimeScheduler.reset();
-		}
+		StepVerifier.withVirtualTime(() -> source, () -> vts, Long.MAX_VALUE)
+		            .thenAwait(Duration.ofSeconds(3))
+		            .expectNextMatches(t -> t.getT1() == 0 && t.getT2() == 2)
+		            .expectNextMatches(t -> t.getT1() == 0 && t.getT2() == 3)
+		            .verifyComplete();
+
 	}
 
 	@Test
 	public void cacheFluxTTL2() {
-		try {
-			//delayElements now uses parallel() so VTS must be enabled everywhere
-			VirtualTimeScheduler vts = VirtualTimeScheduler.getOrSet();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 
-			AtomicInteger i = new AtomicInteger(0);
-			Flux<Integer> source = Flux.defer(() -> Flux.just(i.incrementAndGet()))
-			                           .cache(Duration.ofMillis(2000));
+		AtomicInteger i = new AtomicInteger(0);
+		Flux<Integer> source = Flux.defer(() -> Flux.just(i.incrementAndGet()))
+		                           .cache(Duration.ofMillis(2000), vts);
 
-			StepVerifier.create(source)
-			            .expectNext(1)
-			            .verifyComplete();
+		StepVerifier.create(source)
+		            .expectNext(1)
+		            .verifyComplete();
 
-			StepVerifier.create(source)
-			            .expectNext(1)
-			            .verifyComplete();
+		StepVerifier.create(source)
+		            .expectNext(1)
+		            .verifyComplete();
 
-			vts.advanceTimeBy(Duration.ofSeconds(3));
+		vts.advanceTimeBy(Duration.ofSeconds(3));
 
-			StepVerifier.create(source)
-			            .expectNext(2)
-			            .verifyComplete();
-		}
-		finally {
-			VirtualTimeScheduler.reset();
-		}
+		StepVerifier.create(source)
+		            .expectNext(2)
+		            .verifyComplete();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
@@ -354,11 +354,12 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 	}
 
 	@Test
-	public void expireAfterTtlNormal() throws InterruptedException {
+	public void expireAfterTtlNormal() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 		AtomicInteger subCount = new AtomicInteger();
 		Mono<Integer> source = Mono.defer(() -> Mono.just(subCount.incrementAndGet()));
 
-		Mono<Integer> cached = source.cache(Duration.ofMillis(100))
+		Mono<Integer> cached = source.cache(Duration.ofMillis(100), vts)
 		                             .hide();
 
 		StepVerifier.create(cached)
@@ -367,7 +368,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 		            .as("first subscription caches 1")
 		            .verifyComplete();
 
-		Thread.sleep(110);
+		vts.advanceTimeBy(Duration.ofMillis(110));
 
 		StepVerifier.create(cached)
 		            .expectNext(2)
@@ -401,11 +402,12 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 
 
 	@Test
-	public void expireAfterTtlConditional() throws InterruptedException {
+	public void expireAfterTtlConditional() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 		AtomicInteger subCount = new AtomicInteger();
 		Mono<Integer> source = Mono.defer(() -> Mono.just(subCount.incrementAndGet()));
 
-		Mono<Integer> cached = source.cache(Duration.ofMillis(100))
+		Mono<Integer> cached = source.cache(Duration.ofMillis(100), vts)
 				.hide()
 				.filter(always -> true);
 
@@ -415,7 +417,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 		            .as("first subscription caches 1")
 		            .verifyComplete();
 
-		Thread.sleep(110);
+		vts.advanceTimeBy(Duration.ofMillis(110));
 
 		StepVerifier.create(cached)
 		            .expectNext(2)


### PR DESCRIPTION
Add aliases for Flux.cache(Duration, Scheduler) and Mono.cache(Duration, Scheduler)