### PR TITLE
Update asciidoctor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,11 +26,6 @@ buildscript {
 	classpath 'io.spring.gradle:spring-io-plugin:0.0.4.RELEASE'
 	classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.0'
 	classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
-	classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.9.2'
-	classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16', {
-	  exclude group: 'org.asciidoctor', module: 'asciidoctorj'
-	  exclude group: 'org.jruby', module: 'jruby-complete'
-	}
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,14 +26,16 @@ buildscript {
 	classpath 'io.spring.gradle:spring-io-plugin:0.0.4.RELEASE'
 	classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.0'
 	classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
-	classpath 'org.jruby:jruby-complete:9.1.17.0'
-	classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.7'
-	classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16'
+	classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.9.2'
+	classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16', {
+	  exclude group: 'org.asciidoctor', module: 'asciidoctorj'
+	  exclude group: 'org.jruby', module: 'jruby-complete'
+	}
   }
 }
 
 plugins {
-  id 'org.asciidoctor.convert' version '1.5.6'
+  id 'org.asciidoctor.convert' version '1.5.9.2'
   id "me.champeau.gradle.jmh" version "0.4.7" apply false
   id "org.jetbrains.dokka" version "0.9.16"
   id "me.champeau.gradle.japicmp" version "0.2.6"

--- a/gradle/doc.gradle
+++ b/gradle/doc.gradle
@@ -50,6 +50,10 @@ configure(rootProject) {
 		}
 	}
 
+	dependencies {
+	  asciidoctor 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16'
+	}
+
 	task docsZip(type: Zip, dependsOn: asciidoctor) {
 	  baseName = 'reactor-core-docs'
 	  from("$buildDir/reactor-code/build/asciidoc/pdf/reactor-core-reference-guide-${version}.pdf") { into ("docs/") }


### PR DESCRIPTION
This PR cleanups Asciidoctor dependencies and moves pdf backend off the build classpath to the asciidoctor task's runtime instead.

Also see:
https://asciidoctor.org/docs/asciidoctor-gradle-plugin/#adding-custom-extensions