### PR TITLE
Added code fences in reference guide

### DIFF
--- a/docs/asciidoc/advancedFeatures.adoc
+++ b/docs/asciidoc/advancedFeatures.adoc
@@ -30,6 +30,7 @@ augment it with the encapsulated operators. Doing so applies the same operations
 the subscribers of a sequence and is basically equivalent to chaining the operators
 directly. The following code shows an example:
 
+====
 [source,java]
 ----
 Function<Flux<String>, Flux<String>> filterAndMap =
@@ -41,6 +42,7 @@ Flux.fromIterable(Arrays.asList("blue", "green", "orange", "purple"))
 	.transform(filterAndMap)
 	.subscribe(d -> System.out.println("Subscriber to Transformed MapAndFilter: "+d));
 ----
+====
 
 The following image shows how the `transform` operator encapsulates flows:
 
@@ -48,6 +50,7 @@ image::https://raw.githubusercontent.com/reactor/reactor-core/v3.0.7.RELEASE/src
 
 The preceding example produces the following output:
 
+====
 ----
 blue
 Subscriber to Transformed MapAndFilter: BLUE
@@ -57,6 +60,7 @@ orange
 purple
 Subscriber to Transformed MapAndFilter: PURPLE
 ----
+====
 
 === Using the `compose` Operator
 
@@ -66,6 +70,7 @@ sequence _on a per-subscriber basis_. It means that the function can actually pr
 different operator chain for each subscription (by maintaining some state). The
 following code shows an example:
 
+====
 [source,java]
 ----
 AtomicInteger ai = new AtomicInteger();
@@ -86,6 +91,7 @@ Flux.fromIterable(Arrays.asList("blue", "green", "orange", "purple"))
 composedFlux.subscribe(d -> System.out.println("Subscriber 1 to Composed MapAndFilter :"+d));
 composedFlux.subscribe(d -> System.out.println("Subscriber 2 to Composed MapAndFilter: "+d));
 ----
+====
 
 The following image shows how the `compose` operator works with per-subscriber transformations:
 
@@ -93,6 +99,7 @@ image::https://raw.githubusercontent.com/reactor/reactor-core/v3.0.7.RELEASE/src
 
 The preceding example produces the following output:
 
+====
 ----
 blue
 Subscriber 1 to Composed MapAndFilter :BLUE
@@ -109,9 +116,10 @@ orange
 Subscriber 2 to Composed MapAndFilter: ORANGE
 purple
 ----
+====
 
 [[reactor.hotCold]]
-== Hot vs Cold
+== Hot Versus Cold
 
 So far, we have considered that all `Flux` (and `Mono`) are the same: They all represent
 an asynchronous sequence of data, and nothing happens before you subscribe.
@@ -143,6 +151,7 @@ NOTE: Most other hot publishers in Reactor extend `Processor`.
 
 Consider two other examples. The following code shows the first example:
 
+====
 [source,java]
 ----
 Flux<String> source = Flux.fromIterable(Arrays.asList("blue", "green", "orange", "purple"))
@@ -151,9 +160,11 @@ Flux<String> source = Flux.fromIterable(Arrays.asList("blue", "green", "orange",
 source.subscribe(d -> System.out.println("Subscriber 1: "+d));
 source.subscribe(d -> System.out.println("Subscriber 2: "+d));
 ----
+====
 
 This first example produces the following output:
 
+====
 ----
 Subscriber 1: BLUE
 Subscriber 1: GREEN
@@ -164,6 +175,7 @@ Subscriber 2: GREEN
 Subscriber 2: ORANGE
 Subscriber 2: PURPLE
 ----
+====
 
 The following image shows the replay behavior:
 
@@ -174,6 +186,7 @@ process defined by the operators on the `Flux` to run.
 
 Compare the first example to the second example, shown in the following code:
 
+====
 [source,java]
 ----
 DirectProcessor<String> hotSource = DirectProcessor.create();
@@ -192,9 +205,11 @@ hotSource.onNext("orange");
 hotSource.onNext("purple");
 hotSource.onComplete();
 ----
+====
 
 The second example produces the following output:
 
+====
 ----
 Subscriber 1 to Hot Source: BLUE
 Subscriber 1 to Hot Source: GREEN
@@ -203,6 +218,7 @@ Subscriber 2 to Hot Source: ORANGE
 Subscriber 1 to Hot Source: PURPLE
 Subscriber 2 to Hot Source: PURPLE
 ----
+====
 
 The following image shows how a subscription is broadcast:
 
@@ -247,6 +263,7 @@ allowing for enough new subscribers to come in and cross the connection threshol
 
 Consider the following example:
 
+====
 [source,java]
 ----
 Flux<Integer> source = Flux.range(1, 3)
@@ -263,9 +280,11 @@ System.out.println("will now connect");
 
 co.connect();
 ----
+====
 
 The preceding code produces the following output:
 
+====
 ----
 done subscribing
 will now connect
@@ -277,9 +296,11 @@ subscribed to source
 3
 3
 ----
+====
 
 The following code uses `autoConnect`:
 
+====
 [source,java]
 ----
 Flux<Integer> source = Flux.range(1, 3)
@@ -293,9 +314,11 @@ Thread.sleep(500);
 System.out.println("subscribing second");
 autoCo.subscribe(System.out::println, e -> {}, () -> {});
 ----
+====
 
 The preceding code produces the following output:
 
+====
 ----
 subscribed first
 subscribing second
@@ -307,6 +330,7 @@ subscribed to source
 3
 3
 ----
+====
 
 [[advanced-three-sorts-batching]]
 == Three Sorts of Batching
@@ -338,6 +362,7 @@ This means that groups:
 
 The following example groups values by whether they are even or odd:
 
+====
 [source,java]
 ----
 StepVerifier.create(
@@ -351,6 +376,7 @@ StepVerifier.create(
 	.expectNext("even", "2", "4", "6", "12")
 	.verifyComplete();
 ----
+====
 
 WARNING: Grouping is best suited for when you have a medium to low number of groups. The
 groups must also imperatively be consumed (such as by a `flatMap`) so that `groupBy`
@@ -377,6 +403,7 @@ closes and the two windows overlap.
 
 The following example shows overlapping windows:
 
+====
 [source,java]
 ----
 StepVerifier.create(
@@ -390,6 +417,7 @@ StepVerifier.create(
 		.expectNext(10)
 		.verifyComplete();
 ----
+====
 
 NOTE: With the reverse configuration (`maxSize` < `skip`), some elements from
 the source are dropped and are not part of any window.
@@ -398,6 +426,7 @@ In the case of predicate-based windowing through `windowUntil` and `windowWhile`
 having subsequent source elements that do not match the predicate can also lead
 to empty windows, as demonstrated in the following example:
 
+====
 [source,java]
 ----
 StepVerifier.create(
@@ -411,6 +440,7 @@ StepVerifier.create(
 		// however, no empty completion window is emitted (would contain extra matching elements)
 		.verifyComplete();
 ----
+====
 
 === Buffering with `Flux<List<T>>`
 
@@ -428,6 +458,7 @@ operator emits the collection.
 Buffering can also lead to dropping source elements or having overlapping buffers, as
 the following example shows:
 
+====
 [source,java]
 ----
 StepVerifier.create(
@@ -440,10 +471,12 @@ StepVerifier.create(
 		.expectNext(Collections.singletonList(10))
 		.verifyComplete();
 ----
+====
 
 Unlike in windowing, `bufferUntil` and `bufferWhile` do not emit an empty buffer, as
 the following example shows:
 
+====
 [source,java]
 ----
 StepVerifier.create(
@@ -454,6 +487,7 @@ StepVerifier.create(
 	.expectNext(Collections.singletonList(12)) // triggered by 13
 	.verifyComplete();
 ----
+====
 
 [[advanced-parallelizing-parralelflux]]
 == Parallelizing Work with `ParallelFlux`
@@ -472,6 +506,7 @@ there is a recommended dedicated `Scheduler` for parallel work: `Schedulers.para
 
 Compare the next two examples:
 
+====
 [source,java]
 ----
 Flux.range(1, 10)
@@ -479,7 +514,9 @@ Flux.range(1, 10)
     .subscribe(i -> System.out.println(Thread.currentThread().getName() + " -> " + i));
 ----
 <1> We force a number of rails instead of relying on the number of CPU cores.
+====
 
+====
 [source,java]
 ----
 Flux.range(1, 10)
@@ -487,9 +524,11 @@ Flux.range(1, 10)
     .runOn(Schedulers.parallel())
     .subscribe(i -> System.out.println(Thread.currentThread().getName() + " -> " + i));
 ----
+====
 
 The first example produces the following output:
 
+====
 ----
 main -> 1
 main -> 2
@@ -502,9 +541,11 @@ main -> 8
 main -> 9
 main -> 10
 ----
+====
 
 The second correctly parallelizes on two threads, as shown in the following output:
 
+====
 ----
 parallel-1 -> 1
 parallel-2 -> 2
@@ -517,6 +558,7 @@ parallel-1 -> 9
 parallel-2 -> 8
 parallel-2 -> 10
 ----
+====
 
 If, once you process your sequence in parallel, you want to revert back to a "`normal`"
 `Flux` and apply the rest of the operator chain in a sequential manner, you can use the
@@ -691,6 +733,7 @@ This feature is called `Context`.
 As an illustration of what it looks like, the following example both writes from and
 writes to `Context`:
 
+====
 [source,java]
 ----
 String key = "message";
@@ -703,6 +746,7 @@ StepVerifier.create(r)
             .expectNext("Hello World")
             .verifyComplete();
 ----
+====
 
 In the following sections, we cover `Context` and how to use it, so that you
 can eventually understand the preceding example.
@@ -782,6 +826,7 @@ using a `Context`.
 We first look back at our simple example from the introduction in a bit more detail, as
 the following example shows:
 
+====
 [source,java]
 ----
 String key = "message";
@@ -800,6 +845,7 @@ StepVerifier.create(r)
 <3> We then use `map` to extract the data associated to `"message"` and concatenate that with
 the original word.
 <4> The resulting `Mono<String>` emits `"Hello World"`.
+====
 
 IMPORTANT: The numbering above versus the actual line order is not a mistake. It represents
 the execution order. Even though `subscriberContext` is the last piece of the chain, it is
@@ -811,6 +857,7 @@ IMPORTANT: In your chain of operators, the relative positions of where you write
 is immutable and its content can only be seen by operators above it, as demonstrated in
 the following example:
 
+====
 [source,java]
 ----
 String key = "message";
@@ -827,10 +874,12 @@ StepVerifier.create(r)
 <2> As a result, in the `flatMap`, there is no value associated with our key. A default value
 is used instead.
 <3> The resulting `Mono<String>` thus emits `"Hello Stranger"`.
+====
 
 The following example also demonstrates the immutable nature of the `Context`, and how
 `Mono.subscriberContext()` always returns the `Context` set by `subscriberContext` calls:
 
+====
 [source,java]
 ----
 String key = "message";
@@ -849,11 +898,13 @@ StepVerifier.create(r)
 <3> We re-materialize the `Context` in a `flatMap`
 <4> We read the attempted key in the `Context`
 <5> The key was never set to `"Hello"`.
+====
 
 Similarly, in the case of several attempts to write the same key to the `Context`, the
 relative order of the writes matters, too. Operators that read the `Context` see
 the value that was set closest to being under them, as demonstrated in the following example:
 
+====
 [source,java]
 ----
 String key = "message";
@@ -870,6 +921,7 @@ StepVerifier.create(r)
 <1> A write attempt on key `"message"`.
 <2> Another write attempt on key `"message"`.
 <3> The `map` only saw the value set closest to it (and below it): `"Reactor"`.
+====
 
 In the preceding example, the `Context` is populated with `"World"` during subscription.
 Then the subscription signal moves upstream and another write happens. This produces a
@@ -881,6 +933,7 @@ You might wonder if the `Context` is propagated along with the data signal. If t
 the case, putting another `flatMap` between these two writes would use the value from
 the top `Context`. But this is not the case, as demonstrated by the following example:
 
+====
 [source,java]
 ----
 String key = "message";
@@ -901,6 +954,7 @@ StepVerifier.create(r)
 <3> The first `flatMap` sees second write.
 <4> The second `flatMap` concatenates the result from first one with the value from the first write.
 <5> The `Mono` emits `"Hello Reactor World"`.
+====
 
 The reason is that the `Context` is associated to the `Subscriber` and each operator
 accesses the `Context` by requesting it from its downstream `Subscriber`.
@@ -908,6 +962,7 @@ accesses the `Context` by requesting it from its downstream `Subscriber`.
 One last interesting propagation case is the one where the `Context` is also written to
 inside a `flatMap`, as in the following example:
 
+====
 [source,java]
 ----
 String key = "message";
@@ -928,6 +983,7 @@ StepVerifier.create(r)
 ----
 <1> This `subscriberContext` does not impact anything outside of its `flatMap`.
 <2> This `subscriberContext` impacts the main sequence's `Context`.
+====
 
 In the preceding example, the final emitted value is `"Hello World Reactor"` and not "Hello
 Reactor World", because the `subscriberContext` that writes `"Reactor"` does so as part of
@@ -943,18 +999,22 @@ also looks for a particular Context key to add a correlation ID to the request's
 
 From the user perspective, it is called as follows:
 
+====
 [source,java]
 ----
 doPut("www.example.com", Mono.just("Walter"))
 ----
+====
 
 In order to propagate a correlation ID, it would be called as follows:
 
+====
 [source,java]
 ----
 doPut("www.example.com", Mono.just("Walter"))
 	.subscriberContext(Context.of(HTTP_CORRELATION_ID, "2-j3r9afaf92j-afkaf"))
 ----
+====
 
 As the preceding snippets show, the user code uses `subscriberContext` to populate
 a `Context` with an `HTTP_CORRELATION_ID` key-value pair. The upstream of the operator is
@@ -965,6 +1025,7 @@ user code to the library code.
 The following example shows mock code from the library's perspective that reads the
 context and "`augments the request`" if it can find the correlation ID:
 
+====
 [source,java]
 ----
 static final String HTTP_CORRELATION_ID = "reactive.http.library.correlationId";
@@ -990,6 +1051,7 @@ Mono<Tuple2<Integer, String>> doPut(String url, Mono<String> data) {
 <1> Materialize the `Context` through `Mono.subscriberContext()`.
 <2> Extract a value for a the correlation ID key, as an `Optional`.
 <3> If the key was present in the context, use the correlation ID as a header.
+====
 
 The library snippet zips the data `Mono` with
 `Mono.subscriberContext()`. This gives the library a `Tuple2<String, Context>`, and that
@@ -1003,6 +1065,7 @@ That last part is simulated by the `handle`.
 The whole test that validates the library code used the correlation ID can be written as
 follows:
 
+====
 [source,java]
 ----
 @Test
@@ -1017,6 +1080,7 @@ public void contextForLibraryReactivePut() {
 	            .verifyComplete();
 }
 ----
+====
 
 [[cleanup]]
 == Dealing with Objects that Need Cleanup
@@ -1072,7 +1136,7 @@ When the error happens during the processing of an `onNext` signal, the element 
 
 If that type of element needs cleanup, you need to implement it in the `onOperatorError` hook, possibly on top of error-rewriting code.
 
-=== The `onNextDropped` hook
+=== The `onNextDropped` Hook
 
 With malformed `Publishers`, there could be cases where an operator receives an element when it expected none (typically, after having received the `onError` or `onComplete` signals).
 In such cases, the unexpected element is "`dropped`" -- that is, passed to the `onNextDropped` hook.

--- a/docs/asciidoc/apdx-operatorChoice.adoc
+++ b/docs/asciidoc/apdx-operatorChoice.adoc
@@ -136,7 +136,7 @@ I want to deal with:
 == Peeking into a Sequence
 
 * Without modifying the final sequence, I want to:
-** get notified of / execute additional behavior footnote:[sometimes referred to as "side-effects"] on:
+** get notified of / execute additional behavior (sometimes referred to as "side-effects") on:
 *** emissions: `doOnNext`
 *** completion: `Flux#doOnComplete`, `Mono#doOnSuccess` (includes the result, if any)
 *** error termination: `doOnError`
@@ -227,7 +227,7 @@ I want to deal with:
 *** ...triggered by a companion control Flux: `retryWhen`
 *** ... using a standard backoff strategy (exponential backoff with jitter): `retryBackoff`
 
-* I want to deal with backpressure "errors"footnote:[request max from upstream and apply the strategy when downstream does not produce enough request]...
+* I want to deal with backpressure "errors" (request max from upstream and apply the strategy when downstream does not produce enough request)...
 ** by throwing a special `IllegalStateException`: `Flux#onBackpressureError`
 ** by dropping excess values: `Flux#onBackpressureDrop`
 *** ...except the last one seen: `Flux#onBackpressureLatest`

--- a/docs/asciidoc/apdx-reactorExtra.adoc
+++ b/docs/asciidoc/apdx-reactorExtra.adoc
@@ -7,6 +7,7 @@ users of `reactor-core` with advanced needs.
 As this is a separate artifact, you need to explicitly add it to your build. The following
 example shows how to do so in Gradle:
 
+====
 [source,groovy]
 ----
 dependencies {
@@ -16,6 +17,7 @@ dependencies {
 ----
 <1> Add the reactor extra artifact in addition to core. See <<getting>> for details
 about why you do not need to specify a version if you use the BOM, usage in Maven, and other details.
+====
 
 [[extra-tuples]]
 == `TupleUtils` and Functional Interfaces
@@ -28,6 +30,7 @@ interfaces to a similar interface on the corresponding `Tuple`.
 
 This lets you easily work with independent parts of any `Tuple`, as the following example shows:
 
+====
 [source,java]
 ----
 .map(tuple -> {
@@ -38,14 +41,17 @@ This lets you easily work with independent parts of any `Tuple`, as the followin
   return new Customer(firstName, lastName, address);
 });
 ----
+====
 
 You can rewrite the preceding example as follows:
 
+====
 [source,java]
 ----
 .map(TupleUtils.function(Customer::new)); // <1>
 ----
 <1> (as `Customer` constructor conforms to `Consumer3` functional interface signature)
+====
 
 [[extra-math]]
 == Math Operators With `MathFlux`

--- a/docs/asciidoc/apdx-writingOperator.adoc
+++ b/docs/asciidoc/apdx-writingOperator.adoc
@@ -1,1 +1,1 @@
-== A primer at writing an operator
+== A Primer on Writing an Operator

--- a/docs/asciidoc/coreFeatures.adoc
+++ b/docs/asciidoc/coreFeatures.adoc
@@ -67,6 +67,7 @@ factory methods found in their respective classes.
 For instance, to create a sequence of `String`, you can either enumerate them or put them
 in a collection and create the Flux from it, as follows:
 
+====
 [source,java]
 ----
 Flux<String> seq1 = Flux.just("foo", "bar", "foobar");
@@ -74,9 +75,11 @@ Flux<String> seq1 = Flux.just("foo", "bar", "foobar");
 List<String> iterable = Arrays.asList("foo", "bar", "foobar");
 Flux<String> seq2 = Flux.fromIterable(iterable);
 ----
+====
 
 Other examples of factory methods include the following:
 
+====
 [source,java]
 ----
 Mono<String> noData = Mono.empty(); <1>
@@ -88,6 +91,7 @@ Flux<Integer> numbersFromFiveToSeven = Flux.range(5, 3); <2>
 <1> Notice the factory method honors the generic type even though it has no value.
 <2> The first parameter is the start of the range, while the second parameter is the
 number of items to produce.
+====
 
 When it comes to subscribing, `Flux` and `Mono` make use of Java 8 lambdas. You
 have a wide choice of `.subscribe()` variants that take lambdas for different
@@ -95,6 +99,7 @@ combinations of callbacks, as shown in the following method signatures:
 
 [[subscribeMethods]]
 .Lambda-based subscribe variants for `Flux`
+====
 [source,java]
 ----
 subscribe(); <1>
@@ -120,6 +125,7 @@ subscribe(Consumer<? super T> consumer,
 completes.
 <5> Deal with values and errors and successful completion but also do something with the
 `Subscription` produced by this `subscribe` call.
+====
 
 TIP: These variants return a reference to the subscription that you can use to cancel the
 subscription when no more data is needed. Upon cancellation, the source should stop
@@ -146,6 +152,7 @@ previous operator executed. Unless specified, the topmost operator (the source)
 itself runs on the `Thread` in which the `subscribe()` call was made. The following
 example runs a `Mono` in a new thread:
 
+====
 [source,java]
 ----
 public static void main(String[] args) {
@@ -163,13 +170,16 @@ public static void main(String[] args) {
 <1> The `Mono<String>` is assembled in thread `main`.
 <2> However, it is subscribed to in thread `Thread-0`.
 <3> As a consequence, both the `map` and the `onNext` callback actually run in `Thread-0`
+====
 
 The preceding code produces the following output:
 
+====
 [source]
 ----
 hello thread Thread-0
 ----
+====
 
 In Reactor, the execution model and where the execution happens is determined by the
 `Scheduler` that is used. A
@@ -220,10 +230,12 @@ you the option of providing a different one). For instance, calling the
 By default, this is enabled by `Schedulers.parallel()`. The following line changes the
 Scheduler to a new instance similar to `Schedulers.single()`:
 
+====
 [source,java]
 ----
 Flux.interval(Duration.ofMillis(300), Schedulers.newSingle("test"))
 ----
+====
 
 Reactor offers two means of switching the execution context (or `Scheduler`) in a
 reactive chain: `publishOn` and `subscribeOn`. Both take a `Scheduler` and let you switch
@@ -256,6 +268,7 @@ chained in), as follows:
 
 The following example uses the `publishOn` method:
 
+====
 [source,java]
 ----
 Scheduler s = Schedulers.newParallel("parallel-scheduler", 4); //<1>
@@ -274,6 +287,7 @@ new Thread(() -> flux.subscribe(System.out::println));  //<5>
 <4> The second `map` runs on the `Thread` from <1>.
 <5> This anonymous `Thread` is the one where the _subscription_ happens.
 The print happens on the latest execution context, which is the one from `publishOn`.
+====
 
 === The `subscribeOn` Method
 
@@ -290,6 +304,7 @@ NOTE: Only the earliest `subscribeOn` call in the chain is actually taken into a
 
 The following example uses the `subscribeOn` method:
 
+====
 [source,java]
 ----
 Scheduler s = Schedulers.newParallel("parallel-scheduler", 4); //<1>
@@ -307,6 +322,7 @@ new Thread(() -> flux.subscribe(System.out::println));  //<5>
 <3> ...because `subscribeOn` switches the whole sequence right from subscription time (<5>).
 <4> The second `map` also runs on same thread.
 <5> This anonymous `Thread` is the one where the _subscription_ initially happens, but `subscribeOn` immediately shifts it to one of the four scheduler threads.
+====
 
 [[error.handling]]
 == Handling Errors
@@ -328,12 +344,14 @@ further detect and triage it with the `Exceptions.isErrorCallbackNotImplemented`
 Reactor also offers alternative means of dealing with errors in the middle of the chain,
 as error-handling operators. The following example shows how to do so:
 
+====
 [source,java]
 ----
 Flux.just(1, 2, 0)
     .map(i -> "100 / " + i + " = " + (100 / i)) //this triggers an error with 0
     .onErrorReturn("Divided by zero :("); // error handling example
 ----
+====
 
 IMPORTANT: Before you learn about error-handling operators, you must keep in mind that
 _any error in a reactive sequence is a terminal event_. Even if an error-handling
@@ -364,6 +382,7 @@ When subscribing, the `onError` callback at the end of the chain is akin to a `c
 block. There, execution skips to the catch in case an `Exception` is thrown, as the
 following example shows:
 
+====
 [source,java]
 ----
 Flux<String> s = Flux.range(1, 10)
@@ -377,9 +396,11 @@ s.subscribe(value -> System.out.println("RECEIVED " + value), // <3>
 <2> If everything went well, a second transformation is performed.
 <3> Each successfully transformed value is printed out.
 <4> In case of an error, the sequence terminates and an error message is displayed.
+====
 
 The preceding example is conceptually similar to the following try-catch block:
 
+====
 [source,java]
 ----
 try {
@@ -395,6 +416,7 @@ try {
 <1> If an exception is thrown here...
 <2> ...the rest of the loop is skipped...
 <3> ... and the execution goes straight to here.
+====
 
 Now that we have established a parallel, we can look at the different error handling cases
 and their equivalent operators.
@@ -404,6 +426,7 @@ and their equivalent operators.
 The equivalent of "`Catch and return a static default value`" is `onErrorReturn`.
 The following example shows how to use it:
 
+====
 [source,java]
 ----
 try {
@@ -413,19 +436,23 @@ catch (Throwable error) {
   return "RECOVERED";
 }
 ----
+====
 
 The following example shows the Reactor equivalent:
 
+====
 [source,java]
 ----
 Flux.just(10)
     .map(this::doSomethingDangerous)
     .onErrorReturn("RECOVERED");
 ----
+====
 
 You also have the option of applying a `Predicate` on the exception to decided
 whether or not to recover, as the folloiwng example shows:
 
+====
 [source,java]
 ----
 Flux.just(10)
@@ -433,6 +460,7 @@ Flux.just(10)
     .onErrorReturn(e -> e.getMessage().equals("boom10"), "recovered10"); //<1>
 ----
 <1> Recover only if the message of the exception is `"boom10"`
+====
 
 ==== Fallback Method
 
@@ -444,6 +472,7 @@ For example, if your nominal process is fetching data from an external and unrel
 service but you also keep a local cache of the same data that _can_ be a bit more out of
 date but is more reliable, you could do the following:
 
+====
 [source,java]
 ----
 String v1;
@@ -462,9 +491,11 @@ catch (Throwable error) {
   v2 = getFromCache("key2");
 }
 ----
+====
 
 The following example shows the Reactor equivalent:
 
+====
 [source,java]
 ----
 Flux.just("key1", "key2")
@@ -475,12 +506,14 @@ Flux.just("key1", "key2")
 <1> For each key, asynchronously call the external service.
 <2> If the external service call fails, fall back to the cache for that key. Note that
 we always apply the same fallback, whatever the source error, `e`, is.
+====
 
 Like `onErrorReturn`, `onErrorResume` has variants that let you filter which exceptions
 to fall back on, based either on the exception's class or on a `Predicate`. The fact that it
 takes a `Function` also lets you choose a different fallback sequence to switch to,
 depending on the error encountered. The following example shows how to do so:
 
+====
 [source,java]
 ----
 Flux.just("timeout1", "unknown", "key2")
@@ -499,6 +532,7 @@ Flux.just("timeout1", "unknown", "key2")
 <2> If the source times out, hit the local cache.
 <3> If the source says the key is unknown, create a new entry.
 <4> In all other cases, "`re-throw`".
+====
 
 ==== Dynamic Fallback Value
 
@@ -512,6 +546,7 @@ could instantiate the error-holding variant and pass the exception.
 
 An imperative example would look like the following:
 
+====
 [source,java]
 ----
 try {
@@ -522,10 +557,12 @@ catch (Throwable error) {
   return MyWrapper.fromError(error);
 }
 ----
+====
 
 You can do this reactively in the same way as the fallback method solution,
 by using `onErrorResume`, with a tiny bit of boilerplate, as follows:
 
+====
 [source,java]
 ----
 erroringFlux.onErrorResume(error -> Mono.just( // <1>
@@ -536,12 +573,14 @@ erroringFlux.onErrorResume(error -> Mono.just( // <1>
 `Mono<MyWrapper>` for `onErrorResume`. We use `Mono.just()` for that.
 <2> We need to compute the value out of the exception. Here, we achieved that
 by wrapping the exception with a relevant `MyWrapper` factory method.
+====
 
 ==== Catch and Rethrow
 
 "Catch, wrap to a `BusinessException`, and re-throw" looks like the following in the
 imperative world:
 
+====
 [source,java]
 ----
 try {
@@ -551,10 +590,12 @@ catch (Throwable error) {
   throw new BusinessException("oops, SLA exceeded", error);
 }
 ----
+====
 
 In the "`fallback method`" example, the last line inside the `flatMap` gives us a hint
 at achieving the same reactively, as follows:
 
+====
 [source,java]
 ----
 Flux.just("timeout1")
@@ -563,15 +604,18 @@ Flux.just("timeout1")
             new BusinessException("oops, SLA exceeded", original))
     );
 ----
+====
 
 However, there is a more straightforward way of achieving the same effect with `onErrorMap`:
 
+====
 [source,java]
 ----
 Flux.just("timeout1")
     .flatMap(k -> callExternalService(k))
     .onErrorMap(original -> new BusinessException("oops, SLA exceeded", original));
 ----
+====
 
 ==== Log or React on the Side
 
@@ -580,6 +624,7 @@ it without modifying the sequence (logging it, for instance), you can use the `d
 operator. This is the equivalent of "`Catch, log an error-specific message, and re-throw`"
 pattern, as the following example shows:
 
+====
 [source,java]
 ----
 try {
@@ -591,6 +636,7 @@ catch (RuntimeException error) {
   throw error;
 }
 ----
+====
 
 The `doOnError` operator, as well as all operators prefixed with `doOn` , are sometimes
 referred to as having a "`side-effect`". They let you peek inside the sequence's events without
@@ -599,6 +645,7 @@ modifying them.
 Like the imperative example shown earlier, the following example still propagates the error yet
 ensures that we at least log that the external service had a failure:
 
+====
 [source,java]
 ----
 LongAdder failureStat = new LongAdder();
@@ -615,6 +662,7 @@ Flux.just("unknown")
 <1> The external service call that can fail...
 <2> ...is decorated with a logging and stats side-effect...
 <3> ...after which, it still terminates with an error, unless we use an error-recovery operator here.
+====
 
 We can also imagine we have statistic counters to increment as a second error side-effect.
 
@@ -624,8 +672,9 @@ The last parallel to draw with imperative programming is the cleaning up that ca
 either by using a "`Use of the `finally` block to clean up resources`" or by using a
 "`Java 7 try-with-resource construct`", both shown below:
 
-[source,java]
 .Imperative use of finally
+====
+[source,java]
 ----
 Stats stats = new Stats();
 stats.startTimer();
@@ -636,14 +685,17 @@ finally {
   stats.stopTimerAndRecordTiming();
 }
 ----
+====
 
-[source]
 .Imperative use of try-with-resource
+====
+[source]
 ----
 try (SomeAutoCloseable disposableInstance = new SomeAutoCloseable()) {
   return disposableInstance.toString();
 }
 ----
+====
 
 Both have their Reactor equivalents: `doFinally` and `using`.
 
@@ -652,6 +704,7 @@ sequence terminates (with `onComplete` or `onError`) or is cancelled.
 It gives you a hint as to what kind of termination triggered the side-effect.
 The following example shows how to use `doFinally`:
 
+====
 [source,java]
 .Reactive finally: `doFinally()`
 ----
@@ -672,14 +725,16 @@ Flux.just("foo", "bar")
 <2> Similarly to `finally` blocks, we always record the timing.
 <3> Here we also increment statistics in case of cancellation only.
 <4> `take(1)` cancels after one item is emitted.
+====
 
 On the other hand, `using` handles the case where a `Flux` is derived from a
 resource and that resource must be acted upon whenever processing is done.
 In the following example, we replace the `AutoCloseable` interface of "`try-with-resource`" with a
 `Disposable`:
 
-[source,java]
 .The Disposable resource
+====
+[source,java]
 ----
 AtomicBoolean isDisposed = new AtomicBoolean();
 Disposable disposableInstance = new Disposable() {
@@ -694,12 +749,14 @@ Disposable disposableInstance = new Disposable() {
     }
 };
 ----
+====
 
 Now we can do the reactive equivalent of "`try-with-resource`" on it, which looks
 like the following:
 
-[source,java]
 .Reactive try-with-resource: `using()`
+====
+[source,java]
 ----
 Flux<String> flux =
 Flux.using(
@@ -714,6 +771,7 @@ Flux.using(
 clean up resources.
 <4> After subscription and execution of the sequence, the `isDisposed` atomic boolean
 becomes `true`.
+====
 
 ==== Demonstrating the Terminal Aspect of `onError`
 
@@ -722,6 +780,7 @@ terminate when an error happens, we can use a more visual example with a
 `Flux.interval`. The `interval` operator ticks every x units of time with an increasing
 `Long` value. The following example uses an `interval` operator:
 
+====
 [source,java]
 ----
 Flux<String> flux =
@@ -738,9 +797,11 @@ Thread.sleep(2100); // <1>
 <1> Note that `interval` executes on a *timer* `Scheduler` by default. If we want
 to run that example in a main class, we would need to add a `sleep` call here so that the
 application does not exit immediately without any value being produced.
+====
 
 The preceding example prints out one line every 250ms, as follows:
 
+====
 [source]
 ----
 tick 0
@@ -748,6 +809,7 @@ tick 1
 tick 2
 Uh oh
 ----
+====
 
 Even with one extra second of runtime, no more tick comes in from the `interval`. The
 sequence was indeed terminated by the error.
@@ -763,6 +825,7 @@ This is really a different sequence, and the original one is still terminated.
 To verify that, we can re-use the previous example and append a `retry(1)` to
 retry once instead of using `onErrorReturn`. The following example shows how to do sl:
 
+====
 [source,java]
 ----
 Flux.interval(Duration.ofMillis(250))
@@ -779,9 +842,11 @@ Thread.sleep(2100); // <3>
 <1> `elapsed` associates each value with the duration since previous value was emitted.
 <2> We also want to see when there is an `onError`.
 <3> Ensure we have enough time for our 4x2 ticks.
+====
 
 The preceding example produces the following output:
 
+====
 [source]
 ----
 259,tick 0
@@ -795,8 +860,9 @@ java.lang.RuntimeException: boom
 <1> A new `interval` started, from tick 0. The additional 250ms duration is
 coming from the 4th tick, the one that causes the exception and subsequent
 retry.
+====
 
-As you can see above, `retry(1)` merely re-subscribed to the original `interval`
+As you can see from the preceding example, `retry(1)` merely re-subscribed to the original `interval`
 once, restarting the tick from 0. The second time around, since the exception
 still occurs, it gives up and propagates the error downstream.
 
@@ -822,6 +888,7 @@ The distinction between the previous two cases is important. Simply completing t
 companion would effectively swallow an error. Consider the following way of emulating
 `retry(3)` by using `retryWhen`:
 
+====
 [source,java]
 ----
 Flux<String> flux = Flux
@@ -832,6 +899,7 @@ Flux<String> flux = Flux
 <1> This continuously produces errors, calling for retry attempts.
 <2> `doOnError` before the retry lets us log and see all failures.
 <3> Here, we consider the first three errors as retry-able (`take(3)`) and then give up.
+====
 
 In effect, the preceding example results in an empty `Flux`, but it completes successfully. Since
 `retry(3)` on the same `Flux` would have terminated with the latest error, this
@@ -853,6 +921,7 @@ As a rule of thumb, an unchecked exception is always propagated through `onError
 instance, throwing a `RuntimeException` inside a `map` function translates to an
 `onError` event, as the following code shows:
 
+====
 [source,java]
 ----
 Flux.just("foo")
@@ -860,13 +929,16 @@ Flux.just("foo")
     .subscribe(v -> System.out.println("GOT VALUE"),
                e -> System.out.println("ERROR: " + e));
 ----
+====
 
 The preceding code prints out the following:
 
+====
 [source]
 ----
 ERROR: java.lang.IllegalArgumentException: foo
 ----
+====
 
 TIP: You can tune the `Exception` before it is passed to `onError`, through the use of a
 <<hooks-internal,hook>>.
@@ -887,11 +959,11 @@ If, for example, you need to call some method that declares it `throws` exceptio
 still have to deal with those exceptions in a `try-catch` block. You have several
 options, though:
 
-1. Catch the exception and recover from it. The sequence continues normally.
-2. Catch the exception, wrap it into an _unchecked_ exception, and then throw it
+. Catch the exception and recover from it. The sequence continues normally.
+. Catch the exception, wrap it into an _unchecked_ exception, and then throw it
 (interrupting the sequence). The `Exceptions` utility class can help you with that (we
 get to that next).
-3. If you need to return a `Flux` (for example, you are in a `flatMap`), wrap the
+. If you need to return a `Flux` (for example, you are in a `flatMap`), wrap the
 exception in an error-producing `Flux`, as follows: `return Flux.error(checkedException)`. (The
 sequence also terminates.)
 
@@ -906,6 +978,7 @@ to the root cause of a hierarchy of reactor-specific exceptions).
 Consider the following example of a `map` that uses a conversion method that can throw an
 `IOException`:
 
+====
 [source,java]
 ----
 public String convert(int i) throws IOException {
@@ -915,11 +988,13 @@ public String convert(int i) throws IOException {
     return "OK " + i;
 }
 ----
+====
 
 Now imagine that you want to use that method in a `map`. You must now explicitly catch
 the exception, and your map function cannot re-throw it. So you can propagate it to the
 map's `onError` method as a `RuntimeException`, as follows:
 
+====
 [source,java]
 ----
 Flux<String> converted = Flux
@@ -929,11 +1004,13 @@ Flux<String> converted = Flux
         catch (IOException e) { throw Exceptions.propagate(e); }
     });
 ----
+====
 
 Later on, when subscribing to the preceding `Flux` and reacting to errors (such as in the
 UI), you could revert back to the original exception if you want to do something
 special for IOExceptions. The following example shows how to do so:
 
+====
 [source,java]
 ----
 converted.subscribe(
@@ -947,6 +1024,7 @@ converted.subscribe(
     }
 );
 ----
+====
 
 [[processors]]
 == Processors

--- a/docs/asciidoc/debugging.adoc
+++ b/docs/asciidoc/debugging.adoc
@@ -20,6 +20,7 @@ When you shift to asynchronous code, things can get much more complicated.
 Consider the following stack trace:
 
 .A typically Reactor stack trace
+====
 [source]
 ----
 java.lang.IndexOutOfBoundsException: Source emitted more than one item
@@ -43,6 +44,7 @@ java.lang.IndexOutOfBoundsException: Source emitted more than one item
 	at reactor.core.publisher.Mono.subscribe(Mono.java:3029)
 	at reactor.guide.GuideTests.debuggingCommonStacktrace(GuideTests.java:995)
 ----
+====
 
 There is a lot going on there. We get an `IndexOutOfBoundsException`, which tells us that
 a `source emitted more than one item`.
@@ -71,18 +73,22 @@ line refers to some of our code. Finally, we are getting close.
 Hold on, though. When we go to the source file, all we see is that a
 pre-existing `Flux` is subscribed to, as follows:
 
+====
 [source,java]
 ----
 toDebug.subscribe(System.out::println, Throwable::printStackTrace);
 ----
+====
 
 All of this happened at subscription time, but the `Flux` itself was not
 declared there. Worse, when we go to where the variable is declared, we see the following:
 
+====
 [source,java]
 ----
 public Mono<String> toDebug; //please overlook the public class attribute
 ----
+====
 
 The variable is not instantiated where it is declared. We must assume a worst-case
 scenario where we find out that there could be a few different code paths that set it in
@@ -106,10 +112,12 @@ Fortunately, Reactor comes with  assembly-time instrumentation that is designed 
 This is done by customizing the `Hooks.onOperator` hook at application start (or at
 least before the incriminated `Flux` or `Mono` can be instantiated), as follows:
 
+====
 [source,java]
 ----
 Hooks.onOperatorDebug();
 ----
+====
 
 This starts instrumenting the calls to the `Flux` (and `Mono`) operator  methods (where
 they are assembled into the chain) by wrapping the construction of the operator and
@@ -128,6 +136,7 @@ that new information.
 When we reuse our initial example but activate the `operatorStacktrace` debug feature,
 the stack trace is as follows:
 
+====
 [source]
 ----
 java.lang.IndexOutOfBoundsException: Source emitted more than one item
@@ -160,6 +169,7 @@ part, showing a bit of the operator's internals (so we removed a bit of the snip
 from first to last (error site to subscribe site).
 <6> Each operator that saw the error is mentioned along with the user class and line where it
 was used.
+====
 
 The captured stack trace is appended to the original error as a
 suppressed `OnAssemblyException`. There are two parts to it, but the first section is the
@@ -171,6 +181,7 @@ through JUnit.
 Now that we are armed with enough information to find the culprit, we can have
 a meaningful look at that `scatterAndGather` method:
 
+====
 [source,java]
 ----
 private Mono<String> scatterAndGather(Flux<String> urls) {
@@ -179,6 +190,7 @@ private Mono<String> scatterAndGather(Flux<String> urls) {
 }
 ----
 <1> Sure enough, here is our `single`.
+====
 
 Now we can see what the root cause of the error was a `flatMap` that performs
 several HTTP calls to a few URLs but that is chained with `single`, which is too
@@ -189,16 +201,19 @@ We have solved our problem.
 
 Now consider the following line in the stack trace:
 
+====
 [source]
 ----
 Error has been observed by the following operator(s):
 ----
+====
 
 That second part of the debug stack trace was not necessarily interesting in
 this particular example, because the error was actually happening in the last
 operator in the chain (the one closest to `subscribe`). Considering another
 example might make it more clear:
 
+====
 [source,java]
 ----
 FakeRepository.findAllUserByName(Flux.just("pedro", "simon", "stephane"))
@@ -206,10 +221,12 @@ FakeRepository.findAllUserByName(Flux.just("pedro", "simon", "stephane"))
               .transform(FakeUtils2.enrichUser)
               .blockLast();
 ----
+====
 
 Now imagine that, inside `findAllUserByName`, there is a `map` that fails. Here,
 we would see the following final traceback:
 
+====
 [source,java]
 ----
 Error has been observed by the following operator(s):
@@ -220,6 +237,7 @@ Error has been observed by the following operator(s):
 	|_	Flux.elapsed ⇢ reactor.guide.FakeUtils2.lambda$static$0(FakeUtils2.java:30)
 	|_	Flux.transform ⇢ reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:41)
 ----
+====
 
 This corresponds to the section of the chain of operators that gets notified of the error:
 
@@ -269,11 +287,13 @@ cost than a regular `checkpoint`.
 `checkpoint(String)` includes "`light`" in its output (which can be handy when
 searching), as shown in the following example:
 
+====
 ----
 ...
 	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException:
 Assembly site of producer [reactor.core.publisher.ParallelSource] is identified by light checkpoint [light checkpoint identifier].
 ----
+====
 
 Last but not least, if you want to add a more generic description to the checkpoint but
 still rely on the stack trace mechanism to identify the assembly site, you can force that
@@ -281,6 +301,7 @@ behavior by using the `checkpoint("description", true)` version. We are now back
 initial message for the traceback, augmented with a `description`, as shown in the
 following example:
 
+====
 ----
 Assembly trace from producer [reactor.core.publisher.ParallelSource], described as [descriptionCorrelation1234] : <1>
 	reactor.core.publisher.ParallelFlux.checkpoint(ParallelFlux.java:215)
@@ -289,6 +310,7 @@ Error has been observed by the following operator(s):
 	|_	ParallelFlux.checkpoint ⇢ reactor.core.publisher.FluxOnAssemblyTest.parallelFluxCheckpointDescriptionAndForceStack(FluxOnAssemblyTest.java:225)
 ----
 <1> `descriptionCorrelation1234` is the description provided in the `checkpoint`.
+====
 
 The description could be a static identifier or user-readable description or a wider
 correlation ID (for instance, coming from a header in the case of an HTTP request).
@@ -328,6 +350,7 @@ For instance, suppose we have Logback activated and configured and a chain like
 insight into how it works and what kind of events it propagates upstream to the range,
 as the following example shows:
 
+====
 [source,java]
 ----
 Flux<Integer> flux = Flux.range(1, 10)
@@ -335,9 +358,11 @@ Flux<Integer> flux = Flux.range(1, 10)
                          .take(3);
 flux.subscribe();
 ----
+====
 
 This prints out the following (through the logger's console appender):
 
+====
 ----
 10:45:20.200 [main] INFO  reactor.Flux.Range.1 - | onSubscribe([Synchronous Fuseable] FluxRange.RangeSubscription) <1>
 10:45:20.205 [main] INFO  reactor.Flux.Range.1 - | request(unbounded) <2>
@@ -364,6 +389,7 @@ synchronous or asynchronous fusion.
 downstream.
 <3> Then the range sends three values in a row.
 <4> On the last line, we see `cancel()`.
+====
 
 The last line, (4), is the most interesting. We can see the `take` in action there. It
 operates by cutting the sequence short after it has seen enough elements emitted. In

--- a/docs/asciidoc/faq.adoc
+++ b/docs/asciidoc/faq.adoc
@@ -17,6 +17,7 @@ It is often the case that a source of information is synchronous and blocking.
 To deal with such sources in your Reactor applications, apply the following
 pattern:
 
+====
 [source,java]
 ----
 Mono blockingWrapper = Mono.fromCallable(() -> { <1>
@@ -29,6 +30,7 @@ blockingWrapper = blockingWrapper.subscribeOn(Schedulers.elastic()); <3>
 <2> Return the asynchronous, blocking resource.
 <3> Ensure each subscription happens on a dedicated single-threaded worker
 from `Schedulers.elastic()`.
+====
 
 You should use a `Mono`, because the source returns one value. You should use
 `Schedulers.elastic`, because it creates a dedicated thread to wait for the
@@ -50,6 +52,7 @@ operators is to _chain_ the calls.
 Compare the following two examples:
 
 .without chaining (incorrect)
+====
 [source,java]
 ----
 Flux<String> flux = Flux.just("something", "chain");
@@ -57,18 +60,22 @@ flux.map(secret -> secret.replaceAll(".", "*")); <1>
 flux.subscribe(next -> System.out.println("Received: " + next));
 ----
 <1> The mistake is here. The result is not attached to the `flux` variable.
+====
 
 .without chaining (correct)
+====
 [source,java]
 ----
 Flux<String> flux = Flux.just("something", "chain");
 flux = flux.map(secret -> secret.replaceAll(".", "*"));
 flux.subscribe(next -> System.out.println("Received: " + next));
 ----
+====
 
 The following sample is even better (because it is simpler):
 
 .with chaining (best)
+====
 [source,java]
 ----
 Flux<String> secrets = Flux
@@ -76,34 +83,41 @@ Flux<String> secrets = Flux
   .map(secret -> secret.replaceAll(".", "*"))
   .subscribe(next -> System.out.println("Received: " + next));
 ----
+====
 
 The first version outputs the following:
 
+====
 [source]
 ----
 Received: something
 Received: chain
 ----
+====
 
 The two other versions output the expected values, as follows:
 
+====
 [source]
 ----
 Received: *********
 Received: *****
 ----
+====
 
 [[faq.monoThen]]
 == My `Mono` `zipWith` or `zipWhen` is never called
 
 Consider the following example:
 
+====
 [source,java]
 ----
 myMethod.process("a") // this method returns Mono<Void>
         .zipWith(myMethod.process("b"), combinator) //this is never called
         .subscribe();
 ----
+====
 
 If the source `Mono` is either `empty` or a `Mono<Void>` (a `Mono<Void>` is
 empty for all intents and purposes), some combinations are never called.
@@ -127,6 +141,7 @@ which could help avoid some of these situations. Note that this does not apply t
 which is still guaranteed to be empty. The following example uses `defaultIfEmpty`:
 
 .use `defaultIfEmpty` before `zipWhen`
+====
 [source,java]
 ----
 myMethod.emptySequenceForKey("a") // this method returns empty Mono<String>
@@ -134,9 +149,10 @@ myMethod.emptySequenceForKey("a") // this method returns empty Mono<String>
         .zipWhen(aString -> myMethod.process("b")) //this is called with the empty String
         .subscribe();
 ----
+====
 
 [[faq.retryWhen]]
-== How to use `retryWhen` to emulate `retry(3)`?
+== How to Use `retryWhen` to Emulate `retry(3)`?
 
 The `retryWhen` operator can be quite complex. Hopefully the following snippet of code
 can help you understand how it works by attempting to emulate a simpler
@@ -160,6 +176,7 @@ The following example shows how to implement an exponential backoff with `retryW
 IT delays retries and increases the delay between each attempt (pseudocode:
 delay = attempt number * 100 milliseconds):
 
+====
 [source,java]
 ----
 Flux<String> flux =
@@ -179,9 +196,11 @@ Flux.<String>error(new IllegalArgumentException())
 retries.
 <3> Through `flatMap`, we cause a delay that depends on the attempt's index.
 <4> We also log the time at which the retry happens.
+====
 
 When subscribed to, this fails and terminates after printing out the following:
 
+====
 ----
 java.lang.IllegalArgumentException at 18:02:29.338
 retried at 18:02:29.459 <1>
@@ -194,6 +213,7 @@ java.lang.IllegalArgumentException at 18:02:29.964
 <1> First retry after about 100ms
 <2> Second retry after about 200ms
 <3> Third retry after about 300ms
+====
 
 [[faq.thread-affinity-publishon]]
 == How Do I Ensure Thread Affinity when I Use `publishOn()`?
@@ -205,6 +225,7 @@ occurrence of `publishOn`. So the placement of `publishOn` is significant.
 
 Consider the following example:
 
+====
 [source,java]
 ----
 EmitterProcessor<Integer> processor = EmitterProcessor.create();
@@ -214,6 +235,7 @@ processor.publishOn(scheduler1)
          .doOnNext(i -> processNext(i))
          .subscribe();
 ----
+====
 
 The `transform` function in `map()` is
 run on a worker of `scheduler1`, and the `processNext` method in

--- a/docs/asciidoc/gettingStarted.adoc
+++ b/docs/asciidoc/gettingStarted.adoc
@@ -88,6 +88,7 @@ and specify dependencies by their artifact versions.
 Maven natively supports the BOM concept. First, you need to import the BOM by
 adding the following snippet to your `pom.xml`:
 
+====
 [source,xml]
 ----
 <dependencyManagement> <1>
@@ -104,12 +105,14 @@ adding the following snippet to your `pom.xml`:
 ----
 <1> Notice the `dependencyManagement` tag. This is in addition to the regular
 `dependencies` section.
+====
 
 If the top section (`dependencyManagement`) already exists in your pom, add only the contents.
 
 Next, add your dependencies to the relevant reactor projects, as usual, except without a
 `<version>`, as follows:
 
+====
 [source,xml]
 ----
 <dependencies>
@@ -128,6 +131,7 @@ Next, add your dependencies to the relevant reactor projects, as usual, except w
 <1> Dependency on the core library.
 <2> No version tag here.
 <3> `reactor-test` provides facilities to unit test reactive streams.
+====
 
 === Gradle Installation
 
@@ -137,6 +141,7 @@ plugin.
 
 First, apply the plugin from the Gradle Plugin Portal, as follows:
 
+====
 [source,groovy]
 ----
 plugins {
@@ -145,9 +150,11 @@ plugins {
 ----
 <1> as of this writing, 1.0.6.RELEASE is the latest version of the plugin.
 Check for updates.
+====
 
 Then use it to import the BOM, as follows:
 
+====
 [source,groovy]
 ----
 dependencyManagement {
@@ -156,9 +163,11 @@ dependencyManagement {
      }
 }
 ----
+====
 
 Finally add a dependency to your project, without a version number, as follows:
 
+====
 [source,groovy]
 ----
 dependencies {
@@ -167,6 +176,7 @@ dependencies {
 ----
 <1> There is no third `:` separated section for the version. It is taken from
 the BOM.
+====
 
 === Milestones and Snapshots
 
@@ -175,6 +185,7 @@ repository rather than Maven Central. To add it to your build configuration
 file, use the following snippet:
 
 .Milestones in Maven
+====
 [source,xml]
 ----
 <repositories>
@@ -185,10 +196,12 @@ file, use the following snippet:
 	</repository>
 </repositories>
 ----
+====
 
 For Gradle, use the following snippet:
 
 .Milestones in Gradle
+====
 [source,groovy]
 ----
 repositories {
@@ -196,10 +209,12 @@ repositories {
   mavenCentral()
 }
 ----
+====
 
 Similarly, snapshots are also available in a separate dedicated repository, as the following example show:
 
 .BUILD-SNAPSHOTs in Maven
+====
 [source,xml]
 ----
 <repositories>
@@ -210,8 +225,10 @@ Similarly, snapshots are also available in a separate dedicated repository, as t
 	</repository>
 </repositories>
 ----
+====
 
 .BUILD-SNAPSHOTs in Gradle
+====
 [source,groovy]
 ----
 repositories {
@@ -219,3 +236,4 @@ repositories {
   mavenCentral()
 }
 ----
+====

--- a/docs/asciidoc/kotlin.adoc
+++ b/docs/asciidoc/kotlin.adoc
@@ -21,7 +21,7 @@ or https://bintray.com/bintray/jcenter/org.jetbrains.kotlin%3Akotlin-stdlib-jre8
 == Extensions
 
 [WARNING]
-====
+=====
 As of `Dysprosium-M1` (ie. `reactor-core 3.3.0.M1`), Kotlin extensions are moved to a
 dedicated https://github.com/reactor/reactor-kotlin-extensions[`reactor-kotlin-extensions`]
 module with new package names that start with `reactor.kotlin` instead of simply `reactor`.
@@ -29,12 +29,13 @@ module with new package names that start with `reactor.kotlin` instead of simply
 As a consequence, Kotlin extensions in `reactor-core` module are deprecated.
 The new dependency's groupId and artifactId are:
 
+====
 [source,gradle]
 ----
 io.projectreactor.kotlin:reactor-kotlin-extensions
 ----
 ====
-
+=====
 
 Thanks to its great https://kotlinlang.org/docs/reference/java-interop.html[Java interoperability]
 and to https://kotlinlang.org/docs/reference/extensions.html[Kotlin extensions], Reactor

--- a/docs/asciidoc/processors.adoc
+++ b/docs/asciidoc/processors.adoc
@@ -31,19 +31,23 @@ for the `Processor` by calling `sink()` *once*.
 applications that generate data from multiple threads concurrently. For example, you can create a
 thread-safe serialized sink for `UnicastProcessor` by doing the following:
 
+====
 [source,java]
 ----
 UnicastProcessor<Integer> processor = UnicastProcessor.create();
 FluxSink<Integer> sink = processor.sink(overflowStrategy);
 ----
+====
 
 Multiple producer threads may concurrently generate data on the following serialized
 sink by doing the following:
 
+====
 [source,java]
 ----
 sink.next(n);
 ----
+====
 
 WARNING: Despite the `FluxSink` being adapted for multi-threaded *manual* feeding
 of the `Processor`, it is not possible to mix the subscriber approach with the

--- a/docs/asciidoc/producing.adoc
+++ b/docs/asciidoc/producing.adoc
@@ -25,6 +25,7 @@ state, and your generator function now returns a new state on each round.
 For instance, you could use an `int` as the state:
 
 .Example of state-based `generate`
+====
 [source,java]
 ----
 Flux<String> flux = Flux.generate(
@@ -41,9 +42,11 @@ of 3).
 <3> We also use it to choose when to stop.
 <4> We return a new state that we use in the next invocation (unless the
 sequence terminated in this one).
+====
 
-The code above generates the table of 3, as the following sequence:
+The preceding code generates the table of 3, as the following sequence:
 
+====
 ----
 3 x 0 = 0
 3 x 1 = 3
@@ -57,11 +60,13 @@ The code above generates the table of 3, as the following sequence:
 3 x 9 = 27
 3 x 10 = 30
 ----
+====
 
 You can also use a mutable `<S>`. The example above could for instance be
 rewritten using a single `AtomicLong` as the state, mutating it on each round:
 
 .Mutable state variant
+====
 [source,java]
 ----
 Flux<String> flux = Flux.generate(
@@ -76,12 +81,15 @@ Flux<String> flux = Flux.generate(
 <1> This time, we generate a mutable object as the state.
 <2> We mutate the state here.
 <3> We return the *same* instance as the new state.
+====
 
 TIP: If your state object needs to clean up some resources, use the
 `generate(Supplier<S>, BiFunction, Consumer<S>)` variant to clean up the last
 state instance.
 
-Here is an example of using the generate method that includes a `Consumer`:
+The following example uses the `generate` method that includes a `Consumer`:
+
+====
 [source, java]
 ----
 Flux<String> flux = Flux.generate(
@@ -98,6 +106,7 @@ Flux<String> flux = Flux.generate(
 <2> We mutate the state here.
 <3> We return the *same* instance as the new state.
 <4> We see the last state value (11) as the output of this `Consumer` lambda.
+====
 
 In the case of the state containing a database connection or other resource
 that needs to be handled at the end of the process, the `Consumer` lambda could
@@ -105,7 +114,8 @@ close the connection or  otherwise handle any tasks that should be done at the
 end of the process.
 
 [[producing.create]]
-== Asynchronous & multi-threaded: `create`
+== Asynchronous and Multi-threaded: `create`
+
 `create` is a more advanced form of programmatic creation of a `Flux` which is
 suitable for multiple emissions per round, even from multiple threads.
 
@@ -129,6 +139,7 @@ Imagine that you use a listener-based API. It processes data by chunks
 and has two events: (1) a chunk of data is ready and (2) the processing is
 complete (terminal event), as represented in the `MyEventListener` interface:
 
+====
 [source,java]
 ----
 interface MyEventListener<T> {
@@ -136,9 +147,11 @@ interface MyEventListener<T> {
     void processComplete();
 }
 ----
+====
 
 You can use `create` to bridge this into a `Flux<T>`:
 
+====
 [source,java]
 ----
 Flux<String> bridge = Flux.create(sink -> {
@@ -161,6 +174,7 @@ Flux<String> bridge = Flux.create(sink -> {
 <2> Each element in a chunk becomes an element in the `Flux`.
 <3> The `processComplete` event is translated to `onComplete`.
 <4> All of this is done asynchronously whenever the `myEventProcessor` executes.
+====
 
 Additionally, since `create` can bridge asynchronous APIs and manages backpressure, you
 can refine how to behave backpressure-wise, by indicating an `OverflowStrategy`:
@@ -185,6 +199,7 @@ that it can also be asynchronous and can manage backpressure using any of the
 overflow strategies supported by `create`. However, **only one producing thread**
 may invoke `next`, `complete` or `error` at a time.
 
+====
 [source,java]
 ----
 Flux<String> bridge = Flux.push(sink -> {
@@ -211,6 +226,7 @@ Flux<String> bridge = Flux.push(sink -> {
 <2> Events are pushed to the sink using `next` from a single listener thread.
 <3> `complete` event generated from the same listener thread.
 <4> `error` event also generated from the same listener thread.
+====
 
 === An hybrid push/pull model
 Most Reactor operators, like `create`, follow an hybrid **push/pull** model.
@@ -226,6 +242,7 @@ Note that `push()` and `create()` both allow to set up an `onRequest` consumer
 in order to manage the request amount and to ensure that data is pushed through
 the sink only when there is pending request.
 
+====
 [source,java]
 ----
 Flux<String> bridge = Flux.create(sink -> {
@@ -249,6 +266,7 @@ Flux<String> bridge = Flux.create(sink -> {
 <1> Poll for messages when requests are made.
 <2> If messages are available immediately, push them to the sink.
 <3> The remaining messages that arrive asynchronously later are also delivered.
+====
 
 === Cleaning up after `push()` or `create()`
 
@@ -257,6 +275,7 @@ or termination. `onDispose` can be used to perform cleanup when the `Flux`
 completes, errors out, or is cancelled. `onCancel` can be used to perform any
 action specific to cancellation prior to cleanup with `onDispose`.
 
+====
 [source,java]
 ----
 Flux<String> bridge = Flux.create(sink -> {
@@ -267,6 +286,7 @@ Flux<String> bridge = Flux.create(sink -> {
 ----
 <1> `onCancel` is invoked first, for cancel signal only.
 <2> `onDispose` is invoked for complete, error, or cancel signals.
+====
 
 == Handle
 The `handle` method is a bit different: it is an instance method, meaning that
@@ -279,10 +299,12 @@ arbitrary value out of each source element, possibly skipping some elements. In
 this way, it can serve as a combination of `map` and `filter`. The signature of
 handle is as follows:
 
+====
 [source,java]
 ----
 Flux<R> handle(BiConsumer<T, SynchronousSink<R>>);
 ----
+====
 
 Let's consider an example. The reactive streams specification disallows `null`
 values in a sequence. What if you want to perform a `map` but you want to use
@@ -290,6 +312,8 @@ a preexisting method as the map function, and that method sometimes returns null
 
 For instance, the following method can be applied safely to a source of
 integers:
+
+====
 [source,java]
 ----
 public String alphabet(int letterNumber) {
@@ -300,10 +324,12 @@ public String alphabet(int letterNumber) {
 	return "" + (char) letterIndexAscii;
 }
 ----
+====
 
 We can then use `handle` to remove any nulls:
 
 .Using `handle` for a "map and eliminate nulls" scenario
+====
 [source,java]
 ----
 Flux<String> alphabet = Flux.just(-1, 30, 13, 9, 20)
@@ -318,10 +344,14 @@ alphabet.subscribe(System.out::println);
 <1> Map to letters.
 <2> If the "map function" returns null....
 <3> Filter it out by not calling `sink.next`.
+====
 
 Which will print out:
+
+====
 ----
 M
 I
 T
 ----
+====

--- a/docs/asciidoc/reactiveProgramming.adoc
+++ b/docs/asciidoc/reactiveProgramming.adoc
@@ -38,10 +38,12 @@ calling `onNext`) but can also signal an error (by calling `onError`) or complet
 calling `onComplete`). Both errors and completion terminate the sequence. This can
 be summed up as follows:
 
+====
 [source]
 ----
 onNext x 0..N [onError | onComplete]
 ----
+====
 
 This approach is very flexible. The pattern supports use cases where there is no value,
 one value, or n values (including an infinite sequence of values, such as the continuing
@@ -106,6 +108,7 @@ the second fetches favorite details, and the third offers suggestions with detai
 follows:
 
 .Example of Callback Hell
+====
 [source,java]
 ----
 userService.getFavorites(userId, new Callback<List<String>>() { //<1>
@@ -161,11 +164,13 @@ go to the `favoriteService` to get detailed `Favorite` objects. Since we want on
 we first stream the list of IDs to limit it to five.
 <9> Once again, a callback. This time we get a fully-fledged `Favorite` object that we
 push to the UI inside the UI thread.
+====
 
 That is a lot of code, and it is a bit hard to follow and has repetitive parts.
 Consider its equivalent in Reactor:
 
 .Example of Reactor code equivalent to callback code
+====
 [source,java]
 ----
 userService.getFavorites(userId) // <1>
@@ -184,12 +189,14 @@ userService.getFavorites(userId) // <1>
 <5> At the end, we want to process each piece of data in the UI thread.
 <6> We trigger the flow by describing what to do with the final form of the data
 (show it in a UI list) and what to do in case of an error (show a popup).
+====
 
 What if you want to ensure the favorite IDs are retrieved in less than 800ms or, if it
 takes longer, get them from a cache? In the callback-based code, that is a complicated
 task. In Reactor it becomes as easy as adding a `timeout` operator in the chain, as follows:
 
 .Example of Reactor code with timeout and fallback
+====
 [source,java]
 ----
 userService.getFavorites(userId)
@@ -204,6 +211,7 @@ userService.getFavorites(userId)
 <1> If the part above emits nothing for more than 800ms, propagate an error.
 <2> In case of an error, fall back to the `cacheService`.
 <3> The rest of the chain is similar to the previous example.
+====
 
 `Future` objects are a bit better than callbacks, but they still do not do well at composition,
 despite the improvements brought in Java 8 by `CompletableFuture`. Orchestrating multiple
@@ -219,6 +227,7 @@ statistic and combine these pair-wise, all of it asynchronously. The following e
 does so with a list of type `CompletableFuture`:
 
 .Example of `CompletableFuture` combination
+====
 [source,java]
 ----
 CompletableFuture<List<String>> ids = ifhIds(); // <1>
@@ -263,11 +272,13 @@ reiterate over the list of futures, collecting their results by using `join()`
 (which, here, does not block, since `allOf` ensures the futures are all done).
 <10> Once the whole asynchronous pipeline has been triggered, we wait for it to
 be processed and return the list of results that we can assert.
+====
 
 Since Reactor has more combination operators out of the box, this process can be
 simplified, as follows:
 
 .Example of Reactor code equivalent to future code
+====
 [source,java]
 ----
 Flux<String> ids = ifhrIds(); // <1>
@@ -305,6 +316,7 @@ combining it or subscribing to it. Most probably, we would return the `result` `
 Since we are in a test, we instead block, waiting for the processing to finish, and then
 directly return the aggregated list of values.
 <8> Assert the result.
+====
 
 The perils of using callbacks and `Future` objects are similar and are what reactive programming
 addresses with the `Publisher-Subscriber` pair.

--- a/docs/asciidoc/snippetRetryWhenRetry.adoc
+++ b/docs/asciidoc/snippetRetryWhenRetry.adoc
@@ -1,3 +1,4 @@
+====
 [source,java]
 ----
 Flux<String> flux =
@@ -16,3 +17,4 @@ error.
 <3> To allow for three retries, indexes before 4 return a value to emit.
 <4> In order to terminate the sequence in error, we throw the original exception after
 these three retries.
+====

--- a/docs/asciidoc/subscribe-backpressure.adoc
+++ b/docs/asciidoc/subscribe-backpressure.adoc
@@ -12,6 +12,7 @@ The first request comes from the final subscriber at subscription time, yet the 
 
 The simplest way of customizing the original request is to `subscribe` with a `BaseSubscriber` with the `hookOnSubscribe` method overridden, as the following example shows:
 
+====
 [source,java]
 ----
 Flux.range(1, 10)
@@ -30,14 +31,17 @@ Flux.range(1, 10)
       }
     });
 ----
+====
 
-The preceding snippets prints out the following:
+The preceding snippet prints out the following:
 
+====
 [source]
 ----
 request of 1
 Cancelling after having received 1
 ----
+====
 
 WARNING: When manipulating a request, you must be careful to produce enough demand for
 the sequence to advance, or your Flux can get "`stuck`". That is why `BaseSubscriber`

--- a/docs/asciidoc/subscribe-details.adoc
+++ b/docs/asciidoc/subscribe-details.adoc
@@ -3,6 +3,7 @@
 This section contains minimal examples of each of the five signatures for the `subscribe`
 method. The following code shows an example of the basic method with no arguments:
 
+====
 [source,java]
 ----
 Flux<Integer> ints = Flux.range(1, 3); <1>
@@ -10,11 +11,13 @@ ints.subscribe(); <2>
 ----
 <1> Set up a `Flux` that produces three values when a subscriber attaches.
 <2> Subscribe in the simplest way.
+====
 
 The preceding code produces no visible output, but it does work. The `Flux` produces
 three values. If we provide a lambda, we can make the values visible. The next example
 for the `subscribe` method shows one way to make the values appear:
 
+====
 [source,java]
 ----
 Flux<Integer> ints = Flux.range(1, 3); <1>
@@ -22,19 +25,23 @@ ints.subscribe(i -> System.out.println(i)); <2>
 ----
 <1> Set up a `Flux` that produces three values when a subscriber attaches.
 <2> Subscribe with a subscriber that will print the values.
+====
 
 The preceding code produces the following output:
 
+====
 [source]
 ----
 1
 2
 3
 ----
+====
 
 To demonstrate the next signature, we intentionally introduce an error, as
 shown in the following example:
 
+====
 [source, java]
 ----
 Flux<Integer> ints = Flux.range(1, 4) <1>
@@ -50,10 +57,12 @@ ints.subscribe(i -> System.out.println(i), <5>
 <3> For most values, return the value.
 <4> For one value, force an error.
 <5> Subscribe with a subscriber that includes an error handler.
+====
 
 We now have two lambda expressions: one for the content we expect and one for
 errors. The preceding code produces the following output:
 
+====
 [source]
 ----
 1
@@ -61,10 +70,12 @@ errors. The preceding code produces the following output:
 3
 Error: java.lang.RuntimeException: Got to 4
 ----
+====
 
 The next signature of the `subscribe` method includes both an error handler and
 a handler for completion events, as shown in the following example:
 
+====
 [source,java]
 ----
 Flux<Integer> ints = Flux.range(1, 4); <1>
@@ -74,6 +85,7 @@ ints.subscribe(i -> System.out.println(i),
 ----
 <1> Set up a Flux that produces four values when a subscriber attaches.
 <2> Subscribe with a Subscriber that includes a handler for completion events.
+====
 
 Error signals and completion signals are both terminal events and are exclusive of one
 another (you never get both). To make the completion consumer work, we must take care not
@@ -83,6 +95,7 @@ The completion callback has no input, as represented by an empty pair of
 parentheses: It matches the `run` method in the `Runnable` interface. The preceding code
 produces the following output:
 
+====
 [source]
 ----
 1
@@ -91,6 +104,7 @@ produces the following output:
 4
 Done
 ----
+====
 
 The last signature of the `subscribe` method includes a `Consumer<Subscription>`.
 
@@ -99,6 +113,7 @@ NOTE: That variant requires you to do something with the `Subscription` (perform
 
 The following example shows the last signature of the `subscribe` method:
 
+====
 [source,java]
 ----
 Flux<Integer> ints = Flux.range(1, 4);
@@ -109,6 +124,7 @@ ints.subscribe(i -> System.out.println(i),
 ----
 <1> When we subscribe we receive a `Subscription`. Signal that we want up to `10`
 elements from the source (which will actually emit 4 elements and complete).
+====
 
 === Cancelling a `subscribe()` with Its `Disposable`
 
@@ -151,6 +167,7 @@ the call to `Publisher#subscribe(Subscriber)`.
 Now we can implement one of these. We call it a `SampleSubscriber`. The following
 example shows how it would be attached to a `Flux`:
 
+====
 [source,java]
 ----
 SampleSubscriber<Integer> ss = new SampleSubscriber<Integer>();
@@ -161,10 +178,12 @@ ints.subscribe(i -> System.out.println(i),
     s -> s.request(10));
 ints.subscribe(ss);
 ----
+====
 
 The following example shows what `SampleSubscriber` could look like, as a minimalistic
 implementation of a `BaseSubscriber`:
 
+====
 [source,java]
 ----
 package io.projectreactor.samples;
@@ -186,6 +205,7 @@ public class SampleSubscriber<T> extends BaseSubscriber<T> {
 	}
 }
 ----
+====
 
 The `SampleSubscriber` class extends `BaseSubscriber`, which is the recommended abstract
 class for user-defined `Subscribers` in Reactor. The class offers hooks that can be
@@ -201,6 +221,7 @@ at a time.
 
 The `SampleSubscriber` class produces the following output:
 
+====
 [source]
 ----
 Subscribed
@@ -209,6 +230,7 @@ Subscribed
 3
 4
 ----
+====
 
 `BaseSubscriber` also offers a `requestUnbounded()` method to switch to unbounded mode
 (equivalent to `request(Long.MAX_VALUE)`), as well as a `cancel()` method.

--- a/docs/asciidoc/testing.adoc
+++ b/docs/asciidoc/testing.adoc
@@ -13,6 +13,7 @@ To use it in your tests, you must add it as a test dependency.
 The following example shows how to add `reactor-test` as a dependency in Maven:
 
 .reactor-test in Maven, in `<dependencies>`
+====
 [source,xml]
 ----
 <dependency>
@@ -23,16 +24,19 @@ The following example shows how to add `reactor-test` as a dependency in Maven:
 </dependency>
 ----
 <1> If you use the <<getting,BOM>>, you do not need to specify a `<version>`.
+====
 
 The following example shows how to add `reactor-test` as a dependency in Gradle:
 
 .reactor-test in Gradle, amend the `dependencies` block
+====
 [source,groovy]
 ----
 dependencies {
    testCompile 'io.projectreactor:reactor-test'
 }
 ----
+====
 
 The three main uses of `reactor-test` are as follows:
 
@@ -61,12 +65,14 @@ You can express all of that through the `StepVerifier` API.
 For instance, you could have the following utility method in your codebase that
 decorates a `Flux`:
 
+====
 [source,java]
 ----
 public <T> Flux<T> appendBoomError(Flux<T> source) {
   return source.concatWith(Mono.error(new IllegalArgumentException("boom")));
 }
 ----
+====
 
 In order to test it, you want to verify the following scenario:
 
@@ -75,6 +81,7 @@ error* with the message, `boom`. Subscribe and *verify* these expectations.
 
 In the `StepVerifier` API, this translates to the following test:
 
+====
 [source,java]
 ----
 @Test
@@ -97,6 +104,7 @@ of `thing1`.
 <5> The last signal we expect to happen is a termination of the sequence with an
 `onError`. The exception should have `boom` as a message.
 <6> It is important to trigger the test by calling `verify()`.
+====
 
 The API is a builder. You start by creating a `StepVerifier` and passing the
 sequence to be tested. This offers a choice of methods that let you:
@@ -161,11 +169,13 @@ corresponding tests. You can do so through the `StepVerifier.withVirtualTime` bu
 
 It looks like the following example:
 
+====
 [source,java]
 ----
 StepVerifier.withVirtualTime(() -> Mono.delay(Duration.ofDays(1)))
 //... continue expectations here
 ----
+====
 
 This virtual time feature plugs in a custom `Scheduler` in Reactor's `Schedulers`
 factory. Since these timed operators usually use the default `Schedulers.parallel()`
@@ -201,6 +211,7 @@ first step, it usually fails because the subscription signal is detected. Use
 In order to quickly evaluate the behavior of our `Mono.delay` above, we can finish
 writing our code as follows:
 
+====
 [source,java]
 ----
 StepVerifier.withVirtualTime(() -> Mono.delay(Duration.ofDays(1)))
@@ -213,6 +224,7 @@ StepVerifier.withVirtualTime(() -> Mono.delay(Duration.ofDays(1)))
 <2> Expect nothing to happen for a full day.
 <3> Then expect a delay that emits `0`.
 <4> Then expect completion (and trigger the verification).
+====
 
 We could have used `thenAwait(Duration.ofDays(1))` above, but `expectNoEvent` has the
 benefit of guaranteeing that nothing happened earlier than it should have.
@@ -260,6 +272,7 @@ using `StepVerifierOptions` to create the verifier.
 
 These features are demonstrated in the following snippet:
 
+====
 [source,java]
 ----
 StepVerifier.create(Mono.just(1).map(i -> i + 10),
@@ -276,6 +289,7 @@ StepVerifier.create(Mono.just(1).map(i -> i + 10),
 <3> An example of a `Context`-specific expectation. It must contain value "thing2" for key "thing1".
 <4> We `then()` switch back to setting up normal expectations on the data.
 <5> Let us not forget to `verify()` the whole set of expectations.
+====
 
 == Manually Emitting with `TestPublisher`
 
@@ -328,6 +342,7 @@ For instance, consider the following method, which builds a chain of operators f
 source and uses a `switchIfEmpty` to fall back to a particular alternative if the source
 is empty:
 
+====
 [source,java]
 ----
 public Flux<String> processOrFallback(Mono<String> source, Publisher<String> fallback) {
@@ -336,9 +351,11 @@ public Flux<String> processOrFallback(Mono<String> source, Publisher<String> fal
             .switchIfEmpty(fallback);
 }
 ----
+====
 
 You can test which logical branch of the switchIfEmpty was used, as follows:
 
+====
 [source,java]
 ----
 @Test
@@ -356,12 +373,14 @@ public void testEmptyPathIsUsed() {
                 .verifyComplete();
 }
 ----
+====
 
 However, think about an example where the method produces a `Mono<Void>` instead. It waits
 for the source to complete, performs an additional task, and completes. If the source
 is empty, a fallback `Runnable`-like task must be performed instead. The following example
 shows such a case:
 
+====
 [source,java]
 ----
 private Mono<String> executeCommand(String command) {
@@ -376,6 +395,7 @@ public Mono<Void> processOrFallback(Mono<String> commandSource, Mono<Void> doWhe
 ----
 <1> `then()` forgets about the command result. It cares only that it was completed.
 <2> How to distinguish between two cases that are both empty sequences?
+====
 
 To verify that your `processOrFallback` method does indeed go through the `doWhenEmpty` path,
 you need to write a bit of boilerplate. Namely you need a `Mono<Void>` that:
@@ -389,6 +409,7 @@ to evaluate. This could be a lot of boilerplate when having to apply this patter
 regularly. Fortunately, 3.1.0 introduced an alternative with `PublisherProbe`. The
 following example shows how to use it:
 
+====
 [source,java]
 ----
 @Test
@@ -409,6 +430,7 @@ public void testCommandEmptyPathIsUsed() {
 can check that is was subscribed to...
 <4> ...as well as actually requested data...
 <5> ...and whether or not it was cancelled.
+====
 
 You can also use the probe in place of a `Flux<T>` by calling `.flux()` instead of
 `.mono()`. For cases where you need to probe an execution path but also need the


### PR DESCRIPTION
I added code fences to group samples with their callouts. Consequently, I had to add code fences around the code (and output) samples that don't have callouts, too. I also fixed some capitalization and wording issues that I happened to notice while adding the code fences.