### PR TITLE
fix #1201 Add utility to instrument Executor backing schedulers

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
@@ -26,7 +26,7 @@ final class SchedulerMetricDecorator
 	@Override
 	public synchronized ScheduledExecutorService apply(Scheduler scheduler, ScheduledExecutorService service) {
 		//this is equivalent to `toString`, a detailed name like `parallel("foo", 3)`
-		String schedulerDesc = Scannable
+		String schedulerName = Scannable
 				.from(scheduler)
 				.scanOrDefault(Attr.NAME, scheduler.getClass().getName());
 
@@ -34,11 +34,11 @@ final class SchedulerMetricDecorator
 		String schedulerId =
 				SEEN_SCHEDULERS.computeIfAbsent(scheduler, s -> {
 					int schedulerDifferentiator = SCHEDULER_DIFFERENTIATOR
-							.computeIfAbsent(schedulerDesc, k -> new AtomicInteger(0))
+							.computeIfAbsent(schedulerName, k -> new AtomicInteger(0))
 							.getAndIncrement();
 
-					return (schedulerDifferentiator == 0) ? schedulerDesc
-							: schedulerDesc + "#" + schedulerDifferentiator;
+					return (schedulerDifferentiator == 0) ? schedulerName
+							: schedulerName + "#" + schedulerDifferentiator;
 				});
 
 		//we now want an executorId unique to a given scheduler

--- a/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
@@ -1,0 +1,66 @@
+package reactor.core.scheduler;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
+import reactor.core.Scannable;
+import reactor.core.Scannable.Attr;
+
+import static io.micrometer.core.instrument.Metrics.globalRegistry;
+
+final class SchedulerMetricDecorator
+			implements BiFunction<Scheduler, ScheduledExecutorService, ScheduledExecutorService> {
+
+	final Map<String, AtomicInteger>                                  SCHEDULERS_NAME_COUNTER = new HashMap<>();
+	final Map<String, WeakHashMap<Scheduler, String>>                 UNIQUE_SCHEDULER_NAMES = new HashMap<>();
+
+	final Map<String, AtomicInteger>                                  EXECUTORS_NAME_COUNTER = new HashMap<>();
+	final Map<String, WeakHashMap<ScheduledExecutorService, String>>  EXECUTOR_LOCAL_IDS     = new HashMap<>();
+
+	@Override
+	public synchronized ScheduledExecutorService apply(Scheduler scheduler, ScheduledExecutorService service) {
+		String schedulerName = Scannable
+				.from(scheduler)
+				.scanOrDefault(Attr.NAME, scheduler.getClass().getName());
+
+		String schedulerId = UNIQUE_SCHEDULER_NAMES
+				.computeIfAbsent(schedulerName, key -> new WeakHashMap<>())
+				.computeIfAbsent(scheduler, key -> {
+					int seqNum = SCHEDULERS_NAME_COUNTER
+							.computeIfAbsent(schedulerName, nameKey -> new AtomicInteger())
+	                        .getAndIncrement();
+
+					if (seqNum > 0) {
+						// If we got a name clash, append a sequential number to the name
+						return schedulerName + "#" + seqNum;
+					}
+					else {
+						return schedulerName;
+					}
+				});
+
+		String executorName = EXECUTOR_LOCAL_IDS
+				.computeIfAbsent(schedulerId, key -> new WeakHashMap<>())
+				.computeIfAbsent(service, key -> {
+					int seqNum = EXECUTORS_NAME_COUNTER
+							.computeIfAbsent(schedulerId, nameKey -> new AtomicInteger())
+                            .getAndIncrement();
+
+					return schedulerId + "-" + seqNum;
+				});
+
+		// TODO return the result of ExecutorServiceMetrics#monitor
+		//  once ScheduledExecutorService gets supported by Micrometer
+		//  See https://github.com/micrometer-metrics/micrometer/issues/1021
+		ExecutorServiceMetrics.monitor(globalRegistry, service, executorName,
+				Tag.of("scheduler.id", schedulerId));
+
+		return service;
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
@@ -7,21 +7,26 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
+import io.micrometer.core.instrument.search.Search;
 
+import reactor.core.Disposable;
 import reactor.core.Scannable;
 import reactor.core.Scannable.Attr;
 
 import static io.micrometer.core.instrument.Metrics.globalRegistry;
 
 final class SchedulerMetricDecorator
-			implements BiFunction<Scheduler, ScheduledExecutorService, ScheduledExecutorService> {
+			implements BiFunction<Scheduler, ScheduledExecutorService, ScheduledExecutorService>,
+			           Disposable {
 
+	static final String TAG_SCHEDULER_ID = "reactor.scheduler.id";
 
-	final WeakHashMap<Scheduler, String>        SEEN_SCHEDULERS          = new WeakHashMap<>();
-	final Map<String, AtomicInteger>            SCHEDULER_DIFFERENTIATOR = new HashMap<>();
-	final WeakHashMap<Scheduler, AtomicInteger> EXECUTOR_DIFFERENTIATOR  = new WeakHashMap<>();
+	final WeakHashMap<Scheduler, String>        seenSchedulers          = new WeakHashMap<>();
+	final Map<String, AtomicInteger>            schedulerDifferentiator = new HashMap<>();
+	final WeakHashMap<Scheduler, AtomicInteger> executorDifferentiator  = new WeakHashMap<>();
 
 	@Override
 	public synchronized ScheduledExecutorService apply(Scheduler scheduler, ScheduledExecutorService service) {
@@ -32,8 +37,8 @@ final class SchedulerMetricDecorator
 
 		//we hope that each NAME is unique enough, but we'll differentiate by Scheduler
 		String schedulerId =
-				SEEN_SCHEDULERS.computeIfAbsent(scheduler, s -> {
-					int schedulerDifferentiator = SCHEDULER_DIFFERENTIATOR
+				seenSchedulers.computeIfAbsent(scheduler, s -> {
+					int schedulerDifferentiator = this.schedulerDifferentiator
 							.computeIfAbsent(schedulerName, k -> new AtomicInteger(0))
 							.getAndIncrement();
 
@@ -43,16 +48,42 @@ final class SchedulerMetricDecorator
 
 		//we now want an executorId unique to a given scheduler
 		String executorId = schedulerId + "-" +
-				EXECUTOR_DIFFERENTIATOR.computeIfAbsent(scheduler, key -> new AtomicInteger(0))
-						.getAndIncrement();
+				executorDifferentiator.computeIfAbsent(scheduler, key -> new AtomicInteger(0))
+				                      .getAndIncrement();
 
+		/*
+		Design note: we assume that a given Scheduler won't apply the decorator twice to the
+		same ExecutorService. Even though, it would simply create an extraneous meter for
+		that ExecutorService, which we think is not that bad (compared to paying the price
+		upfront of also tracking executors instances to deduplicate). The main goal is to
+		detect Scheduler instances that have already started decorating their executors,
+		in order to avoid consider two calls in a row as duplicates (yet still being able
+		to distinguish between two instances with the same name and configuration).
+		 */
 
 		// TODO return the result of ExecutorServiceMetrics#monitor
 		//  once ScheduledExecutorService gets supported by Micrometer
 		//  See https://github.com/micrometer-metrics/micrometer/issues/1021
 		ExecutorServiceMetrics.monitor(globalRegistry, service, executorId,
-				Tag.of("scheduler.id", schedulerId));
+				Tag.of(TAG_SCHEDULER_ID, schedulerId));
 
 		return service;
+	}
+
+	@Override
+	public void dispose() {
+		Search.in(globalRegistry)
+		      .tagKeys(TAG_SCHEDULER_ID)
+		      .meters()
+		      .forEach(globalRegistry::remove);
+
+		this.seenSchedulers.clear();
+		this.schedulerDifferentiator.clear();
+		this.executorDifferentiator.clear();
+	}
+
+	@Override
+	public boolean isDisposed() {
+		return false; //never really disposed
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
@@ -7,7 +7,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 import io.micrometer.core.instrument.search.Search;
@@ -23,6 +22,7 @@ final class SchedulerMetricDecorator
 			           Disposable {
 
 	static final String TAG_SCHEDULER_ID = "reactor.scheduler.id";
+	static final String METRICS_DECORATOR_KEY = "reactor.metrics.decorator";
 
 	final WeakHashMap<Scheduler, String>        seenSchedulers          = new WeakHashMap<>();
 	final Map<String, AtomicInteger>            schedulerDifferentiator = new HashMap<>();

--- a/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
@@ -77,13 +77,10 @@ final class SchedulerMetricDecorator
 		      .meters()
 		      .forEach(globalRegistry::remove);
 
+		//note default isDisposed (returning false) is good enough, since the cleared
+		//collections can always be reused even though they probably won't
 		this.seenSchedulers.clear();
 		this.schedulerDifferentiator.clear();
 		this.executorDifferentiator.clear();
-	}
-
-	@Override
-	public boolean isDisposed() {
-		return false; //never really disposed
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -396,7 +396,7 @@ public abstract class Schedulers {
 	 */
 	public static void enableMetrics() {
 		if (Metrics.isInstrumentationAvailable()) {
-			addExecutorServiceDecorator(METRICS_DECORATOR_KEY, new SchedulerMetricDecorator());
+			addExecutorServiceDecorator(SchedulerMetricDecorator.METRICS_DECORATOR_KEY, new SchedulerMetricDecorator());
 		}
 	}
 
@@ -405,7 +405,7 @@ public abstract class Schedulers {
 	 * No-op if {@link #enableMetrics()} hasn't been called.
 	 */
 	public static void disableMetrics() {
-		removeExecutorServiceDecorator(METRICS_DECORATOR_KEY);
+		removeExecutorServiceDecorator(SchedulerMetricDecorator.METRICS_DECORATOR_KEY);
 	}
 
 	/**
@@ -496,11 +496,11 @@ public abstract class Schedulers {
 	 * {@link Disposable#dispose() disposed}.
 	 *
 	 * @param key the key for the executor service decorator to remove
-	 * @return true if a decorator was removed, or false if none was set for that key
+	 * @return the removed decorator, or null if none was set for that key
 	 * @see #addExecutorServiceDecorator(String, BiFunction)
 	 * @see #setExecutorServiceDecorator(String, BiFunction)
 	 */
-	public static boolean removeExecutorServiceDecorator(String key) {
+	public static BiFunction<Scheduler, ScheduledExecutorService, ScheduledExecutorService> removeExecutorServiceDecorator(String key) {
 		BiFunction<Scheduler, ScheduledExecutorService, ScheduledExecutorService> removed;
 		synchronized (DECORATORS) {
 			removed = DECORATORS.remove(key);
@@ -508,7 +508,7 @@ public abstract class Schedulers {
 		if (removed instanceof Disposable) {
 			((Disposable) removed).dispose();
 		}
-		return removed != null;
+		return removed;
 	}
 
 	/**
@@ -695,8 +695,6 @@ public abstract class Schedulers {
 
 	static final Map<String, BiFunction<Scheduler, ScheduledExecutorService, ScheduledExecutorService>>
 			DECORATORS = new LinkedHashMap<>();
-
-	static final String METRICS_DECORATOR_KEY = "reactor.metrics.decorator";
 
 	static volatile Factory factory = DEFAULT;
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersMetricsTest.java
@@ -25,7 +25,6 @@ public class SchedulersMetricsTest {
 	@After
 	public void tearDown() {
 		Schedulers.disableMetrics();
-		Metrics.globalRegistry.forEachMeter(Metrics.globalRegistry::remove);
 		Metrics.removeRegistry(simpleMeterRegistry);
 	}
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersMetricsTest.java
@@ -1,0 +1,87 @@
+package reactor.core.scheduler;
+
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SchedulersMetricsTest {
+
+	final SimpleMeterRegistry simpleMeterRegistry = new SimpleMeterRegistry();
+
+	@Before
+	public void setUp() {
+		Metrics.addRegistry(simpleMeterRegistry);
+		Schedulers.enableMetrics();
+	}
+
+	@After
+	public void tearDown() {
+		Schedulers.disableMetrics();
+		Metrics.globalRegistry.forEachMeter(Metrics.globalRegistry::remove);
+		Metrics.removeRegistry(simpleMeterRegistry);
+	}
+
+	@Test
+	public void metricsActivatedHasDistinctNameTags() {
+		Schedulers.newParallel("A", 3);
+		Schedulers.newParallel("B", 2);
+
+		assertThat(simpleMeterRegistry.getMeters()
+		                              .stream()
+		                              .map(m -> m.getId().getTag("name"))
+		                              .distinct())
+				.containsOnly(
+						"parallel(3,\"A\")-0",
+						"parallel(3,\"A\")-1",
+						"parallel(3,\"A\")-2",
+
+						"parallel(2,\"B\")-0",
+						"parallel(2,\"B\")-1"
+				);
+	}
+
+	@Test
+	public void metricsActivatedHasDistinctSchedulerIdTags() {
+		Schedulers.newParallel("A", 4);
+		Schedulers.newParallel("A", 4);
+		Schedulers.newParallel("A", 3);
+		Schedulers.newSingle("B");
+		Schedulers.newElastic("C").createWorker();
+
+		assertThat(simpleMeterRegistry.getMeters()
+		                              .stream()
+		                              .map(m -> m.getId().getTag("scheduler.id"))
+		                              .distinct())
+				.containsOnly(
+						"parallel(4,\"A\")",
+						"parallel(4,\"A\")#1",
+
+						"parallel(3,\"A\")",
+
+						"single(\"B\")",
+
+						"elastic(\"C\")"
+				);
+	}
+
+	@Test
+	public void metricsActivatedHandleNamingClash() {
+		Schedulers.newParallel("A", 1);
+		Schedulers.newParallel("A", 1);
+		Schedulers.newParallel("A", 1);
+
+		assertThat(simpleMeterRegistry.getMeters()
+		                              .stream()
+		                              .map(m -> m.getId().getTag("name"))
+		                              .distinct())
+				.containsOnly(
+						"parallel(1,\"A\")-0",
+						"parallel(1,\"A\")#1-0",
+						"parallel(1,\"A\")#2-0"
+				);
+	}
+}

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersMetricsTest.java
@@ -1,5 +1,8 @@
 package reactor.core.scheduler;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.After;
@@ -82,6 +85,25 @@ public class SchedulersMetricsTest {
 						"parallel(1,\"A\")-0",
 						"parallel(1,\"A\")#1-0",
 						"parallel(1,\"A\")#2-0"
+				);
+	}
+
+	@Test
+	public void decorateTwiceWithSameSchedulerInstance() {
+		Scheduler instance = Schedulers.newElastic("TWICE", 1);
+
+		ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
+
+		Schedulers.decorateExecutorService(instance, service);
+		Schedulers.decorateExecutorService(instance, service);
+
+		assertThat(simpleMeterRegistry.getMeters()
+		                              .stream()
+		                              .map(m -> m.getId().getTag("name"))
+		                              .distinct())
+				.containsOnly(
+						"elastic(\"TWICE\")-0",
+						"elastic(\"TWICE\")-1"
 				);
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersMetricsTest.java
@@ -25,6 +25,7 @@ public class SchedulersMetricsTest {
 	@After
 	public void tearDown() {
 		Schedulers.disableMetrics();
+		Metrics.globalRegistry.forEachMeter(Metrics.globalRegistry::remove);
 		Metrics.removeRegistry(simpleMeterRegistry);
 	}
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -188,7 +188,7 @@ public class SchedulersTest {
 
 		assertThat(Schedulers.removeExecutorServiceDecorator("k1"))
 				.as("decorator removed")
-				.isTrue();
+				.isSameAs(decorator);
 
 		assertThat(disposeTracker)
 				.as("decorator disposed")
@@ -233,10 +233,10 @@ public class SchedulersTest {
 
 		assertThat(Schedulers.DECORATORS).hasSize(3);
 
-		assertThat(Schedulers.removeExecutorServiceDecorator("k1")).as("decorator1 when present").isTrue();
-		assertThat(Schedulers.removeExecutorServiceDecorator("k1")).as("decorator1 once removed").isFalse();
-		assertThat(Schedulers.removeExecutorServiceDecorator("k2")).as("decorator2").isTrue();
-		assertThat(Schedulers.removeExecutorServiceDecorator("k3")).as("decorator3").isTrue();
+		assertThat(Schedulers.removeExecutorServiceDecorator("k1")).as("decorator1 when present").isSameAs(decorator1);
+		assertThat(Schedulers.removeExecutorServiceDecorator("k1")).as("decorator1 once removed").isNull();
+		assertThat(Schedulers.removeExecutorServiceDecorator("k2")).as("decorator2").isSameAs(decorator2);
+		assertThat(Schedulers.removeExecutorServiceDecorator("k3")).as("decorator3").isSameAs(decorator3);
 
 		assertThat(Schedulers.DECORATORS).isEmpty();
 	}
@@ -245,7 +245,7 @@ public class SchedulersTest {
 	public void schedulerDecoratorRemoveUnknownIgnored() {
 		assertThat(Schedulers.removeExecutorServiceDecorator("keyfoo"))
 				.as("unknown decorator ignored")
-				.isFalse();
+				.isNull();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -233,10 +233,10 @@ public class SchedulersTest {
 
 		assertThat(Schedulers.DECORATORS).hasSize(3);
 
-		assertThat(Schedulers.removeExecutorServiceDecorator("k1")).as("decorator1 when present").isSameAs(decorator1);
-		assertThat(Schedulers.removeExecutorServiceDecorator("k1")).as("decorator1 once removed").isNull();
-		assertThat(Schedulers.removeExecutorServiceDecorator("k2")).as("decorator2").isSameAs(decorator2);
-		assertThat(Schedulers.removeExecutorServiceDecorator("k3")).as("decorator3").isSameAs(decorator3);
+		assertThat(Schedulers.removeExecutorServiceDecorator("k1")).as("decorator1 when present").isTrue();
+		assertThat(Schedulers.removeExecutorServiceDecorator("k1")).as("decorator1 once removed").isFalse();
+		assertThat(Schedulers.removeExecutorServiceDecorator("k2")).as("decorator2").isTrue();
+		assertThat(Schedulers.removeExecutorServiceDecorator("k3")).as("decorator3").isTrue();
 
 		assertThat(Schedulers.DECORATORS).isEmpty();
 	}
@@ -245,7 +245,7 @@ public class SchedulersTest {
 	public void schedulerDecoratorRemoveUnknownIgnored() {
 		assertThat(Schedulers.removeExecutorServiceDecorator("keyfoo"))
 				.as("unknown decorator ignored")
-				.isNull();
+				.isFalse();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -164,6 +164,38 @@ public class SchedulersTest {
 	}
 
 	@Test
+	public void schedulerDecoratorDisposedWhenRemoved() {
+		AtomicBoolean disposeTracker = new AtomicBoolean();
+
+		class DisposableDecorator implements BiFunction<Scheduler, ScheduledExecutorService, ScheduledExecutorService>,
+		                                     Disposable {
+
+			@Override
+			public ScheduledExecutorService apply(Scheduler scheduler,
+					ScheduledExecutorService service) {
+				return service;
+			}
+
+			@Override
+			public void dispose() {
+				disposeTracker.set(true);
+			}
+		}
+
+		DisposableDecorator decorator = new DisposableDecorator();
+
+		Schedulers.addExecutorServiceDecorator("k1", decorator);
+
+		assertThat(Schedulers.removeExecutorServiceDecorator("k1"))
+				.as("decorator removed")
+				.isTrue();
+
+		assertThat(disposeTracker)
+				.as("decorator disposed")
+				.isTrue();
+	}
+
+	@Test
 	public void schedulerDecoratorEmptyDecorators() {
 		assertThat(Schedulers.DECORATORS).isEmpty();
 		assertThatCode(() -> Schedulers.newSingle("foo").dispose())

--- a/reactor-core/src/test/java/reactor/util/MetricsNoMicrometerTest.java
+++ b/reactor-core/src/test/java/reactor/util/MetricsNoMicrometerTest.java
@@ -16,12 +16,16 @@
 
 package reactor.util;
 
+import java.util.concurrent.Executors;
+
 import org.assertj.core.api.Assumptions;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -69,6 +73,23 @@ public class MetricsNoMicrometerTest {
 	public void MonoMetricsFusedNoOp() {
 		assertThatCode(() -> Mono.just("foo").metrics().block())
 				.doesNotThrowAnyException();
+	}
+
+	@Test
+	public void schedulersInstrumentation() {
+		try {
+			assertThatCode(() -> {
+				Schedulers.enableMetrics();
+				Scheduler s = Schedulers.newSingle("foo");
+				Schedulers.decorateExecutorService(s,
+						Executors.newSingleThreadScheduledExecutor());
+				s.schedule(() -> System.out.println("schedulers instrumentation no micrometer"));
+			})
+					.doesNotThrowAnyException();
+		}
+		finally {
+			Schedulers.disableMetrics();
+		}
 	}
 
 }


### PR DESCRIPTION
Also allow to set up a default centralized MeterRegistry to be used by
all metrics operators instead of the global one from Micrometer.