### PR TITLE
fix #1237 Replace Disposables.composite implementation, now list based

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ buildscript {
 
 plugins {
   id 'org.asciidoctor.convert' version '1.5.6'
-  id "me.champeau.gradle.jmh" version "0.4.4" apply false
+  id "me.champeau.gradle.jmh" version "0.4.7" apply false
   id "org.jetbrains.dokka" version "0.9.16"
   id "me.champeau.gradle.japicmp" version "0.2.6"
 }
@@ -67,8 +67,7 @@ ext {
 
   javadocLinks = ["https://docs.oracle.com/javase/8/docs/api/",
 				  "https://docs.oracle.com/javaee/6/api/",
-				  "http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/"] as
-		  String[]
+				  "http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/"] as String[]
 
 
   bundleImportPackages = ['org.slf4j;resolution:=optional;version="[1.5.4,2)"',
@@ -284,6 +283,10 @@ project('reactor-core') {
 		force = true
 	  }
 	}
+  }
+
+  jmh {
+	resultFormat = 'JSON'
   }
 
   task japicmp(type: JapicmpTask) {

--- a/reactor-core/src/jmh/java/reactor/core/CompositeDisposableHashcodeBenchmark.java
+++ b/reactor-core/src/jmh/java/reactor/core/CompositeDisposableHashcodeBenchmark.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import reactor.core.Disposable.Composite;
+
+/**
+ * @author Simon Baslé
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+public class CompositeDisposableHashcodeBenchmark {
+	
+	@Param({"1", "31", "1024", "10000"})
+	public static int elementCount;
+
+	private static class NativeHashCode implements Disposable {
+
+		boolean isDisposed;
+
+		@Override
+		public void dispose() {
+			this.isDisposed = true;
+			Blackhole.consumeCPU(5);
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return isDisposed;
+		}
+	}
+
+	private static class CachingHashCode implements Disposable {
+
+		final int hash;
+		boolean isDisposed;
+
+		public CachingHashCode() {
+			this.hash = super.hashCode();
+		}
+
+		@Override
+		public int hashCode() {
+			return hash;
+		}
+
+		@Override
+		public void dispose() {
+			this.isDisposed = true;
+			Blackhole.consumeCPU(5);
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return isDisposed;
+		}
+	}
+
+	@Benchmark()
+	@BenchmarkMode(Mode.Throughput)
+	public void setWithNativeHashcode(Blackhole bh) {
+		Composite compositeSet = new Disposables.SetCompositeDisposable();
+		Disposable last = new NativeHashCode();
+		for (int i = 0; i < elementCount; i++) {
+			last = new NativeHashCode();
+			compositeSet.add(last);
+		}
+		
+		bh.consume(compositeSet.remove(last));
+		bh.consume(compositeSet.remove(new NativeHashCode()));
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.Throughput)
+	public void setWithCachingHashcode(Blackhole bh) {
+		Composite compositeSet = new Disposables.SetCompositeDisposable();
+		Disposable last = new CachingHashCode();
+		for (int i = 0; i < elementCount; i++) {
+			last = new NativeHashCode();
+			compositeSet.add(last);
+		}
+
+		bh.consume(compositeSet.remove(last));
+		bh.consume(compositeSet.remove(new NativeHashCode()));
+	}
+
+	@Benchmark()
+	@BenchmarkMode(Mode.Throughput)
+	public void listWithNativeHashcode(Blackhole bh) {
+		Composite compositecompositeLight = Disposables.composite();
+		Disposable last = new NativeHashCode();
+		for (int i = 0; i < elementCount; i++) {
+			last = new NativeHashCode();
+			compositecompositeLight.add(last);
+		}
+		
+		bh.consume(compositecompositeLight.remove(last));
+		bh.consume(compositecompositeLight.remove(new NativeHashCode()));
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.Throughput)
+	public void listWithCachingHashcode(Blackhole bh) {
+		Composite compositeLight = Disposables.composite();
+		Disposable last = new CachingHashCode();
+		for (int i = 0; i < elementCount; i++) {
+			last = new NativeHashCode();
+			compositeLight.add(last);
+		}
+
+		bh.consume(compositeLight.remove(last));
+		bh.consume(compositeLight.remove(new CachingHashCode()));
+	}
+
+}

--- a/reactor-core/src/test/java/reactor/core/ListCompositeDisposableTest.java
+++ b/reactor-core/src/test/java/reactor/core/ListCompositeDisposableTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import reactor.core.Disposables.ListCompositeDisposable;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.FakeDisposable;
+import reactor.test.util.RaceTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class ListCompositeDisposableTest {
+
+	@Test
+	public void isDisposed() throws Exception {
+		Disposable.Composite cd = new ListCompositeDisposable();
+
+		assertThat(cd.isDisposed()).isFalse();
+
+		cd.dispose();
+		assertThat(cd.isDisposed()).isTrue();
+	}
+
+	@Test
+	public void add() throws Exception {
+		FakeDisposable d = new FakeDisposable();
+		Disposable.Composite cd = new ListCompositeDisposable();
+
+		assertThat(cd.size()).isZero();
+
+		boolean added = cd.add(d);
+
+		assertThat(added).isTrue();
+		assertThat(cd.size()).isEqualTo(1);
+		assertThat(d.isDisposed()).isFalse();
+	}
+
+	@Test
+	public void addAll() throws Exception {
+		FakeDisposable d1 = new FakeDisposable();
+		FakeDisposable d2 = new FakeDisposable();
+		Disposable.Composite cd = new ListCompositeDisposable();
+
+		assertThat(cd.size()).isZero();
+
+		boolean added = cd.addAll(Arrays.asList(d1, d2));
+
+		assertThat(added).isTrue();
+		assertThat(cd.size()).isEqualTo(2);
+		assertThat(d1.isDisposed()).isFalse();
+		assertThat(d2.isDisposed()).isFalse();
+	}
+
+	@Test
+	public void removeDoesntDispose() throws Exception {
+		FakeDisposable d = new FakeDisposable();
+		Disposable.Composite cd = new ListCompositeDisposable(d);
+
+		assertThat(cd.size()).isEqualTo(1);
+		assertThat(d.isDisposed()).isFalse();
+
+		boolean deleted = cd.remove(d);
+
+		assertThat(deleted).isTrue();
+		assertThat(cd.size()).isZero();
+		assertThat(d.isDisposed()).isFalse();
+	}
+
+	@Test
+	public void disposeDisposesAndDisallowReuse() throws Exception {
+		FakeDisposable d1 = new FakeDisposable();
+		FakeDisposable d2 = new FakeDisposable();
+		Disposable.Composite cd = new ListCompositeDisposable(d1, d2);
+
+		assertThat(cd.size()).isEqualTo(2);
+		assertThat(d1.isDisposed()).isFalse();
+		assertThat(d2.isDisposed()).isFalse();
+
+		cd.dispose();
+
+		assertThat(cd.size()).isZero();
+		assertThat(cd.isDisposed()).isTrue();
+		assertThat(d1.isDisposed()).isTrue();
+		assertThat(d1.disposed).isEqualTo(1);
+		assertThat(d2.isDisposed()).isTrue();
+
+		boolean reuse = cd.add(d1);
+		assertThat(reuse).isFalse();
+		assertThat(cd.size()).isZero();
+		assertThat(d1.disposed).isEqualTo(2);
+	}
+
+	@Test
+	public void removeInexistant() throws Exception {
+		FakeDisposable d = new FakeDisposable();
+		Disposable.Composite cd = new ListCompositeDisposable();
+		boolean deleted = cd.remove(d);
+
+		assertThat(deleted).isFalse();
+		assertThat(d.isDisposed()).isFalse();
+	}
+
+	@Test
+	public void addAfterDispose() throws Exception {
+		FakeDisposable d = new FakeDisposable();
+		Disposable.Composite cd = new ListCompositeDisposable();
+		cd.dispose();
+		boolean added = cd.add(d);
+
+		assertThat(added).isFalse();
+		assertThat(cd.size()).isZero();
+		assertThat(d.isDisposed()).isTrue();
+	}
+
+	@Test
+	public void addAllAfterDispose() throws Exception {
+		FakeDisposable d1 = new FakeDisposable();
+		FakeDisposable d2 = new FakeDisposable();
+		Disposable.Composite cd = new ListCompositeDisposable();
+		cd.dispose();
+		boolean added = cd.addAll(Arrays.asList(d1, d2));
+
+		assertThat(added).isFalse();
+		assertThat(cd.size()).isZero();
+		assertThat(d1.isDisposed()).isTrue();
+		assertThat(d2.isDisposed()).isTrue();
+	}
+
+	@Test
+	public void removeAfterDispose() throws Exception {
+		FakeDisposable d = new FakeDisposable();
+		Disposable.Composite cd = new ListCompositeDisposable();
+		cd.dispose();
+		boolean deleted = cd.remove(d);
+
+		assertThat(deleted).isFalse();
+		assertThat(cd.size()).isZero();
+		assertThat(d.isDisposed()).isFalse();
+	}
+
+	@Test
+	public void disposeAfterDispose() throws Exception {
+		FakeDisposable d = new FakeDisposable();
+		Disposable.Composite cd = new ListCompositeDisposable(d);
+		cd.dispose();
+		cd.dispose();
+
+		assertThat(d.disposed).isEqualTo(1);
+	}
+
+	@Test
+	public void singleErrorDuringDisposal() {
+		Disposable bad = () -> {
+			throw new IllegalStateException("boom");
+		};
+		FakeDisposable good = new FakeDisposable();
+		Disposable.Composite cd = new ListCompositeDisposable(bad, good);
+
+		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(cd::dispose)
+		                                                      .withMessage("boom");
+
+		assertThat(good.isDisposed()).isTrue();
+	}
+
+	@Test
+	public void multipleErrorsDuringDisposal() {
+		Disposable bad1 = () -> {
+			throw new IllegalStateException("boom1");
+		};
+		Disposable bad2 = () -> {
+			throw new IllegalStateException("boom2");
+		};
+		FakeDisposable good = new FakeDisposable();
+		Disposable.Composite cd = new ListCompositeDisposable(bad1, bad2, good);
+
+		assertThatExceptionOfType(RuntimeException.class).isThrownBy(cd::dispose)
+		                                                 .withMessage(
+				                                                 "Multiple exceptions")
+		                                                 .withStackTraceContaining(
+				                                                 "Suppressed: java.lang.IllegalStateException: boom1")
+		                                                 .withStackTraceContaining(
+				                                                 "Suppressed: java.lang.IllegalStateException: boom2");
+
+		assertThat(good.isDisposed()).isTrue();
+	}
+
+	@Test
+	public void constructorIterable() {
+		FakeDisposable d1 = new FakeDisposable();
+		FakeDisposable d2 = new FakeDisposable();
+		List<FakeDisposable> list = Arrays.asList(d1, d2);
+		Disposable.Composite cd = new ListCompositeDisposable(list);
+
+		assertThat(cd.size()).isEqualTo(2);
+
+		cd.remove(d1);
+		cd.remove(d2);
+
+		assertThat(cd.size()).isZero();
+		assertThat(list).hasSize(2);
+	}
+
+	@Test
+	public void disposeConcurrent() {
+		for (int i = 0; i < 500; i++) {
+			final Disposable d1 = new FakeDisposable();
+			final Disposable.Composite cd = new ListCompositeDisposable(d1);
+
+			RaceTestUtils.race(cd::dispose, cd::dispose, Schedulers.elastic());
+		}
+	}
+
+	@Test
+	public void removeConcurrent() {
+		for (int i = 0; i < 500; i++) {
+			final Disposable d1 = new FakeDisposable();
+			final Disposable.Composite cd = new ListCompositeDisposable(d1);
+
+			RaceTestUtils.race(() -> cd.remove(d1), cd::dispose, Schedulers.elastic());
+		}
+	}
+
+	@Test
+	public void sizeConcurrent() {
+		for (int i = 0; i < 500; i++) {
+			final Disposable d1 = new FakeDisposable();
+			final Disposable.Composite cd = new ListCompositeDisposable(d1);
+
+			RaceTestUtils.race(cd::size, cd::dispose, Schedulers.elastic());
+		}
+	}
+
+}

--- a/reactor-core/src/test/java/reactor/core/SetCompositeDisposableTest.java
+++ b/reactor-core/src/test/java/reactor/core/SetCompositeDisposableTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
-import reactor.core.Disposables.CompositeDisposable;
+import reactor.core.Disposables.SetCompositeDisposable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.FakeDisposable;
 import reactor.test.util.RaceTestUtils;
@@ -28,11 +28,11 @@ import reactor.test.util.RaceTestUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class CompositeDisposableTest {
+public class SetCompositeDisposableTest {
 
 	@Test
 	public void isDisposed() throws Exception {
-		Disposable.Composite cd = new CompositeDisposable();
+		Disposable.Composite cd = new SetCompositeDisposable();
 
 		assertThat(cd.isDisposed()).isFalse();
 
@@ -43,7 +43,7 @@ public class CompositeDisposableTest {
 	@Test
 	public void add() throws Exception {
 		FakeDisposable d = new FakeDisposable();
-		Disposable.Composite cd = new CompositeDisposable();
+		Disposable.Composite cd = new SetCompositeDisposable();
 
 		assertThat(cd.size()).isZero();
 
@@ -58,7 +58,7 @@ public class CompositeDisposableTest {
 	public void addAll() throws Exception {
 		FakeDisposable d1 = new FakeDisposable();
 		FakeDisposable d2 = new FakeDisposable();
-		Disposable.Composite cd = new CompositeDisposable();
+		Disposable.Composite cd = new SetCompositeDisposable();
 
 		assertThat(cd.size()).isZero();
 
@@ -73,7 +73,7 @@ public class CompositeDisposableTest {
 	@Test
 	public void removeDoesntDispose() throws Exception {
 		FakeDisposable d = new FakeDisposable();
-		Disposable.Composite cd = new CompositeDisposable(d);
+		Disposable.Composite cd = new SetCompositeDisposable(d);
 
 		assertThat(cd.size()).isEqualTo(1);
 		assertThat(d.isDisposed()).isFalse();
@@ -89,7 +89,7 @@ public class CompositeDisposableTest {
 	public void disposeDisposesAndDisallowReuse() throws Exception {
 		FakeDisposable d1 = new FakeDisposable();
 		FakeDisposable d2 = new FakeDisposable();
-		Disposable.Composite cd = new CompositeDisposable(d1, d2);
+		Disposable.Composite cd = new SetCompositeDisposable(d1, d2);
 
 		assertThat(cd.size()).isEqualTo(2);
 		assertThat(d1.isDisposed()).isFalse();
@@ -112,7 +112,7 @@ public class CompositeDisposableTest {
 	@Test
 	public void removeInexistant() throws Exception {
 		FakeDisposable d = new FakeDisposable();
-		Disposable.Composite cd = new CompositeDisposable();
+		Disposable.Composite cd = new SetCompositeDisposable();
 		boolean deleted = cd.remove(d);
 
 		assertThat(deleted).isFalse();
@@ -122,7 +122,7 @@ public class CompositeDisposableTest {
 	@Test
 	public void addAfterDispose() throws Exception {
 		FakeDisposable d = new FakeDisposable();
-		Disposable.Composite cd = new CompositeDisposable();
+		Disposable.Composite cd = new SetCompositeDisposable();
 		cd.dispose();
 		boolean added = cd.add(d);
 
@@ -135,7 +135,7 @@ public class CompositeDisposableTest {
 	public void addAllAfterDispose() throws Exception {
 		FakeDisposable d1 = new FakeDisposable();
 		FakeDisposable d2 = new FakeDisposable();
-		Disposable.Composite cd = new CompositeDisposable();
+		Disposable.Composite cd = new SetCompositeDisposable();
 		cd.dispose();
 		boolean added = cd.addAll(Arrays.asList(d1, d2));
 
@@ -148,7 +148,7 @@ public class CompositeDisposableTest {
 	@Test
 	public void removeAfterDispose() throws Exception {
 		FakeDisposable d = new FakeDisposable();
-		Disposable.Composite cd = new CompositeDisposable();
+		Disposable.Composite cd = new SetCompositeDisposable();
 		cd.dispose();
 		boolean deleted = cd.remove(d);
 
@@ -160,7 +160,7 @@ public class CompositeDisposableTest {
 	@Test
 	public void disposeAfterDispose() throws Exception {
 		FakeDisposable d = new FakeDisposable();
-		Disposable.Composite cd = new CompositeDisposable(d);
+		Disposable.Composite cd = new SetCompositeDisposable(d);
 		cd.dispose();
 		cd.dispose();
 
@@ -173,7 +173,7 @@ public class CompositeDisposableTest {
 			throw new IllegalStateException("boom");
 		};
 		FakeDisposable good = new FakeDisposable();
-		Disposable.Composite cd = new CompositeDisposable(bad, good);
+		Disposable.Composite cd = new SetCompositeDisposable(bad, good);
 
 		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(cd::dispose)
 		                                                      .withMessage("boom");
@@ -190,7 +190,7 @@ public class CompositeDisposableTest {
 			throw new IllegalStateException("boom2");
 		};
 		FakeDisposable good = new FakeDisposable();
-		Disposable.Composite cd = new CompositeDisposable(bad1, bad2, good);
+		Disposable.Composite cd = new SetCompositeDisposable(bad1, bad2, good);
 
 		assertThatExceptionOfType(RuntimeException.class).isThrownBy(cd::dispose)
 		                                                 .withMessage(
@@ -208,7 +208,7 @@ public class CompositeDisposableTest {
 		FakeDisposable d1 = new FakeDisposable();
 		FakeDisposable d2 = new FakeDisposable();
 		List<FakeDisposable> list = Arrays.asList(d1, d2);
-		Disposable.Composite cd = new CompositeDisposable(list);
+		Disposable.Composite cd = new SetCompositeDisposable(list);
 
 		assertThat(cd.size()).isEqualTo(2);
 
@@ -223,7 +223,7 @@ public class CompositeDisposableTest {
 	public void disposeConcurrent() {
 		for (int i = 0; i < 500; i++) {
 			final Disposable d1 = new FakeDisposable();
-			final Disposable.Composite cd = new CompositeDisposable(d1);
+			final Disposable.Composite cd = new SetCompositeDisposable(d1);
 
 			RaceTestUtils.race(cd::dispose, cd::dispose, Schedulers.elastic());
 		}
@@ -233,7 +233,7 @@ public class CompositeDisposableTest {
 	public void removeConcurrent() {
 		for (int i = 0; i < 500; i++) {
 			final Disposable d1 = new FakeDisposable();
-			final Disposable.Composite cd = new CompositeDisposable(d1);
+			final Disposable.Composite cd = new SetCompositeDisposable(d1);
 
 			RaceTestUtils.race(() -> cd.remove(d1), cd::dispose, Schedulers.elastic());
 		}
@@ -243,7 +243,7 @@ public class CompositeDisposableTest {
 	public void sizeConcurrent() {
 		for (int i = 0; i < 500; i++) {
 			final Disposable d1 = new FakeDisposable();
-			final Disposable.Composite cd = new CompositeDisposable(d1);
+			final Disposable.Composite cd = new SetCompositeDisposable(d1);
 
 			RaceTestUtils.race(cd::size, cd::dispose, Schedulers.elastic());
 		}


### PR DESCRIPTION
The implementation used to be based off an OpenHashSet data structure,
with undocumented yet unnecessary set-like semantics (addind a
Disposable twice would be rejected the second time), at some performance
cost.

This has now been replaced with a simpler implementation with list
semantics, based on delegating to a LinkedList.