### PR TITLE
[test] Do not fail HooksTestStaticInit test in IDE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -377,6 +377,11 @@ project('reactor-core') {
 	doFirst {
 	  println "Additional tests from `testStaticInit` ($includes)"
 	}
+	afterSuite { TestDescriptor descriptor, TestResult result ->
+	    if (!(result.testCount > 0 && result.skippedTestCount == 0)) {
+			throw new GradleException("No static initialization tests were executed")
+		}
+	}
   }
 
   task loops(type: Test, group: 'verification') {

--- a/reactor-core/src/test/java/reactor/core/publisher/HooksTestStaticInit.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/HooksTestStaticInit.java
@@ -36,6 +36,7 @@ import org.junit.After;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class HooksTestStaticInit {
 
@@ -55,9 +56,11 @@ public class HooksTestStaticInit {
 
 	@Test
 	public void syspropDebugModeShouldNotFail() {
-		assertThat(System.getProperties())
-				.as("debug mode set via system property")
-				.containsEntry("reactor.trace.operatorStacktrace", "true");
+		String operatorStacktracePropertyValue = System.getProperties().getProperty("reactor.trace.operatorStacktrace");
+		assumeThat(operatorStacktracePropertyValue)
+				.as("Skipping test as 'reactor.trace.operatorStacktrace' is not set to true (e.g. ran from IDE)")
+				.isEqualTo("true");
+
 		assertThat(Hooks.getOnEachOperatorHooks())
 				.as("debug hook activated")
 				.containsKey(Hooks.ON_OPERATOR_DEBUG_KEY);


### PR DESCRIPTION
Playing with the Reactor code I have noticed that `HooksTestStaticInit` fails when a group of tests is executed from IDE. After reading the code the reason is obvious, however I understand why it was created that way.

It's a corner case test that is separately executed from Gradle. After my change, when executed "accidentally" from IDE, it is skipped - to do not have test execution red. There is a dedicated check in Gradle to ensure that test is not skipped accidentally by some configuration changes.