### PR TITLE
Add an (untyped) way to choose a default MeterRegistry

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
@@ -27,16 +27,17 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
+
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.util.Logger;
 import reactor.util.Loggers;
+import reactor.util.Metrics;
 import reactor.util.annotation.Nullable;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
@@ -183,7 +184,7 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 		this.tags = nameAndTags.getT2();
 
 		if (registry == null) {
-			this.registryCandidate = Metrics.globalRegistry;
+			this.registryCandidate = (MeterRegistry) Metrics.getUnsafeRegistry();
 		}
 		else {
 			this.registryCandidate = registry;

--- a/reactor-core/src/main/java/reactor/util/Metrics.java
+++ b/reactor-core/src/main/java/reactor/util/Metrics.java
@@ -44,8 +44,9 @@ public class Metrics {
 		isMicrometerAvailable = micrometer;
 	}
 
+	//intentionally an Object, so that even with eager loading of fields this won't blow up in NoClassDefFoundError
 	@Nullable
-	private static MeterRegistry defaultRegistry;
+	private static Object defaultRegistry;
 
 	/**
 	 * Check if the current runtime supports metrics / instrumentation, by
@@ -57,20 +58,42 @@ public class Metrics {
 		return isMicrometerAvailable;
 	}
 
+	/**
+	 * Attempt to set up a custom default meter registry for the case where {@link #isInstrumentationAvailable()}.
+	 * <p>
+	 * To avoid referring to micrometer classes, this method takes an arbitrary {@link Object},
+	 * and is thus type-unsafe. The candidate is only accepted if it is a suitable {@code MeterRegistry},
+	 * provided instrumentation is indeed available. Otherwise it is ignored and this method
+	 * returns false.
+	 *
+	 * @param registryCandidate the candidate {@link Object} to set up as meter registry.
+	 * Use {@literal null} to reset.
+	 * @return true if the candidate was accepted, false otherwise.
+	 */
 	public static final boolean setUnsafeRegistry(@Nullable Object registryCandidate) {
 		if (isMicrometerAvailable) {
 			if (registryCandidate == null || registryCandidate instanceof MeterRegistry) {
-				defaultRegistry = (MeterRegistry) registryCandidate;
+				defaultRegistry = registryCandidate;
 				return true;
 			}
 		}
 		return false;
 	}
 
+	/**
+	 * Returns a meter registry IF {@link #isInstrumentationAvailable()} (either the global
+	 * one or a suitable registry that has been set via {@link #setUnsafeRegistry(Object)}),
+	 * or null otherwise. If the value is not null, it can always be casted to a {@code MeterRegistry}.
+	 * <p>
+	 * To avoid referring to micrometer classes, this method returns an {@link Object}, and
+	 * is thus type-unsafe.
+	 *
+	 * @return an {@link Object} that is a suitable default meter registry if relevant, null otherwise.
+	 */
 	@Nullable
 	public static final Object getUnsafeRegistry() {
 		if (isMicrometerAvailable) {
-			return defaultRegistry == null ? globalRegistry : defaultRegistry;
+			return defaultRegistry != null ? defaultRegistry : globalRegistry;
 		}
 		return null;
 	}

--- a/reactor-core/src/main/java/reactor/util/Metrics.java
+++ b/reactor-core/src/main/java/reactor/util/Metrics.java
@@ -16,6 +16,10 @@
 
 package reactor.util;
 
+import io.micrometer.core.instrument.MeterRegistry;
+
+import reactor.util.annotation.Nullable;
+
 import static io.micrometer.core.instrument.Metrics.globalRegistry;
 
 /**
@@ -24,6 +28,7 @@ import static io.micrometer.core.instrument.Metrics.globalRegistry;
  * @author Simon Baslé
  */
 public class Metrics {
+
 
 	static final boolean isMicrometerAvailable;
 
@@ -39,6 +44,9 @@ public class Metrics {
 		isMicrometerAvailable = micrometer;
 	}
 
+	@Nullable
+	private static MeterRegistry defaultRegistry;
+
 	/**
 	 * Check if the current runtime supports metrics / instrumentation, by
 	 * verifying if Micrometer is on the classpath.
@@ -49,4 +57,21 @@ public class Metrics {
 		return isMicrometerAvailable;
 	}
 
+	public static final boolean setUnsafeRegistry(@Nullable Object registryCandidate) {
+		if (isMicrometerAvailable) {
+			if (registryCandidate == null || registryCandidate instanceof MeterRegistry) {
+				defaultRegistry = (MeterRegistry) registryCandidate;
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Nullable
+	public static final Object getUnsafeRegistry() {
+		if (isMicrometerAvailable) {
+			return defaultRegistry == null ? globalRegistry : defaultRegistry;
+		}
+		return null;
+	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsFuseableTest.java
@@ -231,6 +231,25 @@ public class FluxMetricsFuseableTest {
 	}
 
 	@Test
+	public void testUsesCustomizedDefaultRegistryFuseable() {
+		SimpleMeterRegistry otherRegistry = new SimpleMeterRegistry();
+		reactor.util.Metrics.setUnsafeRegistry(otherRegistry);
+		try {
+			assertThat(otherRegistry.getMeters()).isEmpty();
+
+			Flux.just(1, 2)
+			    .metrics()
+			    .subscribe();
+
+			assertThat(otherRegistry.getMeters()).as("registered meters on default registry").isNotEmpty();
+		}
+		finally {
+			reactor.util.Metrics.setUnsafeRegistry(null);
+			otherRegistry.close();
+		}
+	}
+
+	@Test
 	public void splitMetricsOnNameFuseable() {
 		final Flux<Integer> unnamedSource = Flux.just(0).map(v -> 100 / v);
 		final Flux<Integer> namedSource = Flux.range(1, 40)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsTest.java
@@ -104,6 +104,26 @@ public class FluxMetricsTest {
 	}
 
 	@Test
+	public void testUsesCustomizedDefaultRegistry() {
+		SimpleMeterRegistry otherRegistry = new SimpleMeterRegistry();
+		reactor.util.Metrics.setUnsafeRegistry(otherRegistry);
+		try {
+			assertThat(otherRegistry.getMeters()).isEmpty();
+
+			Flux.just(1, 2)
+			    .hide()
+			    .metrics()
+			    .subscribe();
+
+			assertThat(otherRegistry.getMeters()).as("registered meters on default registry").isNotEmpty();
+		}
+		finally {
+			reactor.util.Metrics.setUnsafeRegistry(null);
+			otherRegistry.close();
+		}
+	}
+
+	@Test
 	public void splitMetricsOnName() {
 		final Flux<Integer> unnamedSource = Flux.<Integer>error(new ArithmeticException("boom"))
 				.hide();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsFuseableTest.java
@@ -234,6 +234,25 @@ public class MonoMetricsFuseableTest {
 	}
 
 	@Test
+	public void testUsesCustomizedDefaultRegistryFuseable() {
+		SimpleMeterRegistry otherRegistry = new SimpleMeterRegistry();
+		reactor.util.Metrics.setUnsafeRegistry(otherRegistry);
+		try {
+			assertThat(otherRegistry.getMeters()).isEmpty();
+
+			Mono.just(1)
+			    .metrics()
+			    .subscribe();
+
+			assertThat(otherRegistry.getMeters()).as("registered meters on default registry").isNotEmpty();
+		}
+		finally {
+			reactor.util.Metrics.setUnsafeRegistry(null);
+			otherRegistry.close();
+		}
+	}
+
+	@Test
 	public void splitMetricsOnNameFuseable() {
 		final Mono<Integer> unnamedSource = Mono.just(0).map(v -> 100 / v);
 		final Mono<Integer> namedSource = Mono.just(0).map(v -> 100 / v)

--- a/reactor-core/src/test/java/reactor/util/MetricsNoMicrometerTest.java
+++ b/reactor-core/src/test/java/reactor/util/MetricsNoMicrometerTest.java
@@ -92,4 +92,11 @@ public class MetricsNoMicrometerTest {
 		}
 	}
 
+	@Test
+	public void setUnsafeRegistryAndGetRegistry() {
+		assertThat(Metrics.setUnsafeRegistry("foo")).isFalse();
+
+		assertThat(Metrics.getUnsafeRegistry()).isNull();
+	}
+
 }

--- a/reactor-core/src/test/java/reactor/util/MetricsTest.java
+++ b/reactor-core/src/test/java/reactor/util/MetricsTest.java
@@ -32,6 +32,7 @@
 
 package reactor.util;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,6 +45,22 @@ public class MetricsTest {
 	@Test
 	public void smokeTestMicrometerActiveInTests() {
 		assertThat(Metrics.isInstrumentationAvailable()).isTrue();
+	}
+
+	@Test
+	public void setUnsafeRegistryAndGetRegistry() {
+		SimpleMeterRegistry simpleMeterRegistry = new SimpleMeterRegistry();
+
+		assertThat(Metrics.setUnsafeRegistry("foo")).as("string candidate").isFalse();
+		assertThat(Metrics.setUnsafeRegistry(simpleMeterRegistry)).as("registry candidate").isTrue();
+
+		assertThat(Metrics.getUnsafeRegistry()).as("get before clear")
+		                                       .isSameAs(simpleMeterRegistry);
+
+		assertThat(Metrics.setUnsafeRegistry(null)).as("null candidate")
+		                                           .isTrue();
+		assertThat(Metrics.getUnsafeRegistry()).as("null candidate cleared")
+		                                       .isSameAs(io.micrometer.core.instrument.Metrics.globalRegistry);
 	}
 
 }


### PR DESCRIPTION
This commit adds methods to Metrics that allow choosing a MeterRegistry
that is different from the so far default of _globalRegistry_.

The method is considered "unsafe", because in order to avoid class
loading problems it doesn't expose MeterRegistry as a parameter but
takes a much wider `Object`. Despite that, if Micrometer is on the
classpath, only parameters of type `MeterRegistry` will be taken into
account.