### PR TITLE
URL Cleanup

### DIFF
--- a/docs/svg/conventions.svg
+++ b/docs/svg/conventions.svg
@@ -2,13 +2,13 @@
 <!-- Created with Inkscape (https://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   xmlns:dc="https://purl.org/dc/elements/1.1/"
+   xmlns:cc="https://creativecommons.org/ns#"
+   xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="https://www.w3.org/2000/svg"
+   xmlns="https://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:inkscape="https://www.inkscape.org/namespaces/inkscape"
    width="4209.3296"
    height="2035.1158"
    viewBox="0 0 1113.7184 538.45774"

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/all.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/all.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 11 804 359" width="804" height="359" id="svg138">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 11 804 359" width="804" height="359" id="svg138">
  <defs id="defs25">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/and.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/and.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 19 504 332" width="504" height="332" id="svg101">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 19 504 332" width="504" height="332" id="svg101">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/any.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/any.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 11 810 359" width="810" height="359" id="svg138">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 11 810 359" width="810" height="359" id="svg138">
  <defs id="defs25">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/autoConnect.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/autoConnect.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 60 699 718" width="699" height="718" id="svg264">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="23 60 699 718" width="699" height="718" id="svg264">
  <defs id="defs55">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/autoConnectWithMinSubscribers.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/autoConnectWithMinSubscribers.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 60 685 719" width="685" height="719" id="svg264">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="23 60 685 719" width="685" height="719" id="svg264">
  <defs id="defs55">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/block.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/block.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 25 524.86 304" width="524.86" height="304" id="svg198">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 25 524.86 304" width="524.86" height="304" id="svg198">
  <defs id="defs25">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/blockFirst.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/blockFirst.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 25 525 304" width="525" height="304" id="svg198">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 25 525 304" width="525" height="304" id="svg198">
  <defs id="defs25">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/blockFirstWithTimeout.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/blockFirstWithTimeout.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 25 711 341" width="711" height="341" id="svg198">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 25 711 341" width="711" height="341" id="svg198">
  <defs id="defs25">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/blockLast.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/blockLast.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 25 585 295" width="585" height="295" id="svg198">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 25 585 295" width="585" height="295" id="svg198">
  <defs id="defs25">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/blockLastWithTimeout.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/blockLastWithTimeout.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 25 782 342" width="782" height="342" id="svg198">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 25 782 342" width="782" height="342" id="svg198">
  <defs id="defs25">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/blockOptional.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/blockOptional.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 25 580 303" width="580" height="303" id="svg198">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 25 580 303" width="580" height="303" id="svg198">
  <defs id="defs25">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/blockOptionalWithTimeout.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/blockOptionalWithTimeout.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 25 711 341" width="711" height="341" id="svg198">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 25 711 341" width="711" height="341" id="svg198">
  <defs id="defs25">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/blockWithTimeout.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/blockWithTimeout.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 25 711 341" width="711" height="341" id="svg198">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 25 711 341" width="711" height="341" id="svg198">
  <defs id="defs25">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/buffer.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/buffer.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 1 586 365" width="586" height="365" id="svg135">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 1 586 365" width="586" height="365" id="svg135">
  <defs id="defs18">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferTimeoutWithMaxSizeAndTimespan.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferTimeoutWithMaxSizeAndTimespan.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 0 718 396" width="718" height="396" id="svg249">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 0 718 396" width="718" height="396" id="svg249">
  <defs id="defs24">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferUntil.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferUntil.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 617 317" width="617" height="317" id="svg181">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 617 317" width="617" height="317" id="svg181">
  <defs id="defs18">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferUntilWithCutBefore.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferUntilWithCutBefore.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 617 317" width="617" height="317" id="svg181">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 617 317" width="617" height="317" id="svg181">
  <defs id="defs18">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWhen.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWhen.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 843 475" width="843" height="475" id="svg224">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 843 475" width="843" height="475" id="svg224">
  <defs id="defs20">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWhenWithSupplier.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWhenWithSupplier.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 843 476" width="843" height="476" id="svg224">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 843 476" width="843" height="476" id="svg224">
  <defs id="defs20">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWhile.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWhile.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 616 319" width="616" height="319" id="svg181">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 616 319" width="616" height="319" id="svg181">
  <defs id="defs18">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithBoundary.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithBoundary.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 698 375" width="698" height="375" id="svg181">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 698 375" width="698" height="375" id="svg181">
  <defs id="defs18">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithMaxSize.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithMaxSize.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 23 596 348" width="596" height="348" id="svg196">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 23 596 348" width="596" height="348" id="svg196">
  <defs id="defs28">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithMaxSizeEqualsSkipSize.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithMaxSizeEqualsSkipSize.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 23 596 348" width="596" height="348" id="svg196">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 23 596 348" width="596" height="348" id="svg196">
  <defs id="defs28">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithMaxSizeGreaterThanSkipSize.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithMaxSizeGreaterThanSkipSize.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 596 361" width="596" height="361" id="svg223">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 596 361" width="596" height="361" id="svg223">
  <defs id="defs28">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g10">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithMaxSizeLessThanSkipSize.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithMaxSizeLessThanSkipSize.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 596 361" width="596" height="361" id="svg187">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 596 361" width="596" height="361" id="svg187">
  <defs id="defs24">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithTimespan.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithTimespan.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 0 596 374" width="596" height="374" id="svg215">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 0 596 374" width="596" height="374" id="svg215">
  <defs id="defs24">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithTimespanEqualsOpenBufferEvery.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithTimespanEqualsOpenBufferEvery.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 671 511" width="671" height="511" id="svg181">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 671 511" width="671" height="511" id="svg181">
  <defs id="defs18">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithTimespanGreaterThanOpenBufferEvery.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithTimespanGreaterThanOpenBufferEvery.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 672 468" width="672" height="468" id="svg265">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 672 468" width="672" height="468" id="svg265">
  <defs id="defs29">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithTimespanLessThanOpenBufferEvery.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/bufferWithTimespanLessThanOpenBufferEvery.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 654 453" width="654" height="453" id="svg254">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 654 453" width="654" height="453" id="svg254">
  <defs id="defs24">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/cacheForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/cacheForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 41 591 578" width="591" height="578" id="svg214">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="23 41 591 578" width="591" height="578" id="svg214">
  <defs id="defs33">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/cacheForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/cacheForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 41 478 588" width="478" height="588" id="svg214">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="23 41 478 588" width="478" height="588" id="svg214">
  <defs id="defs33">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/cacheWithHistoryLimitForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/cacheWithHistoryLimitForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 41 626 490" width="626" height="490" id="svg214">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="23 41 626 490" width="626" height="490" id="svg214">
  <defs id="defs33">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/cacheWithTtlAndMaxLimitForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/cacheWithTtlAndMaxLimitForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 60 594 537" width="594" height="537" id="svg251">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="23 60 594 537" width="594" height="537" id="svg251">
  <defs id="defs35">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/cacheWithTtlForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/cacheWithTtlForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 60 602 515" width="602" height="515" id="svg251">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="23 60 602 515" width="602" height="515" id="svg251">
  <defs id="defs35">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/cacheWithTtlForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/cacheWithTtlForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 60 537 491" width="537" height="491" id="svg251">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="23 60 537 491" width="537" height="491" id="svg251">
  <defs id="defs35">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/cancelOnForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/cancelOnForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 20 375 371" width="375" height="371" id="svg174">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 20 375 371" width="375" height="371" id="svg174">
  <defs id="defs31">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#ff5a01" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/cancelOnForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/cancelOnForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 20 307 346" width="307" height="346" id="svg174">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 20 307 346" width="307" height="346" id="svg174">
  <defs id="defs31">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#ff5a01" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/castForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/castForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 87 593 274" width="593" height="274" id="svg123">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 87 593 274" width="593" height="274" id="svg123">
  <defs id="defs24">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/castForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/castForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 87 593 273" width="593" height="273" id="svg72">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 87 593 273" width="593" height="273" id="svg72">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collect.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collect.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 11 581 365" width="581" height="365" id="svg215">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 11 581 365" width="581" height="365" id="svg215">
  <defs id="defs40">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collectList.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collectList.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 67 590 279" width="590" height="279" id="svg118">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 67 590 279" width="590" height="279" id="svg118">
  <defs id="defs14">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collectMapWithKeyAndValueExtractors.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collectMapWithKeyAndValueExtractors.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 -13 597 384" width="597" height="384" id="svg231">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 -13 597 384" width="597" height="384" id="svg231">
  <defs id="defs31">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collectMapWithKeyExtractor.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collectMapWithKeyExtractor.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 -13 597 392" width="597" height="392" id="svg231">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 -13 597 392" width="597" height="392" id="svg231">
  <defs id="defs31">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collectMultiMapWithKeyAndValueExtractors.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collectMultiMapWithKeyAndValueExtractors.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 -16 595 393" width="595" height="393" id="svg204">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 -16 595 393" width="595" height="393" id="svg204">
  <defs id="defs31">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collectMultiMapWithKeyExtractor.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collectMultiMapWithKeyExtractor.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 -16 595 393" width="595" height="393" id="svg204">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 -16 595 393" width="595" height="393" id="svg204">
  <defs id="defs31">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collectSortedList.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collectSortedList.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 -13 597 367" width="597" height="367" id="svg227">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 -13 597 367" width="597" height="367" id="svg227">
  <defs id="defs31">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collectSortedListWithComparator.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collectSortedListWithComparator.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 -13 597 367" width="597" height="367" id="svg227">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 -13 597 367" width="597" height="367" id="svg227">
  <defs id="defs31">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collectWithCollector.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/collectWithCollector.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 11 581 365" width="581" height="365" id="svg215">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 11 581 365" width="581" height="365" id="svg215">
  <defs id="defs40">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/combineLatest.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/combineLatest.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 19 843 360" width="843" height="360" id="svg239">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 19 843 360" width="843" height="360" id="svg239">
  <defs id="defs21">
   <marker orient="auto" refY="0" refX="0" id="Arrow2Lend" overflow="visible">
    <path id="path5247" d="M-11-4L1 0l-12 4c2-2 2-6 0-8z" fill-rule="evenodd" stroke-width="1" stroke-linejoin="round" stroke="#000" stroke-opacity="1" fill="#000" fill-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/composeForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/composeForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 11 579.51 424.76" width="579.51" height="424.76" id="svg138">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 11 579.51 424.76" width="579.51" height="424.76" id="svg138">
  <defs id="defs25">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/composeForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/composeForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 11 576.27 422.7" width="576.27" height="422.7" id="svg138">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 11 576.27 422.7" width="576.27" height="422.7" id="svg138">
  <defs id="defs25">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/concatAsyncSources.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/concatAsyncSources.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="svg148" height="353" width="625" viewBox="20 19 625 353" version="1.1">
+<svg xmlns="https://www.w3.org/2000/svg" id="svg148" height="353" width="625" viewBox="20 19 625 353" version="1.1">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/concatMap.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/concatMap.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 91 496 391" width="496" height="391" id="svg141">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 91 496 391" width="496" height="391" id="svg141">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/concatMapIterable.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/concatMapIterable.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 91 491 300" width="491" height="300" id="svg141">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 91 491 300" width="491" height="300" id="svg141">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/concatVarSources.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/concatVarSources.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 20 610 359" width="610" height="359" id="svg149">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 20 610 359" width="610" height="359" id="svg149">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/concatWithForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/concatWithForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 20 585 340" width="585" height="340" id="svg117">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 20 585 340" width="585" height="340" id="svg117">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/concatWithForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/concatWithForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 20 556 340" width="556" height="340" id="svg117">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 20 556 340" width="556" height="340" id="svg117">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/concatWithValues.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/concatWithValues.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 67 531 293" width="531" height="293" id="svg138">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 67 531 293" width="531" height="293" id="svg138">
  <defs id="defs16">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/count.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/count.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 -3 494.86 367.83" width="494.86" height="367.83" id="svg182">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 -3 494.86 367.83" width="494.86" height="367.83" id="svg182">
  <defs id="defs37">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/createForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/createForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 14 533 467" width="533" height="467" id="svg225">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 14 533 467" width="533" height="467" id="svg225">
  <defs id="defs33">
   <marker id="marker41900" refX="0" refY="0" orient="auto" overflow="visible">
    <path d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" id="path41898" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".4pt" stroke-opacity="1" fill="#5b1d88" fill-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/createForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/createForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 14 440 455" width="440" height="455" id="svg225">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 14 440 455" width="440" height="455" id="svg225">
  <defs id="defs33">
   <marker id="marker41345" refX="0" refY="0" orient="auto" overflow="visible">
    <path d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" id="path41343" fill="#5b1d88" fill-opacity="1" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".53" stroke-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/createWithOverflowStrategy.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/createWithOverflowStrategy.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 14 533 467" width="533" height="467" id="svg225">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 14 533 467" width="533" height="467" id="svg225">
  <defs id="defs33">
   <marker id="marker40610" refX="0" refY="0" orient="auto" overflow="visible">
    <path d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" id="path40608" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".4pt" stroke-opacity="1" fill="#5b1d88" fill-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/defaultIfEmpty.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/defaultIfEmpty.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 98 528 269" width="528" height="269" id="svg70">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 98 528 269" width="528" height="269" id="svg70">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/deferForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/deferForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="26 16 427 326" width="427" height="326" id="svg121">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="26 16 427 326" width="427" height="326" id="svg121">
  <defs id="defs18">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/deferForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/deferForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="26 16 389 336" width="389" height="336" id="svg108">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="26 16 389 336" width="389" height="336" id="svg108">
  <defs id="defs18">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delay.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delay.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 124 312 241" width="312" height="241" id="svg119">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="21 124 312 241" width="312" height="241" id="svg119">
  <defs id="defs27">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#ff5a01" stroke-linejoin="miter">
    <g id="g6">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delayElement.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delayElement.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 104 453 313" width="453" height="313" id="svg171">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="21 104 453 313" width="453" height="313" id="svg171">
  <defs id="defs20">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delayElements.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delayElements.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 104 588 307" width="588" height="307" id="svg171">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="21 104 588 307" width="588" height="307" id="svg171">
  <defs id="defs20">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delaySequence.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delaySequence.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 104 555 347" width="555" height="347" id="svg171">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="21 104 555 347" width="555" height="347" id="svg171">
  <defs id="defs20">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delaySubscriptionForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delaySubscriptionForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 535 335" width="535" height="335" id="svg158">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 535 335" width="535" height="335" id="svg158">
  <defs id="defs28">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delaySubscriptionForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delaySubscriptionForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 485 335" width="485" height="335" id="svg123">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 485 335" width="485" height="335" id="svg123">
  <defs id="defs28">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delaySubscriptionWithPublisherForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delaySubscriptionWithPublisherForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 555 426" width="555" height="426" id="svg165">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 555 426" width="555" height="426" id="svg165">
  <defs id="defs31">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delaySubscriptionWithPublisherForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delaySubscriptionWithPublisherForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 470 417" width="470" height="417" id="svg165">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 470 417" width="470" height="417" id="svg165">
  <defs id="defs31">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delayUntilForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delayUntilForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 20 611 392" width="611" height="392" id="svg121">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 20 611 392" width="611" height="392" id="svg121">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="greyArrowTip" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#c7c7c7" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delayUntilForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/delayUntilForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 20 533 332" width="533" height="332" id="svg121">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 20 533 332" width="533" height="332" id="svg121">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="greyArrowTip" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#c7c7c7" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/dematerializeForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/dematerializeForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 76 854 325" width="854" height="325" id="svg141">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 76 854 325" width="854" height="325" id="svg141">
  <defs id="defs28">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/dematerializeForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/dematerializeForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 76 789 324" width="789" height="324" id="svg84">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 76 789 324" width="789" height="324" id="svg84">
  <defs id="defs16">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/distinct.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/distinct.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 6 590 278" width="590" height="278" id="svg152">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="21 6 590 278" width="590" height="278" id="svg152">
  <defs id="defs14">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/distinctUntilChanged.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/distinctUntilChanged.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 6 590 278" width="590" height="278" id="svg152">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="21 6 590 278" width="590" height="278" id="svg152">
  <defs id="defs14">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/distinctUntilChangedWithKey.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/distinctUntilChangedWithKey.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="21 6 590 278" width="590" height="278" id="svg169">
+<svg xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" version="1.1" viewBox="21 6 590 278" width="590" height="278" id="svg169">
  <defs id="defs24">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/distinctWithKey.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/distinctWithKey.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 6 590 278" width="590" height="278" id="svg163">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="21 6 590 278" width="590" height="278" id="svg163">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doAfterSuccessOrError.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doAfterSuccessOrError.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 25 598 629" width="598" height="629" id="svg88">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 25 598 629" width="598" height="629" id="svg88">
  <defs id="defs16">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doAfterTerminateForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doAfterTerminateForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 25 596 573" width="596" height="573" id="svg155">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 25 596 573" width="596" height="573" id="svg155">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doAfterTerminateForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doAfterTerminateForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 25 356 565" width="356" height="565" id="svg88">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 25 356 565" width="356" height="565" id="svg88">
  <defs id="defs16">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doFinallyForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doFinallyForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 77 788.88 319.5" width="788.88" height="319.5" id="svg125">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 77 788.88 319.5" width="788.88" height="319.5" id="svg125">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doFinallyForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doFinallyForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="565.05" height="347.3" viewBox="0 0 149.5 91.89" version="1.1" id="svg17436">
+<svg xmlns="https://www.w3.org/2000/svg" width="565.05" height="347.3" viewBox="0 0 149.5 91.89" version="1.1" id="svg17436">
  <defs id="defs17430">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnCancelForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnCancelForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 49 595 362" width="595" height="362" id="svg99">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 49 595 362" width="595" height="362" id="svg99">
  <defs id="defs21">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnCancelForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnCancelForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 49 357 364" width="357" height="364" id="svg99">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 49 357 364" width="357" height="364" id="svg99">
  <defs id="defs21">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnComplete.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnComplete.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 89 595 301" width="595" height="301" id="svg87">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 89 595 301" width="595" height="301" id="svg87">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnEachForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnEachForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 77 649 319" width="649" height="319" id="svg125">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 77 649 319" width="649" height="319" id="svg125">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnEachForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnEachForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="488.71" height="346.8" viewBox="0 0 129.31 91.76" version="1.1" id="svg20245">
+<svg xmlns="https://www.w3.org/2000/svg" width="488.71" height="346.8" viewBox="0 0 129.31 91.76" version="1.1" id="svg20245">
  <defs id="defs20239">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnErrorForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnErrorForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 89 414 280" width="414" height="280" id="svg99">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 89 414 280" width="414" height="280" id="svg99">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnErrorForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnErrorForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 89 427.86 262.15" width="427.86" height="262.15" id="svg99">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 89 427.86 262.15" width="427.86" height="262.15" id="svg99">
  <defs id="defs14">
   <marker markerHeight="10" markerWidth="11" viewBox="-1 -5 11 10" stroke-miterlimit="10" id="marker77223" markerUnits="strokeWidth" overflow="visible" orient="auto" color="#34302c" stroke-linejoin="miter">
    <g id="g77221" fill="#34302c" fill-opacity="1" stroke="#34302c" stroke-opacity="1">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnErrorWithClassPredicateForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnErrorWithClassPredicateForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 89 595 606" width="595" height="606" id="svg117">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 89 595 606" width="595" height="606" id="svg117">
  <defs id="defs16">
   <marker stroke-linejoin="miter" color="#34302c" markerHeight="10" markerWidth="11" viewBox="-1 -5 11 10" stroke-miterlimit="10" id="marker69829" markerUnits="strokeWidth" overflow="visible" orient="auto">
    <g id="g69827" stroke="#34302c" stroke-opacity="1" fill="#34302c" fill-opacity="1">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnErrorWithClassPredicateForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnErrorWithClassPredicateForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 89 395.86 576.74" width="395.86" height="576.74" id="svg117">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 89 395.86 576.74" width="395.86" height="576.74" id="svg117">
  <defs id="defs16">
   <marker markerHeight="10" markerWidth="11" viewBox="-1 -5 11 10" stroke-miterlimit="10" id="marker70236" markerUnits="strokeWidth" overflow="visible" orient="auto" color="#34302c" stroke-linejoin="miter">
    <g id="g70234" fill="#34302c" fill-opacity="1" stroke="#34302c" stroke-opacity="1">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnErrorWithPredicateForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnErrorWithPredicateForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 58 595 626" width="595" height="626" id="svg145">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 58 595 626" width="595" height="626" id="svg145">
  <defs id="defs23">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnErrorWithPredicateForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnErrorWithPredicateForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 58 458.86 615.77" width="458.86" height="615.77" id="svg145">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 58 458.86 615.77" width="458.86" height="615.77" id="svg145">
  <defs id="defs23">
   <marker markerHeight="10" markerWidth="11" viewBox="-1 -5 11 10" stroke-miterlimit="10" id="marker71057" markerUnits="strokeWidth" overflow="visible" orient="auto" color="#34302c" stroke-linejoin="miter">
    <g id="g71055" fill="#34302c" fill-opacity="1" stroke="#34302c" stroke-opacity="1">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnNextForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnNextForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 77 607 319" width="607" height="319" id="svg125">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 77 607 319" width="607" height="319" id="svg125">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnNextForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnNextForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 77 378 319" width="378" height="319" id="svg125">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 77 378 319" width="378" height="319" id="svg125">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnRequestForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnRequestForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 58 595 341" width="595" height="341" id="svg106">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 58 595 341" width="595" height="341" id="svg106">
  <defs id="defs21">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnRequestForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnRequestForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 58 428 341" width="428" height="341" id="svg98">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 58 428 341" width="428" height="341" id="svg98">
  <defs id="defs21">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnSubscribe.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnSubscribe.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 33 415 387" width="415" height="387" id="svg86">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 33 415 387" width="415" height="387" id="svg86">
  <defs id="defs21">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnSuccess.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnSuccess.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 89 382.85 274.93" width="382.85" height="274.93" id="svg88">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 89 382.85 274.93" width="382.85" height="274.93" id="svg88">
  <defs id="defs16">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnTerminateForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnTerminateForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 25 595 615" width="595" height="615" id="svg155">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 25 595 615" width="595" height="615" id="svg155">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnTerminateForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doOnTerminateForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 25 399 610" width="399" height="610" id="svg88">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 25 399 610" width="399" height="610" id="svg88">
  <defs id="defs16">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/elapsedForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/elapsedForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 44 593 363" width="593" height="363" id="svg224">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 44 593 363" width="593" height="363" id="svg224">
  <defs id="defs34">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/elapsedForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/elapsedForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 44 406 340" width="406" height="340" id="svg115">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 44 406 340" width="406" height="340" id="svg115">
  <defs id="defs24">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/elementAt.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/elementAt.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 60 342 299" width="342" height="299" id="svg122">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 60 342 299" width="342" height="299" id="svg122">
  <defs id="defs28">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/elementAtWithDefault.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/elementAtWithDefault.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 82 571 280" width="571" height="280" id="svg118">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 82 571 280" width="571" height="280" id="svg118">
  <defs id="defs26">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/empty.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/empty.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="24 27 242 175" width="242" height="175" id="svg50">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="24 27 242 175" width="242" height="175" id="svg50">
  <defs id="defs14">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/error.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/error.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="81 172 324 221" width="324" height="221" id="svg61">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="81 172 324 221" width="324" height="221" id="svg61">
  <defs id="defs14">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/errorWhenRequested.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/errorWhenRequested.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="24 27 324 524" width="324" height="524" id="svg73">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="24 27 324 524" width="324" height="524" id="svg73">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/errorWithSupplier.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/errorWithSupplier.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="81 172 324 221" width="324" height="221" id="svg61">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="81 172 324 221" width="324" height="221" id="svg61">
  <defs id="defs14">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/filterForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/filterForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 87 599 283" width="599" height="283" id="svg166">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 87 599 283" width="599" height="283" id="svg166">
  <defs id="defs23">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/filterForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/filterForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="26 18 538 284" width="538" height="284" id="svg118">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="26 18 538 284" width="538" height="284" id="svg118">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/filterWhenForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/filterWhenForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 87 705 425" width="705" height="425" id="svg166">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 87 705 425" width="705" height="425" id="svg166">
  <defs id="defs23">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/filterWhenForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/filterWhenForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 87 796 425" width="796" height="425" id="svg166">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 87 796 425" width="796" height="425" id="svg166">
  <defs id="defs23">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/firstForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/firstForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 600 400" width="585" height="373" id="svg89">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="0 0 600 400" width="585" height="373" id="svg89">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/firstForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/firstForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="493" height="395" id="svg89">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" width="493" height="395" id="svg89">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 91 568 391" width="568" height="391" id="svg141">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 91 568 391" width="568" height="391" id="svg141">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 91 496 355" width="496" height="355" id="svg141">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 91 496 355" width="496" height="355" id="svg141">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapIterableForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapIterableForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 91 494 331" width="494" height="331" id="svg141">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 91 494 331" width="494" height="331" id="svg141">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapIterableForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapIterableForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 91 494 331" width="494" height="331" id="svg141">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 91 494 331" width="494" height="331" id="svg141">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapMany.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapMany.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 91 496 355" width="496" height="355" id="svg141">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 91 496 355" width="496" height="355" id="svg141">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapManyWithMappersOnTerminalEvents.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapManyWithMappersOnTerminalEvents.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 34 521 346" width="521" height="346" id="svg151">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 34 521 346" width="521" height="346" id="svg151">
  <defs id="defs18">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapSequential.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapSequential.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 10 891 451" width="891" height="451" id="svg277">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 10 891 451" width="891" height="451" id="svg277">
  <defs id="defs30">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapSequentialWithConcurrency.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapSequentialWithConcurrency.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 10 891 451" width="891" height="451" id="svg277">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 10 891 451" width="891" height="451" id="svg277">
  <defs id="defs30">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapSequentialWithConcurrencyAndPrefetch.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapSequentialWithConcurrencyAndPrefetch.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 10 891 451" width="891" height="451" id="svg277">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 10 891 451" width="891" height="451" id="svg277">
  <defs id="defs30">
   <marker markerHeight="12" markerWidth="14" viewBox="-1 -6 14 12" stroke-miterlimit="10" id="FilledArrow_Marker" markerUnits="strokeWidth" overflow="visible" orient="auto" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapWithConcurrency.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapWithConcurrency.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 10 731 451" width="731" height="451" id="svg277">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 10 731 451" width="731" height="451" id="svg277">
  <defs id="defs30">
   <marker markerHeight="12" markerWidth="14" viewBox="-1 -6 14 12" stroke-miterlimit="10" id="FilledArrow_Marker" markerUnits="strokeWidth" overflow="visible" orient="auto" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapWithConcurrencyAndPrefetch.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapWithConcurrencyAndPrefetch.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 10 731 451" width="731" height="451" id="svg277">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 10 731 451" width="731" height="451" id="svg277">
  <defs id="defs30">
   <marker markerHeight="12" markerWidth="14" viewBox="-1 -6 14 12" stroke-miterlimit="10" id="FilledArrow_Marker" markerUnits="strokeWidth" overflow="visible" orient="auto" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapWithMappersOnTerminalEventsForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flatMapWithMappersOnTerminalEventsForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 34 608 365" width="608" height="365" id="svg183">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 34 608 365" width="608" height="365" id="svg183">
  <defs id="defs18">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 79 907 417" width="907" height="417" id="svg151">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 79 907 417" width="907" height="417" id="svg151">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromArray.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromArray.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 79 423 226" width="423" height="226" id="svg151">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 79 423 226" width="423" height="226" id="svg151">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromCallable.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromCallable.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 79 403 233" width="403" height="233" id="svg83">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 79 403 233" width="403" height="233" id="svg83">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 55 585 279" width="585" height="279" id="svg138">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 55 585 279" width="585" height="279" id="svg138">
  <defs id="defs14">
   <marker orient="auto" refY="0" refX="0" id="Arrow1Mend" overflow="visible">
    <path id="path6138" d="M-4 0l-2 2 7-2-7-2 2 2z" fill-rule="evenodd" stroke="#34302c" stroke-width="0" stroke-opacity="1" fill="#34302c" fill-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 55 595 369" width="595" height="369" id="svg103">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 55 595 369" width="595" height="369" id="svg103">
  <defs id="defs14">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromFuture.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromFuture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 81 595 306" width="595" height="306" id="svg95">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 81 595 306" width="595" height="306" id="svg95">
  <defs id="defs18">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromFutureSupplier.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromFutureSupplier.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   xmlns:dc="https://purl.org/dc/elements/1.1/"
+   xmlns:cc="https://creativecommons.org/ns#"
+   xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="https://www.w3.org/2000/svg"
+   xmlns="https://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:inkscape="https://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    viewBox="20 81 595 306"
    width="595"

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromIterable.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromIterable.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 79 423 219" width="423" height="219" id="svg151">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 79 423 219" width="423" height="219" id="svg151">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromRunnable.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromRunnable.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 79 363 234" width="363" height="234" id="svg73">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 79 363 234" width="363" height="234" id="svg73">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromStream.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromStream.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 79 423 221" width="423" height="221" id="svg151">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 79 423 221" width="423" height="221" id="svg151">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromSupplier.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromSupplier.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 79 585 164" width="585" height="164" id="svg83">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 79 585 164" width="585" height="164" id="svg83">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/generate.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/generate.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="svg225" height="272" width="681" viewBox="20 14 681 272" version="1.1">
+<svg xmlns="https://www.w3.org/2000/svg" id="svg225" height="272" width="681" viewBox="20 14 681 272" version="1.1">
  <defs id="defs33">
   <marker orient="auto" refY="0" refX="0" id="Arrow1Send" overflow="visible">
    <path id="path9643" d="M-1 0l-1 1 3-1-3-1z" fill="#3f8de6" fill-opacity="1" fill-rule="evenodd" stroke="#3f8de6" stroke-width="0" stroke-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/generateStateless.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/generateStateless.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 14 666 218" width="666" height="218" id="svg225">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 14 666 218" width="666" height="218" id="svg225">
  <defs id="defs33">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/generateWithCleanup.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/generateWithCleanup.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 14 680.86 312" width="680.86" height="312" id="svg225">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 14 680.86 312" width="680.86" height="312" id="svg225">
  <defs id="defs33">
   <marker orient="auto" refY="0" refX="0" id="Arrow1Send" overflow="visible">
    <path id="path4043" d="M-1 0l-1 1 3-1-3-1z" fill="#34302c" fill-opacity="1" fill-rule="evenodd" stroke="#34302c" stroke-width="0" stroke-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/groupByWithKeyMapper.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/groupByWithKeyMapper.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 596 380" width="596" height="380" id="svg183">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 596 380" width="596" height="380" id="svg183">
  <defs id="defs16">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/groupByWithKeyMapperAndValueMapper.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/groupByWithKeyMapperAndValueMapper.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 596 380" width="596" height="380" id="svg183">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 596 380" width="596" height="380" id="svg183">
  <defs id="defs16">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/groupJoin.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/groupJoin.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="-1 20 659 571" width="659" height="571" id="svg350">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="-1 20 659 571" width="659" height="571" id="svg350">
  <defs id="defs50">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/hasElementForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/hasElementForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 -50 586 289" width="586" height="289" id="svg114">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 -50 586 289" width="586" height="289" id="svg114">
  <defs id="defs21">
   <marker markerHeight="12" markerWidth="14" viewBox="-1 -6 14 12" stroke-miterlimit="10" id="FilledArrow_Marker" markerUnits="strokeWidth" overflow="visible" orient="auto" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/hasElementForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/hasElementForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 -50 586 289" width="586" height="289" id="svg114">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 -50 586 289" width="586" height="289" id="svg114">
  <defs id="defs21">
   <marker markerHeight="12" markerWidth="14" viewBox="-1 -6 14 12" stroke-miterlimit="10" id="FilledArrow_Marker" markerUnits="strokeWidth" overflow="visible" orient="auto" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/hasElements.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/hasElements.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 -50 586 289" width="586" height="289" id="svg114">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 -50 586 289" width="586" height="289" id="svg114">
  <defs id="defs21">
   <marker markerHeight="12" markerWidth="14" viewBox="-1 -6 14 12" stroke-miterlimit="10" id="FilledArrow_Marker" markerUnits="strokeWidth" overflow="visible" orient="auto" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/ignoreElementForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/ignoreElementForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 86 592 274" width="592" height="274" id="svg69">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 86 592 274" width="592" height="274" id="svg69">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/ignoreElementsForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/ignoreElementsForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 86 592 274" width="592" height="274" id="svg69">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 86 592 274" width="592" height="274" id="svg69">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/ignoreElementsForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/ignoreElementsForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 86 404 295" width="404" height="295" id="svg69">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 86 404 295" width="404" height="295" id="svg69">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/index.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/index.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 44 599.86 311.3" width="599.86" height="311.3" id="svg224">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 44 599.86 311.3" width="599.86" height="311.3" id="svg224">
  <defs id="defs34">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/indexWithMapper.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/indexWithMapper.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 44 599.86 312" width="599.86" height="312" id="svg224">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 44 599.86 312" width="599.86" height="312" id="svg224">
  <defs id="defs34">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/interval.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/interval.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="26 74 590 236" width="590" height="236" id="svg224">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="26 74 590 236" width="590" height="236" id="svg224">
  <defs id="defs27">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/intervalWithDelay.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/intervalWithDelay.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="26 74 595 245" width="595" height="245" id="svg245">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="26 74 595 245" width="595" height="245" id="svg245">
  <defs id="defs29">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/join.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/join.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="-1 20 615 572" width="615" height="572" id="svg339">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="-1 20 615 572" width="615" height="572" id="svg339">
  <defs id="defs45">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/just.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/just.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="24 22 585 164" width="585" height="164" id="svg64">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="24 22 585 164" width="585" height="164" id="svg64">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/justMultiple.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/justMultiple.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 79 524 174" width="524" height="174" id="svg151">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 79 524 174" width="524" height="174" id="svg151">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/justOrEmpty.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/justOrEmpty.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 -50 570 384" width="570" height="384" id="svg115">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 -50 570 384" width="570" height="384" id="svg115">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/last.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/last.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 82 491 288" width="491" height="288" id="svg107">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 82 491 288" width="491" height="288" id="svg107">
  <defs id="defs24">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/lastWithDefault.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/lastWithDefault.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 82 581 290" width="581" height="290" id="svg118">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 82 581 290" width="581" height="290" id="svg118">
  <defs id="defs26">
   <marker markerHeight="12" markerWidth="14" viewBox="-1 -6 14 12" stroke-miterlimit="10" id="FilledArrow_Marker" markerUnits="strokeWidth" overflow="visible" orient="auto" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/limitRequest.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/limitRequest.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 44 599.86 343.09" width="599.86" height="343.09" id="svg224">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 44 599.86 343.09" width="599.86" height="343.09" id="svg224">
  <defs id="defs34">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/logForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/logForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 18 914 451" width="914" height="451" id="svg260">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 18 914 451" width="914" height="451" id="svg260">
  <defs id="defs23">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/logForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/logForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 18 914 447" width="914" height="447" id="svg197">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 18 914 447" width="914" height="447" id="svg197">
  <defs id="defs23">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mapForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mapForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 87 589 274" width="589" height="274" id="svg131">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 87 589 274" width="589" height="274" id="svg131">
  <defs id="defs24">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mapForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mapForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 87 316 284" width="316" height="284" id="svg99">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 87 316 284" width="316" height="284" id="svg99">
  <defs id="defs24">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/materializeForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/materializeForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 40 835 384" width="835" height="384" id="svg138">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 40 835 384" width="835" height="384" id="svg138">
  <defs id="defs28">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/materializeForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/materializeForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 40 698 384" width="698" height="384" id="svg78">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 40 698 384" width="698" height="384" id="svg78">
  <defs id="defs16">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeAsyncSources.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeAsyncSources.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 19 636 363" width="636" height="363" id="svg148">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 19 636 363" width="636" height="363" id="svg148">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeFixedSources.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeFixedSources.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 19 629 361" width="629" height="361" id="svg148">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 19 629 361" width="629" height="361" id="svg148">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeOrdered.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeOrdered.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 19 712 366" width="712" height="366" id="svg191">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 19 712 366" width="712" height="366" id="svg191">
  <defs id="defs16">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeOrderedNaturalOrder.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeOrderedNaturalOrder.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 19 712 366" width="712" height="366" id="svg191">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 19 712 366" width="712" height="366" id="svg191">
  <defs id="defs16">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeOrderedWith.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeOrderedWith.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 19 712 350.02" width="712" height="350.02" id="svg191">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 19 712 350.02" width="712" height="350.02" id="svg191">
  <defs id="defs16">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeSequentialAsyncSources.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeSequentialAsyncSources.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 96 736 519" width="736" height="519" id="svg231">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 96 736 519" width="736" height="519" id="svg231">
  <defs id="defs27">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeSequentialVarSources.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeSequentialVarSources.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 96 655 454" width="655" height="454" id="svg231">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 96 655 454" width="655" height="454" id="svg231">
  <defs id="defs27">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeWithForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeWithForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 19 579 390" width="579" height="390" id="svg116">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 19 579 390" width="579" height="390" id="svg116">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeWithForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergeWithForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 19 511 394" width="511" height="394" id="svg116">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 19 511 394" width="511" height="394" id="svg116">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 79 851 445" width="851" height="445" id="svg151">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 79 851 445" width="851" height="445" id="svg151">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/never.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/never.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="24 27 362 162" width="362" height="162" id="svg39">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="24 27 362 162" width="362" height="162" id="svg39">
  <defs id="defs9">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/next.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/next.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 67 278 289" width="278" height="289" id="svg90">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 67 278 289" width="278" height="289" id="svg90">
  <defs id="defs14">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/ofTypeForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/ofTypeForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 87 598.86 283" width="598.86" height="283" id="svg123">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 87 598.86 283" width="598.86" height="283" id="svg123">
  <defs id="defs24">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/ofTypeForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/ofTypeForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 87 468 283" width="468" height="283" id="svg123">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 87 468 283" width="468" height="283" id="svg123">
  <defs id="defs24">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBuffer.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBuffer.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 65 595 435" width="595" height="435" id="svg190">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 65 595 435" width="595" height="435" id="svg190">
  <defs id="defs23">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBufferWithDurationAndMaxSize.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBufferWithDurationAndMaxSize.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 65 681.08 456.51" width="681.08" height="456.51" id="svg190">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 65 681.08 456.51" width="681.08" height="456.51" id="svg190">
  <defs id="defs23">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBufferWithMaxSize.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBufferWithMaxSize.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 65 595 435" width="595" height="435" id="svg190">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 65 595 435" width="595" height="435" id="svg190">
  <defs id="defs23">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureDrop.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureDrop.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 65 509 411" width="509" height="411" id="svg160">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 65 509 411" width="509" height="411" id="svg160">
  <defs id="defs23">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureDropWithConsumer.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureDropWithConsumer.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 65 539 477" width="539" height="477" id="svg160">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 65 539 477" width="539" height="477" id="svg160">
  <defs id="defs23">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureError.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureError.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 65 383 409" width="383" height="409" id="svg148">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 65 383 409" width="383" height="409" id="svg148">
  <defs id="defs23">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureLatest.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureLatest.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 65 517 435" width="517" height="435" id="svg180">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 65 517 435" width="517" height="435" id="svg180">
  <defs id="defs23">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorContinue.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorContinue.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 86 667 593" width="667" height="593" id="svg145">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 86 667 593" width="667" height="593" id="svg145">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorContinueWithClassPredicate.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorContinueWithClassPredicate.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 86 667 593" width="667" height="593" id="svg145">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 86 667 593" width="667" height="593" id="svg145">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorContinueWithPredicate.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorContinueWithPredicate.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 86 726 593" width="726" height="593" id="svg145">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 86 726 593" width="726" height="593" id="svg145">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorMapForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorMapForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 86 431 348" width="431" height="348" id="svg145">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 86 431 348" width="431" height="348" id="svg145">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorMapForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorMapForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 86 431 348" width="431" height="348" id="svg145">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 86 431 348" width="431" height="348" id="svg145">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorMapWithClassPredicateForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorMapWithClassPredicateForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 86 635 348" width="635" height="348" id="svg145">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 86 635 348" width="635" height="348" id="svg145">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorMapWithClassPredicateForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorMapWithClassPredicateForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 86 384 338" width="384" height="338" id="svg145">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 86 384 338" width="384" height="338" id="svg145">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorMapWithPredicateForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorMapWithPredicateForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 86 607 328" width="607" height="328" id="svg145">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 86 607 328" width="607" height="328" id="svg145">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorMapWithPredicateForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorMapWithPredicateForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 86 452 330" width="452" height="330" id="svg145">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 86 452 330" width="452" height="330" id="svg145">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorResumeForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorResumeForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 86 597 388" width="597" height="388" id="svg145">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 86 597 388" width="597" height="388" id="svg145">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorResumeForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorResumeForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 86 516 384" width="516" height="384" id="svg145">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 86 516 384" width="516" height="384" id="svg145">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorReturnForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorReturnForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 86 368 288" width="368" height="288" id="svg126">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 86 368 288" width="368" height="288" id="svg126">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorReturnForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onErrorReturnForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 86 368 288" width="368" height="288" id="svg126">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 86 368 288" width="368" height="288" id="svg126">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/orForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/orForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 19 456 370" width="456" height="370" id="svg89">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 19 456 370" width="456" height="370" id="svg89">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/orForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/orForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 19 324 369" width="324" height="369" id="svg89">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 19 324 369" width="324" height="369" id="svg89">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/parallel.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/parallel.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 595 366" width="595" height="366" id="svg184">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 595 366" width="595" height="366" id="svg184">
  <defs id="defs20">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/publish.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/publish.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 60 596.86 762.01" width="596.86" height="762.01" id="svg264">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="23 60 596.86 762.01" width="596.86" height="762.01" id="svg264">
  <defs id="defs55">
   <marker orient="auto" refY="0" refX="0" id="DotM" overflow="visible">
    <path id="path32183" d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".4pt" stroke-opacity="1" fill="#5b1d88" fill-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/publishNext.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/publishNext.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 60 518 499" width="518" height="499" id="svg166">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="23 60 518 499" width="518" height="499" id="svg166">
  <defs id="defs31">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/publishOnForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/publishOnForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 43 404 318" width="404" height="318" id="svg182">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 43 404 318" width="404" height="318" id="svg182">
  <defs id="defs31">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/publishOnForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/publishOnForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 43 593 317" width="593" height="317" id="svg118">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 43 593 317" width="593" height="317" id="svg118">
  <defs id="defs31">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/push.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/push.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 14 533 415" width="533" height="415" id="svg225">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 14 533 415" width="533" height="415" id="svg225">
  <defs id="defs33">
   <marker id="marker39651" refX="0" refY="0" orient="auto" overflow="visible">
    <path d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" id="path39649" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".4pt" stroke-opacity="1" fill="#5b1d88" fill-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/pushWithOverflowStrategy.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/pushWithOverflowStrategy.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 14 532.86 414" width="532.86" height="414" id="svg225">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 14 532.86 414" width="532.86" height="414" id="svg225">
  <defs id="defs33">
   <marker id="marker38781" refX="0" refY="0" orient="auto" overflow="visible">
    <path d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" id="path38779" fill="#5b1d88" fill-opacity="1" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".53" stroke-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/range.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/range.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="24 27 594.86 192.96" width="594.86" height="192.96" id="svg105">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="24 27 594.86 192.96" width="594.86" height="192.96" id="svg105">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/reduce.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/reduce.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 15 569 381" width="569" height="381" id="svg181">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 15 569 381" width="569" height="381" id="svg181">
  <defs id="defs33">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/reduceWith.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/reduceWith.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 15 571 371" width="571" height="371" id="svg181">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 15 571 371" width="571" height="371" id="svg181">
  <defs id="defs33">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/reduceWithSameReturnType.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/reduceWithSameReturnType.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 15 559 371" width="559" height="371" id="svg181">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 15 559 371" width="559" height="371" id="svg181">
  <defs id="defs33">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/refCount.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/refCount.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 60 699 718" width="699" height="718" id="svg264">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="23 60 699 718" width="699" height="718" id="svg264">
  <defs id="defs55">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/refCountWithMinSubscribers.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/refCountWithMinSubscribers.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 60 757 718" width="757" height="718" id="svg264">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="23 60 757 718" width="757" height="718" id="svg264">
  <defs id="defs55">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/refCountWithMinSubscribersAndGracePeriod.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/refCountWithMinSubscribersAndGracePeriod.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 60 933 548" width="933" height="548" id="svg264">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="23 60 933 548" width="933" height="548" id="svg264">
  <defs id="defs55">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 793 354" width="793" height="354" id="svg233">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 793 354" width="793" height="354" id="svg233">
  <defs id="defs28">
   <marker stroke-linejoin="miter" color="#45b8de" orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker128489" stroke-miterlimit="10" viewBox="-6 -3 7 6" markerWidth="7" markerHeight="6">
    <g id="g128487" stroke="#45b8de" stroke-opacity="1" fill="#45b8de" fill-opacity="1">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 507 354" width="507" height="354" id="svg233">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 507 354" width="507" height="354" id="svg233">
  <defs id="defs28">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker130663" stroke-miterlimit="10" viewBox="-6 -3 7 6" markerWidth="7" markerHeight="6" color="#45b8de" stroke-linejoin="miter">
    <g id="g130661" fill="#45b8de" fill-opacity="1" stroke="#45b8de" stroke-opacity="1">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWhenEmpty.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWhenEmpty.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 36 733 535" width="733" height="535" id="svg237">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 36 733 535" width="733" height="535" id="svg237">
  <defs id="defs36">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWhenForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWhenForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 36 818 536" width="818" height="536" id="svg281">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 36 818 536" width="818" height="536" id="svg281">
  <defs id="defs34">
   <marker stroke-linejoin="miter" color="#34302c" markerHeight="10" markerWidth="11" viewBox="-1 -5 11 10" stroke-miterlimit="10" id="marker146648" markerUnits="strokeWidth" overflow="visible" orient="auto">
    <g id="g146646" stroke="#34302c" stroke-opacity="1" fill="#34302c" fill-opacity="1">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWhenForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWhenForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 36 660 536" width="660" height="536" id="svg281">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 36 660 536" width="660" height="536" id="svg281">
  <defs id="defs34">
   <marker stroke-linejoin="miter" color="#34302c" markerHeight="10" markerWidth="11" viewBox="-1 -5 11 10" stroke-miterlimit="10" id="marker148967" markerUnits="strokeWidth" overflow="visible" orient="auto">
    <g id="g148965" stroke="#34302c" stroke-opacity="1" fill="#34302c" fill-opacity="1">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWithAttemptsAndPredicateForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWithAttemptsAndPredicateForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 710 850" width="710" height="850" id="svg268">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 710 850" width="710" height="850" id="svg268">
  <defs id="defs30">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWithAttemptsAndPredicateForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWithAttemptsAndPredicateForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 527 850" width="527" height="850" id="svg268">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 527 850" width="527" height="850" id="svg268">
  <defs id="defs30">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWithAttemptsForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWithAttemptsForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 603 355" width="603" height="355" id="svg268">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 603 355" width="603" height="355" id="svg268">
  <defs id="defs32">
   <marker stroke-linejoin="miter" color="#45b8de" orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker132360" stroke-miterlimit="10" viewBox="-6 -3 7 6" markerWidth="7" markerHeight="6">
    <g id="g132358" stroke="#45b8de" stroke-opacity="1" fill="#45b8de" fill-opacity="1">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWithAttemptsForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWithAttemptsForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 528 357" width="528" height="357" id="svg268">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 528 357" width="528" height="357" id="svg268">
  <defs id="defs32">
   <marker markerHeight="6" markerWidth="7" viewBox="-6 -3 7 6" stroke-miterlimit="10" id="marker137735" markerUnits="strokeWidth" overflow="visible" orient="auto" color="#45b8de" stroke-linejoin="miter">
    <g id="g137733" fill="#45b8de" fill-opacity="1" stroke="#45b8de" stroke-opacity="1">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWithPredicateForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWithPredicateForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 485 414" width="485" height="414" id="svg268">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 485 414" width="485" height="414" id="svg268">
  <defs id="defs30">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWithPredicateForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/repeatWithPredicateForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 485 414" width="485" height="414" id="svg268">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 485 414" width="485" height="414" id="svg268">
  <defs id="defs30">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/replay.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/replay.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 60 613 669" width="613" height="669" id="svg251">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="23 60 613 669" width="613" height="669" id="svg251">
  <defs id="defs35">
   <marker orient="auto" refY="0" refX="0" id="DotM" overflow="visible">
    <path id="path32183" d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".4pt" stroke-opacity="1" fill="#5b1d88" fill-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/replayWithHistory.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/replayWithHistory.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 60 899.86 667" width="899.86" height="667" id="svg251">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="23 60 899.86 667" width="899.86" height="667" id="svg251">
  <defs id="defs35">
   <marker orient="auto" refY="0" refX="0" id="DotM" overflow="visible">
    <path id="path32183" d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".4pt" stroke-opacity="1" fill="#5b1d88" fill-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/replayWithHistoryAndTtl.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/replayWithHistoryAndTtl.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 60 903 759" width="903" height="759" id="svg251">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="23 60 903 759" width="903" height="759" id="svg251">
  <defs id="defs35">
   <marker orient="auto" refY="0" refX="0" id="DotM" overflow="visible">
    <path id="path32183" d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".4pt" stroke-opacity="1" fill="#5b1d88" fill-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/replayWithTtl.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/replayWithTtl.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 60 665.01 598.23" width="665.01" height="598.23" id="svg251">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="23 60 665.01 598.23" width="665.01" height="598.23" id="svg251">
  <defs id="defs35">
   <marker orient="auto" refY="0" refX="0" id="DotM" overflow="visible">
    <path id="path32183" d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".4pt" stroke-opacity="1" fill="#5b1d88" fill-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryBackoffForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryBackoffForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 1144 383" width="1144" height="383" id="svg233">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 1144 383" width="1144" height="383" id="svg233">
  <defs id="defs28">
   <marker orient="auto" refY="0" refX="0" id="marker6339" overflow="visible">
    <path id="path6337" d="M11 4L-1 0l12-4c-2 2-2 6 0 8z" fill="#34302c" fill-opacity="1" fill-rule="evenodd" stroke="#34302c" stroke-width="1" stroke-linejoin="round" stroke-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryBackoffForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryBackoffForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 1123 381" width="1123" height="381" id="svg233">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 1123 381" width="1123" height="381" id="svg233">
  <defs id="defs28">
   <marker orient="auto" refY="0" refX="0" id="marker6339" overflow="visible">
    <path id="path6337" d="M11 4L-1 0l12-4c-2 2-2 6 0 8z" fill="#34302c" fill-opacity="1" fill-rule="evenodd" stroke="#34302c" stroke-width="1" stroke-linejoin="round" stroke-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 793 356" width="793" height="356" id="svg233">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 793 356" width="793" height="356" id="svg233">
  <defs id="defs28">
   <marker stroke-linejoin="miter" color="#45b8de" orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker173089" stroke-miterlimit="10" viewBox="-6 -3 7 6" markerWidth="7" markerHeight="6">
    <g id="g173087" stroke="#45b8de" stroke-opacity="1" fill="#45b8de" fill-opacity="1">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 507 355" width="507" height="355" id="svg233">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 507 355" width="507" height="355" id="svg233">
  <defs id="defs28">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker177144" stroke-miterlimit="10" viewBox="-6 -3 7 6" markerWidth="7" markerHeight="6" color="#45b8de" stroke-linejoin="miter">
    <g id="g177142" fill="#45b8de" fill-opacity="1" stroke="#45b8de" stroke-opacity="1">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryWhenForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryWhenForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 36 818 536" width="818" height="536" id="svg281">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 36 818 536" width="818" height="536" id="svg281">
  <defs id="defs34">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryWhenForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryWhenForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 36 694 523" width="694" height="523" id="svg281">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 36 694 523" width="694" height="523" id="svg281">
  <defs id="defs34">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryWithAttemptsAndPredicateForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryWithAttemptsAndPredicateForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 710 850" width="710" height="850" id="svg268">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 710 850" width="710" height="850" id="svg268">
  <defs id="defs30">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryWithAttemptsAndPredicateForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryWithAttemptsAndPredicateForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 527 837" width="527" height="837" id="svg268">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 527 837" width="527" height="837" id="svg268">
  <defs id="defs30">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryWithAttemptsForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryWithAttemptsForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 603 355" width="603" height="355" id="svg268">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 603 355" width="603" height="355" id="svg268">
  <defs id="defs32">
   <marker stroke-linejoin="miter" color="#34302c" orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker196206" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10">
    <g id="g196204" stroke="#34302c" stroke-opacity="1" fill="#34302c" fill-opacity="1">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryWithAttemptsForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryWithAttemptsForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 528 357" width="528" height="357" id="svg268">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 528 357" width="528" height="357" id="svg268">
  <defs id="defs32">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker201029" stroke-miterlimit="10" viewBox="-6 -3 7 6" markerWidth="7" markerHeight="6" color="#45b8de" stroke-linejoin="miter">
    <g id="g201027" fill="#45b8de" fill-opacity="1" stroke="#45b8de" stroke-opacity="1">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryWithPredicateForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryWithPredicateForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 485 414" width="485" height="414" id="svg268">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 485 414" width="485" height="414" id="svg268">
  <defs id="defs30">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryWithPredicateForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/retryWithPredicateForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="15 81 485 401" width="485" height="401" id="svg268">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="15 81 485 401" width="485" height="401" id="svg268">
  <defs id="defs30">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sampleAtRegularInterval.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sampleAtRegularInterval.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 -1 673 409" width="673" height="409" id="svg192">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="21 -1 673 409" width="673" height="409" id="svg192">
  <defs id="defs25">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sampleFirstAtRegularInterval.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sampleFirstAtRegularInterval.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 105 658 408" width="658" height="408" id="svg171">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="21 105 658 408" width="658" height="408" id="svg171">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sampleFirstWithSamplerFactory.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sampleFirstWithSamplerFactory.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 95 844 368" width="844" height="368" id="svg224">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="21 95 844 368" width="844" height="368" id="svg224">
  <defs id="defs25">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sampleTimeoutWithThrottlerFactory.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sampleTimeoutWithThrottlerFactory.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="46 197 641 394" width="641" height="394" id="svg191">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="46 197 641 394" width="641" height="394" id="svg191">
  <defs id="defs29">
   <marker markerHeight="12" markerWidth="14" viewBox="-1 -6 14 12" stroke-miterlimit="10" id="FilledArrow_Marker" markerUnits="strokeWidth" overflow="visible" orient="auto" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sampleTimeoutWithThrottlerFactoryAndMaxConcurrency.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sampleTimeoutWithThrottlerFactoryAndMaxConcurrency.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="svg199" height="394" width="641" viewBox="2 -1 641 394" version="1.1">
+<svg xmlns="https://www.w3.org/2000/svg" id="svg199" height="394" width="641" viewBox="2 -1 641 394" version="1.1">
  <defs id="defs34">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sampleWithSampler.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sampleWithSampler.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 -1 624 502" width="624" height="502" id="svg167">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="21 -1 624 502" width="624" height="502" id="svg167">
  <defs id="defs23">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/scan.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/scan.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 15 503 401" width="503" height="401" id="svg203">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 15 503 401" width="503" height="401" id="svg203">
  <defs id="defs29">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/scanWith.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/scanWith.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 14 520 391" width="520" height="391" id="svg225">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 14 520 391" width="520" height="391" id="svg225">
  <defs id="defs33">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/scanWithSameReturnType.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/scanWithSameReturnType.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 15 503 401" width="503" height="401" id="svg203">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 15 503 401" width="503" height="401" id="svg203">
  <defs id="defs29">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sequenceEqual.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sequenceEqual.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="829.01" height="376.33" viewBox="0 0 219.34 99.57" version="1.1" id="svg14018">
+<svg xmlns="https://www.w3.org/2000/svg" width="829.01" height="376.33" viewBox="0 0 219.34 99.57" version="1.1" id="svg14018">
  <defs id="defs14012">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-0-2" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#000" stroke-linejoin="miter">
    <g id="g9-3-5">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/singleForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/singleForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="2 -50 779 384" width="779" height="384" id="svg164">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="2 -50 779 384" width="779" height="384" id="svg164">
  <defs id="defs33">
   <marker markerHeight="12" markerWidth="14" viewBox="-1 -6 14 12" stroke-miterlimit="10" id="FilledArrow_Marker" markerUnits="strokeWidth" overflow="visible" orient="auto" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/singleForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/singleForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="2 -50 430 323" width="430" height="323" id="svg164">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="2 -50 430 323" width="430" height="323" id="svg164">
  <defs id="defs33">
   <marker markerHeight="12" markerWidth="14" viewBox="-1 -6 14 12" stroke-miterlimit="10" id="FilledArrow_Marker" markerUnits="strokeWidth" overflow="visible" orient="auto" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/singleOrEmpty.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/singleOrEmpty.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="-1 -49 782 384" width="782" height="384" id="svg151">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="-1 -49 782 384" width="782" height="384" id="svg151">
  <defs id="defs33">
   <marker markerHeight="12" markerWidth="14" viewBox="-1 -6 14 12" stroke-miterlimit="10" id="FilledArrow_Marker" markerUnits="strokeWidth" overflow="visible" orient="auto" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/singleWithDefault.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/singleWithDefault.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="-1 -50 781 384" width="781" height="384" id="svg161">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="-1 -50 781 384" width="781" height="384" id="svg161">
  <defs id="defs33">
   <marker markerHeight="12" markerWidth="14" viewBox="-1 -6 14 12" stroke-miterlimit="10" id="FilledArrow_Marker" markerUnits="strokeWidth" overflow="visible" orient="auto" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/skip.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/skip.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="9 6 542 342" width="542" height="342" id="svg200">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="9 6 542 342" width="542" height="342" id="svg200">
  <defs id="defs25">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/skipLast.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/skipLast.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="9 6 551 353" width="551" height="353" id="svg200">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="9 6 551 353" width="551" height="353" id="svg200">
  <defs id="defs25">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/skipUntil.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/skipUntil.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="12 6 596 432" width="596" height="432" id="svg183">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="12 6 596 432" width="596" height="432" id="svg183">
  <defs id="defs23">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/skipUntilOther.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/skipUntilOther.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="12 6 690 387" width="690" height="387" id="svg183">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="12 6 690 387" width="690" height="387" id="svg183">
  <defs id="defs23">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/skipWhile.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/skipWhile.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 6 596 367" width="596" height="367" id="svg199">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="21 6 596 367" width="596" height="367" id="svg199">
  <defs id="defs23">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/skipWithTimespan.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/skipWithTimespan.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="12 6 525 366" width="525" height="366" id="svg198">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="12 6 525 366" width="525" height="366" id="svg198">
  <defs id="defs27">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sort.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sort.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="641.16" height="311.54" viewBox="0 0 169.64 82.43" version="1.1" id="svg10343">
+<svg xmlns="https://www.w3.org/2000/svg" width="641.16" height="311.54" viewBox="0 0 169.64 82.43" version="1.1" id="svg10343">
  <defs id="defs10337">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-8-2-9" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#000" stroke-linejoin="miter">
    <g id="g9-0-1-5">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/startWithIterable.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/startWithIterable.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 6 430 365" width="430" height="365" id="svg168">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="21 6 430 365" width="430" height="365" id="svg168">
  <defs id="defs19">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/startWithPublisher.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/startWithPublisher.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 6 541 390" width="541" height="390" id="svg174">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="21 6 541 390" width="541" height="390" id="svg174">
  <defs id="defs19">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/startWithValues.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/startWithValues.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 6 430 365" width="430" height="365" id="svg168">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="21 6 430 365" width="430" height="365" id="svg168">
  <defs id="defs19">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 123 840 417" width="840" height="417" id="svg165">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 123 840 417" width="840" height="417" id="svg165">
  <defs id="defs21">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 123 669 417" width="669" height="417" id="svg165">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 123 669 417" width="669" height="417" id="svg165">
  <defs id="defs21">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeIgoringAllSignalsForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeIgoringAllSignalsForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 123 655 301" width="655" height="301" id="svg165">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 123 655 301" width="655" height="301" id="svg165">
  <defs id="defs21">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeIgoringAllSignalsForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeIgoringAllSignalsForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 123 399 301" width="399" height="301" id="svg165">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 123 399 301" width="399" height="301" id="svg165">
  <defs id="defs21">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeOnForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeOnForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 20 374 381" width="374" height="381" id="svg174">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 20 374 381" width="374" height="381" id="svg174">
  <defs id="defs31">
   <marker markerHeight="12" markerWidth="14" viewBox="-1 -6 14 12" stroke-miterlimit="10" id="FilledArrow_Marker" markerUnits="strokeWidth" overflow="visible" orient="auto" color="#ff5a01" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeOnForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeOnForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 20 374 381" width="374" height="381" id="svg174">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 20 374 381" width="374" height="381" id="svg174">
  <defs id="defs31">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#ff5a01" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeWithOnNextAndOnErrorAndOnCompleteForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeWithOnNextAndOnErrorAndOnCompleteForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 123 654 359" width="654" height="359" id="svg165">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 123 654 359" width="654" height="359" id="svg165">
  <defs id="defs21">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeWithOnNextAndOnErrorAndOnCompleteForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeWithOnNextAndOnErrorAndOnCompleteForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 123 669 358" width="669" height="358" id="svg165">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 123 669 358" width="669" height="358" id="svg165">
  <defs id="defs21">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeWithOnNextAndOnErrorForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeWithOnNextAndOnErrorForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 123 654 359" width="654" height="359" id="svg165">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 123 654 359" width="654" height="359" id="svg165">
  <defs id="defs21">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeWithOnNextAndOnErrorForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeWithOnNextAndOnErrorForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 123 498 358" width="498" height="358" id="svg165">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 123 498 358" width="498" height="358" id="svg165">
  <defs id="defs21">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeWithOnNextForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeWithOnNextForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 123 654 359" width="654" height="359" id="svg165">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 123 654 359" width="654" height="359" id="svg165">
  <defs id="defs21">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeWithOnNextForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/subscribeWithOnNextForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 123 498 358" width="498" height="358" id="svg165">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="18 123 498 358" width="498" height="358" id="svg165">
  <defs id="defs21">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/switchIfEmptyForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/switchIfEmptyForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 99 701 371" width="701" height="371" id="svg92">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 99 701 371" width="701" height="371" id="svg92">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/switchIfEmptyForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/switchIfEmptyForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 99 558 371" width="558" height="371" id="svg92">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 99 558 371" width="558" height="371" id="svg92">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/switchMap.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/switchMap.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="69 51 497 400" width="497" height="400" id="svg262">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="69 51 497 400" width="497" height="400" id="svg262">
  <defs id="defs30">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/switchOnFirst.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/switchOnFirst.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="671.66" height="495.49" viewBox="0 0 177.71 131.1" version="1.1" id="svg11396">
+<svg xmlns="https://www.w3.org/2000/svg" width="671.66" height="495.49" viewBox="0 0 177.71 131.1" version="1.1" id="svg11396">
  <defs id="defs11390">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-8-2-9" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#000" stroke-linejoin="miter">
    <g id="g9-0-1-5">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/switchOnNext.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/switchOnNext.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 20 591 392" width="591" height="392" id="svg143">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 20 591 392" width="591" height="392" id="svg143">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/take.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/take.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 -5 685 315" width="685" height="315" id="svg127">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="21 -5 685 315" width="685" height="315" id="svg127">
  <defs id="defs23">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeLast.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeLast.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="12 6 608 384" width="608" height="384" id="svg195">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="12 6 608 384" width="608" height="384" id="svg195">
  <defs id="defs25">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeUntil.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeUntil.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 87 425 318" width="425" height="318" id="svg149">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 87 425 318" width="425" height="318" id="svg149">
  <defs id="defs26">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeUntilOtherForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeUntilOtherForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 64 662 380" width="662" height="380" id="svg165">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 64 662 380" width="662" height="380" id="svg165">
  <defs id="defs26">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeUntilOtherForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeUntilOtherForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 64 518 392" width="518" height="392" id="svg165">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 64 518 392" width="518" height="392" id="svg165">
  <defs id="defs26">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeWhile.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeWhile.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 3 400 303" width="400" height="303" id="svg136">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="21 3 400 303" width="400" height="303" id="svg136">
  <defs id="defs21">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeWithTimespanForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeWithTimespanForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 63 432 352" width="432" height="352" id="svg163">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 63 432 352" width="432" height="352" id="svg163">
  <defs id="defs30">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeWithTimespanForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeWithTimespanForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 63 446 351" width="446" height="351" id="svg163">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 63 446 351" width="446" height="351" id="svg163">
  <defs id="defs30">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenEmptyForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenEmptyForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 21 383 404" width="383" height="404" id="svg85">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 21 383 404" width="383" height="404" id="svg85">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenEmptyForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenEmptyForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 21 383 404" width="383" height="404" id="svg85">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 21 383 404" width="383" height="404" id="svg85">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 34 425 314" width="425" height="314" id="svg137">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 34 425 314" width="425" height="314" id="svg137">
  <defs id="defs20">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 34 349 304" width="349" height="304" id="svg137">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 34 349 304" width="349" height="304" id="svg137">
  <defs id="defs20">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenManyForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenManyForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 34 496 404" width="496" height="404" id="svg117">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 34 496 404" width="496" height="404" id="svg117">
  <defs id="defs18">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenManyForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenManyForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 34 421 404" width="421" height="404" id="svg117">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 34 421 404" width="421" height="404" id="svg117">
  <defs id="defs18">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenReturn.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenReturn.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 34 331 354" width="331" height="354" id="svg84">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 34 331 354" width="331" height="354" id="svg84">
  <defs id="defs16">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenWithMonoForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenWithMonoForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 34 466 404" width="466" height="404" id="svg137">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 34 466 404" width="466" height="404" id="svg137">
  <defs id="defs20">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenWithMonoForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/thenWithMonoForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 34 370 404" width="370" height="404" id="svg137">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 34 370 404" width="370" height="404" id="svg137">
  <defs id="defs20">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timeoutFallbackForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timeoutFallbackForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="26 116 537 436" width="537" height="436" id="svg284">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="26 116 537 436" width="537" height="436" id="svg284">
  <defs id="defs44">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#000" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timeoutFallbackForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timeoutFallbackForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="26 116 479 421" width="479" height="421" id="svg284">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="26 116 479 421" width="479" height="421" id="svg284">
  <defs id="defs44">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#000" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timeoutForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timeoutForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="26 116 371 402" width="371" height="402" id="svg284">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="26 116 371 402" width="371" height="402" id="svg284">
  <defs id="defs44">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#000" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timeoutForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timeoutForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="26 116 317 381" width="317" height="381" id="svg284">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="26 116 317 381" width="317" height="381" id="svg284">
  <defs id="defs44">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#000" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timeoutPublisher.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timeoutPublisher.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="26 116 311 416" width="311" height="416" id="svg284">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="26 116 311 416" width="311" height="416" id="svg284">
  <defs id="defs44">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#000" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timeoutPublisherAndFallbackForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timeoutPublisherAndFallbackForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="26 116 368 431" width="368" height="431" id="svg284">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="26 116 368 431" width="368" height="431" id="svg284">
  <defs id="defs44">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#000" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timeoutPublisherFunctionAndFallbackForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timeoutPublisherFunctionAndFallbackForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="26 116 577 479" width="577" height="479" id="svg284">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="26 116 577 479" width="577" height="479" id="svg284">
  <defs id="defs44">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#000" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timeoutPublisherFunctionForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timeoutPublisherFunctionForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="26 116 577 435" width="577" height="435" id="svg284">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="26 116 577 435" width="577" height="435" id="svg284">
  <defs id="defs44">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#000" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timestampForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timestampForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 44 526 353" width="526" height="353" id="svg155">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 44 526 353" width="526" height="353" id="svg155">
  <defs id="defs28">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timestampForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/timestampForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 44 223 353" width="223" height="353" id="svg91">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 44 223 353" width="223" height="353" id="svg91">
  <defs id="defs18">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/toFuture.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/toFuture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 -12 618 355" width="618" height="355" id="svg119">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 -12 618 355" width="618" height="355" id="svg119">
  <defs id="defs30">
   <marker id="marker36792" refX="0" refY="0" orient="auto" overflow="visible">
    <path d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" id="path36790" fill="#5b1d88" fill-opacity="1" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".53" stroke-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/toIterable.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/toIterable.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 25 585 417.7" width="585" height="417.7" id="svg159">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 25 585 417.7" width="585" height="417.7" id="svg159">
  <defs id="defs23">
   <marker id="marker36095" refX="0" refY="0" orient="auto" overflow="visible">
    <path d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" id="path36093" fill="#5b1d88" fill-opacity="1" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".53" stroke-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/toIterableWithBatchSize.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/toIterableWithBatchSize.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 25 585 415" width="585" height="415" id="svg159">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 25 585 415" width="585" height="415" id="svg159">
  <defs id="defs23">
   <marker id="marker16643" refX="0" refY="0" orient="auto" overflow="visible">
    <path d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" id="path16641" fill="#5b1d88" fill-opacity="1" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".53" stroke-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/toStream.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/toStream.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 25 585 455.09" width="585" height="455.09" id="svg173">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 25 585 455.09" width="585" height="455.09" id="svg173">
  <defs id="defs23">
   <marker id="marker14547" refX="0" refY="0" orient="auto" overflow="visible">
    <path d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" id="path14545" fill="#5b1d88" fill-opacity="1" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".53" stroke-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/toStreamWithBatchSize.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/toStreamWithBatchSize.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="19 25 585 455.8" width="585" height="455.8" id="svg173">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="19 25 585 455.8" width="585" height="455.8" id="svg173">
  <defs id="defs23">
   <marker orient="auto" refY="0" refX="0" id="marker17536" overflow="visible">
    <path id="path17534" d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#5b1d88" fill-opacity="1" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".53" stroke-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/transformForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/transformForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 11 536.68 424.76" width="536.68" height="424.76" id="svg138">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 11 536.68 424.76" width="536.68" height="424.76" id="svg138">
  <defs id="defs25">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/transformForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/transformForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 11 593.65 422.7" width="593.65" height="422.7" id="svg138">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 11 593.65 422.7" width="593.65" height="422.7" id="svg138">
  <defs id="defs25">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/usingForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/usingForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 34 665 407" width="665" height="407" id="svg150">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 34 665 407" width="665" height="407" id="svg150">
  <defs id="defs42">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g22">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/usingForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/usingForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 34 573 407" width="573" height="407" id="svg150">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 34 573 407" width="573" height="407" id="svg150">
  <defs id="defs42">
   <marker id="marker4893" refX="0" refY="0" orient="auto" overflow="visible">
    <path d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" id="path4891" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".4pt" stroke-opacity="1" fill="#5b1d88" fill-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/usingWhenCleanupErrorForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/usingWhenCleanupErrorForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="20 34 525 406" width="525" height="406" id="svg150">
+<svg xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" version="1.1" viewBox="20 34 525 406" width="525" height="406" id="svg150">
  <defs id="defs42">
   <marker orient="auto" refY="0" refX="0" id="DotM" overflow="visible">
    <path id="path1761" d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".4pt" stroke-opacity="1" fill="#5b1d88" fill-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/usingWhenEarlyCancelForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/usingWhenEarlyCancelForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="20 34 526 372" width="526" height="372" id="svg150">
+<svg xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" version="1.1" viewBox="20 34 526 372" width="526" height="372" id="svg150">
  <defs id="defs42">
   <marker orient="auto" refY="0" refX="0" id="DiamondSstart" overflow="visible">
    <path id="path40747" d="M1-1L0 0l1 1 2-1z" fill-rule="evenodd" stroke="#000" stroke-width="0"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/usingWhenFailureForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/usingWhenFailureForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="20 34 525 399" width="525" height="399" id="svg150">
+<svg xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" version="1.1" viewBox="20 34 525 399" width="525" height="399" id="svg150">
  <defs id="defs42">
   <marker orient="auto" refY="0" refX="0" id="DotM" overflow="visible">
    <path id="path1761" d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".4pt" stroke-opacity="1" fill="#5b1d88" fill-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/usingWhenFailureForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/usingWhenFailureForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="20 34 525 399" width="525" height="399" id="svg150">
+<svg xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" version="1.1" viewBox="20 34 525 399" width="525" height="399" id="svg150">
  <defs id="defs42">
   <marker orient="auto" refY="0" refX="0" id="DotM" overflow="visible">
    <path id="path1761" d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".4pt" stroke-opacity="1" fill="#5b1d88" fill-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/usingWhenSuccessForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/usingWhenSuccessForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="svg150" height="406" width="525" viewBox="20 34 525 406" version="1.1">
+<svg xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" id="svg150" height="406" width="525" viewBox="20 34 525 406" version="1.1">
  <defs id="defs42">
   <marker id="marker21401" refX="0" refY="0" orient="auto" overflow="visible">
    <path d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" id="path21399" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".4pt" stroke-opacity="1" fill="#5b1d88" fill-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/usingWhenSuccessForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/usingWhenSuccessForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="20 34 525 406" width="525" height="406" id="svg150">
+<svg xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" version="1.1" viewBox="20 34 525 406" width="525" height="406" id="svg150">
  <defs id="defs42">
   <marker orient="auto" refY="0" refX="0" id="DotM" overflow="visible">
    <path id="path1761" d="M1.96 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill-rule="evenodd" stroke="#5b1d88" stroke-width=".4pt" stroke-opacity="1" fill="#5b1d88" fill-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/when.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/when.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 34 748 417" width="748" height="417" id="svg137">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 34 748 417" width="748" height="417" id="svg137">
  <defs id="defs20">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/whenDelayError.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/whenDelayError.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 34 748 417" width="748" height="417" id="svg137">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 34 748 417" width="748" height="417" id="svg137">
  <defs id="defs20">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowTimeout.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowTimeout.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 0 653 417" width="653" height="417" id="svg249">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 0 653 417" width="653" height="417" id="svg249">
  <defs id="defs24">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowUntil.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowUntil.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 628 469" width="628" height="469" id="svg181">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 628 469" width="628" height="469" id="svg181">
  <defs id="defs18">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowUntilWithCutBefore.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowUntilWithCutBefore.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 628 451" width="628" height="451" id="svg181">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 628 451" width="628" height="451" id="svg181">
  <defs id="defs18">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWhen.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWhen.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 846 648" width="846" height="648" id="svg224">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 846 648" width="846" height="648" id="svg224">
  <defs id="defs20">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWhile.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWhile.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 628 450" width="628" height="450" id="svg181">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 628 450" width="628" height="450" id="svg181">
  <defs id="defs18">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithBoundary.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithBoundary.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 701 515" width="701" height="515" id="svg181">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 701 515" width="701" height="515" id="svg181">
  <defs id="defs18">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithMaxSize.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithMaxSize.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 23 607 450" width="607" height="450" id="svg196">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 23 607 450" width="607" height="450" id="svg196">
  <defs id="defs28">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithMaxSizeEqualsSkipSize.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithMaxSizeEqualsSkipSize.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 23 607 451" width="607" height="451" id="svg196">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 23 607 451" width="607" height="451" id="svg196">
  <defs id="defs28">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithMaxSizeGreaterThanSkipSize.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithMaxSizeGreaterThanSkipSize.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 633 472" width="633" height="472" id="svg223">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 633 472" width="633" height="472" id="svg223">
  <defs id="defs28">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithMaxSizeLessThanSkipSize.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithMaxSizeLessThanSkipSize.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 595 410" width="595" height="410" id="svg187">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 595 410" width="595" height="410" id="svg187">
  <defs id="defs24">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithTimespan.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithTimespan.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 0 548 498" width="548" height="498" id="svg215">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 0 548 498" width="548" height="498" id="svg215">
  <defs id="defs24">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithTimespanEqualsOpenWindowEvery.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithTimespanEqualsOpenWindowEvery.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 684 560" width="684" height="560" id="svg254">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 684 560" width="684" height="560" id="svg254">
  <defs id="defs24">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithTimespanGreaterThanOpenWindowEvery.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithTimespanGreaterThanOpenWindowEvery.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 684 585" width="684" height="585" id="svg265">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 684 585" width="684" height="585" id="svg265">
  <defs id="defs29">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithTimespanLessThanOpenWindowEvery.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/windowWithTimespanLessThanOpenWindowEvery.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 6 684 527" width="684" height="527" id="svg254">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 6 684 527" width="684" height="527" id="svg254">
  <defs id="defs24">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/withLatestFrom.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/withLatestFrom.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 19 681 370" width="681" height="370" id="svg186">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 19 681 370" width="681" height="370" id="svg186">
  <defs id="defs16">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipAsyncSourcesForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipAsyncSourcesForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 12 1015 421" width="1015" height="421" id="svg164">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 12 1015 421" width="1015" height="421" id="svg164">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipDelayErrorFixedSources.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipDelayErrorFixedSources.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="20 19 542 362" width="542" height="362" id="svg160">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.2" viewBox="20 19 542 362" width="542" height="362" id="svg160">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipDelayErrorIterableSources.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipDelayErrorIterableSources.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 12 695 360" width="695" height="360" id="svg164">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 12 695 360" width="695" height="360" id="svg164">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipDelayErrorVarSourcesWithZipper.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipDelayErrorVarSourcesWithZipper.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="20 19 732 372" width="732" height="372" id="svg160">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.2" viewBox="20 19 732 372" width="732" height="372" id="svg160">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipFixedSourcesForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipFixedSourcesForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="20 19 854 378" width="854" height="378" id="svg160">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.2" viewBox="20 19 854 378" width="854" height="378" id="svg160">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipFixedSourcesForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipFixedSourcesForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="20 19 437 378" width="437" height="378" id="svg160">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.2" viewBox="20 19 437 378" width="437" height="378" id="svg160">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipIterableSourcesForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipIterableSourcesForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 12 831 366" width="831" height="366" id="svg164">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 12 831 366" width="831" height="366" id="svg164">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipIterableSourcesForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipIterableSourcesForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 12 620 366" width="620" height="366" id="svg164">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 12 620 366" width="620" height="366" id="svg164">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipTwoSourcesWithZipperForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipTwoSourcesWithZipperForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="20 19 854 366" width="854" height="366" id="svg160">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.2" viewBox="20 19 854 366" width="854" height="366" id="svg160">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipTwoSourcesWithZipperForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipTwoSourcesWithZipperForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="20 19 597 366" width="597" height="366" id="svg160">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.2" viewBox="20 19 597 366" width="597" height="366" id="svg160">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipVarSourcesWithZipperForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipVarSourcesWithZipperForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="20 19 626 378" width="626" height="378" id="svg160">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.2" viewBox="20 19 626 378" width="626" height="378" id="svg160">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipWhenForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipWhenForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="20 19 577 384" width="577" height="384" id="svg160">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.2" viewBox="20 19 577 384" width="577" height="384" id="svg160">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipWhenWithZipperForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipWhenWithZipperForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="20 19 577 378" width="577" height="378" id="svg160">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.2" viewBox="20 19 577 378" width="577" height="378" id="svg160">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipWithIterableForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipWithIterableForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 12 574 342" width="574" height="342" id="svg164">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 12 574 342" width="574" height="342" id="svg164">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipWithIterableUsingZipperForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipWithIterableUsingZipperForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 12 599 313" width="599" height="313" id="svg164">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.1" viewBox="20 12 599 313" width="599" height="313" id="svg164">
  <defs id="defs16">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipWithOtherForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipWithOtherForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="20 19 826 376" width="826" height="376" id="svg160">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.2" viewBox="20 19 826 376" width="826" height="376" id="svg160">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipWithOtherForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipWithOtherForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="20 19 494 384" width="494" height="384" id="svg160">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.2" viewBox="20 19 494 384" width="494" height="384" id="svg160">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipWithOtherUsingZipperForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipWithOtherUsingZipperForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="20 19 826 370" width="826" height="370" id="svg160">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.2" viewBox="20 19 826 370" width="826" height="370" id="svg160">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipWithOtherUsingZipperForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/zipWithOtherUsingZipperForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="20 19 484 369" width="484" height="369" id="svg160">
+<svg xmlns="https://www.w3.org/2000/svg" version="1.2" viewBox="20 19 484 369" width="484" height="369" id="svg160">
  <defs id="defs14">
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g4">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd (404) with 2 occurrences could not be migrated:  
   ([https](https://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd) result AnnotatedConnectException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/ns with 2 occurrences migrated to:  
  https://creativecommons.org/ns ([https](https://creativecommons.org/ns) result 200).
* [ ] http://www.w3.org/1999/02/22-rdf-syntax-ns with 2 occurrences migrated to:  
  https://www.w3.org/1999/02/22-rdf-syntax-ns ([https](https://www.w3.org/1999/02/22-rdf-syntax-ns) result 200).
* [ ] http://www.w3.org/1999/xlink with 7 occurrences migrated to:  
  https://www.w3.org/1999/xlink ([https](https://www.w3.org/1999/xlink) result 200).
* [ ] http://www.w3.org/2000/svg with 370 occurrences migrated to:  
  https://www.w3.org/2000/svg ([https](https://www.w3.org/2000/svg) result 200).
* [ ] http://www.inkscape.org/namespaces/inkscape with 2 occurrences migrated to:  
  https://www.inkscape.org/namespaces/inkscape ([https](https://www.inkscape.org/namespaces/inkscape) result 301).
* [ ] http://purl.org/dc/elements/1.1/ with 2 occurrences migrated to:  
  https://purl.org/dc/elements/1.1/ ([https](https://purl.org/dc/elements/1.1/) result 302).