### PR TITLE
Fix #1421 clarify order guarantees of `Scheduler#createWorker`

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -15,6 +15,7 @@
  */
 package reactor.core.scheduler;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -101,15 +102,19 @@ public interface Scheduler extends Disposable {
 	}
 	
 	/**
-	 * Creates a worker of this Scheduler that executed task in a strict
-	 * FIFO order, guaranteed non-concurrently with each other.
+	 * Creates a worker of this Scheduler.
 	 * <p>
 	 * Once the Worker is no longer in use, one should call dispose() on it to
 	 * release any resources the particular Scheduler may have used.
 	 * 
-	 * <p>Tasks scheduled with this worker run in FIFO order and strictly non-concurrently, but
-	 * there are no ordering guarantees between different Workers created from the same
-	 * Scheduler.
+	 * <p>Tasks scheduled with this worker are not guaranteed to run in FIFO order and
+	 * strictly non-concurrently.
+	 *
+	 * In its simplest form, worker will purely delegate schedule(Runnable)
+	 * to the {@link ExecutorService#execute} method.
+	 *
+	 * If FIFO order is desired, use trampoline parameter of {@link Schedulers#fromExecutor(Executor, boolean)}
+	 *
 	 * 
 	 * @return the Worker instance.
 	 */

--- a/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -112,7 +112,7 @@ public interface Scheduler extends Disposable {
 	 *
 	 * It depends on the implementation, but Scheduler Workers should usually run tasks in
 	 * FIFO order. Some implementations may entirely delegate the scheduling to an
-	 * underlying structure (like an {@link ExecutorService}`).
+	 * underlying structure (like an {@link ExecutorService}).
 	 *
 	 * If FIFO order is desired, use trampoline parameter of {@link Schedulers#fromExecutor(Executor, boolean)}
 	 *

--- a/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -106,15 +106,10 @@ public interface Scheduler extends Disposable {
 	 * <p>
 	 * Once the Worker is no longer in use, one should call dispose() on it to
 	 * release any resources the particular Scheduler may have used.
-	 * 
-	 * <p>Tasks scheduled with this worker are not guaranteed to run in FIFO order and
-	 * strictly non-concurrently.
 	 *
 	 * It depends on the implementation, but Scheduler Workers should usually run tasks in
 	 * FIFO order. Some implementations may entirely delegate the scheduling to an
 	 * underlying structure (like an {@link ExecutorService}).
-	 *
-	 * If FIFO order is desired, use trampoline parameter of {@link Schedulers#fromExecutor(Executor, boolean)}
 	 *
 	 * @return the Worker instance.
 	 */

--- a/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -110,12 +110,12 @@ public interface Scheduler extends Disposable {
 	 * <p>Tasks scheduled with this worker are not guaranteed to run in FIFO order and
 	 * strictly non-concurrently.
 	 *
-	 * In its simplest form, worker will purely delegate schedule(Runnable)
-	 * to the {@link ExecutorService#execute} method.
+	 * It depends on the implementation, but Scheduler Workers should usually run tasks in
+	 * FIFO order. Some implementations may entirely delegate the scheduling to an
+	 * underlying structure (like an {@link ExecutorService}`).
 	 *
 	 * If FIFO order is desired, use trampoline parameter of {@link Schedulers#fromExecutor(Executor, boolean)}
 	 *
-	 * 
 	 * @return the Worker instance.
 	 */
 	Worker createWorker();
@@ -146,8 +146,7 @@ public interface Scheduler extends Disposable {
 	}
 
 	/**
-	 * A worker representing an asynchronous boundary that executes tasks in
-	 * a FIFO order, guaranteed non-concurrently with respect to each other.
+	 * A worker representing an asynchronous boundary that executes tasks.
 	 *
 	 * @author Stephane Maldini
 	 * @author Simon Baslé

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -74,6 +74,10 @@ public abstract class Schedulers {
 	 * Create a {@link Scheduler} which uses a backing {@link Executor} to schedule
 	 * Runnables for async operators.
 	 *
+	 * <p>Tasks scheduled with workers of this Scheduler are not guaranteed to run in FIFO
+	 * order and strictly non-concurrently.
+	 * If FIFO order is desired, use trampoline parameter of {@link Schedulers#fromExecutor(Executor, boolean)}
+	 *
 	 * @param executor an {@link Executor}
 	 *
 	 * @return a new {@link Scheduler}

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -86,6 +86,10 @@ public abstract class Schedulers {
 	 * Create a {@link Scheduler} which uses a backing {@link Executor} to schedule
 	 * Runnables for async operators.
 	 *
+	 * Trampolining here means tasks submitted in a burst are queued by the Worker itself,
+	 * which acts as a sole task from the perspective of the {@link ExecutorService},
+	 * so no reordering (but also no threading).
+	 *
 	 * @param executor an {@link Executor}
 	 * @param trampoline set to false if this {@link Scheduler} is used by "operators"
 	 * that already conflate {@link Runnable} executions (publishOn, subscribeOn...)


### PR DESCRIPTION
Since the FIFO order is not enforced by `Scheduler` interface,
I've changed the JavaDoc of `createWorker` method to reflect it and
also added a description of trampolining to `Schedulers#fromExecutor`