### PR TITLE
fix #1707 Allow to chose a Scheduler for retryBackoff

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -3502,6 +3502,44 @@ public abstract class Mono<T> implements Publisher<T> {
 
 	/**
 	 * In case of error, retry this {@link Mono} up to {@code numRetries} times using a
+	 * randomized exponential backoff strategy. The jitter factor is {@code 50%}
+	 * but the effective backoff delay cannot be less than {@code firstBackoff} nor more
+	 * than {@code maxBackoff}. The delays and subsequent attempts are materialized on the
+	 * provided backoff {@link Scheduler} (see {@link Mono#delay(Duration, Scheduler)}).
+	 <p>
+	 * The randomized exponential backoff is good at preventing two typical issues with
+	 * other simpler backoff strategies, namely:
+	 * <ul>
+	 *     <li>
+	 *      having an exponentially growing backoff delay with a small initial delay gives
+	 *      the best tradeoff between not overwhelming the server and serving the client as
+	 *      fast as possible
+	 *     </li>
+	 *     <li>
+	 *      having a jitter, or randomized backoff delay, is beneficial in avoiding "retry-storms"
+	 *      where eg. numerous clients would hit the server at the same time, causing it to
+	 *      display transient failures which would cause all clients to retry at the same
+	 *      backoff times, ultimately sparing no load on the server.
+	 *     </li>
+	 * </ul>
+	 *
+	 * <p>
+	 * <img class="marble" src="doc-files/marbles/retryBackoffForFlux.svg" alt="">
+	 *
+	 * @param numRetries the maximum number of attempts before an {@link IllegalStateException}
+	 * is raised (having the original retry-triggering exception as cause).
+	 * @param firstBackoff the first backoff delay to apply then grow exponentially. Also
+	 * minimum delay even taking jitter into account.
+	 * @param maxBackoff the maximum delay to apply despite exponential growth and jitter.
+	 * @param backoffScheduler the {@link Scheduler} on which the delays and subsequent attempts are executed.
+	 * @return a {@link Mono} that retries on onError with exponentially growing randomized delays between retries.
+	 */
+	public final Mono<T> retryBackoff(long numRetries, Duration firstBackoff, Duration maxBackoff, Scheduler backoffScheduler) {
+		return retryBackoff(numRetries, firstBackoff, maxBackoff, 0.5d, backoffScheduler);
+	}
+
+	/**
+	 * In case of error, retry this {@link Mono} up to {@code numRetries} times using a
 	 * randomized exponential backoff strategy, randomized with a user-provided jitter
 	 * factor between {@code 0.d} (no jitter) and {@code 1.0} (default is {@code 0.5}).
 	 * Even with the jitter, the effective backoff delay cannot be less than
@@ -3535,7 +3573,48 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @return a {@link Mono} that retries on onError with exponentially growing randomized delays between retries.
 	 */
 	public final Mono<T> retryBackoff(long numRetries, Duration firstBackoff, Duration maxBackoff, double jitterFactor) {
-		return retryWhen(FluxRetryWhen.randomExponentialBackoffFunction(numRetries, firstBackoff, maxBackoff, jitterFactor));
+		return retryBackoff(numRetries, firstBackoff, maxBackoff, jitterFactor, Schedulers.parallel());
+	}
+
+	/**
+	 * In case of error, retry this {@link Mono} up to {@code numRetries} times using a
+	 * randomized exponential backoff strategy, randomized with a user-provided jitter
+	 * factor between {@code 0.d} (no jitter) and {@code 1.0} (default is {@code 0.5}).
+	 * Even with the jitter, the effective backoff delay cannot be less than
+	 * {@code firstBackoff} nor more than {@code maxBackoff}. The delays and subsequent
+	 * attempts are executed on the provided backoff {@link Scheduler} (see
+	 * {@link Mono#delay(Duration, Scheduler)}).
+	 <p>
+	 * The randomized exponential backoff is good at preventing two typical issues with
+	 * other simpler backoff strategies, namely:
+	 * <ul>
+	 *     <li>
+	 *      having an exponentially growing backoff delay with a small initial delay gives
+	 *      the best tradeoff between not overwhelming the server and serving the client as
+	 *      fast as possible
+	 *     </li>
+	 *     <li>
+	 *      having a jitter, or randomized backoff delay, is beneficial in avoiding "retry-storms"
+	 *      where eg. numerous clients would hit the server at the same time, causing it to
+	 *      display transient failures which would cause all clients to retry at the same
+	 *      backoff times, ultimately sparing no load on the server.
+	 *     </li>
+	 * </ul>
+	 *
+	 * <p>
+	 * <img class="marble" src="doc-files/marbles/retryBackoffForFlux.svg" alt="">
+	 *
+	 * @param numRetries the maximum number of attempts before an {@link IllegalStateException}
+	 * is raised (having the original retry-triggering exception as cause).
+	 * @param firstBackoff the first backoff delay to apply then grow exponentially. Also
+	 * minimum delay even taking jitter into account.
+	 * @param maxBackoff the maximum delay to apply despite exponential growth and jitter.
+	 * @param backoffScheduler the {@link Scheduler} on which the delays and subsequent attempts are executed.
+	 * @param jitterFactor the jitter percentage (as a double between 0.0 and 1.0).
+	 * @return a {@link Mono} that retries on onError with exponentially growing randomized delays between retries.
+	 */
+	public final Mono<T> retryBackoff(long numRetries, Duration firstBackoff, Duration maxBackoff, double jitterFactor, Scheduler backoffScheduler) {
+		return retryWhen(FluxRetryWhen.randomExponentialBackoffFunction(numRetries, firstBackoff, maxBackoff, jitterFactor, backoffScheduler));
 	}
 
 	/**

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRetryWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRetryWhenTest.java
@@ -24,8 +24,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.assertj.core.data.Percentage;
 import org.junit.Test;
+
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
+import reactor.test.scheduler.VirtualTimeScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -252,6 +255,58 @@ public class MonoRetryWhenTest {
 		assertThat(elapsedList.get(2) - elapsedList.get(1)).isEqualTo(200);
 		assertThat(elapsedList.get(3) - elapsedList.get(2)).isEqualTo(400);
 		assertThat(elapsedList.get(4) - elapsedList.get(3)).isEqualTo(800);
+	}
+
+
+	@Test
+	public void monoRetryBackoffWithGivenScheduler() {
+		VirtualTimeScheduler backoffScheduler = VirtualTimeScheduler.create();
+
+		Exception exception = new IOException("boom retry");
+		AtomicInteger errorCount = new AtomicInteger();
+
+		StepVerifier.create(
+				Mono.error(exception)
+				    .doOnError(t -> errorCount.incrementAndGet())
+				    .retryBackoff(4, Duration.ofMillis(10), Duration.ofMillis(100), 0, backoffScheduler)
+		)
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofMillis(400))
+		            .then(() -> assertThat(errorCount).as("errorCount before advanceTime").hasValue(1))
+		            .then(() -> backoffScheduler.advanceTimeBy(Duration.ofMillis(400)))
+		            .then(() -> assertThat(errorCount).as("errorCount after advanceTime").hasValue(5))
+		            .expectErrorSatisfies(e -> assertThat(e).isInstanceOf(IllegalStateException.class)
+		                                                    .hasMessage("Retries exhausted: 4/4")
+		                                                    .hasCause(exception))
+		            .verify(Duration.ofMillis(400)); //test should only take roughly the expectNoEvent time
+	}
+
+
+	@Test
+	public void monoRetryBackoffRetriesOnGivenScheduler() {
+		//the monoRetryBackoffWithGivenScheduler above is not suitable to verify the retry scheduler,
+		// as VTS is akin to immediate() and doesn't really change the Thread
+		Scheduler backoffScheduler = Schedulers.newSingle("backoffScheduler");
+		final IllegalStateException exception = new IllegalStateException("boom");
+		List<String> threadNames = new ArrayList<>(4);
+		try {
+			StepVerifier.create(Mono.error(exception)
+			                        .doOnError(e -> threadNames.add(Thread.currentThread().getName()))
+			                        .retryBackoff(2, Duration.ofMillis(10), Duration.ofMillis(100), 0.5d, backoffScheduler)
+
+			)
+			            .expectErrorSatisfies(e -> assertThat(e).isInstanceOf(IllegalStateException.class)
+			                                                    .hasMessage("Retries exhausted: 2/2")
+			                                                    .hasCause(exception))
+			            .verify(Duration.ofMillis(200));
+
+			assertThat(threadNames)
+					.as("retry runs on backoffScheduler")
+					.containsExactly("main", "backoffScheduler-1", "backoffScheduler-1");
+		}
+		finally {
+			backoffScheduler.dispose();
+		}
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRetryWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRetryWhenTest.java
@@ -287,11 +287,12 @@ public class MonoRetryWhenTest {
 		//the monoRetryBackoffWithGivenScheduler above is not suitable to verify the retry scheduler,
 		// as VTS is akin to immediate() and doesn't really change the Thread
 		Scheduler backoffScheduler = Schedulers.newSingle("backoffScheduler");
+		String main = Thread.currentThread().getName();
 		final IllegalStateException exception = new IllegalStateException("boom");
 		List<String> threadNames = new ArrayList<>(4);
 		try {
 			StepVerifier.create(Mono.error(exception)
-			                        .doOnError(e -> threadNames.add(Thread.currentThread().getName()))
+			                        .doOnError(e -> threadNames.add(Thread.currentThread().getName().replaceFirst("-\\d+", "")))
 			                        .retryBackoff(2, Duration.ofMillis(10), Duration.ofMillis(100), 0.5d, backoffScheduler)
 
 			)
@@ -302,7 +303,7 @@ public class MonoRetryWhenTest {
 
 			assertThat(threadNames)
 					.as("retry runs on backoffScheduler")
-					.containsExactly("main", "backoffScheduler-1", "backoffScheduler-1");
+					.containsExactly(main, "backoffScheduler", "backoffScheduler");
 		}
 		finally {
 			backoffScheduler.dispose();


### PR DESCRIPTION
This scheduler also naturally determines on which thread each retry attempt will be published.

Targeting 3.2.x since the scope is small but introduces good API alignment and quality of life.