### PR TITLE
Generalize Micrometer tagset

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
@@ -236,14 +236,14 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 					.builder(METER_FLOW_DURATION)
 					.tags(commonTags)
 					.tag(TAG_STATUS, TAGVALUE_ON_COMPLETE)
-					.tag(FluxMetrics.TAG_EXCEPTION, "")
+					.tag(TAG_EXCEPTION, "")
 					.description("Times the duration elapsed between a subscription and the onComplete termination of the sequence")
 					.register(registry);
 			this.subscribeToCancelTimer = Timer
 					.builder(METER_FLOW_DURATION)
 					.tags(commonTags)
 					.tag(TAG_STATUS, TAGVALUE_CANCEL)
-					.tag(FluxMetrics.TAG_EXCEPTION, "")
+					.tag(TAG_EXCEPTION, "")
 					.description("Times the duration elapsed between a subscription and the cancellation of the sequence")
 					.register(registry);
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
@@ -230,19 +230,20 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 			List<Tag> commonTags = new ArrayList<>();
 			commonTags.add(Tag.of(TAG_SEQUENCE_NAME, sequenceName));
 			commonTags.add(Tag.of(TAG_SEQUENCE_TYPE, TAGVALUE_FLUX));
-			commonTags.add(Tag.of(TAG_EXCEPTION, ""));
 			commonTags.addAll(sequenceTags);
 
 			this.subscribeToCompleteTimer = Timer
 					.builder(METER_FLOW_DURATION)
 					.tags(commonTags)
 					.tag(TAG_STATUS, TAGVALUE_ON_COMPLETE)
+					.tag(FluxMetrics.TAG_EXCEPTION, "")
 					.description("Times the duration elapsed between a subscription and the onComplete termination of the sequence")
 					.register(registry);
 			this.subscribeToCancelTimer = Timer
 					.builder(METER_FLOW_DURATION)
 					.tags(commonTags)
 					.tag(TAG_STATUS, TAGVALUE_CANCEL)
+					.tag(FluxMetrics.TAG_EXCEPTION, "")
 					.description("Times the duration elapsed between a subscription and the cancellation of the sequence")
 					.register(registry);
 
@@ -372,7 +373,7 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 			//we don't record the time between last onNext and cancel,
 			// because it would skew the onNext count by one
 			this.subscribeToTerminateSample.stop(subscribeToCancelTimer);
-			
+
 			s.cancel();
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import io.micrometer.core.instrument.Clock;
@@ -199,7 +200,6 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 	static class MicrometerFluxMetricsSubscriber<T> implements InnerOperator<T,T> {
 
 		final CoreSubscriber<? super T> actual;
-		final MeterRegistry             registry;
 		final Clock                     clock;
 
 		final Counter             malformedSourceCounter;
@@ -216,7 +216,7 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 
 		final Timer         onNextIntervalTimer;
 		final Timer         subscribeToCompleteTimer;
-		final Timer.Builder subscribeToErrorTimerBuilder;
+		final Function<Throwable, Timer> subscribeToErrorTimerFactory;
 		final Timer         subscribeToCancelTimer;
 
 		MicrometerFluxMetricsSubscriber(CoreSubscriber<? super T> actual,
@@ -225,12 +225,12 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 				String sequenceName,
 				List<Tag> sequenceTags) {
 			this.actual = actual;
-			this.registry = registry;
 			this.clock = clock;
 
 			List<Tag> commonTags = new ArrayList<>();
 			commonTags.add(Tag.of(TAG_SEQUENCE_NAME, sequenceName));
 			commonTags.add(Tag.of(TAG_SEQUENCE_TYPE, TAGVALUE_FLUX));
+			commonTags.add(Tag.of(TAG_EXCEPTION, ""));
 			commonTags.addAll(sequenceTags);
 
 			this.subscribeToCompleteTimer = Timer
@@ -247,11 +247,16 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 					.register(registry);
 
 			//note that Builder ISN'T TRULY IMMUTABLE. This is ok though as there will only ever be one usage.
-			this.subscribeToErrorTimerBuilder = Timer
+			Timer.Builder subscribeToErrorTimerBuilder = Timer
 					.builder(METER_FLOW_DURATION)
 					.tags(commonTags)
 					.tag(TAG_STATUS, TAGVALUE_ON_ERROR)
 					.description("Times the duration elapsed between a subscription and the onError termination of the sequence, with the exception name as a tag");
+			this.subscribeToErrorTimerFactory = e -> {
+				return subscribeToErrorTimerBuilder
+						.tag(TAG_EXCEPTION, e.getClass().getName())
+						.register(registry);
+			};
 
 			this.onNextIntervalTimer = Timer
 					.builder(METER_ON_NEXT_DELAY)
@@ -314,9 +319,7 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 			// because it would skew the onNext count by one
 
 			//register a timer for that particular exception
-			Timer timer = subscribeToErrorTimerBuilder
-					.tag(FluxMetrics.TAG_EXCEPTION, e.getClass().getName())
-					.register(registry);
+			Timer timer = subscribeToErrorTimerFactory.apply(e);
 			//record error termination
 			this.subscribeToTerminateSample.stop(timer);
 
@@ -341,7 +344,7 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 		public void onSubscribe(Subscription s) {
 			if (Operators.validate(this.s, s)) {
 				this.subscribedCounter.increment();
-				this.subscribeToTerminateSample = Timer.start(registry);
+				this.subscribeToTerminateSample = Timer.start(clock);
 				this.lastNextEventNanos = clock.monotonicTime();
 
 				if (s instanceof Fuseable.QueueSubscription) {
@@ -445,9 +448,7 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 				return v;
 			} catch (Throwable e) {
 				//register a timer for that particular exception
-				Timer timer = subscribeToErrorTimerBuilder
-						.tag(FluxMetrics.TAG_EXCEPTION, e.getClass().getName())
-						.register(registry);
+				Timer timer = subscribeToErrorTimerFactory.apply(e);
 				//record error termination
 				this.subscribeToTerminateSample.stop(timer);
 				throw e;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
@@ -107,19 +107,20 @@ final class MonoMetrics<T> extends MonoOperator<T, T> {
 			List<Tag> commonTags = new ArrayList<>();
 			commonTags.add(Tag.of(FluxMetrics.TAG_SEQUENCE_NAME, sequenceName));
 			commonTags.add(Tag.of(FluxMetrics.TAG_SEQUENCE_TYPE, FluxMetrics.TAGVALUE_MONO));
-			commonTags.add(Tag.of(FluxMetrics.TAG_EXCEPTION, ""));
 			commonTags.addAll(sequenceTags);
 
 			this.subscribeToCompleteTimer = Timer
 					.builder(FluxMetrics.METER_FLOW_DURATION)
 					.tags(commonTags)
 					.tag(FluxMetrics.TAG_STATUS, FluxMetrics.TAGVALUE_ON_COMPLETE)
+					.tag(FluxMetrics.TAG_EXCEPTION, "")
 					.description("Times the duration elapsed between a subscription and the onComplete termination of the sequence")
 					.register(registry);
 			this.subscribeToCancelTimer = Timer
 					.builder(FluxMetrics.METER_FLOW_DURATION)
 					.tags(commonTags)
 					.tag(FluxMetrics.TAG_STATUS, FluxMetrics.TAGVALUE_CANCEL)
+					.tag(FluxMetrics.TAG_EXCEPTION, "")
 					.description("Times the duration elapsed between a subscription and the cancellation of the sequence")
 					.register(registry);
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
@@ -79,7 +80,6 @@ final class MonoMetrics<T> extends MonoOperator<T, T> {
 	static class MicrometerMonoMetricsSubscriber<T> implements InnerOperator<T,T> {
 
 		final CoreSubscriber<? super T> actual;
-		final MeterRegistry             registry;
 		final Clock                     clock;
 
 		final Counter             malformedSourceCounter;
@@ -93,8 +93,8 @@ final class MonoMetrics<T> extends MonoOperator<T, T> {
 		Subscription s;
 
 		final Timer         subscribeToCompleteTimer;
-		final Timer.Builder subscribeToErrorTimerBuilder;
 		final Timer         subscribeToCancelTimer;
+		final Function<Throwable, Timer> subscribeToErrorTimerFactory;
 
 		MicrometerMonoMetricsSubscriber(CoreSubscriber<? super T> actual,
 				MeterRegistry registry,
@@ -102,12 +102,12 @@ final class MonoMetrics<T> extends MonoOperator<T, T> {
 				String sequenceName,
 				List<Tag> sequenceTags) {
 			this.actual = actual;
-			this.registry = registry;
 			this.clock = clock;
 
 			List<Tag> commonTags = new ArrayList<>();
 			commonTags.add(Tag.of(FluxMetrics.TAG_SEQUENCE_NAME, sequenceName));
 			commonTags.add(Tag.of(FluxMetrics.TAG_SEQUENCE_TYPE, FluxMetrics.TAGVALUE_MONO));
+			commonTags.add(Tag.of(FluxMetrics.TAG_EXCEPTION, ""));
 			commonTags.addAll(sequenceTags);
 
 			this.subscribeToCompleteTimer = Timer
@@ -124,11 +124,16 @@ final class MonoMetrics<T> extends MonoOperator<T, T> {
 					.register(registry);
 
 			//note that Builder ISN'T TRULY IMMUTABLE. This is ok though as there will only ever be one usage.
-			this.subscribeToErrorTimerBuilder = Timer
+			Timer.Builder subscribeToErrorTimerBuilder = Timer
 					.builder(FluxMetrics.METER_FLOW_DURATION)
 					.tags(commonTags)
 					.tag(FluxMetrics.TAG_STATUS, FluxMetrics.TAGVALUE_ON_ERROR)
 					.description("Times the duration elapsed between a subscription and the onError termination of the sequence, with the exception name as a tag.");
+			this.subscribeToErrorTimerFactory = e -> {
+				return subscribeToErrorTimerBuilder
+						.tag(FluxMetrics.TAG_EXCEPTION, e.getClass().getName())
+						.register(registry);
+			};
 
 			this.subscribedCounter = Counter
 					.builder(FluxMetrics.METER_SUBSCRIBED)
@@ -165,9 +170,7 @@ final class MonoMetrics<T> extends MonoOperator<T, T> {
 			}
 			done = true;
 			//register a timer for that particular exception
-			Timer timer = subscribeToErrorTimerBuilder
-					.tag(FluxMetrics.TAG_EXCEPTION, e.getClass().getName())
-					.register(registry);
+			Timer timer = subscribeToErrorTimerFactory.apply(e);
 			//record error termination
 			this.subscribeToTerminateSample.stop(timer);
 
@@ -190,7 +193,7 @@ final class MonoMetrics<T> extends MonoOperator<T, T> {
 		public void onSubscribe(Subscription s) {
 			if (Operators.validate(this.s, s)) {
 				this.subscribedCounter.increment();
-				this.subscribeToTerminateSample = Timer.start(registry);
+				this.subscribeToTerminateSample = Timer.start(clock);
 
 				if (s instanceof Fuseable.QueueSubscription) {
 					//noinspection unchecked
@@ -270,9 +273,7 @@ final class MonoMetrics<T> extends MonoOperator<T, T> {
 				return v;
 			} catch (Throwable e) {
 				//register a timer for that particular exception
-				Timer timer = subscribeToErrorTimerBuilder
-						.tag(FluxMetrics.TAG_EXCEPTION, e.getClass().getName())
-						.register(registry);
+				Timer timer = subscribeToErrorTimerFactory.apply(e);
 				//record error termination
 				this.subscribeToTerminateSample.stop(timer);
 				throw e;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsTest.java
@@ -38,8 +38,8 @@ import reactor.core.Scannable;
 import reactor.test.publisher.TestPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static reactor.test.publisher.TestPublisher.Violation.CLEANUP_ON_TERMINATE;
 import static reactor.core.publisher.FluxMetrics.*;
+import static reactor.test.publisher.TestPublisher.Violation.CLEANUP_ON_TERMINATE;
 
 public class FluxMetricsTest {
 
@@ -458,8 +458,16 @@ public class FluxMetricsTest {
 	//see https://github.com/reactor/reactor-core/issues/1425
 	@Test
 	public void commonTagSet() {
-		new FluxMetrics<>(Flux.just(1).name("normal"), registry).blockLast();
-		new FluxMetrics<>(Flux.error(new IllegalStateException("dummy")).name("error"), registry)
+		Flux<Integer> source1 = Flux.just(1)
+		                            .name("normal")
+		                            .hide();
+		Flux<Object> source2 = Flux.error(new IllegalStateException("dummy"))
+		                           .name("error")
+		                           .hide();
+
+		new FluxMetrics<>(source1, registry)
+				.blockLast();
+		new FluxMetrics<>(source2, registry)
 				.onErrorReturn(0)
 				.blockLast();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsTest.java
@@ -457,7 +457,7 @@ public class FluxMetricsTest {
 
 	//see https://github.com/reactor/reactor-core/issues/1425
 	@Test
-	public void commonTagSet() {
+	public void flowDurationTagsConsistency() {
 		Flux<Integer> source1 = Flux.just(1)
 		                            .name("normal")
 		                            .hide();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsTest.java
@@ -17,12 +17,15 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.assertj.core.api.SoftAssertions;
@@ -381,6 +384,25 @@ public class MonoMetricsTest {
 		                .summary();
 
 		assertThat(meter).as("tagged find").isNull();
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/1425
+	@Test
+	public void commonTagSet() {
+		new MonoMetrics<>(Mono.just(1).name("normal"), registry).block();
+		new MonoMetrics<>(Mono.error(new IllegalStateException("dummy")).name("error"), registry)
+				.onErrorReturn(0)
+				.block();
+
+		Set<Set<String>> uniqueTagKeySets = registry
+				.find(METER_FLOW_DURATION)
+				.meters()
+				.stream()
+				.map(it -> it.getId().getTags())
+				.map(it -> it.stream().map(Tag::getKey).collect(Collectors.toSet()))
+				.collect(Collectors.toSet());
+
+		assertThat(uniqueTagKeySets).hasSize(1);
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsTest.java
@@ -388,7 +388,7 @@ public class MonoMetricsTest {
 
 	//see https://github.com/reactor/reactor-core/issues/1425
 	@Test
-	public void commonTagSet() {
+	public void flowDurationTagsConsistency() {
 		Mono<Integer> source1 = Mono.just(1)
 		                            .name("normal")
 		                            .hide();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsTest.java
@@ -389,8 +389,16 @@ public class MonoMetricsTest {
 	//see https://github.com/reactor/reactor-core/issues/1425
 	@Test
 	public void commonTagSet() {
-		new MonoMetrics<>(Mono.just(1).name("normal"), registry).block();
-		new MonoMetrics<>(Mono.error(new IllegalStateException("dummy")).name("error"), registry)
+		Mono<Integer> source1 = Mono.just(1)
+		                            .name("normal")
+		                            .hide();
+		Mono<Object> source2 = Mono.error(new IllegalStateException("dummy"))
+		                           .name("error")
+		                           .hide();
+
+		new MonoMetrics<>(source1, registry)
+				.block();
+		new MonoMetrics<>(source2, registry)
 				.onErrorReturn(0)
 				.block();
 


### PR DESCRIPTION
Changes in this PR:
1) moved tag management to one place
2) Added `exception=''` to every `METER_FLOW_DURATION` metric (actual fix)
3) Added tests for both Mono & Flux