### PR TITLE
fix #1293 Index bound error on ParallelLiftFuseable

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelLift.java
@@ -68,9 +68,10 @@ final class ParallelLift<I, O> extends ParallelFlux<O> implements Scannable {
 
 		int i = 0;
 		while (i < subscribers.length) {
-			subscribers[i++] =
-					Objects.requireNonNull(lifter.apply(Scannable.from(source), s[i-1]),
+			subscribers[i] =
+					Objects.requireNonNull(lifter.apply(Scannable.from(source), s[i]),
 							"Lifted subscriber MUST NOT be null");
+			i++;
 		}
 
 		source.subscribe(subscribers);

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelLiftFuseable.java
@@ -71,7 +71,7 @@ final class ParallelLiftFuseable<I, O> extends ParallelFlux<O>
 
 		int i = 0;
 		while (i < subscribers.length) {
-			CoreSubscriber<? super O> actual = s[i - 1];
+			CoreSubscriber<? super O> actual = s[i];
 			CoreSubscriber<? super I> converted =
 					Objects.requireNonNull(lifter.apply(Scannable.from(source), actual),
 							"Lifted subscriber MUST NOT be null");
@@ -84,7 +84,8 @@ final class ParallelLiftFuseable<I, O> extends ParallelFlux<O>
 				converted = new FluxHide.SuppressFuseableSubscriber<>(converted);
 			}
 			//otherwise QS is not required or user already made a compatible conversion
-			subscribers[i++] = converted;
+			subscribers[i] = converted;
+			i++;
 		}
 
 		source.subscribe(subscribers);

--- a/reactor-core/src/test/java/reactor/core/publisher/LiftFunctionTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/LiftFunctionTest.java
@@ -17,6 +17,7 @@
 package reactor.core.publisher;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -24,6 +25,7 @@ import org.reactivestreams.Publisher;
 import reactor.core.Fuseable;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class LiftFunctionTest {
 
@@ -39,6 +41,9 @@ public class LiftFunctionTest {
 		assertThat(liftOperator)
 				.isInstanceOf(Mono.class)
 				.isExactlyInstanceOf(MonoLift.class);
+
+		assertThatCode(() -> liftOperator.subscribe(new BaseSubscriber<Integer>() {}))
+				.doesNotThrowAnyException();
 	}
 
 	@Test
@@ -53,6 +58,9 @@ public class LiftFunctionTest {
 		assertThat(liftOperator)
 				.isInstanceOf(Flux.class)
 				.isExactlyInstanceOf(FluxLift.class);
+
+		assertThatCode(() -> liftOperator.subscribe(new BaseSubscriber<Integer>() {}))
+				.doesNotThrowAnyException();
 	}
 
 	@Test
@@ -68,6 +76,9 @@ public class LiftFunctionTest {
 		assertThat(liftOperator)
 				.isInstanceOf(ParallelFlux.class)
 				.isExactlyInstanceOf(ParallelLift.class);
+
+		assertThatCode(() -> liftOperator.subscribe(new BaseSubscriber<Integer>() {}))
+				.doesNotThrowAnyException();
 	}
 
 	@Test
@@ -82,6 +93,9 @@ public class LiftFunctionTest {
 		assertThat(liftOperator)
 				.isInstanceOf(ConnectableFlux.class)
 				.isExactlyInstanceOf(ConnectableLift.class);
+
+		assertThatCode(() -> liftOperator.subscribe(new BaseSubscriber<Integer>() {}))
+				.doesNotThrowAnyException();
 	}
 
 	@Ignore("GroupedFlux is always fuseable for now")
@@ -113,6 +127,9 @@ public class LiftFunctionTest {
 				.isInstanceOf(Mono.class)
 				.isInstanceOf(Fuseable.class)
 				.isExactlyInstanceOf(MonoLiftFuseable.class);
+
+		assertThatCode(() -> liftOperator.subscribe(new BaseSubscriber<Integer>() {}))
+				.doesNotThrowAnyException();
 	}
 
 	@Test
@@ -127,23 +144,28 @@ public class LiftFunctionTest {
 				.isInstanceOf(Flux.class)
 				.isInstanceOf(Fuseable.class)
 				.isExactlyInstanceOf(FluxLiftFuseable.class);
+
+		assertThatCode(() -> liftOperator.subscribe(new BaseSubscriber<Integer>() {}))
+				.doesNotThrowAnyException();
 	}
 
-	@Ignore("Need a fuseable ParallelFlux")
 	@Test
 	public void liftParallelFluxFuseable() {
-//		ParallelFlux<Integer> source = Flux.just(1)
-//		                                   .parallel(2)
-	//FIXME use collect?
-//		                                   .collect(() -> new ArrayList<Integer>(), (c, v) -> c.add(v));
-//
-//		Operators.LiftFunction<Integer, Integer> liftFunction =
-//				new Operators.LiftFunction<>(null, (s, actual) -> actual);
-//		Publisher<Integer> liftOperator = liftFunction.apply(source);
-//
-//		assertThat(liftOperator)
-//				.isInstanceOf(ParallelFlux.class)
-//				.isExactlyInstanceOf(ParallelLiftFuseable.class);
+		ParallelFlux<List<Integer>> source = Flux
+				.just(1)
+				.parallel(2)
+				.collect(ArrayList::new, List::add);
+
+		Operators.LiftFunction<List<Integer>, List<Integer>> liftFunction =
+				new Operators.LiftFunction<>(null, (s, actual) -> actual);
+		Publisher<List<Integer>> liftOperator = liftFunction.apply(source);
+
+		assertThat(liftOperator)
+				.isInstanceOf(ParallelFlux.class)
+				.isExactlyInstanceOf(ParallelLiftFuseable.class);
+
+		assertThatCode(() -> liftOperator.subscribe(new BaseSubscriber<List<Integer>>() {}))
+				.doesNotThrowAnyException();
 	}
 
 	@Test
@@ -160,6 +182,9 @@ public class LiftFunctionTest {
 				.isInstanceOf(ConnectableFlux.class)
 				.isInstanceOf(Fuseable.class)
 				.isExactlyInstanceOf(ConnectableLiftFuseable.class);
+
+		assertThatCode(() -> liftOperator.subscribe(new BaseSubscriber<Integer>() {}))
+				.doesNotThrowAnyException();
 	}
 
 	@Test


### PR DESCRIPTION
Redo of #1295 over `3.1.x`.