### PR TITLE
Add sanity check with OpenJDK 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 jdk:
   - oraclejdk8
   - openjdk11
+  - openjdk12
 
 sudo: required
 


### PR DESCRIPTION
I was playing again with reactor-core and I'm glad that it builds correctly (in reference to #1327 ;) ) with OpenJDK 12 which I use by defailt. I added a sanity build on Travis to keep an eye on it.