### PR TITLE
fix #1385 Fix refCount(Grace)/Share missing repeat/retry re-subscribes

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
@@ -190,14 +190,14 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 
 		@Override
 		public void onError(Throwable t) {
-			actual.onError(t);
 			connection.upstreamFinished();
+			actual.onError(t);
 		}
 
 		@Override
 		public void onComplete() {
-			actual.onComplete();
 			connection.upstreamFinished();
+			actual.onComplete();
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
@@ -209,18 +209,18 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 
 		@Override
 		public void onError(Throwable t) {
-			actual.onError(t);
 			if (PARENT_DONE.compareAndSet(this, 0, 1)) {
 				parent.terminated(connection);
 			}
+			actual.onError(t);
 		}
 
 		@Override
 		public void onComplete() {
-			actual.onComplete();
 			if (PARENT_DONE.compareAndSet(this, 0, 1)) {
 				parent.terminated(connection);
 			}
+			actual.onComplete();
 		}
 
 		@Override

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
@@ -36,9 +36,62 @@ import reactor.test.subscriber.AssertSubscriber;
 import reactor.test.util.RaceTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class FluxRefCountTest {
+
+	//see https://github.com/reactor/reactor-core/issues/1385
+	@Test
+	public void sizeOneCanRetry() {
+		AtomicInteger subCount = new AtomicInteger();
+
+		final Flux<Object> flux = Flux
+				.generate(() -> 0, (i, sink) -> {
+					if (i == 2)
+						sink.error(new RuntimeException("boom on subscribe #" + subCount.get()));
+					else {
+						sink.next(i);
+					}
+					return i + 1;
+				})
+				//we need to test with an async boundary
+				.subscribeOn(Schedulers.parallel())
+				.doOnSubscribe(s -> subCount.incrementAndGet());
+
+		StepVerifier.create(flux.publish()
+		                        .refCount(1)
+		                        .retry(1))
+		            .expectNext(0, 1, 0, 1)
+		            .expectErrorMessage("boom on subscribe #2")
+		            .verify(Duration.ofSeconds(1));
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/1385
+	@Test
+	public void sizeOneCanRepeat() {
+		AtomicInteger subCount = new AtomicInteger();
+
+		final Flux<Object> flux = Flux
+				.generate(() -> 0, (i, sink) -> {
+					if (i == 2)
+						sink.complete();
+					else {
+						sink.next(i);
+					}
+					return i + 1;
+				})
+				//we need to test with an async boundary
+				.subscribeOn(Schedulers.parallel())
+				.doOnSubscribe(s -> subCount.incrementAndGet());
+
+		StepVerifier.create(flux.publish()
+		                        .refCount(1)
+		                        .repeat(2))
+		            .expectNext(0, 1, 0, 1)
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(1));
+
+		assertThat(subCount).hasValue(2);
+	}
 
 	//see https://github.com/reactor/reactor-core/issues/1260
 	@Test


### PR DESCRIPTION
This commit fixes a bug where `FluxRefCount`/`FluxRefCountGrace` (which
is also accessible through the `FLux#share` API) would miss
re-subscriptions from `repeat` or `retry`. This was due to the state of
connection being reset only AFTER the terminal signal was propagated to
the downstream re-subscribing operator, resulting in the re-subscription
being dismissed by the refcount operator.