### PR TITLE
fix #1742 Polish processor deprecations

### DIFF
--- a/docs/asciidoc/processors.adoc
+++ b/docs/asciidoc/processors.adoc
@@ -74,9 +74,11 @@ data only through direct user action (calling their methods of their `Sink` dire
 through user interaction or by subscribing to an upstream `Publisher` and synchronously
 draining it.
 
-The asynchronous processors are the most complex to instantiate and have a lot of different
-options. Consequently, they expose a `Builder` interface. The simpler processors have
-static factory methods instead.
+TIP: One way of publishing events onto different threads is to use the `EmitterProcessor`
+combined with `publishOn(Scheduler)`. This can for example replace the former `TopicProcessor`,
+which was using `Unsafe` operations and has been moved to
+https://github.com/reactor/reactor-addons/tree/master/reactor-extra/src/main/java/reactor/extra/processor[reactor-extra]
+in 3.3.0.
 
 == Direct Processor
 

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -135,6 +135,7 @@ javadoc {
 
   options.addStringOption('charSet', 'UTF-8')
 
+  options.addBooleanOption('nodeprecated', true)
   options.memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PROTECTED
   options.author = true
   options.header = "$project.name"

--- a/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/TopicProcessor.java
@@ -67,7 +67,7 @@ import reactor.util.concurrent.WaitStrategy;
  * @param <E> Type of dispatched signal
  * @author Stephane Maldini
  * @author Anatoly Kadyshev
- * @deprecated Has been moved to io.projectreactor.addons:reactor-extra:3.3.0+
+ * @deprecated Has been moved to io.projectreactor.addons:reactor-extra:3.3.0+ and will be removed in 3.4.0
  */
 @Deprecated
 public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
@@ -80,7 +80,9 @@ public final class TopicProcessor<E> extends EventLoopProcessor<E>  {
 	 * {@code TopicProcessor<String> processor = TopicProcessor.<String>builder().build()}
 	 *
 	 * @param <T> Type of dispatched signal
+	 * @deprecated Has been moved to io.projectreactor.addons:reactor-extra:3.3.0+ and will be removed in 3.4.0
 	 */
+	@Deprecated
 	public final static class Builder<T> {
 
 		String          name;

--- a/reactor-core/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/WorkQueueProcessor.java
@@ -64,7 +64,7 @@ import reactor.util.concurrent.WaitStrategy;
  *
  * @param <E> Type of dispatched signal
  * @author Stephane Maldini
- * @deprecated Has been moved to io.projectreactor.addons:reactor-extra:3.3.0+
+ * @deprecated Has been moved to io.projectreactor.addons:reactor-extra:3.3.0+ and will be removed in 3.4.0
  */
 @Deprecated
 public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
@@ -77,7 +77,9 @@ public final class WorkQueueProcessor<E> extends EventLoopProcessor<E> {
 	 * {@code WorkQueueProcessor<String> processor = WorkQueueProcessor.<String>builder().build()}
 	 *
 	 * @param <T> Type of dispatched signal
+	 * @deprecated Has been moved to io.projectreactor.addons:reactor-extra:3.3.0+ and will be removed in 3.4.0
 	 */
+	@Deprecated
 	public final static class Builder<T> {
 
 		String          name;

--- a/reactor-core/src/main/java/reactor/util/concurrent/WaitStrategy.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/WaitStrategy.java
@@ -25,7 +25,7 @@ import java.util.function.LongSupplier;
 
 /**
  * Strategy employed to wait for specific {@link LongSupplier} values with various spinning strategies.
- * @deprecated Has been moved to io.projectreactor.addons:reactor-extra:3.3.0+
+ * @deprecated Has been moved to io.projectreactor.addons:reactor-extra:3.3.0+ and will be removed in 3.4.0
  */
 @Deprecated
 public abstract class WaitStrategy {


### PR DESCRIPTION
- make sure builders are also marked as deprecated
 - mention the removal timeline (3.4.0)
 - exclude all deprecated classes from the javadoc
 - mention EmitterProcessor + publishOn as an alternative to
   TopicProcessor, link to reactor-extra