### PR TITLE
fix #1364 EmitterProcessor SYNC fusion completes too early

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -411,7 +411,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 					if (empty) {
 						//async mode only needs to break but SYNC mode needs to perform terminal cleanup here...
 						if (sourceMode == Fuseable.SYNC) {
-							q.poll();
+							//the q is empty
 							done = true;
 							checkTerminated(true, true);
 						}
@@ -439,10 +439,10 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> {
 				}
 			}
 			else if ( sourceMode == Fuseable.SYNC ) {
-				q.poll();
 				done = true;
-				checkTerminated(true, true);
-				return;
+				if (checkTerminated(true, empty)) { //empty can be true if no subscriber
+					break;
+				}
 			}
 
 			missed = WIP.addAndGet(this, -missed);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -455,7 +455,6 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 						if (empty) {
 							//async mode only needs to break but SYNC mode needs to perform terminal cleanup here...
 							if (sourceMode == Fuseable.SYNC) {
-								q.poll();
 								done = true;
 								checkTerminated(true, true);
 							}
@@ -483,10 +482,10 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 					}
 				}
 				else if (sourceMode == Fuseable.SYNC) {
-					q.poll();
 					done = true;
-					checkTerminated(true, true);
-					return;
+					if (checkTerminated(true, true)) {
+						return;
+					}
 				}
 
 				missed = WIP.addAndGet(this, -missed);

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
-import java.util.stream.Stream;
 
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -46,15 +45,30 @@ import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static reactor.core.Scannable.Attr.CANCELLED;
-import static reactor.core.Scannable.Attr.TERMINATED;
-import static reactor.core.Scannable.Attr.*;
 import static reactor.core.Scannable.Attr;
+import static reactor.core.Scannable.Attr.*;
 
 /**
  * @author Stephane Maldini
  */
 public class EmitterProcessorTest {
+
+	//see https://github.com/reactor/reactor-core/issues/1364
+	@Test
+	public void subscribeWithSyncFusionUpstreamFirst() {
+		EmitterProcessor<String> processor = EmitterProcessor.create(16);
+
+		StepVerifier.create(
+				Mono.just("DATA")
+				    .subscribeWith(processor)
+				    .map(String::toLowerCase)
+		)
+		            .expectNext("data")
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(1));
+
+		assertThat(processor.blockFirst()).as("later subscription").isNull();
+	}
 
 	//see https://github.com/reactor/reactor-core/issues/1290
 	@Test


### PR DESCRIPTION
Also realigned FluxPublish, even though the issue is less likely to
happen because unlike EmitterProcessor typical use case is to connect
AFTER downstream subscriptions have been performed.