### PR TITLE
Deprecate `compose` methods

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3406,7 +3406,9 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @return a new {@link Flux}
 	 * @see #transform  transform() for immmediate transformation of {@link Flux}
 	 * @see #as as() for a loose conversion to an arbitrary type
+	 * @deprecated use {@link #as(Function)} with {@link #defer(Supplier)}
 	 */
+	@Deprecated
 	public final <V> Flux<V> compose(Function<? super Flux<T>, ? extends Publisher<V>> transformer) {
 		return defer(() -> transformer.apply(this));
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1759,7 +1759,9 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return a new {@link Mono}
 	 * @see #as as() for a loose conversion to an arbitrary type
 	 * @see #transform(Function)
+	 * @deprecated use {@link #as(Function)} with {@link #defer(Supplier)}
 	 */
+	@Deprecated
 	public final <V> Mono<V> compose(Function<? super Mono<T>, ? extends Publisher<V>> transformer) {
 		return defer(() -> from(transformer.apply(this)));
 	}


### PR DESCRIPTION
As per #1745, this PR deprecates `compose` method. 

However, the suggested alternative (`transform` + `defer`) has a downside - `onAssembly` will be triggered two times (one in `transform` and another in `defer`).
We could advice using `as` + `defer`, but it may not be an easy-to-find alternative. Perhaps renaming the original method to match `transform` is a better option (instead of dropping the method in favour of `as`+`defer`)