### PR TITLE
introduce `ContextAware` interface, store tracking on the context

### DIFF
--- a/reactor-core/src/main/java/reactor/core/ContextAware.java
+++ b/reactor-core/src/main/java/reactor/core/ContextAware.java
@@ -1,0 +1,7 @@
+package reactor.core;
+
+import reactor.util.context.Context;
+
+public interface ContextAware {
+	Context currentContext();
+}

--- a/reactor-core/src/main/java/reactor/core/ContextAware.java
+++ b/reactor-core/src/main/java/reactor/core/ContextAware.java
@@ -1,7 +1,38 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core;
 
 import reactor.util.context.Context;
 
+/**
+ * A common interface for the {@link Context} aware abstractions.
+ *
+ * @see reactor.core.scheduler.Scheduler.ContextRunnable
+ * @see CoreSubscriber
+ *
+ * @author Sergei Egorov
+ */
 public interface ContextAware {
+
+	/**
+	 * Request a {@link Context} from dependent components which can include downstream
+	 * operators during subscribing or a terminal {@link org.reactivestreams.Subscriber}.
+	 *
+	 * @return a resolved context or {@link Context#empty()}
+	 */
 	Context currentContext();
 }

--- a/reactor-core/src/main/java/reactor/core/CoreSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/CoreSubscriber.java
@@ -36,10 +36,7 @@ import reactor.util.context.Context;
 public interface CoreSubscriber<T> extends Subscriber<T>, ContextAware {
 
 	/**
-	 * Request a {@link Context} from dependent components which can include downstream
-	 * operators during subscribing or a terminal {@link org.reactivestreams.Subscriber}.
-	 *
-	 * @return a resolved context or {@link Context#empty()}
+	 * {@inheritDoc}
 	 */
 	default Context currentContext(){
 		return Context.empty();

--- a/reactor-core/src/main/java/reactor/core/CoreSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/CoreSubscriber.java
@@ -33,7 +33,7 @@ import reactor.util.context.Context;
  *
  * @since 3.1.0
  */
-public interface CoreSubscriber<T> extends Subscriber<T> {
+public interface CoreSubscriber<T> extends Subscriber<T>, ContextAware {
 
 	/**
 	 * Request a {@link Context} from dependent components which can include downstream

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
@@ -30,6 +30,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Scheduler.ContextRunnable;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
@@ -89,10 +90,10 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends FluxOp
 		final static int TERMINATED_WITH_ERROR   = 2;
 		final static int TERMINATED_WITH_CANCEL  = 3;
 
-		final int                        batchSize;
-		final long                       timespan;
-		final Scheduler.Worker           timer;
-		final Runnable                   flushTask;
+		final int                       batchSize;
+		final long                      timespan;
+		final Scheduler.Worker          timer;
+		final ContextRunnable flushTask;
 
 		protected Subscription subscription;
 
@@ -130,19 +131,27 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends FluxOp
 			this.ctx = actual.currentContext();
 			this.timespan = timespan;
 			this.timer = timer;
-			this.flushTask = () -> {
-				if (terminated == NOT_TERMINATED) {
-					int index;
-					for(;;){
-						index = this.index;
-						if(index == 0){
-							return;
+			this.flushTask = new ContextRunnable() {
+				@Override
+				public void run() {
+					if (terminated == NOT_TERMINATED) {
+						int index;
+						for(;;){
+							index = BufferTimeoutSubscriber.this.index;
+							if(index == 0){
+								return;
+							}
+							if(INDEX.compareAndSet(BufferTimeoutSubscriber.this, index, 0)){
+								break;
+							}
 						}
-						if(INDEX.compareAndSet(this, index, 0)){
-							break;
-						}
+						flushCallback(null);
 					}
-					flushCallback(null);
+				}
+
+				@Override
+				public Context currentContext() {
+					return ctx;
 				}
 			};
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
@@ -90,10 +90,10 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends FluxOp
 		final static int TERMINATED_WITH_ERROR   = 2;
 		final static int TERMINATED_WITH_CANCEL  = 3;
 
-		final int                       batchSize;
-		final long                      timespan;
-		final Scheduler.Worker          timer;
-		final ContextRunnable flushTask;
+		final int              batchSize;
+		final long             timespan;
+		final Scheduler.Worker timer;
+		final ContextRunnable  flushTask;
 
 		protected Subscription subscription;
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCancelOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCancelOn.java
@@ -47,7 +47,7 @@ final class FluxCancelOn<T> extends FluxOperator<T, T> {
 	}
 
 	static final class CancelSubscriber<T>
-			implements InnerOperator<T, T>, Runnable {
+			implements InnerOperator<T, T>, Scheduler.ContextRunnable {
 
 		final CoreSubscriber<? super T> actual;
 		final Scheduler             scheduler;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxInterval.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxInterval.java
@@ -27,6 +27,7 @@ import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Scheduler.Worker;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * Periodically emits an ever increasing long value either via a ScheduledExecutorService
@@ -83,13 +84,19 @@ final class FluxInterval extends Flux<Long> implements SourceProducer<Long> {
 		return null;
 	}
 
-	static final class IntervalRunnable implements Runnable, Subscription,
+	static final class IntervalRunnable implements Scheduler.ContextRunnable, Subscription,
 	                                               InnerProducer<Long> {
 		final CoreSubscriber<? super Long> actual;
 
 		final Worker worker;
 
 		volatile long requested;
+
+		@Override
+		public Context currentContext() {
+			return actual.currentContext();
+		}
+
 		static final AtomicLongFieldUpdater<IntervalRunnable> REQUESTED =
 				AtomicLongFieldUpdater.newUpdater(IntervalRunnable.class, "requested");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferTimeout.java
@@ -87,7 +87,7 @@ final class FluxOnBackpressureBufferTimeout<O> extends FluxOperator<O, O> {
 	}
 
 	static final class BackpressureBufferTimeoutSubscriber<T> extends ArrayDeque<Object>
-			implements InnerOperator<T, T>, Runnable {
+			implements InnerOperator<T, T>, Scheduler.ContextRunnable {
 
 		final CoreSubscriber<? super T> actual;
 		final Context                   ctx;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
@@ -29,6 +29,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Scheduler.ContextRunnable;
 import reactor.core.scheduler.Scheduler.Worker;
 import reactor.util.annotation.Nullable;
 
@@ -115,7 +116,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 	}
 
 	static final class PublishOnSubscriber<T>
-			implements QueueSubscription<T>, Runnable, InnerOperator<T, T> {
+			implements QueueSubscription<T>, ContextRunnable, InnerOperator<T, T> {
 
 		final CoreSubscriber<? super T> actual;
 
@@ -584,7 +585,7 @@ final class FluxPublishOn<T> extends FluxOperator<T, T> implements Fuseable {
 	}
 
 	static final class PublishOnConditionalSubscriber<T>
-			implements QueueSubscription<T>, Runnable, InnerOperator<T, T> {
+			implements QueueSubscription<T>, ContextRunnable, InnerOperator<T, T> {
 
 		final ConditionalSubscriber<? super T> actual;
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
@@ -182,8 +182,8 @@ final class FluxWindowTimeout<T> extends FluxOperator<T, Flux<T>> {
 
 		Disposable newPeriod() {
 			try {
-				ConsumerIndexHolder r = new ConsumerIndexHolder(producerIndex, this, actual.currentContext());
-				return worker.schedulePeriodically(r, timespan, timespan, TimeUnit.MILLISECONDS);
+				return worker.schedulePeriodically(new ConsumerIndexHolder(producerIndex,
+						this), timespan, timespan, TimeUnit.MILLISECONDS);
 			}
 			catch (Exception e) {
 				actual.onError(Operators.onRejectedExecution(e, s, null, null, actual.currentContext()));
@@ -419,19 +419,15 @@ final class FluxWindowTimeout<T> extends FluxOperator<T, Flux<T>> {
 
 			final long                       index;
 			final WindowTimeoutSubscriber<?> parent;
-			final Context                    context;
 
-			ConsumerIndexHolder(long index,
-					WindowTimeoutSubscriber<?> parent,
-					Context context) {
+			ConsumerIndexHolder(long index, WindowTimeoutSubscriber<?> parent) {
 				this.index = index;
 				this.parent = parent;
-				this.context = context;
 			}
 
 			@Override
 			public Context currentContext() {
-				return context;
+				return parent.currentContext();
 			}
 
 			@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1629,7 +1629,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	* @return a replaying {@link Mono}
 	*/
 	public final Mono<T> cache(Duration ttl, Scheduler timer) {
-		return onAssembly(new MonoCacheTime<>(this, ttl, timer, Context.empty()));
+		return onAssembly(new MonoCacheTime<>(this, ttl, timer));
 	}
 
 	/**
@@ -1655,7 +1655,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 			Supplier<Duration> ttlForEmpty) {
 		return onAssembly(new MonoCacheTime<>(this,
 				ttlForValue, ttlForError, ttlForEmpty,
-				Schedulers.parallel(), Context.empty()));
+				Schedulers.parallel()));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1629,7 +1629,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	* @return a replaying {@link Mono}
 	*/
 	public final Mono<T> cache(Duration ttl, Scheduler timer) {
-		return onAssembly(new MonoCacheTime<>(this, ttl, timer));
+		return onAssembly(new MonoCacheTime<>(this, ttl, timer, Context.empty()));
 	}
 
 	/**
@@ -1655,7 +1655,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 			Supplier<Duration> ttlForEmpty) {
 		return onAssembly(new MonoCacheTime<>(this,
 				ttlForValue, ttlForError, ttlForEmpty,
-				Schedulers.parallel()));
+				Schedulers.parallel(), Context.empty()));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
@@ -43,7 +43,6 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Scheduler.ContextRu
 
 	final Function<? super Signal<T>, Duration> ttlGenerator;
 	final Scheduler                             clock;
-	final Context                               context;
 
 	volatile Signal<T> state;
 	static final AtomicReferenceFieldUpdater<MonoCacheTime, Signal> STATE =
@@ -51,24 +50,19 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Scheduler.ContextRu
 
 	static final Signal<?> EMPTY = new ImmutableSignal<>(Context.empty(), SignalType.ON_NEXT, null, null, null);
 
-	MonoCacheTime(Mono<? extends T> source,
-			Duration ttl,
-			Scheduler clock,
-			Context context) {
+	MonoCacheTime(Mono<? extends T> source, Duration ttl, Scheduler clock) {
 		super(source);
 		this.ttlGenerator = ignoredSignal -> ttl;
 		this.clock = clock;
-		this.context = context;
 		//noinspection unchecked
 		this.state = (Signal<T>) EMPTY;
 	}
 
 	MonoCacheTime(Mono<? extends T> source, Function<? super Signal<T>, Duration> ttlGenerator,
-			Scheduler clock, Context context) {
+			Scheduler clock) {
 		super(source);
 		this.ttlGenerator = ttlGenerator;
 		this.clock = clock;
-		this.context = context;
 		//noinspection unchecked
 		this.state = (Signal<T>) EMPTY;
 	}
@@ -77,9 +71,8 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Scheduler.ContextRu
 			Function<? super T, Duration> valueTtlGenerator,
 			Function<Throwable, Duration> errorTtlGenerator,
 			Supplier<Duration> emptyTtlGenerator,
-			Scheduler clock, Context context) {
+			Scheduler clock) {
 		super(source);
-		this.context = context;
 		this.ttlGenerator = sig -> {
 			if (sig.isOnNext()) return valueTtlGenerator.apply(sig.get());
 			if (sig.isOnError()) return errorTtlGenerator.apply(sig.getThrowable());
@@ -93,7 +86,7 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Scheduler.ContextRu
 
 	@Override
 	public Context currentContext() {
-		return null;
+		return Context.empty();
 	}
 
 	public void run() {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
@@ -37,12 +37,13 @@ import reactor.util.context.Context;
  *
  * @author Simon Baslé
  */
-class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
+class MonoCacheTime<T> extends MonoOperator<T, T> implements Scheduler.ContextRunnable {
 
 	private static final Logger LOGGER = Loggers.getLogger(MonoCacheTime.class);
 
 	final Function<? super Signal<T>, Duration> ttlGenerator;
 	final Scheduler                             clock;
+	final Context                               context;
 
 	volatile Signal<T> state;
 	static final AtomicReferenceFieldUpdater<MonoCacheTime, Signal> STATE =
@@ -50,19 +51,24 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
 
 	static final Signal<?> EMPTY = new ImmutableSignal<>(Context.empty(), SignalType.ON_NEXT, null, null, null);
 
-	MonoCacheTime(Mono<? extends T> source, Duration ttl, Scheduler clock) {
+	MonoCacheTime(Mono<? extends T> source,
+			Duration ttl,
+			Scheduler clock,
+			Context context) {
 		super(source);
 		this.ttlGenerator = ignoredSignal -> ttl;
 		this.clock = clock;
+		this.context = context;
 		//noinspection unchecked
 		this.state = (Signal<T>) EMPTY;
 	}
 
 	MonoCacheTime(Mono<? extends T> source, Function<? super Signal<T>, Duration> ttlGenerator,
-			Scheduler clock) {
+			Scheduler clock, Context context) {
 		super(source);
 		this.ttlGenerator = ttlGenerator;
 		this.clock = clock;
+		this.context = context;
 		//noinspection unchecked
 		this.state = (Signal<T>) EMPTY;
 	}
@@ -71,8 +77,9 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
 			Function<? super T, Duration> valueTtlGenerator,
 			Function<Throwable, Duration> errorTtlGenerator,
 			Supplier<Duration> emptyTtlGenerator,
-			Scheduler clock) {
+			Scheduler clock, Context context) {
 		super(source);
+		this.context = context;
 		this.ttlGenerator = sig -> {
 			if (sig.isOnNext()) return valueTtlGenerator.apply(sig.get());
 			if (sig.isOnError()) return errorTtlGenerator.apply(sig.getThrowable());
@@ -82,6 +89,11 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
 		@SuppressWarnings("unchecked")
 		Signal<T> emptyState = (Signal<T>) EMPTY;
 		this.state = emptyState;
+	}
+
+	@Override
+	public Context currentContext() {
+		return null;
 	}
 
 	public void run() {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
@@ -27,6 +27,7 @@ import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * Emits a single 0L value delayed by some time amount with a help of
@@ -72,10 +73,16 @@ final class MonoDelay extends Mono<Long> implements Scannable,  SourceProducer<L
 		return null;
 	}
 
-	static final class MonoDelayRunnable implements Runnable, InnerProducer<Long> {
+	static final class MonoDelayRunnable implements Scheduler.ContextRunnable, InnerProducer<Long> {
 		final CoreSubscriber<? super Long> actual;
 
 		volatile Disposable cancel;
+
+		@Override
+		public Context currentContext() {
+			return actual.currentContext();
+		}
+
 		static final AtomicReferenceFieldUpdater<MonoDelayRunnable, Disposable> CANCEL =
 				AtomicReferenceFieldUpdater.newUpdater(MonoDelayRunnable.class,
 						Disposable.class,

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPublishOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPublishOn.java
@@ -53,7 +53,7 @@ final class MonoPublishOn<T> extends MonoOperator<T, T> {
 	}
 
 	static final class PublishOnSubscriber<T>
-			implements InnerOperator<T, T>, Runnable {
+			implements InnerOperator<T, T>, Scheduler.ContextRunnable {
 
 		final CoreSubscriber<? super T> actual;
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOnValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOnValue.java
@@ -46,7 +46,7 @@ final class MonoSubscribeOnValue<T> extends Mono<T> implements Scannable {
 	public void subscribe(CoreSubscriber<? super T> actual) {
 		T v = value;
 		if (v == null) {
-			ScheduledEmpty parent = new ScheduledEmpty(actual);
+			ScheduledEmpty parent = new ScheduledEmpty(actual, actual.currentContext());
 			actual.onSubscribe(parent);
 			try {
 				parent.setFuture(scheduler.schedule(parent));

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOnValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSubscribeOnValue.java
@@ -46,7 +46,7 @@ final class MonoSubscribeOnValue<T> extends Mono<T> implements Scannable {
 	public void subscribe(CoreSubscriber<? super T> actual) {
 		T v = value;
 		if (v == null) {
-			ScheduledEmpty parent = new ScheduledEmpty(actual, actual.currentContext());
+			ScheduledEmpty parent = new ScheduledEmpty(actual);
 			actual.onSubscribe(parent);
 			try {
 				parent.setFuture(scheduler.schedule(parent));

--- a/reactor-core/src/main/java/reactor/core/publisher/Tracker.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Tracker.java
@@ -20,8 +20,6 @@ public interface Tracker {
 
 		static final AtomicLong COUNTER = new AtomicLong();
 
-		static final ThreadLocal<Marker> CURRENT = new ThreadLocal<>();
-
 		@Nullable
 		private final Marker parent;
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
@@ -56,16 +56,19 @@ final class DelegateServiceScheduler implements Scheduler, Scannable {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Disposable schedule(Runnable task) {
 		return Schedulers.directSchedule(executor, task, 0L, TimeUnit.MILLISECONDS);
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
 		return Schedulers.directSchedule(executor, task, delay, unit);
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Disposable schedulePeriodically(Runnable task,
 			long initialDelay,
 			long period,

--- a/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
@@ -30,10 +30,12 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import reactor.core.ContextAware;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * Dynamically creates ScheduledExecutorService-based Workers and caches the thread pools, reusing
@@ -275,7 +277,7 @@ final class ElasticScheduler implements Scheduler, Supplier<ScheduledExecutorSer
 		}
 	}
 
-	static final class DirectScheduleTask implements Runnable {
+	static final class DirectScheduleTask implements ContextRunnable {
 
 		final Runnable      delegate;
 		final CachedService cached;
@@ -283,6 +285,11 @@ final class ElasticScheduler implements Scheduler, Supplier<ScheduledExecutorSer
 		DirectScheduleTask(Runnable delegate, CachedService cached) {
 			this.delegate = delegate;
 			this.cached = cached;
+		}
+
+		@Override
+		public Context currentContext() {
+			return delegate instanceof ContextAware ? ((ContextAware) delegate).currentContext() : Context.empty();
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
@@ -154,6 +154,7 @@ final class ElasticScheduler implements Scheduler, Supplier<ScheduledExecutorSer
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Disposable schedule(Runnable task) {
 		CachedService cached = pick();
 
@@ -164,6 +165,7 @@ final class ElasticScheduler implements Scheduler, Supplier<ScheduledExecutorSer
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
 		CachedService cached = pick();
 
@@ -174,6 +176,7 @@ final class ElasticScheduler implements Scheduler, Supplier<ScheduledExecutorSer
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Disposable schedulePeriodically(Runnable task, long initialDelay, long period, TimeUnit unit) {
 		CachedService cached = pick();
 
@@ -329,6 +332,7 @@ final class ElasticScheduler implements Scheduler, Supplier<ScheduledExecutorSer
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public Disposable schedule(Runnable task) {
 			return Schedulers.workerSchedule(cached.exec,
 					tasks,
@@ -338,11 +342,13 @@ final class ElasticScheduler implements Scheduler, Supplier<ScheduledExecutorSer
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
 			return Schedulers.workerSchedule(cached.exec, tasks, task, delay, unit);
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public Disposable schedulePeriodically(Runnable task,
 				long initialDelay,
 				long period,

--- a/reactor-core/src/main/java/reactor/core/scheduler/ExecutorScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ExecutorScheduler.java
@@ -52,6 +52,7 @@ final class ExecutorScheduler implements Scheduler, Scannable {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Disposable schedule(Runnable task) {
 		if(terminated){
 			throw Exceptions.failWithRejected();
@@ -230,6 +231,7 @@ final class ExecutorScheduler implements Scheduler, Scannable {
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public Disposable schedule(Runnable task) {
 			Objects.requireNonNull(task, "task");
 
@@ -303,6 +305,7 @@ final class ExecutorScheduler implements Scheduler, Scannable {
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public Disposable schedule(Runnable task) {
 			Objects.requireNonNull(task, "task");
 			if (terminated) {

--- a/reactor-core/src/main/java/reactor/core/scheduler/ExecutorServiceWorker.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ExecutorServiceWorker.java
@@ -39,16 +39,19 @@ final class ExecutorServiceWorker implements Scheduler.Worker, Disposable, Scann
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Disposable schedule(Runnable task) {
 		return Schedulers.workerSchedule(exec, tasks, task, 0L, TimeUnit.MILLISECONDS);
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
 		return Schedulers.workerSchedule(exec, tasks, task, delay, unit);
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Disposable schedulePeriodically(Runnable task,
 			long initialDelay,
 			long period,

--- a/reactor-core/src/main/java/reactor/core/scheduler/ImmediateScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ImmediateScheduler.java
@@ -43,6 +43,7 @@ final class ImmediateScheduler implements Scheduler, Scannable {
     static final Disposable FINISHED = Disposables.disposed();
     
     @Override
+    @SuppressWarnings("deprecation")
     public Disposable schedule(Runnable task) {
         task.run();
         return FINISHED;
@@ -72,6 +73,7 @@ final class ImmediateScheduler implements Scheduler, Scannable {
         volatile boolean shutdown;
 
         @Override
+        @SuppressWarnings("deprecation")
         public Disposable schedule(Runnable task) {
             if (shutdown) {
                 throw Exceptions.failWithRejected();

--- a/reactor-core/src/main/java/reactor/core/scheduler/InstantPeriodicWorkerTask.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/InstantPeriodicWorkerTask.java
@@ -22,13 +22,15 @@ import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
+import reactor.core.ContextAware;
 import reactor.core.Disposable;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * A runnable task for {@link Scheduler} Workers that can run periodically
  **/
-final class InstantPeriodicWorkerTask implements Disposable, Callable<Void> {
+final class InstantPeriodicWorkerTask implements Disposable, Callable<Void>, ContextAware {
 
 	final Runnable task;
 
@@ -56,6 +58,11 @@ final class InstantPeriodicWorkerTask implements Disposable, Callable<Void> {
 		this.task = task;
 		this.executor = executor;
 		PARENT.lazySet(this, parent);
+	}
+
+	@Override
+	public Context currentContext() {
+		return task instanceof ContextAware ? ((ContextAware) task).currentContext() : Context.empty();
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
@@ -149,16 +149,19 @@ final class ParallelScheduler implements Scheduler, Supplier<ScheduledExecutorSe
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public Disposable schedule(Runnable task) {
 	    return Schedulers.directSchedule(pick(), task, 0L, TimeUnit.MILLISECONDS);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
 	    return Schedulers.directSchedule(pick(), task, delay, unit);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public Disposable schedulePeriodically(Runnable task,
             long initialDelay,
             long period,

--- a/reactor-core/src/main/java/reactor/core/scheduler/PeriodicSchedulerTask.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/PeriodicSchedulerTask.java
@@ -16,15 +16,17 @@
 
 package reactor.core.scheduler;
 
+import reactor.core.ContextAware;
 import reactor.core.Disposable;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
-final class PeriodicSchedulerTask implements Runnable, Disposable, Callable<Void> {
+final class PeriodicSchedulerTask implements Scheduler.ContextRunnable, Disposable, Callable<Void> {
 
 	final Runnable task;
 
@@ -38,6 +40,11 @@ final class PeriodicSchedulerTask implements Runnable, Disposable, Callable<Void
 
 	PeriodicSchedulerTask(Runnable task) {
 		this.task = task;
+	}
+
+	@Override
+	public Context currentContext() {
+		return task instanceof ContextAware ? ((ContextAware) task).currentContext() : Context.empty();
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/PeriodicWorkerTask.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/PeriodicWorkerTask.java
@@ -16,8 +16,10 @@
 
 package reactor.core.scheduler;
 
+import reactor.core.ContextAware;
 import reactor.core.Disposable;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -27,7 +29,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 /**
  * A runnable task for {@link Scheduler} Workers that can run periodically
  **/
-final class PeriodicWorkerTask implements Runnable, Disposable, Callable<Void> {
+final class PeriodicWorkerTask implements Scheduler.ContextRunnable, Disposable, Callable<Void> {
 
 	final Runnable task;
 
@@ -48,6 +50,11 @@ final class PeriodicWorkerTask implements Runnable, Disposable, Callable<Void> {
 	PeriodicWorkerTask(Runnable task, Composite parent) {
 		this.task = task;
 		PARENT.lazySet(this, parent);
+	}
+
+	@Override
+	public Context currentContext() {
+		return task instanceof ContextAware ? ((ContextAware) task).currentContext() : Context.empty();
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -47,7 +47,6 @@ public interface Scheduler extends Disposable {
 	 *
 	 * @return the {@link Disposable} instance that let's one cancel this particular task.
 	 * If the {@link Scheduler} has been shut down, throw a {@link RejectedExecutionException}.
-	 *
 	 * @deprecated use {@link #schedule(ContextRunnable)}  to preserve the context.
 	 */
 	@Deprecated
@@ -61,7 +60,6 @@ public interface Scheduler extends Disposable {
 	 * ordering guarantees between tasks.
 	 *
 	 * @param task the task to execute
-	 *
 	 * @return the {@link Disposable} instance that let's one cancel this particular task.
 	 * If the {@link Scheduler} has been shut down, throw a {@link RejectedExecutionException}.
 	 */
@@ -81,7 +79,6 @@ public interface Scheduler extends Disposable {
 	 * @param unit the unit of measure of the delay amount
 	 * @return the {@link Disposable} that let's one cancel this particular delayed task,
 	 * or throw a {@link RejectedExecutionException} if the Scheduler is not capable of scheduling periodically.
-	 *
 	 * @deprecated use {@link #schedule(ContextRunnable, long, TimeUnit)} to preserve the context.
 	 */
 	@Deprecated
@@ -123,7 +120,6 @@ public interface Scheduler extends Disposable {
 	 * @param unit the unit of measure of the delay amount
 	 * @return the {@link Disposable} that let's one cancel this particular delayed task,
 	 * or throw a {@link RejectedExecutionException} if the Scheduler is not capable of scheduling periodically.
-	 *
 	 * @deprecated use {@link #schedulePeriodically(ContextRunnable, long, long, TimeUnit)} to preserve the context.
 	 */
 	@Deprecated
@@ -252,7 +248,6 @@ public interface Scheduler extends Disposable {
 		 * @param unit the unit of measure of the delay amount
 		 * @return the {@link Disposable} that let's one cancel this particular delayed task,
 		 * or throw a {@link RejectedExecutionException} if the Worker is not capable of scheduling with delay.
-		 *
 		 * @deprecated use {@link #schedule(ContextRunnable, long, TimeUnit)} to preserve the context.
 		 */
 		@Deprecated
@@ -295,7 +290,6 @@ public interface Scheduler extends Disposable {
 		 * @param unit the unit of measure of the delay amount
 		 * @return the {@link Disposable} that let's one cancel this particular delayed task,
 		 * or throw a {@link RejectedExecutionException} if the Worker is not capable of scheduling periodically.
-		 *
 		 * @deprecated use {@link #schedulePeriodically(ContextRunnable, long, long, TimeUnit)} to preserve the context.
 		 */
 		@Deprecated

--- a/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -15,12 +15,12 @@
  */
 package reactor.core.scheduler;
 
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import reactor.core.ContextAware;
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
 
@@ -48,7 +48,12 @@ public interface Scheduler extends Disposable {
 	 * @return the {@link Disposable} instance that let's one cancel this particular task.
 	 * If the {@link Scheduler} has been shut down, throw a {@link RejectedExecutionException}.
 	 */
+	@Deprecated
 	Disposable schedule(Runnable task);
+
+	default Disposable schedule(ContextRunnable task) {
+		return schedule((Runnable) task);
+	}
 
 	/**
 	 * Schedules the execution of the given task with the given delay amount.
@@ -63,8 +68,13 @@ public interface Scheduler extends Disposable {
 	 * @return the {@link Disposable} that let's one cancel this particular delayed task,
 	 * or throw a {@link RejectedExecutionException} if the Scheduler is not capable of scheduling periodically.
 	 */
+	@Deprecated
 	default Disposable schedule(Runnable task, long delay, TimeUnit unit) {
 		throw Exceptions.failWithRejectedNotTimeCapable();
+	}
+
+	default Disposable schedule(ContextRunnable task, long delay, TimeUnit unit) {
+		return schedule((Runnable) task, delay, unit);
 	}
 
 	/**
@@ -85,8 +95,13 @@ public interface Scheduler extends Disposable {
 	 * @return the {@link Disposable} that let's one cancel this particular delayed task,
 	 * or throw a {@link RejectedExecutionException} if the Scheduler is not capable of scheduling periodically.
 	 */
+	@Deprecated
 	default Disposable schedulePeriodically(Runnable task, long initialDelay, long period, TimeUnit unit) {
 		throw Exceptions.failWithRejectedNotTimeCapable();
+	}
+
+	default Disposable schedulePeriodically(ContextRunnable task, long initialDelay, long period, TimeUnit unit) {
+		return schedulePeriodically((Runnable) task, initialDelay, period, unit);
 	}
 
 	/**
@@ -137,6 +152,10 @@ public interface Scheduler extends Disposable {
 	default void start() {
 	}
 
+	interface ContextRunnable extends Runnable, ContextAware {
+
+	}
+
 	/**
 	 * A worker representing an asynchronous boundary that executes tasks.
 	 *
@@ -152,6 +171,10 @@ public interface Scheduler extends Disposable {
 		 * If the Scheduler has been shut down, a {@link RejectedExecutionException} is thrown.
 		 */
 		Disposable schedule(Runnable task);
+
+		default Disposable schedule(ContextRunnable task) {
+			return schedule((Runnable) task);
+		}
 
 		/**
 		 * Schedules the execution of the given task with the given delay amount.
@@ -170,6 +193,10 @@ public interface Scheduler extends Disposable {
 		 */
 		default Disposable schedule(Runnable task, long delay, TimeUnit unit) {
 			throw Exceptions.failWithRejectedNotTimeCapable();
+		}
+
+		default Disposable schedule(ContextRunnable task, long delay, TimeUnit unit) {
+			return schedule((Runnable) task, delay, unit);
 		}
 
 		/**
@@ -191,6 +218,10 @@ public interface Scheduler extends Disposable {
 		 */
 		default Disposable schedulePeriodically(Runnable task, long initialDelay, long period, TimeUnit unit) {
 			throw Exceptions.failWithRejectedNotTimeCapable();
+		}
+
+		default Disposable schedulePeriodically(ContextRunnable task, long initialDelay, long period, TimeUnit unit) {
+			return schedulePeriodically((Runnable) task, initialDelay, period, unit);
 		}
 
 	}

--- a/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -63,6 +63,7 @@ public interface Scheduler extends Disposable {
 	 * @return the {@link Disposable} instance that let's one cancel this particular task.
 	 * If the {@link Scheduler} has been shut down, throw a {@link RejectedExecutionException}.
 	 */
+	@SuppressWarnings("deprecation")
 	default Disposable schedule(ContextRunnable task) {
 		return schedule((Runnable) task);
 	}
@@ -99,6 +100,7 @@ public interface Scheduler extends Disposable {
 	 * @return the {@link Disposable} that let's one cancel this particular delayed task,
 	 * or throw a {@link RejectedExecutionException} if the Scheduler is not capable of scheduling periodically.
 	 */
+	@SuppressWarnings("deprecation")
 	default Disposable schedule(ContextRunnable task, long delay, TimeUnit unit) {
 		return schedule((Runnable) task, delay, unit);
 	}
@@ -145,6 +147,7 @@ public interface Scheduler extends Disposable {
 	 * @return the {@link Disposable} that let's one cancel this particular delayed task,
 	 * or throw a {@link RejectedExecutionException} if the Scheduler is not capable of scheduling periodically.
 	 */
+	@SuppressWarnings("deprecation")
 	default Disposable schedulePeriodically(ContextRunnable task, long initialDelay, long period, TimeUnit unit) {
 		return schedulePeriodically((Runnable) task, initialDelay, period, unit);
 	}
@@ -230,6 +233,7 @@ public interface Scheduler extends Disposable {
 		 * @return the {@link Disposable} instance that let's one cancel this particular task.
 		 * If the Scheduler has been shut down, a {@link RejectedExecutionException} is thrown.
 		 */
+		@SuppressWarnings("deprecation")
 		default Disposable schedule(ContextRunnable task) {
 			return schedule((Runnable) task);
 		}
@@ -270,6 +274,7 @@ public interface Scheduler extends Disposable {
 		 * @return the {@link Disposable} that let's one cancel this particular delayed task,
 		 * or throw a {@link RejectedExecutionException} if the Worker is not capable of scheduling with delay.
 		 */
+		@SuppressWarnings("deprecation")
 		default Disposable schedule(ContextRunnable task, long delay, TimeUnit unit) {
 			return schedule((Runnable) task, delay, unit);
 		}
@@ -314,6 +319,7 @@ public interface Scheduler extends Disposable {
 		 * @return the {@link Disposable} that let's one cancel this particular delayed task,
 		 * or throw a {@link RejectedExecutionException} if the Worker is not capable of scheduling periodically.
 		 */
+		@SuppressWarnings("deprecation")
 		default Disposable schedulePeriodically(ContextRunnable task, long initialDelay, long period, TimeUnit unit) {
 			return schedulePeriodically((Runnable) task, initialDelay, period, unit);
 		}

--- a/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -47,10 +47,24 @@ public interface Scheduler extends Disposable {
 	 *
 	 * @return the {@link Disposable} instance that let's one cancel this particular task.
 	 * If the {@link Scheduler} has been shut down, throw a {@link RejectedExecutionException}.
+	 *
+	 * @deprecated use {@link #schedule(ContextRunnable)}  to preserve the context.
 	 */
 	@Deprecated
 	Disposable schedule(Runnable task);
 
+	/**
+	 * Schedules the non-delayed execution of the given task on this scheduler.
+	 *
+	 * <p>
+	 * This method is safe to be called from multiple threads but there are no
+	 * ordering guarantees between tasks.
+	 *
+	 * @param task the task to execute
+	 *
+	 * @return the {@link Disposable} instance that let's one cancel this particular task.
+	 * If the {@link Scheduler} has been shut down, throw a {@link RejectedExecutionException}.
+	 */
 	default Disposable schedule(ContextRunnable task) {
 		return schedule((Runnable) task);
 	}
@@ -67,12 +81,27 @@ public interface Scheduler extends Disposable {
 	 * @param unit the unit of measure of the delay amount
 	 * @return the {@link Disposable} that let's one cancel this particular delayed task,
 	 * or throw a {@link RejectedExecutionException} if the Scheduler is not capable of scheduling periodically.
+	 *
+	 * @deprecated use {@link #schedule(ContextRunnable, long, TimeUnit)} to preserve the context.
 	 */
 	@Deprecated
 	default Disposable schedule(Runnable task, long delay, TimeUnit unit) {
 		throw Exceptions.failWithRejectedNotTimeCapable();
 	}
 
+	/**
+	 * Schedules the execution of the given task with the given delay amount.
+	 *
+	 * <p>
+	 * This method is safe to be called from multiple threads but there are no
+	 * ordering guarantees between tasks.
+	 *
+	 * @param task the task to schedule
+	 * @param delay the delay amount, non-positive values indicate non-delayed scheduling
+	 * @param unit the unit of measure of the delay amount
+	 * @return the {@link Disposable} that let's one cancel this particular delayed task,
+	 * or throw a {@link RejectedExecutionException} if the Scheduler is not capable of scheduling periodically.
+	 */
 	default Disposable schedule(ContextRunnable task, long delay, TimeUnit unit) {
 		return schedule((Runnable) task, delay, unit);
 	}
@@ -94,12 +123,32 @@ public interface Scheduler extends Disposable {
 	 * @param unit the unit of measure of the delay amount
 	 * @return the {@link Disposable} that let's one cancel this particular delayed task,
 	 * or throw a {@link RejectedExecutionException} if the Scheduler is not capable of scheduling periodically.
+	 *
+	 * @deprecated use {@link #schedulePeriodically(ContextRunnable, long, long, TimeUnit)} to preserve the context.
 	 */
 	@Deprecated
 	default Disposable schedulePeriodically(Runnable task, long initialDelay, long period, TimeUnit unit) {
 		throw Exceptions.failWithRejectedNotTimeCapable();
 	}
 
+	/**
+	 * Schedules a periodic execution of the given task with the given initial delay and period.
+	 *
+	 * <p>
+	 * This method is safe to be called from multiple threads but there are no
+	 * ordering guarantees between tasks.
+	 *
+	 * <p>
+	 * The periodic execution is at a fixed rate, that is, the first execution will be after the initial
+	 * delay, the second after initialDelay + period, the third after initialDelay + 2 * period, and so on.
+	 *
+	 * @param task the task to schedule
+	 * @param initialDelay the initial delay amount, non-positive values indicate non-delayed scheduling
+	 * @param period the period at which the task should be re-executed
+	 * @param unit the unit of measure of the delay amount
+	 * @return the {@link Disposable} that let's one cancel this particular delayed task,
+	 * or throw a {@link RejectedExecutionException} if the Scheduler is not capable of scheduling periodically.
+	 */
 	default Disposable schedulePeriodically(ContextRunnable task, long initialDelay, long period, TimeUnit unit) {
 		return schedulePeriodically((Runnable) task, initialDelay, period, unit);
 	}
@@ -152,6 +201,11 @@ public interface Scheduler extends Disposable {
 	default void start() {
 	}
 
+	/**
+	 * A {@link ContextAware} {@link Runnable} to preserve the current context.
+	 *
+	 * @author Sergei Egorov
+	 */
 	interface ContextRunnable extends Runnable, ContextAware {
 
 	}
@@ -169,9 +223,17 @@ public interface Scheduler extends Disposable {
 		 * @param task the task to schedule
 		 * @return the {@link Disposable} instance that let's one cancel this particular task.
 		 * If the Scheduler has been shut down, a {@link RejectedExecutionException} is thrown.
+		 * @deprecated use {@link #schedule(ContextRunnable)} to preserve the context.
 		 */
+		@Deprecated
 		Disposable schedule(Runnable task);
 
+		/**
+		 * Schedules the task for immediate execution on this worker.
+		 * @param task the task to schedule
+		 * @return the {@link Disposable} instance that let's one cancel this particular task.
+		 * If the Scheduler has been shut down, a {@link RejectedExecutionException} is thrown.
+		 */
 		default Disposable schedule(ContextRunnable task) {
 			return schedule((Runnable) task);
 		}
@@ -190,11 +252,29 @@ public interface Scheduler extends Disposable {
 		 * @param unit the unit of measure of the delay amount
 		 * @return the {@link Disposable} that let's one cancel this particular delayed task,
 		 * or throw a {@link RejectedExecutionException} if the Worker is not capable of scheduling with delay.
+		 *
+		 * @deprecated use {@link #schedule(ContextRunnable, long, TimeUnit)} to preserve the context.
 		 */
+		@Deprecated
 		default Disposable schedule(Runnable task, long delay, TimeUnit unit) {
 			throw Exceptions.failWithRejectedNotTimeCapable();
 		}
 
+		/**
+		 * Schedules the execution of the given task with the given delay amount.
+		 *
+		 * <p>
+		 * This method is safe to be called from multiple threads and tasks are executed in
+		 * some total order. Two tasks scheduled at a same time with the same delay will be
+		 * ordered in FIFO order if the schedule() was called from the same thread or
+		 * in arbitrary order if the schedule() was called from different threads.
+		 *
+		 * @param task the task to schedule
+		 * @param delay the delay amount, non-positive values indicate non-delayed scheduling
+		 * @param unit the unit of measure of the delay amount
+		 * @return the {@link Disposable} that let's one cancel this particular delayed task,
+		 * or throw a {@link RejectedExecutionException} if the Worker is not capable of scheduling with delay.
+		 */
 		default Disposable schedule(ContextRunnable task, long delay, TimeUnit unit) {
 			return schedule((Runnable) task, delay, unit);
 		}
@@ -215,11 +295,31 @@ public interface Scheduler extends Disposable {
 		 * @param unit the unit of measure of the delay amount
 		 * @return the {@link Disposable} that let's one cancel this particular delayed task,
 		 * or throw a {@link RejectedExecutionException} if the Worker is not capable of scheduling periodically.
+		 *
+		 * @deprecated use {@link #schedulePeriodically(ContextRunnable, long, long, TimeUnit)} to preserve the context.
 		 */
+		@Deprecated
 		default Disposable schedulePeriodically(Runnable task, long initialDelay, long period, TimeUnit unit) {
 			throw Exceptions.failWithRejectedNotTimeCapable();
 		}
 
+		/**
+		 * Schedules a periodic execution of the given task with the given initial delay and period.
+		 *
+		 * <p>
+		 * This method is safe to be called from multiple threads.
+		 *
+		 * <p>
+		 * The periodic execution is at a fixed rate, that is, the first execution will be after the initial
+		 * delay, the second after initialDelay + period, the third after initialDelay + 2 * period, and so on.
+		 *
+		 * @param task the task to schedule
+		 * @param initialDelay the initial delay amount, non-positive values indicate non-delayed scheduling
+		 * @param period the period at which the task should be re-executed
+		 * @param unit the unit of measure of the delay amount
+		 * @return the {@link Disposable} that let's one cancel this particular delayed task,
+		 * or throw a {@link RejectedExecutionException} if the Worker is not capable of scheduling periodically.
+		 */
 		default Disposable schedulePeriodically(ContextRunnable task, long initialDelay, long period, TimeUnit unit) {
 			return schedulePeriodically((Runnable) task, initialDelay, period, unit);
 		}

--- a/reactor-core/src/main/java/reactor/core/scheduler/SchedulerTask.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SchedulerTask.java
@@ -21,10 +21,12 @@ import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
+import reactor.core.ContextAware;
 import reactor.core.Disposable;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
-final class SchedulerTask implements Runnable, Disposable, Callable<Void> {
+final class SchedulerTask implements Scheduler.ContextRunnable, Disposable, Callable<Void> {
 
 	final Runnable task;
 
@@ -39,6 +41,11 @@ final class SchedulerTask implements Runnable, Disposable, Callable<Void> {
 
 	SchedulerTask(Runnable task) {
 		this.task = task;
+	}
+
+	@Override
+	public Context currentContext() {
+		return task instanceof ContextAware ? ((ContextAware) task).currentContext() : Context.empty();
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -41,6 +41,7 @@ import reactor.util.Logger;
 import reactor.util.Loggers;
 import reactor.util.Metrics;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 import static reactor.core.Exceptions.unwrap;
 
@@ -763,12 +764,30 @@ public abstract class Schedulers {
 		}
 
 		@Override
+		public Disposable schedule(ContextRunnable task) {
+			return cached.schedule(task);
+		}
+
+		@Override
 		public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
 			return cached.schedule(task, delay, unit);
 		}
 
 		@Override
+		public Disposable schedule(ContextRunnable task, long delay, TimeUnit unit) {
+			return cached.schedule(task, delay, unit);
+		}
+
+		@Override
 		public Disposable schedulePeriodically(Runnable task,
+				long initialDelay,
+				long period,
+				TimeUnit unit) {
+			return cached.schedulePeriodically(task, initialDelay, period, unit);
+		}
+
+		@Override
+		public Disposable schedulePeriodically(ContextRunnable task,
 				long initialDelay,
 				long period,
 				TimeUnit unit) {

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -759,6 +759,7 @@ public abstract class Schedulers {
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public Disposable schedule(Runnable task) {
 			return cached.schedule(task);
 		}
@@ -769,6 +770,7 @@ public abstract class Schedulers {
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
 			return cached.schedule(task, delay, unit);
 		}
@@ -779,6 +781,7 @@ public abstract class Schedulers {
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public Disposable schedulePeriodically(Runnable task,
 				long initialDelay,
 				long period,

--- a/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
@@ -114,16 +114,19 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Disposable schedule(Runnable task) {
 		return Schedulers.directSchedule(executor, task, 0L, TimeUnit.MILLISECONDS);
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
 		return Schedulers.directSchedule(executor, task, delay, unit);
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Disposable schedulePeriodically(Runnable task,
 			long initialDelay,
 			long period,

--- a/reactor-core/src/main/java/reactor/core/scheduler/SingleWorkerScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SingleWorkerScheduler.java
@@ -43,22 +43,26 @@ final class SingleWorkerScheduler implements Scheduler, Executor, Scannable {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public Disposable schedule(Runnable task) {
         return main.schedule(task);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
         return main.schedule(task, delay, unit);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public Disposable schedulePeriodically(Runnable task, long initialDelay,
             long period, TimeUnit unit) {
         return main.schedulePeriodically(task, initialDelay, period, unit);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void execute(Runnable command) {
         main.schedule(command);
     }

--- a/reactor-core/src/main/java/reactor/core/scheduler/WorkerTask.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/WorkerTask.java
@@ -21,8 +21,10 @@ import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
+import reactor.core.ContextAware;
 import reactor.core.Disposable;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * A runnable task for {@link Scheduler} Workers that are time-capable (implementing a
@@ -34,7 +36,7 @@ import reactor.util.annotation.Nullable;
  * @author Simon Baslé
  * @author David Karnok
  */
-final class WorkerTask implements Runnable, Disposable, Callable<Void> {
+final class WorkerTask implements Scheduler.ContextRunnable, Disposable, Callable<Void> {
 
 	final Runnable task;
 
@@ -73,6 +75,11 @@ final class WorkerTask implements Runnable, Disposable, Callable<Void> {
 	WorkerTask(Runnable task, Composite parent) {
 		this.task = task;
 		PARENT.lazySet(this, parent);
+	}
+
+	@Override
+	public Context currentContext() {
+		return task instanceof ContextAware ? ((ContextAware) task).currentContext() : Context.empty();
 	}
 
 	@Override

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
@@ -49,7 +49,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 						return Duration.ofMillis(100 * sig.get());
 					}
 					return Duration.ZERO;
-				}, Schedulers.parallel(), Context.empty());
+				}, Schedulers.parallel());
 
 		cached.block();
 		cached.block();
@@ -95,7 +95,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 				v -> { onNextTtl.incrementAndGet(); return Duration.ofMillis(100 * v);},
 				e -> { onErrorTtl.incrementAndGet(); return Duration.ofMillis(300);},
 				() -> { onEmptyTtl.incrementAndGet(); return Duration.ZERO;} ,
-				Schedulers.parallel(), Context.empty());
+				Schedulers.parallel());
 
 		cached.block();
 		cached.block();
@@ -145,7 +145,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 				v -> { onNextTtl.incrementAndGet(); return Duration.ofMillis(100 * v);},
 				e -> { onErrorTtl.incrementAndGet(); return Duration.ofMillis(4000);},
 				() -> { onEmptyTtl.incrementAndGet(); return Duration.ofMillis(300);} ,
-				Schedulers.parallel(), Context.empty());
+				Schedulers.parallel());
 
 		assertThat(cached.block())
 				.as("1 immediate")
@@ -188,7 +188,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 				v -> Duration.ofMillis(400 / v),
 				t -> Duration.ZERO,
 				() -> Duration.ZERO,
-				Schedulers.parallel(), Context.empty());
+				Schedulers.parallel());
 
 		StepVerifier.create(cached)
 		            .expectErrorSatisfies(e -> assertThat(e)
@@ -205,7 +205,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 				Duration::ofSeconds,
 				t -> Duration.ofSeconds(10),
 				() -> { throw new IllegalStateException("boom"); },
-				Schedulers.parallel(), Context.empty());
+				Schedulers.parallel());
 
 		StepVerifier.create(cached)
 		            .expectErrorSatisfies(e -> assertThat(e)
@@ -224,7 +224,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 				Duration::ofSeconds,
 				t -> { throw new IllegalStateException("boom"); },
 				() -> Duration.ZERO,
-				Schedulers.parallel(), Context.empty());
+				Schedulers.parallel());
 
 		StepVerifier.create(cached)
 		            .expectErrorSatisfies(e -> assertThat(e)
@@ -247,7 +247,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 				},
 				t -> Duration.ofSeconds(10),
 				() -> Duration.ofSeconds(10),
-				Schedulers.parallel(), Context.empty());
+				Schedulers.parallel());
 
 		StepVerifier.create(cached)
 		            .expectErrorSatisfies(e -> assertThat(e)
@@ -284,7 +284,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 					if (count.incrementAndGet() == 1) throw new IllegalStateException("transient");
 					return Duration.ofMillis(100);
 				},
-				Schedulers.parallel(), Context.empty());
+				Schedulers.parallel());
 
 		StepVerifier.create(cached)
 		            .expectErrorSatisfies(e -> assertThat(e)
@@ -321,7 +321,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 					return Duration.ofMillis(100);
 				},
 				() -> Duration.ofSeconds(10),
-				Schedulers.parallel(), Context.empty());
+				Schedulers.parallel());
 
 		StepVerifier.create(cached)
 		            .expectErrorSatisfies(e -> assertThat(e)
@@ -532,7 +532,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 	public void sourceCachedNoCoordinatorLeak() {
 		TestPublisher<Integer> source = TestPublisher.create();
 		MonoCacheTime<Integer> cached = new MonoCacheTime<>(source.mono(), Duration.ofSeconds(2),
-				Schedulers.parallel(), Context.empty());
+				Schedulers.parallel());
 		cached.subscribe();
 		WeakReference<Signal<Integer>> refCoordinator = new WeakReference<>(cached.state);
 
@@ -550,8 +550,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 
 		MonoCacheTime<Integer> cached = new MonoCacheTime<>(source.mono(),
 				Duration.ofMillis(100), //short cache TTL should trigger state change if source is not never
-				Schedulers.parallel(),
-				Context.empty());
+				Schedulers.parallel());
 
 		Disposable d1 = cached.subscribe();
 		cached.subscribe();
@@ -574,8 +573,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 
 		MonoCacheTime<Integer> cached = new MonoCacheTime<>(source.mono(),
 				Duration.ofMillis(100), //short cache TTL should trigger state change if source is not never
-				Schedulers.parallel(),
-				Context.empty());
+				Schedulers.parallel());
 
 		Disposable d1 = cached.subscribe();
 		cached.subscribe();
@@ -599,8 +597,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 
 		MonoCacheTime<Integer> cached = new MonoCacheTime<>(source.mono(),
 				Duration.ofMillis(100), //short cache TTL should trigger state change if source is not never
-				Schedulers.parallel(),
-				Context.empty());
+				Schedulers.parallel());
 
 		cached.subscribe();
 		cached.subscribe();
@@ -622,7 +619,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 		AtomicInteger contextFillCount = new AtomicInteger();
 		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 		Mono<Context> cached = Mono.subscriberContext()
-		                           .as(m -> new MonoCacheTime<>(m, Duration.ofMillis(500), vts, Context.empty()))
+		                           .as(m -> new MonoCacheTime<>(m, Duration.ofMillis(500), vts))
 		                           .subscriberContext(ctx -> ctx.put("a", "GOOD" + contextFillCount.incrementAndGet()));
 
 		//at first pass, the context is captured

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
@@ -49,7 +49,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 						return Duration.ofMillis(100 * sig.get());
 					}
 					return Duration.ZERO;
-				}, Schedulers.parallel());
+				}, Schedulers.parallel(), Context.empty());
 
 		cached.block();
 		cached.block();
@@ -95,7 +95,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 				v -> { onNextTtl.incrementAndGet(); return Duration.ofMillis(100 * v);},
 				e -> { onErrorTtl.incrementAndGet(); return Duration.ofMillis(300);},
 				() -> { onEmptyTtl.incrementAndGet(); return Duration.ZERO;} ,
-				Schedulers.parallel());
+				Schedulers.parallel(), Context.empty());
 
 		cached.block();
 		cached.block();
@@ -145,7 +145,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 				v -> { onNextTtl.incrementAndGet(); return Duration.ofMillis(100 * v);},
 				e -> { onErrorTtl.incrementAndGet(); return Duration.ofMillis(4000);},
 				() -> { onEmptyTtl.incrementAndGet(); return Duration.ofMillis(300);} ,
-				Schedulers.parallel());
+				Schedulers.parallel(), Context.empty());
 
 		assertThat(cached.block())
 				.as("1 immediate")
@@ -188,7 +188,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 				v -> Duration.ofMillis(400 / v),
 				t -> Duration.ZERO,
 				() -> Duration.ZERO,
-				Schedulers.parallel());
+				Schedulers.parallel(), Context.empty());
 
 		StepVerifier.create(cached)
 		            .expectErrorSatisfies(e -> assertThat(e)
@@ -205,7 +205,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 				Duration::ofSeconds,
 				t -> Duration.ofSeconds(10),
 				() -> { throw new IllegalStateException("boom"); },
-				Schedulers.parallel());
+				Schedulers.parallel(), Context.empty());
 
 		StepVerifier.create(cached)
 		            .expectErrorSatisfies(e -> assertThat(e)
@@ -224,7 +224,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 				Duration::ofSeconds,
 				t -> { throw new IllegalStateException("boom"); },
 				() -> Duration.ZERO,
-				Schedulers.parallel());
+				Schedulers.parallel(), Context.empty());
 
 		StepVerifier.create(cached)
 		            .expectErrorSatisfies(e -> assertThat(e)
@@ -247,7 +247,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 				},
 				t -> Duration.ofSeconds(10),
 				() -> Duration.ofSeconds(10),
-				Schedulers.parallel());
+				Schedulers.parallel(), Context.empty());
 
 		StepVerifier.create(cached)
 		            .expectErrorSatisfies(e -> assertThat(e)
@@ -284,7 +284,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 					if (count.incrementAndGet() == 1) throw new IllegalStateException("transient");
 					return Duration.ofMillis(100);
 				},
-				Schedulers.parallel());
+				Schedulers.parallel(), Context.empty());
 
 		StepVerifier.create(cached)
 		            .expectErrorSatisfies(e -> assertThat(e)
@@ -321,7 +321,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 					return Duration.ofMillis(100);
 				},
 				() -> Duration.ofSeconds(10),
-				Schedulers.parallel());
+				Schedulers.parallel(), Context.empty());
 
 		StepVerifier.create(cached)
 		            .expectErrorSatisfies(e -> assertThat(e)
@@ -532,7 +532,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 	public void sourceCachedNoCoordinatorLeak() {
 		TestPublisher<Integer> source = TestPublisher.create();
 		MonoCacheTime<Integer> cached = new MonoCacheTime<>(source.mono(), Duration.ofSeconds(2),
-				Schedulers.parallel());
+				Schedulers.parallel(), Context.empty());
 		cached.subscribe();
 		WeakReference<Signal<Integer>> refCoordinator = new WeakReference<>(cached.state);
 
@@ -550,7 +550,8 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 
 		MonoCacheTime<Integer> cached = new MonoCacheTime<>(source.mono(),
 				Duration.ofMillis(100), //short cache TTL should trigger state change if source is not never
-				Schedulers.parallel());
+				Schedulers.parallel(),
+				Context.empty());
 
 		Disposable d1 = cached.subscribe();
 		cached.subscribe();
@@ -573,7 +574,8 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 
 		MonoCacheTime<Integer> cached = new MonoCacheTime<>(source.mono(),
 				Duration.ofMillis(100), //short cache TTL should trigger state change if source is not never
-				Schedulers.parallel());
+				Schedulers.parallel(),
+				Context.empty());
 
 		Disposable d1 = cached.subscribe();
 		cached.subscribe();
@@ -597,7 +599,8 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 
 		MonoCacheTime<Integer> cached = new MonoCacheTime<>(source.mono(),
 				Duration.ofMillis(100), //short cache TTL should trigger state change if source is not never
-				Schedulers.parallel());
+				Schedulers.parallel(),
+				Context.empty());
 
 		cached.subscribe();
 		cached.subscribe();
@@ -619,7 +622,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 		AtomicInteger contextFillCount = new AtomicInteger();
 		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 		Mono<Context> cached = Mono.subscriberContext()
-		                           .as(m -> new MonoCacheTime<>(m, Duration.ofMillis(500), vts))
+		                           .as(m -> new MonoCacheTime<>(m, Duration.ofMillis(500), vts, Context.empty()))
 		                           .subscriberContext(ctx -> ctx.put("a", "GOOD" + contextFillCount.incrementAndGet()));
 
 		//at first pass, the context is captured

--- a/reactor-core/src/test/java/reactor/core/publisher/TrackingTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/TrackingTest.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.Disposable;
 import reactor.core.scheduler.Schedulers;
 
@@ -146,6 +148,8 @@ public class TrackingTest {
 
 	private static class TestTracker implements Tracker {
 
+		static final Logger log = LoggerFactory.getLogger(TestTracker.class);
+
 		final List<Marker>        markersRecorded = new ArrayList<>();
 		final ThreadLocal<Marker> currentMarker   = new ThreadLocal<>();
 
@@ -166,13 +170,19 @@ public class TrackingTest {
 
 		@Override
 		public void onMarkerCreated(Marker marker) {
+			log.info("onMarkerCreated(" + marker + ")");
 			markersRecorded.add(marker);
+			currentMarker.set(marker);
 		}
 
 		@Override
 		public Disposable onScopePassing(Marker marker) {
+			log.info("onScopePassing(" + marker + ")");
 			currentMarker.set(marker);
-			return () -> currentMarker.set(null);
+			return () -> {
+				log.info("onScopePassingCleanup(" + marker + ")");
+				currentMarker.set(null);
+			};
 		}
 	}
 }

--- a/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
+++ b/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
@@ -254,7 +254,6 @@ public class VirtualTimeScheduler implements Scheduler {
 	}
 
 	@Override
-	@SuppressWarnings("deprecation")
 	public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
 		if (shutdown) {
 			throw Exceptions.failWithRejected();
@@ -283,7 +282,6 @@ public class VirtualTimeScheduler implements Scheduler {
 	}
 
 	@Override
-	@SuppressWarnings("deprecation")
 	public Disposable schedulePeriodically(Runnable task,
 			long initialDelay,
 			long period, TimeUnit unit) {

--- a/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
+++ b/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
+import reactor.core.ContextAware;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.Exceptions;
@@ -35,6 +36,7 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
+import reactor.util.context.Context;
 
 /**
  * A {@link Scheduler} that uses a virtual clock, allowing to manipulate time
@@ -525,7 +527,7 @@ public class VirtualTimeScheduler implements Scheduler {
 		}
 	}
 
-	static class PeriodicDirectTask implements Runnable, Disposable {
+	static class PeriodicDirectTask implements ContextRunnable, Disposable {
 
 		final Runnable run;
 
@@ -533,6 +535,11 @@ public class VirtualTimeScheduler implements Scheduler {
 
 		PeriodicDirectTask(Runnable run) {
 			this.run = run;
+		}
+
+		@Override
+		public Context currentContext() {
+			return run instanceof ContextAware ? ((ContextAware) run).currentContext() : Context.empty();
 		}
 
 		@Override

--- a/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
+++ b/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
@@ -254,6 +254,7 @@ public class VirtualTimeScheduler implements Scheduler {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
 		if (shutdown) {
 			throw Exceptions.failWithRejected();
@@ -282,6 +283,7 @@ public class VirtualTimeScheduler implements Scheduler {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Disposable schedulePeriodically(Runnable task,
 			long initialDelay,
 			long period, TimeUnit unit) {
@@ -411,6 +413,7 @@ public class VirtualTimeScheduler implements Scheduler {
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public Disposable schedule(Runnable run, long delayTime, TimeUnit unit) {
 			if (shutdown) {
 				throw Exceptions.failWithRejected();
@@ -428,6 +431,7 @@ public class VirtualTimeScheduler implements Scheduler {
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public Disposable schedulePeriodically(Runnable task,
 				long initialDelay,
 				long period,


### PR DESCRIPTION
1) Introduced `schedule*(ContextRunnable, ...)` overloads
2) “find usages” on the `(Runnable)` one
3) replaced with `ContextRunnable`
4) repeated until there are no usages of `Runnable` except in `CachedScheduler` and tests