### PR TITLE
Fix flaky `distinctUntilChanged*DoesntRetainObjects` tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -292,7 +292,8 @@ project('reactor-core') {
 			"org.assertj:assertj-core:$assertJVersion",
 			"org.mockito:mockito-core:$mockitoVersion",
 			"org.openjdk.jol:jol-core:0.9",
-			"pl.pragmatists:JUnitParams:$jUnitParamsVersion"
+			"pl.pragmatists:JUnitParams:$jUnitParamsVersion",
+			"org.awaitility:awaitility:3.1.2"
 
 	if ("$compatibleVersion" != "SKIP") {
 	  baseline("io.projectreactor:reactor-core:$compatibleVersion") {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
@@ -30,7 +30,6 @@ import reactor.core.Scannable;
 import reactor.core.publisher.FluxDistinctTest.DistinctDefault;
 import reactor.core.publisher.FluxDistinctTest.DistinctDefaultCancel;
 import reactor.core.publisher.FluxDistinctTest.DistinctDefaultError;
-import reactor.test.MemoryUtils;
 import reactor.test.MemoryUtils.RetainedDetector;
 import reactor.test.MockUtils;
 import reactor.test.StepVerifier;
@@ -38,6 +37,7 @@ import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 public class FluxDistinctUntilChangedTest extends FluxOperatorTest<String, String> {
 
@@ -305,11 +305,11 @@ public class FluxDistinctUntilChangedTest extends FluxOperatorTest<String, Strin
 		            .verifyComplete();
 
 		System.gc();
-		Thread.sleep(500);
-
-		assertThat(retainedDetector.finalizedCount())
-				.as("none retained")
-				.isEqualTo(100);
+		await().untilAsserted(() -> {
+			assertThat(retainedDetector.finalizedCount())
+					.as("none retained")
+					.isEqualTo(100);
+		});
 	}
 
 	@Test
@@ -325,11 +325,11 @@ public class FluxDistinctUntilChangedTest extends FluxOperatorTest<String, Strin
 		            .verifyErrorMessage("boom");
 
 		System.gc();
-		Thread.sleep(500);
-
-		assertThat(retainedDetector.finalizedCount())
-				.as("none retained after error")
-				.isEqualTo(100);
+		await().untilAsserted(() -> {
+			assertThat(retainedDetector.finalizedCount())
+					.as("none retained after error")
+					.isEqualTo(100);
+		});
 	}
 
 	@Test
@@ -346,11 +346,11 @@ public class FluxDistinctUntilChangedTest extends FluxOperatorTest<String, Strin
 		            .verifyComplete();
 
 		System.gc();
-		Thread.sleep(500);
-
-		assertThat(retainedDetector.finalizedCount())
-				.as("none retained after cancel")
-				.isEqualTo(50);
+		await().untilAsserted(() -> {
+			assertThat(retainedDetector.finalizedCount())
+					.as("none retained after cancel")
+					.isEqualTo(50);
+		});
 	}
 
 }


### PR DESCRIPTION
This PR introduces Awaitility and changes `distinctUntilChanged*DoesntRetainObjects` to make a few assertion attempts instead of just one after `Thread.sleep`