### PR TITLE
fix issue with `onBackpressureLatest`

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureLatest.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureLatest.java
@@ -183,7 +183,7 @@ final class FluxOnBackpressureLatest<T> extends FluxOperator<T, T> {
 				}
 
 				if (e != 0L && r != Long.MAX_VALUE) {
-					Operators.produced(REQUESTED, this, 1);
+					Operators.produced(REQUESTED, this, e);
 				}
 
 				missed = WIP.addAndGet(this, -missed);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureLatestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureLatestTest.java
@@ -19,7 +19,9 @@ package reactor.core.publisher;
 import org.junit.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
 import reactor.core.Scannable;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,6 +40,28 @@ public class FluxOnBackpressureLatestTest {
 		Flux.range(1, 10).onBackpressureLatest().subscribe(ts);
 
 		ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+		  .assertNoError()
+		  .assertComplete();
+	}
+
+	@Test
+	public void backpressuredComplex() {
+		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
+
+		Flux.range(1, 10000000)
+		    .subscribeOn(Schedulers.parallel())
+		    .onBackpressureLatest()
+		    .publishOn(Schedulers.single())
+		    .concatMap(Mono::just, 1)
+		    .subscribe(ts);
+
+		for (int i = 0; i < 1000000; i++) {
+			ts.request(10);
+		}
+
+		ts.await();
+
+		ts
 		  .assertNoError()
 		  .assertComplete();
 	}


### PR DESCRIPTION
This PR fixes an issue in `onBackpressureLast` operator which exposes as incorrect backpressure control. For more information see the provided test