### PR TITLE
fix #1185 Avoid unbounded Flux.replay request with bounded subscribers

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -1145,7 +1145,12 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 				s.cancel();
 			}
 			else if (Operators.setOnce(S, this, s)) {
-				s.request(Long.MAX_VALUE);
+				long max = parent.history;
+				for (ReplaySubscription<T> subscriber : subscribers) {
+					max = Math.max(subscriber.fusionMode() != Fuseable.NONE ? Long.MAX_VALUE : subscriber.requested(), max);
+					if (max == Long.MAX_VALUE) break;
+				}
+				s.request(max);
 			}
 		}
 


### PR DESCRIPTION
2 separate commits (the `hide()` and `ConnectableFluxHide` bit was necessary to make tests actually cover the non-fuseable version)