### PR TITLE
fix #1484 Add Loggers.useVerboseConsoleLoggers, default to no TRACE/DEBUG

### DIFF
--- a/reactor-core/src/main/java/reactor/util/Loggers.java
+++ b/reactor-core/src/main/java/reactor/util/Loggers.java
@@ -15,6 +15,7 @@
  */
 package reactor.util;
 
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.function.Function;
@@ -32,10 +33,10 @@ import reactor.util.annotation.Nullable;
  * {@link System#setProperty(String, String) System property} to "{@code JDK}".
  * <p>
  * One can also force the implementation by using the "useXXX" static methods:
- * {@link #useConsoleLoggers()}, {@link #useJdkLoggers()} and {@link #useSl4jLoggers()}
- * (which may throw an Exception if the library isn't on the classpath). Note that the
- * system property method above is preferred, as no cleanup of the logger factory initialized
- * at startup is attempted by the useXXX methods.
+ * {@link #useConsoleLoggers()}, {@link #useVerboseConsoleLoggers()}, {@link #useJdkLoggers()}
+ * and {@link #useSl4jLoggers()} (which may throw an Exception if the library isn't on the
+ * classpath). Note that the system property method above is preferred, as no cleanup of
+ * the logger factory initialized at startup is attempted by the useXXX methods.
  */
 public abstract class Loggers {
 
@@ -61,6 +62,7 @@ public abstract class Loggers {
 	 *
 	 * @see #useJdkLoggers()
 	 * @see #useConsoleLoggers()
+	 * @see #useVerboseConsoleLoggers()
 	 */
 	public static final void resetLoggerFactory() {
 		try {
@@ -91,15 +93,32 @@ public abstract class Loggers {
 	 * Force the usage of Console-based {@link Logger Loggers}, even if SLF4J is available
 	 * on the classpath. Console loggers will output {@link Logger#error(String) ERROR} and
 	 * {@link Logger#warn(String) WARN} levels to {@link System#err} and levels below to
-	 * {@link System#out}. All levels are considered enabled.
+	 * {@link System#out}. All levels <strong>except TRACE and DEBUG</strong> are
+	 * considered enabled. TRACE and DEBUG are omitted.
 	 * <p>
 	 * The previously active logger factory is simply replaced without
 	 * any particular clean-up.
 	 */
 	public static final void useConsoleLoggers() {
 		String name = LoggerFactory.class.getName();
-		LoggerFactory loggerFactory = new ConsoleLoggerFactory();
+		LoggerFactory loggerFactory = new ConsoleLoggerFactory(false);
 		loggerFactory.getLogger(name).debug("Using Console logging");
+		LOGGER_FACTORY = loggerFactory;
+	}
+
+	/**
+	 * Force the usage of Console-based {@link Logger Loggers}, even if SLF4J is available
+	 * on the classpath. Console loggers will output {@link Logger#error(String) ERROR} and
+	 * {@link Logger#warn(String) WARN} levels to {@link System#err} and levels below to
+	 * {@link System#out}. All levels (including TRACE and DEBUG) are considered enabled.
+	 * <p>
+	 * The previously active logger factory is simply replaced without
+	 * any particular clean-up.
+	 */
+	public static final void useVerboseConsoleLoggers() {
+		String name = LoggerFactory.class.getName();
+		LoggerFactory loggerFactory = new ConsoleLoggerFactory(true);
+		loggerFactory.getLogger(name).debug("Using Verbose Console logging");
 		LOGGER_FACTORY = loggerFactory;
 	}
 
@@ -449,15 +468,17 @@ public abstract class Loggers {
 		private final String name;
 		private final PrintStream err;
 		private final PrintStream log;
+		private final boolean verbose;
 
-		ConsoleLogger(String name, PrintStream log, PrintStream err) {
+		ConsoleLogger(String name, PrintStream log, PrintStream err, boolean verbose) {
 			this.name = name;
 			this.log = log;
 			this.err = err;
+			this.verbose = verbose;
 		}
 
-		ConsoleLogger(String name) {
-			this(name, System.out, System.err);
+		ConsoleLogger(String name, boolean verbose) {
+			this(name, System.out, System.err, verbose);
 		}
 
 		@Override
@@ -481,41 +502,59 @@ public abstract class Loggers {
 
 		@Override
 		public boolean isTraceEnabled() {
-			return true;
+			return verbose;
 		}
 
 		@Override
 		public synchronized void trace(String msg) {
+			if (!verbose) {
+				return;
+			}
 			this.log.format("[TRACE] (%s) %s\n", Thread.currentThread().getName(), msg);
 		}
 
 		@Override
 		public synchronized void trace(String format, Object... arguments) {
+			if (!verbose) {
+				return;
+			}
 			this.log.format("[TRACE] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
 		}
 		@Override
 		public synchronized void trace(String msg, Throwable t) {
+			if (!verbose) {
+				return;
+			}
 			this.log.format("[TRACE] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
 			t.printStackTrace(this.log);
 		}
 
 		@Override
 		public boolean isDebugEnabled() {
-			return true;
+			return verbose;
 		}
 
 		@Override
 		public synchronized void debug(String msg) {
+			if (!verbose) {
+				return;
+			}
 			this.log.format("[DEBUG] (%s) %s\n", Thread.currentThread().getName(), msg);
 		}
 
 		@Override
 		public synchronized void debug(String format, Object... arguments) {
+			if (!verbose) {
+				return;
+			}
 			this.log.format("[DEBUG] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
 		}
 
 		@Override
 		public synchronized void debug(String msg, Throwable t) {
+			if (!verbose) {
+				return;
+			}
 			this.log.format("[DEBUG] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
 			t.printStackTrace(this.log);
 		}
@@ -588,9 +627,15 @@ public abstract class Loggers {
 
 		private static final HashMap<String, Logger> consoleLoggers = new HashMap<>();
 
+		final boolean verbose;
+
+		private ConsoleLoggerFactory(boolean verbose) {
+			this.verbose = verbose;
+		}
+
 		@Override
 		public Logger getLogger(String name) {
-			return consoleLoggers.computeIfAbsent(name, ConsoleLogger::new);
+			return consoleLoggers.computeIfAbsent(name, n -> new ConsoleLogger(n, verbose));
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/util/ConsoleLoggerTest.java
+++ b/reactor-core/src/test/java/reactor/util/ConsoleLoggerTest.java
@@ -90,22 +90,15 @@ public class ConsoleLoggerTest {
 
 	@Test
 	public void traceDismissedInNonVerboseMode() {
-		PrintStream out = System.out;
-		Logger log = new Loggers.ConsoleLogger("test", false);
-		System.setOut(new PrintStream(outContent));
-		try {
-			log.trace("foo");
-			log.trace("foo", new IllegalArgumentException("foo"));
-			log.trace("foo {}", "foo");
+		Logger log = new Loggers.ConsoleLogger("test", new PrintStream(outContent), new PrintStream(errContent), false);
+		log.trace("foo");
+		log.trace("foo", new IllegalArgumentException("foo"));
+		log.trace("foo {}", "foo");
 
-			assertThat(outContent.toString()).doesNotContain("foo");
-			assertThat(errContent.toString()).doesNotContain("foo");
+		assertThat(outContent.toString()).doesNotContain("foo");
+		assertThat(errContent.toString()).doesNotContain("foo");
 
-			assertThat(log.isTraceEnabled()).as("isTraceEnabled").isFalse();
-		}
-		finally {
-			System.setOut(out);
-		}
+		assertThat(log.isTraceEnabled()).as("isTraceEnabled").isFalse();
 	}
 
 	@Test
@@ -153,22 +146,15 @@ public class ConsoleLoggerTest {
 
 	@Test
 	public void debugDismissedInNonVerboseMode() {
-		PrintStream out = System.out;
-		Logger log = new Loggers.ConsoleLogger("test", false);
-		System.setOut(new PrintStream(outContent));
-		try {
-			log.debug("foo");
-			log.debug("foo", new IllegalArgumentException("foo"));
-			log.debug("foo {}", "foo");
+		Logger log = new Loggers.ConsoleLogger("test", new PrintStream(outContent), new PrintStream(errContent), false);
+		log.debug("foo");
+		log.debug("foo", new IllegalArgumentException("foo"));
+		log.debug("foo {}", "foo");
 
-			assertThat(outContent.toString()).doesNotContain("foo");
-			assertThat(errContent.toString()).doesNotContain("foo");
+		assertThat(outContent.toString()).doesNotContain("foo");
+		assertThat(errContent.toString()).doesNotContain("foo");
 
-			assertThat(log.isDebugEnabled()).as("isDebugEnabled").isFalse();
-		}
-		finally {
-			System.setOut(out);
-		}
+		assertThat(log.isDebugEnabled()).as("isDebugEnabled").isFalse();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/ConsoleLoggerTest.java
+++ b/reactor-core/src/test/java/reactor/util/ConsoleLoggerTest.java
@@ -36,7 +36,7 @@ public class ConsoleLoggerTest {
 
 	@Before
 	public void setUp() {
-		logger = new Loggers.ConsoleLogger("test", new PrintStream(outContent), new PrintStream(errContent));
+		logger = new Loggers.ConsoleLogger("test", new PrintStream(outContent), new PrintStream(errContent), true);
 	}
 
 	@After
@@ -89,6 +89,26 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
+	public void traceDismissedInNonVerboseMode() {
+		PrintStream out = System.out;
+		Logger log = new Loggers.ConsoleLogger("test", false);
+		System.setOut(new PrintStream(outContent));
+		try {
+			log.trace("foo");
+			log.trace("foo", new IllegalArgumentException("foo"));
+			log.trace("foo {}", "foo");
+
+			assertThat(outContent.toString()).doesNotContain("foo");
+			assertThat(errContent.toString()).doesNotContain("foo");
+
+			assertThat(log.isTraceEnabled()).as("isTraceEnabled").isFalse();
+		}
+		finally {
+			System.setOut(out);
+		}
+	}
+
+	@Test
 	public void isDebugEnabled() throws Exception {
 		assertThat(logger.isDebugEnabled()).isTrue();
 	}
@@ -129,6 +149,26 @@ public class ConsoleLoggerTest {
 		assertThat(outContent.toString())
 				.contains("vararg {} is {}")
 				.contains("param null is null");
+	}
+
+	@Test
+	public void debugDismissedInNonVerboseMode() {
+		PrintStream out = System.out;
+		Logger log = new Loggers.ConsoleLogger("test", false);
+		System.setOut(new PrintStream(outContent));
+		try {
+			log.debug("foo");
+			log.debug("foo", new IllegalArgumentException("foo"));
+			log.debug("foo {}", "foo");
+
+			assertThat(outContent.toString()).doesNotContain("foo");
+			assertThat(errContent.toString()).doesNotContain("foo");
+
+			assertThat(log.isDebugEnabled()).as("isDebugEnabled").isFalse();
+		}
+		finally {
+			System.setOut(out);
+		}
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/LoggersTest.java
+++ b/reactor-core/src/test/java/reactor/util/LoggersTest.java
@@ -64,6 +64,19 @@ public class LoggersTest {
 	}
 
 	@Test
+	public void useVerboseConsoleLoggers() throws Exception {
+		try {
+			Loggers.useVerboseConsoleLoggers();
+			Logger l = Loggers.getLogger("test");
+
+			assertThat(l.getClass().getSimpleName()).isEqualTo("ConsoleLogger");
+		}
+		finally {
+			Loggers.resetLoggerFactory();
+		}
+	}
+
+	@Test
 	public void useJdkLoggers() throws Exception {
 		try {
 			Loggers.useJdkLoggers();


### PR DESCRIPTION
`Behavior change`: `useConsoleLoggers()` does not TRACE or DEBUG anymore.