### PR TITLE
fixes switchOnFirst cancellation and complete case; fixes scheduling instant task

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
@@ -214,7 +214,7 @@ final class FluxSwitchOnFirst<T, R> extends FluxOperator<T, R> {
             CoreSubscriber<? super T> i = inner;
             T f = first;
 
-            if (f == null && i == null) {
+            if (f == null && i == null && !cancelled) {
                 Publisher<? extends R> result;
                 CoreSubscriber<? super R> o = outer;
 
@@ -249,7 +249,7 @@ final class FluxSwitchOnFirst<T, R> extends FluxOperator<T, R> {
             CoreSubscriber<? super T> i = inner;
             T f = first;
 
-            if (f == null && i == null) {
+            if (f == null && i == null && !cancelled) {
                 Publisher<? extends R> result;
                 CoreSubscriber<? super R> o = outer;
 
@@ -526,7 +526,7 @@ final class FluxSwitchOnFirst<T, R> extends FluxOperator<T, R> {
             CoreSubscriber<? super T> i = inner;
             T f = first;
 
-            if (f == null && i == null) {
+            if (f == null && i == null && !cancelled) {
                 Publisher<? extends R> result;
                 CoreSubscriber<? super R> o = outer;
 
@@ -561,7 +561,7 @@ final class FluxSwitchOnFirst<T, R> extends FluxOperator<T, R> {
             CoreSubscriber<? super T> i = inner;
             T f = first;
 
-            if (f == null && i == null) {
+            if (f == null && i == null && !cancelled) {
                 Publisher<? extends R> result;
                 CoreSubscriber<? super R> o = outer;
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/InstantPeriodicWorkerTask.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/InstantPeriodicWorkerTask.java
@@ -52,6 +52,11 @@ final class InstantPeriodicWorkerTask implements Disposable, Callable<Void> {
 
 	Thread thread;
 
+	InstantPeriodicWorkerTask(Runnable task, ExecutorService executor) {
+		this.task = task;
+		this.executor = executor;
+	}
+
 	InstantPeriodicWorkerTask(Runnable task, ExecutorService executor, Composite parent) {
 		this.task = task;
 		this.executor = executor;

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -862,7 +862,8 @@ public abstract class Schedulers {
 			isr.setFirst(f);
 
 			return isr;
-		} else {
+		}
+		else {
 			PeriodicSchedulerTask sr = new PeriodicSchedulerTask(task);
 			Future<?> f = exec.scheduleAtFixedRate(sr, initialDelay, period, unit);
 			sr.setFuture(f);

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -851,7 +851,7 @@ public abstract class Schedulers {
 
 		if (period <= 0L) {
 			InstantPeriodicWorkerTask isr =
-					new InstantPeriodicWorkerTask(task, exec, Disposables.composite());
+					new InstantPeriodicWorkerTask(task, exec);
 			Future<?> f;
 			if (initialDelay <= 0L) {
 				f = exec.submit(isr);

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -35,7 +35,6 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import reactor.core.Disposable;
-import reactor.core.Disposables;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.util.Logger;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
@@ -986,7 +986,7 @@ public class FluxSwitchOnFirstTest {
 
             @Override
             public Disposable schedule(Runnable task) {
-                return Disposables.composite();
+                return Disposables.never();
             }
 
             @Override

--- a/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
@@ -365,7 +365,7 @@ public abstract class AbstractSchedulerTest {
 	}
 
 	@Test(timeout = 10000)
-	final public void scheduleInstantTaskTest() throws Exception {
+	public void scheduleInstantTaskTest() throws Exception {
 		Scheduler s = scheduler();
 
 		try {
@@ -381,7 +381,7 @@ public abstract class AbstractSchedulerTest {
 	}
 
 	@Test(timeout = 10000)
-	final public void scheduleInstantTaskWithDelayTest() throws Exception {
+	public void scheduleInstantTaskWithDelayTest() throws Exception {
 		Scheduler s = scheduler();
 
 		try {

--- a/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
@@ -365,6 +365,38 @@ public abstract class AbstractSchedulerTest {
 	}
 
 	@Test(timeout = 10000)
+	final public void scheduleInstantTaskTest() throws Exception {
+		Scheduler s = scheduler();
+
+		try {
+			CountDownLatch latch = new CountDownLatch(1);
+
+			s.schedulePeriodically(latch::countDown, 0, 0, TimeUnit.MILLISECONDS);
+
+			assertThat(latch.await(100, TimeUnit.MILLISECONDS)).isTrue();
+		}
+		finally {
+			s.dispose();
+		}
+	}
+
+	@Test(timeout = 10000)
+	final public void scheduleInstantTaskWithDelayTest() throws Exception {
+		Scheduler s = scheduler();
+
+		try {
+			CountDownLatch latch = new CountDownLatch(1);
+
+			s.schedulePeriodically(latch::countDown, 50, 0, TimeUnit.MILLISECONDS);
+
+			assertThat(latch.await(100, TimeUnit.MILLISECONDS)).isTrue();
+		}
+		finally {
+			s.dispose();
+		}
+	}
+
+	@Test(timeout = 10000)
 	final public void workerScheduleAndDisposePeriod() throws Exception {
 		Scheduler s = scheduler();
 		Scheduler.Worker w = s.createWorker();

--- a/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTest.java
@@ -365,4 +365,12 @@ public class ExecutorSchedulerTest extends AbstractSchedulerTest {
 			worker.dispose();
 		}
 	}
+
+	@Override
+	@Test
+	public void scheduleInstantTaskTest() {}
+
+	@Override
+	@Test
+	public void scheduleInstantTaskWithDelayTest() {}
 }

--- a/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTrampolineTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTrampolineTest.java
@@ -99,4 +99,12 @@ public class ExecutorSchedulerTrampolineTest extends AbstractSchedulerTest {
 			worker.dispose();
 		}
 	}
+
+	@Override
+	@Test
+	public void scheduleInstantTaskTest() {}
+
+	@Override
+	@Test
+	public void scheduleInstantTaskWithDelayTest() {}
 }

--- a/reactor-core/src/test/java/reactor/core/scheduler/ImmediateSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ImmediateSchedulerTest.java
@@ -80,6 +80,14 @@ public class ImmediateSchedulerTest extends AbstractSchedulerTest {
 		}
 	}
 
+	@Override
+	@Test
+	public void scheduleInstantTaskTest() {}
+
+	@Override
+	@Test
+	public void scheduleInstantTaskWithDelayTest() {}
+
 	@Test
 	public void scanScheduler() {
 		ImmediateScheduler s = (ImmediateScheduler) Schedulers.immediate();

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -1219,6 +1219,21 @@ public class SchedulersTest {
 	}
 
 	@Test
+	public void testDirectScheduleZeroPeriodicallyCancelsSchedulerTask() throws Exception {
+		try(TaskCheckingScheduledExecutor executorService = new TaskCheckingScheduledExecutor()) {
+			CountDownLatch latch = new CountDownLatch(2);
+			Disposable disposable = Schedulers.directSchedulePeriodically(executorService, () -> {
+				latch.countDown();
+			}, 0, 0, TimeUnit.MILLISECONDS);
+			latch.await();
+
+			disposable.dispose();
+
+			assertThat(executorService.isAllTasksCancelledOrDone()).isTrue();
+		}
+	}
+
+	@Test
 	public void testWorkerSchedulePeriodicallyCancelsSchedulerTask() throws Exception {
 		try(TaskCheckingScheduledExecutor executorService = new TaskCheckingScheduledExecutor()) {
 			AtomicInteger zeroDelayZeroPeriod = new AtomicInteger();

--- a/reactor-core/src/test/java/reactor/core/scheduler/SingleWorkerSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SingleWorkerSchedulerTest.java
@@ -77,4 +77,12 @@ public class SingleWorkerSchedulerTest extends AbstractSchedulerTest {
 			workerWithBasicFactory.dispose();
 		}
 	}
+
+	@Override
+	@Test
+	public void scheduleInstantTaskTest() {}
+
+	@Override
+	@Test
+	public void scheduleInstantTaskWithDelayTest() {}
 }


### PR DESCRIPTION
Fix for cancelation case in the `switchOnFirst`operator
Fix for `Schedulers.<any>.schedulePeriodically(() -> {}, 0, 0, TimeUnit.MILLISECONDS)`