### PR TITLE
make default scheduler pool size configurable

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -67,7 +67,7 @@ public abstract class Schedulers {
 	public static final int DEFAULT_POOL_SIZE =
 			Optional.ofNullable(System.getProperty("reactor.schedulers.defaultPoolSize"))
 					.map(Integer::parseInt)
-					.orElseGet(() -> Math.max(4, Runtime.getRuntime().availableProcessors()));
+					.orElseGet(() -> Runtime.getRuntime().availableProcessors());
 
 	static volatile BiConsumer<Thread, ? super Throwable> onHandleErrorHook;
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -59,8 +59,7 @@ public abstract class Schedulers {
 
 	/**
 	 * Default pool size, initialized by system property `reactor.schedulers.defaultPoolSize`
-	 * and falls back to the number of processors available to the runtime
-	 * on init (but with a minimum value of 4).
+	 * and falls back to the number of processors available to the runtime on init.
 	 *
 	 * @see Runtime#availableProcessors()
 	 */

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
-import java.util.stream.Stream;
 
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -105,7 +104,8 @@ public class EmitterProcessorTest {
 		latch.await(8, TimeUnit.SECONDS);
 
 		long count = latch.getCount();
-		org.junit.Assert.assertTrue("Count > 0 : " + count + " (" + list + ")  , Running on " + Schedulers.DEFAULT_POOL_SIZE + " CPU",
+		org.junit.Assert.assertTrue("Count > 0 : " + count + " (" + list + ")  , Running on " +
+						Schedulers.DEFAULT_POOL_SIZE + " CPU",
 				latch.getCount() == 0);
 
 	}

--- a/reactor-core/src/test/java/reactor/core/scheduler/ParallelSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ParallelSchedulerTest.java
@@ -166,7 +166,7 @@ public class ParallelSchedulerTest extends AbstractSchedulerTest {
 					.is(SchedulersTest.CACHED_SCHEDULER);
 			assertThat(Scannable.from(cached).scan(Scannable.Attr.NAME))
 					.as("default parallel()")
-					.isEqualTo("parallel(" + Runtime.getRuntime().availableProcessors() + ",\"parallel\")");
+					.isEqualTo("parallel(" + Schedulers.DEFAULT_POOL_SIZE + ",\"parallel\")");
 
 			assertThat(Scannable.from(workerWithNamedFactory).scan(Scannable.Attr.NAME))
 					.as("workerWithNamedFactory")


### PR DESCRIPTION
Allows the scheduler default poolsize to be configurable via a system property. Falls back to ` Runtime.getRuntime().availableProcessors()`. 

solves  #1243