### PR TITLE
Fix "Apache License, Version 2.0" spelling

### DIFF
--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -74,7 +74,7 @@ def customizePom(pom, gradleProject) {
 			}
 			licenses {
 				license {
-					name 'The Apache Software License, Version 2.0'
+					name 'Apache License, Version 2.0'
 					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}


### PR DESCRIPTION
There are many Java libraries licensed under "Apache License, Version 2.0" that do not use its official spelling.
This causes issues like https://issues.apache.org/jira/browse/MPIR-382: with every library defining its own spelling, it's difficult in large projects to have a clear view of all licenses in use.
This PR changes the license spelling to the official one, as advised by Maven developers.