### PR TITLE
Move original stacktrace after the backtrace

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnAssembly.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnAssembly.java
@@ -435,8 +435,13 @@ final class FluxOnAssembly<T> extends FluxOperator<T, T> implements Fuseable,
 				}
 
 				t = Exceptions.addSuppressed(t, onAssemblyException);
-				onAssemblyException.setStackTrace(t.getStackTrace());
-				t.setStackTrace(new StackTraceElement[0]);
+				final StackTraceElement[] stackTrace = t.getStackTrace();
+				if (stackTrace.length > 0) {
+					onAssemblyException.setStackTrace(stackTrace);
+					t.setStackTrace(new StackTraceElement[] {
+							stackTrace[0]
+					});
+				}
 			}
 
 			onAssemblyException.add(parent, snapshotStack);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnAssembly.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnAssembly.java
@@ -327,6 +327,7 @@ final class FluxOnAssembly<T> extends FluxOperator<T, T> implements Fuseable,
 					sb.append(message);
 					sb.append("\n");
 				}
+				sb.append("Original stack trace:");
 				return sb.toString();
 			}
 		}
@@ -434,6 +435,8 @@ final class FluxOnAssembly<T> extends FluxOperator<T, T> implements Fuseable,
 				}
 
 				t = Exceptions.addSuppressed(t, onAssemblyException);
+				onAssemblyException.setStackTrace(t.getStackTrace());
+				t.setStackTrace(new StackTraceElement[0]);
 			}
 
 			onAssemblyException.add(parent, snapshotStack);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnAssembly.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnAssembly.java
@@ -328,7 +328,7 @@ final class FluxOnAssembly<T> extends FluxOperator<T, T> implements Fuseable,
 					sb.append(message);
 					sb.append("\n");
 				}
-				sb.append("Original stack trace:");
+				sb.append("Stack trace:");
 				return sb.toString();
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnAssembly.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnAssembly.java
@@ -15,6 +15,7 @@
  */
 package reactor.core.publisher;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -437,7 +438,21 @@ final class FluxOnAssembly<T> extends FluxOperator<T, T> implements Fuseable,
 				t = Exceptions.addSuppressed(t, onAssemblyException);
 				final StackTraceElement[] stackTrace = t.getStackTrace();
 				if (stackTrace.length > 0) {
-					onAssemblyException.setStackTrace(stackTrace);
+					StackTraceElement[] newStackTrace = new StackTraceElement[stackTrace.length];
+					int i = 0;
+					for (StackTraceElement stackTraceElement : stackTrace) {
+						String className = stackTraceElement.getClassName();
+
+						if (className.startsWith("reactor.core.publisher.") && className.contains("OnAssembly")) {
+							continue;
+						}
+
+						newStackTrace[i] = stackTraceElement;
+						i++;
+					}
+					newStackTrace = Arrays.copyOf(newStackTrace, i);
+
+					onAssemblyException.setStackTrace(newStackTrace);
 					t.setStackTrace(new StackTraceElement[] {
 							stackTrace[0]
 					});

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
@@ -255,7 +255,7 @@ public class FluxOnAssemblyTest {
 		assertThat(lines)
 				.startsWith(
 						"|_ ParallelFlux.checkpoint ⇢ at reactor.core.publisher.FluxOnAssemblyTest.parallelFluxCheckpointDescriptionAndForceStack(FluxOnAssemblyTest.java:" + (baseline + 4) + ")",
-						"Original stack trace:"
+						"Stack trace:"
 				);
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
@@ -249,8 +249,14 @@ public class FluxOnAssemblyTest {
 		assertThat(debugStack).contains("Assembly trace from producer [reactor.core.publisher.ParallelSource], described as [descriptionCorrelation1234] :\n"
 				+ "\treactor.core.publisher.ParallelFlux.checkpoint(ParallelFlux.java:227)\n"
 				+ "\treactor.core.publisher.FluxOnAssemblyTest.parallelFluxCheckpointDescriptionAndForceStack(FluxOnAssemblyTest.java:" + (baseline + 4) + ")\n");
-		assertThat(debugStack).endsWith("Error has been observed at the following site(s):\n"
-				+ "\t|_ ParallelFlux.checkpoint ⇢ at reactor.core.publisher.FluxOnAssemblyTest.parallelFluxCheckpointDescriptionAndForceStack(FluxOnAssemblyTest.java:" + (baseline + 4) + ")\n\n");
+
+		Iterator<String> lines = seekToBacktrace(debugStack);
+
+		assertThat(lines)
+				.startsWith(
+						"|_ ParallelFlux.checkpoint ⇢ at reactor.core.publisher.FluxOnAssemblyTest.parallelFluxCheckpointDescriptionAndForceStack(FluxOnAssemblyTest.java:" + (baseline + 4) + ")",
+						"Original stack trace:"
+				);
 	}
 
 	@Test
@@ -332,15 +338,7 @@ public class FluxOnAssemblyTest {
 
 		String debugStack = sw.toString();
 
-		Iterator<String> lines = Stream.of(debugStack.split("\n"))
-		                                  .map(String::trim)
-		                                  .iterator();
-
-		while (lines.hasNext()) {
-			if (lines.next().equals("Error has been observed at the following site(s):")) {
-				break;
-			}
-		}
+		Iterator<String> lines = seekToBacktrace(debugStack);
 
 		assertThat(lines.next())
 				.as("first backtrace line")
@@ -368,11 +366,7 @@ public class FluxOnAssemblyTest {
 
 		String debugStack = sw.toString();
 
-		Iterator<String> lines = seekToSupressedAssembly(debugStack);
-
-		assertThat(lines.next())
-				.as("backtrace header")
-				.isEqualTo("Error has been observed at the following site(s):");
+		Iterator<String> lines = seekToBacktrace(debugStack);
 
 		assertThat(lines.next())
 				.as("first backtrace line")
@@ -385,11 +379,13 @@ public class FluxOnAssemblyTest {
 
 	private Iterator<String> seekToBacktrace(String debugStack) {
 		Iterator<String> lines = seekToSupressedAssembly(debugStack);
-
-		assertThat(lines.next())
-				.as("backtrace header")
-				.isEqualTo("Error has been observed at the following site(s):");
-		return lines;
+		while (lines.hasNext()) {
+			String line = lines.next();
+			if (line.equals("Error has been observed at the following site(s):")) {
+				return lines;
+			}
+		}
+		throw new IllegalStateException("Not found!");
 	}
 
 	private Iterator<String> seekToSupressedAssembly(String debugStack) {

--- a/reactor-core/src/test/java/reactor/guide/GuideDebuggingExtraTests.java
+++ b/reactor-core/src/test/java/reactor/guide/GuideDebuggingExtraTests.java
@@ -45,14 +45,14 @@ public class GuideDebuggingExtraTests {
 
 			String debugStack = sw.toString();
 
-			assertThat(debugStack)
+			assertThat(debugStack.substring(0, debugStack.indexOf("Original stack trace:")))
 					.endsWith("Error has been observed at the following site(s):\n"
 							+ "\t|_       Flux.map ⇢ at reactor.guide.FakeRepository.findAllUserByName(FakeRepository.java:27)\n"
 							+ "\t|_       Flux.map ⇢ at reactor.guide.FakeRepository.findAllUserByName(FakeRepository.java:28)\n"
 							+ "\t|_    Flux.filter ⇢ at reactor.guide.FakeUtils1.lambda$static$1(FakeUtils1.java:29)\n"
 							+ "\t|_ Flux.transform ⇢ at reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:40)\n"
 							+ "\t|_   Flux.elapsed ⇢ at reactor.guide.FakeUtils2.lambda$static$0(FakeUtils2.java:30)\n"
-							+ "\t|_ Flux.transform ⇢ at reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:41)\n\n");
+							+ "\t|_ Flux.transform ⇢ at reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:41)\n");
 		}
 		finally {
 			Hooks.resetOnOperatorDebug();

--- a/reactor-core/src/test/java/reactor/guide/GuideDebuggingExtraTests.java
+++ b/reactor-core/src/test/java/reactor/guide/GuideDebuggingExtraTests.java
@@ -45,7 +45,7 @@ public class GuideDebuggingExtraTests {
 
 			String debugStack = sw.toString();
 
-			assertThat(debugStack.substring(0, debugStack.indexOf("Original stack trace:")))
+			assertThat(debugStack.substring(0, debugStack.indexOf("Stack trace:")))
 					.endsWith("Error has been observed at the following site(s):\n"
 							+ "\t|_       Flux.map ⇢ at reactor.guide.FakeRepository.findAllUserByName(FakeRepository.java:27)\n"
 							+ "\t|_       Flux.map ⇢ at reactor.guide.FakeRepository.findAllUserByName(FakeRepository.java:28)\n"

--- a/reactor-core/src/test/java/reactor/guide/GuideTests.java
+++ b/reactor-core/src/test/java/reactor/guide/GuideTests.java
@@ -980,7 +980,7 @@ public class GuideTests {
 				assertThat(withSuppressed.getSuppressed()).hasSize(1);
 				assertThat(withSuppressed.getSuppressed()[0])
 						.hasMessageStartingWith("\nAssembly trace from producer [reactor.core.publisher.MonoSingle] :")
-						.hasMessageEndingWith("Flux.single ⇢ at reactor.guide.GuideTests.scatterAndGather(GuideTests.java:944)\n");
+						.hasMessageContaining("Flux.single ⇢ at reactor.guide.GuideTests.scatterAndGather(GuideTests.java:944)\n");
 			});
 		}
 	}


### PR DESCRIPTION
Before:
```
java.lang.IllegalStateException: boom
	at reactor.guide.FakeRepository.lambda$findAllUserByName$0(FakeRepository.java:27)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableConditionalSubscriber.onNext(FluxMapFuseable.java:273)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:387)
	at reactor.core.publisher.FluxArray$ArrayConditionalSubscription.fastPath(FluxArray.java:339)
	at reactor.core.publisher.FluxArray$ArrayConditionalSubscription.request(FluxArray.java:262)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.request(FluxOnAssembly.java:476)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableConditionalSubscriber.request(FluxMapFuseable.java:346)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.request(FluxOnAssembly.java:476)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableConditionalSubscriber.request(FluxMapFuseable.java:346)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.request(FluxOnAssembly.java:476)
	at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.request(FluxFilterFuseable.java:185)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.request(FluxOnAssembly.java:476)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.request(FluxOnAssembly.java:476)
	at reactor.core.publisher.FluxElapsed$ElapsedSubscriber.request(FluxElapsed.java:115)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.request(FluxOnAssembly.java:476)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.request(FluxOnAssembly.java:476)
	at reactor.core.publisher.LambdaSubscriber.onSubscribe(LambdaSubscriber.java:89)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onSubscribe(FluxOnAssembly.java:460)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onSubscribe(FluxOnAssembly.java:460)
	at reactor.core.publisher.FluxElapsed$ElapsedSubscriber.onSubscribe(FluxElapsed.java:85)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onSubscribe(FluxOnAssembly.java:460)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onSubscribe(FluxOnAssembly.java:460)
	at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.onSubscribe(FluxFilterFuseable.java:82)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onSubscribe(FluxOnAssembly.java:460)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableConditionalSubscriber.onSubscribe(FluxMapFuseable.java:255)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onSubscribe(FluxOnAssembly.java:460)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableConditionalSubscriber.onSubscribe(FluxMapFuseable.java:255)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onSubscribe(FluxOnAssembly.java:460)
	at reactor.core.publisher.FluxArray.subscribe(FluxArray.java:50)
	at reactor.core.publisher.FluxArray.subscribe(FluxArray.java:59)
	at reactor.core.publisher.FluxOnAssembly.subscribe(FluxOnAssembly.java:117)
	at reactor.core.publisher.FluxMapFuseable.subscribe(FluxMapFuseable.java:60)
	at reactor.core.publisher.FluxOnAssembly.subscribe(FluxOnAssembly.java:117)
	at reactor.core.publisher.FluxMapFuseable.subscribe(FluxMapFuseable.java:60)
	at reactor.core.publisher.FluxOnAssembly.subscribe(FluxOnAssembly.java:117)
	at reactor.core.publisher.FluxFilterFuseable.subscribe(FluxFilterFuseable.java:52)
	at reactor.core.publisher.FluxOnAssembly.subscribe(FluxOnAssembly.java:122)
	at reactor.core.publisher.FluxOnAssembly.subscribe(FluxOnAssembly.java:122)
	at reactor.core.publisher.FluxElapsed.subscribe(FluxElapsed.java:43)
	at reactor.core.publisher.FluxOnAssembly.subscribe(FluxOnAssembly.java:122)
	at reactor.core.publisher.FluxOnAssembly.subscribe(FluxOnAssembly.java:122)
	at reactor.core.publisher.Flux.subscribe(Flux.java:7921)
	at reactor.core.publisher.Flux.subscribeWith(Flux.java:8085)
	at reactor.core.publisher.Flux.subscribe(Flux.java:7914)
	at reactor.core.publisher.Flux.subscribe(Flux.java:7878)
	at reactor.core.publisher.Flux.subscribe(Flux.java:7848)
	at reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:42)
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Assembly trace from producer [reactor.core.publisher.FluxMapFuseable] :
	reactor.core.publisher.Flux.map(Flux.java:5731)
	reactor.guide.FakeRepository.findAllUserByName(FakeRepository.java:27)
Error has been observed at the following site(s):
	|_       Flux.map ⇢ at reactor.guide.FakeRepository.findAllUserByName(FakeRepository.java:27)
	|_       Flux.map ⇢ at reactor.guide.FakeRepository.findAllUserByName(FakeRepository.java:28)
	|_    Flux.filter ⇢ at reactor.guide.FakeUtils1.lambda$static$1(FakeUtils1.java:29)
	|_ Flux.transform ⇢ at reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:40)
	|_   Flux.elapsed ⇢ at reactor.guide.FakeUtils2.lambda$static$0(FakeUtils2.java:30)
	|_ Flux.transform ⇢ at reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:41)
```

After:
```
java.lang.IllegalStateException: boom
	at reactor.guide.FakeRepository.lambda$findAllUserByName$0(FakeRepository.java:27)
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Assembly trace from producer [reactor.core.publisher.FluxMapFuseable] :
	reactor.core.publisher.Flux.map(Flux.java:5731)
	reactor.guide.FakeRepository.findAllUserByName(FakeRepository.java:27)
Error has been observed at the following site(s):
	|_       Flux.map ⇢ at reactor.guide.FakeRepository.findAllUserByName(FakeRepository.java:27)
	|_       Flux.map ⇢ at reactor.guide.FakeRepository.findAllUserByName(FakeRepository.java:28)
	|_    Flux.filter ⇢ at reactor.guide.FakeUtils1.lambda$static$1(FakeUtils1.java:29)
	|_ Flux.transform ⇢ at reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:40)
	|_   Flux.elapsed ⇢ at reactor.guide.FakeUtils2.lambda$static$0(FakeUtils2.java:30)
	|_ Flux.transform ⇢ at reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:41)
Stack trace:
	at reactor.guide.FakeRepository.lambda$findAllUserByName$0(FakeRepository.java:27)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableConditionalSubscriber.onNext(FluxMapFuseable.java:273)
	at reactor.core.publisher.FluxArray$ArrayConditionalSubscription.fastPath(FluxArray.java:339)
	at reactor.core.publisher.FluxArray$ArrayConditionalSubscription.request(FluxArray.java:262)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableConditionalSubscriber.request(FluxMapFuseable.java:346)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableConditionalSubscriber.request(FluxMapFuseable.java:346)
	at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.request(FluxFilterFuseable.java:185)
	at reactor.core.publisher.FluxElapsed$ElapsedSubscriber.request(FluxElapsed.java:115)
	at reactor.core.publisher.LambdaSubscriber.onSubscribe(LambdaSubscriber.java:89)
	at reactor.core.publisher.FluxElapsed$ElapsedSubscriber.onSubscribe(FluxElapsed.java:85)
	at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.onSubscribe(FluxFilterFuseable.java:82)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableConditionalSubscriber.onSubscribe(FluxMapFuseable.java:255)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableConditionalSubscriber.onSubscribe(FluxMapFuseable.java:255)
	at reactor.core.publisher.FluxArray.subscribe(FluxArray.java:50)
	at reactor.core.publisher.FluxArray.subscribe(FluxArray.java:59)
	at reactor.core.publisher.FluxMapFuseable.subscribe(FluxMapFuseable.java:60)
	at reactor.core.publisher.FluxMapFuseable.subscribe(FluxMapFuseable.java:60)
	at reactor.core.publisher.FluxFilterFuseable.subscribe(FluxFilterFuseable.java:52)
	at reactor.core.publisher.FluxElapsed.subscribe(FluxElapsed.java:43)
	at reactor.core.publisher.Flux.subscribe(Flux.java:7921)
	at reactor.core.publisher.Flux.subscribeWith(Flux.java:8085)
	at reactor.core.publisher.Flux.subscribe(Flux.java:7914)
	at reactor.core.publisher.Flux.subscribe(Flux.java:7878)
	at reactor.core.publisher.Flux.subscribe(Flux.java:7848)
	at reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:42)
```