### PR TITLE
fix #1452 by propagating cancellation in flux window predicate

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
@@ -348,6 +348,9 @@ final class FluxWindowPredicate<T> extends FluxOperator<T, Flux<T>>
 						}
 
 						if (WIP.decrementAndGet(this) == 0) {
+							if (!done) {
+								s.cancel();
+							}
 							return;
 						}
 


### PR DESCRIPTION
Cancel subscription if there is no work in progress for `FluxWindowOperator`

@simonbasle, @devstdout could you guys have a look at this?

Sorry guys, I have mentioned before I saw tests fail. I am on it

P.S.: that feeling when `Subscription#cancel` is not enough 😅 