### PR TITLE
fix #1270 Explicitly log() QueueSubcription as toString during onNext

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Fuseable.java
+++ b/reactor-core/src/main/java/reactor/core/Fuseable.java
@@ -112,7 +112,7 @@ public interface Fuseable {
 		@Override
 		@Nullable
 		default T peek() {
-			throw new UnsupportedOperationException();
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/Fuseable.java
+++ b/reactor-core/src/main/java/reactor/core/Fuseable.java
@@ -86,6 +86,10 @@ public interface Fuseable {
 	 * @param <T> the value type emitted
 	 */
 	interface QueueSubscription<T> extends Queue<T>, Subscription {
+		
+		String NOT_SUPPORTED_MESSAGE = "Although QueueSubscription extends Queue it is purely internal" +
+				" and only guarantees support for poll/clear/size/isEmpty." +
+				" Instances shouldn't be used/exposed as Queue outside of Reactor operators.";
 
 		/**
 		 * Request a specific fusion mode from this QueueSubscription.
@@ -104,75 +108,76 @@ public interface Fuseable {
 		 */
 		int requestFusion(int requestedMode);
 
+		
 		@Override
 		@Nullable
 		default T peek() {
-			throw new UnsupportedOperationException("Operators should not use this method!");
+			throw new UnsupportedOperationException();
 		}
 
 		@Override
 		default boolean add(@Nullable T t) {
-			throw new UnsupportedOperationException("Operators should not use this method!");
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
 		}
 
 		@Override
 		default boolean offer(@Nullable T t) {
-			throw new UnsupportedOperationException("Operators should not use this method!");
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
 		}
 
 		@Override
 		default T remove() {
-			throw new UnsupportedOperationException("Operators should not use this method!");
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
 		}
 
 		@Override
 		default T element() {
-			throw new UnsupportedOperationException("Operators should not use this method!");
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
 		}
 
 		@Override
 		default boolean contains(@Nullable Object o) {
-			throw new UnsupportedOperationException("Operators should not use this method!");
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
 		}
 
 		@Override
 		default Iterator<T> iterator() {
-			throw new UnsupportedOperationException("Operators should not use this method!");
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
 		}
 
 		@Override
 		default Object[] toArray() {
-			throw new UnsupportedOperationException("Operators should not use this method!");
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
 		}
 
 		@Override
 		default <T1> T1[] toArray(T1[] a) {
-			throw new UnsupportedOperationException("Operators should not use this method!");
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
 		}
 
 		@Override
 		default boolean remove(@Nullable Object o) {
-			throw new UnsupportedOperationException("Operators should not use this method!");
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
 		}
 
 		@Override
 		default boolean containsAll(Collection<?> c) {
-			throw new UnsupportedOperationException("Operators should not use this method!");
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
 		}
 
 		@Override
 		default boolean addAll(Collection<? extends T> c) {
-			throw new UnsupportedOperationException("Operators should not use this method!");
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
 		}
 
 		@Override
 		default boolean removeAll(Collection<?> c) {
-			throw new UnsupportedOperationException("Operators should not use this method!");
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
 		}
 
 		@Override
 		default boolean retainAll(Collection<?> c) {
-			throw new UnsupportedOperationException("Operators should not use this method!");
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/SignalLogger.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SignalLogger.java
@@ -234,16 +234,18 @@ final class SignalLogger<IN> implements SignalPeek<IN> {
 	@Nullable
 	public Consumer<? super IN> onNextCall() {
 		if ((options & ON_NEXT) == ON_NEXT && (level != Level.INFO || log.isInfoEnabled())) {
-			return d -> log(SignalType.ON_NEXT, safeLog(d), source);
+			return d -> safeLog(SignalType.ON_NEXT, d, source);
 		}
 		return null;
 	}
 
-	protected Object safeLog(Object value) {
-		if (value instanceof Fuseable.QueueSubscription) {
-			return value.toString();
+	protected void safeLog(SignalType signalType, Object value, Publisher<IN> source) {
+		try {
+			log(signalType, value, source);
 		}
-		return value;
+		catch (UnsupportedOperationException uoe) {
+			log(signalType, String.valueOf(value), source);
+		}
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/SignalLogger.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SignalLogger.java
@@ -234,9 +234,16 @@ final class SignalLogger<IN> implements SignalPeek<IN> {
 	@Nullable
 	public Consumer<? super IN> onNextCall() {
 		if ((options & ON_NEXT) == ON_NEXT && (level != Level.INFO || log.isInfoEnabled())) {
-			return d -> log(SignalType.ON_NEXT, d, source);
+			return d -> log(SignalType.ON_NEXT, safeLog(d), source);
 		}
 		return null;
+	}
+
+	protected Object safeLog(Object value) {
+		if (value instanceof Fuseable.QueueSubscription) {
+			return value.toString();
+		}
+		return value;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/SignalLogger.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SignalLogger.java
@@ -206,6 +206,10 @@ final class SignalLogger<IN> implements SignalPeek<IN> {
 		}
 		catch (UnsupportedOperationException uoe) {
 			log(signalType, String.valueOf(signalValue));
+			if (log.isDebugEnabled()) {
+				log.debug("UnsupportedOperationException has been raised by the logging framework, does your log() placement make sense? " +
+						"eg. 'window(2).log()' instead of 'window(2).flatMap(w -> w.log())'", uoe);
+			}
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/SignalLoggerTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SignalLoggerTests.java
@@ -55,7 +55,7 @@ public class SignalLoggerTests {
 
 		//verify that passing the subscription directly to logger would have considered
 		// it a Collection and thus failed with this custom Logger.
-		StepVerifier.create(flux.doOnSubscribe(s -> signalLogger.log(s, "")))
+		StepVerifier.create(flux.doOnSubscribe(s -> signalLogger.log(SignalType.ON_SUBSCRIBE, s)))
 		            .expectErrorMatches(t -> t instanceof UnsupportedOperationException &&
 				            t.getMessage().equals("Operators should not use this method!"))
 		            .verify();
@@ -80,7 +80,7 @@ public class SignalLoggerTests {
 
 		//verify that passing the QueueSubscription directly to logger would have considered
 		// it a Collection and thus failed with this custom Logger.
-		StepVerifier.create(flux.doOnNext(w -> signalLogger.log("{}", w)))
+		StepVerifier.create(flux.doOnNext(w -> signalLogger.log(SignalType.ON_NEXT, w)))
 		            .expectErrorMatches(t -> t instanceof UnsupportedOperationException &&
 				            t.getMessage().equals("Operators should not use this method!"))
 		            .verify();
@@ -260,7 +260,7 @@ public class SignalLoggerTests {
 		      .subscribe();
 
 		verify(mockLogger, only()).warn(anyString(), eq(SignalType.ON_NEXT),
-				eq("foo"), any());
+				eq("foo"));
 		verifyNoMoreInteractions(mockLogger);
 	}
 
@@ -275,7 +275,7 @@ public class SignalLoggerTests {
 		      .subscribe();
 
 		verify(mockLogger, only()).warn(anyString(), eq(SignalType.ON_NEXT),
-				eq("foo"), any());
+				eq("foo"));
 		verifyNoMoreInteractions(mockLogger);
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/SignalLoggerTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SignalLoggerTests.java
@@ -57,7 +57,7 @@ public class SignalLoggerTests {
 		// it a Collection and thus failed with this custom Logger.
 		StepVerifier.create(flux.doOnSubscribe(s -> signalLogger.log(SignalType.ON_SUBSCRIBE, s)))
 		            .expectErrorMatches(t -> t instanceof UnsupportedOperationException &&
-				            t.getMessage().equals("Operators should not use this method!"))
+				            t.getMessage().equals(Fuseable.QueueSubscription.NOT_SUPPORTED_MESSAGE))
 		            .verify();
 	}
 
@@ -82,7 +82,7 @@ public class SignalLoggerTests {
 		// it a Collection and thus failed with this custom Logger.
 		StepVerifier.create(flux.doOnNext(w -> signalLogger.log(SignalType.ON_NEXT, w)))
 		            .expectErrorMatches(t -> t instanceof UnsupportedOperationException &&
-				            t.getMessage().equals("Operators should not use this method!"))
+				            t.getMessage().equals(Fuseable.QueueSubscription.NOT_SUPPORTED_MESSAGE))
 		            .verify();
 	}
 


### PR DESCRIPTION
This is done by catching `UnsupportedOperationException` in
`SignalLogger`.

`SignalLogger` has been reworked a bit (`log(...)` was called with a
3rd unused parameter), and the `QueueSubcription` UOE message has been
reworded.