### PR TITLE
Make sure ElasticScheduler.CachedService gets disposed

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
@@ -57,12 +57,12 @@ final class DelegateServiceScheduler implements Scheduler, Scannable {
 
 	@Override
 	public Disposable schedule(Runnable task) {
-		return Schedulers.directSchedule(executor, task, 0L, TimeUnit.MILLISECONDS);
+		return Schedulers.directSchedule(executor, task, null, 0L, TimeUnit.MILLISECONDS);
 	}
 
 	@Override
 	public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
-		return Schedulers.directSchedule(executor, task, delay, unit);
+		return Schedulers.directSchedule(executor, task, null, delay, unit);
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
@@ -151,12 +151,12 @@ final class ParallelScheduler implements Scheduler, Supplier<ScheduledExecutorSe
 
     @Override
     public Disposable schedule(Runnable task) {
-	    return Schedulers.directSchedule(pick(), task, 0L, TimeUnit.MILLISECONDS);
+	    return Schedulers.directSchedule(pick(), task, null, 0L, TimeUnit.MILLISECONDS);
     }
 
     @Override
     public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
-	    return Schedulers.directSchedule(pick(), task, delay, unit);
+	    return Schedulers.directSchedule(pick(), task, null, delay, unit);
     }
 
     @Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -922,10 +922,11 @@ public abstract class Schedulers {
 
 	static Disposable directSchedule(ScheduledExecutorService exec,
 			Runnable task,
+			@Nullable Disposable parent,
 			long delay,
 			TimeUnit unit) {
 		task = onSchedule(task);
-		SchedulerTask sr = new SchedulerTask(task);
+		SchedulerTask sr = new SchedulerTask(task, parent);
 		Future<?> f;
 		if (delay <= 0L) {
 			f = exec.submit((Callable<?>) sr);

--- a/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
@@ -115,12 +115,12 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 
 	@Override
 	public Disposable schedule(Runnable task) {
-		return Schedulers.directSchedule(executor, task, 0L, TimeUnit.MILLISECONDS);
+		return Schedulers.directSchedule(executor, task, null, 0L, TimeUnit.MILLISECONDS);
 	}
 
 	@Override
 	public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
-		return Schedulers.directSchedule(executor, task, delay, unit);
+		return Schedulers.directSchedule(executor, task, null, delay, unit);
 	}
 
 	@Override

--- a/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
@@ -73,7 +73,8 @@ public class ElasticSchedulerTest extends AbstractSchedulerTest {
 				Disposable d = s.schedule(() -> {
 					try {
 						Thread.sleep(10000);
-					} catch (InterruptedException e) {
+					}
+					catch (InterruptedException e) {
 						Thread.currentThread().interrupt();
 					}
 				});
@@ -286,9 +287,11 @@ public class ElasticSchedulerTest extends AbstractSchedulerTest {
 		Scheduler s = Schedulers.newElastic("test-recycle");
 		((ElasticScheduler)s).evictor.shutdownNow();
 
-		try{
+		try {
 			AtomicBoolean stop = new AtomicBoolean(false);
+			CountDownLatch started = new CountDownLatch(1);
 			Disposable d = s.schedule(() -> {
+				started.countDown();
 				// simulate uninterruptible computation
 				for (;;) {
 					if (stop.get()) {
@@ -296,7 +299,7 @@ public class ElasticSchedulerTest extends AbstractSchedulerTest {
 					}
 				}
 			});
-			Thread.sleep(100);
+			started.await();
 			d.dispose();
 
 			Thread.sleep(100);
@@ -309,7 +312,6 @@ public class ElasticSchedulerTest extends AbstractSchedulerTest {
 		}
 		finally {
 			s.dispose();
-			s.dispose();//noop
 		}
 	}
 
@@ -318,15 +320,17 @@ public class ElasticSchedulerTest extends AbstractSchedulerTest {
 		Scheduler s = Schedulers.newElastic("test-recycle");
 		((ElasticScheduler)s).evictor.shutdownNow();
 
-		try{
+		try {
 			Disposable d = s.schedule(() -> {
 				try {
 					Thread.sleep(10000);
-				} catch (InterruptedException e) {
+				}
+				catch (InterruptedException e) {
 					Thread.currentThread().interrupt();
 				}
 			});
 
+			// Dispose twice to test that the executor is returned to the pool only once
 			d.dispose();
 			d.dispose();
 
@@ -335,7 +339,6 @@ public class ElasticSchedulerTest extends AbstractSchedulerTest {
 		}
 		finally {
 			s.dispose();
-			s.dispose();//noop
 		}
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
@@ -68,21 +68,24 @@ public class ElasticSchedulerTest extends AbstractSchedulerTest {
 		((ElasticScheduler)s).evictor.shutdownNow();
 
 		try{
-			Disposable d = s.schedule(() -> {
-				try {
-					Thread.sleep(10000);
-				}
-				catch (InterruptedException e) {
-					Thread.currentThread().interrupt();
-				}
-			});
+			for (int i = 0; i < 100; i++) {
+				Disposable d = s.schedule(() -> {
+					try {
+						Thread.sleep(10000);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+				});
 
-			d.dispose();
+				d.dispose();
+			}
 
 			while(((ElasticScheduler)s).cache.peek() != null){
 				((ElasticScheduler)s).eviction();
 				Thread.sleep(100);
 			}
+
+			assertThat(((ElasticScheduler)s).all).isEmpty();
 		}
 		finally {
 			s.dispose();

--- a/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
@@ -299,7 +299,7 @@ public class ElasticSchedulerTest extends AbstractSchedulerTest {
 					}
 				}
 			});
-			started.await();
+			assertThat(started.await(10, TimeUnit.SECONDS)).as("latch timeout").isTrue();
 			d.dispose();
 
 			Thread.sleep(100);


### PR DESCRIPTION
Fixes #1722.

When `schedule` is called, a `CachedService` is acquired first:

https://github.com/reactor/reactor-core/blob/a0b332b99b25f98461536f01cc18e6b30319301a/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java#L159

`CachedService` is disposed after the task is run:

https://github.com/reactor/reactor-core/blob/a0b332b99b25f98461536f01cc18e6b30319301a/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java#L300

However, if the task is not run (because of immediate disposal), `CachedService` is not disposed.