### PR TITLE
fix #1529 StepVerifier CollectEvent blocks

### DIFF
--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1307,7 +1307,7 @@ final class DefaultStepVerifierBuilder<T>
 				this.completeLatch.countDown();
 				return true;
 			}
-			return true;
+			return false;
 		}
 
 		@SuppressWarnings("unchecked")
@@ -1336,14 +1336,15 @@ final class DefaultStepVerifierBuilder<T>
 					}
 					//possibly re-evaluate the current onNext
 					event = this.script.peek();
+				} else if (event instanceof CollectEvent) {
+					if (onCollect(actualSignal)) {
+						return;
+					}
+					//possibly re-evaluate the current onNext
+					event = this.script.peek();
 				}
 				if (event instanceof SignalCountEvent) {
 					if (onSignalCount(actualSignal, (SignalCountEvent<T>) event)) {
-						return;
-					}
-				}
-				else if (event instanceof CollectEvent) {
-					if (onCollect(actualSignal)) {
 						return;
 					}
 				}

--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -1340,8 +1340,6 @@ final class DefaultStepVerifierBuilder<T>
 					if (onCollect(actualSignal)) {
 						return;
 					}
-					//possibly re-evaluate the current onNext
-					event = this.script.peek();
 				}
 				if (event instanceof SignalCountEvent) {
 					if (onSignalCount(actualSignal, (SignalCountEvent<T>) event)) {

--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -1336,13 +1336,14 @@ final class DefaultStepVerifierBuilder<T>
 					}
 					//possibly re-evaluate the current onNext
 					event = this.script.peek();
-				} else if (event instanceof CollectEvent) {
-					if (onCollect(actualSignal)) {
-						return;
-					}
 				}
 				if (event instanceof SignalCountEvent) {
 					if (onSignalCount(actualSignal, (SignalCountEvent<T>) event)) {
+						return;
+					}
+				}
+				else if (event instanceof CollectEvent) {
+					if (onCollect(actualSignal)) {
 						return;
 					}
 				}

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1218,6 +1218,34 @@ public class StepVerifierTests {
 			            .log()
 			            .verify())
 		        .withMessageContaining("expectNext(9)");
+	}
+
+	@Test
+	public void testExpectRecordedMatches() {
+		List<Integer> expected = Arrays.asList(1,2);
+
+		StepVerifier.create(Flux.just(1,2))
+		            .recordWith(ArrayList::new)
+		            .thenConsumeWhile(i -> i < 2)
+		            .expectRecordedMatches(expected::equals)
+		            .thenCancel()
+		            .verify();
+	}
+
+	@Test
+	public void testExpectRecordedMatchesWithoutComplete() {
+		List<Integer> expected = Arrays.asList(1,2);
+
+		TestPublisher<Integer> publisher = TestPublisher.createCold();
+		publisher.next(1);
+		publisher.next(2);
+
+		StepVerifier.create(publisher)
+		            .recordWith(ArrayList::new)
+		            .thenConsumeWhile(i -> i < 2)
+		            .expectRecordedMatches(expected::equals)
+		            .thenCancel()
+		            .verify();
 	}
 
 	@Test

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -1233,6 +1233,22 @@ public class StepVerifierTests {
 	}
 
 	@Test
+	public void testExpectRecordedMatchesTwice() {
+		List<Integer> expected1 = Arrays.asList(1,2);
+		List<Integer> expected2 = Arrays.asList(3,4);
+
+		StepVerifier.create(Flux.just(1,2,3,4))
+		            .recordWith(ArrayList::new)
+		            .thenConsumeWhile(i -> i < 2)
+		            .expectRecordedMatches(expected1::equals)
+		            .recordWith(ArrayList::new)
+		            .thenConsumeWhile(i -> i < 4)
+		            .expectRecordedMatches(expected2::equals)
+		            .thenCancel()
+		            .verify();
+	}
+
+	@Test
 	public void testExpectRecordedMatchesWithoutComplete() {
 		List<Integer> expected = Arrays.asList(1,2);
 


### PR DESCRIPTION
Fix issue [#1529](https://github.com/reactor/reactor-core/issues/1529)

Fix has also been tested against test [RecordTest](https://github.com/george-hawkins/publish-cancel-test/blob/master/src/test/java/com/example/RecordTest.java) provided by the issue author.

Everything worked fine if publisher ended with `onComplete` signal.
Without `onComplete` ,  `completeLatch` was never decremented and as a result 
verify step blocked forever.


