### PR TITLE
fix #1503 Subscription setup before fromRunnable execution allows cancel

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCallableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCallableTest.java
@@ -16,9 +16,18 @@
 package reactor.core.publisher;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
+import org.assertj.core.data.Offset;
 import org.junit.Test;
+import org.reactivestreams.Subscription;
+
+import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.util.function.Tuple2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -137,5 +146,45 @@ public class MonoCallableTest {
         MonoCallable<Integer> monoCallable = new MonoCallable<>(() -> null);
 
         assertThat(monoCallable.call()).isNull();
+    }
+
+    //see https://github.com/reactor/reactor-core/issues/1503
+    @Test
+    public void callableCancelledBeforeRun() {
+        AtomicBoolean actual = new AtomicBoolean(true);
+        Mono<?> mono = Mono.fromCallable(() -> actual.getAndSet(false))
+                           .doOnSubscribe(Subscription::cancel);
+
+        StepVerifier.create(mono)
+                    .expectSubscription()
+                    .expectNoEvent(Duration.ofSeconds(1))
+                    .thenCancel()
+                    .verify();
+
+        assertThat(actual.get()).as("cancelled before run").isTrue();
+    }
+
+    //see https://github.com/reactor/reactor-core/issues/1503
+    //see https://github.com/reactor/reactor-core/issues/1504
+    @Test
+    public void callableSubscribeToCompleteMeasurement() {
+        AtomicLong subscribeTs = new AtomicLong();
+        Mono<String> mono = Mono.fromCallable(() -> {
+            try {
+                Thread.sleep(500);
+            }
+            catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            return "foo";
+        })
+                                .doOnSubscribe(sub -> subscribeTs.set(-1 * System.nanoTime()))
+                                .doFinally(fin -> subscribeTs.addAndGet(System.nanoTime()));
+
+        StepVerifier.create(mono)
+                    .expectNext("foo")
+                    .verifyComplete();
+
+        assertThat(TimeUnit.NANOSECONDS.toMillis(subscribeTs.get())).isCloseTo(500L, Offset.offset(50L));
     }
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCallableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCallableTest.java
@@ -161,7 +161,7 @@ public class MonoCallableTest {
                     .thenCancel()
                     .verify();
 
-        assertThat(actual.get()).as("cancelled before run").isTrue();
+        assertThat(actual).as("cancelled before run").isTrue();
     }
 
     //see https://github.com/reactor/reactor-core/issues/1503

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRunnableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRunnableTest.java
@@ -142,7 +142,7 @@ public class MonoRunnableTest {
 		            .thenCancel()
 		            .verify();
 
-		assertThat(actual.get()).as("cancelled before run").isTrue();
+		assertThat(actual).as("cancelled before run").isTrue();
 	}
 
 	//see https://github.com/reactor/reactor-core/issues/1503

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRunnableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRunnableTest.java
@@ -16,13 +16,21 @@
 
 package reactor.core.publisher;
 
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.assertj.core.data.Offset;
 import org.junit.Assert;
 import org.junit.Test;
+import org.reactivestreams.Subscription;
+
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.util.function.Tuple2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -119,5 +127,43 @@ public class MonoRunnableTest {
 		    .block();
 
 		Assert.assertEquals(1000, c[0]);
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/1503
+	@Test
+	public void runnableCancelledBeforeRun() {
+		AtomicBoolean actual = new AtomicBoolean(true);
+		Mono<?> mono = Mono.fromRunnable(() -> actual.set(false))
+		                   .doOnSubscribe(Subscription::cancel);
+
+		StepVerifier.create(mono)
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofSeconds(1))
+		            .thenCancel()
+		            .verify();
+
+		assertThat(actual.get()).as("cancelled before run").isTrue();
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/1503
+	//see https://github.com/reactor/reactor-core/issues/1504
+	@Test
+	public void runnableSubscribeToCompleteMeasurement() {
+		AtomicLong subscribeTs = new AtomicLong();
+		Mono<Object> mono = Mono.fromRunnable(() -> {
+			try {
+				Thread.sleep(500);
+			}
+			catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+		})
+		                      .doOnSubscribe(sub -> subscribeTs.set(-1 * System.nanoTime()))
+		                      .doFinally(fin -> subscribeTs.addAndGet(System.nanoTime()));
+
+		StepVerifier.create(mono)
+		            .verifyComplete();
+
+		assertThat(TimeUnit.NANOSECONDS.toMillis(subscribeTs.get())).isCloseTo(500L, Offset.offset(50L));
 	}
 }


### PR DESCRIPTION
This commit calls `onSubscribe` on the downstream of `Mono#fromRunnable`,
ignoring requests but allowing for the case where the subscription would
be cancelled before the `Runnable` had a chance to execute.

This allows preventing execution of the `Runnable`. It also let the
operator behave better with operators that trigger behavior during
subscription (eg. `elapsed()` or `doOnSubscribe`).