### PR TITLE
Fix a race in FluxBufferTimeout on flush.

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
@@ -164,9 +164,10 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends FluxOp
 		}
 
 		void flushCallback(@Nullable T ev) { //TODO investigate ev not used
-			C v = values;
+			final C v;
 			boolean flush = false;
 			synchronized (this) {
+				v = values;
 				if (v != null && !v.isEmpty()) {
 					values = bufferSupplier.get();
 					flush = true;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
@@ -17,8 +17,12 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import org.junit.Test;
 import org.reactivestreams.Subscription;
@@ -29,6 +33,7 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.scheduler.VirtualTimeScheduler;
+import reactor.test.util.RaceTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -203,6 +208,32 @@ public class FluxBufferTimeoutTest {
 		test.cancel();
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
 		assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
+	}
+
+	@Test
+	public void flushShouldNotRaceWithNext() {
+		Set<Integer> seen = new HashSet<>();
+		Consumer<List<Integer>> consumer = integers -> {
+			for (Integer i : integers) {
+				if (!seen.add(i)) {
+					throw new IllegalStateException("Duplicate! " + i);
+				}
+			}
+		};
+		CoreSubscriber<List<Integer>> actual = new LambdaSubscriber<>(consumer, null, null, null);
+
+		FluxBufferTimeout.BufferTimeoutSubscriber<Integer, List<Integer>> test = new FluxBufferTimeout.BufferTimeoutSubscriber<Integer, List<Integer>>(
+				actual, 3, 1000, Schedulers.elastic().createWorker(), ArrayList::new);
+		test.onSubscribe(Operators.emptySubscription());
+
+		AtomicInteger counter = new AtomicInteger();
+		for (int i = 0; i < 500; i++) {
+			RaceTestUtils.race(
+					() -> test.onNext(counter.getAndIncrement()),
+					() -> test.onNext(counter.getAndIncrement()),
+					Schedulers.elastic()
+			);
+		}
 	}
 
 	//see https://github.com/reactor/reactor-core/issues/1247

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
@@ -230,7 +230,7 @@ public class FluxBufferTimeoutTest {
 		for (int i = 0; i < 500; i++) {
 			RaceTestUtils.race(
 					() -> test.onNext(counter.getAndIncrement()),
-					() -> test.onNext(counter.getAndIncrement()),
+					() -> test.flushCallback(null),
 					Schedulers.elastic()
 			);
 		}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
+import org.junit.After;
 import org.junit.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -38,6 +39,11 @@ import reactor.test.util.RaceTestUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxBufferTimeoutTest {
+
+	@After
+	public void tearDown() {
+		VirtualTimeScheduler.reset();
+	}
 
 	Flux<List<Integer>> scenario_bufferWithTimeoutAccumulateOnTimeOrSize() {
 		return Flux.range(1, 6)


### PR DESCRIPTION
On flush, values must be accessed inside a `synchronized` block to
avoid a race condition when `nextCallback` modifies the collection.

This makes it consistent with the rest of access to the variable.
Other operators do the same.

Fixes #1532.