### PR TITLE
Use "check" task as an aggregator, not "test"

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -213,7 +213,7 @@ task testNoMicrometer(type: Test, group: 'verification') {
 //inherit basic test task + common configuration in root
 //always depend on testStaticInit, skip testNG on Travis, skip loops when not releasing
 //note that this way the tasks can be run individually
-test {
+check {
   dependsOn testStaticInit
   dependsOn testNoMicrometer
   if (System.env.TRAVIS != "true") {


### PR DESCRIPTION
Since "Delegate to Gradle" uses "test" task as a runner,
the task should not depend on other test tasks.

There is "check" task in Gradle that should be used for running the checks.
It depends on the "test" task already.