### PR TITLE
improve #1220 FluxUsingWhen termination/cancel detection, scan + tests

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoUsingWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoUsingWhen.java
@@ -198,7 +198,12 @@ final class MonoUsingWhen<T, S> extends Mono<T> implements Fuseable, SourceProdu
 
 		@Override
 		public Object scanUnsafe(Attr key) {
-			return null; //TODO enrich
+			if (key == Attr.PARENT) return s;
+			if (key == Attr.ACTUAL) return actual;
+			if (key == Attr.PREFETCH) return Integer.MAX_VALUE;
+			if (key == Attr.TERMINATED) return resourceProvided;
+
+			return null;
 		}
 	}
 


### PR DESCRIPTION
This is a follow up to FluxUsingWhen that improves how termination and
cancellation are detected by the operator (especially for scan's
benefit). It adds a private interface for parents of CommitInner and
RollbackInner so that they can call the parent back to update its
terminated state.