### PR TITLE
fix #1403 NullPointerException in some logger format

### DIFF
--- a/reactor-core/src/main/java/reactor/util/Loggers.java
+++ b/reactor-core/src/main/java/reactor/util/Loggers.java
@@ -287,7 +287,7 @@ public abstract class Loggers {
 	/**
 	 * Wrapper over JDK logger
 	 */
-	private static class JdkLogger implements Logger {
+	static final class JdkLogger implements Logger {
 
 		private final java.util.logging.Logger logger;
 
@@ -401,12 +401,12 @@ public abstract class Loggers {
 		}
 
 		@Nullable
-		private String format(@Nullable String from, @Nullable Object... arguments){
+		final String format(@Nullable String from, @Nullable Object... arguments){
 			if(from != null) {
 				String computed = from;
 				if (arguments != null && arguments.length != 0) {
 					for (Object argument : arguments) {
-						computed = computed.replaceFirst("\\{\\}", Matcher.quoteReplacement(argument.toString()));
+						computed = computed.replaceFirst("\\{\\}", Matcher.quoteReplacement(String.valueOf(argument)));
 					}
 				}
 				return computed;
@@ -427,7 +427,7 @@ public abstract class Loggers {
 	 * A {@link Logger} that has all levels enabled. error and warn log to System.err
 	 * while all other levels log to System.out (printstreams can be changed via constructor).
 	 */
-	static class ConsoleLogger implements Logger {
+	static final class ConsoleLogger implements Logger {
 
 		private final String name;
 		private final PrintStream err;
@@ -449,12 +449,12 @@ public abstract class Loggers {
 		}
 
 		@Nullable
-		private String format(@Nullable String from, @Nullable Object... arguments){
+		final String format(@Nullable String from, @Nullable Object... arguments){
 			if(from != null) {
 				String computed = from;
 				if (arguments != null && arguments.length != 0) {
 					for (Object argument : arguments) {
-						computed = computed.replaceFirst("\\{\\}", Matcher.quoteReplacement(argument.toString()));
+						computed = computed.replaceFirst("\\{\\}", Matcher.quoteReplacement(String.valueOf(argument)));
 					}
 				}
 				return computed;

--- a/reactor-core/src/test/java/reactor/util/ConsoleLoggerTest.java
+++ b/reactor-core/src/test/java/reactor/util/ConsoleLoggerTest.java
@@ -78,6 +78,17 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
+	public void traceNulls() {
+		logger.trace("vararg {} is {}", (Object[]) null);
+		logger.trace("param {} is {}", null, null);
+
+		assertThat(errContent.size()).isZero();
+		assertThat(outContent.toString())
+				.contains("vararg {} is {}")
+				.contains("param null is null");
+	}
+
+	@Test
 	public void isDebugEnabled() throws Exception {
 		assertThat(logger.isDebugEnabled()).isTrue();
 	}
@@ -110,6 +121,17 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
+	public void debugNulls() {
+		logger.debug("vararg {} is {}", (Object[]) null);
+		logger.debug("param {} is {}", null, null);
+
+		assertThat(errContent.size()).isZero();
+		assertThat(outContent.toString())
+				.contains("vararg {} is {}")
+				.contains("param null is null");
+	}
+
+	@Test
 	public void isInfoEnabled() throws Exception {
 		assertThat(logger.isInfoEnabled()).isTrue();
 	}
@@ -139,6 +161,17 @@ public class ConsoleLoggerTest {
 				.startsWith("[ INFO] (" + Thread.currentThread().getName() + ") with cause - java.lang.IllegalStateException: cause" +
 						"\njava.lang.IllegalStateException: cause\n" +
 						"\tat reactor.util.ConsoleLoggerTest");
+	}
+
+	@Test
+	public void infoNulls() {
+		logger.info("vararg {} is {}", (Object[]) null);
+		logger.info("param {} is {}", null, null);
+
+		assertThat(errContent.size()).isZero();
+		assertThat(outContent.toString())
+				.contains("vararg {} is {}")
+				.contains("param null is null");
 	}
 
 	@Test
@@ -175,6 +208,17 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
+	public void warnNulls() {
+		logger.warn("vararg {} is {}", (Object[]) null);
+		logger.warn("param {} is {}", null, null);
+
+		assertThat(errContent.toString())
+				.contains("vararg {} is {}")
+				.contains("param null is null");
+		assertThat(outContent.size()).isZero();
+	}
+
+	@Test
 	public void isErrorEnabled() throws Exception {
 		assertThat(logger.isErrorEnabled()).isTrue();
 	}
@@ -204,6 +248,26 @@ public class ConsoleLoggerTest {
 				.startsWith("[ERROR] (" + Thread.currentThread().getName() + ") with cause - java.lang.IllegalStateException: cause" +
 						"\njava.lang.IllegalStateException: cause\n" +
 						"\tat reactor.util.ConsoleLoggerTest");
+	}
+
+	@Test
+	public void errorNulls() {
+		logger.error("vararg {} is {}", (Object[]) null);
+		logger.error("param {} is {}", null, null);
+
+		assertThat(errContent.toString())
+				.contains("vararg {} is {}")
+				.contains("param null is null");
+		assertThat(outContent.size()).isZero();
+	}
+
+	@Test
+	public void formatNull() {
+		logger.info(null, null, null);
+
+		assertThat(errContent.size()).isZero();
+		assertThat(outContent.toString())
+				.isEqualTo("[ INFO] (" + Thread.currentThread().getName() + ") null\n");
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/util/JdkLoggerTest.java
+++ b/reactor-core/src/test/java/reactor/util/JdkLoggerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util;
+
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JdkLoggerTest {
+
+	@Test
+	public void formatNullFormat() {
+		Loggers.JdkLogger jdkLogger = new Loggers.JdkLogger(Mockito.mock(java.util.logging.Logger.class));
+
+		assertThat(jdkLogger.format(null, (Object[]) null))
+				.as("null format should be interpreted as null")
+				.isNull();
+	}
+
+	@Test
+	public void nullFormatIsAcceptedByUnderlyingLogger() {
+		StringBuilder log = new StringBuilder();
+		Logger underlyingLogger = Logger.getAnonymousLogger();
+		underlyingLogger.setLevel(Level.FINEST);
+		underlyingLogger.addHandler(
+				new Handler() {
+					@Override
+					public void publish(LogRecord record) {
+						log.append(record.getMessage());
+					}
+
+					@Override
+					public void flush() { }
+
+					@Override
+					public void close() throws SecurityException { }
+				});
+
+		Loggers.JdkLogger jdkLogger = new Loggers.JdkLogger(underlyingLogger);
+
+		jdkLogger.trace(null, null, null);
+
+		assertThat(log.toString()).isEqualTo("null");
+	}
+
+	@Test
+	public void formatNullVararg() {
+		Loggers.JdkLogger jdkLogger= new Loggers.JdkLogger(Mockito.mock(java.util.logging.Logger.class));
+
+		assertThat(jdkLogger.format("test {} is {}", (Object[]) null))
+				.as("format should be returned as is")
+				.isEqualTo("test {} is {}");
+	}
+
+	@Test
+	public void formatNullParamInVararg() {
+		Loggers.JdkLogger jdkLogger= new Loggers.JdkLogger(Mockito.mock(java.util.logging.Logger.class));
+
+		assertThat(jdkLogger.format("test {} is {}", null, null))
+				.as("placeholders should be replaced by null")
+				.isEqualTo("test null is null");
+	}
+
+}


### PR DESCRIPTION
This commit fixes an NPE triggered by null parameters in format method
of the JDK and Console Logger variants.