### PR TITLE
fix #1739 Enforce a name for Schedulers.fromExecutorService

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
@@ -45,11 +45,10 @@ import reactor.util.annotation.Nullable;
  */
 final class DelegateServiceScheduler implements Scheduler, Scannable {
 
-	@Nullable
 	final String executorName;
 	final ScheduledExecutorService executor;
 
-	DelegateServiceScheduler(@Nullable String executorName, ExecutorService executorService) {
+	DelegateServiceScheduler(String executorName, ExecutorService executorService) {
 			this.executorName = executorName;
 			ScheduledExecutorService exec = convert(executorService);
 			this.executor = Schedulers.decorateExecutorService(this, exec);
@@ -110,16 +109,7 @@ final class DelegateServiceScheduler implements Scheduler, Scannable {
 
 	@Override
 	public String toString() {
-		StringBuilder ts = new StringBuilder(Schedulers.FROM_EXECUTOR_SERVICE)
-				.append('(');
-		if (executorName != null) {
-			ts.append(executorName);
-		}
-		else {
-			ts.append("anonymous");
-		}
-		ts.append(')');
-		return ts.toString();
+		return Schedulers.FROM_EXECUTOR_SERVICE + '(' + executorName + ')';
 	}
 
 	static final class UnsupportedScheduledExecutorService

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -123,7 +123,8 @@ public abstract class Schedulers {
 	 */
 	@Deprecated
 	public static Scheduler fromExecutorService(ExecutorService executorService) {
-		return fromExecutorService(executorService, null);
+		String executorServiceHashcode = Integer.toHexString(System.identityHashCode(executorService));
+		return fromExecutorService(executorService, "anonymousExecutor@" + executorServiceHashcode);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -114,14 +114,14 @@ public abstract class Schedulers {
 	/**
 	 * Create a {@link Scheduler} which uses a backing {@link ExecutorService} to schedule
 	 * Runnables for async operators.
+	 * <p>
+	 * Prefer using {@link #fromExecutorService(ExecutorService, String)},
+	 * especially if you plan on using metrics as this gives the executor a meaningful identifier.
 	 *
 	 * @param executorService an {@link ExecutorService}
 	 *
 	 * @return a new {@link Scheduler}
-	 * @deprecated prefer using {@link #fromExecutorService(ExecutorService, String)},
-	 * especially if you plan on using metrics as this gives the executor a meaningful identifier
 	 */
-	@Deprecated
 	public static Scheduler fromExecutorService(ExecutorService executorService) {
 		String executorServiceHashcode = Integer.toHexString(System.identityHashCode(executorService));
 		return fromExecutorService(executorService, "anonymousExecutor@" + executorServiceHashcode);

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -46,7 +46,7 @@ import static reactor.core.Exceptions.unwrap;
 
 /**
  * {@link Schedulers} provides various {@link Scheduler} factories useable by {@link
- * reactor.core.publisher.Flux#publishOn publishOn} or {@link reactor.core.publisher.Mono#subscribeOn
+ * reactor.core.publisher.Flux#publishOn(Scheduler) publishOn} or {@link reactor.core.publisher.Mono#subscribeOn
  * subscribeOn} :
  * <p>
  * <ul> <li>{@link #fromExecutorService(ExecutorService)}}. </li> <li>{@link #newParallel}
@@ -118,9 +118,24 @@ public abstract class Schedulers {
 	 * @param executorService an {@link ExecutorService}
 	 *
 	 * @return a new {@link Scheduler}
+	 * @deprecated prefer using {@link #fromExecutorService(ExecutorService, String)},
+	 * especially if you plan on using metrics as this gives the executor a meaningful identifier
 	 */
+	@Deprecated
 	public static Scheduler fromExecutorService(ExecutorService executorService) {
-		return new DelegateServiceScheduler(executorService);
+		return fromExecutorService(executorService, null);
+	}
+
+	/**
+	 * Create a {@link Scheduler} which uses a backing {@link ExecutorService} to schedule
+	 * Runnables for async operators.
+	 *
+	 * @param executorService an {@link ExecutorService}
+	 *
+	 * @return a new {@link Scheduler}
+	 */
+	public static Scheduler fromExecutorService(ExecutorService executorService, String executorName) {
+		return new DelegateServiceScheduler(executorName, executorService);
 	}
 
 	/**

--- a/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
@@ -19,10 +19,13 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
 import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.Exceptions;
 
 import static org.assertj.core.api.Assertions.*;
@@ -31,6 +34,27 @@ import static org.assertj.core.api.Assertions.*;
  * @author Stephane Maldini
  */
 public abstract class AbstractSchedulerTest {
+
+	/**
+	 * Add {@link Disposable} resources to this composite to automatically clean them
+	 * up at the end of each test.
+	 */
+	protected final Disposable.Composite toCleanUp = Disposables.composite();
+
+	/**
+	 * Register a {@link Disposable} for automatic cleanup and return it for chaining.
+	 * @param resource the resource to clean up at end of test
+	 * @param <D> the type of the resource
+	 * @return the resource
+	 */
+	protected <D extends Disposable> D autoCleanup(D resource) {
+		toCleanUp.add(resource);
+		return resource;
+	}
+	@After
+	public void cleanupCompositeDisposable() {
+		toCleanUp.dispose();
+	}
 
 	protected abstract Scheduler scheduler();
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/DelegateServiceSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/DelegateServiceSchedulerTest.java
@@ -143,7 +143,7 @@ public class DelegateServiceSchedulerTest extends AbstractSchedulerTest {
 	}
 
 	@Test
-	public void scanName() {
+	public void scanNameAnonymous() {
 		Scheduler fixedThreadPool = Schedulers.fromExecutorService(Executors.newFixedThreadPool(3));
 		Scheduler cachedThreadPool = Schedulers.fromExecutorService(Executors.newCachedThreadPool());
 		Scheduler singleThread = Schedulers.fromExecutorService(Executors.newSingleThreadExecutor());
@@ -151,16 +151,37 @@ public class DelegateServiceSchedulerTest extends AbstractSchedulerTest {
 		try {
 			assertThat(Scannable.from(fixedThreadPool).scan(Scannable.Attr.NAME))
 					.as("fixedThreadPool")
-					.startsWith("fromExecutorService(java.util.concurrent.ThreadPoolExecutor@")
-					.endsWith("[Running, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 0])");
+					.isEqualTo("fromExecutorService(anonymous)");
 			assertThat(Scannable.from(cachedThreadPool).scan(Scannable.Attr.NAME))
 					.as("cachedThreadPool")
-					.startsWith("fromExecutorService(java.util.concurrent.ThreadPoolExecutor@")
-					.endsWith("[Running, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 0])");
+					.isEqualTo("fromExecutorService(anonymous)");
 			assertThat(Scannable.from(singleThread).scan(Scannable.Attr.NAME))
 					.as("singleThread")
-					.startsWith("fromExecutorService(java.util.concurrent.Executors$FinalizableDelegatedExecutorService@")
-					.endsWith(")");
+					.isEqualTo("fromExecutorService(anonymous)");
+		}
+		finally {
+			fixedThreadPool.dispose();
+			cachedThreadPool.dispose();
+			singleThread.dispose();
+		}
+	}
+
+	@Test
+	public void scanNameExplicit() {
+		Scheduler fixedThreadPool = Schedulers.fromExecutorService(Executors.newFixedThreadPool(3), "fixedThreadPool(3)");
+		Scheduler cachedThreadPool = Schedulers.fromExecutorService(Executors.newCachedThreadPool(), "cachedThreadPool");
+		Scheduler singleThread = Schedulers.fromExecutorService(Executors.newSingleThreadExecutor(), "singleThreadExecutor");
+
+		try {
+			assertThat(Scannable.from(fixedThreadPool).scan(Scannable.Attr.NAME))
+					.as("fixedThreadPool")
+					.isEqualTo("fromExecutorService(fixedThreadPool(3))");
+			assertThat(Scannable.from(cachedThreadPool).scan(Scannable.Attr.NAME))
+					.as("cachedThreadPool")
+					.isEqualTo("fromExecutorService(cachedThreadPool)");
+			assertThat(Scannable.from(singleThread).scan(Scannable.Attr.NAME))
+					.as("singleThread")
+					.isEqualTo("fromExecutorService(singleThreadExecutor)");
 		}
 		finally {
 			fixedThreadPool.dispose();

--- a/reactor-core/src/test/java/reactor/core/scheduler/DelegateServiceSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/DelegateServiceSchedulerTest.java
@@ -16,6 +16,7 @@
 package reactor.core.scheduler;
 
 import java.time.Duration;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -144,20 +145,28 @@ public class DelegateServiceSchedulerTest extends AbstractSchedulerTest {
 
 	@Test
 	public void scanNameAnonymous() {
-		Scheduler fixedThreadPool = Schedulers.fromExecutorService(Executors.newFixedThreadPool(3));
-		Scheduler cachedThreadPool = Schedulers.fromExecutorService(Executors.newCachedThreadPool());
-		Scheduler singleThread = Schedulers.fromExecutorService(Executors.newSingleThreadExecutor());
+		final ExecutorService fixedExecutor = Executors.newFixedThreadPool(3);
+		final ExecutorService cachedExecutor = Executors.newCachedThreadPool();
+		final ExecutorService singleExecutor = Executors.newSingleThreadExecutor();
+
+		Scheduler fixedThreadPool = Schedulers.fromExecutorService(fixedExecutor);
+		Scheduler cachedThreadPool = Schedulers.fromExecutorService(cachedExecutor);
+		Scheduler singleThread = Schedulers.fromExecutorService(singleExecutor);
+
+		String fixedId = Integer.toHexString(System.identityHashCode(fixedExecutor));
+		String cachedId = Integer.toHexString(System.identityHashCode(cachedExecutor));
+		String singleId = Integer.toHexString(System.identityHashCode(singleExecutor));
 
 		try {
 			assertThat(Scannable.from(fixedThreadPool).scan(Scannable.Attr.NAME))
 					.as("fixedThreadPool")
-					.isEqualTo("fromExecutorService(anonymous)");
+					.isEqualTo("fromExecutorService(anonymousExecutor@" + fixedId + ")");
 			assertThat(Scannable.from(cachedThreadPool).scan(Scannable.Attr.NAME))
 					.as("cachedThreadPool")
-					.isEqualTo("fromExecutorService(anonymous)");
+					.isEqualTo("fromExecutorService(anonymousExecutor@" + cachedId + ")");
 			assertThat(Scannable.from(singleThread).scan(Scannable.Attr.NAME))
 					.as("singleThread")
-					.isEqualTo("fromExecutorService(anonymous)");
+					.isEqualTo("fromExecutorService(anonymousExecutor@" + singleId + ")");
 		}
 		finally {
 			fixedThreadPool.dispose();


### PR DESCRIPTION
This avoids relying on the underlying ExecutorService's toString, at
least for the purpose of calling `scan(Attr.NAME)`.

Previously, relying on the backing ExecutorService#toString method
was not ideal as this generally depends on the state of the executor,
which is not ideal for most usages of `NAME` and especially not for
metrics (where NAME is used a a differentiating tag for the meters).