### PR TITLE
Fixed NPE in ConsoleLogger(JdkLogger)#format

### DIFF
--- a/reactor-core/src/main/java/reactor/util/Loggers.java
+++ b/reactor-core/src/main/java/reactor/util/Loggers.java
@@ -423,7 +423,8 @@ public abstract class Loggers {
 				String computed = from;
 				if (arguments != null && arguments.length != 0) {
 					for (Object argument : arguments) {
-						computed = computed.replaceFirst("\\{\\}", Matcher.quoteReplacement(argument.toString()));
+						computed = computed.replaceFirst("\\{\\}", Matcher.quoteReplacement(
+								argument != null ? argument.toString() : "null"));
 					}
 				}
 				return computed;
@@ -471,7 +472,9 @@ public abstract class Loggers {
 				String computed = from;
 				if (arguments != null && arguments.length != 0) {
 					for (Object argument : arguments) {
-						computed = computed.replaceFirst("\\{\\}", Matcher.quoteReplacement(argument.toString()));
+						computed = computed.replaceFirst("\\{\\}", Matcher.quoteReplacement(
+								argument != null ? argument.toString() : "null"
+						));
 					}
 				}
 				return computed;


### PR DESCRIPTION
When formatting the log message and the argument is `NULL`,
`null` string will be applied as a replacement for `{}`.