### PR TITLE
Fix typo "Hook" instead of "Hooks" (#1420)

### DIFF
--- a/docs/asciidoc/debugging.adoc
+++ b/docs/asciidoc/debugging.adoc
@@ -99,7 +99,7 @@ bit of experience, we can see that it is not ideal by itself in more advanced ca
 Fortunately, Reactor comes with a debugging-oriented capability of
 *assembly-time instrumentation*.
 
-This is done by customizing the `Hook.onOperator` hook *at application start* (or at
+This is done by customizing the `Hooks.onOperator` hook *at application start* (or at
 least before the incriminated `Flux` or `Mono` can be instantiated), as follows:
 [source,java]
 ----


### PR DESCRIPTION
Found a typo in the "[Activating Debug Mode](https://projectreactor.io/docs/core/release/reference/#debug-activate)" section  of the documentation.