### PR TITLE
fix #1356 combineLatest ClassCastException with single source

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCombineLatest.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCombineLatest.java
@@ -155,10 +155,16 @@ final class FluxCombineLatest<T, R> extends Flux<R> implements Fuseable, Scannab
 			Operators.complete(actual);
 			return;
 		}
-		if (n == 1 && a[0] instanceof Fuseable) {
+		if (n == 1) {
 			Function<T, R> f = t -> combiner.apply(new Object[]{t});
-			new FluxMapFuseable<>(from(a[0]), f).subscribe(actual);
-			return;
+			if (a[0] instanceof Fuseable) {
+				new FluxMapFuseable<>(from(a[0]), f).subscribe(actual);
+				return;
+			}
+			else if (!(actual instanceof QueueSubscription)) {
+				new FluxMap<>(from(a[0]), f).subscribe(actual);
+				return;
+			}
 		}
 
 		Queue<SourceAndArray> queue = queueSupplier.get();

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCombineLatest.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCombineLatest.java
@@ -155,14 +155,9 @@ final class FluxCombineLatest<T, R> extends Flux<R> implements Fuseable, Scannab
 			Operators.complete(actual);
 			return;
 		}
-		if (n == 1) {
+		if (n == 1 && a[0] instanceof Fuseable) {
 			Function<T, R> f = t -> combiner.apply(new Object[]{t});
-			if (a[0] instanceof Fuseable) {
-				new FluxMapFuseable<>(from(a[0]), f).subscribe(actual);
-			}
-			else {
-				new FluxMap<>(from(a[0]), f).subscribe(actual);
-			}
+			new FluxMapFuseable<>(from(a[0]), f).subscribe(actual);
 			return;
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCombineLatestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCombineLatestTest.java
@@ -303,4 +303,28 @@ public class FluxCombineLatestTest extends FluxOperatorTest<String, String> {
 		test.cancel();
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
 	}
+
+	@Test
+	public void singleSourceNormal() {
+		List<String> result = Flux.combineLatest(
+				Collections.singletonList(Flux.just(1, 2, 3).hide()),
+				(arr) -> arr[0].toString())
+		                          //the map is Fuseable and sees the combine as fuseable too
+		                          .map(x -> x + "!")
+		                          .collectList()
+		                          .block();
+		assertThat(result).containsExactly("1!", "2!", "3!");
+	}
+
+	@Test
+	public void singleSourceFused() {
+		List<String> result = Flux.combineLatest(
+				Collections.singletonList(Flux.just(1, 2, 3)),
+				(arr) -> arr[0].toString())
+		                          //the map is Fuseable and sees the combine as fuseable too
+		                          .map(x -> x + "!")
+		                          .collectList()
+		                          .block();
+		assertThat(result).containsExactly("1!", "2!", "3!");
+	}
 }


### PR DESCRIPTION
The `ClassCastException` only happens when there is a single source which is NOT `Fuseable` and the operator downstream of `combineLatest` IS `Fuseable`.

This fix only optimizes the single-source case into a `map` when said source is `Fuseable`, degenerating into the coordinator implementation when it is not (thus preventing the class cast down the road).