### PR TITLE
Second pass at building under JDK 9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
 plugins {
   id 'org.asciidoctor.convert' version '1.5.6'
   id "me.champeau.gradle.jmh" version "0.4.4" apply false
-  id "org.jetbrains.dokka" version "0.9.15"
+  id "org.jetbrains.dokka" version "0.9.16"
   id "me.champeau.gradle.japicmp" version "0.2.6"
 }
 
@@ -398,8 +398,7 @@ project('reactor-core') {
 	archives sourcesJar
 	archives javadocJar
 	archives docsZip
-	if (!JavaVersion.current().isJava9Compatible())
-	  archives kdocZip
+	archives kdocZip
   }
 
   jacocoTestReport.dependsOn test
@@ -514,8 +513,7 @@ project('reactor-test') {
   }
 
   artifacts {
-	if (!JavaVersion.current().isJava9Compatible())
-	  archives kdocZip
+	archives kdocZip
   }
 
   jar.finalizedBy(japicmp)

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ import me.champeau.gradle.japicmp.JapicmpTask
 import org.gradle.api.internal.plugins.osgi.OsgiHelper
 
 buildscript {
-  ext.kotlinVersion = '1.1.61'
+  ext.kotlinVersion = '1.2.51'
   repositories {
 	maven { url "http://repo.spring.io/plugins-release" }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -22,11 +22,13 @@ buildscript {
 	maven { url "http://repo.spring.io/plugins-release" }
   }
   dependencies {
-	classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7',
-			'io.spring.gradle:spring-io-plugin:0.0.4.RELEASE',
-			'com.github.jengelman.gradle.plugins:shadow:1.2.0',
-			'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.11',
-			"org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
+	classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
+	classpath 'io.spring.gradle:spring-io-plugin:0.0.4.RELEASE'
+	classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.0'
+	classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
+	classpath 'org.jruby:jruby-complete:9.1.17.0'
+	classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.7'
+	classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16'
   }
 }
 

--- a/gradle/doc.gradle
+++ b/gradle/doc.gradle
@@ -21,13 +21,7 @@ configure(rootProject) {
 			include "index.asciidoc"
 		}
 		outputDir file("$buildDir/reactor-code/build/asciidoc")
-		//TODO remove once a working combination of asciidoctorj, asciidoctorj-pdf and asciidoctor-gradle-plugin is found
-		if (JavaVersion.current().isJava9Compatible()) {
-		  backends = ['html5']
-		}
-		else {
-		  backends = ['html5', 'pdf']
-		}
+	  backends = ['html5', 'pdf']
 		logDocuments = true
 		options = [
 				doctype: 'book'

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
@@ -306,7 +306,7 @@ public class FluxMergeOrderedTest {
 		CoreSubscriber<? super Integer> actual = new LambdaSubscriber<>(null, null, null, null);
 
 		FluxMergeOrdered.MergeOrderedMainProducer<Integer> test =
-				new FluxMergeOrdered.MergeOrderedMainProducer<>(actual, Comparator.naturalOrder(), 123, 4);
+				new FluxMergeOrdered.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4);
 
 		assertThat(test.scan(Scannable.Attr.ACTUAL))
 				.isSameAs(actual)
@@ -333,7 +333,7 @@ public class FluxMergeOrderedTest {
 	public void scanInner() {
 		CoreSubscriber<? super Integer> actual = new LambdaSubscriber<>(null, null, null, null);
 		FluxMergeOrdered.MergeOrderedMainProducer<Integer> main =
-				new FluxMergeOrdered.MergeOrderedMainProducer<>(actual, Comparator.naturalOrder(), 123, 4);
+				new FluxMergeOrdered.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4);
 
 		FluxMergeOrdered.MergeOrderedInnerSubscriber<Integer> test = new FluxMergeOrdered.MergeOrderedInnerSubscriber<>(
 				main, 123);
@@ -362,7 +362,7 @@ public class FluxMergeOrderedTest {
 		CoreSubscriber<? super Integer> actual = new LambdaSubscriber<>(null, null, null, null);
 
 		FluxMergeOrdered.MergeOrderedMainProducer<Integer> test =
-				new FluxMergeOrdered.MergeOrderedMainProducer<>(actual, Comparator.naturalOrder(), 123, 4);
+				new FluxMergeOrdered.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4);
 
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> {
@@ -377,7 +377,7 @@ public class FluxMergeOrderedTest {
 	public void innerRequestAmountIgnoredAssumedOne() {
 		CoreSubscriber<? super Integer> actual = new LambdaSubscriber<>(null, null, null, null);
 		FluxMergeOrdered.MergeOrderedMainProducer<Integer> main =
-				new FluxMergeOrdered.MergeOrderedMainProducer<>(actual, Comparator.naturalOrder(), 123, 4);
+				new FluxMergeOrdered.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4);
 
 		FluxMergeOrdered.MergeOrderedInnerSubscriber<Integer> test = new FluxMergeOrdered.MergeOrderedInnerSubscriber<>(
 				main, 4);


### PR DESCRIPTION
(merge with rebase)

 - Reactivate AsciidoctorJ PDF build under JDK9
 - For JDK9 compilation, fix type ambiguity in a test
 - Reactivate Dokka in JDK9, bumping to 0.9.16
 - Bump Kotlin to 1.2.51