### PR TITLE
Reintroduce Kotlin extensions, this time as Deprecated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ buildscript {
 plugins {
   id 'org.asciidoctor.convert' version '1.5.9.2'
   id "me.champeau.gradle.jmh" version "0.4.7" apply false
-  id "org.jetbrains.dokka" version "0.9.16"
   id "me.champeau.gradle.japicmp" version "0.2.6"
   id "de.undercouch.download" version "3.4.3"
   id "org.unbroken-dome.test-sets" version "1.5.1" apply false // 2.x version does not work with Gradle 4.10

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@
 import org.gradle.api.internal.plugins.osgi.OsgiHelper
 
 buildscript {
+  ext.kotlinVersion = '1.2.51'
   repositories {
 	maven { url "https://repo.spring.io/plugins-release" }
   }
@@ -23,12 +24,14 @@ buildscript {
 	classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
 	classpath 'io.spring.gradle:spring-io-plugin:0.0.4.RELEASE'
 	classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.0'
+	classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
   }
 }
 
 plugins {
   id 'org.asciidoctor.convert' version '1.5.9.2'
   id "me.champeau.gradle.jmh" version "0.4.7" apply false
+  id "org.jetbrains.dokka" version "0.9.16"
   id "me.champeau.gradle.japicmp" version "0.2.6"
   id "de.undercouch.download" version "3.4.3"
   id "org.unbroken-dome.test-sets" version "1.5.1" apply false // 2.x version does not work with Gradle 4.10
@@ -71,6 +74,7 @@ ext {
 
 
   bundleImportPackages = ['org.slf4j;resolution:=optional;version="[1.5.4,2)"',
+						  'kotlin.*;resolution:=optional',
 						  'io.micrometer.*;resolution:=optional',
 						  '!javax.annotation',
 						  '!javax.annotation.meta',
@@ -79,6 +83,7 @@ ext {
 
 configure(subprojects) { p ->
   apply plugin: 'java'
+  apply plugin: 'kotlin'
   apply plugin: 'jacoco'
   apply plugin: 'propdeps'
   apply plugin: 'osgi'
@@ -156,6 +161,16 @@ configure(subprojects) { p ->
 	targetCompatibility = 1.8
   }
 
+  compileKotlin {
+	kotlinOptions.jvmTarget = "1.8"
+	kotlinOptions.freeCompilerArgs = ["-Xjsr305=strict"]
+  }
+
+  compileTestKotlin {
+	kotlinOptions.jvmTarget = "1.8"
+	kotlinOptions.freeCompilerArgs = ["-Xjsr305=strict"]
+  }
+
   if (JavaVersion.current().isJava8Compatible()) {
 	compileTestJava.options.compilerArgs += "-parameters"
 	p.tasks.withType(Javadoc) {
@@ -203,6 +218,13 @@ configure(subprojects) { p ->
 	  }
 	}
   }
+
+  // now that kotlin-gradle-plugin 1.1.60 is out with fix for https://youtrack.jetbrains.com/issue/KT-17564
+  // be wary and fail if the issue of source file duplication in jar comes up again
+  sourcesJar {
+	duplicatesStrategy = DuplicatesStrategy.FAIL
+  }
+
 }
 
 if (project.hasProperty('platformVersion')) {

--- a/docs/asciidoc/index.asciidoc
+++ b/docs/asciidoc/index.asciidoc
@@ -36,6 +36,12 @@ endif::[]
 
 //TODO see other sections from consuming.adoc
 
+include::kotlin.adoc[leveloffset=1]
+ifeval::["{backend}" == "html5"]
+https://github.com/reactor/reactor-core/edit/master/docs/asciidoc/kotlin.adoc[Suggest Edit, title="Suggest an edit to the above section via github", role="fa fa-edit"]
+to "<<kotlin>>"
+endif::[]
+
 include::testing.adoc[leveloffset=1]
 ifeval::["{backend}" == "html5"]
 https://github.com/reactor/reactor-core/edit/master/docs/asciidoc/testing.adoc[Suggest Edit, title="Suggest an edit to the above section via github", role="fa fa-edit"]

--- a/docs/asciidoc/kotlin.adoc
+++ b/docs/asciidoc/kotlin.adoc
@@ -1,0 +1,88 @@
+[[kotlin]]
+= Kotlin support
+
+[[kotlin-introduction]]
+https://kotlinlang.org[Kotlin] is a statically-typed language targeting the JVM (and other platforms),
+which allows writing concise and elegant code while providing very good
+https://kotlinlang.org/docs/reference/java-interop.html[interoperability] with
+existing libraries written in Java.
+
+This section describes Reactor's first-class support for Kotlin.
+
+[[kotlin-requirements]]
+== Requirements
+
+Reactor supports Kotlin 1.1+ and requires
+https://bintray.com/bintray/jcenter/org.jetbrains.kotlin%3Akotlin-stdlib[`kotlin-stdlib`]
+(or one of its https://bintray.com/bintray/jcenter/org.jetbrains.kotlin%3Akotlin-stdlib-jre7[`kotlin-stdlib-jre7`]
+or https://bintray.com/bintray/jcenter/org.jetbrains.kotlin%3Akotlin-stdlib-jre8[`kotlin-stdlib-jre8`] variants).
+
+[[kotlin-extensions]]
+== Extensions
+
+Thanks to its great https://kotlinlang.org/docs/reference/java-interop.html[Java interoperability]
+and to https://kotlinlang.org/docs/reference/extensions.html[Kotlin extensions], Reactor
+Kotlin APIs leverage regular Java APIs and are additionally enhanced by a few Kotlin-specific APIs
+that are available out of the box within Reactor artifacts.
+
+NOTE: Keep in mind that Kotlin extensions need to be imported to be used. This means
+for example that the `Throwable.toFlux` Kotlin extension
+is available only if `import reactor.core.publisher.toFlux` is imported.
+That said, similar to static imports, an IDE should automatically suggest the import in most cases.
+
+For example, https://kotlinlang.org/docs/reference/inline-functions.html#reified-type-parameters[Kotlin reified type parameters]
+provide a workaround for JVM https://docs.oracle.com/javase/tutorial/java/generics/erasure.html[generics type erasure],
+and Reactor provides some extensions to take advantage of this feature.
+
+The following table compares Reactor with Java against Reactor with Kotlin and extensions:
+
+|===
+|*Java*|*Kotlin with extensions*
+|`Mono.just("foo")`
+|`"foo".toMono()`
+|`Flux.fromIterable(list)`
+|`list.toFlux()`
+|`Mono.error(new RuntimeException())`
+|`RuntimeException().toMono()`
+|`Flux.error(new RuntimeException())`
+|`RuntimeException().toFlux()`
+|`flux.ofType(Foo.class)`
+|`flux.ofType<Foo>()` or `flux.ofType(Foo::class)`
+|`StepVerifier.create(flux).verifyComplete()`
+|`flux.test().verifyComplete()`
+|===
+
+The https://projectreactor.io/docs/core/release/kdoc-api/[Reactor KDoc API] lists and documents
+all the available Kotlin extensions.
+
+[[kotlin-null-safety]]
+== Null Safety
+
+One of Kotlin's key features is https://kotlinlang.org/docs/reference/null-safety.html[null safety],
+which cleanly deals with `null` values at compile time rather than bumping into the famous
+`NullPointerException` at runtime. This makes applications safer through nullability
+declarations and expressive "`value or no value`" semantics without paying the cost of wrappers such as `Optional`.
+(Kotlin allows using functional constructs with nullable values. See this
+https://www.baeldung.com/kotlin-null-safety[comprehensive guide to Kotlin null-safety].)
+
+Although Java does not let one express null safety in its type-system, Reactor <<null-safety,now
+provides null safety>> of the whole Reactor API through tooling-friendly annotations declared
+in the `reactor.util.annotation` package.
+By default, types from Java APIs used in Kotlin are recognized as
+https://kotlinlang.org/docs/reference/java-interop.html#null-safety-and-platform-types[platform types]
+for which null-checks are relaxed.
+https://github.com/Kotlin/KEEP/blob/jsr-305/proposals/jsr-305-custom-nullability-qualifiers.md[Kotlin support for JSR 305 annotations]
+and Reactor nullability annotations provide null-safety for the whole Reactor API to Kotlin developers,
+with the advantage of dealing with `null`-related issues at compile time.
+
+You can configure the JSR 305 checks by adding the `-Xjsr305` compiler flag with the following
+options: `-Xjsr305={strict|warn|ignore}`.
+
+For kotlin versions 1.1.50+, the default behavior is the same as `-Xjsr305=warn`.
+The `strict` value is required to have the Reactor API full null-safety taken into account
+but should be considered experimental, since the Reactor API nullability declaration could evolve
+even between minor releases, as more checks may be added in the future).
+
+NOTE: Nullability for generic type arguments, variable arguments, and array elements is not supported yet,
+but itshould be in an upcoming release. See https://github.com/Kotlin/KEEP/issues/79[this dicussion]
+for up-to-date information.

--- a/docs/asciidoc/kotlin.adoc
+++ b/docs/asciidoc/kotlin.adoc
@@ -22,15 +22,16 @@ or https://bintray.com/bintray/jcenter/org.jetbrains.kotlin%3Akotlin-stdlib-jre8
 
 [WARNING]
 ====
-As of `Dysprosium-M1` (ie. `reactor-core 3.3.0.M1`), Kotlin extensions are deprecated in
-core and have been moved to https://github.com/reactor/reactor-kotlin-extensions. The package
-names start with `reactor.kotlin` instead of simply `reactor`.
+As of `Dysprosium-M1` (ie. `reactor-core 3.3.0.M1`), Kotlin extensions are moved to a
+dedicated https://github.com/reactor/reactor-kotlin-extensions[`reactor-kotlin-extensions`]
+module with new package names that start with `reactor.kotlin` instead of simply `reactor`.
 
-Please add the following dependency to your project:
+As a consequence, Kotlin extensions in `reactor-core` module are deprecated.
+The new dependency's groupId and artifactId are:
 
 [source,gradle]
 ----
-io.projectreactor.kotlin:reactor-kotlin-extensions:1.1.0.BUILD-SNAPSHOT
+io.projectreactor.kotlin:reactor-kotlin-extensions
 ----
 ====
 

--- a/docs/asciidoc/kotlin.adoc
+++ b/docs/asciidoc/kotlin.adoc
@@ -7,7 +7,7 @@ which allows writing concise and elegant code while providing very good
 https://kotlinlang.org/docs/reference/java-interop.html[interoperability] with
 existing libraries written in Java.
 
-This section describes Reactor's first-class support for Kotlin.
+This section describes Reactor's support for Kotlin.
 
 [[kotlin-requirements]]
 == Requirements
@@ -20,6 +20,21 @@ or https://bintray.com/bintray/jcenter/org.jetbrains.kotlin%3Akotlin-stdlib-jre8
 [[kotlin-extensions]]
 == Extensions
 
+[WARNING]
+====
+As of `Dysprosium-M1` (ie. `reactor-core 3.3.0.M1`), Kotlin extensions are deprecated in
+core and have been moved to https://github.com/reactor/reactor-kotlin-extensions. The package
+names start with `reactor.kotlin` instead of simply `reactor`.
+
+Please add the following dependency to your project:
+
+[source,gradle]
+----
+io.projectreactor.kotlin:reactor-kotlin-extensions:1.1.0.BUILD-SNAPSHOT
+----
+====
+
+
 Thanks to its great https://kotlinlang.org/docs/reference/java-interop.html[Java interoperability]
 and to https://kotlinlang.org/docs/reference/extensions.html[Kotlin extensions], Reactor
 Kotlin APIs leverage regular Java APIs and are additionally enhanced by a few Kotlin-specific APIs
@@ -27,7 +42,7 @@ that are available out of the box within Reactor artifacts.
 
 NOTE: Keep in mind that Kotlin extensions need to be imported to be used. This means
 for example that the `Throwable.toFlux` Kotlin extension
-is available only if `import reactor.core.publisher.toFlux` is imported.
+is available only if `import reactor.kotlin.core.publisher.toFlux` is imported.
 That said, similar to static imports, an IDE should automatically suggest the import in most cases.
 
 For example, https://kotlinlang.org/docs/reference/inline-functions.html#reified-type-parameters[Kotlin reified type parameters]
@@ -52,8 +67,9 @@ The following table compares Reactor with Java against Reactor with Kotlin and e
 |`flux.test().verifyComplete()`
 |===
 
-The https://projectreactor.io/docs/core/release/kdoc-api/[Reactor KDoc API] lists and documents
-all the available Kotlin extensions.
+//The https://projectreactor.io/docs/core/release/kdoc-api/[Reactor KDoc API] lists and documents
+//all the available Kotlin extensions.
+//TODO publish the dokka, make it a module and add the link back here
 
 [[kotlin-null-safety]]
 == Null Safety

--- a/docs/asciidoc/kotlin.adoc
+++ b/docs/asciidoc/kotlin.adoc
@@ -67,9 +67,8 @@ The following table compares Reactor with Java against Reactor with Kotlin and e
 |`flux.test().verifyComplete()`
 |===
 
-//The https://projectreactor.io/docs/core/release/kdoc-api/[Reactor KDoc API] lists and documents
-//all the available Kotlin extensions.
-//TODO publish the dokka, make it a module and add the link back here
+The https://projectreactor.io/docs/kotlin/release/kdoc-api/[Reactor KDoc API] lists and documents
+all the available Kotlin extensions.
 
 [[kotlin-null-safety]]
 == Null Safety

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -47,14 +47,13 @@ dependencies {
   // JSR-305 annotations
   optional "com.google.code.findbugs:jsr305:3.0.2"
 
-  // For NotNull
-  optional 'org.jetbrains:annotations:13.0'
-
   //Optional Logging Operator
   optional "org.slf4j:slf4j-api:$slf4jVersion"
 
   //Optional Metrics
   optional "io.micrometer:micrometer-core:$micrometerVersion"
+
+  optional("org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}")
 
   //Optional BlockHound support
   optional 'io.projectreactor.tools:blockhound:1.0.0.M3'
@@ -129,15 +128,9 @@ task japicmp(type: JapicmpTask) {
 		  'reactor.core.publisher.TopicProcessor',
 		  'reactor.core.publisher.EventLoopProcessor$Slot',
 		  'reactor.util.concurrent.WaitStrategy',
-		  'reactor.core.publisher.MonoProcessor',
-		  'reactor.core.publisher.FluxExtensionsKt',
-		  'reactor.core.publisher.FluxExtensionsKt$toFlux$1',
-		  'reactor.core.publisher.FluxExtensionsKt$toIterable$1',
-		  'reactor.core.publisher.MonoExtensionsKt',
-		  'reactor.core.publisher.MonoWhenFunctionsKt',
-		  'reactor.core.publisher.MonoWhenFunctionsKt$zip$1',
-		  'reactor.util.function.TupleExtensionsKt',
+		  'reactor.core.publisher.MonoProcessor'
   ]
+//	classExcludes = []
 //	methodExcludes = ["reactor.core.Scannable#operatorName()"]
 }
 
@@ -159,6 +152,11 @@ javadoc {
 				   "implNote:a:Implementation Note:", "reactor.errorMode:m:Error Mode Support",
 				   "reactor.discard:m:onDiscard Support"]
 
+  // In Java 9, javadoc generator will complain if it finds invalid class files in the classpath
+  // And Kotlin produces such classes, plus kotlin plugin puts them in the main sourceSet
+  classpath = sourceSets.main.output.filter { !it.absolutePath.contains("kotlin") }
+  classpath += sourceSets.main.compileClasspath
+
   maxMemory = "1024m"
   destinationDir = new File(project.buildDir, "docs/javadoc")
 
@@ -175,6 +173,44 @@ javadoc {
 	  include "**/doc-files/**/*"
 	}
   }
+}
+
+// Need https://github.com/Kotlin/dokka/issues/184 to be fixed to avoid "Can't find node by signature" log spam
+task dokka(type: org.jetbrains.dokka.gradle.DokkaTask) {
+  dependsOn jar
+  group = "documentation"
+  description = "Generates Kotlin API documentation."
+  moduleName = "reactor-core"
+  jdkVersion = 8
+
+  outputFormat = "html"
+  outputDirectory = new File(project.buildDir, "docs/kdoc")
+
+  //this is needed so that links to java classes are resolved
+  doFirst {
+	classpath += project.jar.outputs.files.getFiles()
+	classpath += project.sourceSets.main.compileClasspath
+  }
+  //this is needed so that the kdoc only generates for kotlin classes
+  //(default kotlinTasks sourceSet also includes java)
+  kotlinTasks {
+
+  }
+  processConfigurations = []
+  sourceDirs = files("src/main/kotlin")
+
+  externalDocumentationLink {
+	url = new URL("https://projectreactor.io/docs/core/release/api/")
+  }
+  externalDocumentationLink {
+	url = new URL("https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/")
+  }
+}
+
+task kdocZip(type: Zip, dependsOn: dokka) {
+  //ends up similar to javadoc jar: reactor-core-xxxx.RELEASE-kdoc.zip
+  classifier = 'kdoc'
+  from("${project.buildDir}/docs/kdoc")
 }
 
 task testStaticInit(type: Test, group: 'verification') {
@@ -250,6 +286,7 @@ artifacts {
   archives sourcesJar
   archives javadocJar
   archives rootProject.tasks.docsZip
+  archives kdocZip
 }
 
 jacocoTestReport.dependsOn test

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -175,44 +175,6 @@ javadoc {
   }
 }
 
-// Need https://github.com/Kotlin/dokka/issues/184 to be fixed to avoid "Can't find node by signature" log spam
-task dokka(type: org.jetbrains.dokka.gradle.DokkaTask) {
-  dependsOn jar
-  group = "documentation"
-  description = "Generates Kotlin API documentation."
-  moduleName = "reactor-core"
-  jdkVersion = 8
-
-  outputFormat = "html"
-  outputDirectory = new File(project.buildDir, "docs/kdoc")
-
-  //this is needed so that links to java classes are resolved
-  doFirst {
-	classpath += project.jar.outputs.files.getFiles()
-	classpath += project.sourceSets.main.compileClasspath
-  }
-  //this is needed so that the kdoc only generates for kotlin classes
-  //(default kotlinTasks sourceSet also includes java)
-  kotlinTasks {
-
-  }
-  processConfigurations = []
-  sourceDirs = files("src/main/kotlin")
-
-  externalDocumentationLink {
-	url = new URL("https://projectreactor.io/docs/core/release/api/")
-  }
-  externalDocumentationLink {
-	url = new URL("https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/")
-  }
-}
-
-task kdocZip(type: Zip, dependsOn: dokka) {
-  //ends up similar to javadoc jar: reactor-core-xxxx.RELEASE-kdoc.zip
-  classifier = 'kdoc'
-  from("${project.buildDir}/docs/kdoc")
-}
-
 task testStaticInit(type: Test, group: 'verification') {
   systemProperty 'reactor.trace.operatorStacktrace', 'true'
   include '**/*TestStaticInit.*'
@@ -286,7 +248,6 @@ artifacts {
   archives sourcesJar
   archives javadocJar
   archives rootProject.tasks.docsZip
-  archives kdocZip
 }
 
 jacocoTestReport.dependsOn test

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoBridges.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoBridges.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.core.publisher;
+
+import java.util.function.Function;
+
+import org.reactivestreams.Publisher;
+
+/**
+ * Utilities to avoid vararg array copying overhead when relaying vararg parameters
+ * to underlying Java methods from their corresponding Kotlin functions.
+ * <p>
+ * When <a href="https://youtrack.jetbrains.com/issue/KT-17043">this</a> issue is
+ * resolved, uses of these bridge methods can be removed.
+ *
+ * @author DoHyung Kim
+ * @since 3.1
+ */
+final class MonoBridges {
+
+    static <R> Mono<R> zip(Function<? super Object[], ? extends R> combinator, Mono<?>[] monos) {
+        return Mono.zip(combinator, monos);
+    }
+
+    static Mono<Void> when(Publisher<?>[] sources) {
+        return Mono.when(sources);
+    }
+}

--- a/reactor-core/src/main/kotlin/reactor/core/publisher/FluxExtensions.kt
+++ b/reactor-core/src/main/kotlin/reactor/core/publisher/FluxExtensions.kt
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher
+
+import org.reactivestreams.Publisher
+import java.util.stream.Stream
+import kotlin.reflect.KClass
+
+
+/**
+ * Extension to convert any [Publisher] of [T] to a [Flux].
+ *
+ * Note this extension doesn't make much sense on a [Flux] but it won't be converted so it
+ * doesn't hurt.
+ *
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T : Any> Publisher<T>.toFlux(): Flux<T> = Flux.from(this)
+
+/**
+ * Extension for transforming an [Iterator] to a [Flux].
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T : Any> Iterator<T>.toFlux(): Flux<T> = toIterable().toFlux()
+
+/**
+ * Extension for transforming an [Iterable] to a [Flux].
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T : Any> Iterable<T>.toFlux(): Flux<T> = Flux.fromIterable(this)
+
+/**
+ * Extension for transforming a [Sequence] to a [Flux].
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T : Any> Sequence<T>.toFlux(): Flux<T> = Flux.fromIterable(object : Iterable<T> {
+    override fun iterator(): Iterator<T> = this@toFlux.iterator()
+})
+
+/**
+ * Extension for transforming a [Stream] to a [Flux].
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T : Any> Stream<T>.toFlux(): Flux<T> = Flux.fromStream(this)
+
+/**
+ * Extension for transforming a [BooleanArray] to a [Flux].
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun BooleanArray.toFlux(): Flux<Boolean> = this.toList().toFlux()
+
+/**
+ * Extension for transforming a [ByteArray] to a [Flux].
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun ByteArray.toFlux(): Flux<Byte> = this.toList().toFlux()
+
+/**
+ * Extension for transforming a [ShortArray] to a [Flux].
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun ShortArray.toFlux(): Flux<Short> = this.toList().toFlux()
+
+/**
+ * Extension for transforming a [IntArray] to a [Flux].
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun IntArray.toFlux(): Flux<Int> = this.toList().toFlux()
+
+/**
+ * Extension for transforming a [LongArray] to a [Flux].
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun LongArray.toFlux(): Flux<Long> = this.toList().toFlux()
+
+/**
+ * Extension for transforming a [FloatArray] to a [Flux].
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun FloatArray.toFlux(): Flux<Float> = this.toList().toFlux()
+
+/**
+ * Extension for transforming a [DoubleArray] to a [Flux].
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun DoubleArray.toFlux(): Flux<Double> = this.toList().toFlux()
+
+/**
+ * Extension for transforming an [Array] to a [Flux].
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T> Array<out T>.toFlux(): Flux<T> = Flux.fromArray(this)
+
+private fun <T> Iterator<T>.toIterable() = object : Iterable<T> {
+    override fun iterator(): Iterator<T> = this@toIterable
+}
+
+/**
+ * Extension for transforming an exception to a [Flux] that completes with the specified error.
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T> Throwable.toFlux(): Flux<T> = Flux.error(this)
+
+/**
+ * Extension for [Flux.cast] providing a `cast<Foo>()` variant.
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+inline fun <reified T : Any> Flux<*>.cast(): Flux<T> = cast(T::class.java)
+
+
+/**
+ * Extension for [Flux.doOnError] providing a [KClass] based variant.
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T, E : Throwable> Flux<T>.doOnError(exceptionType: KClass<E>, onError: (E) -> Unit): Flux<T> =
+        doOnError(exceptionType.java) { onError(it) }
+
+/**
+ * Extension for [Flux.onErrorMap] providing a [KClass] based variant.
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T, E : Throwable> Flux<T>.onErrorMap(exceptionType: KClass<E>, mapper: (E) -> Throwable): Flux<T> =
+        onErrorMap(exceptionType.java) { mapper(it) }
+
+/**
+ * Extension for [Flux.ofType] providing a `ofType<Foo>()` variant.
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+inline fun <reified T : Any> Flux<*>.ofType(): Flux<T> = ofType(T::class.java)
+
+/**
+ * Extension for [Flux.onErrorResume] providing a [KClass] based variant.
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T : Any, E : Throwable> Flux<T>.onErrorResume(exceptionType: KClass<E>, fallback: (E) -> Publisher<T>): Flux<T> =
+        onErrorResume(exceptionType.java) { fallback(it) }
+
+/**
+ * Extension for [Flux.onErrorReturn] providing a [KClass] based variant.
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T : Any, E : Throwable> Flux<T>.onErrorReturn(exceptionType: KClass<E>, value: T): Flux<T> =
+        onErrorReturn(exceptionType.java, value)
+
+/**
+ * Extension for flattening [Flux] of [Iterable]
+ *
+ * @author Igor Perikov
+ * @since 3.1
+ */
+fun <T : Any> Flux<out Iterable<T>>.split(): Flux<T> = this.flatMapIterable { it }
+
+/**
+ * Extension for [Flux.switchIfEmpty] accepting a function providing a Publisher. This allows having a deferred execution with
+ * the [switchIfEmpty] operator
+ *
+ * @author Kevin Davin
+ * @since 3.2
+ */
+fun <T> Flux<T>.switchIfEmpty(s: () -> Publisher<T>): Flux<T> = this.switchIfEmpty(Flux.defer { s() })

--- a/reactor-core/src/main/kotlin/reactor/core/publisher/FluxExtensions.kt
+++ b/reactor-core/src/main/kotlin/reactor/core/publisher/FluxExtensions.kt
@@ -30,6 +30,8 @@ import kotlin.reflect.KClass
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlux()", "reactor.kotlin.core.publisher.toFlux"))
 fun <T : Any> Publisher<T>.toFlux(): Flux<T> = Flux.from(this)
 
 /**
@@ -38,6 +40,8 @@ fun <T : Any> Publisher<T>.toFlux(): Flux<T> = Flux.from(this)
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlux()", "reactor.kotlin.core.publisher.toFlux"))
 fun <T : Any> Iterator<T>.toFlux(): Flux<T> = toIterable().toFlux()
 
 /**
@@ -46,6 +50,8 @@ fun <T : Any> Iterator<T>.toFlux(): Flux<T> = toIterable().toFlux()
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlux()", "reactor.kotlin.core.publisher.toFlux"))
 fun <T : Any> Iterable<T>.toFlux(): Flux<T> = Flux.fromIterable(this)
 
 /**
@@ -54,6 +60,8 @@ fun <T : Any> Iterable<T>.toFlux(): Flux<T> = Flux.fromIterable(this)
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlux()", "reactor.kotlin.core.publisher.toFlux"))
 fun <T : Any> Sequence<T>.toFlux(): Flux<T> = Flux.fromIterable(object : Iterable<T> {
     override fun iterator(): Iterator<T> = this@toFlux.iterator()
 })
@@ -64,6 +72,8 @@ fun <T : Any> Sequence<T>.toFlux(): Flux<T> = Flux.fromIterable(object : Iterabl
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlux()", "reactor.kotlin.core.publisher.toFlux"))
 fun <T : Any> Stream<T>.toFlux(): Flux<T> = Flux.fromStream(this)
 
 /**
@@ -72,6 +82,8 @@ fun <T : Any> Stream<T>.toFlux(): Flux<T> = Flux.fromStream(this)
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlux()", "reactor.kotlin.core.publisher.toFlux"))
 fun BooleanArray.toFlux(): Flux<Boolean> = this.toList().toFlux()
 
 /**
@@ -80,6 +92,8 @@ fun BooleanArray.toFlux(): Flux<Boolean> = this.toList().toFlux()
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlux()", "reactor.kotlin.core.publisher.toFlux"))
 fun ByteArray.toFlux(): Flux<Byte> = this.toList().toFlux()
 
 /**
@@ -88,6 +102,8 @@ fun ByteArray.toFlux(): Flux<Byte> = this.toList().toFlux()
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlux()", "reactor.kotlin.core.publisher.toFlux"))
 fun ShortArray.toFlux(): Flux<Short> = this.toList().toFlux()
 
 /**
@@ -96,6 +112,8 @@ fun ShortArray.toFlux(): Flux<Short> = this.toList().toFlux()
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlux()", "reactor.kotlin.core.publisher.toFlux"))
 fun IntArray.toFlux(): Flux<Int> = this.toList().toFlux()
 
 /**
@@ -104,6 +122,8 @@ fun IntArray.toFlux(): Flux<Int> = this.toList().toFlux()
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlux()", "reactor.kotlin.core.publisher.toFlux"))
 fun LongArray.toFlux(): Flux<Long> = this.toList().toFlux()
 
 /**
@@ -112,6 +132,8 @@ fun LongArray.toFlux(): Flux<Long> = this.toList().toFlux()
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlux()", "reactor.kotlin.core.publisher.toFlux"))
 fun FloatArray.toFlux(): Flux<Float> = this.toList().toFlux()
 
 /**
@@ -120,6 +142,8 @@ fun FloatArray.toFlux(): Flux<Float> = this.toList().toFlux()
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlux()", "reactor.kotlin.core.publisher.toFlux"))
 fun DoubleArray.toFlux(): Flux<Double> = this.toList().toFlux()
 
 /**
@@ -128,6 +152,8 @@ fun DoubleArray.toFlux(): Flux<Double> = this.toList().toFlux()
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlux()", "reactor.kotlin.core.publisher.toFlux"))
 fun <T> Array<out T>.toFlux(): Flux<T> = Flux.fromArray(this)
 
 private fun <T> Iterator<T>.toIterable() = object : Iterable<T> {
@@ -140,6 +166,8 @@ private fun <T> Iterator<T>.toIterable() = object : Iterable<T> {
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlux<T>()", "reactor.kotlin.core.publisher.toFlux"))
 fun <T> Throwable.toFlux(): Flux<T> = Flux.error(this)
 
 /**
@@ -148,6 +176,8 @@ fun <T> Throwable.toFlux(): Flux<T> = Flux.error(this)
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("cast<T>()", "reactor.kotlin.core.publisher.cast"))
 inline fun <reified T : Any> Flux<*>.cast(): Flux<T> = cast(T::class.java)
 
 
@@ -157,6 +187,8 @@ inline fun <reified T : Any> Flux<*>.cast(): Flux<T> = cast(T::class.java)
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("doOnError(exceptionType, onError)", "reactor.kotlin.core.publisher.doOnError"))
 fun <T, E : Throwable> Flux<T>.doOnError(exceptionType: KClass<E>, onError: (E) -> Unit): Flux<T> =
         doOnError(exceptionType.java) { onError(it) }
 
@@ -166,6 +198,8 @@ fun <T, E : Throwable> Flux<T>.doOnError(exceptionType: KClass<E>, onError: (E) 
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("onErrorMap(exceptionType, mapper)", "reactor.kotlin.core.publisher.onErrorMap"))
 fun <T, E : Throwable> Flux<T>.onErrorMap(exceptionType: KClass<E>, mapper: (E) -> Throwable): Flux<T> =
         onErrorMap(exceptionType.java) { mapper(it) }
 
@@ -175,6 +209,8 @@ fun <T, E : Throwable> Flux<T>.onErrorMap(exceptionType: KClass<E>, mapper: (E) 
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("ofType<T>()", "reactor.kotlin.core.publisher.ofType"))
 inline fun <reified T : Any> Flux<*>.ofType(): Flux<T> = ofType(T::class.java)
 
 /**
@@ -183,6 +219,8 @@ inline fun <reified T : Any> Flux<*>.ofType(): Flux<T> = ofType(T::class.java)
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("onErrorResume(exceptionType, fallback)", "reactor.kotlin.core.publisher.onErrorResume"))
 fun <T : Any, E : Throwable> Flux<T>.onErrorResume(exceptionType: KClass<E>, fallback: (E) -> Publisher<T>): Flux<T> =
         onErrorResume(exceptionType.java) { fallback(it) }
 
@@ -192,6 +230,8 @@ fun <T : Any, E : Throwable> Flux<T>.onErrorResume(exceptionType: KClass<E>, fal
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("onErrorReturn(exceptionType, value)", "reactor.kotlin.core.publisher.onErrorReturn"))
 fun <T : Any, E : Throwable> Flux<T>.onErrorReturn(exceptionType: KClass<E>, value: T): Flux<T> =
         onErrorReturn(exceptionType.java, value)
 
@@ -201,6 +241,8 @@ fun <T : Any, E : Throwable> Flux<T>.onErrorReturn(exceptionType: KClass<E>, val
  * @author Igor Perikov
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("split()", "reactor.kotlin.core.publisher.split"))
 fun <T : Any> Flux<out Iterable<T>>.split(): Flux<T> = this.flatMapIterable { it }
 
 /**
@@ -210,4 +252,6 @@ fun <T : Any> Flux<out Iterable<T>>.split(): Flux<T> = this.flatMapIterable { it
  * @author Kevin Davin
  * @since 3.2
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("switchIfEmpty(s)", "reactor.kotlin.core.publisher.switchIfEmpty"))
 fun <T> Flux<T>.switchIfEmpty(s: () -> Publisher<T>): Flux<T> = this.switchIfEmpty(Flux.defer { s() })

--- a/reactor-core/src/main/kotlin/reactor/core/publisher/MonoExtensions.kt
+++ b/reactor-core/src/main/kotlin/reactor/core/publisher/MonoExtensions.kt
@@ -32,6 +32,8 @@ import kotlin.reflect.KClass
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toMono()", "reactor.kotlin.core.publisher.toMono"))
 fun <T> Publisher<T>.toMono(): Mono<T> = Mono.from(this)
 
 /**
@@ -39,6 +41,8 @@ fun <T> Publisher<T>.toMono(): Mono<T> = Mono.from(this)
  *
  * @author Sergio Dos Santos
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toMono()", "reactor.kotlin.core.publisher.toMono"))
 fun <T> (() -> T?).toMono(): Mono<T> = Mono.fromSupplier(this)
 
 /**
@@ -47,6 +51,8 @@ fun <T> (() -> T?).toMono(): Mono<T> = Mono.fromSupplier(this)
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toMono()", "reactor.kotlin.core.publisher.toMono"))
 fun <T : Any> T.toMono(): Mono<T> = Mono.just(this)
 
 /**
@@ -55,6 +61,8 @@ fun <T : Any> T.toMono(): Mono<T> = Mono.just(this)
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toMono()", "reactor.kotlin.core.publisher.toMono"))
 fun <T> CompletableFuture<out T?>.toMono(): Mono<T> = Mono.fromFuture(this)
 
 /**
@@ -63,6 +71,8 @@ fun <T> CompletableFuture<out T?>.toMono(): Mono<T> = Mono.fromFuture(this)
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toMono()", "reactor.kotlin.core.publisher.toMono"))
 fun <T> Callable<T?>.toMono(): Mono<T> = Mono.fromCallable(this::call)
 
 /**
@@ -71,6 +81,8 @@ fun <T> Callable<T?>.toMono(): Mono<T> = Mono.fromCallable(this::call)
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toMono<T>()", "reactor.kotlin.core.publisher.toMono"))
 fun <T> Throwable.toMono(): Mono<T> = Mono.error(this)
 
 /**
@@ -79,6 +91,8 @@ fun <T> Throwable.toMono(): Mono<T> = Mono.error(this)
  * @author Sebastien
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("cast<T>()", "reactor.kotlin.core.publisher.cast"))
 inline fun <reified T : Any> Mono<*>.cast(): Mono<T> = cast(T::class.java)
 
 /**
@@ -87,6 +101,8 @@ inline fun <reified T : Any> Mono<*>.cast(): Mono<T> = cast(T::class.java)
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("doOnError(exceptionType, onError)", "reactor.kotlin.core.publisher.doOnError"))
 fun <T, E : Throwable> Mono<T>.doOnError(exceptionType: KClass<E>, onError: (E) -> Unit): Mono<T> =
         doOnError(exceptionType.java) { onError(it) }
 
@@ -96,6 +112,8 @@ fun <T, E : Throwable> Mono<T>.doOnError(exceptionType: KClass<E>, onError: (E) 
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("onErrorMap(exceptionType, mapper)", "reactor.kotlin.core.publisher.onErrorMap"))
 fun <T, E : Throwable> Mono<T>.onErrorMap(exceptionType: KClass<E>, mapper: (E) -> Throwable): Mono<T> =
         onErrorMap(exceptionType.java) { mapper(it) }
 
@@ -105,6 +123,8 @@ fun <T, E : Throwable> Mono<T>.onErrorMap(exceptionType: KClass<E>, mapper: (E) 
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("ofType<T>()", "reactor.kotlin.core.publisher.ofType"))
 inline fun <reified T : Any> Mono<*>.ofType(): Mono<T> = ofType(T::class.java)
 
 /**
@@ -113,6 +133,8 @@ inline fun <reified T : Any> Mono<*>.ofType(): Mono<T> = ofType(T::class.java)
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("onErrorResume(exceptionType, fallback)", "reactor.kotlin.core.publisher.onErrorResume"))
 fun <T : Any, E : Throwable> Mono<T>.onErrorResume(exceptionType: KClass<E>, fallback: (E) -> Mono<T>): Mono<T> =
         onErrorResume(exceptionType.java) { fallback(it) }
 
@@ -122,6 +144,8 @@ fun <T : Any, E : Throwable> Mono<T>.onErrorResume(exceptionType: KClass<E>, fal
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("onErrorReturn(exceptionType, value)", "reactor.kotlin.core.publisher.onErrorReturn"))
 fun <T : Any, E : Throwable> Mono<T>.onErrorReturn(exceptionType: KClass<E>, value: T): Mono<T> =
         onErrorReturn(exceptionType.java, value)
 
@@ -132,4 +156,6 @@ fun <T : Any, E : Throwable> Mono<T>.onErrorReturn(exceptionType: KClass<E>, val
  * @author Kevin Davin
  * @since 3.2
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("switchIfEmpty(s)", "reactor.kotlin.core.publisher.switchIfEmpty"))
 fun <T> Mono<T>.switchIfEmpty(s: () -> Mono<T>): Mono<T> = this.switchIfEmpty(Mono.defer { s() })

--- a/reactor-core/src/main/kotlin/reactor/core/publisher/MonoExtensions.kt
+++ b/reactor-core/src/main/kotlin/reactor/core/publisher/MonoExtensions.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher
+
+import org.reactivestreams.Publisher
+import java.util.concurrent.Callable
+import java.util.concurrent.CompletableFuture
+import java.util.function.Supplier
+import kotlin.reflect.KClass
+
+/**
+ * Extension to convert any [Publisher] of [T] to a [Mono] that only emits its first
+ * element.
+ *
+ * Note this extension doesn't make much sense on a [Mono] but it won't be converted so it
+ * doesn't hurt.
+ *
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T> Publisher<T>.toMono(): Mono<T> = Mono.from(this)
+
+/**
+ * Extension to convert any [Supplier] of [T] to a [Mono] that emits supplied element.
+ *
+ * @author Sergio Dos Santos
+ */
+fun <T> (() -> T?).toMono(): Mono<T> = Mono.fromSupplier(this)
+
+/**
+ * Extension for transforming an object to a [Mono].
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T : Any> T.toMono(): Mono<T> = Mono.just(this)
+
+/**
+ * Extension for transforming an [CompletableFuture] to a [Mono].
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T> CompletableFuture<out T?>.toMono(): Mono<T> = Mono.fromFuture(this)
+
+/**
+ * Extension for transforming an [Callable] to a [Mono].
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T> Callable<T?>.toMono(): Mono<T> = Mono.fromCallable(this::call)
+
+/**
+ * Extension for transforming an exception to a [Mono] that completes with the specified error.
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T> Throwable.toMono(): Mono<T> = Mono.error(this)
+
+/**
+ * Extension for [Mono.cast] providing a `cast<Foo>()` variant.
+ *
+ * @author Sebastien
+ * @since 3.1
+ */
+inline fun <reified T : Any> Mono<*>.cast(): Mono<T> = cast(T::class.java)
+
+/**
+ * Extension for [Mono.doOnError] providing a [KClass] based variant.
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T, E : Throwable> Mono<T>.doOnError(exceptionType: KClass<E>, onError: (E) -> Unit): Mono<T> =
+        doOnError(exceptionType.java) { onError(it) }
+
+/**
+ * Extension for [Mono.onErrorMap] providing a [KClass] based variant.
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T, E : Throwable> Mono<T>.onErrorMap(exceptionType: KClass<E>, mapper: (E) -> Throwable): Mono<T> =
+        onErrorMap(exceptionType.java) { mapper(it) }
+
+/**
+ * Extension for [Mono.ofType] providing a `ofType<Foo>()` variant.
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+inline fun <reified T : Any> Mono<*>.ofType(): Mono<T> = ofType(T::class.java)
+
+/**
+ * Extension for [Mono.onErrorResume] providing a [KClass] based variant.
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T : Any, E : Throwable> Mono<T>.onErrorResume(exceptionType: KClass<E>, fallback: (E) -> Mono<T>): Mono<T> =
+        onErrorResume(exceptionType.java) { fallback(it) }
+
+/**
+ * Extension for [Mono.onErrorReturn] providing a [KClass] based variant.
+ *
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun <T : Any, E : Throwable> Mono<T>.onErrorReturn(exceptionType: KClass<E>, value: T): Mono<T> =
+        onErrorReturn(exceptionType.java, value)
+
+/**
+ * Extension for [Mono.switchIfEmpty] accepting a function providing a Mono. This allows having a deferred execution with
+ * the [switchIfEmpty] operator
+ *
+ * @author Kevin Davin
+ * @since 3.2
+ */
+fun <T> Mono<T>.switchIfEmpty(s: () -> Mono<T>): Mono<T> = this.switchIfEmpty(Mono.defer { s() })

--- a/reactor-core/src/main/kotlin/reactor/core/publisher/MonoFunctions.kt
+++ b/reactor-core/src/main/kotlin/reactor/core/publisher/MonoFunctions.kt
@@ -29,6 +29,8 @@ import org.reactivestreams.Publisher
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("whenComplete()", "reactor.kotlin.core.publisher.whenComplete"))
 fun Iterable<Publisher<*>>.whenComplete(): Mono<Void> = Mono.`when`(this)
 
 /**
@@ -40,6 +42,8 @@ fun Iterable<Publisher<*>>.whenComplete(): Mono<Void> = Mono.`when`(this)
  * @author DoHyung Kim
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("zip(combinator)", "reactor.kotlin.core.publisher.zip"))
 @Suppress("UNCHECKED_CAST")
 inline fun <T, R> Iterable<Mono<T>>.zip(crossinline combinator: (List<T>) -> R): Mono<R> =
         Mono.zip(this) { combinator(it.asList() as List<T>) }
@@ -52,6 +56,8 @@ inline fun <T, R> Iterable<Mono<T>>.zip(crossinline combinator: (List<T>) -> R):
  * @author Sebastien Deleuze
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("whenComplete(*sources)", "reactor.kotlin.core.publisher.whenComplete"))
 fun whenComplete(vararg sources: Publisher<*>): Mono<Void> = MonoBridges.`when`(sources)
 
 /**
@@ -60,6 +66,8 @@ fun whenComplete(vararg sources: Publisher<*>): Mono<Void> = MonoBridges.`when`(
  * @author DoHyung Kim
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("zip(*monos, combinator)", "reactor.kotlin.core.publisher.zip"))
 @Suppress("UNCHECKED_CAST")
 fun <R> zip(vararg monos: Mono<*>, combinator: (Array<*>) -> R): Mono<R> =
         MonoBridges.zip(combinator, monos)

--- a/reactor-core/src/main/kotlin/reactor/core/publisher/MonoFunctions.kt
+++ b/reactor-core/src/main/kotlin/reactor/core/publisher/MonoFunctions.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:JvmName("MonoWhenFunctionsKt") // TODO Remove in next major version
+package reactor.core.publisher
+
+import org.reactivestreams.Publisher
+
+/**
+ * Aggregates this [Iterable] of void [Publisher]s into a new [Mono].
+ * An alias for a corresponding [Mono.when] to avoid use of `when`, which is a keyword in Kotlin.
+ *
+ * TODO Move to MonoExtensions.kt in next major version
+ *
+ * @author DoHyung Kim
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun Iterable<Publisher<*>>.whenComplete(): Mono<Void> = Mono.`when`(this)
+
+/**
+ * Merges this [Iterable] of [Mono]s into a new [Mono] by combining them
+ * with [combinator].
+ *
+ * TODO Move to MonoExtensions.kt in next major version
+ *
+ * @author DoHyung Kim
+ * @since 3.1
+ */
+@Suppress("UNCHECKED_CAST")
+inline fun <T, R> Iterable<Mono<T>>.zip(crossinline combinator: (List<T>) -> R): Mono<R> =
+        Mono.zip(this) { combinator(it.asList() as List<T>) }
+
+/**
+ * Aggregates the given void [Publisher]s into a new void [Mono].
+ * An alias for a corresponding [Mono.when] to avoid use of `when`, which is a keyword in Kotlin.
+ *
+ * @author DoHyung Kim
+ * @author Sebastien Deleuze
+ * @since 3.1
+ */
+fun whenComplete(vararg sources: Publisher<*>): Mono<Void> = MonoBridges.`when`(sources)
+
+/**
+ * Aggregates the given [Mono]s into a new [Mono].
+ *
+ * @author DoHyung Kim
+ * @since 3.1
+ */
+@Suppress("UNCHECKED_CAST")
+fun <R> zip(vararg monos: Mono<*>, combinator: (Array<*>) -> R): Mono<R> =
+        MonoBridges.zip(combinator, monos)

--- a/reactor-core/src/main/kotlin/reactor/util/function/TupleExtensions.kt
+++ b/reactor-core/src/main/kotlin/reactor/util/function/TupleExtensions.kt
@@ -23,6 +23,8 @@ package reactor.util.function
  * @author DoHyung Kim
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions and import reactor.kotlin.core.util.function.component1",
+        ReplaceWith("component1()", "reactor.kotlin.core.util.function.component1"))
 operator fun <T> Tuple2<T, *>.component1(): T = t1
 
 /**
@@ -31,6 +33,8 @@ operator fun <T> Tuple2<T, *>.component1(): T = t1
  * @author DoHyung Kim
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions and import reactor.kotlin.core.util.function.component2",
+        ReplaceWith("component2()", "reactor.kotlin.core.util.function.component2"))
 operator fun <T> Tuple2<*, T>.component2(): T = t2
 
 /**
@@ -39,6 +43,8 @@ operator fun <T> Tuple2<*, T>.component2(): T = t2
  * @author DoHyung Kim
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions and import reactor.kotlin.core.util.function.component3",
+        ReplaceWith("component3()", "reactor.kotlin.core.util.function.component3"))
 operator fun <T> Tuple3<*, *, T>.component3(): T = t3
 
 /**
@@ -47,6 +53,8 @@ operator fun <T> Tuple3<*, *, T>.component3(): T = t3
  * @author DoHyung Kim
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions and import reactor.kotlin.core.util.function.component4",
+        ReplaceWith("component4()", "reactor.kotlin.core.util.function.component4"))
 operator fun <T> Tuple4<*, *, *, T>.component4(): T = t4
 
 /**
@@ -55,6 +63,8 @@ operator fun <T> Tuple4<*, *, *, T>.component4(): T = t4
  * @author DoHyung Kim
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions and import reactor.kotlin.core.util.function.component5",
+        ReplaceWith("component5()", "reactor.kotlin.core.util.function.component5"))
 operator fun <T> Tuple5<*, *, *, *, T>.component5(): T = t5
 
 /**
@@ -63,6 +73,8 @@ operator fun <T> Tuple5<*, *, *, *, T>.component5(): T = t5
  * @author DoHyung Kim
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions and import reactor.kotlin.core.util.function.component6",
+        ReplaceWith("component6()", "reactor.kotlin.core.util.function.component6"))
 operator fun <T> Tuple6<*, *, *, *, *, T>.component6(): T = t6
 
 /**
@@ -71,6 +83,8 @@ operator fun <T> Tuple6<*, *, *, *, *, T>.component6(): T = t6
  * @author DoHyung Kim
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions and import reactor.kotlin.core.util.function.component7",
+        ReplaceWith("component7()", "reactor.kotlin.core.util.function.component7"))
 operator fun <T> Tuple7<*, *, *, *, *, *, T>.component7(): T = t7
 
 /**
@@ -79,4 +93,6 @@ operator fun <T> Tuple7<*, *, *, *, *, *, T>.component7(): T = t7
  * @author DoHyung Kim
  * @since 3.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions and import reactor.kotlin.core.util.function.component8",
+        ReplaceWith("component8()", "reactor.kotlin.core.util.function.component8"))
 operator fun <T> Tuple8<*, *, *, *, *, *, *, T>.component8(): T = t8

--- a/reactor-core/src/main/kotlin/reactor/util/function/TupleExtensions.kt
+++ b/reactor-core/src/main/kotlin/reactor/util/function/TupleExtensions.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.function
+
+
+/**
+ * Extension for [Tuple2] to work with destructuring declarations.
+ *
+ * @author DoHyung Kim
+ * @since 3.1
+ */
+operator fun <T> Tuple2<T, *>.component1(): T = t1
+
+/**
+ * Extension for [Tuple2] to work with destructuring declarations.
+ *
+ * @author DoHyung Kim
+ * @since 3.1
+ */
+operator fun <T> Tuple2<*, T>.component2(): T = t2
+
+/**
+ * Extension for [Tuple3] to work with destructuring declarations.
+ *
+ * @author DoHyung Kim
+ * @since 3.1
+ */
+operator fun <T> Tuple3<*, *, T>.component3(): T = t3
+
+/**
+ * Extension for [Tuple4] to work with destructuring declarations.
+ *
+ * @author DoHyung Kim
+ * @since 3.1
+ */
+operator fun <T> Tuple4<*, *, *, T>.component4(): T = t4
+
+/**
+ * Extension for [Tuple5] to work with destructuring declarations.
+ *
+ * @author DoHyung Kim
+ * @since 3.1
+ */
+operator fun <T> Tuple5<*, *, *, *, T>.component5(): T = t5
+
+/**
+ * Extension for [Tuple6] to work with destructuring declarations.
+ *
+ * @author DoHyung Kim
+ * @since 3.1
+ */
+operator fun <T> Tuple6<*, *, *, *, *, T>.component6(): T = t6
+
+/**
+ * Extension for [Tuple7] to work with destructuring declarations.
+ *
+ * @author DoHyung Kim
+ * @since 3.1
+ */
+operator fun <T> Tuple7<*, *, *, *, *, *, T>.component7(): T = t7
+
+/**
+ * Extension for [Tuple8] to work with destructuring declarations.
+ *
+ * @author DoHyung Kim
+ * @since 3.1
+ */
+operator fun <T> Tuple8<*, *, *, *, *, *, *, T>.component8(): T = t8

--- a/reactor-core/src/test/kotlin/reactor/core/publisher/FluxExtensionsTests.kt
+++ b/reactor-core/src/test/kotlin/reactor/core/publisher/FluxExtensionsTests.kt
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert
+import org.junit.Test
+import org.reactivestreams.Publisher
+import reactor.test.StepVerifier
+import reactor.test.test
+import reactor.test.verifyError
+import java.io.IOException
+
+class FluxExtensionsTests {
+
+    @Test
+    fun `Iterator to Flux`() {
+        StepVerifier
+                .create(listOf("foo", "bar", "baz").listIterator().toFlux())
+                .expectNext("foo", "bar", "baz")
+                .verifyComplete()
+    }
+
+    @Test
+    fun `Iterable to Flux`() {
+        StepVerifier
+                .create(listOf("foo", "bar", "baz").asIterable().toFlux())
+                .expectNext("foo", "bar", "baz")
+                .verifyComplete()
+    }
+
+    @Test
+    fun `Sequence to Flux`() {
+        StepVerifier
+                .create(listOf("foo", "bar", "baz").asSequence().toFlux())
+                .expectNext("foo", "bar", "baz")
+                .verifyComplete()
+    }
+
+    @Test
+    fun `Stream to Flux`() {
+        StepVerifier
+                .create(listOf("foo", "bar", "baz").stream().toFlux())
+                .expectNext("foo", "bar", "baz")
+                .verifyComplete()
+    }
+
+    @Test
+    fun `ByteArray to Flux`() {
+        StepVerifier
+                .create(byteArrayOf(Byte.MAX_VALUE, Byte.MIN_VALUE, Byte.MAX_VALUE).toFlux())
+                .expectNext(Byte.MAX_VALUE, Byte.MIN_VALUE, Byte.MAX_VALUE)
+                .verifyComplete()
+    }
+
+    @Test
+    fun `ShortArray to Flux`() {
+        StepVerifier
+                .create(shortArrayOf(1, 2, 3).toFlux())
+                .expectNext(1, 2, 3)
+                .verifyComplete()
+    }
+
+    @Test
+    fun `IntArray to Flux`() {
+        StepVerifier
+                .create(intArrayOf(1, 2, 3).toFlux())
+                .expectNext(1, 2, 3)
+                .verifyComplete()
+    }
+
+    @Test
+    fun `LongArray to Flux`() {
+        StepVerifier
+                .create(longArrayOf(1, 2, 3).toFlux())
+                .expectNext(1, 2, 3)
+                .verifyComplete()
+    }
+
+    @Test
+    fun `FloatArray to Flux`() {
+        StepVerifier
+                .create(floatArrayOf(1.0F, 2.0F, 3.0F).toFlux())
+                .expectNext(1.0F, 2.0F, 3.0F)
+                .verifyComplete()
+    }
+
+    @Test
+    fun `DoubleArray to Flux`() {
+        StepVerifier
+                .create(doubleArrayOf(1.0, 2.0, 3.0).toFlux())
+                .expectNext(1.0, 2.0, 3.0)
+                .verifyComplete()
+    }
+
+    @Test
+    fun `BooleanArray to Flux`() {
+        StepVerifier
+                .create(booleanArrayOf(true, false, true).toFlux())
+                .expectNext(true, false, true)
+                .verifyComplete()
+    }
+
+
+    @Test
+    fun `Throwable to Flux`() {
+        StepVerifier
+                .create(IllegalStateException().toFlux<Any>())
+                .verifyError(IllegalStateException::class)
+    }
+
+    @Test
+    fun `cast() with generic parameter`() {
+        val fluxOfAny: Flux<Any> = Flux.just("foo")
+        StepVerifier
+                .create(fluxOfAny.cast<String>())
+                .expectNext("foo").verifyComplete()
+    }
+
+    @Test
+    fun doOnError() {
+        val fluxOnError: Flux<Any> = IllegalStateException().toFlux()
+        var invoked = false
+        fluxOnError.doOnError(IllegalStateException::class) {
+            invoked = true
+        }.subscribe()
+        Assert.assertTrue(invoked)
+    }
+
+    @Test
+    fun onErrorMap() {
+        StepVerifier
+                .create(IOException()
+                        .toFlux<Any>()
+                        .onErrorMap(IOException::class, ::IllegalStateException))
+                .verifyError<IllegalStateException>()
+    }
+
+    @Test
+    fun `ofType() with generic parameter`() {
+        StepVerifier
+                .create(arrayOf("foo", 1).toFlux().ofType<String>())
+                .expectNext("foo").verifyComplete()
+    }
+
+    @Test
+    fun onErrorResume() {
+        val flux = IOException().toFlux<String>().onErrorResume(IOException::class) { "foo".toMono() }
+        StepVerifier
+                .create(flux)
+                .expectNext("foo")
+                .verifyComplete()
+    }
+
+    @Test
+    fun onErrorReturn() {
+        StepVerifier
+                .create(IOException()
+                    .toFlux<String>()
+                    .onErrorReturn(IOException::class, "foo"))
+                .expectNext("foo")
+                .verifyComplete()
+    }
+
+    @Test
+    fun publisherToFlux() {
+        //fake naive publisher
+        val p: Publisher<String> = Publisher {
+            it.onSubscribe(Operators.emptySubscription())
+            it.onNext("a")
+            it.onNext("b")
+            it.onComplete()
+        }
+
+        val f = p.toFlux()
+
+        f.test()
+                .expectNext("a", "b")
+                .verifyComplete()
+
+        assertThat(f).isNotSameAs(p)
+    }
+
+    @Test
+    fun fluxToFlux() {
+        val f = Flux.range(1, 2)
+
+        assertThat(f.toFlux()).isSameAs(f)
+    }
+
+    @Test
+    fun monoToFlux() {
+        val m = Mono.just(2)
+        val f = m.toFlux()
+
+        assertThat(f).isNotSameAs(m)
+        f.test()
+                .expectNext(2)
+                .verifyComplete()
+    }
+
+    @Test
+    fun splitFlux() {
+        val f = listOf(listOf(1, 2), listOf(3, 4)).toFlux()
+        StepVerifier
+                .create(f.split())
+                .expectNext(1, 2, 3, 4)
+                .verifyComplete()
+    }
+
+    @Test
+    fun `switchIfEmpty with defer execution`() {
+        val flux: Flux<Int> = listOf(1, 2, 3)
+                .toFlux()
+                .switchIfEmpty { throw RuntimeException("error which should not happen due to defered execution") }
+
+        StepVerifier
+                .create(flux)
+                .expectNext(1, 2, 3)
+                .verifyComplete()
+    }
+}

--- a/reactor-core/src/test/kotlin/reactor/core/publisher/MonoExtensionsTests.kt
+++ b/reactor-core/src/test/kotlin/reactor/core/publisher/MonoExtensionsTests.kt
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert
+import org.junit.Test
+import org.reactivestreams.Publisher
+import reactor.test.StepVerifier
+import reactor.test.publisher.TestPublisher
+import reactor.test.test
+import reactor.test.verifyError
+import java.io.IOException
+import java.util.concurrent.Callable
+import java.util.concurrent.CompletableFuture
+
+class MonoExtensionsTests {
+
+    @Test
+    fun anyToMono() {
+        StepVerifier
+                .create("foo".toMono())
+                .expectNext("foo")
+                .verifyComplete()
+    }
+
+    @Test
+    fun supplierToMono() {
+        val supplier: () -> String = { "a" }
+
+        val m = supplier.toMono()
+
+        m.test()
+                .expectNext("a")
+                .verifyComplete()
+    }
+
+    @Test
+    fun publisherToMono() {
+        //fake naive publisher
+        val p: Publisher<String> = Publisher {
+            it.onSubscribe(Operators.emptySubscription())
+            it.onNext("a")
+            it.onNext("b")
+            it.onComplete()
+        }
+
+        val m = p.toMono()
+
+        assertThat(m).isNotSameAs(p)
+        m.test()
+                .expectNext("a")
+                .verifyComplete()
+    }
+    @Test
+    fun fluxToMono() {
+        val f = Flux.range(1, 2)
+        val m = f.toMono()
+
+        assertThat(m).isNotSameAs(f)
+        m.test()
+                .expectNext(1)
+                .verifyComplete()
+    }
+
+    @Test
+    fun monoToMono() {
+        val m = Mono.just(2)
+        assertThat(m.toMono()).isSameAs(m)
+    }
+
+    @Test
+    fun completableFutureToMono() {
+        val future = CompletableFuture<String>()
+
+        val verifier = StepVerifier.create(future.toMono())
+                .expectNext("foo")
+                .expectComplete()
+        future.complete("foo")
+        verifier.verify()
+    }
+
+    @Test
+    fun nullableCompletableFutureToMonoWithMap() {
+        val future = CompletableFuture<String?>()
+
+        val verifier = StepVerifier.create(future.toMono().map { it.toUpperCase() })
+            .expectComplete()
+        future.complete(null)
+        verifier.verify()
+    }
+
+    @Test
+    fun callableToMono() {
+        val callable = Callable { "foo" }
+        val verifier = StepVerifier.create(callable.toMono())
+                .expectNext("foo")
+                .expectComplete()
+        verifier.verify()
+    }
+
+    @Test
+    fun nullableCallableToMonoWithMap() {
+        val callable = Callable<String?> { "foo" }
+        val verifier = StepVerifier.create(callable.toMono().map { it.toUpperCase() })
+            .expectNext("FOO")
+            .expectComplete()
+        verifier.verify()
+    }
+
+    @Test
+    fun nullableCallableToEmptyMonoWitMap() {
+        val callable = Callable<String?> { null }
+        val verifier = StepVerifier.create(callable.toMono().map { it.toUpperCase() })
+            .expectComplete()
+        verifier.verify()
+    }
+
+    @Test
+    fun nullableLambdaToEmptyMono() {
+        val callable = { null }
+        val verifier = StepVerifier.create(callable.toMono())
+            .expectComplete()
+        verifier.verify()
+    }
+
+    @Test
+    fun nullableLambdaToEmptyMonoWithMap() {
+        @Suppress("USELESS_CAST")
+        val callable = { null as String? }
+        val verifier = StepVerifier.create(callable.toMono().map { it.toUpperCase() })
+            .expectComplete()
+        verifier.verify()
+    }
+
+    @Test
+    fun throwableToMono() {
+        StepVerifier.create(IllegalStateException()
+                .toMono<Any>())
+                .verifyError(IllegalStateException::class)
+    }
+
+    @Test
+    fun `cast() with generic parameter`() {
+        val monoOfAny: Mono<Any> = Mono.just("foo")
+        StepVerifier
+                .create(monoOfAny.cast<String>())
+                .expectNext("foo")
+                .verifyComplete()
+    }
+
+    @Test
+    fun doOnError() {
+        val monoOnError: Mono<Any> = IllegalStateException().toMono()
+        var invoked = false
+        monoOnError.doOnError(IllegalStateException::class) {
+            invoked = true
+        }.subscribe()
+        Assert.assertTrue(invoked)
+    }
+
+    @Test
+    fun onErrorMap() {
+        StepVerifier.create(IOException()
+                .toMono<Any>()
+                .onErrorMap(IOException::class, ::IllegalStateException))
+                .verifyError<IllegalStateException>()
+    }
+
+    @Test
+    fun `ofType() with generic parameter`() {
+        StepVerifier.create("foo".toMono().ofType<String>()).expectNext("foo").verifyComplete()
+        StepVerifier.create("foo".toMono().ofType<Int>()).verifyComplete()
+    }
+
+    @Test
+    fun onErrorResume() {
+        val mono = IOException().toMono<String>().onErrorResume(IOException::class) { "foo".toMono() }
+        StepVerifier.create(mono)
+                .expectNext("foo")
+                .verifyComplete()
+    }
+
+    @Test
+    fun onErrorReturn() {
+        StepVerifier.create(IOException()
+                .toMono<String>()
+                .onErrorReturn(IOException::class, "foo"))
+                .expectNext("foo")
+                .verifyComplete()
+    }
+
+    @Test
+    fun `switchIfEmpty with defer execution`() {
+        val mono: Mono<String> = "foo"
+                .toMono()
+                .switchIfEmpty { throw RuntimeException("error which should not happen due to defered execution") }
+
+        StepVerifier
+                .create(mono)
+                .expectNext("foo")
+                .verifyComplete()
+    }
+
+    @Test
+    fun `whenComplete on an Iterable of void Publishers`() {
+        val publishers = Array(3) { TestPublisher.create<Void>() }
+        publishers.forEach { it.complete() }
+        StepVerifier.create(publishers.asIterable().whenComplete())
+                .verifyComplete()
+    }
+
+    @Test
+    fun `whenComplete on an Iterable of String Publishers`() {
+        val publishers = Array(3) { TestPublisher.create<String>() }
+        publishers.forEach { it.complete() }
+        StepVerifier.create(publishers.asIterable().whenComplete())
+                .verifyComplete()
+    }
+
+    @Test
+    fun `zip with an Iterable of Mono + and a combinator`() {
+        StepVerifier.create(listOf("foo1".toMono(), "foo2".toMono(), "foo3".toMono())
+                .zip { it.reduce { acc, s -> acc + s }})
+                .expectNext("foo1foo2foo3")
+                .verifyComplete()
+    }
+
+    @Test
+    fun `zip on an Iterable of Monos with combinator`() {
+        StepVerifier.create(listOf("foo1", "foo2", "foo3").map { it.toMono() }.zip { it.joinToString() })
+                .expectNext("foo1, foo2, foo3")
+                .verifyComplete()
+    }
+
+}

--- a/reactor-core/src/test/kotlin/reactor/core/publisher/MonoFunctionsTests.kt
+++ b/reactor-core/src/test/kotlin/reactor/core/publisher/MonoFunctionsTests.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher
+
+import org.junit.Test
+import reactor.test.StepVerifier
+import reactor.test.publisher.TestPublisher
+
+class MonoFunctionsTests {
+
+    @Test
+    fun `whenComplete with void Publishers`() {
+        val publishers = Array(3) { TestPublisher.create<Void>() }
+        publishers.forEach { it.complete() }
+        StepVerifier.create(whenComplete(*publishers))
+                .verifyComplete()
+    }
+
+    @Test
+    fun `whenComplete with two Monos`() {
+        StepVerifier.create(whenComplete("foo1".toMono(), "foo2".toMono()))
+                .verifyComplete()
+    }
+
+    @Test
+    fun `zip with Monos and combinator`() {
+        val mono = zip("foo1".toMono(), "foo2".toMono(), "foo3".toMono()) { it.joinToString() }
+        StepVerifier.create(mono)
+                .expectNext("foo1, foo2, foo3")
+                .verifyComplete()
+    }
+
+}

--- a/reactor-core/src/test/kotlin/reactor/util/function/TupleExtensionsTests.kt
+++ b/reactor-core/src/test/kotlin/reactor/util/function/TupleExtensionsTests.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.function
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+object O1; object O2; object O3; object O4
+object O5; object O6; object O7; object O8
+
+class TupleDestructuringTests {
+
+    @Test
+    fun destructureTuple2() {
+        val (t1, t2) = Tuples.of(O1, O2)
+        assertEquals(t1, O1)
+        assertEquals(t2, O2)
+    }
+
+    @Test
+    fun destructureTuple3() {
+        val (t1, t2, t3) = Tuples.of(O1, O2, O3)
+        assertEquals(t1, O1)
+        assertEquals(t2, O2)
+        assertEquals(t3, O3)
+    }
+
+    @Test
+    fun destructureTuple4() {
+        val (t1, t2, t3, t4) = Tuples.of(O1, O2, O3, O4)
+        assertEquals(t1, O1)
+        assertEquals(t2, O2)
+        assertEquals(t3, O3)
+        assertEquals(t4, O4)
+    }
+
+    @Test
+    fun destructureTuple5() {
+        val (t1, t2, t3, t4, t5) = Tuples.of(O1, O2, O3, O4, O5)
+        assertEquals(t1, O1)
+        assertEquals(t2, O2)
+        assertEquals(t3, O3)
+        assertEquals(t4, O4)
+        assertEquals(t5, O5)
+    }
+
+    @Test
+    fun destructureTuple6() {
+        val (t1, t2, t3, t4, t5, t6) = Tuples.of(O1, O2, O3, O4, O5, O6)
+        assertEquals(t1, O1)
+        assertEquals(t2, O2)
+        assertEquals(t3, O3)
+        assertEquals(t4, O4)
+        assertEquals(t5, O5)
+        assertEquals(t6, O6)
+    }
+
+    @Test
+    fun destructureTuple7() {
+        val (t1, t2, t3, t4, t5, t6, t7) = Tuples.of(O1, O2, O3, O4, O5, O6, O7)
+        assertEquals(t1, O1)
+        assertEquals(t2, O2)
+        assertEquals(t3, O3)
+        assertEquals(t4, O4)
+        assertEquals(t5, O5)
+        assertEquals(t6, O6)
+        assertEquals(t7, O7)
+    }
+
+    @Test
+    fun destructureTuple8() {
+        val (t1, t2, t3, t4, t5, t6, t7, t8) = Tuples.of(O1, O2, O3, O4, O5, O6, O7, O8)
+        assertEquals(t1, O1)
+        assertEquals(t2, O2)
+        assertEquals(t3, O3)
+        assertEquals(t4, O4)
+        assertEquals(t5, O5)
+        assertEquals(t6, O6)
+        assertEquals(t7, O7)
+        assertEquals(t8, O8)
+    }
+}

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -63,9 +63,6 @@ task japicmp(type: JapicmpTask) {
   includeSynthetic = true
 
   //TODO after a release, remove the reactor-test exclusions below if any
-  classExcludes = [
-          'reactor.test.StepVerifierExtensionsKt',
-  ]
 }
 
 javadoc {
@@ -84,6 +81,11 @@ javadoc {
 		  .plus("https://projectreactor.io/docs/core/release/api/") as String[])
   options.tags = [ "apiNote:a:API Note:", "implSpec:a:Implementation Requirements:",
 				   "implNote:a:Implementation Note:" ]
+
+  // In Java 9, javadoc generator will complain if it finds invalid class files in the classpath
+  // And Kotlin produces such classes, plus kotlin plugin puts them in the main sourceSet
+  classpath = sourceSets.main.output.filter { !it.absolutePath.contains("kotlin") }
+  classpath += sourceSets.main.compileClasspath
 
   maxMemory = "1024m"
   destinationDir = new File(project.buildDir, "docs/javadoc")

--- a/reactor-test/src/main/kotlin/reactor/test/StepVerifierExtensions.kt
+++ b/reactor-test/src/main/kotlin/reactor/test/StepVerifierExtensions.kt
@@ -29,6 +29,8 @@ import kotlin.reflect.KClass
  *
  * @author Sebastien Deleuze
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("expectError(kClass)", "reactor.kotlin.test.expectError"))
 fun LastStep.expectError(kClass: KClass<out Throwable>): StepVerifier = expectError(kClass.java)
 
 /**
@@ -36,6 +38,8 @@ fun LastStep.expectError(kClass: KClass<out Throwable>): StepVerifier = expectEr
  *
  * @author Sebastien Deleuze
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("expectError()", "reactor.kotlin.test.expectError"))
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 inline fun <reified T : Throwable> LastStep.expectError(): StepVerifier = expectError(T::class.java)
 
@@ -44,6 +48,8 @@ inline fun <reified T : Throwable> LastStep.expectError(): StepVerifier = expect
  *
  * @author Sebastien Deleuze
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("verifyError(kClass)", "reactor.kotlin.test.verifyError"))
 fun LastStep.verifyError(kClass: KClass<out Throwable>): Duration = verifyError(kClass.java)
 
 /**
@@ -51,6 +57,8 @@ fun LastStep.verifyError(kClass: KClass<out Throwable>): Duration = verifyError(
  *
  * @author Sebastien Deleuze
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("verifyError()", "reactor.kotlin.test.verifyError"))
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 inline fun <reified T : Throwable> LastStep.verifyError(): Duration = verifyError(T::class.java)
 
@@ -59,6 +67,8 @@ inline fun <reified T : Throwable> LastStep.verifyError(): Duration = verifyErro
  *
  * @author Sebastien Deleuze
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("hasDroppedErrorOfType(kClass)", "reactor.kotlin.test.hasDroppedErrorOfType"))
 fun Assertions.hasDroppedErrorOfType(kClass: KClass<out Throwable>): Assertions = hasDroppedErrorOfType(kClass.java)
 
 /**
@@ -66,6 +76,8 @@ fun Assertions.hasDroppedErrorOfType(kClass: KClass<out Throwable>): Assertions 
  *
  * @author Sebastien Deleuze
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("hasDroppedErrorOfType()", "reactor.kotlin.test.hasDroppedErrorOfType"))
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 inline fun <reified T : Throwable> Assertions.hasDroppedErrorOfType(): Assertions = hasDroppedErrorOfType(T::class.java)
 
@@ -74,6 +86,8 @@ inline fun <reified T : Throwable> Assertions.hasDroppedErrorOfType(): Assertion
  *
  * @author Sebastien Deleuze
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("hasOperatorErrorOfType(kClass)", "reactor.kotlin.test.hasOperatorErrorOfType"))
 fun Assertions.hasOperatorErrorOfType(kClass: KClass<out Throwable>): Assertions = hasOperatorErrorOfType(kClass.java)
 
 /**
@@ -81,6 +95,8 @@ fun Assertions.hasOperatorErrorOfType(kClass: KClass<out Throwable>): Assertions
  *
  * @author Sebastien Deleuze
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("hasDroppedErrorOfType()", "reactor.kotlin.test.hasDroppedErrorOfType"))
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 inline fun <reified T : Throwable> Assertions.hasOperatorErrorOfType(): Assertions = hasOperatorErrorOfType(T::class.java)
 
@@ -89,6 +105,8 @@ inline fun <reified T : Throwable> Assertions.hasOperatorErrorOfType(): Assertio
  *
  * @author Sebastien Deleuze
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("test()", "reactor.kotlin.test.test"))
 fun <T> Flux<T>.test(): StepVerifier.FirstStep<T> = StepVerifier.create(this)
 
 /**
@@ -96,6 +114,8 @@ fun <T> Flux<T>.test(): StepVerifier.FirstStep<T> = StepVerifier.create(this)
  *
  * @author Sebastien Deleuze
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("test(n)", "reactor.kotlin.test.test"))
 fun <T> Flux<T>.test(n: Long): StepVerifier.FirstStep<T> = StepVerifier.create(this, n)
 
 /**
@@ -103,6 +123,8 @@ fun <T> Flux<T>.test(n: Long): StepVerifier.FirstStep<T> = StepVerifier.create(t
  *
  * @author Sebastien Deleuze
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("test()", "reactor.kotlin.test.test"))
 fun <T> Mono<T>.test(): StepVerifier.FirstStep<T> = StepVerifier.create(this)
 
 /**
@@ -110,4 +132,6 @@ fun <T> Mono<T>.test(): StepVerifier.FirstStep<T> = StepVerifier.create(this)
  *
  * @author Sebastien Deleuze
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("test(n)", "reactor.kotlin.test.test"))
 fun <T> Mono<T>.test(n: Long): StepVerifier.FirstStep<T> = StepVerifier.create(this, n)

--- a/reactor-test/src/main/kotlin/reactor/test/StepVerifierExtensions.kt
+++ b/reactor-test/src/main/kotlin/reactor/test/StepVerifierExtensions.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.test
+
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier.Assertions
+import reactor.test.StepVerifier.LastStep
+import java.time.Duration
+import kotlin.reflect.KClass
+
+
+/**
+ * Extension for [StepVerifier.LastStep.expectError] providing a [KClass] based variant.
+ *
+ * @author Sebastien Deleuze
+ */
+fun LastStep.expectError(kClass: KClass<out Throwable>): StepVerifier = expectError(kClass.java)
+
+/**
+ * Extension for [StepVerifier.LastStep.expectError] providing a `expectError<Foo>()` variant.
+ *
+ * @author Sebastien Deleuze
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline fun <reified T : Throwable> LastStep.expectError(): StepVerifier = expectError(T::class.java)
+
+/**
+ * Extension for [StepVerifier.LastStep.verifyError] providing a [KClass] based variant.
+ *
+ * @author Sebastien Deleuze
+ */
+fun LastStep.verifyError(kClass: KClass<out Throwable>): Duration = verifyError(kClass.java)
+
+/**
+ * Extension for [StepVerifier.LastStep.verifyError] providing a `verifyError<Foo>()` variant.
+ *
+ * @author Sebastien Deleuze
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline fun <reified T : Throwable> LastStep.verifyError(): Duration = verifyError(T::class.java)
+
+/**
+ * Extension for [StepVerifier.Assertions.hasDroppedErrorOfType] providing a [KClass] based variant.
+ *
+ * @author Sebastien Deleuze
+ */
+fun Assertions.hasDroppedErrorOfType(kClass: KClass<out Throwable>): Assertions = hasDroppedErrorOfType(kClass.java)
+
+/**
+ * Extension for [StepVerifier.Assertions.hasDroppedErrorOfType] providing a `hasDroppedErrorOfType<Foo>()` variant.
+ *
+ * @author Sebastien Deleuze
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline fun <reified T : Throwable> Assertions.hasDroppedErrorOfType(): Assertions = hasDroppedErrorOfType(T::class.java)
+
+/**
+ * Extension for [StepVerifier.Assertions.hasOperatorErrorOfType] providing a [KClass] based variant.
+ *
+ * @author Sebastien Deleuze
+ */
+fun Assertions.hasOperatorErrorOfType(kClass: KClass<out Throwable>): Assertions = hasOperatorErrorOfType(kClass.java)
+
+/**
+ * Extension for [StepVerifier.Assertions.hasOperatorErrorOfType] providing a `hasOperatorErrorOfType<Foo>()` variant.
+ *
+ * @author Sebastien Deleuze
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline fun <reified T : Throwable> Assertions.hasOperatorErrorOfType(): Assertions = hasOperatorErrorOfType(T::class.java)
+
+/**
+ * Extension for testing [Flux] with [StepVerifier] API.
+ *
+ * @author Sebastien Deleuze
+ */
+fun <T> Flux<T>.test(): StepVerifier.FirstStep<T> = StepVerifier.create(this)
+
+/**
+ * Extension for testing [Flux] with [StepVerifier] API.
+ *
+ * @author Sebastien Deleuze
+ */
+fun <T> Flux<T>.test(n: Long): StepVerifier.FirstStep<T> = StepVerifier.create(this, n)
+
+/**
+ * Extension for testing [Mono] with [StepVerifier] API.
+ *
+ * @author Sebastien Deleuze
+ */
+fun <T> Mono<T>.test(): StepVerifier.FirstStep<T> = StepVerifier.create(this)
+
+/**
+ * Extension for testing [Mono] with [StepVerifier] API.
+ *
+ * @author Sebastien Deleuze
+ */
+fun <T> Mono<T>.test(n: Long): StepVerifier.FirstStep<T> = StepVerifier.create(this, n)

--- a/reactor-test/src/test/kotlin/reactor/test/StepVerifierExtensionsTests.kt
+++ b/reactor-test/src/test/kotlin/reactor/test/StepVerifierExtensionsTests.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.test
+
+import org.junit.Test
+import reactor.core.publisher.toMono
+
+class StepVerifierExtensionsTests {
+
+    @Test
+    fun `expectError() with KClass parameter`() {
+        IllegalStateException()
+                .toMono<Void>()
+                .test()
+                .verifyError(IllegalStateException::class)
+    }
+
+    @Test
+    fun `expectError() with generic parameter`() {
+        IllegalStateException()
+                .toMono<Void>()
+                .test()
+                .verifyError<IllegalStateException>()
+    }
+
+    @Test
+    fun `verifyError() with KClass parameter`() {
+        IllegalStateException()
+                .toMono<Void>()
+                .test()
+                .verifyError(IllegalStateException::class)
+    }
+
+    @Test
+    fun `verifyError() with generic parameter`() {
+        IllegalStateException()
+                .toMono<Void>()
+                .test()
+                .verifyError<IllegalStateException>()
+    }
+
+}


### PR DESCRIPTION
This also removes dokka from the build for now.