### PR TITLE
fix #1528 - FluxPublish hangs for infinite Flux.fromStream

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -467,6 +467,9 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 									inner,1) ==
 									Long.MIN_VALUE){
 								cancel = Integer.MIN_VALUE;
+								if (sourceMode == Fuseable.SYNC) {
+									return;
+								}
 							}
 						}
 


### PR DESCRIPTION
Fix prevents following flux from hanging in [loop](https://github.com/reactor/reactor-core/blob/master/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java#L381)

```
Flux.fromStream(Stream.iterate(0, i -> i + 1))
       .publish()
       .autoConnect()
       .take(10)
```

I do not understand why there is a problem with `fromStream` whereas `Flux.interval` works without fix.
