### PR TITLE
fix #1652 Unwrap CompletionException in Mono#fromFuture

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCompletionStage.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCompletionStage.java
@@ -17,6 +17,7 @@ package reactor.core.publisher;
 
 import java.util.Objects;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 
 import reactor.core.CoreSubscriber;
@@ -75,7 +76,10 @@ final class MonoCompletionStage<T> extends Mono<T>
                 return;
             }
             try {
-                if (e != null) {
+                if (e instanceof CompletionException) {
+                    actual.onError(e.getCause());
+                }
+                else if (e != null) {
                     actual.onError(e);
                 }
                 else if (v != null) {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCompletionStageTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCompletionStageTest.java
@@ -147,16 +147,6 @@ public class MonoCompletionStageTest {
 	}
 
 	@Test
-	public void failedFutureIsPropagatedDirectly() {
-		Throwable expected = new IllegalStateException("boom");
-		CompletionStage<Integer> future = CompletableFuture.failedFuture(expected);
-
-		Mono.fromCompletionStage(future)
-		    .as(StepVerifier::create)
-		    .verifyErrorSatisfies(e -> assertThat(e).isSameAs(expected));
-	}
-
-	@Test
 	public void lateFailureIsPropagatedDirectly() {
 		Throwable expected = new IllegalStateException("boom");
 		CompletableFuture<Integer> future = new CompletableFuture<>();


### PR DESCRIPTION
The CompletionException wraps the original Throwable, but only when it
is thrown from within user-provided functions transforming the
CompletionStage.

However, as Subscriber#onError gladly accepts a Throwable, it makes
sense to unwrap the CompletionException for the benefit of the
downstream Subscriber.