### PR TITLE
[build] Change the way japicmp gets its baseline (don't rely on Gradle)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ plugins {
   id "me.champeau.gradle.jmh" version "0.4.7" apply false
   id "org.jetbrains.dokka" version "0.9.16"
   id "me.champeau.gradle.japicmp" version "0.2.6"
+  id "de.undercouch.download" version "3.4.3"
 }
 
 apply from: "gradle/doc.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -62,8 +62,13 @@ ext {
   mockitoVersion = '2.23.0'
   jUnitParamsVersion = '1.1.1'
 
-  javadocLinks = ["https://docs.oracle.com/javase/8/docs/api/",
-				  "https://docs.oracle.com/javaee/6/api/",
+  jdk = JavaVersion.current().majorVersion
+  jdkJavadoc = "https://docs.oracle.com/javase/$jdk/docs/api/"
+  if (JavaVersion.current().isJava11Compatible()) {
+	jdkJavadoc = "https://docs.oracle.com/en/java/javase/$jdk/docs/api/"
+  }
+
+  javadocLinks = [jdkJavadoc,
 				  "http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/"] as String[]
 
 

--- a/gradle/doc.gradle
+++ b/gradle/doc.gradle
@@ -16,6 +16,14 @@
 configure(rootProject) {
 	apply plugin: 'org.asciidoctor.convert'
 
+  configure(subprojects) { p ->
+	p.tasks.withType(Javadoc).all {
+	  afterEvaluate {
+		println "JDK Javadoc link for ${p.name} is ${rootProject.jdkJavadoc}"
+	  }
+	}
+  }
+
 	asciidoctor {
 	  sourceDir "$rootDir/docs/asciidoc/"
 	  sources {

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -28,7 +28,6 @@ sourceSets {
 configurations {
   compileOnly.extendsFrom jsr166backport
   testCompile.extendsFrom jsr166backport
-  baseline
   noMicrometerTestRuntime {
 	extendsFrom testRuntime
 	exclude group:"io.micrometer", module:"micrometer-core"
@@ -71,13 +70,6 @@ dependencies {
 		  "pl.pragmatists:JUnitParams:$jUnitParamsVersion",
 		  "org.awaitility:awaitility:3.1.2"
 
-  if ("$compatibleVersion" != "SKIP") {
-	baseline("io.projectreactor:reactor-core:$compatibleVersion") {
-	  transitive = false
-	  force = true
-	}
-  }
-
   noMicrometerTestCompile sourceSets.main.output
   noMicrometerTestCompile sourceSets.test.output
   noMicrometerTestCompile configurations.testCompile
@@ -88,9 +80,15 @@ jmh {
   resultFormat = 'JSON'
 }
 
+task downloadBaseline(type: Download) {
+  onlyIf { "$compatibleVersion" != "SKIP" }
+  src "${repositories.mavenCentral().url}io/projectreactor/reactor-core/$compatibleVersion/reactor-core-${compatibleVersion}.jar"
+  dest "${buildDir}/baselineLibs/reactor-core-${compatibleVersion}.jar"
+}
+
 task japicmp(type: JapicmpTask) {
   onlyIf { "$compatibleVersion" != "SKIP" }
-  oldClasspath = configurations.baseline
+  oldClasspath = files("${buildDir}/baselineLibs/reactor-core-${compatibleVersion}.jar")
   newClasspath = files(jar.archivePath)
   onlyBinaryIncompatibleModified = true
   failOnModification = true
@@ -256,7 +254,8 @@ artifacts {
 
 jacocoTestReport.dependsOn test
 check.dependsOn jacocoTestReport
-jar.finalizedBy(japicmp)
+jar.finalizedBy(downloadBaseline)
+downloadBaseline.finalizedBy(japicmp)
 
 if (JavaVersion.current().java9Compatible) {
   sourceSets {

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -17,10 +17,6 @@ import me.champeau.gradle.japicmp.JapicmpTask
 
 description = 'Reactor Test support'
 
-configurations {
-  baseline
-}
-
 dependencies {
   compile project(":reactor-core")
 
@@ -31,18 +27,17 @@ dependencies {
   testCompile "org.hamcrest:hamcrest-library:1.3",
 		  "org.assertj:assertj-core:$assertJVersion",
 		  "org.mockito:mockito-core:$mockitoVersion"
+}
 
-  if ("$compatibleVersion" != "SKIP") {
-	baseline("io.projectreactor:reactor-test:$compatibleVersion") {
-	  transitive = false
-	  force = true
-	}
-  }
+task downloadBaseline(type: Download) {
+  onlyIf { "$compatibleVersion" != "SKIP" }
+  src "${repositories.mavenCentral().url}io/projectreactor/reactor-test/$compatibleVersion/reactor-test-${compatibleVersion}.jar"
+  dest "${buildDir}/baselineLibs/reactor-test-${compatibleVersion}.jar"
 }
 
 task japicmp(type: JapicmpTask) {
   onlyIf { "$compatibleVersion" != "SKIP" }
-  oldClasspath = configurations.baseline
+  oldClasspath = files("${buildDir}/baselineLibs/reactor-test-${compatibleVersion}.jar")
   newClasspath = files(jar.archivePath)
   onlyBinaryIncompatibleModified = true
   failOnModification = true
@@ -125,4 +120,5 @@ artifacts {
   archives kdocZip
 }
 
-jar.finalizedBy(japicmp)
+jar.finalizedBy(downloadBaseline)
+downloadBaseline.finalizedBy(japicmp)


### PR DESCRIPTION
Now an explicit download of the baseline jar on MavenCentral using the
[`download-gradle-task`](https://github.com/michel-kraemer/gradle-download-task).

Maven configuration dependency resolution seems to always resolve to the
freshly built jar, resulting in japicmp comparing latest version with
itself :(