### PR TITLE
fix #1305 Remove no-consumer onErrorContinue variants

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -4162,7 +4162,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * @param onNext the callback to call on {@link Subscriber#onNext}
 	 *
-	 * @reactor.errorMode This operator supports {@link #onErrorContinue() resuming on errors}
+	 * @reactor.errorMode This operator supports {@link #onErrorContinue(BiConsumer) resuming on errors}
 	 * (including when fusion is enabled). Exceptions thrown by the consumer are passed to
 	 * the {@link #onErrorContinue(BiConsumer)} error consumer (the value consumer
 	 * is not invoked, as the source element will be part of the sequence). The onNext
@@ -4489,7 +4489,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * @param p the {@link Predicate} to test values against
 	 *
-	 * @reactor.errorMode This operator supports {@link #onErrorContinue() resuming on errors}
+	 * @reactor.errorMode This operator supports {@link #onErrorContinue(BiConsumer) resuming on errors}
 	 * (including when fusion is enabled). Exceptions thrown by the predicate are
 	 * considered as if the predicate returned false: they cause the source value to be
 	 * dropped and a new element ({@code request(1)}) being requested from upstream.
@@ -4578,7 +4578,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param mapper the {@link Function} to transform input sequence into N sequences {@link Publisher}
 	 * @param <R> the merged output sequence type
 	 *
-	 * @reactor.errorMode This operator supports {@link #onErrorContinue() resuming on errors}
+	 * @reactor.errorMode This operator supports {@link #onErrorContinue(BiConsumer) resuming on errors}
 	 * in the mapper {@link Function}. Exceptions thrown by the mapper then behave as if
 	 * it had mapped the value to an empty publisher. If the mapper does map to a scalar
 	 * publisher (an optimization in which the value can be resolved immediately without
@@ -4620,7 +4620,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param concurrency the maximum number of in-flight inner sequences
 	 * @param <V> the merged output sequence type
 	 *
-	 * @reactor.errorMode This operator supports {@link #onErrorContinue() resuming on errors}
+	 * @reactor.errorMode This operator supports {@link #onErrorContinue(BiConsumer) resuming on errors}
 	 * in the mapper {@link Function}. Exceptions thrown by the mapper then behave as if
 	 * it had mapped the value to an empty publisher. If the mapper does map to a scalar
 	 * publisher (an optimization in which the value can be resolved immediately without
@@ -4666,7 +4666,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param prefetch the maximum in-flight elements from each inner {@link Publisher} sequence
 	 * @param <V> the merged output sequence type
 	 *
-	 * @reactor.errorMode This operator supports {@link #onErrorContinue() resuming on errors}
+	 * @reactor.errorMode This operator supports {@link #onErrorContinue(BiConsumer) resuming on errors}
 	 * in the mapper {@link Function}. Exceptions thrown by the mapper then behave as if
 	 * it had mapped the value to an empty publisher. If the mapper does map to a scalar
 	 * publisher (an optimization in which the value can be resolved immediately without
@@ -4710,7 +4710,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param prefetch the maximum in-flight elements from each inner {@link Publisher} sequence
 	 * @param <V> the merged output sequence type
 	 *
-	 * @reactor.errorMode This operator supports {@link #onErrorContinue() resuming on errors}
+	 * @reactor.errorMode This operator supports {@link #onErrorContinue(BiConsumer) resuming on errors}
 	 * in the mapper {@link Function}. Exceptions thrown by the mapper then behave as if
 	 * it had mapped the value to an empty publisher. If the mapper does map to a scalar
 	 * publisher (an optimization in which the value can be resolved immediately without
@@ -5156,7 +5156,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param handler the handling {@link BiConsumer}
 	 * @param <R> the transformed type
 	 *
-	 * @reactor.errorMode This operator supports {@link #onErrorContinue() resuming on errors} (including when
+	 * @reactor.errorMode This operator supports {@link #onErrorContinue(BiConsumer) resuming on errors} (including when
 	 * fusion is enabled) when the {@link BiConsumer} throws an exception or if an error is signaled explicitly via
 	 * {@link SynchronousSink#error(Throwable)}.
 	 *
@@ -5590,7 +5590,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param mapper the synchronous transforming {@link Function}
 	 * @param <V> the transformed type
 	 *
-	 * @reactor.errorMode This operator supports {@link #onErrorContinue() resuming on errors}
+	 * @reactor.errorMode This operator supports {@link #onErrorContinue(BiConsumer) resuming on errors}
 	 * (including when fusion is enabled). Exceptions thrown by the mapper then cause the
 	 * source value to be dropped and a new element ({@code request(1)}) being requested
 	 * from upstream.
@@ -5993,65 +5993,6 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Let compatible operators <strong>upstream</strong> recover from an error by dropping the incriminating
-	 * element from the sequence and continuing with subsequent elements.
-	 * <p>
-	 * Note that this error handling mode is not necessarily implemented by all operators
-	 * (look for the {@code Error Mode Support} javadoc section to find operators that
-	 * support it).
-	 * The error and associated root-cause element are dropped to {@link Operators#onErrorDropped(Throwable, Context)}
-	 * and {@link Operators#onNextDropped(Object, Context)} respectively.
-	 *
-	 * @return a {@link Flux} that attempts to continue processing on errors.
-	 */
-	public final Flux<T> onErrorContinue() {
-		return subscriberContext(Context.of(
-				OnNextFailureStrategy.KEY_ON_NEXT_ERROR_STRATEGY,
-				OnNextFailureStrategy.resumeDrop()));
-	}
-
-	/**
-	 * Let compatible operators <strong>upstream</strong> recover from some errors by dropping the
-	 * incriminating element from the sequence and continuing with subsequent elements.
-	 * Only errors matching the specified {@code type} are recovered from.
-	 * <p>
-	 * Note that this error handling mode is not necessarily implemented by all operators
-	 * (look for the {@code Error Mode Support} javadoc section to find operators that
-	 * support it).
-	 * The error and associated root-cause element are dropped to {@link Operators#onErrorDropped(Throwable, Context)}
-	 * and {@link Operators#onNextDropped(Object, Context)} respectively.
-	 *
-	 * @param type the class of the exception type to handle.
-	 * @return a {@link Flux} that attempts to continue processing on some errors.
-	 */
-	public final Flux<T> onErrorContinue(Class<? extends Throwable> type) {
-		return subscriberContext(Context.of(
-				OnNextFailureStrategy.KEY_ON_NEXT_ERROR_STRATEGY,
-				OnNextFailureStrategy.resumeDropIf(type::isInstance)
-		));
-	}
-
-	/**
-	 * Let compatible operators <strong>upstream</strong> recover from some errors by dropping the
-	 * incriminating element from the sequence and continuing with subsequent elements.
-	 * Only errors matching the {@link Predicate} are recovered from.
-	 * <p>
-	 * Note that this error handling mode is not necessarily implemented by all operators
-	 * (look for the {@code Error Mode Support} javadoc section to find operators that
-	 * support it).
-	 * The error and associated root-cause element are dropped to {@link Operators#onErrorDropped(Throwable, Context)}
-	 * and {@link Operators#onNextDropped(Object, Context)} respectively.
-	 *
-	 * @return a {@link Flux} that attempts to continue processing on some errors.
-	 */
-	public final Flux<T> onErrorContinue(Predicate<Throwable> errorPredicate) {
-		return subscriberContext(Context.of(
-				OnNextFailureStrategy.KEY_ON_NEXT_ERROR_STRATEGY,
-				OnNextFailureStrategy.resumeDropIf(errorPredicate)
-		));
-	}
-
-	/**
 	 * Let compatible operators <strong>upstream</strong> recover from errors by dropping the
 	 * incriminating element from the sequence and continuing with subsequent elements.
 	 * Only errors matching the {@link Predicate} are recovered from.
@@ -6112,13 +6053,13 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * If an {@link #onErrorContinue()} variant has been used before, reverts to the default
+	 * If an {@link #onErrorContinue(BiConsumer)} variant has been used before, reverts to the default
 	 * 'STOP' mode where errors are terminal events. It can be used for easier scoping of
 	 * the on next failure strategy or to override the inherited strategy in a sub-stream
-	 * (for example in a flatMap). It has no effect if {@link #onErrorContinue()} has not
+	 * (for example in a flatMap). It has no effect if {@link #onErrorContinue(BiConsumer)} has not
 	 * been used.
 	 *
-	 * @return a {@link Flux} that terminates on errors, even if {@link #onErrorContinue()}
+	 * @return a {@link Flux} that terminates on errors, even if {@link #onErrorContinue(BiConsumer)}
 	 * was used before
 	 */
 	public final Flux<T> onErrorStop() {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
@@ -911,7 +911,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 				.just(1, 2)
 				.hide()
 				.<Integer>concatMap(f -> null)
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 		StepVerifier.create(test)
 				.expectNoFusionSupport()
@@ -934,7 +934,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 						return Mono.just(f);
 					}
 				})
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 		StepVerifier.create(test)
 				.expectNoFusionSupport()
@@ -958,7 +958,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 						return Mono.just(f);
 					}
 				})
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 		StepVerifier.create(test)
 				.expectNoFusionSupport()
@@ -979,7 +979,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 						throw new ArithmeticException("boom");
 					}
 				}))
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 		StepVerifier.create(test)
 				.expectNoFusionSupport()
@@ -1002,7 +1002,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 						return Mono.just(f);
 					}
 				})
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 
 		StepVerifier.create(test)
@@ -1028,7 +1028,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 						return Mono.just(f);
 					}
 				})
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 
 		StepVerifier.create(test)
@@ -1046,7 +1046,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 				.just(0, 1)
 				.hide()
 				.concatMap(f ->  Flux.range(f, 1).map(i -> 1/i).onErrorStop())
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 		StepVerifier.create(test)
 				.expectNoFusionSupport()
@@ -1063,7 +1063,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 				.just(0, 1)
 				.hide()
 				.concatMap(f ->  Flux.range(f, 1).publishOn(Schedulers.parallel()).map(i -> 1 / i).onErrorStop())
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 		StepVerifier.create(test)
 				.expectNoFusionSupport()
@@ -1080,7 +1080,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 				.just(0, 1)
 				.hide()
 				.concatMap(f ->  Mono.just(f).map(i -> 1/i))
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 		StepVerifier.create(test)
 				.expectNoFusionSupport()
@@ -1097,7 +1097,7 @@ public class FluxConcatMapTest extends FluxOperatorTest<String, String> {
 				.just(0, 1)
 				.hide()
 				.concatMap(f ->  Mono.just(f).publishOn(Schedulers.parallel()).map(i -> 1/i))
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 		StepVerifier.create(test)
 				.expectNoFusionSupport()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -1442,7 +1442,7 @@ public class FluxFlatMapTest {
 				.just(1, 2)
 				.hide()
 				.<Integer>flatMap(f -> null)
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 		StepVerifier.create(test)
 		            .expectNoFusionSupport()
@@ -1466,7 +1466,7 @@ public class FluxFlatMapTest {
 						return Mono.just(f);
 					}
 				})
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 		StepVerifier.create(test)
 				.expectNoFusionSupport()
@@ -1492,7 +1492,7 @@ public class FluxFlatMapTest {
 					}
 				})
 				.doOnNext(i -> i++)
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 		StepVerifier.create(test)
 				.expectNoFusionSupport()
@@ -1513,7 +1513,7 @@ public class FluxFlatMapTest {
 						throw new ArithmeticException("boom");
 					}
 				}))
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 		StepVerifier.create(test)
 				.expectNoFusionSupport()
@@ -1536,7 +1536,7 @@ public class FluxFlatMapTest {
 						return Mono.just(f);
 					}
 				}, Queues.SMALL_BUFFER_SIZE, Queues.XS_BUFFER_SIZE)
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 
 		StepVerifier.create(test)
@@ -1562,7 +1562,7 @@ public class FluxFlatMapTest {
 						return Mono.just(f);
 					}
 				}, Queues.SMALL_BUFFER_SIZE, Queues.XS_BUFFER_SIZE)
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 
 		StepVerifier.create(test)
@@ -1580,7 +1580,7 @@ public class FluxFlatMapTest {
 				.just(0, 1)
 				.hide()
 				.flatMap(f ->  Flux.range(f, 1).map(i -> 1/i).onErrorStop())
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 		StepVerifier.create(test)
 				.expectNoFusionSupport()
@@ -1597,7 +1597,7 @@ public class FluxFlatMapTest {
 				.just(0, 1)
 				.hide()
 				.flatMap(f ->  Flux.range(f, 1).publishOn(Schedulers.parallel()).map(i -> 1/i).onErrorStop())
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 		StepVerifier.create(test)
 				.expectNoFusionSupport()
@@ -1614,7 +1614,7 @@ public class FluxFlatMapTest {
 				.just(0, 1)
 				.hide()
 				.flatMap(f ->  Mono.just(f).map(i -> 1/i))
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 		StepVerifier.create(test)
 				.expectNoFusionSupport()
@@ -1631,7 +1631,7 @@ public class FluxFlatMapTest {
 				.just(0, 1)
 				.hide()
 				.flatMap(f ->  Mono.just(f).publishOn(Schedulers.parallel()).map(i -> 1/i))
-				.onErrorContinue();
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
 
 		StepVerifier.create(test)
 				.expectNoFusionSupport()


### PR DESCRIPTION
These variants would defer to the `Hooks.onErrorDropped` hook, which
itself defaults to logging-and-throwing, defeating the purpose of the
continue feature unless the hook was also set. As the signatures looked
simpler, they would encourage people to use them without necessarily
thinking about the hook.