### PR TITLE
Display source code as java

### DIFF
--- a/docs/asciidoc/coreFeatures.adoc
+++ b/docs/asciidoc/coreFeatures.adoc
@@ -689,7 +689,7 @@ finally {
 
 .Imperative use of try-with-resource
 ====
-[source]
+[source,java]
 ----
 try (SomeAutoCloseable disposableInstance = new SomeAutoCloseable()) {
   return disposableInstance.toString();


### PR DESCRIPTION
The code was formatted by default as javascript instead of java code. It's an Obvious Fix .