### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,7 @@ import org.gradle.api.internal.plugins.osgi.OsgiHelper
 buildscript {
   ext.kotlinVersion = '1.2.51'
   repositories {
-	maven { url "http://repo.spring.io/plugins-release" }
+	maven { url "https://repo.spring.io/plugins-release" }
   }
   dependencies {
 	classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
@@ -69,7 +69,7 @@ ext {
   }
 
   javadocLinks = [jdkJavadoc,
-				  "http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/"] as String[]
+				  "https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/"] as String[]
 
 
   bundleImportPackages = ['org.slf4j;resolution:=optional;version="[1.5.4,2)"',
@@ -107,12 +107,12 @@ configure(subprojects) { p ->
   repositories {
 	mavenLocal()
 	if (version.endsWith('BUILD-SNAPSHOT') || project.hasProperty('platformVersion')) {
-	  maven { url 'http://repo.spring.io/libs-snapshot' }
+	  maven { url 'https://repo.spring.io/libs-snapshot' }
 	}
 
 	mavenCentral()
 	jcenter()
-	maven { url 'http://repo.spring.io/libs-milestone' }
+	maven { url 'https://repo.spring.io/libs-milestone' }
 	maven { url "https://oss.sonatype.org/content/repositories/releases/" }
 
   }

--- a/gradle/doc.gradle
+++ b/gradle/doc.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -70,12 +70,12 @@ def customizePom(pom, gradleProject) {
 			url = 'https://github.com/reactor/reactor-core'
 			organization {
 				name = 'reactor'
-				url = 'http://github.com/reactor'
+				url = 'https://github.com/reactor'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -164,10 +164,10 @@ task dokka(type: org.jetbrains.dokka.gradle.DokkaTask) {
   sourceDirs = files("src/main/kotlin")
 
   externalDocumentationLink {
-	url = new URL("http://projectreactor.io/docs/core/release/api/")
+	url = new URL("https://projectreactor.io/docs/core/release/api/")
   }
   externalDocumentationLink {
-	url = new URL("http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/")
+	url = new URL("https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/")
   }
 }
 

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -62,7 +62,7 @@ javadoc {
   options.header = "$project.name"
   options.stylesheetFile = file("$rootDir/docs/api/stylesheet.css")
   options.links(rootProject.ext.javadocLinks
-		  .plus("http://projectreactor.io/docs/core/release/api/") as String[])
+		  .plus("https://projectreactor.io/docs/core/release/api/") as String[])
   options.tags = [ "apiNote:a:API Note:", "implSpec:a:Implementation Requirements:",
 				   "implNote:a:Implementation Note:" ]
 
@@ -100,13 +100,13 @@ task dokka(type: org.jetbrains.dokka.gradle.DokkaTask) {
   sourceDirs = files("src/main/kotlin")
 
   externalDocumentationLink {
-	url = new URL("http://projectreactor.io/docs/core/release/api/")
+	url = new URL("https://projectreactor.io/docs/core/release/api/")
   }
   externalDocumentationLink {
-	url = new URL("http://projectreactor.io/docs/test/release/api/")
+	url = new URL("https://projectreactor.io/docs/test/release/api/")
   }
   externalDocumentationLink {
-	url = new URL("http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/")
+	url = new URL("https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/")
   }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://github.com/reactor migrated to:  
  https://github.com/reactor ([https](https://github.com/reactor) result 200).
* http://projectreactor.io/docs/core/release/api/ migrated to:  
  https://projectreactor.io/docs/core/release/api/ ([https](https://projectreactor.io/docs/core/release/api/) result 200).
* http://projectreactor.io/docs/test/release/api/ migrated to:  
  https://projectreactor.io/docs/test/release/api/ ([https](https://projectreactor.io/docs/test/release/api/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/ migrated to:  
  https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/ ([https](https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/) result 200).
* http://repo.spring.io/libs-milestone migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/libs-snapshot migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/plugins-release migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).