### PR TITLE
fix #1547 Eagerly invoke Mono#doOnEach handler(complete) during onNext

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDoOnEach.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDoOnEach.java
@@ -41,6 +41,6 @@ final class MonoDoOnEach<T> extends MonoOperator<T, T> {
 	public void subscribe(CoreSubscriber<? super T> actual) {
 		//TODO fuseable version?
 		//TODO conditional version?
-		source.subscribe(new FluxDoOnEach.DoOnEachSubscriber<>(actual, onSignal));
+		source.subscribe(new FluxDoOnEach.DoOnEachSubscriber<>(actual, onSignal, true));
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDoOnEachTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDoOnEachTest.java
@@ -302,7 +302,7 @@ public class FluxDoOnEachTest {
 		FluxDoOnEach<Integer> peek =
 				new FluxDoOnEach<>(Flux.just(1), s -> { });
 		FluxDoOnEach.DoOnEachSubscriber<Integer> test =
-				new FluxDoOnEach.DoOnEachSubscriber<>(actual, peek.onSignal);
+				new FluxDoOnEach.DoOnEachSubscriber<>(actual, peek.onSignal, false);
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/MonoTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/MonoTests.java
@@ -51,7 +51,7 @@ public class MonoTests {
 		            .expectSubscription()
 		            .expectNext(1)
 		            .expectComplete()
-		            .verify();
+		            .verify(Duration.ofSeconds(5));
 
 		assertThat(signals.size(), is(2));
 		assertThat("onNext", signals.get(0).get(), is(1));


### PR DESCRIPTION
This commit aligns Mono's doOnEach with eg. doOnSuccess
(MonoPeekTerminal) regarding the eager invocation of the handler with
an onComplete Signal whenever onNext is received.

As a result, putting doOnEach before doOnSuccess in a chain won't give
out of order invocations anymore.