### PR TITLE
URL Cleanup

### DIFF
--- a/docs/svg/conventions.svg
+++ b/docs/svg/conventions.svg
@@ -4,7 +4,7 @@
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromFutureSupplier.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/fromFutureSupplier.svg
@@ -2,7 +2,7 @@
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [x] http://www.w3.org/1999/02/22-rdf-syntax-ns with 2 occurrences migrated to:  
  https://www.w3.org/1999/02/22-rdf-syntax-ns ([https](https://www.w3.org/1999/02/22-rdf-syntax-ns) result 200).
* [x] http://www.inkscape.org/ with 1 occurrences migrated to:  
  https://www.inkscape.org/ ([https](https://www.inkscape.org/) result 301).
* [x] http://purl.org/dc/dcmitype/StillImage with 2 occurrences migrated to:  
  https://purl.org/dc/dcmitype/StillImage ([https](https://purl.org/dc/dcmitype/StillImage) result 302).

# Ignored
These URLs were intentionally ignored.

* http://creativecommons.org/ns with 2 occurrences
* http://purl.org/dc/elements/1.1/ with 2 occurrences
* http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd with 2 occurrences
* http://www.inkscape.org/namespaces/inkscape with 2 occurrences
* http://www.w3.org/1999/xlink with 7 occurrences
* http://www.w3.org/2000/svg with 359 occurrences