### PR TITLE
Macro-Fusion on identical operators (#1556)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Non-Blocking [Reactive Streams](https://www.reactive-streams.org/) Foundation fo
 
 The `master` branch is now dedicated to development of the `3.3.x` line.
 
+The `master` branch is now dedicated to development of the `3.3.x` line.
+
 ## Getting it
    
 **Reactor 3 requires Java 8 or + to run**.

--- a/benchmarks/src/jmh/java/reactor/core/publisher/FusionProof.java
+++ b/benchmarks/src/jmh/java/reactor/core/publisher/FusionProof.java
@@ -1,0 +1,93 @@
+package reactor.core.publisher;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.RunnerException;
+import reactor.core.publisher.Mono;
+
+@State(Scope.Benchmark)
+@Fork(1)
+public class FusionProof {
+
+//    @Param({"1", "31", "1024", "10000"})
+//    public static int elementCount;
+
+    @Benchmark()
+    @BenchmarkMode(Mode.Throughput)
+    public void monoFussedOptimizationProof() {
+        Mono.just(1)
+            .map(Function.identity())
+            .map(Function.identity())
+            .map(Function.identity())
+            .map(Function.identity())
+            .map(Function.identity())
+            .map(Function.identity())
+            .map(Function.identity())
+            .map(Function.identity())
+            .map(Function.identity())
+            .map(Function.identity())
+            .block();
+    }
+
+    @Benchmark()
+    @BenchmarkMode(Mode.Throughput)
+    public void monoNonFusedChain() {
+        Mono<Integer> source = Mono.just(1);
+        MonoMapFuseable<Integer, Integer> map1 = new MonoMapFuseable<>(source, Function.identity());
+        MonoMapFuseable<Integer, Integer> map2 = new MonoMapFuseable<>(map1, Function.identity());
+        MonoMapFuseable<Integer, Integer> map3 = new MonoMapFuseable<>(map2, Function.identity());
+        MonoMapFuseable<Integer, Integer> map4 = new MonoMapFuseable<>(map3, Function.identity());
+        MonoMapFuseable<Integer, Integer> map5 = new MonoMapFuseable<>(map4, Function.identity());
+        MonoMapFuseable<Integer, Integer> map6 = new MonoMapFuseable<>(map5, Function.identity());
+        MonoMapFuseable<Integer, Integer> map7 = new MonoMapFuseable<>(map6, Function.identity());
+        MonoMapFuseable<Integer, Integer> map8 = new MonoMapFuseable<>(map7, Function.identity());
+        MonoMapFuseable<Integer, Integer> map9 = new MonoMapFuseable<>(map8, Function.identity());
+        MonoMapFuseable<Integer, Integer> map10 = new MonoMapFuseable<>(map9, Function.identity());
+        map10.block();
+    }
+
+
+    @Benchmark()
+    @BenchmarkMode(Mode.Throughput)
+    public void flux100000FussedOptimizationProof() {
+        Flux.range(1, 100000)
+            .map(Function.identity())
+            .map(Function.identity())
+            .map(Function.identity())
+            .map(Function.identity())
+            .map(Function.identity())
+            .map(Function.identity())
+            .map(Function.identity())
+            .map(Function.identity())
+            .map(Function.identity())
+            .map(Function.identity())
+            .blockLast();
+    }
+
+    @Benchmark()
+    @BenchmarkMode(Mode.Throughput)
+    public void flux100000NonFusedChain() {
+        Flux<Integer> source = Flux.range(1, 100000);
+        FluxMapFuseable<Integer, Integer> map1 = new FluxMapFuseable<>(source, Function.identity());
+        FluxMapFuseable<Integer, Integer> map2 = new FluxMapFuseable<>(map1, Function.identity());
+        FluxMapFuseable<Integer, Integer> map3 = new FluxMapFuseable<>(map2, Function.identity());
+        FluxMapFuseable<Integer, Integer> map4 = new FluxMapFuseable<>(map3, Function.identity());
+        FluxMapFuseable<Integer, Integer> map5 = new FluxMapFuseable<>(map4, Function.identity());
+        FluxMapFuseable<Integer, Integer> map6 = new FluxMapFuseable<>(map5, Function.identity());
+        FluxMapFuseable<Integer, Integer> map7 = new FluxMapFuseable<>(map6, Function.identity());
+        FluxMapFuseable<Integer, Integer> map8 = new FluxMapFuseable<>(map7, Function.identity());
+        FluxMapFuseable<Integer, Integer> map9 = new FluxMapFuseable<>(map8, Function.identity());
+        FluxMapFuseable<Integer, Integer> map10 = new FluxMapFuseable<>(map9, Function.identity());
+        map10.blockLast();
+    }
+}

--- a/reactor-core/src/main/java/reactor/core/Fuseable.java
+++ b/reactor-core/src/main/java/reactor/core/Fuseable.java
@@ -20,8 +20,10 @@ import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.Callable;
 
+import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import reactor.core.publisher.Flux;
 import reactor.util.annotation.Nullable;
 
 /**
@@ -64,6 +66,27 @@ public interface Fuseable {
 		 * @return true if consumed, false if dropped and a new value can be immediately sent
 		 */
 		boolean tryOnNext(T t);
+	}
+
+	interface Composite {
+	    enum Type {
+	        MAP, FILTER, HANDLE,
+            DO_ON_SUBSCRIBE, DO_ON_NEXT, DO_ON_ERROR, DO_ON_COMPLETE,
+		    DO_ON_REQUEST, DO_ON_CANCEL,
+		    DO_ON_SUCCESS, DO_ON_TERMINATE, DO_AFTER_TERMINATE,
+	    }
+
+        /**
+         *
+         * @param composite function to compose with
+         *
+         * @param type the type of composeable function
+         * @param <K> result type in case of re-mapping
+         *
+         * @return returns the result of composition or {@link null} in case it is impossible to compose {@link Flux}es.
+         */
+		@Nullable
+		<K> Publisher<K> tryCompose(Object composite, Type type);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -4074,6 +4074,12 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final Flux<T> doAfterTerminate(Runnable afterTerminate) {
 		Objects.requireNonNull(afterTerminate, "afterTerminate");
+		if (this instanceof Fuseable.Composite) {
+			Flux<T> composedFlux = (Flux<T>)((Fuseable.Composite) this).tryCompose(afterTerminate, Fuseable.Composite.Type.DO_AFTER_TERMINATE);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, null, null, null, null, afterTerminate, null, null);
 	}
 
@@ -4088,6 +4094,13 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final Flux<T> doOnCancel(Runnable onCancel) {
 		Objects.requireNonNull(onCancel, "onCancel");
+		if (this instanceof Fuseable.Composite) {
+			Flux<T> composedFlux =
+				(Flux<T>)((Fuseable.Composite) this).tryCompose(onCancel, Fuseable.Composite.Type.DO_ON_CANCEL);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, null, null, null, null, null, null, onCancel);
 	}
 
@@ -4102,6 +4115,13 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final Flux<T> doOnComplete(Runnable onComplete) {
 		Objects.requireNonNull(onComplete, "onComplete");
+		if (this instanceof Fuseable.Composite) {
+			Flux<T> composedFlux =
+				(Flux<T>)((Fuseable.Composite) this).tryCompose(onComplete, Fuseable.Composite.Type.DO_ON_COMPLETE);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, null, null, null, onComplete, null, null, null);
 	}
 
@@ -4169,6 +4189,12 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final Flux<T> doOnError(Consumer<? super Throwable> onError) {
 		Objects.requireNonNull(onError, "onError");
+		if (this instanceof Fuseable.Composite) {
+			Flux<T> composedFlux = (Flux<T>)((Fuseable.Composite) this).tryCompose(onError, Fuseable.Composite.Type.DO_ON_ERROR);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, null, null, onError, null, null, null, null);
 	}
 
@@ -4230,6 +4256,12 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final Flux<T> doOnNext(Consumer<? super T> onNext) {
 		Objects.requireNonNull(onNext, "onNext");
+		if (this instanceof Fuseable.Composite) {
+			Flux<T> composedFlux = (Flux<T>)((Fuseable.Composite) this).tryCompose(onNext, Fuseable.Composite.Type.DO_ON_NEXT);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, null, onNext, null, null, null, null, null);
 	}
 
@@ -4249,6 +4281,12 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final Flux<T> doOnRequest(LongConsumer consumer) {
 		Objects.requireNonNull(consumer, "consumer");
+		if (this instanceof Fuseable.Composite) {
+			Flux<T> composedFlux = (Flux<T>)((Fuseable.Composite) this).tryCompose(consumer, Fuseable.Composite.Type.DO_ON_REQUEST);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, null, null, null, null, null, consumer, null);
 	}
 
@@ -4267,6 +4305,12 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final Flux<T> doOnSubscribe(Consumer<? super Subscription> onSubscribe) {
 		Objects.requireNonNull(onSubscribe, "onSubscribe");
+		if (this instanceof Fuseable.Composite) {
+			Flux<T> composedFlux = (Flux<T>)((Fuseable.Composite) this).tryCompose(onSubscribe, Fuseable.Composite.Type.DO_ON_SUBSCRIBE);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, onSubscribe, null, null, null, null, null, null);
 	}
 
@@ -4282,6 +4326,13 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final Flux<T> doOnTerminate(Runnable onTerminate) {
 		Objects.requireNonNull(onTerminate, "onTerminate");
+		if (this instanceof Fuseable.Composite) {
+			Flux<T> composedFlux =
+				(Flux<T>)((Fuseable.Composite) this).tryCompose(onTerminate, Fuseable.Composite.Type.DO_ON_TERMINATE);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this,
 				null,
 				null,
@@ -4559,6 +4610,12 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @return a new {@link Flux} containing only values that pass the predicate test
 	 */
 	public final Flux<T> filter(Predicate<? super T> p) {
+		if (this instanceof Fuseable.Composite) {
+            Flux<T> composedFlux = (Flux<T>)((Fuseable.Composite) this).tryCompose(p, Fuseable.Composite.Type.FILTER);
+            if (composedFlux != null) {
+                return onAssembly(composedFlux);
+            }
+        }
 		if (this instanceof Fuseable) {
 			return onAssembly(new FluxFilterFuseable<>(this, p));
 		}
@@ -5684,6 +5741,12 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @return a transformed {@link Flux}
 	 */
 	public final <V> Flux<V> map(Function<? super T, ? extends V> mapper) {
+	    if (this instanceof Fuseable.Composite) {
+            Flux<V> composedFlux = (Flux<V>)((Fuseable.Composite) this).tryCompose(mapper, Fuseable.Composite.Type.MAP);
+            if (composedFlux != null) {
+                return onAssembly(composedFlux);
+            }
+        }
 		if (this instanceof Fuseable) {
 			return onAssembly(new FluxMapFuseable<>(this, mapper));
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilter.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilter.java
@@ -33,7 +33,7 @@ import reactor.util.context.Context;
  *
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
-final class FluxFilter<T> extends FluxOperator<T, T> {
+final class FluxFilter<T> extends FluxOperator<T, T> implements Fuseable.Composite {
 
 	final Predicate<? super T> predicate;
 
@@ -41,6 +41,16 @@ final class FluxFilter<T> extends FluxOperator<T, T> {
 		super(source);
 		this.predicate = Objects.requireNonNull(predicate, "predicate");
 	}
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K> FluxFilter<K> tryCompose(Object composable, Type type) {
+        if (type == Type.FILTER && composable instanceof Predicate) {
+            Predicate<? super T> composed = predicate.and((Predicate) composable);
+            return (FluxFilter) new FluxFilter<>(source, composed);
+        }
+        return null;
+    }
 
 	@Override
 	@SuppressWarnings("unchecked")

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
@@ -32,7 +32,8 @@ import reactor.util.context.Context;
  *
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
-final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable {
+final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable,
+                                                                        Fuseable.Composite {
 
 	final Predicate<? super T> predicate;
 
@@ -40,6 +41,16 @@ final class FluxFilterFuseable<T> extends FluxOperator<T, T> implements Fuseable
 		super(source);
 		this.predicate = Objects.requireNonNull(predicate, "predicate");
 	}
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K> FluxFilterFuseable<K> tryCompose(Object composable, Type type) {
+        if (type == Type.FILTER && composable instanceof Predicate) {
+            Predicate<? super T> composed = predicate.and((Predicate) composable);
+            return (FluxFilterFuseable) new FluxFilterFuseable<T>(source, composed);
+        }
+        return null;
+    }
 
 	@Override
 	@SuppressWarnings("unchecked")

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPeek.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPeek.java
@@ -21,6 +21,7 @@ import java.util.function.LongConsumer;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
+import reactor.core.Fuseable;
 import reactor.core.Fuseable.ConditionalSubscriber;
 import reactor.core.publisher.FluxPeekFuseable.PeekConditionalSubscriber;
 import reactor.util.annotation.Nullable;
@@ -38,7 +39,7 @@ import reactor.util.context.Context;
  * @param <T> the value type
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
-final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
+final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T>, Fuseable.Composite {
 
 	final Consumer<? super Subscription> onSubscribeCall;
 
@@ -81,6 +82,137 @@ final class FluxPeek<T> extends FluxOperator<T, T> implements SignalPeek<T> {
 			return;
 		}
 		source.subscribe(new PeekSubscriber<>(actual, this));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <K> FluxPeek<K> tryCompose(Object composite, Fuseable.Composite.Type type) {
+		if (composite instanceof Consumer) {
+			Consumer consumerComposable = (Consumer) composite;
+			switch (type) {
+				case DO_ON_SUBSCRIBE: {
+					Consumer<? super Subscription> composed =
+						onSubscribeCall == null
+							? consumerComposable
+							: onSubscribeCall.andThen(consumerComposable);
+					return (FluxPeek) new FluxPeek<>(source,
+						composed,
+						onNextCall,
+						onErrorCall,
+						onCompleteCall,
+						onAfterTerminateCall,
+						onRequestCall,
+						onCancelCall);
+				}
+				case DO_ON_NEXT: {
+					Consumer<? super T> composed =
+						onNextCall == null ?
+							consumerComposable : onNextCall.andThen(consumerComposable);
+					return (FluxPeek) new FluxPeek<>(source,
+						onSubscribeCall,
+						composed,
+						onErrorCall,
+						onCompleteCall,
+						onAfterTerminateCall,
+						onRequestCall,
+						onCancelCall);
+				}
+				case DO_ON_ERROR: {
+					Consumer<? super Throwable> composed =
+						onErrorCall == null ?
+							consumerComposable : onErrorCall.andThen(consumerComposable);
+					return (FluxPeek) new FluxPeek<>(source,
+						onSubscribeCall,
+						onNextCall,
+						composed,
+						onCompleteCall,
+						onAfterTerminateCall,
+						onRequestCall,
+						onCancelCall);
+				}
+			}
+		}
+		else if (composite instanceof Runnable) {
+			Runnable runnableComposable = (Runnable) composite;
+			switch (type) {
+				case DO_ON_COMPLETE: {
+					Runnable composed =
+						onCompleteCall == null ? runnableComposable : () -> {
+							onCompleteCall.run();
+							runnableComposable.run();
+						};
+					return (FluxPeek) new FluxPeek<>(source,
+						onSubscribeCall,
+						onNextCall,
+						onErrorCall,
+						composed,
+						onAfterTerminateCall,
+						onRequestCall,
+						onCancelCall);
+				}
+				case DO_ON_TERMINATE: {
+					Runnable composedCompletion =
+						onCompleteCall == null ? runnableComposable : () -> {
+							onCompleteCall.run();
+							runnableComposable.run();
+						};
+					Consumer<? super Throwable> composedError =
+						onErrorCall == null ? (e) -> runnableComposable.run() :
+							onErrorCall.andThen((e) -> runnableComposable.run());
+					return (FluxPeek) new FluxPeek<>(source,
+						onSubscribeCall,
+						onNextCall,
+						composedError,
+						composedCompletion,
+						onAfterTerminateCall,
+						onRequestCall,
+						onCancelCall);
+				}
+				case DO_AFTER_TERMINATE: {
+					Runnable composed =
+						onAfterTerminateCall == null ? runnableComposable : () -> {
+							onAfterTerminateCall.run();
+							runnableComposable.run();
+						};
+					return (FluxPeek) new FluxPeek<>(source,
+						onSubscribeCall,
+						onNextCall,
+						onErrorCall,
+						onCompleteCall,
+						composed,
+						onRequestCall,
+						onCancelCall);
+				}
+				case DO_ON_CANCEL: {
+					Runnable composed =
+						onCancelCall == null ? runnableComposable : () -> {
+							onCancelCall.run();
+							runnableComposable.run();
+						};
+					return (FluxPeek) new FluxPeek<>(source,
+						onSubscribeCall,
+						onNextCall,
+						onErrorCall,
+						onCompleteCall,
+						onAfterTerminateCall,
+						onRequestCall,
+						composed);
+				}
+			}
+		}
+		else if (type == Fuseable.Composite.Type.DO_ON_REQUEST && composite instanceof LongConsumer) {
+			LongConsumer composed =
+				onRequestCall == null ? (LongConsumer) composite : onRequestCall.andThen((LongConsumer) composite);
+			return (FluxPeek) new FluxPeek<>(source,
+				onSubscribeCall,
+				onNextCall,
+				onErrorCall,
+				onCompleteCall,
+				onAfterTerminateCall,
+				composed,
+				onCancelCall);
+		}
+		return null;
 	}
 
 	static final class PeekSubscriber<T> implements InnerOperator<T, T> {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
@@ -40,7 +40,7 @@ import reactor.util.context.Context;
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
 final class FluxPeekFuseable<T> extends FluxOperator<T, T>
-		implements Fuseable, SignalPeek<T> {
+		implements Fuseable, SignalPeek<T>, Fuseable.Composite {
 
 	final Consumer<? super Subscription> onSubscribeCall;
 
@@ -84,6 +84,136 @@ final class FluxPeekFuseable<T> extends FluxOperator<T, T>
 			return;
 		}
 		source.subscribe(new PeekFuseableSubscriber<>(actual, this));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <K> FluxPeekFuseable<K> tryCompose(Object composite, Type type) {
+		if (composite instanceof Consumer) {
+			Consumer consumerComposable = (Consumer) composite;
+			switch (type) {
+				case DO_ON_SUBSCRIBE: {
+					Consumer<? super Subscription> composed =
+						onSubscribeCall == null ?
+							consumerComposable : onSubscribeCall.andThen(consumerComposable);
+					return (FluxPeekFuseable) new FluxPeekFuseable<>(source,
+						composed,
+						onNextCall,
+						onErrorCall,
+						onCompleteCall,
+						onAfterTerminateCall,
+						onRequestCall,
+						onCancelCall);
+				}
+				case DO_ON_NEXT: {
+					Consumer<? super T> composed =
+						onNextCall == null ?
+							consumerComposable : onNextCall.andThen(consumerComposable);
+					return (FluxPeekFuseable) new FluxPeekFuseable<>(source,
+						onSubscribeCall,
+						composed,
+						onErrorCall,
+						onCompleteCall,
+						onAfterTerminateCall,
+						onRequestCall,
+						onCancelCall);
+				}
+				case DO_ON_ERROR: {
+					Consumer<? super Throwable> composed =
+						onErrorCall == null ?
+							consumerComposable : onErrorCall.andThen(consumerComposable);
+					return (FluxPeekFuseable) new FluxPeekFuseable<>(source,
+						onSubscribeCall,
+						onNextCall,
+						composed,
+						onCompleteCall,
+						onAfterTerminateCall,
+						onRequestCall,
+						onCancelCall);
+				}
+			}
+		}
+		else if (composite instanceof Runnable) {
+			Runnable runnableComposable = (Runnable) composite;
+			switch (type) {
+				case DO_ON_COMPLETE: {
+					Runnable composed =
+						onCompleteCall == null ? runnableComposable : () -> {
+							onCompleteCall.run();
+							runnableComposable.run();
+						};
+					return (FluxPeekFuseable) new FluxPeekFuseable<>(source,
+						onSubscribeCall,
+						onNextCall,
+						onErrorCall,
+						composed,
+						onAfterTerminateCall,
+						onRequestCall,
+						onCancelCall);
+				}
+				case DO_ON_TERMINATE: {
+					Runnable composedCompletion =
+						onCompleteCall == null ? runnableComposable : () -> {
+							onCompleteCall.run();
+							runnableComposable.run();
+						};
+					Consumer<? super Throwable> composedError =
+						onErrorCall == null ? (e) -> runnableComposable.run() :
+							onErrorCall.andThen((e) -> runnableComposable.run());
+					return (FluxPeekFuseable) new FluxPeekFuseable<>(source,
+						onSubscribeCall,
+						onNextCall,
+						composedError,
+						composedCompletion,
+						onAfterTerminateCall,
+						onRequestCall,
+						onCancelCall);
+				}
+				case DO_AFTER_TERMINATE: {
+					Runnable composed =
+						onAfterTerminateCall == null ? runnableComposable : () -> {
+							onAfterTerminateCall.run();
+							runnableComposable.run();
+						};
+					return (FluxPeekFuseable) new FluxPeekFuseable<>(source,
+						onSubscribeCall,
+						onNextCall,
+						onErrorCall,
+						onCompleteCall,
+						composed,
+						onRequestCall,
+						onCancelCall);
+				}
+				case DO_ON_CANCEL: {
+					Runnable composed =
+						onCancelCall == null ? runnableComposable : () -> {
+							onCancelCall.run();
+							runnableComposable.run();
+						};
+					return (FluxPeekFuseable) new FluxPeekFuseable<>(source,
+						onSubscribeCall,
+						onNextCall,
+						onErrorCall,
+						onCompleteCall,
+						onAfterTerminateCall,
+						onRequestCall,
+						composed);
+				}
+			}
+		}
+		else if (type == Type.DO_ON_REQUEST && composite instanceof LongConsumer) {
+			LongConsumer composed =
+				onRequestCall == null ? (LongConsumer) composite : onRequestCall.andThen((LongConsumer) composite);
+			return (FluxPeekFuseable) new FluxPeekFuseable<>(source,
+				onSubscribeCall,
+				onNextCall,
+				onErrorCall,
+				onCompleteCall,
+				onAfterTerminateCall,
+				composed,
+				onCancelCall);
+		}
+		return null;
 	}
 
 	static final class PeekFuseableSubscriber<T>

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1961,6 +1961,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return a new {@link Mono}
 	 */
 	public final Mono<T> doAfterSuccessOrError(BiConsumer<? super T, Throwable> afterSuccessOrError) {
+		if (this instanceof Fuseable.Composite) {
+			Mono<T> composedFlux =
+				(Mono<T>)((Fuseable.Composite) this).tryCompose(afterSuccessOrError, Fuseable.Composite.Type.DO_AFTER_TERMINATE);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return onAssembly(new MonoPeekTerminal<>(this, null, null, afterSuccessOrError));
 	}
 
@@ -2019,6 +2026,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 */
 	public final Mono<T> doOnCancel(Runnable onCancel) {
 		Objects.requireNonNull(onCancel, "onCancel");
+		if (this instanceof Fuseable.Composite) {
+			Mono<T> composedFlux =
+				(Mono<T>)((Fuseable.Composite) this).tryCompose(onCancel, Fuseable.Composite.Type.DO_ON_CANCEL);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, null, null, null, null, null, onCancel);
 	}
 
@@ -2061,6 +2075,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 */
 	public final Mono<T> doOnNext(Consumer<? super T> onNext) {
 		Objects.requireNonNull(onNext, "onNext");
+		if (this instanceof Fuseable.Composite) {
+			Mono<T> composedFlux =
+				(Mono<T>)((Fuseable.Composite) this).tryCompose(onNext, Fuseable.Composite.Type.DO_ON_NEXT);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, null, onNext, null, null, null, null);
 	}
 
@@ -2083,6 +2104,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 */
 	public final Mono<T> doOnSuccess(Consumer<? super T> onSuccess) {
 		Objects.requireNonNull(onSuccess, "onSuccess");
+		if (this instanceof Fuseable.Composite) {
+			Mono<T> composedFlux =
+				(Mono<T>)((Fuseable.Composite) this).tryCompose(onSuccess, Fuseable.Composite.Type.DO_ON_SUCCESS);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return onAssembly(new MonoPeekTerminal<>(this, onSuccess, null, null));
 	}
 
@@ -2125,6 +2153,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 */
 	public final Mono<T> doOnError(Consumer<? super Throwable> onError) {
 		Objects.requireNonNull(onError, "onError");
+		if (this instanceof Fuseable.Composite) {
+			Mono<T> composedFlux =
+				(Mono<T>)((Fuseable.Composite) this).tryCompose(onError, Fuseable.Composite.Type.DO_ON_ERROR);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, null, null, onError, null, null, null);
 	}
 
@@ -2184,6 +2219,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 */
 	public final Mono<T> doOnRequest(final LongConsumer consumer) {
 		Objects.requireNonNull(consumer, "consumer");
+		if (this instanceof Fuseable.Composite) {
+			Mono<T> composedFlux =
+				(Mono<T>)((Fuseable.Composite) this).tryCompose(consumer, Fuseable.Composite.Type.DO_ON_REQUEST);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, null, null, null, null, consumer, null);
 	}
 
@@ -2202,6 +2244,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 */
 	public final Mono<T> doOnSubscribe(Consumer<? super Subscription> onSubscribe) {
 		Objects.requireNonNull(onSubscribe, "onSubscribe");
+		if (this instanceof Fuseable.Composite) {
+			Mono<T> composedFlux =
+				(Mono<T>)((Fuseable.Composite) this).tryCompose(onSubscribe, Fuseable.Composite.Type.DO_ON_SUBSCRIBE);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, onSubscribe, null, null,  null, null, null);
 	}
 
@@ -2223,6 +2272,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 */
 	public final Mono<T> doOnSuccessOrError(BiConsumer<? super T, Throwable> onSuccessOrError) {
 		Objects.requireNonNull(onSuccessOrError, "onSuccessOrError");
+		if (this instanceof Fuseable.Composite) {
+			Mono<T> composedFlux =
+				(Mono<T>)((Fuseable.Composite) this).tryCompose(onSuccessOrError, Fuseable.Composite.Type.DO_ON_TERMINATE);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return onAssembly(new MonoPeekTerminal<>(this, null, onSuccessOrError, null));
 	}
 
@@ -2238,6 +2294,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 */
 	public final Mono<T> doOnTerminate(Runnable onTerminate) {
 		Objects.requireNonNull(onTerminate, "onTerminate");
+		if (this instanceof Fuseable.Composite) {
+			Mono<T> composedFlux =
+				(Mono<T>)((Fuseable.Composite) this).tryCompose(onTerminate, Fuseable.Composite.Type.DO_ON_TERMINATE);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this,
 				null,
 				null,
@@ -2446,6 +2509,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return a filtered {@link Mono}
 	 */
 	public final Mono<T> filter(final Predicate<? super T> tester) {
+		if (this instanceof Fuseable.Composite) {
+			Mono<T> composedFlux =
+				(Mono<T>)((Fuseable.Composite) this).tryCompose(tester, Fuseable.Composite.Type.FILTER);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		if (this instanceof Fuseable) {
 			return onAssembly(new MonoFilterFuseable<>(this, tester));
 		}
@@ -2796,6 +2866,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return a new {@link Mono}
 	 */
 	public final <R> Mono<R> map(Function<? super T, ? extends R> mapper) {
+		if (this instanceof Fuseable.Composite) {
+			Mono<R> composedFlux =
+				(Mono<R>)((Fuseable.Composite) this).tryCompose(mapper, Fuseable.Composite.Type.MAP);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		if (this instanceof Fuseable) {
 			return onAssembly(new MonoMapFuseable<>(this, mapper));
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFilterFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFilterFuseable.java
@@ -28,13 +28,23 @@ import reactor.core.Fuseable;
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
 final class MonoFilterFuseable<T> extends MonoOperator<T, T>
-		implements Fuseable {
+		implements Fuseable, Fuseable.Composite {
 
 	final Predicate<? super T> predicate;
 
 	MonoFilterFuseable(Mono<? extends T> source, Predicate<? super T> predicate) {
 		super(source);
 		this.predicate = Objects.requireNonNull(predicate, "predicate");
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <K> MonoFilterFuseable<K> tryCompose(Object composable, Composite.Type type) {
+		if (type == Composite.Type.FILTER && composable instanceof Predicate) {
+			Predicate<? super T> composed = predicate.and((Predicate) composable);
+			return (MonoFilterFuseable) new MonoFilterFuseable<T>(source, composed);
+		}
+		return null;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMap.java
@@ -28,7 +28,7 @@ import reactor.core.Fuseable;
  * @param <R> the result value type
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
-final class MonoMap<T, R> extends MonoOperator<T, R> {
+final class MonoMap<T, R> extends MonoOperator<T, R> implements Fuseable.Composite {
 
 	final Function<? super T, ? extends R> mapper;
 
@@ -53,5 +53,15 @@ final class MonoMap<T, R> extends MonoOperator<T, R> {
 			return;
 		}
 		source.subscribe(new FluxMap.MapSubscriber<>(actual, mapper));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <K> MonoMap<T, K> tryCompose(Object composite, Fuseable.Composite.Type type) {
+		if (type == Fuseable.Composite.Type.MAP && composite instanceof Function) {
+			Function<T, K> composed = mapper.andThen((Function) composite);
+			return new MonoMap<>(source, composed);
+		}
+		return null;
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMapFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMapFuseable.java
@@ -31,7 +31,7 @@ import reactor.core.Fuseable;
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
 final class MonoMapFuseable<T, R> extends MonoOperator<T, R>
-		implements Fuseable {
+		implements Fuseable, Fuseable.Composite {
 
 	final Function<? super T, ? extends R> mapper;
 
@@ -59,4 +59,13 @@ final class MonoMapFuseable<T, R> extends MonoOperator<T, R>
 		source.subscribe(new FluxMapFuseable.MapFuseableSubscriber<>(actual, mapper));
 	}
 
+	@Override
+	@SuppressWarnings("unchecked")
+	public <K> MonoMapFuseable<T, K> tryCompose(Object composite, Fuseable.Composite.Type type) {
+		if (type == Fuseable.Composite.Type.MAP && composite instanceof Function) {
+			Function<T, K> composed = mapper.andThen((Function) composite);
+			return new MonoMapFuseable<>(source, composed);
+		}
+		return null;
+	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPeekFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPeekFuseable.java
@@ -32,7 +32,7 @@ import reactor.util.annotation.Nullable;
  *
  */
 final class MonoPeekFuseable<T> extends MonoOperator<T, T>
-		implements Fuseable, SignalPeek<T> {
+		implements Fuseable, SignalPeek<T>, Fuseable.Composite {
 
 	final Consumer<? super Subscription> onSubscribeCall;
 
@@ -72,6 +72,97 @@ final class MonoPeekFuseable<T> extends MonoOperator<T, T>
 			return;
 		}
 		source.subscribe(new FluxPeekFuseable.PeekFuseableSubscriber<>(actual, this));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <K> MonoPeekFuseable<K> tryCompose(Object composite, Fuseable.Composite.Type type) {
+		if (composite instanceof Consumer) {
+			Consumer consumerComposable = (Consumer) composite;
+			switch (type) {
+				case DO_ON_SUBSCRIBE: {
+					Consumer<? super Subscription> composed =
+						onSubscribeCall == null ? consumerComposable :
+							onSubscribeCall.andThen(consumerComposable);
+					return (MonoPeekFuseable) new MonoPeekFuseable<>(source,
+						composed,
+						onNextCall,
+						onErrorCall,
+						onCompleteCall,
+						onRequestCall,
+						onCancelCall);
+				}
+				case DO_ON_NEXT: {
+					Consumer<? super T> composed =
+						onNextCall == null ?
+							consumerComposable : onNextCall.andThen(consumerComposable);
+					return (MonoPeekFuseable) new MonoPeekFuseable<>(source,
+						onSubscribeCall,
+						composed,
+						onErrorCall,
+						onCompleteCall,
+						onRequestCall,
+						onCancelCall);
+				}
+				case DO_ON_ERROR: {
+					Consumer<? super Throwable> composed =
+						onErrorCall == null ?
+							consumerComposable : onErrorCall.andThen(consumerComposable);
+					return (MonoPeekFuseable) new MonoPeekFuseable<>(source,
+						onSubscribeCall,
+						onNextCall,
+						composed,
+						onCompleteCall,
+						onRequestCall,
+						onCancelCall);
+				}
+			}
+		}
+		else if (composite instanceof Runnable) {
+			Runnable runnableComposable = (Runnable) composite;
+			switch (type) {
+				case DO_ON_COMPLETE: {
+					Runnable composed =
+						onCompleteCall == null ? runnableComposable : () -> {
+							onCompleteCall.run();
+							(runnableComposable).run();
+						};
+					return (MonoPeekFuseable) new MonoPeekFuseable<>(source,
+						onSubscribeCall,
+						onNextCall,
+						onErrorCall,
+						composed,
+						onRequestCall,
+						onCancelCall);
+				}
+				case DO_ON_CANCEL: {
+					Runnable composed =
+						onCancelCall == null ? runnableComposable : () -> {
+							onCancelCall.run();
+							(runnableComposable).run();
+						};
+					return (MonoPeekFuseable) new MonoPeekFuseable<>(source,
+						onSubscribeCall,
+						onNextCall,
+						onErrorCall,
+						onCompleteCall,
+						onRequestCall,
+						composed);
+				}
+			}
+		}
+		else if (type == Fuseable.Composite.Type.DO_ON_REQUEST && composite instanceof LongConsumer) {
+			LongConsumer composed =
+				onRequestCall == null ? (LongConsumer) composite : onRequestCall.andThen((LongConsumer) composite);
+			return (MonoPeekFuseable) new MonoPeekFuseable<>(source,
+				onSubscribeCall,
+				onNextCall,
+				onErrorCall,
+				onCompleteCall,
+				composed,
+				onCancelCall);
+		}
+		return null;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFilter.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFilter.java
@@ -27,7 +27,7 @@ import reactor.util.annotation.Nullable;
  *
  * @param <T> the input value type
  */
-final class ParallelFilter<T> extends ParallelFlux<T> implements Scannable{
+final class ParallelFilter<T> extends ParallelFlux<T> implements Scannable, Fuseable.Composite {
 
 	final ParallelFlux<T> source;
 	
@@ -44,6 +44,16 @@ final class ParallelFilter<T> extends ParallelFlux<T> implements Scannable{
 		if (key == Attr.PARENT) return source;
 		if (key == Attr.PREFETCH) return getPrefetch();
 
+		return null;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <K> ParallelFilter<K> tryCompose(Object composable, Type type) {
+		if (type == Type.FILTER && composable instanceof Predicate) {
+			Predicate<? super T> composed = predicate.and((Predicate) composable);
+			return (ParallelFilter) new ParallelFilter<>(source, composed);
+		}
 		return null;
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -39,6 +39,7 @@ import reactor.core.CorePublisher;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
+import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.core.publisher.FluxConcatMap.ErrorMode;
 import reactor.core.publisher.FluxOnAssembly.AssemblyLightSnapshot;
@@ -366,6 +367,13 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 */
 	public final ParallelFlux<T> doAfterTerminate(Runnable afterTerminate) {
 		Objects.requireNonNull(afterTerminate, "afterTerminate");
+		if (this instanceof Fuseable.Composite) {
+			ParallelFlux<T> composedFlux =
+				(ParallelFlux<T>)((Fuseable.Composite) this).tryCompose(afterTerminate, Fuseable.Composite.Type.DO_AFTER_TERMINATE);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, null, null, null, null, afterTerminate, null, null, null);
 	}
 
@@ -378,6 +386,13 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 */
 	public final ParallelFlux<T> doOnCancel(Runnable onCancel) {
 		Objects.requireNonNull(onCancel, "onCancel");
+		if (this instanceof Fuseable.Composite) {
+			ParallelFlux<T> composedFlux =
+				(ParallelFlux<T>)((Fuseable.Composite) this).tryCompose(onCancel, Fuseable.Composite.Type.DO_ON_CANCEL);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, null, null, null, null, null, null, null, onCancel);
 	}
 
@@ -390,6 +405,13 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 */
 	public final ParallelFlux<T> doOnComplete(Runnable onComplete) {
 		Objects.requireNonNull(onComplete, "onComplete");
+		if (this instanceof Fuseable.Composite) {
+			ParallelFlux<T> composedFlux =
+				(ParallelFlux<T>)((Fuseable.Composite) this).tryCompose(onComplete, Fuseable.Composite.Type.DO_ON_COMPLETE);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, null, null, null, onComplete, null, null, null, null);
 	}
 
@@ -435,6 +457,13 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 */
 	public final ParallelFlux<T> doOnError(Consumer<? super Throwable> onError) {
 		Objects.requireNonNull(onError, "onError");
+		if (this instanceof Fuseable.Composite) {
+			ParallelFlux<T> composedFlux =
+				(ParallelFlux<T>)((Fuseable.Composite) this).tryCompose(onError, Fuseable.Composite.Type.DO_ON_ERROR);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, null, null, onError, null, null, null, null, null);
 	}
 
@@ -452,6 +481,13 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 */
 	public final ParallelFlux<T> doOnSubscribe(Consumer<? super Subscription> onSubscribe) {
 		Objects.requireNonNull(onSubscribe, "onSubscribe");
+		if (this instanceof Fuseable.Composite) {
+			ParallelFlux<T> composedFlux =
+				(ParallelFlux<T>)((Fuseable.Composite) this).tryCompose(onSubscribe, Fuseable.Composite.Type.DO_ON_SUBSCRIBE);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, null, null, null, null, null, onSubscribe, null, null);
 	}
 
@@ -464,6 +500,13 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 */
 	public final ParallelFlux<T> doOnNext(Consumer<? super T> onNext) {
 		Objects.requireNonNull(onNext, "onNext");
+		if (this instanceof Fuseable.Composite) {
+			ParallelFlux<T> composedFlux =
+				(ParallelFlux<T>)((Fuseable.Composite) this).tryCompose(onNext, Fuseable.Composite.Type.DO_ON_NEXT);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, onNext, null, null, null, null, null, null, null);
 	}
 
@@ -477,6 +520,13 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 */
 	public final ParallelFlux<T> doOnRequest(LongConsumer onRequest) {
 		Objects.requireNonNull(onRequest, "onRequest");
+		if (this instanceof Fuseable.Composite) {
+			ParallelFlux<T> composedFlux =
+				(ParallelFlux<T>)((Fuseable.Composite) this).tryCompose(onRequest, Fuseable.Composite.Type.DO_ON_REQUEST);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this, null, null, null, null, null, null, onRequest, null);
 	}
 
@@ -488,6 +538,13 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 */
 	public final ParallelFlux<T> doOnTerminate(Runnable onTerminate) {
 		Objects.requireNonNull(onTerminate, "onTerminate");
+		if (this instanceof Fuseable.Composite) {
+			ParallelFlux<T> composedFlux =
+				(ParallelFlux<T>)((Fuseable.Composite) this).tryCompose(onTerminate, Fuseable.Composite.Type.DO_ON_TERMINATE);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return doOnSignal(this,
 				null,
 				null,
@@ -511,6 +568,13 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 */
 	public final ParallelFlux<T> filter(Predicate<? super T> predicate) {
 		Objects.requireNonNull(predicate, "predicate");
+		if (this instanceof Fuseable.Composite) {
+			ParallelFlux<T> composedFlux =
+				(ParallelFlux<T>)((Fuseable.Composite) this).tryCompose(predicate, Fuseable.Composite.Type.FILTER);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return onAssembly(new ParallelFilter<>(this, predicate));
 	}
 
@@ -733,6 +797,13 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 */
 	public final <U> ParallelFlux<U> map(Function<? super T, ? extends U> mapper) {
 		Objects.requireNonNull(mapper, "mapper");
+		if (this instanceof Fuseable.Composite) {
+			ParallelFlux<U> composedFlux =
+				(ParallelFlux<U>)((Fuseable.Composite) this).tryCompose(mapper, Fuseable.Composite.Type.MAP);
+			if (composedFlux != null) {
+				return onAssembly(composedFlux);
+			}
+		}
 		return onAssembly(new ParallelMap<>(this, mapper));
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelMap.java
@@ -28,7 +28,7 @@ import reactor.util.annotation.Nullable;
  * @param <T> the input value type
  * @param <R> the output value type
  */
-final class ParallelMap<T, R> extends ParallelFlux<R> implements Scannable {
+final class ParallelMap<T, R> extends ParallelFlux<R> implements Scannable, Fuseable.Composite {
 
 	final ParallelFlux<T> source;
 	
@@ -45,6 +45,16 @@ final class ParallelMap<T, R> extends ParallelFlux<R> implements Scannable {
 		if (key == Attr.PARENT) return source;
 		if (key == Attr.PREFETCH) return getPrefetch();
 
+		return null;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <K> ParallelMap<T, K> tryCompose(Object composite, Type type) {
+		if (type == Type.MAP && composite instanceof Function) {
+			Function<T, K> composed = mapper.andThen((Function) composite);
+			return new ParallelMap<>(source, composed);
+		}
 		return null;
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
@@ -247,7 +247,7 @@ public class FluxOnAssemblyTest {
 		String debugStack = sw.toString();
 
 		assertThat(debugStack).contains("Assembly trace from producer [reactor.core.publisher.ParallelSource], described as [descriptionCorrelation1234] :\n"
-				+ "\treactor.core.publisher.ParallelFlux.checkpoint(ParallelFlux.java:224)\n"
+				+ "\treactor.core.publisher.ParallelFlux.checkpoint(ParallelFlux.java:225)\n"
 				+ "\treactor.core.publisher.FluxOnAssemblyTest.parallelFluxCheckpointDescriptionAndForceStack(FluxOnAssemblyTest.java:" + (baseline + 4) + ")\n");
 		assertThat(debugStack).endsWith("Error has been observed at the following site(s):\n"
 				+ "\t|_ ParallelFlux.checkpoint ⇢ at reactor.core.publisher.FluxOnAssemblyTest.parallelFluxCheckpointDescriptionAndForceStack(FluxOnAssemblyTest.java:" + (baseline + 4) + ")\n\n");

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
@@ -675,6 +675,7 @@ public class FluxPeekFuseableTest {
 		                                 .doOnError(e -> {
 			                                 throw new IllegalStateException("fromOnError", e);
 		                                 })
+		                                 .hide()
 		                                 .doOnError(e -> {
 			                                 throw new IllegalStateException("fromOnError2", e);
 		                                 })
@@ -743,6 +744,7 @@ public class FluxPeekFuseableTest {
 		                                 .doOnError(e -> {
 			                                 throw new IllegalStateException("fromOnError", e);
 		                                 })
+		                                 .hide()
 		                                 .doOnError(e -> {
 			                                 throw new IllegalStateException("fromOnError2", e);
 		                                 })


### PR DESCRIPTION
This PR provides PoC for #1556.

Notable things: 

1) New interface for Macro-Fusion called `Composite`. 
2) Each Operator which implements `Composite` can try fuse with upstream using method `tryCompose`.
3) The `tryCompose` method may return `Publisher` (which means - hooray, I have been fused) or `null` which means - fusion is not supported with upstream, so it is necessary to go typical path.


This PoC Includes the simples fusion for `map`, `filter`, `doOnSignal` for every `Publisher` in Reactor-Core.

The following naive JMH measurements: 

![image](https://user-images.githubusercontent.com/5380167/58791566-19581800-85fb-11e9-9522-cfa935bf0fb5.png)

Benchmark details: 

https://gist.github.com/OlegDokuka/5ac39adcb21fbbc21454309a31a31790
  