### PR TITLE
fix #1656 ParallelFlux#doOnEach should receive the context

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelDoOnEach.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelDoOnEach.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.core.publisher;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.LongConsumer;
+
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
+import reactor.core.Scannable;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+
+/**
+ * Execute a Consumer in each 'rail' for the current element passing through.
+ *
+ * @param <T> the value type
+ */
+final class ParallelDoOnEach<T> extends ParallelFlux<T> implements Scannable {
+
+	final ParallelFlux<T> source;
+
+	final BiConsumer<Context, ? super T>         onNext;
+	final BiConsumer<Context, ? super Throwable> onError;
+	final Consumer<Context>                      onComplete;
+
+	ParallelDoOnEach(
+			ParallelFlux<T> source,
+			@Nullable BiConsumer<Context, ? super T> onNext,
+			@Nullable BiConsumer<Context, ? super Throwable> onError,
+			@Nullable Consumer<Context> onComplete
+	) {
+		this.source = source;
+
+		this.onNext = onNext;
+		this.onError = onError;
+		this.onComplete = onComplete;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public void subscribe(CoreSubscriber<? super T>[] subscribers) {
+		if (!validate(subscribers)) {
+			return;
+		}
+
+		int n = subscribers.length;
+
+		CoreSubscriber<? super T>[] parents = new CoreSubscriber[n];
+
+		boolean conditional = subscribers[0] instanceof Fuseable.ConditionalSubscriber;
+
+		for (int i = 0; i < n; i++) {
+			CoreSubscriber<? super T> subscriber = subscribers[i];
+			SignalPeek<T> signalPeek = new DoOnEachSignalPeek(subscriber.currentContext());
+
+			if (conditional) {
+				parents[i] = new FluxPeekFuseable.PeekConditionalSubscriber<>(
+						(Fuseable.ConditionalSubscriber<T>) subscriber, signalPeek);
+			}
+			else {
+				parents[i] = new FluxPeek.PeekSubscriber<>(subscriber, signalPeek);
+			}
+		}
+
+		source.subscribe(parents);
+	}
+
+	@Override
+	public int parallelism() {
+		return source.parallelism();
+	}
+
+	@Override
+	public int getPrefetch() {
+		return source.getPrefetch();
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PARENT) return source;
+		if (key == Attr.PREFETCH) return getPrefetch();
+
+		return null;
+	}
+
+	private class DoOnEachSignalPeek implements SignalPeek<T> {
+
+		Consumer<? super T> onNextCall;
+
+		Consumer<? super Throwable> onErrorCall;
+
+		Runnable onCompleteCall;
+
+		public DoOnEachSignalPeek(Context ctx) {
+			onNextCall = onNext != null ? v -> onNext.accept(ctx, v) : null;
+			onErrorCall = onError != null ? e -> onError.accept(ctx, e) : null;
+			onCompleteCall = onComplete != null ? () -> onComplete.accept(ctx) : null;
+		}
+
+		@Override
+		public Consumer<? super Subscription> onSubscribeCall() {
+			return null;
+		}
+
+		@Override
+		public Consumer<? super T> onNextCall() {
+			return onNextCall;
+		}
+
+		@Override
+		public Consumer<? super Throwable> onErrorCall() {
+			return onErrorCall;
+		}
+
+		@Override
+		public Runnable onCompleteCall() {
+			return onCompleteCall;
+		}
+
+		@Override
+		public Runnable onAfterTerminateCall() {
+			return null;
+		}
+
+		@Override
+		public LongConsumer onRequestCall() {
+			return null;
+		}
+
+		@Override
+		public Runnable onCancelCall() {
+			return null;
+		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			return null;
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -417,12 +417,12 @@ public abstract class ParallelFlux<T> implements Publisher<T> {
 	 */
 	public final ParallelFlux<T> doOnEach(Consumer<? super Signal<T>> signalConsumer) {
 		Objects.requireNonNull(signalConsumer, "signalConsumer");
-		return doOnSignal(this,
-				v -> signalConsumer.accept(Signal.next(v)),
-				null,
-				e -> signalConsumer.accept(Signal.error(e)),
-				() -> signalConsumer.accept(Signal.complete()),
-				null, null, null, null);
+		return onAssembly(new ParallelDoOnEach<>(
+				this,
+				(ctx, v) -> signalConsumer.accept(Signal.next(v, ctx)),
+				(ctx, e) -> signalConsumer.accept(Signal.error(e, ctx)),
+				ctx -> signalConsumer.accept(Signal.complete(ctx))
+		));
 	}
 
 	/**

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -38,6 +39,7 @@ import org.junit.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+
 import reactor.core.Disposable;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -45,6 +47,7 @@ import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.concurrent.Queues;
+import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -965,6 +968,30 @@ public class ParallelFluxTest {
 		assertThat(finished).as("cancelled latch").isTrue();
 		assertThat(d.isDisposed()).as("disposed").isTrue();
 		assertThat(nextCount.get()).as("received count").isEqualTo(3);
+	}
+
+	@Test
+	public void contextPropagation() {
+		List<String> results = new CopyOnWriteArrayList<>();
+		Flux.just(1, 2, 3)
+		    .parallel()
+		    .doOnEach(s -> {
+			    String valueFromContext = s.getContext()
+			                               .getOrDefault("test", null);
+			    results.add(s + " " + valueFromContext);
+		    })
+		    .reduce(Integer::sum)
+		    .subscriberContext(Context.of("test", "Hello!"))
+		    .block();
+
+		assertThat(results).contains(
+				"onNext(1) Hello!",
+				"onNext(2) Hello!",
+				"onNext(3) Hello!",
+				"onComplete() Hello!",
+				"onComplete() Hello!",
+				"onComplete() Hello!"
+		);
 	}
 
 	private void tryToSleep(long value)

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
@@ -974,7 +974,7 @@ public class ParallelFluxTest {
 	public void contextPropagation() {
 		List<String> results = new CopyOnWriteArrayList<>();
 		Flux.just(1, 2, 3)
-		    .parallel()
+		    .parallel(3)
 		    .doOnEach(s -> {
 			    String valueFromContext = s.getContext()
 			                               .getOrDefault("test", null);
@@ -984,7 +984,7 @@ public class ParallelFluxTest {
 		    .subscriberContext(Context.of("test", "Hello!"))
 		    .block();
 
-		assertThat(results).contains(
+		assertThat(results).containsExactlyInAnyOrder(
 				"onNext(1) Hello!",
 				"onNext(2) Hello!",
 				"onNext(3) Hello!",

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
@@ -970,8 +970,9 @@ public class ParallelFluxTest {
 		assertThat(nextCount.get()).as("received count").isEqualTo(3);
 	}
 
+	// https://github.com/reactor/reactor-core/issues/1656
 	@Test
-	public void contextPropagation() {
+	public void doOnEachContext() {
 		List<String> results = new CopyOnWriteArrayList<>();
 		Flux.just(1, 2, 3)
 		    .parallel(3)


### PR DESCRIPTION
`ParallelFlux#doOnEach` was passing signals to the consumers,
but `context` property of these signals was not set due to
the use of ParallelPeek.

This change introduces context-passing `ParallelDoOnEach`.

Fixes #1656