### PR TITLE
URL Cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ If you prefer real-time discussion, we also have a [Gitter channel](https://gitt
  - **Ensure the bug was not already reported**: Do a bit of searching
 in our [Issues](https://github.com/reactor/reactor-core/issues/) to see if you
 can find something similar
- - If you don't find something similar, **open a [new issue](http://github.com/reactor/reactor-core/issues/new)**.
+ - If you don't find something similar, **open a [new issue](https://github.com/reactor/reactor-core/issues/new)**.
  Be sure to follow the template and to include a title and clear description.
  Add as much relevant information as possible, and a code sample or an executable test case demonstrating the expected behavior that is not occurring
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Reactor Core
 
 [![Join the chat at https://gitter.im/reactor/reactor](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/reactor/reactor?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Reactor Core](https://maven-badges.herokuapp.com/maven-central/io.projectreactor/reactor-core/badge.svg?style=plastic)](http://mvnrepository.com/artifact/io.projectreactor/reactor-core) [![Latest](https://img.shields.io/github/release/reactor/reactor-core/all.svg)]() 
+[![Reactor Core](https://maven-badges.herokuapp.com/maven-central/io.projectreactor/reactor-core/badge.svg?style=plastic)](https://mvnrepository.com/artifact/io.projectreactor/reactor-core) [![Latest](https://img.shields.io/github/release/reactor/reactor-core/all.svg)]() 
 
 [![Download](https://api.bintray.com/packages/spring/jars/io.projectreactor/images/download.svg)](https://bintray.com/spring/jars/io.projectreactor/_latestVersion)
 
@@ -9,7 +9,7 @@
 [![Codecov](https://img.shields.io/codecov/c/github/reactor/reactor-core.svg)]()
 
 
-Non-Blocking [Reactive Streams](http://reactive-streams.org) Foundation for the JVM both implementing a [Reactive Extensions](http://reactivex.io) inspired API and efficient event streaming support.
+Non-Blocking [Reactive Streams](https://www.reactive-streams.org/) Foundation for the JVM both implementing a [Reactive Extensions](http://reactivex.io) inspired API and efficient event streaming support.
 
 ## Getting it
    
@@ -19,8 +19,8 @@ With Gradle from repo.spring.io or Maven Central repositories (stable releases o
 
 ```groovy
     repositories {
-//      maven { url 'http://repo.spring.io/snapshot' }
-      maven { url 'http://repo.spring.io/milestone' }
+//      maven { url 'https://repo.spring.io/snapshot' }
+      maven { url 'https://repo.spring.io/milestone' }
       mavenCentral()
     }
 
@@ -32,12 +32,12 @@ With Gradle from repo.spring.io or Maven Central repositories (stable releases o
     }
 ```
 
-See the [reference documentation](http://projectreactor.io/docs/core/release/reference/docs/index.html#getting)
+See the [reference documentation](https://projectreactor.io/docs/core/release/reference/docs/index.html#getting)
 for more information on getting it (eg. using Maven, or on how to get milestones and snapshots).
 
 > **Note about Android support**: Reactor 3 doesn't officially support nor target Android.
 However it should work fine with Android SDK 26 (Android O) and above. See the
-[complete note](http://projectreactor.io/docs/core/release/reference/docs/index.html#prerequisites)
+[complete note](https://projectreactor.io/docs/core/release/reference/docs/index.html#prerequisites)
 in the reference guide.
 
 
@@ -54,7 +54,7 @@ A Reactive Streams Publisher with basic flow operators.
 - Static factories on Flux allow for source generation from arbitrary callbacks types.
 - Instance methods allows operational building, materialized on each _Flux#subscribe()_, _Flux#subscribe()_ or multicasting operations such as _Flux#publish_ and _Flux#publishNext_.
 
-[<img src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/flux.png" width="500">](http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html)
+[<img src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/flux.png" width="500">](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html)
 
 Flux in action :
 ```java
@@ -73,7 +73,7 @@ A Reactive Streams Publisher constrained to *ZERO* or *ONE* element with appropr
 - Static factories on Mono allow for deterministic *zero or one* sequence generation from arbitrary callbacks types.
 - Instance methods allows operational building, materialized on each _Mono#subscribe()_ or _Mono#get()_ eventually called.
 
-[<img src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/mono.png" width="500">](http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html)
+[<img src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/mono.png" width="500">](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html)
 
 Mono in action :
 ```java
@@ -95,11 +95,11 @@ Tuple2<Long, Long> nowAndLater =
 
 ## Schedulers
 
-Reactor uses a [Scheduler](http://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Scheduler.html) as a
+Reactor uses a [Scheduler](https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Scheduler.html) as a
 contract for arbitrary task execution. It provides some guarantees required by Reactive
 Streams flows like FIFO execution.
 
-You can use or create efficient [schedulers](http://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Schedulers.html)
+You can use or create efficient [schedulers](https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Schedulers.html)
 to jump thread on the producing flows (subscribeOn) or receiving flows (publishOn):
 
 ```java
@@ -117,7 +117,7 @@ Mono.fromCallable( () -> System.currentTimeMillis() )
 
 ## ParallelFlux
 
-[ParallelFlux](http://projectreactor.io/docs/core/release/api/reactor/core/publisher/ParallelFlux.html) can starve your CPU's from any sequence whose work can be subdivided in concurrent
+[ParallelFlux](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/ParallelFlux.html) can starve your CPU's from any sequence whose work can be subdivided in concurrent
  tasks. Turn back into a `Flux` with `ParallelFlux#sequential()`, an unordered join or
  use abitrary merge strategies via 'groups()'.
 
@@ -158,16 +158,16 @@ Flux.create(sink -> {
 
 ## The Backpressure Thing
 
-Most of this cool stuff uses bounded ring buffer implementation under the hood to mitigate signal processing difference between producers and consumers. Now, the operators and processors or any standard reactive stream component working on the sequence will be instructed to flow in when these buffers have free room AND only then. This means that we make sure we both have a deterministic capacity model (bounded buffer) and we never block (request more data on write capacity). Yup, it's not rocket science after all, the boring part is already being worked by us in collaboration with [Reactive Streams Commons](http://github.com/reactor/reactive-streams-commons) on going research effort.
+Most of this cool stuff uses bounded ring buffer implementation under the hood to mitigate signal processing difference between producers and consumers. Now, the operators and processors or any standard reactive stream component working on the sequence will be instructed to flow in when these buffers have free room AND only then. This means that we make sure we both have a deterministic capacity model (bounded buffer) and we never block (request more data on write capacity). Yup, it's not rocket science after all, the boring part is already being worked by us in collaboration with [Reactive Streams Commons](https://github.com/reactor/reactive-streams-commons) on going research effort.
 
 ## What's more in it ?
 
-"Operator Fusion" (flow optimizers), health state observers, helpers to build custom reactive components, bounded queue generator, hash-wheel timer, converters from/to Java 9 Flow, Publisher and Java 8 CompletableFuture. The repository contains a `reactor-test` project with test features like the [`StepVerifier`](http://projectreactor.io/docs/test/release/api/index.html?reactor/test/StepVerifier.html).
+"Operator Fusion" (flow optimizers), health state observers, helpers to build custom reactive components, bounded queue generator, hash-wheel timer, converters from/to Java 9 Flow, Publisher and Java 8 CompletableFuture. The repository contains a `reactor-test` project with test features like the [`StepVerifier`](https://projectreactor.io/docs/test/release/api/index.html?reactor/test/StepVerifier.html).
 
 -------------------------------------
 
 ## Reference Guide
-http://projectreactor.io/docs/core/release/reference/docs/index.html
+https://projectreactor.io/docs/core/release/reference/docs/index.html
 
 ## Javadoc
 https://projectreactor.io/docs/core/release/api/
@@ -182,13 +182,13 @@ https://www.infoq.com/articles/reactor-by-example
 https://github.com/reactor/head-first-reactive-with-spring-and-reactor/
 
 ## Beyond Reactor Core
-- Everything to jump outside the JVM with the non-blocking drivers from [Reactor Netty](http://github.com/reactor/reactor-netty).
-- [Reactor Addons](http://github.com/reactor/reactor-addons) provide for adapters and extra operators for Reactor 3.
+- Everything to jump outside the JVM with the non-blocking drivers from [Reactor Netty](https://github.com/reactor/reactor-netty).
+- [Reactor Addons](https://github.com/reactor/reactor-addons) provide for adapters and extra operators for Reactor 3.
 
 -------------------------------------
-_Powered by [Reactive Streams Commons](http://github.com/reactor/reactive-streams-commons)_
+_Powered by [Reactive Streams Commons](https://github.com/reactor/reactive-streams-commons)_
 
 _Licensed under [Apache Software License 2.0](www.apache.org/licenses/LICENSE-2.0)_
 
-_Sponsored by [Pivotal](http://pivotal.io)_
+_Sponsored by [Pivotal](https://pivotal.io)_
 

--- a/reactor-core/src/main/java/reactor/adapter/package-info.java
+++ b/reactor-core/src/main/java/reactor/adapter/package-info.java
@@ -18,7 +18,7 @@
  * Adapt
  * {@link org.reactivestreams.Publisher} to Java 9+
  * {@link reactor.adapter.JdkFlowAdapter Flow.Publisher}. More adapter can be found
- * under http://github.com/reactor/reactor-addons/reactor-adapter including RxJava1 and
+ * under https://github.com/reactor/reactor-addons/reactor-adapter including RxJava1 and
  * RxJava2.
  *
  * @author Stephane Maldini

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
@@ -32,7 +32,7 @@ import reactor.util.annotation.Nullable;
  * Please note, that along with multiple consumers, current implementation of
  * DirectProcessor supports multiple producers. However, all producers must produce
  * messages on the same Thread, otherwise
- * <a href="http://www.reactive-streams.org/">Reactive Streams Spec</a> contract is
+ * <a href="https://www.reactive-streams.org/">Reactive Streams Spec</a> contract is
  * violated.
  * <p>
  *      <img width="640" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.2.0.M2/src/docs/marble/directprocessornormal.png" alt="">

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -77,7 +77,7 @@ import reactor.util.function.Tuples;
  * <p>
  * The recommended way to learn about the {@link Flux} API and discover new operators is
  * through the reference documentation, rather than through this javadoc (as opposed to
- * learning more about individual operators). See the <a href="http://projectreactor.io/docs/core/release/reference/docs/index.html#which-operator">
+ * learning more about individual operators). See the <a href="https://projectreactor.io/docs/core/release/reference/docs/index.html#which-operator">
  * "which operator do I need?" appendix</a>.
  *
  * <p>

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMergeOrdered.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMergeOrdered.java
@@ -43,7 +43,7 @@ import reactor.util.concurrent.Queues;
  * @author David Karnok
  * @author Simon Baslé
  */
-//source: http://akarnokd.blogspot.fr/2017/09/java-9-flow-api-ordered-merge.html
+//source: https://akarnokd.blogspot.fr/2017/09/java-9-flow-api-ordered-merge.html
 final class FluxMergeOrdered<T> extends Flux<T> implements SourceProducer<T> {
 
 	final int                      prefetch;

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -68,7 +68,7 @@ import reactor.util.function.Tuples;
  * <p>
  * The recommended way to learn about the {@link Mono} API and discover new operators is
  * through the reference documentation, rather than through this javadoc (as opposed to
- * learning more about individual operators). See the <a href="http://projectreactor.io/docs/core/release/reference/docs/index.html#which-operator">
+ * learning more about individual operators). See the <a href="https://projectreactor.io/docs/core/release/reference/docs/index.html#which-operator">
  * "which operator do I need?" appendix</a>.
  *
  * <p><img width="640"

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -48,7 +48,7 @@ import static reactor.core.Fuseable.NONE;
  * size and to cap concurrent additive operations to Long.MAX_VALUE,
  * which is generic to {@link Subscription#request(long)} handling.
  *
- * Combine utils available to operator implementations, @see http://github.com/reactor/reactive-streams-commons
+ * Combine utils available to operator implementations, @see https://github.com/reactor/reactive-streams-commons
  *
  */
 public abstract class Operators {

--- a/reactor-core/src/main/java/reactor/core/publisher/RingBuffer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/RingBuffer.java
@@ -549,7 +549,7 @@ enum  UnsafeSupport {
 
 		// ensure the unsafe supports all necessary methods to work around the mistake in the latest OpenJDK
 		// https://github.com/netty/netty/issues/1061
-		// http://www.mail-archive.com/jdk6-dev@openjdk.java.net/msg00698.html
+		// https://www.mail-archive.com/jdk6-dev@openjdk.java.net/msg00698.html
 		if (unsafe != null) {
 			final Unsafe finalUnsafe = unsafe;
 			Object maybeException;

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -40,7 +40,7 @@ import reactor.util.context.Context;
  * However, it should be noticed that multi-producer case is only valid if appropriate
  * Queue
  * is provided. Otherwise, it could break
- * <a href="http://www.reactive-streams.org/">Reactive Streams Spec</a> if Publishers
+ * <a href="https://www.reactive-streams.org/">Reactive Streams Spec</a> if Publishers
  * publish on different threads.
  *
  * <p>
@@ -53,14 +53,14 @@ import reactor.util.context.Context;
  * <p>
  *      <b>Note: </b> UnicastProcessor does not respect the actual subscriber's
  *      demand as it is described in
- *      <a href="http://www.reactive-streams.org/">Reactive Streams Spec</a>. However,
+ *      <a href="https://www.reactive-streams.org/">Reactive Streams Spec</a>. However,
  *      UnicastProcessor embraces configurable Queue internally which allows enabling
  *      backpressure support and preventing of consumer's overwhelming.
  *
  *      Hence, interaction model between producers and UnicastProcessor will be PUSH
  *      only. In opposite, interaction model between UnicastProcessor and consumer will be
  *      PUSH-PULL as defined in
- *      <a href="http://www.reactive-streams.org/">Reactive Streams Spec</a>.
+ *      <a href="https://www.reactive-streams.org/">Reactive Streams Spec</a>.
  *
  *      In the case when upstream's signals overflow the bound of internal Queue,
  *      UnicastProcessor will fail with signaling onError(

--- a/reactor-core/src/test/java/reactor/guide/GuideTests.java
+++ b/reactor-core/src/test/java/reactor/guide/GuideTests.java
@@ -937,7 +937,7 @@ public class GuideTests {
 
 	private Flux<String> urls() {
 		return Flux.range(1, 5)
-		           .map(i -> "http://mysite.io/quote/" + i);
+		           .map(i -> "https://www.mysite.io/quote" + i);
 	}
 
 	private Flux<String> doRequest(String url) {

--- a/src/api/overview.html
+++ b/src/api/overview.html
@@ -22,7 +22,7 @@ under
     <p>
         Reactor Core is a succinct and powerful foundational library for building reactive and efficient applications
         on the JVM.
-        More detailed documentation is available on the <a href="http://projectreactor.io/docs/core/release/reference/"
+        More detailed documentation is available on the <a href="https://projectreactor.io/docs/core/release/reference/"
                                                            target="_blank">reference guide</a>.
     </p>
 </div>

--- a/src/api/stylesheet.css
+++ b/src/api/stylesheet.css
@@ -109,7 +109,7 @@ Document title and Copyright styles
     position: absolute;
     right: 2px;
     top: 10px;
-    background: url(http://projectreactor.io/assets/img/logo-2x.png) no-repeat 0 -30px;
+    background: url(https://projectreactor.io/assets/img/logo-2x.png) no-repeat 0 -30px;
     background-size: 189px 60px;
     height: 40px;
     width: 44px;

--- a/src/docbook/xsl/common.xsl
+++ b/src/docbook/xsl/common.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
 

--- a/src/docbook/xsl/epub.xsl
+++ b/src/docbook/xsl/epub.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
 

--- a/src/docbook/xsl/html.xsl
+++ b/src/docbook/xsl/html.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
 

--- a/src/docbook/xsl/pdf.xsl
+++ b/src/docbook/xsl/pdf.xsl
@@ -22,7 +22,7 @@ under the License.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:d="http://docbook.org/ns/docbook"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl d"
                 version='1.0'>
 

--- a/src/docs/asciidoc/aboutDoc.adoc
+++ b/src/docs/asciidoc/aboutDoc.adoc
@@ -7,7 +7,7 @@ often refer to other pieces.
 
 == Latest Version & Copyright Notice
 The Reactor reference guide is available as HTML documents. The latest copy is available
-at http://projectreactor.io/docs/core/release/reference/docs/index.html
+at https://projectreactor.io/docs/core/release/reference/docs/index.html
 
 Copies of this document may be made for your own use and for distribution to others,
 provided that you do not charge any fee for such copies and further provided that each
@@ -15,7 +15,7 @@ copy contains this Copyright Notice, whether distributed in print or electronica
 
 == Contributing to the Documentation
 The reference guide is written in
-http://asciidoctor.org/docs/asciidoc-writers-guide/[Asciidoc]
+https://asciidoctor.org/docs/asciidoc-writers-guide/[Asciidoc]
 format and sources can be found at
 https://github.com/reactor/reactor-core/tree/master/src/docs/asciidoc.
 
@@ -37,10 +37,10 @@ There are several ways to reach out for help with Reactor.
 
 * Get in touch with the community on https://gitter.im/reactor/reactor[Gitter].
 * Ask a question on stackoverflow.com at
-http://stackoverflow.com/tags/project-reactor[`project-reactor`].
+https://stackoverflow.com/tags/project-reactor[`project-reactor`].
 * Report bugs in Github issues. The following repositories are closely monitored:
-http://github.com/reactor/reactor-core/issues[reactor-core] (which covers the
-essential features) and http://github.com/reactor/reactor-addons/issues[reactor-addons]
+https://github.com/reactor/reactor-core/issues[reactor-core] (which covers the
+essential features) and https://github.com/reactor/reactor-addons/issues[reactor-addons]
 (which covers reactor-test and adapters issues).
 
 NOTE: All of Reactor is open source,

--- a/src/docs/asciidoc/gettingStarted.adoc
+++ b/src/docs/asciidoc/gettingStarted.adoc
@@ -186,7 +186,7 @@ For Gradle, use the following snippet:
 [source,groovy]
 ----
 repositories {
-  maven { url 'http://repo.spring.io/milestone' }
+  maven { url 'https://repo.spring.io/milestone' }
   mavenCentral()
 }
 ----
@@ -209,7 +209,7 @@ Similarly, snapshots are also available in a separate dedicated repository:
 [source,groovy]
 ----
 repositories {
-  maven { url 'http://repo.spring.io/snapshot' }
+  maven { url 'https://repo.spring.io/snapshot' }
   mavenCentral()
 }
 ----

--- a/src/docs/asciidoc/kotlin.adoc
+++ b/src/docs/asciidoc/kotlin.adoc
@@ -68,7 +68,7 @@ One of Kotlin's key features is https://kotlinlang.org/docs/reference/null-safet
 `NullPointerException` at runtime. This makes applications safer through nullability
 declarations and expressing "value or no value" semantics without paying the cost of wrappers like `Optional`.
 (Kotlin allows using functional constructs with nullable values; check out this
-http://www.baeldung.com/kotlin-null-safety[comprehensive guide to Kotlin null-safety].)
+https://www.baeldung.com/kotlin-null-safety[comprehensive guide to Kotlin null-safety].)
 
 Although Java does not allow one to express null-safety in its type-system, Reactor <<null-safety,now
 provides null-safety>> of the whole Reactor API via tooling-friendly annotations declared

--- a/src/docs/asciidoc/stylesheets/asciidoctor.css
+++ b/src/docs/asciidoc/stylesheets/asciidoctor.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/colony.css
+++ b/src/docs/asciidoc/stylesheets/colony.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/foundation-lime.css
+++ b/src/docs/asciidoc/stylesheets/foundation-lime.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/foundation-potion.css
+++ b/src/docs/asciidoc/stylesheets/foundation-potion.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/foundation.css
+++ b/src/docs/asciidoc/stylesheets/foundation.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/github.css
+++ b/src/docs/asciidoc/stylesheets/github.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/golo.css
+++ b/src/docs/asciidoc/stylesheets/golo.css
@@ -1,5 +1,5 @@
 @import url(https://fonts.googleapis.com/css?family=Montserrat:400,700);
-@import url(http://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css);
 
 
 #header .details br+span.author:before {
@@ -18,7 +18,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/iconic.css
+++ b/src/docs/asciidoc/stylesheets/iconic.css
@@ -1,9 +1,9 @@
-/* Inspired by the O'Reilly typography and the Atlas user manual | http://oreilly.com */
-@import url(http://fonts.googleapis.com/css?family=Lato:400,700,700italic,400italic);
+/* Inspired by the O'Reilly typography and the Atlas user manual | https://oreilly.com */
+@import url(https://fonts.googleapis.com/css?family=Lato:400,700,700italic,400italic);
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/maker.css
+++ b/src/docs/asciidoc/stylesheets/maker.css
@@ -1,8 +1,8 @@
-@import url(http://fonts.googleapis.com/css?family=Glegoo);
+@import url(https://fonts.googleapis.com/css?family=Glegoo);
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/readthedocs.css
+++ b/src/docs/asciidoc/stylesheets/readthedocs.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/rocket-panda.css
+++ b/src/docs/asciidoc/stylesheets/rocket-panda.css
@@ -1,8 +1,8 @@
-@import url(http://openshift.redhat.com/app/assets-20130701203230/overpass.css);
+@import url(https://openshift.redhat.com/app/assets-20130701203230/overpass.css);
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/rubygems.css
+++ b/src/docs/asciidoc/stylesheets/rubygems.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://docbook.sourceforge.net/release/xsl/current/epub3/chunk.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/epub3/chunk.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/fo/highlight.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/fo/highlight.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/html/highlight.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/html/highlight.xsl) result AnnotatedConnectException).
* [ ] http://reactivex.io (200) with 1 occurrences could not be migrated:  
   ([https](https://reactivex.io) result SSLHandshakeException).
* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://mysite.io/quote/ (302) with 1 occurrences migrated to:  
  https://www.mysite.io/quote ([https](https://mysite.io/quote/) result AnnotatedConnectException).
* [ ] http://github.com/reactor/reactor-addons/reactor-adapter (301) with 1 occurrences migrated to:  
  https://github.com/reactor/reactor-addons/reactor-adapter ([https](https://github.com/reactor/reactor-addons/reactor-adapter) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://asciidoctor.org/docs/asciidoc-writers-guide/ with 1 occurrences migrated to:  
  https://asciidoctor.org/docs/asciidoc-writers-guide/ ([https](https://asciidoctor.org/docs/asciidoc-writers-guide/) result 200).
* [ ] http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css with 12 occurrences migrated to:  
  https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css ([https](https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css) result 200).
* [ ] http://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css with 1 occurrences migrated to:  
  https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css ([https](https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css) result 200).
* [ ] http://fonts.googleapis.com/css?family=Glegoo with 1 occurrences migrated to:  
  https://fonts.googleapis.com/css?family=Glegoo ([https](https://fonts.googleapis.com/css?family=Glegoo) result 200).
* [ ] http://fonts.googleapis.com/css?family=Lato:400,700,700italic,400italic with 1 occurrences migrated to:  
  https://fonts.googleapis.com/css?family=Lato:400,700,700italic,400italic ([https](https://fonts.googleapis.com/css?family=Lato:400,700,700italic,400italic) result 200).
* [ ] http://github.com/reactor/reactive-streams-commons with 3 occurrences migrated to:  
  https://github.com/reactor/reactive-streams-commons ([https](https://github.com/reactor/reactive-streams-commons) result 200).
* [ ] http://github.com/reactor/reactor-addons with 1 occurrences migrated to:  
  https://github.com/reactor/reactor-addons ([https](https://github.com/reactor/reactor-addons) result 200).
* [ ] http://github.com/reactor/reactor-addons/issues with 1 occurrences migrated to:  
  https://github.com/reactor/reactor-addons/issues ([https](https://github.com/reactor/reactor-addons/issues) result 200).
* [ ] http://github.com/reactor/reactor-core/issues with 1 occurrences migrated to:  
  https://github.com/reactor/reactor-core/issues ([https](https://github.com/reactor/reactor-core/issues) result 200).
* [ ] http://github.com/reactor/reactor-netty with 1 occurrences migrated to:  
  https://github.com/reactor/reactor-netty ([https](https://github.com/reactor/reactor-netty) result 200).
* [ ] http://mvnrepository.com/artifact/io.projectreactor/reactor-core with 1 occurrences migrated to:  
  https://mvnrepository.com/artifact/io.projectreactor/reactor-core ([https](https://mvnrepository.com/artifact/io.projectreactor/reactor-core) result 200).
* [ ] http://pivotal.io with 1 occurrences migrated to:  
  https://pivotal.io ([https](https://pivotal.io) result 200).
* [ ] http://projectreactor.io/assets/img/logo-2x.png with 1 occurrences migrated to:  
  https://projectreactor.io/assets/img/logo-2x.png ([https](https://projectreactor.io/assets/img/logo-2x.png) result 200).
* [ ] http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html with 1 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html ([https](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html) result 200).
* [ ] http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html with 1 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html ([https](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html) result 200).
* [ ] http://projectreactor.io/docs/core/release/api/reactor/core/publisher/ParallelFlux.html with 1 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/api/reactor/core/publisher/ParallelFlux.html ([https](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/ParallelFlux.html) result 200).
* [ ] http://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Scheduler.html with 1 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Scheduler.html ([https](https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Scheduler.html) result 200).
* [ ] http://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Schedulers.html with 1 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Schedulers.html ([https](https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Schedulers.html) result 200).
* [ ] http://projectreactor.io/docs/core/release/reference/ with 1 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/reference/ ([https](https://projectreactor.io/docs/core/release/reference/) result 200).
* [ ] http://projectreactor.io/docs/test/release/api/index.html?reactor/test/StepVerifier.html with 1 occurrences migrated to:  
  https://projectreactor.io/docs/test/release/api/index.html?reactor/test/StepVerifier.html ([https](https://projectreactor.io/docs/test/release/api/index.html?reactor/test/StepVerifier.html) result 200).
* [ ] http://stackoverflow.com/tags/project-reactor with 1 occurrences migrated to:  
  https://stackoverflow.com/tags/project-reactor ([https](https://stackoverflow.com/tags/project-reactor) result 200).
* [ ] http://www.baeldung.com/kotlin-null-safety with 1 occurrences migrated to:  
  https://www.baeldung.com/kotlin-null-safety ([https](https://www.baeldung.com/kotlin-null-safety) result 200).
* [ ] http://www.mail-archive.com/jdk6-dev@openjdk.java.net/msg00698.html with 1 occurrences migrated to:  
  https://www.mail-archive.com/jdk6-dev@openjdk.java.net/msg00698.html ([https](https://www.mail-archive.com/jdk6-dev@openjdk.java.net/msg00698.html) result 200).
* [ ] http://www.reactive-streams.org/ with 4 occurrences migrated to:  
  https://www.reactive-streams.org/ ([https](https://www.reactive-streams.org/) result 200).
* [ ] http://reactive-streams.org (301) with 1 occurrences migrated to:  
  https://www.reactive-streams.org/ ([https](https://reactive-streams.org) result 200).
* [ ] http://openshift.redhat.com/app/assets-20130701203230/overpass.css with 1 occurrences migrated to:  
  https://openshift.redhat.com/app/assets-20130701203230/overpass.css ([https](https://openshift.redhat.com/app/assets-20130701203230/overpass.css) result 301).
* [ ] http://oreilly.com with 1 occurrences migrated to:  
  https://oreilly.com ([https](https://oreilly.com) result 301).
* [ ] http://akarnokd.blogspot.fr/2017/09/java-9-flow-api-ordered-merge.html with 1 occurrences migrated to:  
  https://akarnokd.blogspot.fr/2017/09/java-9-flow-api-ordered-merge.html ([https](https://akarnokd.blogspot.fr/2017/09/java-9-flow-api-ordered-merge.html) result 302).
* [ ] http://github.com/reactor/reactor-core/issues/new with 1 occurrences migrated to:  
  https://github.com/reactor/reactor-core/issues/new ([https](https://github.com/reactor/reactor-core/issues/new) result 302).
* [ ] http://projectreactor.io/docs/core/release/reference/docs/index.html with 6 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/reference/docs/index.html ([https](https://projectreactor.io/docs/core/release/reference/docs/index.html) result 302).
* [ ] http://repo.spring.io/milestone with 2 occurrences migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* [ ] http://repo.spring.io/snapshot with 2 occurrences migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 1 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 6 occurrences