### PR TITLE
Introduce `CorePublisher` interface.

### DIFF
--- a/reactor-core/src/main/java/reactor/core/CorePublisher.java
+++ b/reactor-core/src/main/java/reactor/core/CorePublisher.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core;
+
+import java.util.function.Function;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import reactor.core.publisher.Hooks;
+import reactor.util.context.Context;
+
+/**
+ * A {@link CoreSubscriber} aware publisher.
+ *
+ *
+ * @param <T> the {@link CoreSubscriber} data type
+ *
+ * @since 3.3.0
+ */
+public interface CorePublisher<T> extends Publisher<T> {
+
+	/**
+	 * An internal {@link Publisher#subscribe(Subscriber)} that will bypass
+	 * {@link Hooks#onLastOperator(Function)} pointcut.
+	 * <p>
+	 * In addition to behave as expected by {@link Publisher#subscribe(Subscriber)}
+	 * in a controlled manner, it supports direct subscribe-time {@link Context} passing.
+	 *
+	 * @param subscriber the {@link Subscriber} interested into the published sequence
+	 * @see Publisher#subscribe(Subscriber)
+	 */
+	void subscribe(CoreSubscriber<? super T> subscriber);
+
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -49,6 +49,7 @@ import java.util.stream.Stream;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import reactor.core.CorePublisher;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
@@ -110,7 +111,7 @@ import reactor.util.function.Tuples;
  *
  * @see Mono
  */
-public abstract class Flux<T> implements Publisher<T> {
+public abstract class Flux<T> implements CorePublisher<T> {
 
 //	 ==============================================================================================================
 //	 Static Generators
@@ -2340,7 +2341,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	@Nullable
 	public final T blockFirst() {
 		BlockingFirstSubscriber<T> subscriber = new BlockingFirstSubscriber<>();
-		onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(subscriber));
 		return subscriber.blockingGet();
 	}
 
@@ -2363,7 +2364,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	@Nullable
 	public final T blockFirst(Duration timeout) {
 		BlockingFirstSubscriber<T> subscriber = new BlockingFirstSubscriber<>();
-		onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(subscriber));
 		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
 	}
 
@@ -2385,7 +2386,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	@Nullable
 	public final T blockLast() {
 		BlockingLastSubscriber<T> subscriber = new BlockingLastSubscriber<>();
-		onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(subscriber));
 		return subscriber.blockingGet();
 	}
 
@@ -2409,7 +2410,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	@Nullable
 	public final T blockLast(Duration timeout) {
 		BlockingLastSubscriber<T> subscriber = new BlockingLastSubscriber<>();
-		onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(subscriber));
 		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
 	}
 
@@ -7740,7 +7741,7 @@ public abstract class Flux<T> implements Publisher<T> {
 
 	@Override
 	public final void subscribe(Subscriber<? super T> actual) {
-		onLastAssembly(this).subscribe(Operators.toCoreSubscriber(actual));
+		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(actual));
 	}
 
 	/**
@@ -9147,8 +9148,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param source the source to apply assembly hooks onto
 	 *
 	 * @return the source, potentially wrapped with assembly time cross-cutting behavior
+	 * @deprecated use {@link Hooks#onLastOperator(CorePublisher)}
 	 */
 	@SuppressWarnings("unchecked")
+	@Deprecated
 	protected static <T> Flux<T> onLastAssembly(Flux<T> source) {
 		Function<Publisher, Publisher> hook = Hooks.onLastOperatorHook;
 		if(hook == null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -100,7 +100,7 @@ import reactor.util.function.Tuples;
  * {@link #subscribe(Subscriber)} used internally for {@link Context} passing. User
  * provided {@link Subscriber} may
  * be passed to this "subscribe" extension but will loose the available
- * per-subscribe @link Hooks#onSubscribe}.
+ * per-subscribe {@link Hooks#onLastOperator}.
  *
  * @param <T> the element type of this Reactive Streams {@link Publisher}
  *

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -2341,7 +2341,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	@Nullable
 	public final T blockFirst() {
 		BlockingFirstSubscriber<T> subscriber = new BlockingFirstSubscriber<>();
-		Operators.doSubscribe(this, subscriber);
+		Operators.onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
 		return subscriber.blockingGet();
 	}
 
@@ -2364,7 +2364,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	@Nullable
 	public final T blockFirst(Duration timeout) {
 		BlockingFirstSubscriber<T> subscriber = new BlockingFirstSubscriber<>();
-		Operators.doSubscribe(this, subscriber);
+		Operators.onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
 		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
 	}
 
@@ -2386,7 +2386,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	@Nullable
 	public final T blockLast() {
 		BlockingLastSubscriber<T> subscriber = new BlockingLastSubscriber<>();
-		Operators.doSubscribe(this, subscriber);
+		Operators.onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
 		return subscriber.blockingGet();
 	}
 
@@ -2410,7 +2410,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	@Nullable
 	public final T blockLast(Duration timeout) {
 		BlockingLastSubscriber<T> subscriber = new BlockingLastSubscriber<>();
-		Operators.doSubscribe(this, subscriber);
+		Operators.onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
 		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
 	}
 
@@ -7740,9 +7740,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public final void subscribe(Subscriber<? super T> actual) {
-		Operators.doSubscribe(this, actual);
+		Operators.onLastAssembly(this).subscribe(Operators.toCoreSubscriber(actual));
 	}
 
 	/**
@@ -9149,7 +9148,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @param source the source to apply assembly hooks onto
 	 *
 	 * @return the source, potentially wrapped with assembly time cross-cutting behavior
-	 * @deprecated use {@link Operators#doSubscribe(CorePublisher, Subscriber)}
+	 * @deprecated use {@link Operators#onLastAssembly(CorePublisher)}
 	 */
 	@SuppressWarnings("unchecked")
 	@Deprecated

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -100,7 +100,7 @@ import reactor.util.function.Tuples;
  * {@link #subscribe(Subscriber)} used internally for {@link Context} passing. User
  * provided {@link Subscriber} may
  * be passed to this "subscribe" extension but will loose the available
- * per-subscribe @link Hooks#onLastOperator}.
+ * per-subscribe @link Hooks#onSubscribe}.
  *
  * @param <T> the element type of this Reactive Streams {@link Publisher}
  *
@@ -2341,7 +2341,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	@Nullable
 	public final T blockFirst() {
 		BlockingFirstSubscriber<T> subscriber = new BlockingFirstSubscriber<>();
-		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		Operators.doSubscribe(this, subscriber);
 		return subscriber.blockingGet();
 	}
 
@@ -2364,7 +2364,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	@Nullable
 	public final T blockFirst(Duration timeout) {
 		BlockingFirstSubscriber<T> subscriber = new BlockingFirstSubscriber<>();
-		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		Operators.doSubscribe(this, subscriber);
 		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
 	}
 
@@ -2386,7 +2386,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	@Nullable
 	public final T blockLast() {
 		BlockingLastSubscriber<T> subscriber = new BlockingLastSubscriber<>();
-		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		Operators.doSubscribe(this, subscriber);
 		return subscriber.blockingGet();
 	}
 
@@ -2410,7 +2410,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	@Nullable
 	public final T blockLast(Duration timeout) {
 		BlockingLastSubscriber<T> subscriber = new BlockingLastSubscriber<>();
-		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		Operators.doSubscribe(this, subscriber);
 		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
 	}
 
@@ -7740,8 +7740,9 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public final void subscribe(Subscriber<? super T> actual) {
-		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(actual));
+		Operators.doSubscribe(this, actual);
 	}
 
 	/**
@@ -9148,7 +9149,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @param source the source to apply assembly hooks onto
 	 *
 	 * @return the source, potentially wrapped with assembly time cross-cutting behavior
-	 * @deprecated use {@link Hooks#onLastOperator(CorePublisher)}
+	 * @deprecated use {@link Operators#doSubscribe(CorePublisher, Subscriber)}
 	 */
 	@SuppressWarnings("unchecked")
 	@Deprecated

--- a/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
@@ -27,9 +27,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
-import reactor.core.CorePublisher;
-import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.publisher.FluxOnAssembly.AssemblySnapshot;
 import reactor.util.Logger;
@@ -465,35 +462,6 @@ public abstract class Hooks {
 		log.debug("Reset to factory defaults : onNextError");
 		synchronized (log) {
 			onNextErrorHook = null;
-		}
-	}
-
-	@SuppressWarnings("unchecked")
-	static <T> CorePublisher<T> onLastOperator(CorePublisher<T> source) {
-		Function<Publisher, Publisher> hook = Hooks.onLastOperatorHook;
-		final Publisher<T> publisher;
-		if (hook == null) {
-			publisher = source;
-		}
-		else {
-			publisher = Objects.requireNonNull(hook.apply(source),"LastOperator hook returned null");
-		}
-
-		if (publisher instanceof CorePublisher) {
-			return (CorePublisher<T>) publisher;
-		}
-		else {
-			return new CorePublisher<T>() {
-				@Override
-				public void subscribe(CoreSubscriber<? super T> subscriber) {
-					publisher.subscribe(subscriber);
-				}
-
-				@Override
-				public void subscribe(Subscriber<? super T> s) {
-					publisher.subscribe(s);
-				}
-			};
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
@@ -27,6 +27,9 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import reactor.core.CorePublisher;
+import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.publisher.FluxOnAssembly.AssemblySnapshot;
 import reactor.util.Logger;
@@ -462,6 +465,35 @@ public abstract class Hooks {
 		log.debug("Reset to factory defaults : onNextError");
 		synchronized (log) {
 			onNextErrorHook = null;
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	static <T> CorePublisher<T> onLastOperator(CorePublisher<T> source) {
+		Function<Publisher, Publisher> hook = Hooks.onLastOperatorHook;
+		final Publisher<T> publisher;
+		if (hook == null) {
+			publisher = source;
+		}
+		else {
+			publisher = Objects.requireNonNull(hook.apply(source),"LastOperator hook returned null");
+		}
+
+		if (publisher instanceof CorePublisher) {
+			return (CorePublisher<T>) publisher;
+		}
+		else {
+			return new CorePublisher<T>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super T> subscriber) {
+					publisher.subscribe(subscriber);
+				}
+
+				@Override
+				public void subscribe(Subscriber<? super T> s) {
+					publisher.subscribe(s);
+				}
+			};
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1497,7 +1497,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	@Nullable
 	public T block() {
 		BlockingMonoSubscriber<T> subscriber = new BlockingMonoSubscriber<>();
-		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		Operators.doSubscribe(this, subscriber);
 		return subscriber.blockingGet();
 	}
 
@@ -1521,7 +1521,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	@Nullable
 	public T block(Duration timeout) {
 		BlockingMonoSubscriber<T> subscriber = new BlockingMonoSubscriber<>();
-		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		Operators.doSubscribe(this, subscriber);
 		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
 	}
 
@@ -1542,7 +1542,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 */
 	public Optional<T> blockOptional() {
 		BlockingOptionalMonoSubscriber<T> subscriber = new BlockingOptionalMonoSubscriber<>();
-		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		Operators.doSubscribe(this, subscriber);
 		return subscriber.blockingGet();
 	}
 
@@ -1567,7 +1567,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 */
 	public Optional<T> blockOptional(Duration timeout) {
 		BlockingOptionalMonoSubscriber<T> subscriber = new BlockingOptionalMonoSubscriber<>();
-		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		Operators.doSubscribe(this, subscriber);
 		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
 	}
 
@@ -3693,7 +3693,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 
 	@Override
 	public final void subscribe(Subscriber<? super T> actual) {
-		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(actual));
+		Operators.doSubscribe(this, actual);
 	}
 
 	/**
@@ -4300,7 +4300,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @param source the source to apply assembly hooks onto
 	 *
 	 * @return the source, potentially wrapped with assembly time cross-cutting behavior
-	 * @deprecated use {@link Hooks#onLastOperator(CorePublisher)}
+	 * @deprecated use {@link Operators#doSubscribe(CorePublisher, Subscriber)}
 	 */
 	@SuppressWarnings("unchecked")
 	@Deprecated

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -41,6 +41,7 @@ import java.util.stream.LongStream;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import reactor.core.CorePublisher;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Fuseable;
@@ -98,7 +99,7 @@ import reactor.util.function.Tuples;
  * @author Simon Baslé
  * @see Flux
  */
-public abstract class Mono<T> implements Publisher<T> {
+public abstract class Mono<T> implements CorePublisher<T> {
 
 //	 ==============================================================================================================
 //	 Static Generators
@@ -1496,7 +1497,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	@Nullable
 	public T block() {
 		BlockingMonoSubscriber<T> subscriber = new BlockingMonoSubscriber<>();
-		onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(subscriber));
 		return subscriber.blockingGet();
 	}
 
@@ -1520,7 +1521,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	@Nullable
 	public T block(Duration timeout) {
 		BlockingMonoSubscriber<T> subscriber = new BlockingMonoSubscriber<>();
-		onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(subscriber));
 		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
 	}
 
@@ -1541,7 +1542,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 */
 	public Optional<T> blockOptional() {
 		BlockingOptionalMonoSubscriber<T> subscriber = new BlockingOptionalMonoSubscriber<>();
-		onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(subscriber));
 		return subscriber.blockingGet();
 	}
 
@@ -1566,7 +1567,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 */
 	public Optional<T> blockOptional(Duration timeout) {
 		BlockingOptionalMonoSubscriber<T> subscriber = new BlockingOptionalMonoSubscriber<>();
-		onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
+		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(subscriber));
 		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
 	}
 
@@ -3692,7 +3693,7 @@ public abstract class Mono<T> implements Publisher<T> {
 
 	@Override
 	public final void subscribe(Subscriber<? super T> actual) {
-		onLastAssembly(this).subscribe(Operators.toCoreSubscriber(actual));
+		Hooks.onLastOperator(this).subscribe(Operators.toCoreSubscriber(actual));
 	}
 
 	/**
@@ -4299,8 +4300,10 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @param source the source to apply assembly hooks onto
 	 *
 	 * @return the source, potentially wrapped with assembly time cross-cutting behavior
+	 * @deprecated use {@link Hooks#onLastOperator(CorePublisher)}
 	 */
 	@SuppressWarnings("unchecked")
+	@Deprecated
 	protected static <T> Mono<T> onLastAssembly(Mono<T> source) {
 		Function<Publisher, Publisher> hook = Hooks.onLastOperatorHook;
 		if(hook == null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1497,7 +1497,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	@Nullable
 	public T block() {
 		BlockingMonoSubscriber<T> subscriber = new BlockingMonoSubscriber<>();
-		Operators.doSubscribe(this, subscriber);
+		Operators.onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
 		return subscriber.blockingGet();
 	}
 
@@ -1521,7 +1521,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	@Nullable
 	public T block(Duration timeout) {
 		BlockingMonoSubscriber<T> subscriber = new BlockingMonoSubscriber<>();
-		Operators.doSubscribe(this, subscriber);
+		Operators.onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
 		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
 	}
 
@@ -1542,7 +1542,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 */
 	public Optional<T> blockOptional() {
 		BlockingOptionalMonoSubscriber<T> subscriber = new BlockingOptionalMonoSubscriber<>();
-		Operators.doSubscribe(this, subscriber);
+		Operators.onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
 		return subscriber.blockingGet();
 	}
 
@@ -1567,7 +1567,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 */
 	public Optional<T> blockOptional(Duration timeout) {
 		BlockingOptionalMonoSubscriber<T> subscriber = new BlockingOptionalMonoSubscriber<>();
-		Operators.doSubscribe(this, subscriber);
+		Operators.onLastAssembly(this).subscribe(Operators.toCoreSubscriber(subscriber));
 		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
 	}
 
@@ -3693,7 +3693,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 
 	@Override
 	public final void subscribe(Subscriber<? super T> actual) {
-		Operators.doSubscribe(this, actual);
+		Operators.onLastAssembly(this).subscribe(Operators.toCoreSubscriber(actual));
 	}
 
 	/**
@@ -4300,7 +4300,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @param source the source to apply assembly hooks onto
 	 *
 	 * @return the source, potentially wrapped with assembly time cross-cutting behavior
-	 * @deprecated use {@link Operators#doSubscribe(CorePublisher, Subscriber)}
+	 * @deprecated use {@link Operators#onLastAssembly(CorePublisher)}
 	 */
 	@SuppressWarnings("unchecked")
 	@Deprecated

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -790,18 +790,7 @@ public abstract class Operators {
 			return (CorePublisher<T>) publisher;
 		}
 		else {
-			return new CorePublisher<T>() {
-				@Override
-				public void subscribe(CoreSubscriber<? super T> subscriber) {
-					publisher.subscribe(subscriber);
-				}
-
-				@Override
-				public void subscribe(Subscriber<? super T> s) {
-					publisher.subscribe(s);
-
-				}
-			};
+			return new CorePublisherAdapter<>(publisher);
 		}
 	}
 
@@ -1258,6 +1247,26 @@ public abstract class Operators {
 	}
 
 	Operators() {
+	}
+
+	static final class CorePublisherAdapter<T> implements CorePublisher<T> {
+
+		final Publisher<T> publisher;
+
+		CorePublisherAdapter(Publisher<T> publisher) {
+			this.publisher = publisher;
+		}
+
+		@Override
+		public void subscribe(CoreSubscriber<? super T> subscriber) {
+			publisher.subscribe(subscriber);
+		}
+
+		@Override
+		public void subscribe(Subscriber<? super T> s) {
+			publisher.subscribe(s);
+
+		}
 	}
 
 	static final CoreSubscriber<?> EMPTY_SUBSCRIBER = new CoreSubscriber<Object>() {

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -1005,13 +1005,11 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public final void subscribe(CoreSubscriber<? super T> subscriber) {
-		if (subscriber instanceof MultiSubscriber) {
-			subscribe(((MultiSubscriber<? super T>) subscriber).getSubscribers());
-		}
-		else {
-			subscribe((Subscriber<? super T>) subscriber);
-		}
+	public final void subscribe(CoreSubscriber<? super T> s) {
+		FluxHide.SuppressFuseableSubscriber<T> subscriber =
+				new FluxHide.SuppressFuseableSubscriber<>(Operators.toCoreSubscriber(s));
+
+		sequential().subscribe(Operators.toCoreSubscriber(subscriber));
 	}
 
 	/**
@@ -1030,19 +1028,29 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 			@Nullable Runnable onComplete,
 			@Nullable Consumer<? super Subscription> onSubscribe){
 
-		@SuppressWarnings("unchecked")
-		LambdaSubscriber<? super T>[] subscribers = new LambdaSubscriber[parallelism()];
+		CorePublisher<T> publisher = Operators.onLastAssembly(this);
+		if (publisher instanceof ParallelFlux) {
+			@SuppressWarnings("unchecked")
+			LambdaSubscriber<? super T>[] subscribers = new LambdaSubscriber[parallelism()];
 
-		int i = 0;
-		while(i < subscribers.length){
-			subscribers[i++] =
-					new LambdaSubscriber<>(onNext, onError, onComplete, onSubscribe);
+			int i = 0;
+			while(i < subscribers.length){
+				subscribers[i++] =
+						new LambdaSubscriber<>(onNext, onError, onComplete, onSubscribe);
+			}
+
+			((ParallelFlux<T>) publisher).subscribe(subscribers);
+
+			return Disposables.composite(subscribers);
 		}
+		else {
+			LambdaSubscriber<? super T> subscriber =
+					new LambdaSubscriber<>(onNext, onError, onComplete, onSubscribe);
 
-		@SuppressWarnings("unchecked")
-		MultiSubscriber<T> multiSubscriber = new MultiSubscriber<>((CoreSubscriber<T>[]) subscribers);
-		Operators.onLastAssembly(this).subscribe(multiSubscriber);
-		return Disposables.composite(subscribers);
+			publisher.subscribe(Operators.toCoreSubscriber(new FluxHide.SuppressFuseableSubscriber<>(subscriber)));
+
+			return subscriber;
+		}
 	}
 
 	/**
@@ -1284,39 +1292,6 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 		}
 
 		return both;
-	}
-
-	private static class MultiSubscriber<T> implements CoreSubscriber<T> {
-
-		final CoreSubscriber<T>[] subscribers;
-
-		private MultiSubscriber(CoreSubscriber<T>[] subscribers) {
-			this.subscribers = subscribers;
-		}
-
-		public CoreSubscriber<T>[] getSubscribers() {
-			return subscribers;
-		}
-
-		@Override
-		public void onSubscribe(Subscription s) {
-			throw new IllegalStateException("Not implemented");
-		}
-
-		@Override
-		public void onNext(T t) {
-			throw new IllegalStateException("Not implemented");
-		}
-
-		@Override
-		public void onError(Throwable t) {
-			throw new IllegalStateException("Not implemented");
-		}
-
-		@Override
-		public void onComplete() {
-			throw new IllegalStateException("Not implemented");
-		}
 	}
 
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -1041,7 +1041,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 
 		@SuppressWarnings("unchecked")
 		MultiSubscriber<T> multiSubscriber = new MultiSubscriber<>((CoreSubscriber<T>[]) subscribers);
-		Hooks.onLastOperator(this).subscribe(multiSubscriber);
+		Operators.doSubscribe(this, multiSubscriber);
 		return Disposables.composite(subscribers);
 	}
 
@@ -1054,8 +1054,10 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	@Override
 	@SuppressWarnings("unchecked")
 	public final void subscribe(Subscriber<? super T> s) {
-		Hooks.onLastOperator(sequential())
-		    .subscribe(new FluxHide.SuppressFuseableSubscriber<>(Operators.toCoreSubscriber(s)));
+		FluxHide.SuppressFuseableSubscriber<T> subscriber =
+				new FluxHide.SuppressFuseableSubscriber<>(Operators.toCoreSubscriber(s));
+
+		Operators.doSubscribe(sequential(), subscriber);
 	}
 
 	/**
@@ -1210,7 +1212,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 * @param source the source to wrap
 	 *
 	 * @return the potentially wrapped source
-	 * @deprecated use {@link Hooks#onLastOperator(CorePublisher)}
+	 * @deprecated use {@link Operators#doSubscribe(CorePublisher, Subscriber)}
 	 */
 	@SuppressWarnings("unchecked")
 	@Deprecated

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -35,6 +35,7 @@ import java.util.logging.Level;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import reactor.core.CorePublisher;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
@@ -65,7 +66,7 @@ import reactor.util.concurrent.Queues;
  *
  * @param <T> the value type
  */
-public abstract class ParallelFlux<T> implements Publisher<T> {
+public abstract class ParallelFlux<T> implements CorePublisher<T> {
 
 	/**
 	 * Take a Publisher and prepare to consume it on multiple 'rails' (one per CPU core)
@@ -1002,6 +1003,17 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 		return subscribe(onNext, onError, onComplete, null);
 	}
 
+	@Override
+	@SuppressWarnings("unchecked")
+	public final void subscribe(CoreSubscriber<? super T> subscriber) {
+		if (subscriber instanceof MultiSubscriber) {
+			subscribe(((MultiSubscriber<? super T>) subscriber).getSubscribers());
+		}
+		else {
+			subscribe((Subscriber<? super T>) subscriber);
+		}
+	}
+
 	/**
 	 * Subscribes to this {@link ParallelFlux} by providing an onNext, onError,
 	 * onComplete and onSubscribe callback and triggers the execution chain for all
@@ -1027,7 +1039,9 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 					new LambdaSubscriber<>(onNext, onError, onComplete, onSubscribe);
 		}
 
-		onLastAssembly(this).subscribe(subscribers);
+		@SuppressWarnings("unchecked")
+		MultiSubscriber<T> multiSubscriber = new MultiSubscriber<>((CoreSubscriber<T>[]) subscribers);
+		Hooks.onLastOperator(this).subscribe(multiSubscriber);
 		return Disposables.composite(subscribers);
 	}
 
@@ -1040,7 +1054,7 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	@Override
 	@SuppressWarnings("unchecked")
 	public final void subscribe(Subscriber<? super T> s) {
-		Flux.onLastAssembly(sequential())
+		Hooks.onLastOperator(sequential())
 		    .subscribe(new FluxHide.SuppressFuseableSubscriber<>(Operators.toCoreSubscriber(s)));
 	}
 
@@ -1196,8 +1210,10 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	 * @param source the source to wrap
 	 *
 	 * @return the potentially wrapped source
+	 * @deprecated use {@link Hooks#onLastOperator(CorePublisher)}
 	 */
 	@SuppressWarnings("unchecked")
+	@Deprecated
 	protected static <T> ParallelFlux<T> onLastAssembly(ParallelFlux<T> source) {
 		Function<Publisher, Publisher> hook = Hooks.onLastOperatorHook;
 		if (hook == null) {
@@ -1266,6 +1282,39 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 		}
 
 		return both;
+	}
+
+	private static class MultiSubscriber<T> implements CoreSubscriber<T> {
+
+		final CoreSubscriber<T>[] subscribers;
+
+		private MultiSubscriber(CoreSubscriber<T>[] subscribers) {
+			this.subscribers = subscribers;
+		}
+
+		public CoreSubscriber<T>[] getSubscribers() {
+			return subscribers;
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			throw new IllegalStateException("Not implemented");
+		}
+
+		@Override
+		public void onNext(T t) {
+			throw new IllegalStateException("Not implemented");
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			throw new IllegalStateException("Not implemented");
+		}
+
+		@Override
+		public void onComplete() {
+			throw new IllegalStateException("Not implemented");
+		}
 	}
 
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -1041,7 +1041,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 
 		@SuppressWarnings("unchecked")
 		MultiSubscriber<T> multiSubscriber = new MultiSubscriber<>((CoreSubscriber<T>[]) subscribers);
-		Operators.doSubscribe(this, multiSubscriber);
+		Operators.onLastAssembly(this).subscribe(multiSubscriber);
 		return Disposables.composite(subscribers);
 	}
 
@@ -1057,7 +1057,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 		FluxHide.SuppressFuseableSubscriber<T> subscriber =
 				new FluxHide.SuppressFuseableSubscriber<>(Operators.toCoreSubscriber(s));
 
-		Operators.doSubscribe(sequential(), subscriber);
+		Operators.onLastAssembly(sequential()).subscribe(Operators.toCoreSubscriber(subscriber));
 	}
 
 	/**
@@ -1212,7 +1212,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 * @param source the source to wrap
 	 *
 	 * @return the potentially wrapped source
-	 * @deprecated use {@link Operators#doSubscribe(CorePublisher, Subscriber)}
+	 * @deprecated use {@link Operators#onLastAssembly(CorePublisher)}
 	 */
 	@SuppressWarnings("unchecked")
 	@Deprecated

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
@@ -232,7 +232,7 @@ public class FluxOnAssemblyTest {
 		String debugStack = sw.toString();
 
 		assertThat(debugStack).contains("Assembly trace from producer [reactor.core.publisher.ParallelSource], described as [descriptionCorrelation1234] :\n"
-				+ "\treactor.core.publisher.ParallelFlux.checkpoint(ParallelFlux.java:223)\n"
+				+ "\treactor.core.publisher.ParallelFlux.checkpoint(ParallelFlux.java:224)\n"
 				+ "\treactor.core.publisher.FluxOnAssemblyTest.parallelFluxCheckpointDescriptionAndForceStack(FluxOnAssemblyTest.java:225)\n");
 		assertThat(debugStack).endsWith("Error has been observed by the following operator(s):\n"
 				+ "\t|_\tParallelFlux.checkpoint ⇢ reactor.core.publisher.FluxOnAssemblyTest.parallelFluxCheckpointDescriptionAndForceStack(FluxOnAssemblyTest.java:225)\n\n");

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
@@ -1009,26 +1009,26 @@ public class ParallelFluxTest {
 		List<Integer> results = new CopyOnWriteArrayList<>();
 		CountDownLatch latch = new CountDownLatch(1);
 		Flux.just(1, 2, 3).parallel().subscribe(new CoreSubscriber<Integer>() {
-		    @Override
-		    public void onSubscribe(Subscription s) {
-		        s.request(Long.MAX_VALUE);
-		    }
+			@Override
+			public void onSubscribe(Subscription s) {
+				s.request(Long.MAX_VALUE);
+			}
 
-		    @Override
-		    public void onNext(Integer integer) {
-		        results.add(integer);
-		    }
+			@Override
+			public void onNext(Integer integer) {
+				results.add(integer);
+			}
 
-		    @Override
-		    public void onError(Throwable t) {
-		        t.printStackTrace();
-		    }
+			@Override
+			public void onError(Throwable t) {
+				t.printStackTrace();
+			}
 
-		    @Override
-		    public void onComplete() {
-		        latch.countDown();
-		    }
-	    });
+			@Override
+			public void onComplete() {
+				latch.countDown();
+			}
+		});
 
 		latch.await(1, TimeUnit.SECONDS);
 


### PR DESCRIPTION
By introducing this interface, we make it possible to write generic
`onLastOperator` hooks, where return type is just `CorePublisher`
(previous implementation was forcing the return type to be the same as
input type, and the hook logic wasn't shared between Publishers)