### PR TITLE
fix #1732 (bis) assertMaxRequested to actually check maxRequest <= n

### DIFF
--- a/reactor-test/src/main/java/reactor/test/publisher/ColdTestPublisher.java
+++ b/reactor-test/src/main/java/reactor/test/publisher/ColdTestPublisher.java
@@ -266,7 +266,7 @@ final class ColdTestPublisher<T> extends TestPublisher<T> {
 		                        .min()
 		                        .orElse(0);
 		if (minRequest < n) {
-			throw new AssertionError("Expected minimum request of " + n + "; got " + minRequest);
+			throw new AssertionError("Expected smallest requested amount to be >= " + n + "; got " + minRequest);
 		}
 		return this;
 	}
@@ -278,8 +278,8 @@ final class ColdTestPublisher<T> extends TestPublisher<T> {
 		                        .mapToLong(s -> s.requested)
 		                        .max()
 		                        .orElse(0);
-		if (maxRequest < n) {
-			throw new AssertionError("Expected maximum request of " + n + "; got " + maxRequest);
+		if (maxRequest > n) {
+			throw new AssertionError("Expected largest requested amount to be <= " + n + "; got " + maxRequest);
 		}
 		return this;
 	}

--- a/reactor-test/src/main/java/reactor/test/publisher/DefaultTestPublisher.java
+++ b/reactor-test/src/main/java/reactor/test/publisher/DefaultTestPublisher.java
@@ -304,7 +304,7 @@ class DefaultTestPublisher<T> extends TestPublisher<T> {
 		                        .min()
 		                        .orElse(0);
 		if (minRequest < n) {
-			throw new AssertionError("Expected minimum request of " + n + "; got " + minRequest);
+			throw new AssertionError("Expected smallest requested amount to be >= " + n + "; got " + minRequest);
 		}
 		return this;
 	}
@@ -316,8 +316,8 @@ class DefaultTestPublisher<T> extends TestPublisher<T> {
 		                        .mapToLong(s -> s.requested)
 		                        .max()
 		                        .orElse(0);
-		if (maxRequest < n) {
-			throw new AssertionError("Expected maximum request of " + n + "; got " + maxRequest);
+		if (maxRequest > n) {
+			throw new AssertionError("Expected largest requested amount to be <= " + n + "; got " + maxRequest);
 		}
 		return this;
 	}

--- a/reactor-test/src/main/java/reactor/test/publisher/TestPublisher.java
+++ b/reactor-test/src/main/java/reactor/test/publisher/TestPublisher.java
@@ -102,7 +102,7 @@ public abstract class TestPublisher<T> implements Publisher<T>, PublisherProbe<T
 
 	/**
 	 * Assert that the current maximum request of all this publisher's subscribers
-	 * is &gt;= {@code n}. Can be {@link Long#MAX_VALUE} in case a subscriber has made
+	 * is &lt;= {@code n}. Can be {@link Long#MAX_VALUE} in case a subscriber has made
 	 * an unbounded request.
 	 *
 	 * @param n the expected maximum request including {@link Long#MAX_VALUE}

--- a/reactor-test/src/test/java/reactor/test/publisher/ColdTestPublisherTests.java
+++ b/reactor-test/src/test/java/reactor/test/publisher/ColdTestPublisherTests.java
@@ -250,7 +250,7 @@ public class ColdTestPublisherTests {
 		                                 .emit("foo"))
 		            .expectNext("foo").expectComplete() // N/A
 		            .verify())
-		        .withMessageContaining("Expected minimum request of 6; got 5");
+		        .withMessageContaining("Expected smallest requested amount to be >= 6; got 5");
 
 		publisher.assertCancelled();
 		publisher.assertNoSubscribers();
@@ -285,11 +285,11 @@ public class ColdTestPublisherTests {
 	public void expectMaxRequestedFailure() {
 		TestPublisher<String> publisher = TestPublisher.createCold();
 
-		Flux.from(publisher).limitRequest(5).subscribe();
+		Flux.from(publisher).limitRequest(7).subscribe();
 
 		assertThatExceptionOfType(AssertionError.class)
 				.isThrownBy(() -> publisher.assertMaxRequested(6))
-				.withMessage("Expected maximum request of 6; got 5");
+				.withMessage("Expected largest requested amount to be <= 6; got 7");
 	}
 
 	@Test

--- a/reactor-test/src/test/java/reactor/test/publisher/DefaultTestPublisherTests.java
+++ b/reactor-test/src/test/java/reactor/test/publisher/DefaultTestPublisherTests.java
@@ -305,7 +305,7 @@ public class DefaultTestPublisherTests {
 		                                 .emit("foo"))
 		            .expectNext("foo").expectComplete() // N/A
 		            .verify())
-		        .withMessageContaining("Expected minimum request of 6; got 5");
+		        .withMessageContaining("Expected smallest requested amount to be >= 6; got 5");
 
 		publisher.assertCancelled();
 		publisher.assertNoSubscribers();
@@ -340,11 +340,11 @@ public class DefaultTestPublisherTests {
 	public void expectMaxRequestedFailure() {
 		TestPublisher<String> publisher = TestPublisher.create();
 
-		Flux.from(publisher).limitRequest(5).subscribe();
+		Flux.from(publisher).limitRequest(7).subscribe();
 
 		assertThatExceptionOfType(AssertionError.class)
 				.isThrownBy(() -> publisher.assertMaxRequested(6))
-				.withMessage("Expected maximum request of 6; got 5");
+				.withMessage("Expected largest requested amount to be <= 6; got 7");
 	}
 
 	@Test


### PR DESCRIPTION
Also improved the wording of the assertion error for both
assertMaxRequested and assertMinRequested.

Follow-up and fix up of #1733