### PR TITLE
Use BlockHound 1.0.0.M3 instead of a SNAPSHOT

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -56,9 +56,7 @@ dependencies {
   optional("org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}")
 
   //Optional BlockHound support
-  optional 'io.projectreactor.tools:blockhound:1.0.0.BUILD-SNAPSHOT'
-
-  blockHoundTestRuntime 'io.projectreactor.tools:blockhound:1.0.0.BUILD-SNAPSHOT'
+  optional 'io.projectreactor.tools:blockhound:1.0.0.M3'
 
   //Optional JDK 9 Converter
   jsr166backport "io.projectreactor:jsr166:1.0.0.RELEASE"


### PR DESCRIPTION
[BlockHound 1.0.0.M3 is out](https://github.com/reactor/BlockHound/releases/tag/1.0.0.M3), featuring built-in awareness of the native SPI support in reactor-core.

We should update the version we depend on.