### PR TITLE
Bugfix for cancellation before terminal signal in SwitchOnFirst

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
@@ -214,7 +214,7 @@ final class FluxSwitchOnFirst<T, R> extends FluxOperator<T, R> {
             CoreSubscriber<? super T> i = inner;
             T f = first;
 
-            if (f == null && i == null) {
+            if (f == null && i == null && !cancelled) {
                 Publisher<? extends R> result;
                 CoreSubscriber<? super R> o = outer;
 
@@ -249,7 +249,7 @@ final class FluxSwitchOnFirst<T, R> extends FluxOperator<T, R> {
             CoreSubscriber<? super T> i = inner;
             T f = first;
 
-            if (f == null && i == null) {
+            if (f == null && i == null && !cancelled) {
                 Publisher<? extends R> result;
                 CoreSubscriber<? super R> o = outer;
 
@@ -526,7 +526,7 @@ final class FluxSwitchOnFirst<T, R> extends FluxOperator<T, R> {
             CoreSubscriber<? super T> i = inner;
             T f = first;
 
-            if (f == null && i == null) {
+            if (f == null && i == null && !cancelled) {
                 Publisher<? extends R> result;
                 CoreSubscriber<? super R> o = outer;
 
@@ -561,7 +561,7 @@ final class FluxSwitchOnFirst<T, R> extends FluxOperator<T, R> {
             CoreSubscriber<? super T> i = inner;
             T f = first;
 
-            if (f == null && i == null) {
+            if (f == null && i == null && !cancelled) {
                 Publisher<? extends R> result;
                 CoreSubscriber<? super R> o = outer;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
@@ -141,7 +141,7 @@ public class FluxSwitchOnFirstTest {
                                         latch.await();
                                     }
                                     catch (InterruptedException e) {
-                                        e.printStackTrace();
+                                        throw new RuntimeException(e);
                                     }
                                 })
                                 .hide()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
@@ -103,7 +103,6 @@ public class FluxSwitchOnFirstTest {
 
     @Test
     public void shouldNotSubscribeTwiceWhenCanceled() {
-        Schedulers.single().start();
         CountDownLatch latch = new CountDownLatch(1);
         StepVerifier.create(Flux.just(1L)
                                 .doOnComplete(() -> {
@@ -121,8 +120,8 @@ public class FluxSwitchOnFirstTest {
                                 .switchOnFirst((s, f) -> f)
                                 .doOnSubscribe(s ->
                                     Schedulers
-                                        .single()
-                                        .schedulePeriodically(s::cancel, 10, 0, TimeUnit.MILLISECONDS)
+                                            .single()
+                                            .schedule(s::cancel, 10, TimeUnit.MILLISECONDS)
                                 )
         )
                     .expectSubscription()
@@ -135,7 +134,6 @@ public class FluxSwitchOnFirstTest {
 
     @Test
     public void shouldNotSubscribeTwiceConditionalWhenCanceled() {
-        Schedulers.single().start();
         CountDownLatch latch = new CountDownLatch(1);
         StepVerifier.create(Flux.just(1L)
                                 .doOnComplete(() -> {
@@ -155,7 +153,7 @@ public class FluxSwitchOnFirstTest {
                                 .doOnSubscribe(s ->
                                     Schedulers
                                         .single()
-                                        .schedulePeriodically(s::cancel, 10, 0, TimeUnit.MILLISECONDS)
+                                        .schedule(s::cancel, 10, TimeUnit.MILLISECONDS)
                                 )
         )
                     .expectSubscription()


### PR DESCRIPTION
fixes double subscriptions on state cleanup when cancellation is before the terminal signal