### PR TITLE
log() operator swallows unhandled errors

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/SignalLoggerTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SignalLoggerTests.java
@@ -279,6 +279,22 @@ public class SignalLoggerTests {
 		verifyNoMoreInteractions(mockLogger);
 	}
 
+	@Test(expected = UnsupportedOperationException.class)
+	public void loggingDoesNotSwallowUnhandledExceptionsInFlux() {
+		Mono
+				.error(new UnsupportedOperationException())
+//				.log()
+				.subscribe();
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void loggingDoesNotSwallowUnhandledExceptionsInMono() {
+		Flux
+				.error(new UnsupportedOperationException())
+//				.log()
+				.subscribe();
+	}
+
 	private void demonstrateLogError() {
 		Loggers.getLogger("logError.default")
 		       .warn("The following logs should demonstrate similar error output, but respectively at ERROR, DEBUG and TRACE levels");


### PR DESCRIPTION
In synchronous `Flux`/`Mono`, when there is no `error` callback in `subscribe()`, the exception in thrown in the client thread. That's not the case if `log()` operator is used.

If you uncomment `log()` operator, the test fails. The presence of this operator should be absolutely transparent. This PR only provides a test case, it doesn't fix the problem, probably somewhere in `PeekConditionalSubscriber` (?)