### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Reactor Core
 
 [![Join the chat at https://gitter.im/reactor/reactor](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/reactor/reactor?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Reactor Core](https://maven-badges.herokuapp.com/maven-central/io.projectreactor/reactor-core/badge.svg?style=plastic)](http://mvnrepository.com/artifact/io.projectreactor/reactor-core) [![Latest](https://img.shields.io/github/release/reactor/reactor-core/all.svg)]() 
+[![Reactor Core](https://maven-badges.herokuapp.com/maven-central/io.projectreactor/reactor-core/badge.svg?style=plastic)](https://mvnrepository.com/artifact/io.projectreactor/reactor-core) [![Latest](https://img.shields.io/github/release/reactor/reactor-core/all.svg)]() 
 
 [![Download](https://api.bintray.com/packages/spring/jars/io.projectreactor/images/download.svg)](https://bintray.com/spring/jars/io.projectreactor/_latestVersion)
 
@@ -11,7 +11,7 @@
 [![Total Alerts](https://img.shields.io/lgtm/alerts/g/reactor/reactor-core.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/reactor/reactor-core/alerts)
 
 
-Non-Blocking [Reactive Streams](http://reactive-streams.org) Foundation for the JVM both implementing a [Reactive Extensions](http://reactivex.io) inspired API and efficient event streaming support.
+Non-Blocking [Reactive Streams](https://www.reactive-streams.org/) Foundation for the JVM both implementing a [Reactive Extensions](http://reactivex.io) inspired API and efficient event streaming support.
 
 The `master` branch is now dedicated to development of the `3.3.x` line.
 
@@ -23,8 +23,8 @@ With Gradle from repo.spring.io or Maven Central repositories (stable releases o
 
 ```groovy
     repositories {
-//      maven { url 'http://repo.spring.io/snapshot' }
-      maven { url 'http://repo.spring.io/milestone' }
+//      maven { url 'https://repo.spring.io/snapshot' }
+      maven { url 'https://repo.spring.io/milestone' }
       mavenCentral()
     }
 
@@ -36,12 +36,12 @@ With Gradle from repo.spring.io or Maven Central repositories (stable releases o
     }
 ```
 
-See the [reference documentation](http://projectreactor.io/docs/core/release/reference/docs/index.html#getting)
+See the [reference documentation](https://projectreactor.io/docs/core/release/reference/docs/index.html#getting)
 for more information on getting it (eg. using Maven, or on how to get milestones and snapshots).
 
 > **Note about Android support**: Reactor 3 doesn't officially support nor target Android.
 However it should work fine with Android SDK 26 (Android O) and above. See the
-[complete note](http://projectreactor.io/docs/core/release/reference/docs/index.html#prerequisites)
+[complete note](https://projectreactor.io/docs/core/release/reference/docs/index.html#prerequisites)
 in the reference guide.
 
 
@@ -58,7 +58,7 @@ A Reactive Streams Publisher with basic flow operators.
 - Static factories on Flux allow for source generation from arbitrary callbacks types.
 - Instance methods allows operational building, materialized on each _Flux#subscribe()_, _Flux#subscribe()_ or multicasting operations such as _Flux#publish_ and _Flux#publishNext_.
 
-[<img src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/flux.png" width="500">](http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html)
+[<img src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/flux.png" width="500">](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html)
 
 Flux in action :
 ```java
@@ -77,7 +77,7 @@ A Reactive Streams Publisher constrained to *ZERO* or *ONE* element with appropr
 - Static factories on Mono allow for deterministic *zero or one* sequence generation from arbitrary callbacks types.
 - Instance methods allows operational building, materialized on each _Mono#subscribe()_ or _Mono#get()_ eventually called.
 
-[<img src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/mono.png" width="500">](http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html)
+[<img src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/mono.png" width="500">](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html)
 
 Mono in action :
 ```java
@@ -99,11 +99,11 @@ Tuple2<Long, Long> nowAndLater =
 
 ## Schedulers
 
-Reactor uses a [Scheduler](http://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Scheduler.html) as a
+Reactor uses a [Scheduler](https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Scheduler.html) as a
 contract for arbitrary task execution. It provides some guarantees required by Reactive
 Streams flows like FIFO execution.
 
-You can use or create efficient [schedulers](http://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Schedulers.html)
+You can use or create efficient [schedulers](https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Schedulers.html)
 to jump thread on the producing flows (subscribeOn) or receiving flows (publishOn):
 
 ```java
@@ -121,7 +121,7 @@ Mono.fromCallable( () -> System.currentTimeMillis() )
 
 ## ParallelFlux
 
-[ParallelFlux](http://projectreactor.io/docs/core/release/api/reactor/core/publisher/ParallelFlux.html) can starve your CPU's from any sequence whose work can be subdivided in concurrent
+[ParallelFlux](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/ParallelFlux.html) can starve your CPU's from any sequence whose work can be subdivided in concurrent
  tasks. Turn back into a `Flux` with `ParallelFlux#sequential()`, an unordered join or
  use arbitrary merge strategies via 'groups()'.
 
@@ -162,16 +162,16 @@ Flux.create(sink -> {
 
 ## The Backpressure Thing
 
-Most of this cool stuff uses bounded ring buffer implementation under the hood to mitigate signal processing difference between producers and consumers. Now, the operators and processors or any standard reactive stream component working on the sequence will be instructed to flow in when these buffers have free room AND only then. This means that we make sure we both have a deterministic capacity model (bounded buffer) and we never block (request more data on write capacity). Yup, it's not rocket science after all, the boring part is already being worked by us in collaboration with [Reactive Streams Commons](http://github.com/reactor/reactive-streams-commons) on going research effort.
+Most of this cool stuff uses bounded ring buffer implementation under the hood to mitigate signal processing difference between producers and consumers. Now, the operators and processors or any standard reactive stream component working on the sequence will be instructed to flow in when these buffers have free room AND only then. This means that we make sure we both have a deterministic capacity model (bounded buffer) and we never block (request more data on write capacity). Yup, it's not rocket science after all, the boring part is already being worked by us in collaboration with [Reactive Streams Commons](https://github.com/reactor/reactive-streams-commons) on going research effort.
 
 ## What's more in it ?
 
-"Operator Fusion" (flow optimizers), health state observers, helpers to build custom reactive components, bounded queue generator, hash-wheel timer, converters from/to Java 9 Flow, Publisher and Java 8 CompletableFuture. The repository contains a `reactor-test` project with test features like the [`StepVerifier`](http://projectreactor.io/docs/test/release/api/index.html?reactor/test/StepVerifier.html).
+"Operator Fusion" (flow optimizers), health state observers, helpers to build custom reactive components, bounded queue generator, hash-wheel timer, converters from/to Java 9 Flow, Publisher and Java 8 CompletableFuture. The repository contains a `reactor-test` project with test features like the [`StepVerifier`](https://projectreactor.io/docs/test/release/api/index.html?reactor/test/StepVerifier.html).
 
 -------------------------------------
 
 ## Reference Guide
-http://projectreactor.io/docs/core/release/reference/docs/index.html
+https://projectreactor.io/docs/core/release/reference/docs/index.html
 
 ## Javadoc
 https://projectreactor.io/docs/core/release/api/
@@ -186,13 +186,13 @@ https://www.infoq.com/articles/reactor-by-example
 https://github.com/reactor/head-first-reactive-with-spring-and-reactor/
 
 ## Beyond Reactor Core
-- Everything to jump outside the JVM with the non-blocking drivers from [Reactor Netty](http://github.com/reactor/reactor-netty).
-- [Reactor Addons](http://github.com/reactor/reactor-addons) provide for adapters and extra operators for Reactor 3.
+- Everything to jump outside the JVM with the non-blocking drivers from [Reactor Netty](https://github.com/reactor/reactor-netty).
+- [Reactor Addons](https://github.com/reactor/reactor-addons) provide for adapters and extra operators for Reactor 3.
 
 -------------------------------------
-_Powered by [Reactive Streams Commons](http://github.com/reactor/reactive-streams-commons)_
+_Powered by [Reactive Streams Commons](https://github.com/reactor/reactive-streams-commons)_
 
 _Licensed under [Apache Software License 2.0](www.apache.org/licenses/LICENSE-2.0)_
 
-_Sponsored by [Pivotal](http://pivotal.io)_
+_Sponsored by [Pivotal](https://pivotal.io)_
 

--- a/docs/api/overview.html
+++ b/docs/api/overview.html
@@ -22,7 +22,7 @@ under
     <p>
         Reactor Core is a succinct and powerful foundational library for building reactive and efficient applications
         on the JVM.
-        More detailed documentation is available on the <a href="http://projectreactor.io/docs/core/release/reference/"
+        More detailed documentation is available on the <a href="https://projectreactor.io/docs/core/release/reference/"
                                                            target="_blank">reference guide</a>.
     </p>
 </div>

--- a/docs/api/stylesheet.css
+++ b/docs/api/stylesheet.css
@@ -108,7 +108,7 @@ Document title and Copyright styles
     position: absolute;
     right: 2px;
     top: 10px;
-    background: url(http://projectreactor.io/assets/img/logo-2x.png) no-repeat 0 -30px;
+    background: url(https://projectreactor.io/assets/img/logo-2x.png) no-repeat 0 -30px;
     background-size: 189px 60px;
     height: 40px;
     width: 44px;

--- a/docs/asciidoc/aboutDoc.adoc
+++ b/docs/asciidoc/aboutDoc.adoc
@@ -7,7 +7,7 @@ often refer to other pieces.
 
 == Latest Version & Copyright Notice
 The Reactor reference guide is available as HTML documents. The latest copy is available
-at http://projectreactor.io/docs/core/release/reference/docs/index.html
+at https://projectreactor.io/docs/core/release/reference/docs/index.html
 
 Copies of this document may be made for your own use and for distribution to others,
 provided that you do not charge any fee for such copies and further provided that each
@@ -15,7 +15,7 @@ copy contains this Copyright Notice, whether distributed in print or electronica
 
 == Contributing to the Documentation
 The reference guide is written in
-http://asciidoctor.org/docs/asciidoc-writers-guide/[Asciidoc]
+https://asciidoctor.org/docs/asciidoc-writers-guide/[Asciidoc]
 format and sources can be found at
 https://github.com/reactor/reactor-core/tree/master/docs/asciidoc.
 
@@ -38,10 +38,10 @@ There are several ways to reach out for help with Reactor.
 
 * Get in touch with the community on https://gitter.im/reactor/reactor[Gitter].
 * Ask a question on stackoverflow.com at
-http://stackoverflow.com/tags/project-reactor[`project-reactor`].
+https://stackoverflow.com/tags/project-reactor[`project-reactor`].
 * Report bugs in Github issues. The following repositories are closely monitored:
-http://github.com/reactor/reactor-core/issues[reactor-core] (which covers the
-essential features) and http://github.com/reactor/reactor-addons/issues[reactor-addons]
+https://github.com/reactor/reactor-core/issues[reactor-core] (which covers the
+essential features) and https://github.com/reactor/reactor-addons/issues[reactor-addons]
 (which covers reactor-test and adapters issues).
 
 NOTE: All of Reactor is open source,

--- a/docs/asciidoc/gettingStarted.adoc
+++ b/docs/asciidoc/gettingStarted.adoc
@@ -16,7 +16,7 @@ Reactor is a fully non-blocking reactive programming foundation for the JVM, wit
 efficient demand management (in the form of managing "backpressure"). It integrates
 directly with the Java 8 functional APIs, notably `CompletableFuture`, `Stream`, and
 `Duration`. It offers composable asynchronous sequence APIs `Flux` (for [N] elements) and
-`Mono` (for [0|1] elements), extensively implementing the [Reactive Streams](http://www.reactive-streams.org/)
+`Mono` (for [0|1] elements), extensively implementing the [Reactive Streams](https://www.reactive-streams.org/)
 specification.
 
 Reactor also supports non-blocking inter-process communication with the
@@ -182,7 +182,7 @@ For Gradle, use the following snippet:
 [source,groovy]
 ----
 repositories {
-  maven { url 'http://repo.spring.io/milestone' }
+  maven { url 'https://repo.spring.io/milestone' }
   mavenCentral()
 }
 ----
@@ -205,7 +205,7 @@ Similarly, snapshots are also available in a separate dedicated repository:
 [source,groovy]
 ----
 repositories {
-  maven { url 'http://repo.spring.io/snapshot' }
+  maven { url 'https://repo.spring.io/snapshot' }
   mavenCentral()
 }
 ----

--- a/docs/asciidoc/highlight/CHANGES.md
+++ b/docs/asciidoc/highlight/CHANGES.md
@@ -336,7 +336,7 @@ Improvements to existing languages and styles:
 - Recognize b-prefixed chars and strings in Rust
 - Better numbers handling in Verilog
 
-[Brendan Rocks]: http://brendanrocks.com
+[Brendan Rocks]: https://brendanrocks.com
 [Raphaël Assénat]: https://github.com/raphnet
 [Matt Evans]: https://github.com/matthewevans
 [Martin Braun]: https://github.com/mbr0wn
@@ -391,7 +391,7 @@ Other notable changes:
 [webworkers]: https://github.com/isagalaev/highlight.js#web-workers
 [Jeremy Hull]: https://github.com/sourrust
 [#348]: https://github.com/isagalaev/highlight.js/issues/348
-[sg]: http://highlightjs.readthedocs.org/en/latest/style-guide.html
+[sg]: https://highlightjs.readthedocs.org/en/latest/style-guide.html
 [issues]: https://github.com/isagalaev/highlight.js/issues
 [Nebuleon Fumika]: https://github.com/Nebuleon
 [prince]: https://github.com/prince-0203
@@ -669,7 +669,7 @@ New languages in this release:
 - *ERB* (Ruby in HTML) by [Lucas Mazza][]
 - *Roboconf* by [Vincent Zurczak][]
 
-[b]: http://highlightjs.readthedocs.org/en/latest/building-testing.html
+[b]: https://highlightjs.readthedocs.org/en/latest/building-testing.html
 [Jeremy Hull]: https://github.com/sourrust
 [ik]: https://twitter.com/IvanKleshnin/status/514041599484231680
 [Max Mikhailov]: https://github.com/seven-phases-max
@@ -800,7 +800,7 @@ Other improvements:
 - Various improvements to Objective-C definition by [Matt Diephouse][].
 - Fixed highlighting of generics in Java.
 
-[ll]: http://highlightjs.readthedocs.org/en/latest/api.html#listlanguages
+[ll]: https://highlightjs.readthedocs.org/en/latest/api.html#listlanguages
 [Sindre Sorhus]: https://github.com/sindresorhus
 [Heiko August]: https://github.com/auge8472
 [Nikolay Lisienko]: https://github.com/neor-ru
@@ -893,10 +893,10 @@ Miscellaneous improvements:
 - Big overhaul of relevance counting for a number of languages. Please do report
   bugs about mis-detection of non-trivial code snippets!
 
-[API reference]: http://highlightjs.readthedocs.org/en/latest/api.html
+[API reference]: https://highlightjs.readthedocs.org/en/latest/api.html
 
-[cr]: http://highlightjs.readthedocs.org/en/latest/css-classes-reference.html
-[api docs]: http://highlightjs.readthedocs.org/en/latest/api.html
+[cr]: https://highlightjs.readthedocs.org/en/latest/css-classes-reference.html
+[api docs]: https://highlightjs.readthedocs.org/en/latest/api.html
 [variants]: https://groups.google.com/d/topic/highlightjs/VoGC9-1p5vk/discussion
 [beginKeywords]: https://github.com/isagalaev/highlight.js/commit/6c7fdea002eb3949577a85b3f7930137c7c3038d
 [php-html]: https://twitter.com/highlightjs/status/408890903017689088
@@ -941,12 +941,12 @@ Improvements:
 [mehdid]: https://github.com/mehdid
 [nbraud]: https://github.com/nbraud
 [revig]: https://github.com/revig
-[lcs]: http://livecode.com/developers/guides/server/
+[lcs]: https://livecode.com/developers/guides/server/
 [sylvestre]: https://github.com/sylvestre
 [isagalaev]: https://github.com/isagalaev
 [treep]: https://github.com/treep
 [sourrust]: https://github.com/sourrust
-[d]: http://highlightjs.org/download/
+[d]: https://highlightjs.org/download/
 
 
 ## New core developers
@@ -974,7 +974,7 @@ This long overdue version is a snapshot of the current source tree with all the
 changes that happened during the past year. Sorry for taking so long!
 
 Along with the changes in code highlight.js has finally got its new home at
-<http://highlightjs.org/>, moving from its cradle on Software Maniacs which it
+<https://highlightjs.org/>, moving from its cradle on Software Maniacs which it
 outgrew a long time ago. Be sure to report any bugs about the site to
 <mailto:info@highlightjs.org>.
 
@@ -1009,7 +1009,7 @@ New style themes:
 - Mono Blue by [Ivan Sagalaev][] (uses a single color hue for everything)
 - Foundation by [Dan Allen][]
 
-[noformnocontent]: http://nn.mit-license.org/
+[noformnocontent]: https://nn.mit-license.org/
 [Damien White]: https://github.com/visoft
 [Alexander Marenin]: https://github.com/ioncreature
 [Simon Madine]: https://github.com/thingsinjars
@@ -1050,7 +1050,7 @@ Other notable changes:
 - Also Oleg Efimov did a great job of moving all the docs for language and style
   developers and contributors from the old wiki under the source code in the
   "docs" directory. Now these docs are nicely presented at
-  <http://highlightjs.readthedocs.org/>.
+  <https://highlightjs.readthedocs.org/>.
 
 [ng]: https://github.com/nathan11g
 [dd]: https://github.com/drdrang
@@ -1081,10 +1081,10 @@ A Summer crop:
   fixes, including a pretty significant refactoring of Ruby.
 
 [mf]: https://github.com/mfornos
-[tm]: http://jmblog.github.com/color-themes-for-highlightjs/
+[tm]: https://jmblog.github.com/color-themes-for-highlightjs/
 [tm0]: https://github.com/ChrisKempson/Tomorrow-Theme
 [cd]: https://github.com/caseman
-[amd]: http://requirejs.org/docs/whyamd.html
+[amd]: https://requirejs.org/docs/whyamd.html
 
 
 ## Version 7.0
@@ -1125,8 +1125,8 @@ language detection.
 
 Overall highlight.js currently supports 51 languages and 20 style themes.
 
-[node.js]: http://nodejs.org/
-[api]: http://softwaremaniacs.org/wiki/doku.php/highlight.js:api
+[node.js]: https://nodejs.org/
+[api]: https://highlightjs.readthedocs.org/
 [p]: http://softwaremaniacs.org/blog/2012/05/10/http-and-json-in-highlight-js/en/
 [pojoaque]: http://web-cms-designs.com/ftopict-10-pojoaque-style-for-highlight-js-code-highlighter.html
 [ao]: https://github.com/angelolloqui
@@ -1161,7 +1161,7 @@ from all this activity:
 [oe]: https://github.com/Sannis
 [db]: https://github.com/btd
 [jc]: https://github.com/seejohnrun
-[lm]: http://grigio.org/
+[lm]: https://grigio.org/
 [ak]: https://github.com/geekpanth3r
 [es]: https://github.com/bolknote
 [log]: https://github.com/isagalaev/highlight.js/commits/
@@ -1178,7 +1178,7 @@ This version also adds a new original style Arta. Its author pumbur maintains a
 [heavily modified fork of highlight.js][pb] on GitHub.
 
 [jh]: https://github.com/sourrust
-[solarized]: http://ethanschoonover.com/solarized
+[solarized]: https://ethanschoonover.com/solarized
 [pb]: https://github.com/pumbur/highlight.js
 
 
@@ -1252,9 +1252,9 @@ Bug fixes:
   just replaces the contents.
 - Small fixes in browser compatibility and heuristics.
 
-[c++ 0x]: http://ru.wikipedia.org/wiki/C%2B%2B0x
-[html 5]: http://en.wikipedia.org/wiki/HTML5
-[ik]: http://kalnitsky.org.ua/
+[c++ 0x]: https://ru.wikipedia.org/wiki/C%252B%252B0x
+[html 5]: https://en.wikipedia.org/wiki/HTML5
+[ik]: https://kalnitsky.org.ua/
 
 ### For developers
 
@@ -1282,8 +1282,8 @@ expected one. Test summary is displayed right above all language snippets.
 Fine people at [Yandex][] agreed to host highlight.js on their big fast servers.
 [Link up][l]!
 
-[yandex]: http://yandex.com/
-[l]: http://softwaremaniacs.org/soft/highlight/en/download/
+[yandex]: https://yandex.com/
+[l]: https://highlightjs.org/download/
 
 
 ## Version 5.10 — "Paris".
@@ -1307,8 +1307,8 @@ New languages:
   Nginx config
 - [Vladimir Moskva][vm] made a definition for TeX
 
-[pl]: http://kung-fu-tzu.ru/
-[vm]: http://fulc.ru/
+[pl]: https://kung-fu-tzu.ru/
+[vm]: https://fulc.ru/
 
 Fixes for existing languages:
 
@@ -1317,8 +1317,8 @@ Fixes for existing languages:
 - the definition of SQL has become more solid and now it shouldn't be overly
   greedy when it comes to language detection
 
-[ls]: http://gnuu.org/
-[yard]: http://yardoc.org/
+[ls]: https://gnuu.org/
+[yard]: https://yardoc.org/
 
 The highlighter has become more usable as a library allowing to do highlighting
 from initialization code of JS frameworks and in ajax methods (see.
@@ -1327,8 +1327,8 @@ readme.eng.txt).
 Also this version drops support for the [WordPress][wp] plugin. Everyone is
 welcome to [pick up its maintenance][p] if needed.
 
-[wp]: http://wordpress.org/
-[p]: http://bazaar.launchpad.net/~isagalaev/+junk/highlight/annotate/342/src/wp_highlight.js.php
+[wp]: https://wordpress.org/
+[p]: https://bazaar.launchpad.net/~isagalaev/+junk/highlight/annotate/342/src/wp_highlight.js.php
 
 
 ## Version 5.8
@@ -1372,10 +1372,10 @@ Also in this version:
 - Yura Zaripov has sent two styles: Brown Paper and School Book.
 - Oleg Volchkov has sent a definition for [Parser 3][p3].
 
-[1]: http://softwaremaniacs.org/forum/highlightjs/6612/
-[p3]: http://www.parser.ru/
-[vp]: http://vasily.polovnyov.ru/
-[vd]: http://dolzhenko.blogspot.com/
+[1]: https://pytalk.ru/forum/highlightjs/6612/
+[p3]: https://www.parser.ru/
+[vp]: https://vasily.polovnyov.ru/
+[vd]: https://dolzhenko.blogspot.com/
 
 
 ## Version 5.2
@@ -1400,9 +1400,9 @@ contributions!
   the matter.
 
 [vooon]: http://vehq.ru/about/
-[rukeba]: http://rukeba.com/
-[drake]: http://drakeguan.org/
-[ke]: http://k-evdokimenko.moikrug.ru/
+[rukeba]: https://rukeba.com/
+[drake]: https://drakeguan.org/
+[ke]: https://k-evdokimenko.moikrug.ru/
 
 
 ## Version 5.0
@@ -1429,7 +1429,7 @@ This version comes with two contributions from [Jason Diamond][jd]:
 
 Plus there are a couple of minor bug fixes for parsing HTML and XML attributes.
 
-[jd]: http://jason.diamond.name/weblog/
+[jd]: https://jason.diamond.name/weblog/
 
 
 ## Version 4.2
@@ -1451,10 +1451,10 @@ Other changes:
 - better auto-detection of C++ and PHP
 - HTML allows embedded VBScript (`<% .. %>`)
 
-[f]: http://softwaremaniacs.org/forum/highlightjs/
-[voldmar]: http://voldmar.ya.ru/
-[mel]: http://en.wikipedia.org/wiki/Maya_Embedded_Language
-[drake]: http://drakeguan.org/
+[f]: https://pytalk.ru/forum/highlightjs/
+[voldmar]: https://voldmar.ya.ru/
+[mel]: https://en.wikipedia.org/wiki/Maya_Embedded_Language
+[drake]: https://drakeguan.org/
 
 
 ## Version 4.1
@@ -1479,10 +1479,10 @@ Python and C++ which improved auto-detection for the latter (it was shame that
 thanks go to Sam for getting rid of my stylistic comments in code that were
 getting in the way of [JSMin][].
 
-[zenburn]: http://en.wikipedia.org/wiki/Zenburn
-[alenacpp]: http://alenacpp.blogspot.com/
-[bug]: http://softwaremaniacs.org/forum/viewtopic.php?id=1823
-[jsmin]: http://code.google.com/p/jsmin-php/
+[zenburn]: https://en.wikipedia.org/wiki/Zenburn
+[alenacpp]: https://alenacpp.blogspot.com/
+[bug]: https://pytalk.ru/forum/viewtopic.php?id=1823
+[jsmin]: https://code.google.com/p/jsmin-php/
 
 
 ## Version 4.0
@@ -1516,7 +1516,7 @@ and didn't highlight custom tags. In this version I tried to make custom XML to
 be detected and highlighted by its own rules. Which by the way include such
 things as CDATA sections and processing instructions (`<? ... ?>`).
 
-[f]: http://softwaremaniacs.org/forum/viewforum.php?id=6
+[f]: https://pytalk.ru/forum/viewforum.php?id=6
 
 
 ## Version 3.3
@@ -1527,7 +1527,7 @@ paste an HTML code generated by the highlighter for any code snippet. This can
 be useful in situations when one can't use the script itself on a site.
 
 
-[xonix]: http://xonixx.blogspot.com/
+[xonix]: https://xonixx.blogspot.com/
 
 
 ## Version 3.2 consists completely of contributions:
@@ -1549,7 +1549,7 @@ SQL definition but I'd never started it be it from the ground up :-)
 The engine itself has got a long awaited feature of grouping keywords
 ("keyword", "built-in function", "literal"). No more hacks!
 
-[1]: http://roudakov.ru/
+[1]: https://roudakov.ru/
 
 
 ## Version 3.0
@@ -1632,7 +1632,7 @@ already downloaded that one!
 - this same way allows now correct highlighting of keywords in some tricky
   places (like keyword "End" at the end of Delphi classes)
 
-[ak]: http://anton.kovalyov.net/
+[ak]: https://anton.kovalyov.net/
 
 
 ## Version 1.0
@@ -1643,4 +1643,4 @@ It's the first version available with English description. Feel free to post
 your comments and question to [highlight.js forum][forum]. And don't be afraid
 if you find there some fancy Cyrillic letters -- it's for Russian users too :-)
 
-[forum]: http://softwaremaniacs.org/forum/viewforum.php?id=6
+[forum]: https://pytalk.ru/forum/viewforum.php?id=6

--- a/docs/asciidoc/highlight/README.md
+++ b/docs/asciidoc/highlight/README.md
@@ -136,15 +136,15 @@ for details.
 The official site for the library is at <https://highlightjs.org/>.
 
 Further in-depth documentation for the API and other topics is at
-<http://highlightjs.readthedocs.io/>.
+<https://highlightjs.readthedocs.io/>.
 
 Authors and contributors are listed in the [AUTHORS.en.txt][8] file.
 
-[1]: http://highlightjs.readthedocs.io/en/latest/api.html#inithighlightingonload
-[2]: http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html
-[3]: http://highlightjs.readthedocs.io/en/latest/api.html#highlightblock-block
-[4]: http://highlightjs.readthedocs.io/en/latest/api.html#configure-options
+[1]: https://highlightjs.readthedocs.io/en/latest/api.html#inithighlightingonload
+[2]: https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html
+[3]: https://highlightjs.readthedocs.io/en/latest/api.html#highlightblock-block
+[4]: https://highlightjs.readthedocs.io/en/latest/api.html#configure-options
 [5]: https://highlightjs.org/download/
-[6]: http://highlightjs.readthedocs.io/en/latest/building-testing.html
+[6]: https://highlightjs.readthedocs.io/en/latest/building-testing.html
 [7]: https://github.com/isagalaev/highlight.js/blob/master/LICENSE
 [8]: https://github.com/isagalaev/highlight.js/blob/master/AUTHORS.en.txt

--- a/docs/asciidoc/highlight/README.ru.md
+++ b/docs/asciidoc/highlight/README.ru.md
@@ -128,15 +128,15 @@ Highlight.js распространяется под лицензией BSD. П�
 Официальный сайт билиотеки расположен по адресу <https://highlightjs.org/>.
 
 Более подробная документация по API и другим темам расположена на
-<http://highlightjs.readthedocs.io/>.
+<https://highlightjs.readthedocs.io/>.
 
 Авторы и контрибьюторы перечислены в файле [AUTHORS.ru.txt][8] file.
 
-[1]: http://highlightjs.readthedocs.io/en/latest/api.html#inithighlightingonload
-[2]: http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html
-[3]: http://highlightjs.readthedocs.io/en/latest/api.html#highlightblock-block
-[4]: http://highlightjs.readthedocs.io/en/latest/api.html#configure-options
+[1]: https://highlightjs.readthedocs.io/en/latest/api.html#inithighlightingonload
+[2]: https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html
+[3]: https://highlightjs.readthedocs.io/en/latest/api.html#highlightblock-block
+[4]: https://highlightjs.readthedocs.io/en/latest/api.html#configure-options
 [5]: https://highlightjs.org/download/
-[6]: http://highlightjs.readthedocs.io/en/latest/building-testing.html
+[6]: https://highlightjs.readthedocs.io/en/latest/building-testing.html
 [7]: https://github.com/isagalaev/highlight.js/blob/master/LICENSE
 [8]: https://github.com/isagalaev/highlight.js/blob/master/AUTHORS.ru.txt

--- a/docs/asciidoc/kotlin.adoc
+++ b/docs/asciidoc/kotlin.adoc
@@ -68,7 +68,7 @@ One of Kotlin's key features is https://kotlinlang.org/docs/reference/null-safet
 `NullPointerException` at runtime. This makes applications safer through nullability
 declarations and expressing "value or no value" semantics without paying the cost of wrappers like `Optional`.
 (Kotlin allows using functional constructs with nullable values; check out this
-http://www.baeldung.com/kotlin-null-safety[comprehensive guide to Kotlin null-safety].)
+https://www.baeldung.com/kotlin-null-safety[comprehensive guide to Kotlin null-safety].)
 
 Although Java does not allow one to express null-safety in its type-system, Reactor <<null-safety,now
 provides null-safety>> of the whole Reactor API via tooling-friendly annotations declared

--- a/docs/asciidoc/stylesheets/reactor.css
+++ b/docs/asciidoc/stylesheets/reactor.css
@@ -1,5 +1,5 @@
 @import url(https://fonts.googleapis.com/css?family=Montserrat:400,700);
-@import url(http://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css);
 
 
 #header .details br+span.author:before {
@@ -18,7 +18,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/docs/svg/conventions.svg
+++ b/docs/svg/conventions.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<!-- Created with Inkscape (https://www.inkscape.org/) -->
 
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="https://creativecommons.org/ns#"
+   xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:inkscape="https://www.inkscape.org/namespaces/inkscape"
    width="4209.3296"
    height="2035.1158"
    viewBox="0 0 1113.7184 538.45774"
@@ -3105,7 +3105,7 @@
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+           rdf:resource="https://purl.org/dc/dcmitype/StillImage" />
         <dc:title />
       </cc:Work>
     </rdf:RDF>

--- a/docs/svg/conventions.svg
+++ b/docs/svg/conventions.svg
@@ -3,12 +3,12 @@
 
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="https://creativecommons.org/ns#"
-   xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="https://www.inkscape.org/namespaces/inkscape"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="4209.3296"
    height="2035.1158"
    viewBox="0 0 1113.7184 538.45774"

--- a/reactor-core/src/main/java/reactor/adapter/package-info.java
+++ b/reactor-core/src/main/java/reactor/adapter/package-info.java
@@ -18,7 +18,7 @@
  * Adapt
  * {@link org.reactivestreams.Publisher} to Java 9+
  * {@link reactor.adapter.JdkFlowAdapter Flow.Publisher}. More adapter can be found
- * under https://github.com/reactor/reactor-addons/reactor-adapter including RxJava1 and
+ * in reactor-adapter under https://github.com/reactor/reactor-addons/ including RxJava1 and
  * RxJava2.
  *
  * @author Stephane Maldini

--- a/reactor-core/src/main/java/reactor/adapter/package-info.java
+++ b/reactor-core/src/main/java/reactor/adapter/package-info.java
@@ -18,7 +18,7 @@
  * Adapt
  * {@link org.reactivestreams.Publisher} to Java 9+
  * {@link reactor.adapter.JdkFlowAdapter Flow.Publisher}. More adapter can be found
- * under http://github.com/reactor/reactor-addons/reactor-adapter including RxJava1 and
+ * under https://github.com/reactor/reactor-addons/reactor-adapter including RxJava1 and
  * RxJava2.
  *
  * @author Stephane Maldini

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
@@ -32,7 +32,7 @@ import reactor.util.annotation.Nullable;
  * Please note, that along with multiple consumers, current implementation of
  * DirectProcessor supports multiple producers. However, all producers must produce
  * messages on the same Thread, otherwise
- * <a href="http://www.reactive-streams.org/">Reactive Streams Spec</a> contract is
+ * <a href="https://www.reactive-streams.org/">Reactive Streams Spec</a> contract is
  * violated.
  * <p>
  *      <img width="640" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.2.0.M2/src/docs/marble/directprocessornormal.png" alt="">

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -81,7 +81,7 @@ import reactor.util.function.Tuples;
  * <p>
  * The recommended way to learn about the {@link Flux} API and discover new operators is
  * through the reference documentation, rather than through this javadoc (as opposed to
- * learning more about individual operators). See the <a href="http://projectreactor.io/docs/core/release/reference/docs/index.html#which-operator">
+ * learning more about individual operators). See the <a href="https://projectreactor.io/docs/core/release/reference/docs/index.html#which-operator">
  * "which operator do I need?" appendix</a>.
  *
  * <p>

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMergeOrdered.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMergeOrdered.java
@@ -43,7 +43,7 @@ import reactor.util.concurrent.Queues;
  * @author David Karnok
  * @author Simon Baslé
  */
-//source: http://akarnokd.blogspot.fr/2017/09/java-9-flow-api-ordered-merge.html
+//source: https://akarnokd.blogspot.fr/2017/09/java-9-flow-api-ordered-merge.html
 final class FluxMergeOrdered<T> extends Flux<T> implements SourceProducer<T> {
 
 	final int                      prefetch;

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -72,7 +72,7 @@ import reactor.util.function.Tuples;
  * <p>
  * The recommended way to learn about the {@link Mono} API and discover new operators is
  * through the reference documentation, rather than through this javadoc (as opposed to
- * learning more about individual operators). See the <a href="http://projectreactor.io/docs/core/release/reference/docs/index.html#which-operator">
+ * learning more about individual operators). See the <a href="https://projectreactor.io/docs/core/release/reference/docs/index.html#which-operator">
  * "which operator do I need?" appendix</a>.
  *
  * <p><img class="marble" src="doc-files/marbles/mono.svg" alt="">

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -49,7 +49,7 @@ import static reactor.core.Fuseable.NONE;
  * size and to cap concurrent additive operations to Long.MAX_VALUE,
  * which is generic to {@link Subscription#request(long)} handling.
  *
- * Combine utils available to operator implementations, @see http://github.com/reactor/reactive-streams-commons
+ * Combine utils available to operator implementations, @see https://github.com/reactor/reactive-streams-commons
  *
  */
 public abstract class Operators {

--- a/reactor-core/src/main/java/reactor/core/publisher/RingBuffer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/RingBuffer.java
@@ -549,7 +549,7 @@ enum  UnsafeSupport {
 
 		// ensure the unsafe supports all necessary methods to work around the mistake in the latest OpenJDK
 		// https://github.com/netty/netty/issues/1061
-		// http://www.mail-archive.com/jdk6-dev@openjdk.java.net/msg00698.html
+		// https://www.mail-archive.com/jdk6-dev@openjdk.java.net/msg00698.html
 		if (unsafe != null) {
 			final Unsafe finalUnsafe = unsafe;
 			Object maybeException;

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -40,7 +40,7 @@ import reactor.util.context.Context;
  * However, it should be noticed that multi-producer case is only valid if appropriate
  * Queue
  * is provided. Otherwise, it could break
- * <a href="http://www.reactive-streams.org/">Reactive Streams Spec</a> if Publishers
+ * <a href="https://www.reactive-streams.org/">Reactive Streams Spec</a> if Publishers
  * publish on different threads.
  *
  * <p>
@@ -53,14 +53,14 @@ import reactor.util.context.Context;
  * <p>
  *      <b>Note: </b> UnicastProcessor does not respect the actual subscriber's
  *      demand as it is described in
- *      <a href="http://www.reactive-streams.org/">Reactive Streams Spec</a>. However,
+ *      <a href="https://www.reactive-streams.org/">Reactive Streams Spec</a>. However,
  *      UnicastProcessor embraces configurable Queue internally which allows enabling
  *      backpressure support and preventing of consumer's overwhelming.
  *
  *      Hence, interaction model between producers and UnicastProcessor will be PUSH
  *      only. In opposite, interaction model between UnicastProcessor and consumer will be
  *      PUSH-PULL as defined in
- *      <a href="http://www.reactive-streams.org/">Reactive Streams Spec</a>.
+ *      <a href="https://www.reactive-streams.org/">Reactive Streams Spec</a>.
  *
  *      In the case when upstream's signals overflow the bound of internal Queue,
  *      UnicastProcessor will fail with signaling onError(

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromFutureSupplier.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromFutureSupplier.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="https://creativecommons.org/ns#"
-   xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="https://www.inkscape.org/namespaces/inkscape"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    viewBox="20 81 595 306"
    width="595"

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromFutureSupplier.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromFutureSupplier.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="https://creativecommons.org/ns#"
+   xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:inkscape="https://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    viewBox="20 81 595 306"
    width="595"
@@ -21,7 +21,7 @@
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+           rdf:resource="https://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>

--- a/reactor-core/src/test/java/reactor/guide/GuideTests.java
+++ b/reactor-core/src/test/java/reactor/guide/GuideTests.java
@@ -932,7 +932,7 @@ public class GuideTests {
 
 	private Flux<String> urls() {
 		return Flux.range(1, 5)
-		           .map(i -> "http://mysite.io/quote/" + i);
+		           .map(i -> "https://www.mysite.io/quote" + i);
 	}
 
 	private Flux<String> doRequest(String url) {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

**review: unless commented otherwise, these are in highlight.js readme/changelog so not very important**

- [x] http://christopher.kaster.ws (200) with 1 occurrences could not be migrated:  
   ([https](https://christopher.kaster.ws) result ConnectTimeoutException).
- [x] http://desh.su/ (200) with 1 occurrences could not be migrated:  
   ([https](https://desh.su/) result SSLHandshakeException).
- [x] http://reactivex.io (200) with 1 occurrences could not be migrated:  
   ([https](https://reactivex.io) result SSLHandshakeException). **action: none. issue on their side to have the github certificate work on their custom domain**
- [x] http://ribkit.sourceforge.net/ (200) with 1 occurrences could not be migrated:  
   ([https](https://ribkit.sourceforge.net/) result AnnotatedConnectException).
- [x] http://softwaremaniacs.org/blog/2011/04/25/highlight-js-60-beta/en/ (200) with 1 occurrences could not be migrated:  
   ([https](https://softwaremaniacs.org/blog/2011/04/25/highlight-js-60-beta/en/) result SSLHandshakeException).
- [x] http://softwaremaniacs.org/blog/2012/05/10/http-and-json-in-highlight-js/en/ (200) with 1 occurrences could not be migrated:  
   ([https](https://softwaremaniacs.org/blog/2012/05/10/http-and-json-in-highlight-js/en/) result SSLHandshakeException).
- [x] http://web-cms-designs.com/ftopict-10-pojoaque-style-for-highlight-js-code-highlighter.html (200) with 1 occurrences could not be migrated:  
   ([https](https://web-cms-designs.com/ftopict-10-pojoaque-style-for-highlight-js-code-highlighter.html) result SSLHandshakeException).
- [x] http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd (404) with 2 occurrences could not be migrated:  
   ([https](https://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd) result AnnotatedConnectException). **action: left as is (`xmlns`)**
- [x] http://vehq.ru/about/ (404) with 1 occurrences could not be migrated:  
   ([https](https://vehq.ru/about/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

**review: most of these are part of changes.md of highlight.js, part of asciidoctor**

- [x] http://softwaremaniacs.org/forum/highlightjs/ (301) with 1 occurrences migrated to:  
  https://pytalk.ru/forum/highlightjs/ ([https](https://softwaremaniacs.org/forum/highlightjs/) result ConnectTimeoutException).
- [x] http://softwaremaniacs.org/forum/highlightjs/6612/ (301) with 1 occurrences migrated to:  
  https://pytalk.ru/forum/highlightjs/6612/ ([https](https://softwaremaniacs.org/forum/highlightjs/6612/) result ConnectTimeoutException).
- [x] http://softwaremaniacs.org/forum/viewforum.php?id=6 (301) with 2 occurrences migrated to:  
  https://pytalk.ru/forum/viewforum.php?id=6 ([https](https://softwaremaniacs.org/forum/viewforum.php?id=6) result ConnectTimeoutException).
- [x] http://softwaremaniacs.org/forum/viewtopic.php?id=1823 (301) with 1 occurrences migrated to:  
  https://pytalk.ru/forum/viewtopic.php?id=1823 ([https](https://softwaremaniacs.org/forum/viewtopic.php?id=1823) result ConnectTimeoutException).
- [x] http://mysite.io/quote/ (302) with 1 occurrences migrated to:  
  https://www.mysite.io/quote ([https](https://mysite.io/quote/) result AnnotatedConnectException). **reason: example for docs**
- [x] http://jason.diamond.name/weblog/ (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://jason.diamond.name/weblog/ ([https](https://jason.diamond.name/weblog/) result ConnectTimeoutException).
- [x] http://kalnitsky.org.ua/ (UnknownHostException) with 1 occurrences migrated to:  
  https://kalnitsky.org.ua/ ([https](https://kalnitsky.org.ua/) result UnknownHostException).
- [x] http://ru.wikipedia.org/wiki/C%2B%2B0x (301) with 1 occurrences migrated to:  
  https://ru.wikipedia.org/wiki/C%252B%252B0x ([https](https://ru.wikipedia.org/wiki/C%2B%2B0x) result 400).
- [x] http://en.wikipedia.org/wiki/Zenburn (301) with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Zenburn ([https](https://en.wikipedia.org/wiki/Zenburn) result 404).
- [x] http://github.com/reactor/reactor-addons/reactor-adapter (301) with 1 occurrences migrated to:  
  https://github.com/reactor/reactor-addons/reactor-adapter ([https](https://github.com/reactor/reactor-addons/reactor-adapter) result 404). **action: replaced the whole URL and javadoc wording to point to root project**
- [x] http://voldmar.ya.ru/ (404) with 1 occurrences migrated to:  
  https://voldmar.ya.ru/ ([https](https://voldmar.ya.ru/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://alenacpp.blogspot.com/ with 1 occurrences migrated to:  
  https://alenacpp.blogspot.com/ ([https](https://alenacpp.blogspot.com/) result 200).
* http://anton.kovalyov.net/ with 1 occurrences migrated to:  
  https://anton.kovalyov.net/ ([https](https://anton.kovalyov.net/) result 200).
* http://asciidoctor.org/docs/asciidoc-writers-guide/ with 1 occurrences migrated to:  
  https://asciidoctor.org/docs/asciidoc-writers-guide/ ([https](https://asciidoctor.org/docs/asciidoc-writers-guide/) result 200).
* http://bazaar.launchpad.net/~isagalaev/+junk/highlight/annotate/342/src/wp_highlight.js.php with 1 occurrences migrated to:  
  https://bazaar.launchpad.net/~isagalaev/+junk/highlight/annotate/342/src/wp_highlight.js.php ([https](https://bazaar.launchpad.net/~isagalaev/+junk/highlight/annotate/342/src/wp_highlight.js.php) result 200).
* http://brendanrocks.com with 1 occurrences migrated to:  
  https://brendanrocks.com ([https](https://brendanrocks.com) result 200).
* http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css with 1 occurrences migrated to:  
  https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css ([https](https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css) result 200).
* http://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css with 1 occurrences migrated to:  
  https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css ([https](https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css) result 200).
* http://creativecommons.org/ns with 2 occurrences migrated to:  
  https://creativecommons.org/ns ([https](https://creativecommons.org/ns) result 200).
* http://dolzhenko.blogspot.com/ with 1 occurrences migrated to:  
  https://dolzhenko.blogspot.com/ ([https](https://dolzhenko.blogspot.com/) result 200).
* http://drakeguan.org/ with 2 occurrences migrated to:  
  https://drakeguan.org/ ([https](https://drakeguan.org/) result 200).
* http://en.wikipedia.org/wiki/HTML5 with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/HTML5 ([https](https://en.wikipedia.org/wiki/HTML5) result 200).
* http://en.wikipedia.org/wiki/Maya_Embedded_Language with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Maya_Embedded_Language ([https](https://en.wikipedia.org/wiki/Maya_Embedded_Language) result 200).
* http://fulc.ru/ with 1 occurrences migrated to:  
  https://fulc.ru/ ([https](https://fulc.ru/) result 200).
* http://github.com/reactor/reactive-streams-commons with 3 occurrences migrated to:  
  https://github.com/reactor/reactive-streams-commons ([https](https://github.com/reactor/reactive-streams-commons) result 200).
* http://github.com/reactor/reactor-addons with 1 occurrences migrated to:  
  https://github.com/reactor/reactor-addons ([https](https://github.com/reactor/reactor-addons) result 200).
* http://github.com/reactor/reactor-addons/issues with 1 occurrences migrated to:  
  https://github.com/reactor/reactor-addons/issues ([https](https://github.com/reactor/reactor-addons/issues) result 200).
* http://github.com/reactor/reactor-core/issues with 1 occurrences migrated to:  
  https://github.com/reactor/reactor-core/issues ([https](https://github.com/reactor/reactor-core/issues) result 200).
* http://github.com/reactor/reactor-netty with 1 occurrences migrated to:  
  https://github.com/reactor/reactor-netty ([https](https://github.com/reactor/reactor-netty) result 200).
* http://gnuu.org/ with 1 occurrences migrated to:  
  https://gnuu.org/ ([https](https://gnuu.org/) result 200).
* http://grigio.org/ with 1 occurrences migrated to:  
  https://grigio.org/ ([https](https://grigio.org/) result 200).
* http://highlightjs.org/ with 1 occurrences migrated to:  
  https://highlightjs.org/ ([https](https://highlightjs.org/) result 200).
* http://highlightjs.org/download/ with 1 occurrences migrated to:  
  https://highlightjs.org/download/ ([https](https://highlightjs.org/download/) result 200).
* http://softwaremaniacs.org/soft/highlight/en/download/ (301) with 1 occurrences migrated to:  
  https://highlightjs.org/download/ ([https](https://softwaremaniacs.org/soft/highlight/en/download/) result 200).
* http://highlightjs.readthedocs.io/en/latest/api.html with 6 occurrences migrated to:  
  https://highlightjs.readthedocs.io/en/latest/api.html ([https](https://highlightjs.readthedocs.io/en/latest/api.html) result 200).
* http://highlightjs.readthedocs.io/en/latest/building-testing.html with 2 occurrences migrated to:  
  https://highlightjs.readthedocs.io/en/latest/building-testing.html ([https](https://highlightjs.readthedocs.io/en/latest/building-testing.html) result 200).
* http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html with 2 occurrences migrated to:  
  https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html ([https](https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html) result 200).
* http://kung-fu-tzu.ru/ with 1 occurrences migrated to:  
  https://kung-fu-tzu.ru/ ([https](https://kung-fu-tzu.ru/) result 200).
* http://mvnrepository.com/artifact/io.projectreactor/reactor-core with 1 occurrences migrated to:  
  https://mvnrepository.com/artifact/io.projectreactor/reactor-core ([https](https://mvnrepository.com/artifact/io.projectreactor/reactor-core) result 200).
* http://nn.mit-license.org/ with 1 occurrences migrated to:  
  https://nn.mit-license.org/ ([https](https://nn.mit-license.org/) result 200).
* http://pivotal.io with 1 occurrences migrated to:  
  https://pivotal.io ([https](https://pivotal.io) result 200).
* http://projectreactor.io/assets/img/logo-2x.png with 1 occurrences migrated to:  
  https://projectreactor.io/assets/img/logo-2x.png ([https](https://projectreactor.io/assets/img/logo-2x.png) result 200).
* http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html with 1 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html ([https](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html) result 200).
* http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html with 1 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html ([https](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html) result 200).
* http://projectreactor.io/docs/core/release/api/reactor/core/publisher/ParallelFlux.html with 1 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/api/reactor/core/publisher/ParallelFlux.html ([https](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/ParallelFlux.html) result 200).
* http://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Scheduler.html with 1 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Scheduler.html ([https](https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Scheduler.html) result 200).
* http://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Schedulers.html with 1 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Schedulers.html ([https](https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Schedulers.html) result 200).
* http://projectreactor.io/docs/core/release/reference/ with 1 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/reference/ ([https](https://projectreactor.io/docs/core/release/reference/) result 200).
* http://projectreactor.io/docs/test/release/api/index.html?reactor/test/StepVerifier.html with 1 occurrences migrated to:  
  https://projectreactor.io/docs/test/release/api/index.html?reactor/test/StepVerifier.html ([https](https://projectreactor.io/docs/test/release/api/index.html?reactor/test/StepVerifier.html) result 200).
* http://requirejs.org/docs/whyamd.html with 1 occurrences migrated to:  
  https://requirejs.org/docs/whyamd.html ([https](https://requirejs.org/docs/whyamd.html) result 200).
* http://roudakov.ru/ with 1 occurrences migrated to:  
  https://roudakov.ru/ ([https](https://roudakov.ru/) result 200).
* http://rukeba.com/ with 1 occurrences migrated to:  
  https://rukeba.com/ ([https](https://rukeba.com/) result 200).
* http://stackoverflow.com/tags/project-reactor with 1 occurrences migrated to:  
  https://stackoverflow.com/tags/project-reactor ([https](https://stackoverflow.com/tags/project-reactor) result 200).
* http://vasily.polovnyov.ru/ with 1 occurrences migrated to:  
  https://vasily.polovnyov.ru/ ([https](https://vasily.polovnyov.ru/) result 200).
* http://wordpress.org/ with 1 occurrences migrated to:  
  https://wordpress.org/ ([https](https://wordpress.org/) result 200).
* http://www.baeldung.com/kotlin-null-safety with 1 occurrences migrated to:  
  https://www.baeldung.com/kotlin-null-safety ([https](https://www.baeldung.com/kotlin-null-safety) result 200).
* http://www.mail-archive.com/jdk6-dev@openjdk.java.net/msg00698.html with 1 occurrences migrated to:  
  https://www.mail-archive.com/jdk6-dev@openjdk.java.net/msg00698.html ([https](https://www.mail-archive.com/jdk6-dev@openjdk.java.net/msg00698.html) result 200).
* http://www.parser.ru/ with 1 occurrences migrated to:  
  https://www.parser.ru/ ([https](https://www.parser.ru/) result 200).
* http://www.reactive-streams.org/ with 5 occurrences migrated to:  
  https://www.reactive-streams.org/ ([https](https://www.reactive-streams.org/) result 200).
* http://reactive-streams.org (301) with 1 occurrences migrated to:  
  https://www.reactive-streams.org/ ([https](https://reactive-streams.org) result 200).
* http://www.w3.org/1999/02/22-rdf-syntax-ns with 2 occurrences migrated to:  
  https://www.w3.org/1999/02/22-rdf-syntax-ns ([https](https://www.w3.org/1999/02/22-rdf-syntax-ns) result 200).
* http://yandex.com/ with 1 occurrences migrated to:  
  https://yandex.com/ ([https](https://yandex.com/) result 200).
* http://yardoc.org/ with 1 occurrences migrated to:  
  https://yardoc.org/ ([https](https://yardoc.org/) result 200).
* http://code.google.com/p/jsmin-php/ with 1 occurrences migrated to:  
  https://code.google.com/p/jsmin-php/ ([https](https://code.google.com/p/jsmin-php/) result 301).
* http://ethanschoonover.com/solarized with 1 occurrences migrated to:  
  https://ethanschoonover.com/solarized ([https](https://ethanschoonover.com/solarized) result 301).
* http://softwaremaniacs.org/wiki/doku.php/highlight.js:api (301) with 1 occurrences migrated to:  
  https://highlightjs.readthedocs.org/ ([https](https://softwaremaniacs.org/wiki/doku.php/highlight.js:api) result 301).
* http://highlightjs.readthedocs.org/ with 1 occurrences migrated to:  
  https://highlightjs.readthedocs.org/ ([https](https://highlightjs.readthedocs.org/) result 301).
* http://highlightjs.readthedocs.org/en/latest/api.html with 3 occurrences migrated to:  
  https://highlightjs.readthedocs.org/en/latest/api.html ([https](https://highlightjs.readthedocs.org/en/latest/api.html) result 301).
* http://highlightjs.readthedocs.org/en/latest/building-testing.html with 1 occurrences migrated to:  
  https://highlightjs.readthedocs.org/en/latest/building-testing.html ([https](https://highlightjs.readthedocs.org/en/latest/building-testing.html) result 301).
* http://highlightjs.readthedocs.org/en/latest/css-classes-reference.html with 1 occurrences migrated to:  
  https://highlightjs.readthedocs.org/en/latest/css-classes-reference.html ([https](https://highlightjs.readthedocs.org/en/latest/css-classes-reference.html) result 301).
* http://highlightjs.readthedocs.org/en/latest/style-guide.html with 1 occurrences migrated to:  
  https://highlightjs.readthedocs.org/en/latest/style-guide.html ([https](https://highlightjs.readthedocs.org/en/latest/style-guide.html) result 301).
* http://jmblog.github.com/color-themes-for-highlightjs/ with 1 occurrences migrated to:  
  https://jmblog.github.com/color-themes-for-highlightjs/ ([https](https://jmblog.github.com/color-themes-for-highlightjs/) result 301).
* http://k-evdokimenko.moikrug.ru/ with 1 occurrences migrated to:  
  https://k-evdokimenko.moikrug.ru/ ([https](https://k-evdokimenko.moikrug.ru/) result 301).
* http://www.inkscape.org/ with 1 occurrences migrated to:  
  https://www.inkscape.org/ ([https](https://www.inkscape.org/) result 301).
* http://www.inkscape.org/namespaces/inkscape with 2 occurrences migrated to:  
  https://www.inkscape.org/namespaces/inkscape ([https](https://www.inkscape.org/namespaces/inkscape) result 301).
* http://akarnokd.blogspot.fr/2017/09/java-9-flow-api-ordered-merge.html with 1 occurrences migrated to:  
  https://akarnokd.blogspot.fr/2017/09/java-9-flow-api-ordered-merge.html ([https](https://akarnokd.blogspot.fr/2017/09/java-9-flow-api-ordered-merge.html) result 302).
* http://highlightjs.readthedocs.io/ with 2 occurrences migrated to:  
  https://highlightjs.readthedocs.io/ ([https](https://highlightjs.readthedocs.io/) result 302).
* http://livecode.com/developers/guides/server/ with 1 occurrences migrated to:  
  https://livecode.com/developers/guides/server/ ([https](https://livecode.com/developers/guides/server/) result 302).
* http://nodejs.org/ with 1 occurrences migrated to:  
  https://nodejs.org/ ([https](https://nodejs.org/) result 302).
* http://projectreactor.io/docs/core/release/reference/docs/index.html with 6 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/reference/docs/index.html ([https](https://projectreactor.io/docs/core/release/reference/docs/index.html) result 302).
* http://purl.org/dc/dcmitype/StillImage with 2 occurrences migrated to:  
  https://purl.org/dc/dcmitype/StillImage ([https](https://purl.org/dc/dcmitype/StillImage) result 302).
* http://repo.spring.io/milestone with 2 occurrences migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* http://repo.spring.io/snapshot with 2 occurrences migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).
* http://xonixx.blogspot.com/ with 1 occurrences migrated to:  
  https://xonixx.blogspot.com/ ([https](https://xonixx.blogspot.com/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://purl.org/dc/elements/1.1/ with 2 occurrences
* http://www.w3.org/1999/xhtml with 2 occurrences
* http://www.w3.org/1999/xlink with 7 occurrences
* http://www.w3.org/2000/svg with 370 occurrences

# Additional Manual Actions
Amended the PR to revert xmlns changes in SVG