### PR TITLE
fix #1329 Detect conversion cycle of Mono.from(Flux.from(mono))

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -301,6 +301,14 @@ public abstract class Mono<T> implements Publisher<T> {
 			Mono<T> casted = (Mono<T>) source;
 			return casted;
 		}
+		if (source instanceof FluxSourceMono
+				|| source instanceof FluxSourceMonoFuseable) {
+			@SuppressWarnings("unchecked")
+			FluxFromMonoOperator<T, T> wrapper = (FluxFromMonoOperator<T,T>) source;
+			@SuppressWarnings("unchecked")
+			Mono<T> extracted = (Mono<T>) wrapper.source;
+			return extracted;
+		}
 		if (source instanceof Flux) {
 			@SuppressWarnings("unchecked")
 			Flux<T> casted = (Flux<T>) source;


### PR DESCRIPTION
This commit allows detection of _some_ cases where a back-and-forth
conversion is applied to a Mono, like `Mono.from(Flux.from(mono))`.

When it is the case (and to the exception of an original Mono that is
Callable), this optimization unwraps the original Mono during the second
conversion, returning the original instance directly.

Callable Monos like `Mono.empty` are not wrapped but resolved and
rewritten as `Flux.empty/error/just`, which makes the optimization
impossible in these cases.