### PR TITLE
fix #1393 null can be passed to reduce lambda if cancelled, causing NPE

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoReduceSeed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoReduceSeed.java
@@ -114,19 +114,21 @@ final class MonoReduceSeed<T, R> extends MonoFromFluxOperator<T, R>
 
 		@Override
 		public void onNext(T t) {
-			R v;
+			R v = this.value;
+			R accumulated;
 
-			try {
-				v = Objects.requireNonNull(accumulator.apply(value, t),
-						"The accumulator returned a null value");
+			if (v != null) { //value null when cancelled
+				try {
+					accumulated = Objects.requireNonNull(accumulator.apply(v, t),
+							"The accumulator returned a null value");
 
+				}
+				catch (Throwable e) {
+					onError(Operators.onOperatorError(this, e, t, actual.currentContext()));
+					return;
+				}
+				value = accumulated;
 			}
-			catch (Throwable e) {
-				onError(Operators.onOperatorError(this, e, t, actual.currentContext()));
-				return;
-			}
-
-			value = v;
 		}
 
 		@Override

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoReduceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoReduceTest.java
@@ -16,6 +16,7 @@
 
 package reactor.core.publisher;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -30,6 +31,7 @@ import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.publisher.ReduceOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.test.util.RaceTestUtils;
 
 import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -198,6 +200,29 @@ public class MonoReduceTest extends ReduceOperatorTest<String, String>{
 			e.printStackTrace();
 		}
 		return "x" + x + "y" + y;
+	}
+
+	@Test
+	public void onNextAndCancelRace() {
+		List<Integer> list = new ArrayList<>();
+		final AssertSubscriber<Object> testSubscriber = AssertSubscriber.create();
+
+		MonoReduceSeed.ReduceSeedSubscriber<Integer, List<Integer>> sub =
+				new MonoReduceSeed.ReduceSeedSubscriber<>(testSubscriber,
+						(l, next) -> {
+							l.add(next);
+							return l;
+						}, list);
+
+		sub.onSubscribe(Operators.emptySubscription());
+
+		//the race alone _could_ previously produce a NPE
+		RaceTestUtils.race(() -> sub.onNext(1), sub::cancel);
+		testSubscriber.assertNoError();
+
+		//to be even more sure, we try an onNext AFTER the cancel
+		sub.onNext(2);
+		testSubscriber.assertNoError();
 	}
 
 	@Test


### PR DESCRIPTION
This commit fixes a race condition that would result in a null
being passed to the BiFunction of the seeded variant, which could
trigger a NullPointerException depending on said function.

This was due to `cancel()` nulling out the accumulated value / seed,
which was not guarded against in `onNext`.