### PR TITLE
make `expectAccessibleContext` work with `initialContext` from `StepVerifier`

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/ContextTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ContextTests.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 import reactor.test.StepVerifier;
+import reactor.test.StepVerifierOptions;
 import reactor.util.context.Context;
 
 import static org.hamcrest.Matchers.is;
@@ -249,6 +250,46 @@ public class ContextTests {
 				    .subscriberContext(Context.empty())
 		)
 		            .expectNextMatches(Context::isEmpty)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void expectAccessibleContextWithInitialContext() {
+		StepVerifierOptions stepVerifierOptions = StepVerifierOptions.create()
+		                                                             .withInitialContext(Context.of("foo", "bar"));
+
+		StepVerifier.create(Mono.just(1), stepVerifierOptions)
+		            .expectAccessibleContext()
+		            .contains("foo", "bar")
+		            .then()
+		            .expectNext(1)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void contextAccessibleWithEmptySubscriptionAndOperator1() {
+		StepVerifier.create(Flux.empty()
+		                        .subscriberContext(Context.of("a", "b")))
+		            .expectAccessibleContext()
+		            .contains("a", "b")
+		            .then()
+		            .verifyComplete();
+	}
+
+	@Test
+	public void contextAccessibleWithEmptySubscriptionAndOperator2() {
+		StepVerifier.create(Flux.empty()
+		                        .map(i -> i), StepVerifierOptions.create().withInitialContext(Context.of("a", "b")))
+		            .expectAccessibleContext()
+		            .contains("a", "b")
+		            .then()
+		            .verifyComplete();
+	}
+
+	@Test
+	public void contextNotAccessibleWithEmptySubscriptionOnly() {
+		StepVerifier.create(Flux.empty(), StepVerifierOptions.create().withInitialContext(Context.of("a", "b")))
+		            .expectNoAccessibleContext()
 		            .verifyComplete();
 	}
 }

--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -53,6 +53,7 @@ import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
+import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;
 import reactor.core.publisher.Signal;
 import reactor.test.scheduler.VirtualTimeScheduler;
@@ -2278,13 +2279,28 @@ final class DefaultStepVerifierBuilder<T>
 		@Override
 		public StepVerifier.Step<T> then() {
 			return step.consumeSubscriptionWith(s -> {
+				//the current subscription
 				Scannable lowest = Scannable.from(s);
-				Scannable verifierSubscriber = Scannable.from(lowest.scan(Scannable.Attr.ACTUAL));
 
-				Context c = Flux.fromStream(verifierSubscriber.parents())
+				//attempt to go back to the leftmost parent to check the Context from its perspective
+				Context c = Flux.<Scannable>
+						fromStream(lowest.parents())
 						.ofType(CoreSubscriber.class)
+						.takeLast(1)
+						.singleOrEmpty()
+						//no parent? must be a ScalaSubscription or similar source
+						.switchIfEmpty(
+								Mono.just(lowest)
+								    //unless it is directly a CoreSubscriber, let's try to scan the leftmost, see if it has an ACTUAL
+								    .map(sc -> (sc instanceof CoreSubscriber) ?
+										    sc :
+										    sc.scanOrDefault(Scannable.Attr.ACTUAL, Scannable.from(null)))
+								    //we are ultimately only interested in CoreSubscribers' Context
+								    .ofType(CoreSubscriber.class)
+						)
 						.map(CoreSubscriber::currentContext)
-						.blockLast();
+						//if it wasn't a CoreSubscriber (eg. custom or vanilla Subscriber) there won't be a Context
+						.block();
 
 				this.contextExpectations.accept(c);
 			});

--- a/reactor-test/src/test/java/reactor/test/DefaultContextExpectationsTest.java
+++ b/reactor-test/src/test/java/reactor/test/DefaultContextExpectationsTest.java
@@ -25,6 +25,8 @@ import java.util.function.Function;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ThrowableAssertAlternative;
 import org.junit.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
 import reactor.core.publisher.Flux;
 import reactor.test.DefaultStepVerifierBuilder.DefaultContextExpectations;
 import reactor.test.StepVerifier.ContextExpectations;
@@ -81,8 +83,24 @@ public class DefaultContextExpectationsTest {
 	}
 
 	@Test
-	public void notContextAccessible() {
-		assertContextExpectationFails(s -> s, e -> e)
+	public void notContextAccessibleDueToPublisher() {
+		Publisher<Integer> publisher = subscriber -> subscriber.onSubscribe(new Subscription() {
+			@Override
+			public void request(long l) {
+				subscriber.onComplete();
+			}
+
+			@Override
+			public void cancel() {
+				//NO-OP
+			}
+		});
+
+		Step<Integer> step = StepVerifier.create(publisher);
+		DefaultContextExpectations<Integer> expectations = new DefaultContextExpectations<>(step);
+
+		assertThatExceptionOfType(AssertionError.class)
+				.isThrownBy(() -> expectations.then().verifyComplete())
 				.withMessage("No propagated Context");
 	}
 


### PR DESCRIPTION
See #1434 