### PR TITLE
fix #1247 Multiple bufferTimeout and bufferWhen issues

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
@@ -231,7 +231,7 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends FluxOp
 					timespanRegistration = timer.schedule(flushTask, timespan, TimeUnit.MILLISECONDS);
 				}
 				catch (RejectedExecutionException ree) {
-					onError(Operators.onRejectedExecution(ree, this, null, value,
+					onError(Operators.onRejectedExecution(ree, subscription, null, value,
 							actual.currentContext()));
 					return;
 				}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferWhen.java
@@ -84,8 +84,8 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 
 		BufferWhenOpenSubscriber<OPEN> bos = new BufferWhenOpenSubscriber<>(main);
 		if (main.subscribers.add(bos)) {
-			source.subscribe(main);
 			start.subscribe(bos);
+			source.subscribe(main);
 		}
 	}
 
@@ -207,7 +207,7 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 				synchronized (this) {
 					buffers = null;
 				}
-				if (WINDOWS.getAndIncrement(this) != 0) {
+				if (WINDOWS.getAndIncrement(this) == 0) {
 					queue.clear();
 				}
 			}


### PR DESCRIPTION
This commit fixe a few issues in bufferTimeout and bufferWhen:
 - a TTL-task rejection in bufferTimeout onNext would not propagate an
 error because it cancels the subscriber rather than the actual
 - bufferWhen should subscribes to source first and buffer-opening
 second
 - bufferWhen race between cancel and drain is wrongly handled, as
 cancel checks the wrong state for the WINDOWS guard