### PR TITLE
Do not mark `onEachOperatorHook` field as volatile.

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
@@ -497,8 +497,8 @@ public abstract class Hooks {
 	}
 
 	//Hooks that are transformative
-	static volatile Function<Publisher, Publisher>                             onEachOperatorHook;
-	static volatile Function<Publisher, Publisher>                             onLastOperatorHook;
+	static Function<Publisher, Publisher> onEachOperatorHook;
+	static Function<Publisher, Publisher> onLastOperatorHook;
 	static volatile BiFunction<? super Throwable, Object, ? extends Throwable> onOperatorErrorHook;
 
 	//Hooks that are just callbacks

--- a/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
@@ -498,7 +498,7 @@ public abstract class Hooks {
 
 	//Hooks that are transformative
 	static Function<Publisher, Publisher> onEachOperatorHook;
-	static Function<Publisher, Publisher> onLastOperatorHook;
+	static volatile Function<Publisher, Publisher> onLastOperatorHook;
 	static volatile BiFunction<? super Throwable, Object, ? extends Throwable> onOperatorErrorHook;
 
 	//Hooks that are just callbacks


### PR DESCRIPTION
Since every operator at assembly time accesses these fields,
we should relax the guarantees and avoid a volatile access.


/cc @akarnokd 