### PR TITLE
fix #1666 Use queue.size() for onBackpressureBuffer maxSize evaluation

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -5877,7 +5877,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * Note that should the cancelled source produce further overflowing elements, these
 	 * would be passed to the {@link Hooks#onNextDropped(Consumer) onNextDropped hook}.
 	 * <p>
-	 * <img class="marble" src="doc-files/marbles/onBackpressureBufferWithMaxSize.svg" alt="">
+	 * <img class="marble" src="doc-files/marbles/onBackpressureBufferWithMaxSizeConsumer.svg" alt="">
 	 *
 	 * @reactor.discard This operator discards the buffered overflow elements upon cancellation or error triggered by a data signal,
 	 * as well as elements that are rejected by the buffer due to {@code maxSize} (even though
@@ -5903,7 +5903,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * error will be delayed after the current backlog is consumed.
 	 *
 	 * <p>
-	 * <img class="marble" src="doc-files/marbles/onBackpressureBufferWithMaxSize.svg" alt="">
+	 * <img class="marble" src="doc-files/marbles/onBackpressureBufferWithMaxSizeStrategyDropOldest.svg" alt="">
 	 *
 	 * @reactor.discard This operator discards the buffered overflow elements upon cancellation or error triggered by a data signal,
 	 * as well as elements that are rejected by the buffer due to {@code maxSize} (even though
@@ -5938,7 +5938,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * invoked immediately.
 	 *
 	 * <p>
-	 * <img class="marble" src="doc-files/marbles/onBackpressureBufferWithMaxSize.svg" alt="">
+	 * <img class="marble" src="doc-files/marbles/onBackpressureBufferWithMaxSizeStrategyDropOldest.svg" alt="">
 	 *
 	 * @reactor.discard This operator discards the buffered overflow elements upon cancellation or error triggered by a data signal,
 	 * as well as elements that are rejected by the buffer due to {@code maxSize} (even though

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -5845,10 +5845,11 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Request an unbounded demand and push to the returned {@link Flux}, or park the
-	 * observed elements if not enough demand is requested downstream. Errors will be
-	 * immediately emitted on overflow regardless of the pending buffer.
-	 *
+	 * Request an unbounded demand and push to the returned {@link Flux}, or park up to
+	 * {@code maxSize} elements when not enough demand is requested downstream.
+	 * The first element past this buffer to arrive out of sync with the downstream
+	 * subscriber's demand (the "overflowing" element) immediately triggers an overflow
+	 * error and cancels the source.
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/onBackpressureBufferWithMaxSize.svg" alt="">
 	 *
@@ -5865,11 +5866,16 @@ public abstract class Flux<T> implements Publisher<T> {
 	}
 
 	/**
-	 * Request an unbounded demand and push to the returned {@link Flux}, or park the
-	 * observed elements if not enough demand is requested downstream. Overflow error
-	 * will be delayed after the current backlog is consumed. However the
-	 * {@link Consumer} will be immediately invoked.
-	 *
+	 * Request an unbounded demand and push to the returned {@link Flux}, or park up to
+	 * {@code maxSize} elements when not enough demand is requested downstream.
+	 * The first element past this buffer to arrive out of sync with the downstream
+	 * subscriber's demand (the "overflowing" element) is immediately passed to a
+	 * {@link Consumer} and the source is cancelled.
+	 * The {@link Flux} is going to terminate with an overflow error, but this error is
+	 * delayed, which lets the subscriber make more requests for the content of the buffer.
+	 * <p>
+	 * Note that should the cancelled source produce further overflowing elements, these
+	 * would be passed to the {@link Hooks#onNextDropped(Consumer) onNextDropped hook}.
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/onBackpressureBufferWithMaxSize.svg" alt="">
 	 *
@@ -5877,7 +5883,7 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * as well as elements that are rejected by the buffer due to {@code maxSize} (even though
 	 * they are passed to the {@code onOverflow} {@link Consumer} first).
 	 *
-	 * @param maxSize maximum buffer backlog size before overflow callback is called
+	 * @param maxSize maximum buffer backlog size before overflow callback is called and source is cancelled
 	 * @param onOverflow callback to invoke on overflow
 	 *
 	 * @return a backpressured {@link Flux} that buffers with a bounded capacity

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBuffer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBuffer.java
@@ -139,6 +139,7 @@ final class FluxOnBackpressureBuffer<O> extends FluxOperator<O, O> implements Fu
 			if (key == Attr.ERROR) return error;
 			if (key == Attr.PREFETCH) return Integer.MAX_VALUE;
 			if (key == Attr.DELAY_ERROR) return delayError;
+			if (key == Attr.CAPACITY) return capacityOrSkip == Integer.MAX_VALUE ? Queues.capacity(queue) : capacityOrSkip;
 
 			return InnerOperator.super.scanUnsafe(key);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBufferWithMaxSize.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBufferWithMaxSize.svg
@@ -1,754 +1,95 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   version="1.1"
-   viewBox="18 65 595 435"
-   width="595"
-   height="435"
-   id="svg190"
-   sodipodi:docname="onBackpressureBufferWithMaxSize.svg"
-   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
-  <metadata
-     id="metadata4243">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="640"
-     inkscape:window-height="480"
-     id="namedview4241"
-     showgrid="false"
-     inkscape:current-layer="svg190" />
-  <defs
-     id="defs23">
-    <marker
-       orient="auto"
-       overflow="visible"
-       markerUnits="strokeWidth"
-       id="FilledArrow_Marker"
-       stroke-miterlimit="10"
-       viewBox="-1 -6 14 12"
-       markerWidth="14"
-       markerHeight="12"
-       color="#34302c"
-       stroke-linejoin="miter">
-      <g
-         id="g4">
-        <path
-           d="M12 0L0-4v9z"
-           id="path2"
-           fill="currentColor"
-           stroke="currentColor"
-           stroke-width="1" />
-      </g>
-    </marker>
-    <font-face
-       font-family="'Tahoma','Nimbus Sans L'"
-       font-size="24"
-       panose-1="2 11 9 2 3 0 4 2 2 3"
-       units-per-em="1000"
-       underline-position="-75"
-       underline-thickness="50"
-       slope="0"
-       x-height="501"
-       cap-height="682"
-       ascent="923"
-       descent="-235"
-       font-weight="700"
-       id="font-face7"
-       stemv="0"
-       stemh="0"
-       accent-height="0"
-       ideographic="0"
-       alphabetic="0"
-       mathematical="0"
-       hanging="0"
-       v-ideographic="0"
-       v-alphabetic="0"
-       v-mathematical="0"
-       v-hanging="0"
-       strikethrough-position="0"
-       strikethrough-thickness="0"
-       overline-position="0"
-       overline-thickness="0">
-      <font-face-src>
-        <font-face-name
-           name="Tahoma-Bold" />
-      </font-face-src>
-    </font-face>
-    <marker
-       orient="auto"
-       overflow="visible"
-       markerUnits="strokeWidth"
-       id="FilledArrow_Marker_2"
-       stroke-miterlimit="10"
-       viewBox="-1 -5 11 10"
-       markerWidth="11"
-       markerHeight="10"
-       color="#34302c"
-       stroke-linejoin="miter">
-      <g
-         id="g11">
-        <path
-           d="M8 0L0-3v6z"
-           id="path9"
-           fill="currentColor"
-           stroke="currentColor"
-           stroke-width="1" />
-      </g>
-    </marker>
-    <marker
-       orient="auto"
-       overflow="visible"
-       markerUnits="strokeWidth"
-       id="FilledArrow_Marker_3"
-       stroke-miterlimit="10"
-       viewBox="-6 -3 7 6"
-       markerWidth="7"
-       markerHeight="6"
-       color="#34302c"
-       stroke-linejoin="miter">
-      <g
-         id="g16">
-        <path
-           d="M-5 0l5 2v-4z"
-           id="path14"
-           fill="currentColor"
-           stroke="currentColor"
-           stroke-width="1" />
-      </g>
-    </marker>
-    <font-face
-       font-family="'Tahoma','Nimbus Sans L'"
-       font-size="16"
-       panose-1="2 11 5 2 2 1 4 2 2 3"
-       units-per-em="1000"
-       underline-position="-75"
-       underline-thickness="50"
-       slope="0"
-       x-height="450"
-       cap-height="687"
-       ascent="918"
-       descent="-230"
-       font-weight="400"
-       id="font-face19"
-       stemv="0"
-       stemh="0"
-       accent-height="0"
-       ideographic="0"
-       alphabetic="0"
-       mathematical="0"
-       hanging="0"
-       v-ideographic="0"
-       v-alphabetic="0"
-       v-mathematical="0"
-       v-hanging="0"
-       strikethrough-position="0"
-       strikethrough-thickness="0"
-       overline-position="0"
-       overline-thickness="0">
-      <font-face-src>
-        <font-face-name
-           name="Tahoma" />
-      </font-face-src>
-    </font-face>
-    <font-face
-       font-family="'Tahoma','Nimbus Sans L'"
-       font-size="16"
-       panose-1="2 11 9 2 3 0 4 2 2 3"
-       units-per-em="1000"
-       underline-position="-75"
-       underline-thickness="50"
-       slope="0"
-       x-height="501"
-       cap-height="682"
-       ascent="923"
-       descent="-235"
-       font-weight="700"
-       id="font-face21"
-       stemv="0"
-       stemh="0"
-       accent-height="0"
-       ideographic="0"
-       alphabetic="0"
-       mathematical="0"
-       hanging="0"
-       v-ideographic="0"
-       v-alphabetic="0"
-       v-mathematical="0"
-       v-hanging="0"
-       strikethrough-position="0"
-       strikethrough-thickness="0"
-       overline-position="0"
-       overline-thickness="0">
-      <font-face-src>
-        <font-face-name
-           name="Tahoma-Bold" />
-      </font-face-src>
-    </font-face>
-    <marker
-       orient="auto"
-       overflow="visible"
-       markerUnits="strokeWidth"
-       id="FilledArrow_Marker_3-3"
-       stroke-miterlimit="10"
-       viewBox="-1 -5 11 10"
-       markerWidth="11"
-       markerHeight="10"
-       color="#45b8de"
-       stroke-linejoin="miter">
-      <g
-         id="g16-6">
-        <path
-           d="M8 0L0-3v6z"
-           id="path14-7"
-           fill="currentColor"
-           stroke="currentColor"
-           stroke-width="1" />
-      </g>
-    </marker>
-  </defs>
-  <path
-     id="line31"
-     d="M24 95h557"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="none"
-     stroke-opacity="1"
-     marker-end="url(#FilledArrow_Marker)" />
-  <path
-     d="M37 270h549l1 1v88l-1 1H37l-1-1v-88z"
-     id="path36"
-     fill="#fff"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <circle
-     id="ellipse53"
-     cy="95"
-     cx="188"
-     r="23"
-     fill="#e6ba31"
-     fill-opacity="1"
-     stroke="none"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <circle
-     id="ellipse55"
-     cy="95"
-     cx="188"
-     r="23"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <path
-     id="line58"
-     d="M188 118l-1 132"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="2,6"
-     stroke-opacity="1"
-     marker-end="url(#FilledArrow_Marker_2)" />
-  <circle
-     id="ellipse66"
-     cy="95"
-     cx="258"
-     r="23"
-     fill="#ff5a01"
-     fill-opacity="1"
-     stroke="none"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <circle
-     id="ellipse68"
-     cy="95"
-     cx="258"
-     r="23"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <circle
-     id="ellipse74"
-     cy="95"
-     cx="131"
-     r="23"
-     fill="#6cb33e"
-     fill-opacity="1"
-     stroke="none"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <circle
-     id="ellipse76"
-     cy="95"
-     cx="131"
-     r="23"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <circle
-     id="ellipse79"
-     cy="95"
-     cx="329"
-     r="23"
-     fill="#e739ce"
-     fill-opacity="1"
-     stroke="none"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <circle
-     id="ellipse81"
-     cy="95"
-     cx="329"
-     r="23"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <path
-     id="line84"
-     d="M131 118v132"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="2,6"
-     stroke-opacity="1"
-     marker-end="url(#FilledArrow_Marker_2)" />
-  <path
-     id="line87"
-     d="M329 118v132"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="2,6"
-     stroke-opacity="1"
-     marker-end="url(#FilledArrow_Marker_2)" />
-  <path
-     id="line106"
-     d="M131 362v66"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="2,5.99999997"
-     stroke-opacity="1"
-     marker-end="url(#FilledArrow_Marker_2)" />
-  <path
-     id="line138"
-     d="M24 471h557"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="none"
-     stroke-opacity="1"
-     marker-end="url(#FilledArrow_Marker)" />
-  <path
-     id="path151"
-     d="M546 447h1l2 2v44l-2 2h-1l-2-2v-44z"
-     fill="#34302c"
-     fill-opacity="1"
-     stroke="none"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <circle
-     id="ellipse154"
-     cy="471"
-     cx="131"
-     r="23"
-     fill="#6cb33e"
-     fill-opacity="1"
-     stroke="none"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <circle
-     id="ellipse156"
-     cy="471"
-     cx="131"
-     r="23"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <path
-     id="line165"
-     d="M258 118l-1 132"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="2,6"
-     stroke-opacity="1"
-     marker-end="url(#FilledArrow_Marker_2)" />
-  <text
-     y="278"
-     x="-43"
-     id="text937"
-     stroke-dasharray="none"
-     stroke-opacity="1"
-     stroke="none"
-     fill-opacity="1"
-     fill="#34302c">
-    <tspan
-       id="tspan933"
-       y="300"
-       x="111"
-       font-weight="700"
-       font-size="24"
-       font-family="Tahoma,'Nimbus Sans L'"
-       fill="#34302c">onBackpressureBuffer ( <tspan
-   id="tspan923"
-   font-weight="400"
-   font-size="21">maxSize = 2</tspan>
- )</tspan>
-  </text>
-  <circle
-     cx="258"
-     cy="95"
-     id="ellipse939"
-     r="23"
-     fill="#ff5a01"
-     fill-opacity="1"
-     stroke="none"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <circle
-     cx="258"
-     cy="95"
-     id="ellipse941"
-     r="23"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <circle
-     cx="329"
-     cy="95"
-     id="ellipse943"
-     r="23"
-     fill="#e739ce"
-     fill-opacity="1"
-     stroke="none"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <circle
-     cx="329"
-     cy="95"
-     id="ellipse945"
-     r="23"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <path
-     id="line940"
-     d="M78 470l-1-90"
-     fill="none"
-     fill-opacity="1"
-     stroke="#45b8de"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="1.99999997,5.99999991"
-     stroke-opacity="1"
-     marker-end="url(#FilledArrow_Marker_3-3)" />
-  <text
-     y="57"
-     x="-461"
-     transform="rotate(-90)"
-     id="text944"
-     fill="#45b8de"
-     fill-opacity="1"
-     stroke="none"
-     stroke-dasharray="none"
-     stroke-opacity="1">
-    <tspan
-       font-size="14"
-       font-weight="400"
-       x="-461"
-       y="70"
-       id="tspan942"
-       font-family="Tahoma,'Nimbus Sans L'"
-       fill="#45b8de">request(1)</tspan>
-  </text>
-  <path
-     id="line1113"
-     d="M78 268l-1-150"
-     fill="none"
-     fill-opacity="1"
-     stroke="#45b8de"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="1.99999998,5.99999998"
-     stroke-opacity="1"
-     marker-end="url(#FilledArrow_Marker_3-3)" />
-  <text
-     id="text1117"
-     transform="rotate(-90)"
-     x="-259"
-     y="57"
-     fill="#45b8de"
-     fill-opacity="1"
-     stroke="none"
-     stroke-dasharray="none"
-     stroke-opacity="1">
-    <tspan
-       id="tspan1115"
-       y="70"
-       x="-259"
-       font-weight="400"
-       font-size="14"
-       font-family="Tahoma,'Nimbus Sans L'"
-       fill="#45b8de">request(<tspan
-   id="tspan1121"
-   font-weight="700">unbounded</tspan>
- )</tspan>
-  </text>
-  <path
-     id="line1123"
-     d="m 329.13193,361.11581 v 79.40864"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2.00000001, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)"
-     sodipodi:nodetypes="cc" />
-  <path
-     d="M111 322h41c5 0 8 7 8 15 0 7-3 14-8 14h-41c-5 0-9-7-9-14 0-8 4-15 9-15z"
-     id="path22706"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-miterlimit="4"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <path
-     d="M173 323h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z"
-     id="path22706-1"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-miterlimit="4"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <path
-     id="path22771"
-     d="M239 323h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-miterlimit="4"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <circle
-     cx="180"
-     cy="337"
-     id="ellipse947"
-     r="11"
-     fill="#e6ba31"
-     fill-opacity="1"
-     stroke="none"
-     stroke-width="1"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <circle
-     cx="246"
-     cy="337"
-     id="ellipse983"
-     r="11"
-     fill="#e6ba31"
-     fill-opacity="1"
-     stroke="none"
-     stroke-width="1"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <circle
-     r="11"
-     id="circle22801"
-     cy="337"
-     cx="274"
-     fill="#ff5a01"
-     fill-opacity="1"
-     stroke="none"
-     stroke-width="1"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <path
-     d="M73 313h486"
-     id="line130-4"
-     fill="none"
-     fill-opacity="1"
-     stroke="#34302c"
-     stroke-width="2"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-dasharray="none"
-     stroke-opacity="1" />
-  <path
-     d="M194 323v28"
-     id="path22839"
-     fill="none"
-     fill-rule="evenodd"
-     stroke="#000"
-     stroke-width="1"
-     stroke-linecap="butt"
-     stroke-linejoin="miter"
-     stroke-opacity="1" />
-  <path
-     id="path22841"
-     d="M132 323v28"
-     fill="none"
-     fill-rule="evenodd"
-     stroke="#000"
-     stroke-width="1"
-     stroke-linecap="butt"
-     stroke-linejoin="miter"
-     stroke-opacity="1" />
-  <path
-     d="M260 323v28"
-     id="path22843"
-     fill="none"
-     fill-rule="evenodd"
-     stroke="#000"
-     stroke-width="1"
-     stroke-linecap="butt"
-     stroke-linejoin="miter"
-     stroke-opacity="1" />
-  <g
-     transform="translate(-219.88237,84.497438)"
-     id="g15622">
-    <path
-       style="fill:#ef2200;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:connector-curvature="0"
-       d="m 566.60156,403.15625 -2,2 h -3 l -31,-31 v -3 l 2,-2 h 3 l 31,31 z"
-       id="path1034" />
-    <path
-       style="fill:#ef2200;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:connector-curvature="0"
-       d="m 564.60156,369.15625 2,2 v 3 l -31,31 h -3 l -2,-2 v -3 l 31,-31 z"
-       id="path1036" />
-  </g>
-  <path
-     d="m 363.6436,268 -1,-150"
-     id="path9497"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#45b8de;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99999998, 5.99999998;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_3-3)" />
-  <text
-     y="342.64359"
-     x="-259"
-     transform="rotate(-90)"
-     id="text9503"
-     style="fill:#45b8de;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
-    <tspan
-       font-size="14"
-       font-weight="400"
-       x="-259"
-       y="355.64359"
-       id="tspan9501"
-       style="font-weight:400;font-size:14px;font-family:Tahoma, 'Nimbus Sans L';fill:#45b8de">cancel()</tspan>
-  </text>
-  <path
-     stroke-miterlimit="4"
-     d="m 308.77554,323 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
-     id="path9505"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     r="11"
-     id="circle9507"
-     cy="337"
-     cx="315.77554"
-     style="fill:#e6ba31;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     cx="343.77554"
-     cy="337"
-     id="circle9509"
-     r="11"
-     style="fill:#ff5a01;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="path9511"
-     d="m 329.77554,323 v 28"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 65 532.71 434" width="532.71" height="434" id="svg190">
+ <defs id="defs23">
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g4">
+    <path d="M12 0L0-4v9z" id="path2" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face7" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma-Bold"/>
+   </font-face-src>
+  </font-face>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g11">
+    <path d="M8 0L0-3v6z" id="path9" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3" stroke-miterlimit="10" viewBox="-6 -3 7 6" markerWidth="7" markerHeight="6" color="#34302c" stroke-linejoin="miter">
+   <g id="g16">
+    <path d="M-5 0l5 2v-4z" id="path14" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="16" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face19" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma"/>
+   </font-face-src>
+  </font-face>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="16" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face21" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma-Bold"/>
+   </font-face-src>
+  </font-face>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g16-6">
+    <path d="M8 0L0-3v6z" id="path14-7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+ </defs>
+ <path id="line31" d="M24.01 94h476.86" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
+ <path d="M36.06 269H543.8l.92 1v88l-.92 1H36.06l-.92-1v-88z" id="path36" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse53" cy="94" cx="186.42" r="23" fill="#e6ba31" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse55" cy="94" cx="186.42" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line58" d="M186.42 117l-1 132" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <circle id="ellipse66" cy="94" cx="256.42" r="23" fill="#ff5a01" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse68" cy="94" cx="256.42" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse74" cy="94" cx="129.42" r="23" fill="#6cb33e" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse76" cy="94" cx="129.42" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse79" cy="94" cx="327.42" r="23" fill="#e739ce" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse81" cy="94" cx="327.42" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line84" d="M129.42 117v132" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <path id="line87" d="M327.42 117v132" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <path id="line106" d="M129.42 361v66" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,5.99999997" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <path id="line138" d="M24.01 470h476.86" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
+ <circle id="ellipse154" cy="470" cx="129.42" r="23" fill="#6cb33e" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse156" cy="470" cx="129.42" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line165" d="M256.42 117l-1 132" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <text y="277" x="-64.58" id="text937" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan933" y="299" x="89.42" font-weight="700" font-size="24" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c">onBackpressureBuffer ( <tspan id="tspan923" font-weight="400" font-size="21">maxSize = 2</tspan> )</tspan>
+ </text>
+ <circle cx="256.42" cy="94" id="ellipse939" r="23" fill="#ff5a01" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="256.42" cy="94" id="ellipse941" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="327.42" cy="94" id="ellipse943" r="23" fill="#e739ce" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="327.42" cy="94" id="ellipse945" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line940" d="M76.42 469l-1-90" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999997,5.99999991" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3)"/>
+ <text y="55.42" x="-460" transform="rotate(-90)" id="text944" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="14" font-weight="400" x="-460" y="68.42" id="tspan942" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request(1)</tspan>
+ </text>
+ <path id="line1113" d="M76.42 267l-1-150" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999998,5.99999998" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3)"/>
+ <text id="text1117" transform="rotate(-90)" x="-258" y="55.42" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan1115" y="68.42" x="-258" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request(<tspan id="tspan1121" font-weight="700">unbounded</tspan> )</tspan>
+ </text>
+ <path id="line1123" d="M327.55 360.12v79.4" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000001,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <path d="M109.42 321h41c5 0 8 7 8 15 0 7-3 14-8 14h-41c-5 0-9-7-9-14 0-8 4-15 9-15z" id="path22706" stroke-miterlimit="4" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M171.42 322h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z" id="path22706-1" stroke-miterlimit="4" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path22771" d="M237.42 322h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z" stroke-miterlimit="4" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="178.42" cy="336" id="ellipse947" r="11" fill="#e6ba31" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="244.42" cy="336" id="ellipse983" r="11" fill="#e6ba31" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="11" id="circle22801" cy="336" cx="272.42" fill="#ff5a01" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M51.42 312h486" id="line130-4" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M192.42 322v28" id="path22839" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
+ <path id="path22841" d="M130.42 322v28" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
+ <path d="M258.42 322v28" id="path22843" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
+ <g transform="translate(-221.46 83.5)" id="g15622" fill="#ef2200" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <path d="M566.6 403.16l-2 2h-3l-31-31v-3l2-2h3l31 31z" id="path1034"/>
+  <path d="M564.6 369.16l2 2v3l-31 31h-3l-2-2v-3l31-31z" id="path1036"/>
+ </g>
+ <path d="M362.06 267l-1-150" id="path9497" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999998,5.99999998" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3)"/>
+ <text y="341.06" x="-258" transform="rotate(-90)" id="text9503" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="14" font-weight="400" x="-258" y="354.06" id="tspan9501" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">cancel()</tspan>
+ </text>
+ <path stroke-miterlimit="4" d="M307.2 322h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z" id="path9505" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="11" id="circle9507" cy="336" cx="314.2" fill="#e6ba31" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="342.2" cy="336" id="circle9509" r="11" fill="#ff5a01" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path9511" d="M328.2 322v28" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
 </svg>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBufferWithMaxSize.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBufferWithMaxSize.svg
@@ -1,102 +1,754 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 65 595 435" width="595" height="435" id="svg190">
- <defs id="defs23">
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
-   <g id="g4">
-    <path d="M12 0L0-4v9z" id="path2" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face7" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
-   <font-face-src>
-    <font-face-name name="Tahoma-Bold"/>
-   </font-face-src>
-  </font-face>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g11">
-    <path d="M8 0L0-3v6z" id="path9" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3" stroke-miterlimit="10" viewBox="-6 -3 7 6" markerWidth="7" markerHeight="6" color="#34302c" stroke-linejoin="miter">
-   <g id="g16">
-    <path d="M-5 0l5 2v-4z" id="path14" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="16" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face19" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
-   <font-face-src>
-    <font-face-name name="Tahoma"/>
-   </font-face-src>
-  </font-face>
-  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="16" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face21" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
-   <font-face-src>
-    <font-face-name name="Tahoma-Bold"/>
-   </font-face-src>
-  </font-face>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
-   <g id="g16-6">
-    <path d="M8 0L0-3v6z" id="path14-7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
- </defs>
- <path id="line31" d="M24 95h557" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
- <path d="M37 270h549l1 1v88l-1 1H37l-1-1v-88z" id="path36" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <circle id="ellipse53" cy="95" cx="188" r="23" fill="#e6ba31" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
- <circle id="ellipse55" cy="95" cx="188" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <path id="line58" d="M188 118l-1 132" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
- <path id="line63" d="M393 119v131" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
- <circle id="ellipse66" cy="95" cx="258" r="23" fill="#ff5a01" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
- <circle id="ellipse68" cy="95" cx="258" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <path id="path71" d="M393 70h1l2 2v45l-2 2h-1l-2-2V72z" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
- <circle id="ellipse74" cy="95" cx="131" r="23" fill="#6cb33e" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
- <circle id="ellipse76" cy="95" cx="131" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <circle id="ellipse79" cy="95" cx="329" r="23" fill="#e739ce" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
- <circle id="ellipse81" cy="95" cx="329" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <path id="line84" d="M131 118v132" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
- <path id="line87" d="M329 118v132" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
- <path id="line106" d="M131 362v66" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,5.99999997" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
- <path id="line112" d="M457 362v66" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,5.99999997" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
- <path id="line115" d="M509 362l1 66" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,5.99999997" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
- <path id="line138" d="M24 471h557" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
- <circle id="ellipse146" cy="471" cx="457" r="23" fill="#ff5a01" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
- <circle id="ellipse148" cy="471" cx="457" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <path id="path151" d="M546 447h1l2 2v44l-2 2h-1l-2-2v-44z" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
- <circle id="ellipse154" cy="471" cx="131" r="23" fill="#6cb33e" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
- <circle id="ellipse156" cy="471" cx="131" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <circle id="ellipse159" cy="471" cx="510" r="23" fill="#e739ce" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
- <circle id="ellipse161" cy="471" cx="510" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <path id="line165" d="M258 118l-1 132" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
- <text y="278" x="-43" id="text937" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan933" y="300" x="111" font-weight="700" font-size="24" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c">onBackpressureBuffer ( <tspan id="tspan923" font-weight="400" font-size="21">maxSize = 2</tspan> )</tspan>
- </text>
- <circle cx="258" cy="95" id="ellipse939" r="23" fill="#ff5a01" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
- <circle cx="258" cy="95" id="ellipse941" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <circle cx="329" cy="95" id="ellipse943" r="23" fill="#e739ce" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
- <circle cx="329" cy="95" id="ellipse945" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <path id="line940" d="M78 470l-1-90" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999997,5.99999991" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3)"/>
- <text y="57" x="-461" transform="rotate(-90)" id="text944" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
-  <tspan font-size="14" font-weight="400" x="-461" y="70" id="tspan942" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request(1)</tspan>
- </text>
- <path id="line1093" d="M418 470l-1-90" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999997,5.99999991" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3)"/>
- <text id="text1097" transform="rotate(-90)" x="-461" y="397" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan1095" y="410" x="-461" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request(2)</tspan>
- </text>
- <path id="line1113" d="M78 268l-1-150" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999998,5.99999998" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3)"/>
- <text id="text1117" transform="rotate(-90)" x="-259" y="57" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan1115" y="70" x="-259" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request(<tspan id="tspan1121" font-weight="700">unbounded</tspan> )</tspan>
- </text>
- <path id="line1123" d="M545 362l1 66" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,5.99999997" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
- <path d="M111 322h41c5 0 8 7 8 15 0 7-3 14-8 14h-41c-5 0-9-7-9-14 0-8 4-15 9-15z" id="path22706" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
- <path d="M173 323h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z" id="path22706-1" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
- <path id="path22771" d="M239 323h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
- <path d="M305 323h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z" id="path22773" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
- <path id="path22775" d="M437 323h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
- <circle cx="180" cy="337" id="ellipse947" r="11" fill="#e6ba31" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
- <circle cx="246" cy="337" id="ellipse983" r="11" fill="#e6ba31" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
- <circle r="11" id="circle22801" cy="337" cx="274" fill="#ff5a01" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
- <circle cx="312" cy="337" id="circle22805" r="11" fill="#ff5a01" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
- <circle cx="340" cy="337" id="circle22807" r="11" fill="#e739ce" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
- <path d="M73 313h486" id="line130-4" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <path d="M194 323v28" id="path22839" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
- <path id="path22841" d="M132 323v28" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
- <path d="M260 323v28" id="path22843" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
- <path id="path22845" d="M326 323v28" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
- <path d="M458 323v28" id="path22847" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   viewBox="18 65 595 435"
+   width="595"
+   height="435"
+   id="svg190"
+   sodipodi:docname="onBackpressureBufferWithMaxSize.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata4243">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview4241"
+     showgrid="false"
+     inkscape:current-layer="svg190" />
+  <defs
+     id="defs23">
+    <marker
+       orient="auto"
+       overflow="visible"
+       markerUnits="strokeWidth"
+       id="FilledArrow_Marker"
+       stroke-miterlimit="10"
+       viewBox="-1 -6 14 12"
+       markerWidth="14"
+       markerHeight="12"
+       color="#34302c"
+       stroke-linejoin="miter">
+      <g
+         id="g4">
+        <path
+           d="M12 0L0-4v9z"
+           id="path2"
+           fill="currentColor"
+           stroke="currentColor"
+           stroke-width="1" />
+      </g>
+    </marker>
+    <font-face
+       font-family="'Tahoma','Nimbus Sans L'"
+       font-size="24"
+       panose-1="2 11 9 2 3 0 4 2 2 3"
+       units-per-em="1000"
+       underline-position="-75"
+       underline-thickness="50"
+       slope="0"
+       x-height="501"
+       cap-height="682"
+       ascent="923"
+       descent="-235"
+       font-weight="700"
+       id="font-face7"
+       stemv="0"
+       stemh="0"
+       accent-height="0"
+       ideographic="0"
+       alphabetic="0"
+       mathematical="0"
+       hanging="0"
+       v-ideographic="0"
+       v-alphabetic="0"
+       v-mathematical="0"
+       v-hanging="0"
+       strikethrough-position="0"
+       strikethrough-thickness="0"
+       overline-position="0"
+       overline-thickness="0">
+      <font-face-src>
+        <font-face-name
+           name="Tahoma-Bold" />
+      </font-face-src>
+    </font-face>
+    <marker
+       orient="auto"
+       overflow="visible"
+       markerUnits="strokeWidth"
+       id="FilledArrow_Marker_2"
+       stroke-miterlimit="10"
+       viewBox="-1 -5 11 10"
+       markerWidth="11"
+       markerHeight="10"
+       color="#34302c"
+       stroke-linejoin="miter">
+      <g
+         id="g11">
+        <path
+           d="M8 0L0-3v6z"
+           id="path9"
+           fill="currentColor"
+           stroke="currentColor"
+           stroke-width="1" />
+      </g>
+    </marker>
+    <marker
+       orient="auto"
+       overflow="visible"
+       markerUnits="strokeWidth"
+       id="FilledArrow_Marker_3"
+       stroke-miterlimit="10"
+       viewBox="-6 -3 7 6"
+       markerWidth="7"
+       markerHeight="6"
+       color="#34302c"
+       stroke-linejoin="miter">
+      <g
+         id="g16">
+        <path
+           d="M-5 0l5 2v-4z"
+           id="path14"
+           fill="currentColor"
+           stroke="currentColor"
+           stroke-width="1" />
+      </g>
+    </marker>
+    <font-face
+       font-family="'Tahoma','Nimbus Sans L'"
+       font-size="16"
+       panose-1="2 11 5 2 2 1 4 2 2 3"
+       units-per-em="1000"
+       underline-position="-75"
+       underline-thickness="50"
+       slope="0"
+       x-height="450"
+       cap-height="687"
+       ascent="918"
+       descent="-230"
+       font-weight="400"
+       id="font-face19"
+       stemv="0"
+       stemh="0"
+       accent-height="0"
+       ideographic="0"
+       alphabetic="0"
+       mathematical="0"
+       hanging="0"
+       v-ideographic="0"
+       v-alphabetic="0"
+       v-mathematical="0"
+       v-hanging="0"
+       strikethrough-position="0"
+       strikethrough-thickness="0"
+       overline-position="0"
+       overline-thickness="0">
+      <font-face-src>
+        <font-face-name
+           name="Tahoma" />
+      </font-face-src>
+    </font-face>
+    <font-face
+       font-family="'Tahoma','Nimbus Sans L'"
+       font-size="16"
+       panose-1="2 11 9 2 3 0 4 2 2 3"
+       units-per-em="1000"
+       underline-position="-75"
+       underline-thickness="50"
+       slope="0"
+       x-height="501"
+       cap-height="682"
+       ascent="923"
+       descent="-235"
+       font-weight="700"
+       id="font-face21"
+       stemv="0"
+       stemh="0"
+       accent-height="0"
+       ideographic="0"
+       alphabetic="0"
+       mathematical="0"
+       hanging="0"
+       v-ideographic="0"
+       v-alphabetic="0"
+       v-mathematical="0"
+       v-hanging="0"
+       strikethrough-position="0"
+       strikethrough-thickness="0"
+       overline-position="0"
+       overline-thickness="0">
+      <font-face-src>
+        <font-face-name
+           name="Tahoma-Bold" />
+      </font-face-src>
+    </font-face>
+    <marker
+       orient="auto"
+       overflow="visible"
+       markerUnits="strokeWidth"
+       id="FilledArrow_Marker_3-3"
+       stroke-miterlimit="10"
+       viewBox="-1 -5 11 10"
+       markerWidth="11"
+       markerHeight="10"
+       color="#45b8de"
+       stroke-linejoin="miter">
+      <g
+         id="g16-6">
+        <path
+           d="M8 0L0-3v6z"
+           id="path14-7"
+           fill="currentColor"
+           stroke="currentColor"
+           stroke-width="1" />
+      </g>
+    </marker>
+  </defs>
+  <path
+     id="line31"
+     d="M24 95h557"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="none"
+     stroke-opacity="1"
+     marker-end="url(#FilledArrow_Marker)" />
+  <path
+     d="M37 270h549l1 1v88l-1 1H37l-1-1v-88z"
+     id="path36"
+     fill="#fff"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <circle
+     id="ellipse53"
+     cy="95"
+     cx="188"
+     r="23"
+     fill="#e6ba31"
+     fill-opacity="1"
+     stroke="none"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <circle
+     id="ellipse55"
+     cy="95"
+     cx="188"
+     r="23"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <path
+     id="line58"
+     d="M188 118l-1 132"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="2,6"
+     stroke-opacity="1"
+     marker-end="url(#FilledArrow_Marker_2)" />
+  <circle
+     id="ellipse66"
+     cy="95"
+     cx="258"
+     r="23"
+     fill="#ff5a01"
+     fill-opacity="1"
+     stroke="none"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <circle
+     id="ellipse68"
+     cy="95"
+     cx="258"
+     r="23"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <circle
+     id="ellipse74"
+     cy="95"
+     cx="131"
+     r="23"
+     fill="#6cb33e"
+     fill-opacity="1"
+     stroke="none"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <circle
+     id="ellipse76"
+     cy="95"
+     cx="131"
+     r="23"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <circle
+     id="ellipse79"
+     cy="95"
+     cx="329"
+     r="23"
+     fill="#e739ce"
+     fill-opacity="1"
+     stroke="none"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <circle
+     id="ellipse81"
+     cy="95"
+     cx="329"
+     r="23"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <path
+     id="line84"
+     d="M131 118v132"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="2,6"
+     stroke-opacity="1"
+     marker-end="url(#FilledArrow_Marker_2)" />
+  <path
+     id="line87"
+     d="M329 118v132"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="2,6"
+     stroke-opacity="1"
+     marker-end="url(#FilledArrow_Marker_2)" />
+  <path
+     id="line106"
+     d="M131 362v66"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="2,5.99999997"
+     stroke-opacity="1"
+     marker-end="url(#FilledArrow_Marker_2)" />
+  <path
+     id="line138"
+     d="M24 471h557"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="none"
+     stroke-opacity="1"
+     marker-end="url(#FilledArrow_Marker)" />
+  <path
+     id="path151"
+     d="M546 447h1l2 2v44l-2 2h-1l-2-2v-44z"
+     fill="#34302c"
+     fill-opacity="1"
+     stroke="none"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <circle
+     id="ellipse154"
+     cy="471"
+     cx="131"
+     r="23"
+     fill="#6cb33e"
+     fill-opacity="1"
+     stroke="none"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <circle
+     id="ellipse156"
+     cy="471"
+     cx="131"
+     r="23"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <path
+     id="line165"
+     d="M258 118l-1 132"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="2,6"
+     stroke-opacity="1"
+     marker-end="url(#FilledArrow_Marker_2)" />
+  <text
+     y="278"
+     x="-43"
+     id="text937"
+     stroke-dasharray="none"
+     stroke-opacity="1"
+     stroke="none"
+     fill-opacity="1"
+     fill="#34302c">
+    <tspan
+       id="tspan933"
+       y="300"
+       x="111"
+       font-weight="700"
+       font-size="24"
+       font-family="Tahoma,'Nimbus Sans L'"
+       fill="#34302c">onBackpressureBuffer ( <tspan
+   id="tspan923"
+   font-weight="400"
+   font-size="21">maxSize = 2</tspan>
+ )</tspan>
+  </text>
+  <circle
+     cx="258"
+     cy="95"
+     id="ellipse939"
+     r="23"
+     fill="#ff5a01"
+     fill-opacity="1"
+     stroke="none"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <circle
+     cx="258"
+     cy="95"
+     id="ellipse941"
+     r="23"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <circle
+     cx="329"
+     cy="95"
+     id="ellipse943"
+     r="23"
+     fill="#e739ce"
+     fill-opacity="1"
+     stroke="none"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <circle
+     cx="329"
+     cy="95"
+     id="ellipse945"
+     r="23"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <path
+     id="line940"
+     d="M78 470l-1-90"
+     fill="none"
+     fill-opacity="1"
+     stroke="#45b8de"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="1.99999997,5.99999991"
+     stroke-opacity="1"
+     marker-end="url(#FilledArrow_Marker_3-3)" />
+  <text
+     y="57"
+     x="-461"
+     transform="rotate(-90)"
+     id="text944"
+     fill="#45b8de"
+     fill-opacity="1"
+     stroke="none"
+     stroke-dasharray="none"
+     stroke-opacity="1">
+    <tspan
+       font-size="14"
+       font-weight="400"
+       x="-461"
+       y="70"
+       id="tspan942"
+       font-family="Tahoma,'Nimbus Sans L'"
+       fill="#45b8de">request(1)</tspan>
+  </text>
+  <path
+     id="line1113"
+     d="M78 268l-1-150"
+     fill="none"
+     fill-opacity="1"
+     stroke="#45b8de"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="1.99999998,5.99999998"
+     stroke-opacity="1"
+     marker-end="url(#FilledArrow_Marker_3-3)" />
+  <text
+     id="text1117"
+     transform="rotate(-90)"
+     x="-259"
+     y="57"
+     fill="#45b8de"
+     fill-opacity="1"
+     stroke="none"
+     stroke-dasharray="none"
+     stroke-opacity="1">
+    <tspan
+       id="tspan1115"
+       y="70"
+       x="-259"
+       font-weight="400"
+       font-size="14"
+       font-family="Tahoma,'Nimbus Sans L'"
+       fill="#45b8de">request(<tspan
+   id="tspan1121"
+   font-weight="700">unbounded</tspan>
+ )</tspan>
+  </text>
+  <path
+     id="line1123"
+     d="m 329.13193,361.11581 v 79.40864"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2.00000001, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)"
+     sodipodi:nodetypes="cc" />
+  <path
+     d="M111 322h41c5 0 8 7 8 15 0 7-3 14-8 14h-41c-5 0-9-7-9-14 0-8 4-15 9-15z"
+     id="path22706"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-miterlimit="4"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <path
+     d="M173 323h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z"
+     id="path22706-1"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-miterlimit="4"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <path
+     id="path22771"
+     d="M239 323h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-miterlimit="4"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <circle
+     cx="180"
+     cy="337"
+     id="ellipse947"
+     r="11"
+     fill="#e6ba31"
+     fill-opacity="1"
+     stroke="none"
+     stroke-width="1"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <circle
+     cx="246"
+     cy="337"
+     id="ellipse983"
+     r="11"
+     fill="#e6ba31"
+     fill-opacity="1"
+     stroke="none"
+     stroke-width="1"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <circle
+     r="11"
+     id="circle22801"
+     cy="337"
+     cx="274"
+     fill="#ff5a01"
+     fill-opacity="1"
+     stroke="none"
+     stroke-width="1"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <path
+     d="M73 313h486"
+     id="line130-4"
+     fill="none"
+     fill-opacity="1"
+     stroke="#34302c"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-dasharray="none"
+     stroke-opacity="1" />
+  <path
+     d="M194 323v28"
+     id="path22839"
+     fill="none"
+     fill-rule="evenodd"
+     stroke="#000"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke-opacity="1" />
+  <path
+     id="path22841"
+     d="M132 323v28"
+     fill="none"
+     fill-rule="evenodd"
+     stroke="#000"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke-opacity="1" />
+  <path
+     d="M260 323v28"
+     id="path22843"
+     fill="none"
+     fill-rule="evenodd"
+     stroke="#000"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke-opacity="1" />
+  <g
+     transform="translate(-219.88237,84.497438)"
+     id="g15622">
+    <path
+       style="fill:#ef2200;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       d="m 566.60156,403.15625 -2,2 h -3 l -31,-31 v -3 l 2,-2 h 3 l 31,31 z"
+       id="path1034" />
+    <path
+       style="fill:#ef2200;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       d="m 564.60156,369.15625 2,2 v 3 l -31,31 h -3 l -2,-2 v -3 l 31,-31 z"
+       id="path1036" />
+  </g>
+  <path
+     d="m 363.6436,268 -1,-150"
+     id="path9497"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#45b8de;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99999998, 5.99999998;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_3-3)" />
+  <text
+     y="342.64359"
+     x="-259"
+     transform="rotate(-90)"
+     id="text9503"
+     style="fill:#45b8de;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
+    <tspan
+       font-size="14"
+       font-weight="400"
+       x="-259"
+       y="355.64359"
+       id="tspan9501"
+       style="font-weight:400;font-size:14px;font-family:Tahoma, 'Nimbus Sans L';fill:#45b8de">cancel()</tspan>
+  </text>
+  <path
+     stroke-miterlimit="4"
+     d="m 308.77554,323 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
+     id="path9505"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     r="11"
+     id="circle9507"
+     cy="337"
+     cx="315.77554"
+     style="fill:#e6ba31;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     cx="343.77554"
+     cy="337"
+     id="circle9509"
+     r="11"
+     style="fill:#ff5a01;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path9511"
+     d="m 329.77554,323 v 28"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
 </svg>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBufferWithMaxSizeConsumer.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBufferWithMaxSizeConsumer.svg
@@ -1,742 +1,139 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   version="1.1"
-   viewBox="18 65 594.86414 446"
-   width="594.86414"
-   height="446"
-   id="svg190"
-   sodipodi:docname="onBackpressureBufferWithMaxSizeHandler.svg"
-   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
-  <metadata
-     id="metadata4243">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="640"
-     inkscape:window-height="480"
-     id="namedview4241"
-     showgrid="false"
-     inkscape:current-layer="svg190"
-     fit-margin-top="5"
-     fit-margin-right="5"
-     fit-margin-left="5"
-     fit-margin-bottom="5" />
-  <defs
-     id="defs23">
-    <marker
-       orient="auto"
-       overflow="visible"
-       markerUnits="strokeWidth"
-       id="FilledArrow_Marker"
-       stroke-miterlimit="10"
-       viewBox="-1 -6 14 12"
-       markerWidth="14"
-       markerHeight="12"
-       style="color:#34302c;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10">
-      <g
-         id="g4">
-        <path
-           d="M 12,0 0,-4 v 9 z"
-           id="path2"
-           inkscape:connector-curvature="0"
-           style="fill:currentColor;stroke:currentColor;stroke-width:1" />
-      </g>
-    </marker>
-    <font-face
-       font-family="'Tahoma','Nimbus Sans L'"
-       font-size="24"
-       panose-1="2 11 9 2 3 0 4 2 2 3"
-       units-per-em="1000"
-       underline-position="-75"
-       underline-thickness="50"
-       slope="0"
-       x-height="501"
-       cap-height="682"
-       ascent="923"
-       descent="-235"
-       font-weight="700"
-       id="font-face7"
-       stemv="0"
-       stemh="0"
-       accent-height="0"
-       ideographic="0"
-       alphabetic="0"
-       mathematical="0"
-       hanging="0"
-       v-ideographic="0"
-       v-alphabetic="0"
-       v-mathematical="0"
-       v-hanging="0"
-       strikethrough-position="0"
-       strikethrough-thickness="0"
-       overline-position="0"
-       overline-thickness="0">
-      <font-face-src>
-        <font-face-name
-           name="Tahoma-Bold" />
-      </font-face-src>
-    </font-face>
-    <marker
-       orient="auto"
-       overflow="visible"
-       markerUnits="strokeWidth"
-       id="FilledArrow_Marker_2"
-       stroke-miterlimit="10"
-       viewBox="-1 -5 11 10"
-       markerWidth="11"
-       markerHeight="10"
-       style="color:#34302c;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10">
-      <g
-         id="g11">
-        <path
-           d="M 8,0 0,-3 v 6 z"
-           id="path9"
-           inkscape:connector-curvature="0"
-           style="fill:currentColor;stroke:currentColor;stroke-width:1" />
-      </g>
-    </marker>
-    <marker
-       orient="auto"
-       overflow="visible"
-       markerUnits="strokeWidth"
-       id="FilledArrow_Marker_3"
-       stroke-miterlimit="10"
-       viewBox="-6 -3 7 6"
-       markerWidth="7"
-       markerHeight="6"
-       style="color:#34302c;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10">
-      <g
-         id="g16">
-        <path
-           d="M -5,0 0,2 V -2 Z"
-           id="path14"
-           inkscape:connector-curvature="0"
-           style="fill:currentColor;stroke:currentColor;stroke-width:1" />
-      </g>
-    </marker>
-    <font-face
-       font-family="'Tahoma','Nimbus Sans L'"
-       font-size="16"
-       panose-1="2 11 5 2 2 1 4 2 2 3"
-       units-per-em="1000"
-       underline-position="-75"
-       underline-thickness="50"
-       slope="0"
-       x-height="450"
-       cap-height="687"
-       ascent="918"
-       descent="-230"
-       font-weight="400"
-       id="font-face19"
-       stemv="0"
-       stemh="0"
-       accent-height="0"
-       ideographic="0"
-       alphabetic="0"
-       mathematical="0"
-       hanging="0"
-       v-ideographic="0"
-       v-alphabetic="0"
-       v-mathematical="0"
-       v-hanging="0"
-       strikethrough-position="0"
-       strikethrough-thickness="0"
-       overline-position="0"
-       overline-thickness="0">
-      <font-face-src>
-        <font-face-name
-           name="Tahoma" />
-      </font-face-src>
-    </font-face>
-    <font-face
-       font-family="'Tahoma','Nimbus Sans L'"
-       font-size="16"
-       panose-1="2 11 9 2 3 0 4 2 2 3"
-       units-per-em="1000"
-       underline-position="-75"
-       underline-thickness="50"
-       slope="0"
-       x-height="501"
-       cap-height="682"
-       ascent="923"
-       descent="-235"
-       font-weight="700"
-       id="font-face21"
-       stemv="0"
-       stemh="0"
-       accent-height="0"
-       ideographic="0"
-       alphabetic="0"
-       mathematical="0"
-       hanging="0"
-       v-ideographic="0"
-       v-alphabetic="0"
-       v-mathematical="0"
-       v-hanging="0"
-       strikethrough-position="0"
-       strikethrough-thickness="0"
-       overline-position="0"
-       overline-thickness="0">
-      <font-face-src>
-        <font-face-name
-           name="Tahoma-Bold" />
-      </font-face-src>
-    </font-face>
-    <marker
-       orient="auto"
-       overflow="visible"
-       markerUnits="strokeWidth"
-       id="FilledArrow_Marker_3-3"
-       stroke-miterlimit="10"
-       viewBox="-1 -5 11 10"
-       markerWidth="11"
-       markerHeight="10"
-       style="color:#45b8de;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10">
-      <g
-         id="g16-6">
-        <path
-           d="M 8,0 0,-3 v 6 z"
-           id="path14-7"
-           inkscape:connector-curvature="0"
-           style="fill:currentColor;stroke:currentColor;stroke-width:1" />
-      </g>
-    </marker>
-    <marker
-       style="color:#45b8de;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10"
-       orient="auto"
-       overflow="visible"
-       markerUnits="strokeWidth"
-       id="FilledArrow_Marker_3-3-6"
-       stroke-miterlimit="10"
-       viewBox="-1 -5 11 10"
-       markerWidth="11"
-       markerHeight="10">
-      <g
-         id="g16-6-5">
-        <path
-           style="fill:currentColor;stroke:currentColor;stroke-width:1"
-           inkscape:connector-curvature="0"
-           d="M 8,0 0,-3 v 6 z"
-           id="path14-7-3" />
-      </g>
-    </marker>
-  </defs>
-  <path
-     id="line31"
-     d="M 24.014242,94 H 581.01424"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#FilledArrow_Marker)" />
-  <path
-     d="M 37.014242,268.2469 H 586.01424 l 1,1.1417 v 100.46969 l -1,1.1417 H 37.014242 l -1,-1.1417 V 269.3886 Z"
-     id="path36"
-     inkscape:connector-curvature="0"
-     style="fill:#ffffff;fill-opacity:1;stroke:#34302c;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     id="ellipse55"
-     cy="94"
-     cx="188.01424"
-     r="23"
-     style="fill:#e6ba31;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="line58"
-     d="m 188.01424,117 -1,132"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
-  <circle
-     id="ellipse68"
-     cy="94"
-     cx="258.01425"
-     r="23"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     id="ellipse76"
-     cy="94"
-     cx="131.01424"
-     r="23"
-     style="fill:#6cb33e;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     id="ellipse81"
-     cy="94"
-     cx="329.01425"
-     r="23"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="line84"
-     d="M 131.01424,117 V 249"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
-  <path
-     id="line87"
-     d="M 329.01424,117 V 249"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
-  <path
-     id="line106"
-     d="m 131.01424,373 v 66"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 5.99999997;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
-  <path
-     id="line112"
-     d="m 437.01424,373 v 66"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 5.99999997;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
-  <path
-     id="line115"
-     d="m 489.01424,373 1,66"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 5.99999997;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
-  <path
-     id="line138"
-     d="M 24.014242,482 H 581.01424"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#FilledArrow_Marker)" />
-  <circle
-     id="ellipse148"
-     cy="482"
-     cx="437.01425"
-     r="23"
-     style="fill:#e6ba31;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     id="ellipse156"
-     cy="482"
-     cx="131.01424"
-     r="23"
-     style="fill:#6cb33e;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     id="ellipse161"
-     cy="482"
-     cx="490.01425"
-     r="23"
-     style="fill:#ff5a01;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="line165"
-     d="m 258.01424,117 -1,132"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
-  <text
-     y="285"
-     x="-115.51897"
-     id="text937"
-     style="fill:#34302c;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
-    <tspan
-       id="tspan933"
-       y="307"
-       x="38.481033"
-       font-weight="700"
-       font-size="24"
-       style="font-weight:700;font-size:24px;font-family:Tahoma, 'Nimbus Sans L';fill:#34302c">onBackpressureBuffer ( <tspan
-   id="tspan923"
-   font-weight="400"
-   font-size="21"
-   style="font-weight:400;font-size:21px">maxSize = 2,</tspan>
-</tspan>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 65 594.86 446" width="594.86" height="446" id="svg190">
+ <defs id="defs23">
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g4">
+    <path d="M12 0L0-4v9z" id="path2" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face7" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma-Bold"/>
+   </font-face-src>
+  </font-face>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g11">
+    <path d="M8 0L0-3v6z" id="path9" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3" stroke-miterlimit="10" viewBox="-6 -3 7 6" markerWidth="7" markerHeight="6" color="#34302c" stroke-linejoin="miter">
+   <g id="g16">
+    <path d="M-5 0l5 2v-4z" id="path14" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="16" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face19" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma"/>
+   </font-face-src>
+  </font-face>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="16" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face21" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma-Bold"/>
+   </font-face-src>
+  </font-face>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g16-6">
+    <path d="M8 0L0-3v6z" id="path14-7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3-6" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g16-6-5">
+    <path d="M8 0L0-3v6z" id="path14-7-3" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+ </defs>
+ <path id="line31" d="M24.01 94h557" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
+ <path d="M37.01 268.25h549l1 1.14v100.47l-1 1.14h-549l-1-1.14V269.39z" id="path36" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse55" cy="94" cx="188.01" r="23" fill="#e6ba31" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line58" d="M188.01 117l-1 132" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <circle id="ellipse68" cy="94" cx="258.01" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse76" cy="94" cx="131.01" r="23" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse81" cy="94" cx="329.01" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line84" d="M131.01 117v132" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <path id="line87" d="M329.01 117v132" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <path id="line106" d="M131.01 373v66" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,5.99999997" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <path id="line112" d="M437.01 373v66" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,5.99999997" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <path id="line115" d="M489.01 373l1 66" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,5.99999997" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <path id="line138" d="M24.01 482h557" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
+ <circle id="ellipse148" cy="482" cx="437.01" r="23" fill="#e6ba31" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse156" cy="482" cx="131.01" r="23" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse161" cy="482" cx="490.01" r="23" fill="#ff5a01" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line165" d="M258.01 117l-1 132" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <circle cx="258.01" cy="94" id="ellipse941" r="23" fill="#ff5a01" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="329.01" cy="94" id="ellipse945" r="23" fill="#e739ce" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line940" d="M78.01 481l-1-90" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999997,5.99999991" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3)"/>
+ <text y="57.01" x="-472" transform="rotate(-90)" id="text944" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="14" font-weight="400" x="-472" y="70.01" id="tspan942" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request(1)</tspan>
+ </text>
+ <path id="line1093" d="M398.01 481l-1-90" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999997,5.99999991" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3)"/>
+ <text id="text1097" transform="rotate(-90)" x="-472" y="377.01" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan1095" y="390.01" x="-472" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request(2)</tspan>
+ </text>
+ <path id="line1113" d="M78.01 267l-1-150" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999998,5.99999998" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3)"/>
+ <text id="text1117" transform="rotate(-90)" x="-258" y="57.01" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan1115" y="70.01" x="-258" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request(<tspan id="tspan1121" font-weight="700">unbounded</tspan> )</tspan>
+ </text>
+ <path id="line1123" d="M545.01 373l1 66" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,5.99999997" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <path d="M111.01 333h41c5 0 8 7 8 15 0 7-3 14-8 14h-41c-5 0-9-7-9-14 0-8 4-15 9-15z" id="path22706" stroke-miterlimit="4" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M173.01 334h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z" id="path22706-1" stroke-miterlimit="4" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path22771" d="M239.01 334h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z" stroke-miterlimit="4" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path22775" d="M417.01 334h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z" stroke-miterlimit="4" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="180.01" cy="348" id="ellipse947" r="11" fill="#e6ba31" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="246.01" cy="348" id="ellipse983" r="11" fill="#e6ba31" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="11" id="circle22801" cy="348" cx="274.01" fill="#ff5a01" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M55.79 324h511.44" id="line130-4" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M194.01 334v28" id="path22839" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
+ <path id="path22841" d="M132.01 334v28" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
+ <path d="M260.01 334v28" id="path22843" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
+ <path d="M438.01 334v28" id="path22847" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
+ <rect id="rect269288" width="38.09" height="38.09" x="306.98" y="386.11" ry="9.87" rx="9.87" opacity=".98" fill="none" fill-opacity="1" stroke="#000" stroke-width="1.81" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0" stroke-opacity="1"/>
+ <path d="M318.15 386.74v-7.62h.32" id="path269290" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1.81" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path269292" d="M326.18 386.74v-7.62h.32" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1.81" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M334.22 386.74v-7.62h.31" id="path269294" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1.81" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path269296" d="M318.15 431.76v-7.62h.32" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1.81" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M326.18 431.76v-7.62h.32" id="path269298" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1.81" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path269300" d="M334.22 431.76v-7.62h.31" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1.81" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M344.35 405.12h7.62v.32" id="path269302" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1.81" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path269304" d="M344.35 396.7h7.62v.32" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1.81" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
+ <path transform="matrix(0 .34091 .20267 0 261.13 227.71)" d="M433.96 320.96l-28.32 16.35v-32.7z" id="path269306" opacity="1" fill="#000" fill-opacity="1" stroke="none" stroke-width="3.8" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0" stroke-opacity="1"/>
+ <path id="path269308" d="M299.35 397.12h7.62v.32" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1.81" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M299.35 413.22h7.62v.31" id="path269310" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1.81" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path269312" d="M344.35 413.22h7.62v.31" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1.81" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M299.35 405.12h7.62v.32" id="path269314" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1.81" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="326.34" cy="404.59" id="circle269485" r="11.36" fill="#e739ce" fill-opacity="1" stroke="#000" stroke-width=".99" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <g id="g3500" transform="translate(32)" stroke-dasharray="none" stroke-opacity="1">
+  <text id="text937" x="-115.52" y="285" fill="#34302c" fill-opacity="1" stroke="none">
+   <tspan font-size="24" font-weight="700" x="38.48" y="307" id="tspan933" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c">onBackpressureBuffer ( <tspan font-size="21" font-weight="400" id="tspan923">maxSize = 2,</tspan> </tspan>
   </text>
-  <circle
-     cx="258.01425"
-     cy="94"
-     id="ellipse941"
-     r="23"
-     style="fill:#ff5a01;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     cx="329.01425"
-     cy="94"
-     id="ellipse945"
-     r="23"
-     style="fill:#e739ce;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="line940"
-     d="m 78.014242,481 -1,-90"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#45b8de;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99999997, 5.99999991;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_3-3)" />
-  <text
-     y="57.014244"
-     x="-472"
-     transform="rotate(-90)"
-     id="text944"
-     style="fill:#45b8de;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
-    <tspan
-       font-size="14"
-       font-weight="400"
-       x="-472"
-       y="70.014244"
-       id="tspan942"
-       style="font-weight:400;font-size:14px;font-family:Tahoma, 'Nimbus Sans L';fill:#45b8de">request(1)</tspan>
+  <text y="285" x="356.35" id="text13224" fill="#34302c" fill-opacity="1" stroke="none">
+   <tspan id="tspan13222" y="307" x="510.35" font-weight="700" font-size="24" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c">)</tspan>
   </text>
-  <path
-     id="line1093"
-     d="m 398.01424,481 -1,-90"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#45b8de;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99999997, 5.99999991;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_3-3)" />
-  <text
-     id="text1097"
-     transform="rotate(-90)"
-     x="-472"
-     y="377.01425"
-     style="fill:#45b8de;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
-    <tspan
-       id="tspan1095"
-       y="390.01425"
-       x="-472"
-       font-weight="400"
-       font-size="14"
-       style="font-weight:400;font-size:14px;font-family:Tahoma, 'Nimbus Sans L';fill:#45b8de">request(2)</tspan>
-  </text>
-  <path
-     id="line1113"
-     d="m 78.014242,267 -1,-150"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#45b8de;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99999998, 5.99999998;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_3-3)" />
-  <text
-     id="text1117"
-     transform="rotate(-90)"
-     x="-258"
-     y="57.014244"
-     style="fill:#45b8de;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
-    <tspan
-       id="tspan1115"
-       y="70.014244"
-       x="-258"
-       font-weight="400"
-       font-size="14"
-       style="font-weight:400;font-size:14px;font-family:Tahoma, 'Nimbus Sans L';fill:#45b8de">request(<tspan
-   id="tspan1121"
-   font-weight="700"
-   style="font-weight:700">unbounded</tspan>
- )</tspan>
-  </text>
-  <path
-     id="line1123"
-     d="m 545.01424,373 1,66"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 5.99999997;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
-  <path
-     d="m 111.01424,333 h 41 c 5,0 8,7 8,15 0,7 -3,14 -8,14 h -41 c -5,0 -9,-7 -9,-14 0,-8 4,-15 9,-15 z"
-     id="path22706"
-     stroke-miterlimit="4"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     d="m 173.01424,334 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
-     id="path22706-1"
-     stroke-miterlimit="4"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="path22771"
-     d="m 239.01424,334 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
-     stroke-miterlimit="4"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="path22775"
-     d="m 417.01424,334 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
-     stroke-miterlimit="4"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     cx="180.01424"
-     cy="348"
-     id="ellipse947"
-     r="11"
-     style="fill:#e6ba31;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     cx="246.01424"
-     cy="348"
-     id="ellipse983"
-     r="11"
-     style="fill:#e6ba31;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     r="11"
-     id="circle22801"
-     cy="348"
-     cx="274.01425"
-     style="fill:#ff5a01;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     d="M 73.014242,324 H 559.01424"
-     id="line130-4"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     d="m 194.01424,334 v 28"
-     id="path22839"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     id="path22841"
-     d="m 132.01424,334 v 28"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="m 260.01424,334 v 28"
-     id="path22843"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="m 438.01424,334 v 28"
-     id="path22847"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <text
-     style="fill:#34302c;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1"
-     id="text13224"
-     x="356.34546"
-     y="285">
-    <tspan
-       style="font-weight:700;font-size:24px;font-family:Tahoma, 'Nimbus Sans L';fill:#34302c"
-       font-size="24"
-       font-weight="700"
-       x="510.34546"
-       y="307"
-       id="tspan13222">)</tspan>
-  </text>
-  <rect
-     style="opacity:0.98000004;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.80954421;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect269288"
-     width="38.091766"
-     height="38.091766"
-     x="306.97617"
-     y="386.10876"
-     ry="9.8690033"
-     rx="9.8690033" />
-  <path
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 318.15113,386.74279 v -7.61832 h 0.31744"
-     id="path269290"
-     inkscape:connector-curvature="0" />
-  <path
-     inkscape:connector-curvature="0"
-     id="path269292"
-     d="m 326.18316,386.74279 v -7.61832 h 0.31744"
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 334.21518,386.74279 v -7.61832 h 0.31744"
-     id="path269294"
-     inkscape:connector-curvature="0" />
-  <path
-     inkscape:connector-curvature="0"
-     id="path269296"
-     d="m 318.15113,431.76014 v -7.61832 h 0.31744"
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 326.18316,431.76014 v -7.61832 h 0.31744"
-     id="path269298"
-     inkscape:connector-curvature="0" />
-  <path
-     inkscape:connector-curvature="0"
-     id="path269300"
-     d="m 334.21518,431.76014 v -7.61832 h 0.31744"
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 344.35362,405.1249 h 7.61835 v 0.31748"
-     id="path269302"
-     inkscape:connector-curvature="0" />
-  <path
-     inkscape:connector-curvature="0"
-     id="path269304"
-     d="m 344.35362,396.70075 h 7.61835 v 0.31748"
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     transform="matrix(0,0.3409104,0.20267471,0,261.13282,227.71271)"
-     inkscape:transform-center-y="0.55154359"
-     d="m 433.96231,320.95932 -28.32115,16.35123 v -32.70246 z"
-     inkscape:randomized="0"
-     inkscape:rounded="0"
-     inkscape:flatsided="true"
-     sodipodi:arg2="1.0471976"
-     sodipodi:arg1="0"
-     sodipodi:r2="9.4403858"
-     sodipodi:r1="18.880772"
-     sodipodi:cy="320.95932"
-     sodipodi:cx="415.08154"
-     sodipodi:sides="3"
-     id="path269306"
-     style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.8043468;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     sodipodi:type="star" />
-  <path
-     inkscape:connector-curvature="0"
-     id="path269308"
-     d="m 299.35217,397.12485 h 7.61835 v 0.31748"
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 299.35217,413.21642 h 7.61835 v 0.31748"
-     id="path269310"
-     inkscape:connector-curvature="0" />
-  <path
-     inkscape:connector-curvature="0"
-     id="path269312"
-     d="m 344.35362,413.21642 h 7.61835 v 0.31748"
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 299.35217,405.12486 h 7.61835 v 0.31748"
-     id="path269314"
-     inkscape:connector-curvature="0" />
-  <circle
-     cx="326.33682"
-     cy="404.59106"
-     id="circle269485"
-     r="11.361237"
-     style="fill:#e739ce;fill-opacity:1;stroke:#000000;stroke-width:0.98793352;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <g
-     transform="matrix(0.60816227,0,0,0.60816227,526.01348,393.5675)"
-     id="g180274-2">
-    <rect
-       style="opacity:0.98000004;fill:none;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="rect180248-8"
-       width="54.538609"
-       height="54.538609"
-       x="-101"
-       y="-186"
-       ry="10.907722"
-       rx="10.907722" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M -85,-185.09228 V -196 h 0.45449"
-       id="path180250-4"
-       inkscape:connector-curvature="0" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path180252-3"
-       d="M -73.5,-185.09228 V -196 h 0.45449"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M -62,-185.09228 V -196 h 0.45449"
-       id="path180254-1"
-       inkscape:connector-curvature="0" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path180256-1"
-       d="m -85,-120.63779 v -10.90772 h 0.45449"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m -73.5,-120.63779 v -10.90772 h 0.45449"
-       id="path180258-8"
-       inkscape:connector-curvature="0" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path180260-8"
-       d="m -62,-120.63779 v -10.90772 h 0.45449"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path180262-8"
-       d="m -47.484096,-170.27339 h 10.90772 v 0.4545"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m -47.484096,-158.77339 h 10.90772 v 0.4545"
-       id="path180264-7"
-       inkscape:connector-curvature="0" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path180266-2"
-       d="m -47.484096,-147.27338 h 10.90772 v 0.45449"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m -112.09008,-170.27339 h 10.90772 v 0.4545"
-       id="path180268-4"
-       inkscape:connector-curvature="0" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path180270-2"
-       d="m -112.09008,-158.77339 h 10.90772 v 0.4545"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m -112.09008,-147.27338 h 10.90772 v 0.45449"
-       id="path180272-9"
-       inkscape:connector-curvature="0" />
+  <g stroke-miterlimit="4" id="g180274-2" transform="translate(526.01 393.57) scale(.60816)" fill="none" stroke="#000" stroke-width="2">
+   <rect rx="10.91" ry="10.91" y="-186" x="-101" height="54.54" width="54.54" id="rect180248-8" opacity=".98" fill-opacity="1" stroke-linecap="round" stroke-linejoin="round" stroke-dashoffset="0"/>
+   <path id="path180250-4" d="M-85-185.1V-196h.45" fill-rule="evenodd" stroke-linecap="butt" stroke-linejoin="miter"/>
+   <path d="M-73.5-185.1V-196h.45" id="path180252-3" fill-rule="evenodd" stroke-linecap="butt" stroke-linejoin="miter"/>
+   <path id="path180254-1" d="M-62-185.1V-196h.45" fill-rule="evenodd" stroke-linecap="butt" stroke-linejoin="miter"/>
+   <path d="M-85-120.64v-10.9h.45" id="path180256-1" fill-rule="evenodd" stroke-linecap="butt" stroke-linejoin="miter"/>
+   <path id="path180258-8" d="M-73.5-120.64v-10.9h.45" fill-rule="evenodd" stroke-linecap="butt" stroke-linejoin="miter"/>
+   <path d="M-62-120.64v-10.9h.45" id="path180260-8" fill-rule="evenodd" stroke-linecap="butt" stroke-linejoin="miter"/>
+   <path d="M-47.48-170.27h10.9v.45" id="path180262-8" fill-rule="evenodd" stroke-linecap="butt" stroke-linejoin="miter"/>
+   <path id="path180264-7" d="M-47.48-158.77h10.9v.45" fill-rule="evenodd" stroke-linecap="butt" stroke-linejoin="miter"/>
+   <path d="M-47.48-147.27h10.9v.45" id="path180266-2" fill-rule="evenodd" stroke-linecap="butt" stroke-linejoin="miter"/>
+   <path id="path180268-4" d="M-112.09-170.27h10.9v.45" fill-rule="evenodd" stroke-linecap="butt" stroke-linejoin="miter"/>
+   <path d="M-112.09-158.77h10.9v.45" id="path180270-2" fill-rule="evenodd" stroke-linecap="butt" stroke-linejoin="miter"/>
+   <path id="path180272-9" d="M-112.09-147.27h10.9v.45" fill-rule="evenodd" stroke-linecap="butt" stroke-linejoin="miter"/>
   </g>
-  <circle
-     cx="480.76849"
-     cy="297.37665"
-     id="circle252552"
-     r="11.361237"
-     style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.98793352;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     stroke-miterlimit="4"
-     d="m 307.56211,334 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
-     id="path13381"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     r="11"
-     id="circle13383"
-     cy="348"
-     cx="314.56213"
-     style="fill:#e6ba31;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     cx="342.56213"
-     cy="348"
-     id="circle13385"
-     r="11"
-     style="fill:#ff5a01;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="path13387"
-     d="m 328.56211,334 v 28"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="m 362.75925,263.35093 -1,-149.99999"
-     id="path9497"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#45b8de;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99999998, 5.99999998;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_3-3-6)" />
-  <text
-     y="341.75925"
-     x="-254.35094"
-     transform="rotate(-90)"
-     id="text9503"
-     style="fill:#45b8de;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
-    <tspan
-       font-size="14"
-       font-weight="400"
-       x="-254.35094"
-       y="354.75925"
-       id="tspan9501"
-       style="font-weight:400;font-size:14px;font-family:Tahoma, 'Nimbus Sans L';fill:#45b8de">cancel()</tspan>
-  </text>
-  <g
-     transform="translate(-0.79169176,94.535907)"
-     id="g15622">
-    <path
-       style="fill:#ef2200;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:connector-curvature="0"
-       d="m 566.60156,403.15625 -2,2 h -3 l -31,-31 v -3 l 2,-2 h 3 l 31,31 z"
-       id="path1034" />
-    <path
-       style="fill:#ef2200;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:connector-curvature="0"
-       d="m 564.60156,369.15625 2,2 v 3 l -31,31 h -3 l -2,-2 v -3 l 31,-31 z"
-       id="path1036" />
-  </g>
+  <circle r="11.36" id="circle252552" cy="297.38" cx="480.77" fill="#fff" fill-opacity="1" stroke="#000" stroke-width=".99" stroke-linecap="round" stroke-linejoin="round"/>
+ </g>
+ <path stroke-miterlimit="4" d="M307.56 334h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z" id="path13381" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="11" id="circle13383" cy="348" cx="314.56" fill="#e6ba31" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="342.56" cy="348" id="circle13385" r="11" fill="#ff5a01" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path13387" d="M328.56 334v28" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
+ <path d="M362.76 263.35l-1-150" id="path9497" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999998,5.99999998" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-6)"/>
+ <text y="341.76" x="-254.35" transform="rotate(-90)" id="text9503" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="14" font-weight="400" x="-254.35" y="354.76" id="tspan9501" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">cancel()</tspan>
+ </text>
+ <g transform="translate(-.8 94.54)" id="g15622" fill="#ef2200" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <path d="M566.6 403.16l-2 2h-3l-31-31v-3l2-2h3l31 31z" id="path1034"/>
+  <path d="M564.6 369.16l2 2v3l-31 31h-3l-2-2v-3l31-31z" id="path1036"/>
+ </g>
 </svg>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBufferWithMaxSizeConsumer.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBufferWithMaxSizeConsumer.svg
@@ -1,0 +1,742 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   viewBox="18 65 594.86414 446"
+   width="594.86414"
+   height="446"
+   id="svg190"
+   sodipodi:docname="onBackpressureBufferWithMaxSizeHandler.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata4243">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview4241"
+     showgrid="false"
+     inkscape:current-layer="svg190"
+     fit-margin-top="5"
+     fit-margin-right="5"
+     fit-margin-left="5"
+     fit-margin-bottom="5" />
+  <defs
+     id="defs23">
+    <marker
+       orient="auto"
+       overflow="visible"
+       markerUnits="strokeWidth"
+       id="FilledArrow_Marker"
+       stroke-miterlimit="10"
+       viewBox="-1 -6 14 12"
+       markerWidth="14"
+       markerHeight="12"
+       style="color:#34302c;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10">
+      <g
+         id="g4">
+        <path
+           d="M 12,0 0,-4 v 9 z"
+           id="path2"
+           inkscape:connector-curvature="0"
+           style="fill:currentColor;stroke:currentColor;stroke-width:1" />
+      </g>
+    </marker>
+    <font-face
+       font-family="'Tahoma','Nimbus Sans L'"
+       font-size="24"
+       panose-1="2 11 9 2 3 0 4 2 2 3"
+       units-per-em="1000"
+       underline-position="-75"
+       underline-thickness="50"
+       slope="0"
+       x-height="501"
+       cap-height="682"
+       ascent="923"
+       descent="-235"
+       font-weight="700"
+       id="font-face7"
+       stemv="0"
+       stemh="0"
+       accent-height="0"
+       ideographic="0"
+       alphabetic="0"
+       mathematical="0"
+       hanging="0"
+       v-ideographic="0"
+       v-alphabetic="0"
+       v-mathematical="0"
+       v-hanging="0"
+       strikethrough-position="0"
+       strikethrough-thickness="0"
+       overline-position="0"
+       overline-thickness="0">
+      <font-face-src>
+        <font-face-name
+           name="Tahoma-Bold" />
+      </font-face-src>
+    </font-face>
+    <marker
+       orient="auto"
+       overflow="visible"
+       markerUnits="strokeWidth"
+       id="FilledArrow_Marker_2"
+       stroke-miterlimit="10"
+       viewBox="-1 -5 11 10"
+       markerWidth="11"
+       markerHeight="10"
+       style="color:#34302c;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10">
+      <g
+         id="g11">
+        <path
+           d="M 8,0 0,-3 v 6 z"
+           id="path9"
+           inkscape:connector-curvature="0"
+           style="fill:currentColor;stroke:currentColor;stroke-width:1" />
+      </g>
+    </marker>
+    <marker
+       orient="auto"
+       overflow="visible"
+       markerUnits="strokeWidth"
+       id="FilledArrow_Marker_3"
+       stroke-miterlimit="10"
+       viewBox="-6 -3 7 6"
+       markerWidth="7"
+       markerHeight="6"
+       style="color:#34302c;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10">
+      <g
+         id="g16">
+        <path
+           d="M -5,0 0,2 V -2 Z"
+           id="path14"
+           inkscape:connector-curvature="0"
+           style="fill:currentColor;stroke:currentColor;stroke-width:1" />
+      </g>
+    </marker>
+    <font-face
+       font-family="'Tahoma','Nimbus Sans L'"
+       font-size="16"
+       panose-1="2 11 5 2 2 1 4 2 2 3"
+       units-per-em="1000"
+       underline-position="-75"
+       underline-thickness="50"
+       slope="0"
+       x-height="450"
+       cap-height="687"
+       ascent="918"
+       descent="-230"
+       font-weight="400"
+       id="font-face19"
+       stemv="0"
+       stemh="0"
+       accent-height="0"
+       ideographic="0"
+       alphabetic="0"
+       mathematical="0"
+       hanging="0"
+       v-ideographic="0"
+       v-alphabetic="0"
+       v-mathematical="0"
+       v-hanging="0"
+       strikethrough-position="0"
+       strikethrough-thickness="0"
+       overline-position="0"
+       overline-thickness="0">
+      <font-face-src>
+        <font-face-name
+           name="Tahoma" />
+      </font-face-src>
+    </font-face>
+    <font-face
+       font-family="'Tahoma','Nimbus Sans L'"
+       font-size="16"
+       panose-1="2 11 9 2 3 0 4 2 2 3"
+       units-per-em="1000"
+       underline-position="-75"
+       underline-thickness="50"
+       slope="0"
+       x-height="501"
+       cap-height="682"
+       ascent="923"
+       descent="-235"
+       font-weight="700"
+       id="font-face21"
+       stemv="0"
+       stemh="0"
+       accent-height="0"
+       ideographic="0"
+       alphabetic="0"
+       mathematical="0"
+       hanging="0"
+       v-ideographic="0"
+       v-alphabetic="0"
+       v-mathematical="0"
+       v-hanging="0"
+       strikethrough-position="0"
+       strikethrough-thickness="0"
+       overline-position="0"
+       overline-thickness="0">
+      <font-face-src>
+        <font-face-name
+           name="Tahoma-Bold" />
+      </font-face-src>
+    </font-face>
+    <marker
+       orient="auto"
+       overflow="visible"
+       markerUnits="strokeWidth"
+       id="FilledArrow_Marker_3-3"
+       stroke-miterlimit="10"
+       viewBox="-1 -5 11 10"
+       markerWidth="11"
+       markerHeight="10"
+       style="color:#45b8de;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10">
+      <g
+         id="g16-6">
+        <path
+           d="M 8,0 0,-3 v 6 z"
+           id="path14-7"
+           inkscape:connector-curvature="0"
+           style="fill:currentColor;stroke:currentColor;stroke-width:1" />
+      </g>
+    </marker>
+    <marker
+       style="color:#45b8de;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10"
+       orient="auto"
+       overflow="visible"
+       markerUnits="strokeWidth"
+       id="FilledArrow_Marker_3-3-6"
+       stroke-miterlimit="10"
+       viewBox="-1 -5 11 10"
+       markerWidth="11"
+       markerHeight="10">
+      <g
+         id="g16-6-5">
+        <path
+           style="fill:currentColor;stroke:currentColor;stroke-width:1"
+           inkscape:connector-curvature="0"
+           d="M 8,0 0,-3 v 6 z"
+           id="path14-7-3" />
+      </g>
+    </marker>
+  </defs>
+  <path
+     id="line31"
+     d="M 24.014242,94 H 581.01424"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#FilledArrow_Marker)" />
+  <path
+     d="M 37.014242,268.2469 H 586.01424 l 1,1.1417 v 100.46969 l -1,1.1417 H 37.014242 l -1,-1.1417 V 269.3886 Z"
+     id="path36"
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1;stroke:#34302c;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     id="ellipse55"
+     cy="94"
+     cx="188.01424"
+     r="23"
+     style="fill:#e6ba31;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="line58"
+     d="m 188.01424,117 -1,132"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
+  <circle
+     id="ellipse68"
+     cy="94"
+     cx="258.01425"
+     r="23"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     id="ellipse76"
+     cy="94"
+     cx="131.01424"
+     r="23"
+     style="fill:#6cb33e;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     id="ellipse81"
+     cy="94"
+     cx="329.01425"
+     r="23"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="line84"
+     d="M 131.01424,117 V 249"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
+  <path
+     id="line87"
+     d="M 329.01424,117 V 249"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
+  <path
+     id="line106"
+     d="m 131.01424,373 v 66"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 5.99999997;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
+  <path
+     id="line112"
+     d="m 437.01424,373 v 66"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 5.99999997;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
+  <path
+     id="line115"
+     d="m 489.01424,373 1,66"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 5.99999997;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
+  <path
+     id="line138"
+     d="M 24.014242,482 H 581.01424"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#FilledArrow_Marker)" />
+  <circle
+     id="ellipse148"
+     cy="482"
+     cx="437.01425"
+     r="23"
+     style="fill:#e6ba31;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     id="ellipse156"
+     cy="482"
+     cx="131.01424"
+     r="23"
+     style="fill:#6cb33e;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     id="ellipse161"
+     cy="482"
+     cx="490.01425"
+     r="23"
+     style="fill:#ff5a01;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="line165"
+     d="m 258.01424,117 -1,132"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
+  <text
+     y="285"
+     x="-115.51897"
+     id="text937"
+     style="fill:#34302c;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
+    <tspan
+       id="tspan933"
+       y="307"
+       x="38.481033"
+       font-weight="700"
+       font-size="24"
+       style="font-weight:700;font-size:24px;font-family:Tahoma, 'Nimbus Sans L';fill:#34302c">onBackpressureBuffer ( <tspan
+   id="tspan923"
+   font-weight="400"
+   font-size="21"
+   style="font-weight:400;font-size:21px">maxSize = 2,</tspan>
+</tspan>
+  </text>
+  <circle
+     cx="258.01425"
+     cy="94"
+     id="ellipse941"
+     r="23"
+     style="fill:#ff5a01;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     cx="329.01425"
+     cy="94"
+     id="ellipse945"
+     r="23"
+     style="fill:#e739ce;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="line940"
+     d="m 78.014242,481 -1,-90"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#45b8de;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99999997, 5.99999991;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_3-3)" />
+  <text
+     y="57.014244"
+     x="-472"
+     transform="rotate(-90)"
+     id="text944"
+     style="fill:#45b8de;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
+    <tspan
+       font-size="14"
+       font-weight="400"
+       x="-472"
+       y="70.014244"
+       id="tspan942"
+       style="font-weight:400;font-size:14px;font-family:Tahoma, 'Nimbus Sans L';fill:#45b8de">request(1)</tspan>
+  </text>
+  <path
+     id="line1093"
+     d="m 398.01424,481 -1,-90"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#45b8de;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99999997, 5.99999991;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_3-3)" />
+  <text
+     id="text1097"
+     transform="rotate(-90)"
+     x="-472"
+     y="377.01425"
+     style="fill:#45b8de;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
+    <tspan
+       id="tspan1095"
+       y="390.01425"
+       x="-472"
+       font-weight="400"
+       font-size="14"
+       style="font-weight:400;font-size:14px;font-family:Tahoma, 'Nimbus Sans L';fill:#45b8de">request(2)</tspan>
+  </text>
+  <path
+     id="line1113"
+     d="m 78.014242,267 -1,-150"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#45b8de;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99999998, 5.99999998;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_3-3)" />
+  <text
+     id="text1117"
+     transform="rotate(-90)"
+     x="-258"
+     y="57.014244"
+     style="fill:#45b8de;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
+    <tspan
+       id="tspan1115"
+       y="70.014244"
+       x="-258"
+       font-weight="400"
+       font-size="14"
+       style="font-weight:400;font-size:14px;font-family:Tahoma, 'Nimbus Sans L';fill:#45b8de">request(<tspan
+   id="tspan1121"
+   font-weight="700"
+   style="font-weight:700">unbounded</tspan>
+ )</tspan>
+  </text>
+  <path
+     id="line1123"
+     d="m 545.01424,373 1,66"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 5.99999997;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
+  <path
+     d="m 111.01424,333 h 41 c 5,0 8,7 8,15 0,7 -3,14 -8,14 h -41 c -5,0 -9,-7 -9,-14 0,-8 4,-15 9,-15 z"
+     id="path22706"
+     stroke-miterlimit="4"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="m 173.01424,334 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
+     id="path22706-1"
+     stroke-miterlimit="4"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path22771"
+     d="m 239.01424,334 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
+     stroke-miterlimit="4"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path22775"
+     d="m 417.01424,334 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
+     stroke-miterlimit="4"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     cx="180.01424"
+     cy="348"
+     id="ellipse947"
+     r="11"
+     style="fill:#e6ba31;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     cx="246.01424"
+     cy="348"
+     id="ellipse983"
+     r="11"
+     style="fill:#e6ba31;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     r="11"
+     id="circle22801"
+     cy="348"
+     cx="274.01425"
+     style="fill:#ff5a01;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="M 73.014242,324 H 559.01424"
+     id="line130-4"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="m 194.01424,334 v 28"
+     id="path22839"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     id="path22841"
+     d="m 132.01424,334 v 28"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     d="m 260.01424,334 v 28"
+     id="path22843"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     d="m 438.01424,334 v 28"
+     id="path22847"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <text
+     style="fill:#34302c;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1"
+     id="text13224"
+     x="356.34546"
+     y="285">
+    <tspan
+       style="font-weight:700;font-size:24px;font-family:Tahoma, 'Nimbus Sans L';fill:#34302c"
+       font-size="24"
+       font-weight="700"
+       x="510.34546"
+       y="307"
+       id="tspan13222">)</tspan>
+  </text>
+  <rect
+     style="opacity:0.98000004;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.80954421;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect269288"
+     width="38.091766"
+     height="38.091766"
+     x="306.97617"
+     y="386.10876"
+     ry="9.8690033"
+     rx="9.8690033" />
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 318.15113,386.74279 v -7.61832 h 0.31744"
+     id="path269290"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path269292"
+     d="m 326.18316,386.74279 v -7.61832 h 0.31744"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 334.21518,386.74279 v -7.61832 h 0.31744"
+     id="path269294"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path269296"
+     d="m 318.15113,431.76014 v -7.61832 h 0.31744"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 326.18316,431.76014 v -7.61832 h 0.31744"
+     id="path269298"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path269300"
+     d="m 334.21518,431.76014 v -7.61832 h 0.31744"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 344.35362,405.1249 h 7.61835 v 0.31748"
+     id="path269302"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path269304"
+     d="m 344.35362,396.70075 h 7.61835 v 0.31748"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     transform="matrix(0,0.3409104,0.20267471,0,261.13282,227.71271)"
+     inkscape:transform-center-y="0.55154359"
+     d="m 433.96231,320.95932 -28.32115,16.35123 v -32.70246 z"
+     inkscape:randomized="0"
+     inkscape:rounded="0"
+     inkscape:flatsided="true"
+     sodipodi:arg2="1.0471976"
+     sodipodi:arg1="0"
+     sodipodi:r2="9.4403858"
+     sodipodi:r1="18.880772"
+     sodipodi:cy="320.95932"
+     sodipodi:cx="415.08154"
+     sodipodi:sides="3"
+     id="path269306"
+     style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.8043468;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     sodipodi:type="star" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path269308"
+     d="m 299.35217,397.12485 h 7.61835 v 0.31748"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 299.35217,413.21642 h 7.61835 v 0.31748"
+     id="path269310"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path269312"
+     d="m 344.35362,413.21642 h 7.61835 v 0.31748"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.80954421;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 299.35217,405.12486 h 7.61835 v 0.31748"
+     id="path269314"
+     inkscape:connector-curvature="0" />
+  <circle
+     cx="326.33682"
+     cy="404.59106"
+     id="circle269485"
+     r="11.361237"
+     style="fill:#e739ce;fill-opacity:1;stroke:#000000;stroke-width:0.98793352;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <g
+     transform="matrix(0.60816227,0,0,0.60816227,526.01348,393.5675)"
+     id="g180274-2">
+    <rect
+       style="opacity:0.98000004;fill:none;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect180248-8"
+       width="54.538609"
+       height="54.538609"
+       x="-101"
+       y="-186"
+       ry="10.907722"
+       rx="10.907722" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M -85,-185.09228 V -196 h 0.45449"
+       id="path180250-4"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path180252-3"
+       d="M -73.5,-185.09228 V -196 h 0.45449"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M -62,-185.09228 V -196 h 0.45449"
+       id="path180254-1"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path180256-1"
+       d="m -85,-120.63779 v -10.90772 h 0.45449"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m -73.5,-120.63779 v -10.90772 h 0.45449"
+       id="path180258-8"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path180260-8"
+       d="m -62,-120.63779 v -10.90772 h 0.45449"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path180262-8"
+       d="m -47.484096,-170.27339 h 10.90772 v 0.4545"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m -47.484096,-158.77339 h 10.90772 v 0.4545"
+       id="path180264-7"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path180266-2"
+       d="m -47.484096,-147.27338 h 10.90772 v 0.45449"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m -112.09008,-170.27339 h 10.90772 v 0.4545"
+       id="path180268-4"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path180270-2"
+       d="m -112.09008,-158.77339 h 10.90772 v 0.4545"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m -112.09008,-147.27338 h 10.90772 v 0.45449"
+       id="path180272-9"
+       inkscape:connector-curvature="0" />
+  </g>
+  <circle
+     cx="480.76849"
+     cy="297.37665"
+     id="circle252552"
+     r="11.361237"
+     style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.98793352;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     stroke-miterlimit="4"
+     d="m 307.56211,334 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
+     id="path13381"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     r="11"
+     id="circle13383"
+     cy="348"
+     cx="314.56213"
+     style="fill:#e6ba31;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     cx="342.56213"
+     cy="348"
+     id="circle13385"
+     r="11"
+     style="fill:#ff5a01;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path13387"
+     d="m 328.56211,334 v 28"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     d="m 362.75925,263.35093 -1,-149.99999"
+     id="path9497"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#45b8de;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99999998, 5.99999998;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_3-3-6)" />
+  <text
+     y="341.75925"
+     x="-254.35094"
+     transform="rotate(-90)"
+     id="text9503"
+     style="fill:#45b8de;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
+    <tspan
+       font-size="14"
+       font-weight="400"
+       x="-254.35094"
+       y="354.75925"
+       id="tspan9501"
+       style="font-weight:400;font-size:14px;font-family:Tahoma, 'Nimbus Sans L';fill:#45b8de">cancel()</tspan>
+  </text>
+  <g
+     transform="translate(-0.79169176,94.535907)"
+     id="g15622">
+    <path
+       style="fill:#ef2200;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       d="m 566.60156,403.15625 -2,2 h -3 l -31,-31 v -3 l 2,-2 h 3 l 31,31 z"
+       id="path1034" />
+    <path
+       style="fill:#ef2200;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       d="m 564.60156,369.15625 2,2 v 3 l -31,31 h -3 l -2,-2 v -3 l 31,-31 z"
+       id="path1036" />
+  </g>
+</svg>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBufferWithMaxSizeStrategyDropOldest.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBufferWithMaxSizeStrategyDropOldest.svg
@@ -1,0 +1,578 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   viewBox="18 65 618.79474 435"
+   width="618.79474"
+   height="435"
+   id="svg190"
+   sodipodi:docname="onBackpressureBufferWithMaxSizeStrategyDropOldest.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata4243">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview4241"
+     showgrid="false"
+     inkscape:current-layer="svg190"
+     fit-margin-top="5"
+     fit-margin-left="5"
+     fit-margin-right="5"
+     fit-margin-bottom="5" />
+  <defs
+     id="defs23">
+    <marker
+       orient="auto"
+       overflow="visible"
+       markerUnits="strokeWidth"
+       id="FilledArrow_Marker"
+       stroke-miterlimit="10"
+       viewBox="-1 -6 14 12"
+       markerWidth="14"
+       markerHeight="12"
+       style="color:#34302c;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10">
+      <g
+         id="g4">
+        <path
+           d="M 12,0 0,-4 v 9 z"
+           id="path2"
+           inkscape:connector-curvature="0"
+           style="fill:currentColor;stroke:currentColor;stroke-width:1" />
+      </g>
+    </marker>
+    <font-face
+       font-family="'Tahoma','Nimbus Sans L'"
+       font-size="24"
+       panose-1="2 11 9 2 3 0 4 2 2 3"
+       units-per-em="1000"
+       underline-position="-75"
+       underline-thickness="50"
+       slope="0"
+       x-height="501"
+       cap-height="682"
+       ascent="923"
+       descent="-235"
+       font-weight="700"
+       id="font-face7"
+       stemv="0"
+       stemh="0"
+       accent-height="0"
+       ideographic="0"
+       alphabetic="0"
+       mathematical="0"
+       hanging="0"
+       v-ideographic="0"
+       v-alphabetic="0"
+       v-mathematical="0"
+       v-hanging="0"
+       strikethrough-position="0"
+       strikethrough-thickness="0"
+       overline-position="0"
+       overline-thickness="0">
+      <font-face-src>
+        <font-face-name
+           name="Tahoma-Bold" />
+      </font-face-src>
+    </font-face>
+    <marker
+       orient="auto"
+       overflow="visible"
+       markerUnits="strokeWidth"
+       id="FilledArrow_Marker_2"
+       stroke-miterlimit="10"
+       viewBox="-1 -5 11 10"
+       markerWidth="11"
+       markerHeight="10"
+       style="color:#34302c;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10">
+      <g
+         id="g11">
+        <path
+           d="M 8,0 0,-3 v 6 z"
+           id="path9"
+           inkscape:connector-curvature="0"
+           style="fill:currentColor;stroke:currentColor;stroke-width:1" />
+      </g>
+    </marker>
+    <marker
+       orient="auto"
+       overflow="visible"
+       markerUnits="strokeWidth"
+       id="FilledArrow_Marker_3"
+       stroke-miterlimit="10"
+       viewBox="-6 -3 7 6"
+       markerWidth="7"
+       markerHeight="6"
+       style="color:#34302c;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10">
+      <g
+         id="g16">
+        <path
+           d="M -5,0 0,2 V -2 Z"
+           id="path14"
+           inkscape:connector-curvature="0"
+           style="fill:currentColor;stroke:currentColor;stroke-width:1" />
+      </g>
+    </marker>
+    <font-face
+       font-family="'Tahoma','Nimbus Sans L'"
+       font-size="16"
+       panose-1="2 11 5 2 2 1 4 2 2 3"
+       units-per-em="1000"
+       underline-position="-75"
+       underline-thickness="50"
+       slope="0"
+       x-height="450"
+       cap-height="687"
+       ascent="918"
+       descent="-230"
+       font-weight="400"
+       id="font-face19"
+       stemv="0"
+       stemh="0"
+       accent-height="0"
+       ideographic="0"
+       alphabetic="0"
+       mathematical="0"
+       hanging="0"
+       v-ideographic="0"
+       v-alphabetic="0"
+       v-mathematical="0"
+       v-hanging="0"
+       strikethrough-position="0"
+       strikethrough-thickness="0"
+       overline-position="0"
+       overline-thickness="0">
+      <font-face-src>
+        <font-face-name
+           name="Tahoma" />
+      </font-face-src>
+    </font-face>
+    <font-face
+       font-family="'Tahoma','Nimbus Sans L'"
+       font-size="16"
+       panose-1="2 11 9 2 3 0 4 2 2 3"
+       units-per-em="1000"
+       underline-position="-75"
+       underline-thickness="50"
+       slope="0"
+       x-height="501"
+       cap-height="682"
+       ascent="923"
+       descent="-235"
+       font-weight="700"
+       id="font-face21"
+       stemv="0"
+       stemh="0"
+       accent-height="0"
+       ideographic="0"
+       alphabetic="0"
+       mathematical="0"
+       hanging="0"
+       v-ideographic="0"
+       v-alphabetic="0"
+       v-mathematical="0"
+       v-hanging="0"
+       strikethrough-position="0"
+       strikethrough-thickness="0"
+       overline-position="0"
+       overline-thickness="0">
+      <font-face-src>
+        <font-face-name
+           name="Tahoma-Bold" />
+      </font-face-src>
+    </font-face>
+    <marker
+       orient="auto"
+       overflow="visible"
+       markerUnits="strokeWidth"
+       id="FilledArrow_Marker_3-3"
+       stroke-miterlimit="10"
+       viewBox="-1 -5 11 10"
+       markerWidth="11"
+       markerHeight="10"
+       style="color:#45b8de;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10">
+      <g
+         id="g16-6">
+        <path
+           d="M 8,0 0,-3 v 6 z"
+           id="path14-7"
+           inkscape:connector-curvature="0"
+           style="fill:currentColor;stroke:currentColor;stroke-width:1" />
+      </g>
+    </marker>
+  </defs>
+  <path
+     id="line31"
+     d="M 39.897391,95 H 596.89739"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#FilledArrow_Marker)" />
+  <path
+     d="M 25.101261,270 H 629.69349 l 1.10127,1 v 88 l -1.10127,1 H 25.101261 L 24,359 v -88 z"
+     id="path36"
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1;stroke:#34302c;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     id="ellipse53"
+     cy="95"
+     cx="203.89738"
+     r="23"
+     style="fill:#e6ba31;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     id="ellipse55"
+     cy="95"
+     cx="203.89738"
+     r="23"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="line58"
+     d="m 203.89739,118 -1,132"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
+  <path
+     id="line63"
+     d="M 408.89739,119 V 250"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
+  <circle
+     id="ellipse66"
+     cy="95"
+     cx="273.8974"
+     r="23"
+     style="fill:#ff5a01;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     id="ellipse68"
+     cy="95"
+     cx="273.8974"
+     r="23"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path71"
+     d="m 408.89739,70 h 1 l 2,2 v 45 l -2,2 h -1 l -2,-2 V 72 Z"
+     inkscape:connector-curvature="0"
+     style="fill:#34302c;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     id="ellipse74"
+     cy="95"
+     cx="146.89738"
+     r="23"
+     style="fill:#6cb33e;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     id="ellipse76"
+     cy="95"
+     cx="146.89738"
+     r="23"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     id="ellipse79"
+     cy="95"
+     cx="344.8974"
+     r="23"
+     style="fill:#e739ce;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     id="ellipse81"
+     cy="95"
+     cx="344.8974"
+     r="23"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="line84"
+     d="M 146.89739,118 V 250"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
+  <path
+     id="line87"
+     d="M 344.89739,118 V 250"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
+  <path
+     id="line106"
+     d="m 146.89739,362 v 66"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 5.99999997;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
+  <path
+     id="line112"
+     d="m 472.89739,362 v 66"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 5.99999997;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
+  <path
+     id="line115"
+     d="m 524.89739,362 1,66"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 5.99999997;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
+  <path
+     id="line138"
+     d="M 39.897391,471 H 596.89739"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#FilledArrow_Marker)" />
+  <circle
+     id="ellipse146"
+     cy="471"
+     cx="472.8974"
+     r="23"
+     style="fill:#ff5a01;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     id="ellipse148"
+     cy="471"
+     cx="472.8974"
+     r="23"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path151"
+     d="m 561.89739,447 h 1 l 2,2 v 44 l -2,2 h -1 l -2,-2 v -44 z"
+     inkscape:connector-curvature="0"
+     style="fill:#34302c;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     id="ellipse154"
+     cy="471"
+     cx="146.89738"
+     r="23"
+     style="fill:#6cb33e;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     id="ellipse156"
+     cy="471"
+     cx="146.89738"
+     r="23"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     id="ellipse159"
+     cy="471"
+     cx="525.8974"
+     r="23"
+     style="fill:#e739ce;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     id="ellipse161"
+     cy="471"
+     cx="525.8974"
+     r="23"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="line165"
+     d="m 273.89739,118 -1,132"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
+  <text
+     y="278"
+     x="-122.83796"
+     id="text937"
+     style="fill:#34302c;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
+    <tspan
+       id="tspan933"
+       y="300"
+       x="31.162039"
+       font-weight="700"
+       font-size="24"
+       style="font-weight:700;font-size:24px;font-family:Tahoma, 'Nimbus Sans L';fill:#34302c">onBackpressureBuffer ( <tspan
+   id="tspan923"
+   font-weight="400"
+   font-size="21"
+   style="font-weight:400;font-size:21px">maxSize = 2,</tspan>
+ <tspan
+   style="font-weight:normal"
+   id="tspan13530">DROP_OLDEST</tspan>
+)</tspan>
+  </text>
+  <circle
+     cx="273.8974"
+     cy="95"
+     id="ellipse939"
+     r="23"
+     style="fill:#ff5a01;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     cx="273.8974"
+     cy="95"
+     id="ellipse941"
+     r="23"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     cx="344.8974"
+     cy="95"
+     id="ellipse943"
+     r="23"
+     style="fill:#e739ce;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     cx="344.8974"
+     cy="95"
+     id="ellipse945"
+     r="23"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="line940"
+     d="m 93.897391,470 -1,-90"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#45b8de;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99999997, 5.99999991;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_3-3)" />
+  <text
+     y="72.897392"
+     x="-461"
+     transform="rotate(-90)"
+     id="text944"
+     style="fill:#45b8de;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
+    <tspan
+       font-size="14"
+       font-weight="400"
+       x="-461"
+       y="85.897392"
+       id="tspan942"
+       style="font-weight:400;font-size:14px;font-family:Tahoma, 'Nimbus Sans L';fill:#45b8de">request(1)</tspan>
+  </text>
+  <path
+     id="line1093"
+     d="m 433.89739,470 -1,-90"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#45b8de;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99999997, 5.99999991;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_3-3)" />
+  <text
+     id="text1097"
+     transform="rotate(-90)"
+     x="-461"
+     y="412.8974"
+     style="fill:#45b8de;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
+    <tspan
+       id="tspan1095"
+       y="425.8974"
+       x="-461"
+       font-weight="400"
+       font-size="14"
+       style="font-weight:400;font-size:14px;font-family:Tahoma, 'Nimbus Sans L';fill:#45b8de">request(2)</tspan>
+  </text>
+  <path
+     id="line1113"
+     d="m 93.897391,268 -1,-150"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#45b8de;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99999998, 5.99999998;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_3-3)" />
+  <text
+     id="text1117"
+     transform="rotate(-90)"
+     x="-259"
+     y="72.897392"
+     style="fill:#45b8de;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
+    <tspan
+       id="tspan1115"
+       y="85.897392"
+       x="-259"
+       font-weight="400"
+       font-size="14"
+       style="font-weight:400;font-size:14px;font-family:Tahoma, 'Nimbus Sans L';fill:#45b8de">request(<tspan
+   id="tspan1121"
+   font-weight="700"
+   style="font-weight:700">unbounded</tspan>
+ )</tspan>
+  </text>
+  <path
+     id="line1123"
+     d="m 560.89739,362 1,66"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 5.99999997;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
+  <path
+     d="m 126.89739,322 h 41 c 5,0 8,7 8,15 0,7 -3,14 -8,14 h -41 c -5,0 -9,-7 -9,-14 0,-8 4,-15 9,-15 z"
+     id="path22706"
+     stroke-miterlimit="4"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="m 188.89739,323 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
+     id="path22706-1"
+     stroke-miterlimit="4"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path22771"
+     d="m 254.89739,323 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
+     stroke-miterlimit="4"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="m 320.89739,323 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
+     id="path22773"
+     stroke-miterlimit="4"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path22775"
+     d="m 452.89739,323 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
+     stroke-miterlimit="4"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     cx="195.89738"
+     cy="337"
+     id="ellipse947"
+     r="11"
+     style="fill:#e6ba31;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     cx="261.8974"
+     cy="337"
+     id="ellipse983"
+     r="11"
+     style="fill:#e6ba31;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     r="11"
+     id="circle22801"
+     cy="337"
+     cx="289.8974"
+     style="fill:#ff5a01;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     cx="327.8974"
+     cy="337"
+     id="circle22805"
+     r="11"
+     style="fill:#ff5a01;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
+  <circle
+     cx="355.8974"
+     cy="337"
+     id="circle22807"
+     r="11"
+     style="fill:#e739ce;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="M 37.364586,313 H 617.43017"
+     id="line130-4"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="m 209.89739,323 v 28"
+     id="path22839"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     id="path22841"
+     d="m 147.89739,323 v 28"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     d="m 275.89739,323 v 28"
+     id="path22843"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     id="path22845"
+     d="m 341.89739,323 v 28"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     d="m 473.89739,323 v 28"
+     id="path22847"
+     inkscape:connector-curvature="0"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+</svg>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBufferWithMaxSizeStrategyDropOldest.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/onBackpressureBufferWithMaxSizeStrategyDropOldest.svg
@@ -1,578 +1,102 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   version="1.1"
-   viewBox="18 65 618.79474 435"
-   width="618.79474"
-   height="435"
-   id="svg190"
-   sodipodi:docname="onBackpressureBufferWithMaxSizeStrategyDropOldest.svg"
-   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
-  <metadata
-     id="metadata4243">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="640"
-     inkscape:window-height="480"
-     id="namedview4241"
-     showgrid="false"
-     inkscape:current-layer="svg190"
-     fit-margin-top="5"
-     fit-margin-left="5"
-     fit-margin-right="5"
-     fit-margin-bottom="5" />
-  <defs
-     id="defs23">
-    <marker
-       orient="auto"
-       overflow="visible"
-       markerUnits="strokeWidth"
-       id="FilledArrow_Marker"
-       stroke-miterlimit="10"
-       viewBox="-1 -6 14 12"
-       markerWidth="14"
-       markerHeight="12"
-       style="color:#34302c;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10">
-      <g
-         id="g4">
-        <path
-           d="M 12,0 0,-4 v 9 z"
-           id="path2"
-           inkscape:connector-curvature="0"
-           style="fill:currentColor;stroke:currentColor;stroke-width:1" />
-      </g>
-    </marker>
-    <font-face
-       font-family="'Tahoma','Nimbus Sans L'"
-       font-size="24"
-       panose-1="2 11 9 2 3 0 4 2 2 3"
-       units-per-em="1000"
-       underline-position="-75"
-       underline-thickness="50"
-       slope="0"
-       x-height="501"
-       cap-height="682"
-       ascent="923"
-       descent="-235"
-       font-weight="700"
-       id="font-face7"
-       stemv="0"
-       stemh="0"
-       accent-height="0"
-       ideographic="0"
-       alphabetic="0"
-       mathematical="0"
-       hanging="0"
-       v-ideographic="0"
-       v-alphabetic="0"
-       v-mathematical="0"
-       v-hanging="0"
-       strikethrough-position="0"
-       strikethrough-thickness="0"
-       overline-position="0"
-       overline-thickness="0">
-      <font-face-src>
-        <font-face-name
-           name="Tahoma-Bold" />
-      </font-face-src>
-    </font-face>
-    <marker
-       orient="auto"
-       overflow="visible"
-       markerUnits="strokeWidth"
-       id="FilledArrow_Marker_2"
-       stroke-miterlimit="10"
-       viewBox="-1 -5 11 10"
-       markerWidth="11"
-       markerHeight="10"
-       style="color:#34302c;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10">
-      <g
-         id="g11">
-        <path
-           d="M 8,0 0,-3 v 6 z"
-           id="path9"
-           inkscape:connector-curvature="0"
-           style="fill:currentColor;stroke:currentColor;stroke-width:1" />
-      </g>
-    </marker>
-    <marker
-       orient="auto"
-       overflow="visible"
-       markerUnits="strokeWidth"
-       id="FilledArrow_Marker_3"
-       stroke-miterlimit="10"
-       viewBox="-6 -3 7 6"
-       markerWidth="7"
-       markerHeight="6"
-       style="color:#34302c;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10">
-      <g
-         id="g16">
-        <path
-           d="M -5,0 0,2 V -2 Z"
-           id="path14"
-           inkscape:connector-curvature="0"
-           style="fill:currentColor;stroke:currentColor;stroke-width:1" />
-      </g>
-    </marker>
-    <font-face
-       font-family="'Tahoma','Nimbus Sans L'"
-       font-size="16"
-       panose-1="2 11 5 2 2 1 4 2 2 3"
-       units-per-em="1000"
-       underline-position="-75"
-       underline-thickness="50"
-       slope="0"
-       x-height="450"
-       cap-height="687"
-       ascent="918"
-       descent="-230"
-       font-weight="400"
-       id="font-face19"
-       stemv="0"
-       stemh="0"
-       accent-height="0"
-       ideographic="0"
-       alphabetic="0"
-       mathematical="0"
-       hanging="0"
-       v-ideographic="0"
-       v-alphabetic="0"
-       v-mathematical="0"
-       v-hanging="0"
-       strikethrough-position="0"
-       strikethrough-thickness="0"
-       overline-position="0"
-       overline-thickness="0">
-      <font-face-src>
-        <font-face-name
-           name="Tahoma" />
-      </font-face-src>
-    </font-face>
-    <font-face
-       font-family="'Tahoma','Nimbus Sans L'"
-       font-size="16"
-       panose-1="2 11 9 2 3 0 4 2 2 3"
-       units-per-em="1000"
-       underline-position="-75"
-       underline-thickness="50"
-       slope="0"
-       x-height="501"
-       cap-height="682"
-       ascent="923"
-       descent="-235"
-       font-weight="700"
-       id="font-face21"
-       stemv="0"
-       stemh="0"
-       accent-height="0"
-       ideographic="0"
-       alphabetic="0"
-       mathematical="0"
-       hanging="0"
-       v-ideographic="0"
-       v-alphabetic="0"
-       v-mathematical="0"
-       v-hanging="0"
-       strikethrough-position="0"
-       strikethrough-thickness="0"
-       overline-position="0"
-       overline-thickness="0">
-      <font-face-src>
-        <font-face-name
-           name="Tahoma-Bold" />
-      </font-face-src>
-    </font-face>
-    <marker
-       orient="auto"
-       overflow="visible"
-       markerUnits="strokeWidth"
-       id="FilledArrow_Marker_3-3"
-       stroke-miterlimit="10"
-       viewBox="-1 -5 11 10"
-       markerWidth="11"
-       markerHeight="10"
-       style="color:#45b8de;overflow:visible;stroke-linejoin:miter;stroke-miterlimit:10">
-      <g
-         id="g16-6">
-        <path
-           d="M 8,0 0,-3 v 6 z"
-           id="path14-7"
-           inkscape:connector-curvature="0"
-           style="fill:currentColor;stroke:currentColor;stroke-width:1" />
-      </g>
-    </marker>
-  </defs>
-  <path
-     id="line31"
-     d="M 39.897391,95 H 596.89739"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#FilledArrow_Marker)" />
-  <path
-     d="M 25.101261,270 H 629.69349 l 1.10127,1 v 88 l -1.10127,1 H 25.101261 L 24,359 v -88 z"
-     id="path36"
-     inkscape:connector-curvature="0"
-     style="fill:#ffffff;fill-opacity:1;stroke:#34302c;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     id="ellipse53"
-     cy="95"
-     cx="203.89738"
-     r="23"
-     style="fill:#e6ba31;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     id="ellipse55"
-     cy="95"
-     cx="203.89738"
-     r="23"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="line58"
-     d="m 203.89739,118 -1,132"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
-  <path
-     id="line63"
-     d="M 408.89739,119 V 250"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
-  <circle
-     id="ellipse66"
-     cy="95"
-     cx="273.8974"
-     r="23"
-     style="fill:#ff5a01;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     id="ellipse68"
-     cy="95"
-     cx="273.8974"
-     r="23"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="path71"
-     d="m 408.89739,70 h 1 l 2,2 v 45 l -2,2 h -1 l -2,-2 V 72 Z"
-     inkscape:connector-curvature="0"
-     style="fill:#34302c;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     id="ellipse74"
-     cy="95"
-     cx="146.89738"
-     r="23"
-     style="fill:#6cb33e;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     id="ellipse76"
-     cy="95"
-     cx="146.89738"
-     r="23"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     id="ellipse79"
-     cy="95"
-     cx="344.8974"
-     r="23"
-     style="fill:#e739ce;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     id="ellipse81"
-     cy="95"
-     cx="344.8974"
-     r="23"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="line84"
-     d="M 146.89739,118 V 250"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
-  <path
-     id="line87"
-     d="M 344.89739,118 V 250"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
-  <path
-     id="line106"
-     d="m 146.89739,362 v 66"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 5.99999997;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
-  <path
-     id="line112"
-     d="m 472.89739,362 v 66"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 5.99999997;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
-  <path
-     id="line115"
-     d="m 524.89739,362 1,66"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 5.99999997;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
-  <path
-     id="line138"
-     d="M 39.897391,471 H 596.89739"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#FilledArrow_Marker)" />
-  <circle
-     id="ellipse146"
-     cy="471"
-     cx="472.8974"
-     r="23"
-     style="fill:#ff5a01;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     id="ellipse148"
-     cy="471"
-     cx="472.8974"
-     r="23"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="path151"
-     d="m 561.89739,447 h 1 l 2,2 v 44 l -2,2 h -1 l -2,-2 v -44 z"
-     inkscape:connector-curvature="0"
-     style="fill:#34302c;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     id="ellipse154"
-     cy="471"
-     cx="146.89738"
-     r="23"
-     style="fill:#6cb33e;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     id="ellipse156"
-     cy="471"
-     cx="146.89738"
-     r="23"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     id="ellipse159"
-     cy="471"
-     cx="525.8974"
-     r="23"
-     style="fill:#e739ce;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     id="ellipse161"
-     cy="471"
-     cx="525.8974"
-     r="23"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="line165"
-     d="m 273.89739,118 -1,132"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 6;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
-  <text
-     y="278"
-     x="-122.83796"
-     id="text937"
-     style="fill:#34302c;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
-    <tspan
-       id="tspan933"
-       y="300"
-       x="31.162039"
-       font-weight="700"
-       font-size="24"
-       style="font-weight:700;font-size:24px;font-family:Tahoma, 'Nimbus Sans L';fill:#34302c">onBackpressureBuffer ( <tspan
-   id="tspan923"
-   font-weight="400"
-   font-size="21"
-   style="font-weight:400;font-size:21px">maxSize = 2,</tspan>
- <tspan
-   style="font-weight:normal"
-   id="tspan13530">DROP_OLDEST</tspan>
-)</tspan>
-  </text>
-  <circle
-     cx="273.8974"
-     cy="95"
-     id="ellipse939"
-     r="23"
-     style="fill:#ff5a01;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     cx="273.8974"
-     cy="95"
-     id="ellipse941"
-     r="23"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     cx="344.8974"
-     cy="95"
-     id="ellipse943"
-     r="23"
-     style="fill:#e739ce;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     cx="344.8974"
-     cy="95"
-     id="ellipse945"
-     r="23"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="line940"
-     d="m 93.897391,470 -1,-90"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#45b8de;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99999997, 5.99999991;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_3-3)" />
-  <text
-     y="72.897392"
-     x="-461"
-     transform="rotate(-90)"
-     id="text944"
-     style="fill:#45b8de;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
-    <tspan
-       font-size="14"
-       font-weight="400"
-       x="-461"
-       y="85.897392"
-       id="tspan942"
-       style="font-weight:400;font-size:14px;font-family:Tahoma, 'Nimbus Sans L';fill:#45b8de">request(1)</tspan>
-  </text>
-  <path
-     id="line1093"
-     d="m 433.89739,470 -1,-90"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#45b8de;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99999997, 5.99999991;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_3-3)" />
-  <text
-     id="text1097"
-     transform="rotate(-90)"
-     x="-461"
-     y="412.8974"
-     style="fill:#45b8de;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
-    <tspan
-       id="tspan1095"
-       y="425.8974"
-       x="-461"
-       font-weight="400"
-       font-size="14"
-       style="font-weight:400;font-size:14px;font-family:Tahoma, 'Nimbus Sans L';fill:#45b8de">request(2)</tspan>
-  </text>
-  <path
-     id="line1113"
-     d="m 93.897391,268 -1,-150"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#45b8de;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99999998, 5.99999998;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_3-3)" />
-  <text
-     id="text1117"
-     transform="rotate(-90)"
-     x="-259"
-     y="72.897392"
-     style="fill:#45b8de;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
-    <tspan
-       id="tspan1115"
-       y="85.897392"
-       x="-259"
-       font-weight="400"
-       font-size="14"
-       style="font-weight:400;font-size:14px;font-family:Tahoma, 'Nimbus Sans L';fill:#45b8de">request(<tspan
-   id="tspan1121"
-   font-weight="700"
-   style="font-weight:700">unbounded</tspan>
- )</tspan>
-  </text>
-  <path
-     id="line1123"
-     d="m 560.89739,362 1,66"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2, 5.99999997;stroke-opacity:1;marker-end:url(#FilledArrow_Marker_2)" />
-  <path
-     d="m 126.89739,322 h 41 c 5,0 8,7 8,15 0,7 -3,14 -8,14 h -41 c -5,0 -9,-7 -9,-14 0,-8 4,-15 9,-15 z"
-     id="path22706"
-     stroke-miterlimit="4"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     d="m 188.89739,323 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
-     id="path22706-1"
-     stroke-miterlimit="4"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="path22771"
-     d="m 254.89739,323 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
-     stroke-miterlimit="4"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     d="m 320.89739,323 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
-     id="path22773"
-     stroke-miterlimit="4"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     id="path22775"
-     d="m 452.89739,323 h 41 c 5,0 9,6 9,14 0,8 -4,14 -9,14 h -41 c -5,0 -9,-6 -9,-14 0,-8 4,-14 9,-14 z"
-     stroke-miterlimit="4"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     cx="195.89738"
-     cy="337"
-     id="ellipse947"
-     r="11"
-     style="fill:#e6ba31;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     cx="261.8974"
-     cy="337"
-     id="ellipse983"
-     r="11"
-     style="fill:#e6ba31;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     r="11"
-     id="circle22801"
-     cy="337"
-     cx="289.8974"
-     style="fill:#ff5a01;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     cx="327.8974"
-     cy="337"
-     id="circle22805"
-     r="11"
-     style="fill:#ff5a01;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
-  <circle
-     cx="355.8974"
-     cy="337"
-     id="circle22807"
-     r="11"
-     style="fill:#e739ce;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     d="M 37.364586,313 H 617.43017"
-     id="line130-4"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-opacity:1;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     d="m 209.89739,323 v 28"
-     id="path22839"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     id="path22841"
-     d="m 147.89739,323 v 28"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="m 275.89739,323 v 28"
-     id="path22843"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     id="path22845"
-     d="m 341.89739,323 v 28"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="m 473.89739,323 v 28"
-     id="path22847"
-     inkscape:connector-curvature="0"
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="18 65 661.18 462.8" width="661.18" height="462.8" id="svg190">
+ <defs id="defs23">
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g4">
+    <path d="M12 0L0-4v9z" id="path2" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face7" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma-Bold"/>
+   </font-face-src>
+  </font-face>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g11">
+    <path d="M8 0L0-3v6z" id="path9" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3" stroke-miterlimit="10" viewBox="-6 -3 7 6" markerWidth="7" markerHeight="6" color="#34302c" stroke-linejoin="miter">
+   <g id="g16">
+    <path d="M-5 0l5 2v-4z" id="path14" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="16" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face19" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma"/>
+   </font-face-src>
+  </font-face>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="16" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face21" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma-Bold"/>
+   </font-face-src>
+  </font-face>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g16-6">
+    <path d="M8 0L0-3v6z" id="path14-7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+ </defs>
+ <path id="line31" d="M61.09 108.9h557" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
+ <path d="M39.02 283.9h619.13l1.13 1v88l-1.13 1H39.02l-1.12-1v-88z" id="path36" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse53" cy="108.9" cx="225.09" r="23" fill="#e6ba31" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse55" cy="108.9" cx="225.09" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line58" d="M225.09 131.9l-1 132" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <path id="line63" d="M430.09 132.9v131" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <circle id="ellipse66" cy="108.9" cx="295.09" r="23" fill="#ff5a01" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse68" cy="108.9" cx="295.09" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path71" d="M430.09 83.9h1l2 2v45l-2 2h-1l-2-2v-45z" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse74" cy="108.9" cx="168.09" r="23" fill="#6cb33e" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse76" cy="108.9" cx="168.09" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse79" cy="108.9" cx="366.09" r="23" fill="#e739ce" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse81" cy="108.9" cx="366.09" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line84" d="M168.09 131.9v132" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <path id="line87" d="M366.09 131.9v132" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <path id="line106" d="M168.09 375.9v66" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,5.99999997" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <path id="line112" d="M494.09 375.9v66" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,5.99999997" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <path id="line115" d="M546.09 375.9l1 66" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,5.99999997" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <path id="line138" d="M61.09 484.9h557" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
+ <circle id="ellipse146" cy="484.9" cx="494.09" r="23" fill="#ff5a01" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse148" cy="484.9" cx="494.09" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path151" d="M583.09 460.9h1l2 2v44l-2 2h-1l-2-2v-44z" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse154" cy="484.9" cx="168.09" r="23" fill="#6cb33e" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse156" cy="484.9" cx="168.09" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse159" cy="484.9" cx="547.09" r="23" fill="#e739ce" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse161" cy="484.9" cx="547.09" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line165" d="M295.09 131.9l-1 132" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <text y="291.9" x="-101.65" id="text937" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan933" y="313.9" x="52.35" font-weight="700" font-size="24" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c">onBackpressureBuffer ( <tspan id="tspan923" font-weight="400" font-size="21">maxSize = 2,</tspan> <tspan id="tspan13530" font-weight="400">DROP_OLDEST</tspan> )</tspan>
+ </text>
+ <circle cx="295.09" cy="108.9" id="ellipse939" r="23" fill="#ff5a01" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="295.09" cy="108.9" id="ellipse941" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="366.09" cy="108.9" id="ellipse943" r="23" fill="#e739ce" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="366.09" cy="108.9" id="ellipse945" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line940" d="M115.09 483.9l-1-90" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999997,5.99999991" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3)"/>
+ <text y="94.09" x="-474.9" transform="rotate(-90)" id="text944" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="14" font-weight="400" x="-474.9" y="107.09" id="tspan942" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request(1)</tspan>
+ </text>
+ <path id="line1093" d="M455.09 483.9l-1-90" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999997,5.99999991" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3)"/>
+ <text id="text1097" transform="rotate(-90)" x="-474.9" y="434.09" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan1095" y="447.09" x="-474.9" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request(2)</tspan>
+ </text>
+ <path id="line1113" d="M115.09 281.9l-1-150" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999998,5.99999998" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3)"/>
+ <text id="text1117" transform="rotate(-90)" x="-272.9" y="94.09" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan1115" y="107.09" x="-272.9" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request(<tspan id="tspan1121" font-weight="700">unbounded</tspan> )</tspan>
+ </text>
+ <path id="line1123" d="M582.09 375.9l1 66" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,5.99999997" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)"/>
+ <path d="M148.09 335.9h41c5 0 8 7 8 15 0 7-3 14-8 14h-41c-5 0-9-7-9-14 0-8 4-15 9-15z" id="path22706" stroke-miterlimit="4" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M210.09 336.9h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z" id="path22706-1" stroke-miterlimit="4" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path22771" d="M276.09 336.9h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z" stroke-miterlimit="4" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M342.09 336.9h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z" id="path22773" stroke-miterlimit="4" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path22775" d="M474.09 336.9h41c5 0 9 6 9 14s-4 14-9 14h-41c-5 0-9-6-9-14s4-14 9-14z" stroke-miterlimit="4" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="217.09" cy="350.9" id="ellipse947" r="11" fill="#e6ba31" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="283.09" cy="350.9" id="ellipse983" r="11" fill="#e6ba31" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="11" id="circle22801" cy="350.9" cx="311.09" fill="#ff5a01" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="349.09" cy="350.9" id="circle22805" r="11" fill="#ff5a01" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="377.09" cy="350.9" id="circle22807" r="11" fill="#e739ce" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M45.6 326.9h605.98" id="line130-4" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M231.09 336.9v28" id="path22839" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
+ <path id="path22841" d="M169.09 336.9v28" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
+ <path d="M297.09 336.9v28" id="path22843" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
+ <path id="path22845" d="M363.09 336.9v28" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
+ <path d="M495.09 336.9v28" id="path22847" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
 </svg>

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferTest.java
@@ -15,10 +15,15 @@
  */
 package reactor.core.publisher;
 
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -26,7 +31,9 @@ import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
+import reactor.test.StepVerifierOptions;
 import reactor.test.publisher.FluxOperatorTest;
+import reactor.test.publisher.TestPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -73,7 +80,7 @@ public class FluxOnBackpressureBufferTest
 	public void onBackpressureBufferMax() {
 		StepVerifier.create(Flux.range(1, 100)
 		                        .hide()
-		                        .onBackpressureBuffer(8), 0)
+		                        .onBackpressureBuffer(3), 0)
 		            .thenRequest(7)
 		            .expectNext(1, 2, 3, 4, 5, 6, 7)
 		            .thenAwait()
@@ -96,54 +103,129 @@ public class FluxOnBackpressureBufferTest
 		            .verifyErrorMatches(Exceptions::isOverflow);
 	}
 
+	//see https://github.com/reactor/reactor-core/issues/1666
 	@Test
-	public void onBackpressureBufferMaxCallbackOverflow() {
-		AtomicInteger last = new AtomicInteger();
+	public void onBackpressureBufferMaxCallbackUnder8() {
+		CopyOnWriteArrayList<Integer> overflown = new CopyOnWriteArrayList<>();
+		AtomicInteger producedCounter = new AtomicInteger();
 
-		StepVerifier.create(Flux.range(1, 100)
+		StepVerifier.create(Flux.range(1, 15)
+		                        .doOnNext(i -> producedCounter.incrementAndGet())
 		                        .hide()
-		                        .onBackpressureBuffer(8, last::set, BufferOverflowStrategy.ERROR), 0)
+		                        .onBackpressureBuffer(3, overflown::add),
+				StepVerifierOptions.create().initialRequest(0).checkUnderRequesting(false))
+		            .thenRequest(5)
+		            .expectNext(1, 2, 3, 4, 5)
+		            .thenAwait() //at this point the buffer is overrun since the range request was unbounded
+		            .thenRequest(100) //requesting more empties the buffer before an overflow error is propagated
+		            .expectNext(6, 7, 8)
+		            .expectErrorMatches(Exceptions::isOverflow)
+		            .verifyThenAssertThat()
+		            .hasNotDroppedElements();
 
-		            .thenRequest(7)
-		            .expectNext(1, 2, 3, 4, 5, 6, 7)
-		            .then(() -> assertThat(last.get()).isEqualTo(16))
-		            .thenRequest(9)
-		            .expectNextCount(8)
+		assertThat(overflown).as("passed to overflow handler").containsExactly(9);
+		assertThat(producedCounter).as("good source cancelled on first overflow").hasValue(9);
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/1666
+	@Test
+	public void onBackpressureBufferMaxCallbackSourceEmitsAfterComplete() {
+		TestPublisher<Integer> testPublisher = TestPublisher.createNoncompliant(TestPublisher.Violation.DEFER_CANCELLATION);
+		CopyOnWriteArrayList<Integer> overflown = new CopyOnWriteArrayList<>();
+		AtomicInteger producedCounter = new AtomicInteger();
+
+		StepVerifier.create(testPublisher.flux()
+		                                 .doOnNext(i -> producedCounter.incrementAndGet())
+		                                 .onBackpressureBuffer(3, overflown::add),
+				StepVerifierOptions.create().initialRequest(0).checkUnderRequesting(false))
+		            .thenRequest(5)
+					.then(() -> testPublisher.next(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+		            .expectNext(1, 2, 3, 4, 5)
+		            .thenAwait() //at this point the buffer is overrun since the range request was unbounded
+		            .thenRequest(100) //requesting more empties the buffer before an overflow error is propagated
+		            .expectNext(6, 7, 8)
+		            .expectErrorMatches(Exceptions::isOverflow)
+		            .verifyThenAssertThat()
+		            .hasDroppedExactly(10, 11, 12, 13, 14, 15);
+
+		//the rest, asserted above, is dropped because the source was cancelled
+		assertThat(overflown).as("passed to overflow handler").containsExactly(9);
+		assertThat(producedCounter).as("bad source produced").hasValue(15);
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/1666
+	@Test
+	public void stepByStepRequesting() {
+		List<Long> discardedItems = Collections.synchronizedList(new ArrayList<>());
+		AtomicInteger sourceProduced = new AtomicInteger();
+		AtomicInteger sourceCancelledAt = new AtomicInteger(-1);
+
+		StepVerifier.withVirtualTime(() ->
+						Flux.interval(Duration.ofSeconds(1)) // lets emit 1 item per second; starting with zero
+						    .take(8)
+						    .doOnNext(v -> sourceProduced.incrementAndGet())
+						    .doOnCancel(() -> sourceCancelledAt.set(sourceProduced.get() - 1))
+						    .onBackpressureBuffer(2, discardedItems::add)
+				, 0)
+		            .expectSubscription()
+		            .thenAwait(Duration.ofSeconds(1)) // request is in sync with producer for now
+		            //stores 0: (0)
+		            .thenRequest(1)
+		            //drains 0: ()
+		            .expectNext(0L)
+		            .thenAwait(Duration.ofSeconds(2)) // request is behind producer by 1
+		            //stores 1 and 2: (1, 2)
+		            .thenRequest(1)
+		            //drains 1: (2)
+		            .expectNext(1L)
+		            .thenAwait(Duration.ofSeconds(2))//request has now been behind producer two times
+		            //stores 3: (2, 3), attempts to store 4 => overflows 4, cancels
+		            .then(() -> Assertions.assertThat(sourceCancelledAt).as("source cancelled at").hasValue(4))
+		            .thenRequest(1)
+		            //drains 2: (3)
+		            .expectNext(2L)
+		            .thenAwait(Duration.ofSeconds(4)) //this shouldn't produce any new elements as source cancelled
+		            .thenRequest(1)
+		            //finally drains buffer: (), propagate overflow
+		            .expectNext(3L)
 		            .verifyErrorMatches(Exceptions::isOverflow);
+
+		Assertions.assertThat(discardedItems).containsExactly(4L);
+		Assertions.assertThat(sourceProduced).as("source produced").hasValue(5);
 	}
 
 	@Test
-	public void onBackpressureBufferMaxCallbackOverflow2() {
-		AtomicInteger last = new AtomicInteger();
-
+	public void gh1666_bufferThree() {
+		AtomicInteger overflow = new AtomicInteger(-1);
 		StepVerifier.create(Flux.range(1, 100)
 		                        .hide()
-		                        .onBackpressureBuffer(8, last::set,
-				                        BufferOverflowStrategy.DROP_OLDEST), 0)
+		                        .onBackpressureBuffer(3, overflow::set)
+				, 0)
+		            .expectSubscription()
+		            .thenRequest(1)
+		            .expectNext(1)
+		            .thenAwait()
+		            .thenCancel()
+		            .verify();
 
-		            .thenRequest(7)
-		            .expectNext(1, 2, 3, 4, 5, 6, 7)
-		            .then(() -> assertThat(last.get()).isEqualTo(92))
-		            .thenRequest(9)
-		            .expectNext(93, 94, 95, 96, 97, 98, 99, 100)
-		            .verifyComplete();
+		assertThat(overflow).as("overflow value").hasValue(5);
 	}
 
 	@Test
-	public void onBackpressureBufferMaxCallbackOverflow3() {
-		AtomicInteger last = new AtomicInteger();
-
+	public void gh1666_bufferNine() {
+		AtomicInteger overflow = new AtomicInteger();
 		StepVerifier.create(Flux.range(1, 100)
 		                        .hide()
-		                        .onBackpressureBuffer(8, last::set,
-				                        BufferOverflowStrategy.DROP_LATEST), 0)
+		                        .onBackpressureBuffer(9, overflow::set)
+				, 0)
+		            .expectSubscription()
+		            .thenRequest(1)
+		            .expectNext(1)
+		            .thenAwait()
+		            .thenCancel()
+		            .verify();
 
-		            .thenRequest(7)
-		            .expectNext(1, 2, 3, 4, 5, 6, 7)
-		            .then(() -> assertThat(last.get()).isEqualTo(100))
-		            .thenRequest(9)
-		            .expectNext(8, 9, 10, 11, 12, 13, 14, 15)
-		            .verifyComplete();
+		assertThat(overflow).as("overflow value").hasValue(11);
 	}
 
 	@Test


### PR DESCRIPTION
The queue.offer() can be unreliable, mainly due to Spsc*Queue rounding the
requested capacity up to the nearest power of two, as well as 
Queues.get(capacity) rounding up capacity to a minimum of 8...

This commit keeps track of the exact buffer size and compares it to the 
queue size() when in bounded mode.

The documentation has been improved to reflect this, as well as the marble
diagram of both variants with a bufferSize and no strategy (the strategy
one being a different implementation that is not impacted).

Tests have been added, and some tests that didn't cover 
FluxOnBackpressureBuffer have been moved to the more correct 
FluxOnBackpressureStrategyTest case.