### PR TITLE
fix #1453 Converted eager toString call from index operator to lazy

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxIndex.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxIndex.java
@@ -90,7 +90,7 @@ final class FluxIndex<T, I> extends FluxOperator<T, I> {
 			long i = this.index;
 			try {
 				I typedIndex = Objects.requireNonNull(indexMapper.apply(i, t),
-						"indexMapper returned a null value at raw index " + i +
+						() -> "indexMapper returned a null value at raw index " + i +
 								" for value " + t);
 				this.index = i + 1L;
 				actual.onNext(typedIndex);
@@ -183,7 +183,7 @@ final class FluxIndex<T, I> extends FluxOperator<T, I> {
 			long i = this.index;
 			try {
 				typedIndex = Objects.requireNonNull(indexMapper.apply(i, t),
-						"indexMapper returned a null value at raw index " + i +
+						() -> "indexMapper returned a null value at raw index " + i +
 								" for value " + t);
 				this.index = i + 1L;
 			}
@@ -205,7 +205,7 @@ final class FluxIndex<T, I> extends FluxOperator<T, I> {
 			long i = this.index;
 			try {
 				I typedIndex = Objects.requireNonNull(indexMapper.apply(i, t),
-						"indexMapper returned a null value at raw index " + i +
+						() -> "indexMapper returned a null value at raw index " + i +
 								" for value " + t);
 				this.index = i + 1L;
 				actual.onNext(typedIndex);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxIndex.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxIndex.java
@@ -41,7 +41,8 @@ final class FluxIndex<T, I> extends FluxOperator<T, I> {
 	FluxIndex(Flux<T> source,
 			BiFunction<? super Long, ? super T, ? extends I> indexMapper) {
 		super(source);
-		this.indexMapper = Objects.requireNonNull(indexMapper, "indexMapper must be non null");
+		this.indexMapper = new NullSafeIndexMapper(Objects.requireNonNull(indexMapper,
+				"indexMapper must be non null"));
 	}
 
 	@Override
@@ -89,9 +90,7 @@ final class FluxIndex<T, I> extends FluxOperator<T, I> {
 
 			long i = this.index;
 			try {
-				I typedIndex = Objects.requireNonNull(indexMapper.apply(i, t),
-						() -> "indexMapper returned a null value at raw index " + i +
-								" for value " + t);
+				I typedIndex = indexMapper.apply(i, t);
 				this.index = i + 1L;
 				actual.onNext(typedIndex);
 			}
@@ -182,9 +181,7 @@ final class FluxIndex<T, I> extends FluxOperator<T, I> {
 			I typedIndex;
 			long i = this.index;
 			try {
-				typedIndex = Objects.requireNonNull(indexMapper.apply(i, t),
-						() -> "indexMapper returned a null value at raw index " + i +
-								" for value " + t);
+				typedIndex = indexMapper.apply(i, t);
 				this.index = i + 1L;
 			}
 			catch (Throwable e) {
@@ -204,9 +201,7 @@ final class FluxIndex<T, I> extends FluxOperator<T, I> {
 
 			long i = this.index;
 			try {
-				I typedIndex = Objects.requireNonNull(indexMapper.apply(i, t),
-						() -> "indexMapper returned a null value at raw index " + i +
-								" for value " + t);
+				I typedIndex = indexMapper.apply(i, t);
 				this.index = i + 1L;
 				actual.onNext(typedIndex);
 			}
@@ -262,4 +257,22 @@ final class FluxIndex<T, I> extends FluxOperator<T, I> {
 		}
 	}
 
+	private class NullSafeIndexMapper implements BiFunction<Long, T, I> {
+
+		private final BiFunction<? super Long, ? super T, ? extends I> indexMapper;
+
+		public NullSafeIndexMapper(BiFunction<? super Long, ? super T, ? extends I> indexMapper) {
+			this.indexMapper = indexMapper;
+		}
+
+		@Override
+		public I apply(Long i, T t) {
+			I typedIndex = indexMapper.apply(i, t);
+			if (typedIndex == null) {
+				throw new NullPointerException("indexMapper returned a null value" +
+						" at raw index " + i + " for value " + t);
+			}
+			return typedIndex;
+		}
+	}
 }


### PR DESCRIPTION
Due to use of `Objects.requireNonNull(Object, String)` varaiant, toString for each element that was passing through the operator was evaluated eagerly. 
Rather than using Supplier<String> variant of Objects.requireNonNull() which would have created Supplier instances unnecessarily, used traditional null check. As the check for null safe index mapping was repeated thrice in FluxIndex, created a NullSafeIndexMapper class which wraps actual indexMapper and provides null safe check. NullSafeIndexMapper instance is created once from the constructor.