### PR TITLE
fix #1712 Flux.publish().autoConnect(0) should drop early items

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -335,7 +335,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 					return;
 				}
 				int n = a.length;
-				int j = 0;
+				int j = -1;
 				for (int i = 0; i < n; i++) {
 					if (a[i] == inner) {
 						j = i;
@@ -343,7 +343,8 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 					}
 				}
 
-				if (j < 0) { //TODO investigate condition always false
+				if (j < 0) {
+					//inner was not found
 					return;
 				}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -907,4 +907,20 @@ public class EmitterProcessorTest {
 		            .expectComplete()
 		            .verify(Duration.ofSeconds(4));
 	}
+
+	@Test
+	public void removeUnknownInnerIgnored() {
+		EmitterProcessor<Integer> processor = EmitterProcessor.create();
+		EmitterProcessor.EmitterInner<Integer> inner = new EmitterProcessor.EmitterInner<>(null, processor);
+		EmitterProcessor.EmitterInner<Integer> notInner = new EmitterProcessor.EmitterInner<>(null, processor);
+
+		processor.add(inner);
+		assertThat(processor.subscribers).as("adding inner").hasSize(1);
+
+		processor.remove(notInner);
+		assertThat(processor.subscribers).as("post remove notInner").hasSize(1);
+
+		processor.remove(inner);
+		assertThat(processor.subscribers).as("post remove inner").isEmpty();
+	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
@@ -31,6 +31,7 @@ import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
+import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.concurrent.Queues;
 
@@ -639,7 +640,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 	}
 
 	//see https://github.com/reactor/reactor-core/issues/1528
-	@Test
+	@Test(timeout = 4000)
 	public void syncFusionFromInfiniteStream() {
 		final ConnectableFlux<Integer> publish =
 				Flux.fromStream(Stream.iterate(0, i -> i + 1))
@@ -654,7 +655,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 	}
 
 	//see https://github.com/reactor/reactor-core/issues/1528
-	@Test
+	@Test(timeout = 4000)
 	public void syncFusionFromInfiniteStreamAndTake() {
 		final Flux<Integer> publish =
 				Flux.fromStream(Stream.iterate(0, i -> i + 1))
@@ -666,6 +667,42 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 		            .expectNextCount(10)
 		            .expectComplete()
 		            .verify(Duration.ofSeconds(4));
+	}
+
+	@Test
+	public void dataDroppedIfConnectImmediately() {
+		TestPublisher<Integer> publisher = TestPublisher.create();
+		ConnectableFlux<Integer> connectableFlux = publisher.flux().publish();
+
+		connectableFlux.connect();
+
+		publisher.next(1);
+		publisher.next(2);
+		publisher.next(3);
+
+		StepVerifier.create(connectableFlux)
+		            .expectSubscription()
+		            .then(() -> publisher.next(99))
+		            .expectNext(99)
+		            .then(publisher::complete)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void dataDroppedIfAutoconnectZero() {
+		TestPublisher<Integer> publisher = TestPublisher.create();
+		Flux<Integer> flux = publisher.flux().publish().autoConnect(0);
+
+		publisher.next(1);
+		publisher.next(2);
+		publisher.next(3);
+
+		StepVerifier.create(flux)
+		            .expectSubscription()
+		            .then(() -> publisher.next(99))
+		            .expectNext(99)
+		            .then(publisher::complete)
+		            .verifyComplete();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
@@ -667,4 +667,20 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 		            .expectComplete()
 		            .verify(Duration.ofSeconds(4));
 	}
+
+	@Test
+	public void removeUnknownInnerIgnored() {
+		FluxPublish.PublishSubscriber<Integer> subscriber = new FluxPublish.PublishSubscriber<>(1, null);
+		FluxPublish.PublishInner<Integer> inner = new FluxPublish.PublishInner<>(null);
+		FluxPublish.PublishInner<Integer> notInner = new FluxPublish.PublishInner<>(null);
+
+		subscriber.add(inner);
+		assertThat(subscriber.subscribers).as("adding inner").hasSize(1);
+
+		subscriber.remove(notInner);
+		assertThat(subscriber.subscribers).as("post remove notInner").hasSize(1);
+
+		subscriber.remove(inner);
+		assertThat(subscriber.subscribers).as("post remove inner").isEmpty();
+	}
 }


### PR DESCRIPTION
This is linked to #1528, the previous fix having introduced a regression 
where early connection without subscribers is not handled correctly and 
accumulates received items instead of "dropping" them.

This is because, unlike EmitterProcessor, FluxPublish should distinguish 
initial connection with empty subscribers array vs empty subscribers array
that is due to removing the last inner (ie. cancelling).

This commit also ensures that disconnectAction, which is synonymous to 
cancellation, sets the subscribers array to CANCELLED, not INIT.

Bonus points: Fix FluxPublish detection of legit inners in remove()

Any inner could previously be passed to remove(), which would fail to check
the inner was actually part of the subscribers array.