### PR TITLE
fix #1242 Improve metrics on Flux and Mono

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
@@ -137,9 +137,9 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 	static final String TAG_SEQUENCE_TYPE    = "type";
 
 	//... tag values are free-for-all
-	static final String TAGVALUE_ON_ERROR    = "onError";
-	static final String TAGVALUE_ON_COMPLETE = "onComplete";
-	static final String TAGVALUE_CANCEL      = "cancel";
+	static final String TAGVALUE_ON_ERROR    = "error";
+	static final String TAGVALUE_ON_COMPLETE = "completed";
+	static final String TAGVALUE_CANCEL      = "cancelled";
 	static final String TAGVALUE_FLUX        = "Flux";
 	static final String TAGVALUE_MONO        = "Mono";
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
@@ -267,6 +267,7 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 					.description("Times the duration elapsed between a subscription and the cancellation of the sequence")
 					.register(registry);
 
+			//note that Builder ISN'T TRULY IMMUTABLE. This is ok though as there will only ever be one usage.
 			this.subscribeToErrorTimerBuilder = Timer
 					.builder(METER_FLOW_DURATION)
 					.tags(commonTags)

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetricsFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetricsFuseable.java
@@ -19,7 +19,6 @@ package reactor.core.publisher;
 import java.util.List;
 
 import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
@@ -72,8 +71,8 @@ final class FluxMetricsFuseable<T> extends FluxOperator<T, T> implements Fuseabl
 		if (registryCandidate != null) {
 			registry = registryCandidate;
 		}
-		source.subscribe(new FluxMetrics.MicrometerMetricsFuseableSubscriber<>(actual, registry,
-				Clock.SYSTEM, this.name, this.tags, false));
+		source.subscribe(new FluxMetrics.MicrometerFluxMetricsFuseableSubscriber<>(actual, registry,
+				Clock.SYSTEM, this.name, this.tags));
 	}
 
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
@@ -124,6 +124,7 @@ final class MonoMetrics<T> extends MonoOperator<T, T> {
 					.description("Times the duration elapsed between a subscription and the cancellation of the sequence")
 					.register(registry);
 
+			//note that Builder ISN'T TRULY IMMUTABLE. This is ok though as there will only ever be one usage.
 			this.subscribeToErrorTimerBuilder = Timer
 					.builder(FluxMetrics.METER_FLOW_DURATION)
 					.tags(commonTags)

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
@@ -16,14 +16,18 @@
 
 package reactor.core.publisher;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
-import reactor.core.publisher.FluxMetrics.MicrometerMetricsSubscriber;
+import reactor.core.Fuseable;
 import reactor.util.annotation.Nullable;
 import reactor.util.function.Tuple2;
 
@@ -69,8 +73,219 @@ final class MonoMetrics<T> extends MonoOperator<T, T> {
 		if (meterRegistry != null) {
 			registry = meterRegistry;
 		}
-		source.subscribe(new MicrometerMetricsSubscriber<>(actual, registry,
-				Clock.SYSTEM, this.name, this.tags,true));
+		source.subscribe(new MicrometerMonoMetricsSubscriber<>(actual, registry,
+				Clock.SYSTEM, this.name, this.tags));
+	}
+
+	static class MicrometerMonoMetricsSubscriber<T> implements InnerOperator<T,T> {
+
+		final CoreSubscriber<? super T> actual;
+		final MeterRegistry             registry;
+		final Clock                     clock;
+
+		final Counter             malformedSourceCounter;
+		final Counter             subscribedCounter;
+
+		Timer.Sample subscribeToTerminateSample;
+
+		boolean done;
+		@Nullable
+		Fuseable.QueueSubscription<T> qs;
+		Subscription s;
+
+		final Timer         subscribeToCompleteTimer;
+		final Timer.Builder subscribeToErrorTimerBuilder;
+		final Timer         subscribeToCancelTimer;
+
+		MicrometerMonoMetricsSubscriber(CoreSubscriber<? super T> actual,
+				MeterRegistry registry,
+				Clock clock,
+				String sequenceName,
+				List<Tag> sequenceTags) {
+			this.actual = actual;
+			this.registry = registry;
+			this.clock = clock;
+
+			List<Tag> commonTags = new ArrayList<>();
+			commonTags.add(Tag.of(FluxMetrics.TAG_SEQUENCE_NAME, sequenceName));
+			commonTags.add(Tag.of(FluxMetrics.TAG_SEQUENCE_TYPE, FluxMetrics.TAGVALUE_MONO));
+			commonTags.addAll(sequenceTags);
+
+			this.subscribeToCompleteTimer = Timer
+					.builder(FluxMetrics.METER_FLOW_DURATION)
+					.tags(commonTags)
+					.tag(FluxMetrics.TAG_STATUS, FluxMetrics.TAGVALUE_ON_COMPLETE)
+					.description("Times the duration elapsed between a subscription and the onComplete termination of the sequence")
+					.register(registry);
+			this.subscribeToCancelTimer = Timer
+					.builder(FluxMetrics.METER_FLOW_DURATION)
+					.tags(commonTags)
+					.tag(FluxMetrics.TAG_STATUS, FluxMetrics.TAGVALUE_CANCEL)
+					.description("Times the duration elapsed between a subscription and the cancellation of the sequence")
+					.register(registry);
+
+			this.subscribeToErrorTimerBuilder = Timer
+					.builder(FluxMetrics.METER_FLOW_DURATION)
+					.tags(commonTags)
+					.tag(FluxMetrics.TAG_STATUS, FluxMetrics.TAGVALUE_ON_ERROR)
+					.description("Times the duration elapsed between a subscription and the onError termination of the sequence, with the exception name as a tag.");
+
+			this.subscribedCounter = Counter
+					.builder(FluxMetrics.METER_SUBSCRIBED)
+					.tags(commonTags)
+					.baseUnit("subscribers")
+					.description("Counts how many Reactor sequences have been subscribed to")
+					.register(registry);
+
+			this.malformedSourceCounter = registry.counter(FluxMetrics.METER_MALFORMED, commonTags);
+		}
+
+		@Override
+		public CoreSubscriber<? super T> actual() {
+			return actual;
+		}
+
+		@Override
+		public void onNext(T t) {
+			if (done) {
+				this.malformedSourceCounter.increment();
+				Operators.onNextDropped(t, actual.currentContext());
+				return;
+			}
+
+			actual.onNext(t);
+		}
+
+		@Override
+		public void onError(Throwable e) {
+			if (done) {
+				this.malformedSourceCounter.increment();
+				Operators.onErrorDropped(e, actual.currentContext());
+				return;
+			}
+			done = true;
+			//register a timer for that particular exception
+			Timer timer = subscribeToErrorTimerBuilder
+					.tag(FluxMetrics.TAG_EXCEPTION, e.getClass().getName())
+					.register(registry);
+			//record error termination
+			this.subscribeToTerminateSample.stop(timer);
+
+			actual.onError(e);
+		}
+
+		@Override
+		public void onComplete() {
+			if (done) {
+				this.malformedSourceCounter.increment();
+				return;
+			}
+			done = true;
+			this.subscribeToTerminateSample.stop(subscribeToCompleteTimer);
+
+			actual.onComplete();
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.validate(this.s, s)) {
+				this.subscribedCounter.increment();
+				this.subscribeToTerminateSample = Timer.start(registry);
+
+				if (s instanceof Fuseable.QueueSubscription) {
+					//noinspection unchecked
+					this.qs = (Fuseable.QueueSubscription<T>) s;
+				}
+				this.s = s;
+				actual.onSubscribe(this);
+
+			}
+		}
+
+		@Override
+		public void request(long l) {
+			if (Operators.validate(l)) {
+				s.request(l);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			this.subscribeToTerminateSample.stop(subscribeToCancelTimer);
+
+			s.cancel();
+		}
+	}
+
+	/**
+	 * @implNote we don't want to particularly track fusion-specific calls, as this
+	 * subscriber would only detect fused subsequences immediately upstream of it, so
+	 * Counters would be a bit irrelevant. We however want to instrument onNext counts.
+	 *
+	 * @param <T>
+	 */
+	static final class MicrometerMonoMetricsFuseableSubscriber<T> extends MicrometerMonoMetricsSubscriber<T>
+			implements Fuseable, Fuseable.QueueSubscription<T> {
+
+		private boolean syncFused;
+
+		MicrometerMonoMetricsFuseableSubscriber(CoreSubscriber<? super T> actual,
+				MeterRegistry registry, Clock clock, String sequenceName, List<Tag> sequenceTags) {
+			super(actual, registry, clock, sequenceName, sequenceTags);
+		}
+
+		@Override
+		public int requestFusion(int mode) {
+			//Simply negotiate the fusion by delegating:
+			if (qs != null) {
+				int negotiated = qs.requestFusion(mode);
+				this.syncFused = negotiated == Fuseable.SYNC;
+				return negotiated;
+			}
+			return Fuseable.NONE; //should not happen unless requestFusion called before subscribe
+		}
+
+		@Override
+		@Nullable
+		public T poll() {
+			if (qs == null) {
+				return null;
+			}
+			try {
+				T v = qs.poll();
+
+				if (v == null && syncFused) {
+					//this is also a complete event
+					this.subscribeToTerminateSample.stop(subscribeToCompleteTimer);
+				}
+				return v;
+			} catch (Throwable e) {
+				//register a timer for that particular exception
+				Timer timer = subscribeToErrorTimerBuilder
+						.tag(FluxMetrics.TAG_EXCEPTION, e.getClass().getName())
+						.register(registry);
+				//record error termination
+				this.subscribeToTerminateSample.stop(timer);
+				throw e;
+			}
+		}
+
+		@Override
+		public void clear() {
+			if (qs != null) {
+				qs.clear();
+			}
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return qs == null || qs.isEmpty();
+		}
+
+		@Override
+		public int size() {
+			return qs == null ? 0 : qs.size();
+		}
 	}
 
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMetricsFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMetricsFuseable.java
@@ -24,7 +24,7 @@ import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
-import reactor.core.publisher.FluxMetrics.MicrometerMetricsFuseableSubscriber;
+import reactor.core.publisher.MonoMetrics.MicrometerMonoMetricsFuseableSubscriber;
 import reactor.util.annotation.Nullable;
 import reactor.util.function.Tuple2;
 
@@ -71,8 +71,8 @@ final class MonoMetricsFuseable<T> extends MonoOperator<T, T> implements Fuseabl
 		if (registryCandidate != null) {
 			registry = registryCandidate;
 		}
-		source.subscribe(new MicrometerMetricsFuseableSubscriber<>(actual, registry,
-				Clock.SYSTEM, this.name, this.tags, true));
+		source.subscribe(new MicrometerMonoMetricsFuseableSubscriber<>(actual, registry,
+				Clock.SYSTEM, this.name, this.tags));
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsTest.java
@@ -25,6 +25,7 @@ import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -279,17 +280,19 @@ public class FluxMetricsTest {
 		                               .tag(TAG_STATUS, TAGVALUE_CANCEL)
 		                               .timer();
 
-		assertThat(stcCompleteTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to complete timer")
-				.isGreaterThanOrEqualTo(100);
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(stcCompleteTimer.max(TimeUnit.MILLISECONDS))
+					.as("subscribe to complete timer")
+					.isGreaterThanOrEqualTo(100);
 
-		assertThat(stcErrorTimer)
-				.as("subscribe to error timer is lazily registered")
-				.isNull();
+			softly.assertThat(stcErrorTimer)
+					.as("subscribe to error timer is lazily registered")
+					.isNull();
 
-		assertThat(stcCancelTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to cancel timer")
-				.isZero();
+			softly.assertThat(stcCancelTimer.max(TimeUnit.MILLISECONDS))
+					.as("subscribe to cancel timer")
+					.isZero();
+		});
 	}
 
 	@Test
@@ -314,17 +317,19 @@ public class FluxMetricsTest {
 		                               .tag(TAG_STATUS, TAGVALUE_CANCEL)
 		                               .timer();
 
-		assertThat(stcCompleteTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to complete timer")
-				.isZero();
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(stcCompleteTimer.max(TimeUnit.MILLISECONDS))
+					.as("subscribe to complete timer")
+					.isZero();
 
-		assertThat(stcErrorTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to error timer")
-				.isGreaterThanOrEqualTo(100);
+			softly.assertThat(stcErrorTimer.max(TimeUnit.MILLISECONDS))
+					.as("subscribe to error timer")
+					.isGreaterThanOrEqualTo(100);
 
-		assertThat(stcCancelTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to cancel timer")
-				.isZero();
+			softly.assertThat(stcCancelTimer.max(TimeUnit.MILLISECONDS))
+					.as("subscribe to cancel timer")
+					.isZero();
+		});
 	}
 
 	@Test
@@ -348,17 +353,19 @@ public class FluxMetricsTest {
 		                               .tag(TAG_STATUS, TAGVALUE_CANCEL)
 		                               .timer();
 
-		assertThat(stcCompleteTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to complete timer")
-				.isZero();
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(stcCompleteTimer.max(TimeUnit.MILLISECONDS))
+					.as("subscribe to complete timer")
+					.isZero();
 
-		assertThat(stcErrorTimer)
-				.as("subscribe to error timer is lazily registered")
-				.isNull();
+			softly.assertThat(stcErrorTimer)
+					.as("subscribe to error timer is lazily registered")
+					.isNull();
 
-		assertThat(stcCancelTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to cancel timer")
-				.isGreaterThanOrEqualTo(100);
+			softly.assertThat(stcCancelTimer.max(TimeUnit.MILLISECONDS))
+					.as("subscribe to cancel timer")
+					.isGreaterThanOrEqualTo(100);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsFuseableTest.java
@@ -30,6 +30,7 @@ import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -317,17 +318,19 @@ public class MonoMetricsFuseableTest {
 		                               .tag(TAG_STATUS, TAGVALUE_CANCEL)
 		                               .timer();
 
-		assertThat(stcCompleteTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to complete timer")
-				.isGreaterThanOrEqualTo(100);
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(stcCompleteTimer.max(TimeUnit.MILLISECONDS))
+			      .as("subscribe to complete timer")
+			      .isGreaterThanOrEqualTo(100);
 
-		assertThat(stcErrorTimer)
-				.as("subscribe to error timer lazily registered")
-				.isNull();
+			softly.assertThat(stcErrorTimer)
+			      .as("subscribe to error timer lazily registered")
+			      .isNull();
 
-		assertThat(stcCancelTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to cancel timer")
-				.isZero();
+			softly.assertThat(stcCancelTimer.max(TimeUnit.MILLISECONDS))
+			      .as("subscribe to cancel timer")
+			      .isZero();
+		});
 	}
 
 	@Test
@@ -350,17 +353,19 @@ public class MonoMetricsFuseableTest {
 		                               .tag(TAG_STATUS, TAGVALUE_CANCEL)
 		                               .timer();
 
-		assertThat(stcCompleteTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to complete timer")
-				.isZero();
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(stcCompleteTimer.max(TimeUnit.MILLISECONDS))
+					.as("subscribe to complete timer")
+					.isZero();
 
-		assertThat(stcErrorTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to error timer")
-				.isGreaterThanOrEqualTo(100);
+			softly.assertThat(stcErrorTimer.max(TimeUnit.MILLISECONDS))
+					.as("subscribe to error timer")
+					.isGreaterThanOrEqualTo(100);
 
-		assertThat(stcCancelTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to cancel timer")
-				.isZero();
+			softly.assertThat(stcCancelTimer.max(TimeUnit.MILLISECONDS))
+					.as("subscribe to cancel timer")
+					.isZero();
+		});
 	}
 
 	@Test
@@ -383,17 +388,19 @@ public class MonoMetricsFuseableTest {
 		                               .tag(TAG_STATUS, TAGVALUE_CANCEL)
 		                               .timer();
 
-		assertThat(stcCompleteTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to complete timer")
-				.isZero();
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(stcCompleteTimer.max(TimeUnit.MILLISECONDS))
+					.as("subscribe to complete timer")
+					.isZero();
 
-		assertThat(stcErrorTimer)
-				.as("subscribe to error timer is lazily registered")
-				.isNull();
+			softly.assertThat(stcErrorTimer)
+					.as("subscribe to error timer is lazily registered")
+					.isNull();
 
-		assertThat(stcCancelTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to cancel timer")
-				.isGreaterThanOrEqualTo(100);
+			softly.assertThat(stcCancelTimer.max(TimeUnit.MILLISECONDS))
+					.as("subscribe to cancel timer")
+					.isGreaterThanOrEqualTo(100);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsTest.java
@@ -25,6 +25,7 @@ import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -293,17 +294,19 @@ public class MonoMetricsTest {
 		                               .tag(TAG_STATUS, TAGVALUE_CANCEL)
 		                               .timer();
 
-		assertThat(stcCompleteTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to complete timer")
-				.isZero();
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(stcCompleteTimer.max(TimeUnit.MILLISECONDS))
+					.as("subscribe to complete timer")
+					.isZero();
 
-		assertThat(stcErrorTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to error timer")
-				.isGreaterThanOrEqualTo(100);
+			softly.assertThat(stcErrorTimer.max(TimeUnit.MILLISECONDS))
+					.as("subscribe to error timer")
+					.isGreaterThanOrEqualTo(100);
 
-		assertThat(stcCancelTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to cancel timer")
-				.isZero();
+			softly.assertThat(stcCancelTimer.max(TimeUnit.MILLISECONDS))
+					.as("subscribe to cancel timer")
+					.isZero();
+		});
 	}
 
 	@Test
@@ -326,17 +329,19 @@ public class MonoMetricsTest {
 		                               .tag(TAG_STATUS, TAGVALUE_CANCEL)
 		                               .timer();
 
-		assertThat(stcCompleteTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to complete timer")
-				.isZero();
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(stcCompleteTimer.max(TimeUnit.MILLISECONDS))
+					.as("subscribe to complete timer")
+					.isZero();
 
-		assertThat(stcErrorTimer)
-				.as("subscribe to error timer is lazily registered")
-				.isNull();
+			softly.assertThat(stcErrorTimer)
+					.as("subscribe to error timer is lazily registered")
+					.isNull();
 
-		assertThat(stcCancelTimer.max(TimeUnit.MILLISECONDS))
-				.as("subscribe to cancel timer")
-				.isGreaterThanOrEqualTo(100);
+			softly.assertThat(stcCancelTimer.max(TimeUnit.MILLISECONDS))
+					.as("subscribe to cancel timer")
+					.isGreaterThanOrEqualTo(100);
+		});
 	}
 
 	@Test


### PR DESCRIPTION
- split Mono implementation from Flux implementation
 - Mono doesn't record onNext delays nor requests
 - rename meter 'reactor.subscribe.to.terminate' to 'reactor.flow
 .duration'
 - remove 'reactor' prefix from tag names and rename some:
   - 'reactor.termination.type' to 'status'
   - 'reactor.sequence.name' to 'flow'
   - 'reactor.sequence.type' to 'type'
 - duration meter tagged with `status == ERROR` is lazily created to
   also be tagged with the Exception's class name
 - rename the 'status' values:
   - 'onError' to 'error'
   - 'onComplete' to 'completed'
   - 'cancel' to 'cancelled'