### PR TITLE
fix #1528 Potential infinite loop when cancelling SYNC-fused FluxPublish

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -390,8 +390,9 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 					return;
 				}
 
-				if (!empty) {
-					PubSubInner<T>[] a = subscribers;
+				PubSubInner<T>[] a = subscribers;
+
+				if (a != EMPTY && !empty) {
 					long maxRequested = Long.MAX_VALUE;
 
 					int len = a.length;
@@ -483,8 +484,8 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 				}
 				else if (sourceMode == Fuseable.SYNC) {
 					done = true;
-					if (checkTerminated(true, true)) {
-						return;
+					if (checkTerminated(true, empty)) {
+						break;
 					}
 				}
 


### PR DESCRIPTION
This commit fixes a missing exit condition in Flux.publish drain loop
when the subscribers have been cancelled with a fusion sourceMode of
SYNC.

Additionally, a `checkTerminated` call in the drain loop is made to
correctly check the `empty` state instead of assuming it is empty, and
to break instead of returning in that case, allowing for work stealing
to still happen.