### PR TITLE
Fix #1349 Include sequence name when timing out using timeout operator

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTimeout.java
@@ -22,6 +22,8 @@ import java.util.function.Function;
 import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
 
+import static reactor.core.publisher.FluxTimeout.addNameToTimeoutDescription;
+
 /**
  * Signals a timeout (or switches to another sequence) in case a per-item generated
  * Publisher source fires an item or completes before the next item arrives from the main
@@ -67,7 +69,8 @@ final class MonoTimeout<T, U, V> extends MonoOperator<T, T> {
 		CoreSubscriber<T> serial = Operators.serialize(actual);
 
 		FluxTimeout.TimeoutMainSubscriber<T, V> main =
-				new FluxTimeout.TimeoutMainSubscriber<>(serial, NEVER, other, timeoutDescription);
+				new FluxTimeout.TimeoutMainSubscriber<>(serial, NEVER, other,
+						addNameToTimeoutDescription(source, timeoutDescription));
 
 		serial.onSubscribe(main);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
@@ -353,13 +353,24 @@ public class FluxTimeoutTest {
 	}
 
 	@Test
-	public void timeoutDurationMessage() {
+	public void timeoutDurationMessageDefault() {
 		StepVerifier.withVirtualTime(() -> Flux.never()
 		                                       .timeout(Duration.ofHours(1)))
 		            .thenAwait(Duration.ofHours(2))
 		            .expectErrorMessage("Did not observe any item or terminal signal within " +
-				            "3600000ms (and no fallback has been configured)")
+				            "3600000ms in 'source(FluxNever)' (and no fallback has been configured)")
 		            .verify();
+	}
+
+	@Test
+	public void timeoutDurationMessageWithName() {
+		StepVerifier.withVirtualTime(() -> Flux.never()
+				.name("Name")
+				.timeout(Duration.ofHours(1)))
+				.thenAwait(Duration.ofHours(2))
+				.expectErrorMessage("Did not observe any item or terminal signal within " +
+						"3600000ms in 'Name' (and no fallback has been configured)")
+				.verify();
 	}
 
 
@@ -368,7 +379,7 @@ public class FluxTimeoutTest {
 		StepVerifier.create(Flux.never()
 		                        .timeout(Mono.just("immediate")))
 		            .expectErrorMessage("Did not observe any item or terminal signal within " +
-				            "first signal from a Publisher (and no fallback has been configured)")
+				            "first signal from a Publisher in 'source(FluxNever)' (and no fallback has been configured)")
 		            .verify();
 	}
 
@@ -383,7 +394,7 @@ public class FluxTimeoutTest {
 				                        }))
 		            .expectNext("foo")
 		            .expectErrorMessage("Did not observe any item or terminal signal within " +
-				            "first signal from a Publisher (and no fallback has been configured)")
+				            "first signal from a Publisher in 'source(FluxConcatArray)' (and no fallback has been configured)")
 		            .verify();
 
 		assertThat(generatorUsed.get()).as("generator used").isTrue();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
@@ -124,12 +124,25 @@ public class MonoTimeoutTest {
 	}
 
 	@Test
-	public void timeoutDurationMessage() {
+	public void timeoutDurationMessageDefault() {
 		StepVerifier.withVirtualTime(() -> Mono.never()
 		                                       .timeout(Duration.ofHours(1)))
 		            .thenAwait(Duration.ofHours(2))
 		            .expectErrorMessage("Did not observe any item or terminal signal within " +
-				            "3600000ms (and no fallback has been configured)")
+				            "3600000ms in 'source(MonoNever)' (and no fallback has been " +
+				            "configured)")
+		            .verify();
+	}
+
+	@Test
+	public void timeoutDurationMessageWithName() {
+		StepVerifier.withVirtualTime(() -> Mono.never()
+		                                       .name("Name")
+		                                       .timeout(Duration.ofHours(1)))
+		            .thenAwait(Duration.ofHours(2))
+		            .expectErrorMessage("Did not observe any item or terminal signal within " +
+				            "3600000ms in 'Name' (and no fallback has been " +
+				            "configured)")
 		            .verify();
 	}
 
@@ -139,7 +152,8 @@ public class MonoTimeoutTest {
 		StepVerifier.create(Mono.never()
 		                        .timeout(Mono.just("immediate")))
 		            .expectErrorMessage("Did not observe any item or terminal signal within " +
-				            "first signal from a Publisher (and no fallback has been configured)")
+				            "first signal from a Publisher in 'source(MonoNever)' " +
+				            "(and no fallback has been configured)")
 		            .verify();
 	}
 }


### PR DESCRIPTION
Use sequence name in the exception thrown by `timeout` operator on
timeout to facilitate debugging. It will default to 'reactor' if name
is not specified.