### PR TITLE
fix #1745 Deprecate compose/transform and replace with aliases

### DIFF
--- a/docs/asciidoc/advancedFeatures.adoc
+++ b/docs/asciidoc/advancedFeatures.adoc
@@ -22,9 +22,9 @@ patterns that can help you reuse and mutualize code, notably for operators or co
 of operators that you might want to apply regularly in your codebase. If you think of a
 chain of operators as a recipe, you can create a "`cookbook`" of operator recipes.
 
-=== Using the `transform` Operator
+=== Using the `composeNow` Operator
 
-The `transform` operator lets you encapsulate a piece of an operator chain into a
+The `composeNow` operator lets you encapsulate a piece of an operator chain into a
 function. That function is applied to an original operator chain at assembly time to
 augment it with the encapsulated operators. Doing so applies the same operations to all
 the subscribers of a sequence and is basically equivalent to chaining the operators
@@ -39,12 +39,12 @@ f -> f.filter(color -> !color.equals("orange"))
 
 Flux.fromIterable(Arrays.asList("blue", "green", "orange", "purple"))
 	.doOnNext(System.out::println)
-	.transform(filterAndMap)
+	.composeNow(filterAndMap)
 	.subscribe(d -> System.out.println("Subscriber to Transformed MapAndFilter: "+d));
 ----
 ====
 
-The following image shows how the `transform` operator encapsulates flows:
+The following image shows how the `composeNow` operator encapsulates flows:
 
 image::https://raw.githubusercontent.com/reactor/reactor-core/v3.0.7.RELEASE/src/docs/marble/gs-transform.png[Transform Operator : encapsulate flows]
 
@@ -62,9 +62,9 @@ Subscriber to Transformed MapAndFilter: PURPLE
 ----
 ====
 
-=== Using the `compose` Operator
+=== Using the `composeLater` Operator
 
-The `compose` operator is similar to `transform` and also lets you encapsulate operators
+The `composeLater` operator is similar to `composeNow` and also lets you encapsulate operators
 in a function. The major difference is that this function is applied to the original
 sequence _on a per-subscriber basis_. It means that the function can actually produce a
 different operator chain for each subscription (by maintaining some state). The
@@ -86,14 +86,14 @@ return f.filter(color -> !color.equals("orange"))
 Flux<String> composedFlux =
 Flux.fromIterable(Arrays.asList("blue", "green", "orange", "purple"))
     .doOnNext(System.out::println)
-    .compose(filterAndMap);
+    .composeLater(filterAndMap);
 
 composedFlux.subscribe(d -> System.out.println("Subscriber 1 to Composed MapAndFilter :"+d));
 composedFlux.subscribe(d -> System.out.println("Subscriber 2 to Composed MapAndFilter: "+d));
 ----
 ====
 
-The following image shows how the `compose` operator works with per-subscriber transformations:
+The following image shows how the `composeLater` operator works with per-subscriber transformations:
 
 image::https://raw.githubusercontent.com/reactor/reactor-core/v3.0.7.RELEASE/src/docs/marble/gs-compose.png[Compose Operator : Per Subscriber transformation]
 

--- a/docs/asciidoc/apdx-operatorChoice.adoc
+++ b/docs/asciidoc/apdx-operatorChoice.adoc
@@ -7,7 +7,7 @@ is covered by a combination of operators, it is presented as a method call, with
 leading dot and parameters in parentheses, as follows: `.methodCall(parameter)`.
 
 //TODO flux:  publishOn/subscribeOn/cancelOn
-//compose/transform, repeatWhen, sort, startWith
+//composeLater/composeNow, repeatWhen, sort, startWith
 //TODO Mono.sequenceEqual
 
 I want to deal with:

--- a/docs/asciidoc/debugging.adoc
+++ b/docs/asciidoc/debugging.adoc
@@ -217,8 +217,8 @@ example might make it more clear:
 [source,java]
 ----
 FakeRepository.findAllUserByName(Flux.just("pedro", "simon", "stephane"))
-              .transform(FakeUtils1.applyFilters)
-              .transform(FakeUtils2.enrichUser)
+              .composeNow(FakeUtils1.applyFilters)
+              .composeNow(FakeUtils2.enrichUser)
               .blockLast();
 ----
 ====
@@ -233,9 +233,9 @@ Error has been observed by the following operator(s):
 	|_	Flux.map ⇢ reactor.guide.FakeRepository.findAllUserByName(FakeRepository.java:27)
 	|_	Flux.map ⇢ reactor.guide.FakeRepository.findAllUserByName(FakeRepository.java:28)
 	|_	Flux.filter ⇢ reactor.guide.FakeUtils1.lambda$static$1(FakeUtils1.java:29)
-	|_	Flux.transform ⇢ reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:40)
+	|_	Flux.composeNow ⇢ reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:40)
 	|_	Flux.elapsed ⇢ reactor.guide.FakeUtils2.lambda$static$0(FakeUtils2.java:30)
-	|_	Flux.transform ⇢ reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:41)
+	|_	Flux.composeNow ⇢ reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:41)
 ----
 ====
 
@@ -244,10 +244,10 @@ This corresponds to the section of the chain of operators that gets notified of 
 . The exception originates in the first `map`.
 . It is seen by a second `map` (both in fact correspond to the `findAllUserByName`
 method).
-. It is then seen by a `filter` and a `transform`, which indicate that part of the chain
+. It is then seen by a `filter` and a `composeNow`, which indicate that part of the chain
 is constructed by a reusable transformation function (here, the `applyFilters` utility
 method).
-. Finally, it is seen by an `elapsed` and a `transform`. Once again, `elapsed` is applied
+. Finally, it is seen by an `elapsed` and a `composeNow`. Once again, `elapsed` is applied
 by the transformation function of that second transform.
 
 We deal with a form of instrumentation here, and creating a stack trace is costly. That

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3397,18 +3397,64 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * flux.compose(original -> original.log());
 	 * </pre></blockquote>
 	 * <p>
-	 * <img class="marble" src="doc-files/marbles/composeForFlux.svg" alt="">
+	 * <img class="marble" src="doc-files/marbles/composeLaterForFlux.svg" alt="">
 	 *
 	 * @param transformer the {@link Function} to lazily map this {@link Flux} into a target {@link Publisher}
 	 * instance for each new subscriber
 	 * @param <V> the item type in the returned {@link Publisher}
 	 *
 	 * @return a new {@link Flux}
-	 * @see #transform  transform() for immmediate transformation of {@link Flux}
+	 * @see #composeNow  composeNow() for immmediate transformation of {@link Flux}
 	 * @see #as as() for a loose conversion to an arbitrary type
+	 * @deprecated will be removed in 3.4.0, use {@link #composeLater(Function)} instead
 	 */
+	@Deprecated
 	public final <V> Flux<V> compose(Function<? super Flux<T>, ? extends Publisher<V>> transformer) {
 		return defer(() -> transformer.apply(this));
+	}
+
+	/**
+	 * Defer the transformation of this {@link Flux} in order to generate a target {@link Flux} type.
+	 * A transformation will occur for each {@link Subscriber}. For instance:
+	 * <blockquote><pre>
+	 * flux.composeLater(original -> original.log());
+	 * </pre></blockquote>
+	 * <p>
+	 * <img class="marble" src="doc-files/marbles/composeLaterForFlux.svg" alt="">
+	 *
+	 * @param transformer the {@link Function} to lazily map this {@link Flux} into a target {@link Publisher}
+	 * instance for each new subscriber
+	 * @param <V> the item type in the returned {@link Publisher}
+	 *
+	 * @return a new {@link Flux}
+	 * @see #composeNow(Function) composeNow() for immmediate transformation of {@link Flux}
+	 * @see #as as() for a loose conversion to an arbitrary type
+	 */
+	public final <V> Flux<V> composeLater(Function<? super Flux<T>, ? extends Publisher<V>> transformer) {
+		return defer(() -> transformer.apply(this));
+	}
+
+	/**
+	 * Transform this {@link Flux} in order to generate a target {@link Flux}. Unlike
+	 * {@link #composeLater(Function)}, the provided function is executed as part of assembly.
+	 * <blockquote><pre>
+	 * Function<Flux, Flux> applySchedulers = flux -> flux.subscribeOn(Schedulers.elastic())
+	 *                                                    .publishOn(Schedulers.parallel());
+	 * flux.composeNow(applySchedulers).map(v -> v * v).subscribe();
+	 * </pre></blockquote>
+	 * <p>
+	 * <img class="marble" src="doc-files/marbles/composeNowForFlux.svg" alt="">
+	 *
+	 * @param transformer the {@link Function} to immediately map this {@link Flux} into a target {@link Flux}
+	 * instance.
+	 * @param <V> the item type in the returned {@link Flux}
+	 *
+	 * @return a new {@link Flux}
+	 * @see #composeLater(Function) for deferred composition of {@link Flux} for each {@link Subscriber}
+	 * @see #as for a loose conversion to an arbitrary type
+	 */
+	public final <V> Flux<V> composeNow(Function<? super Flux<T>, ? extends Publisher<V>> transformer) {
+		return onAssembly(from(transformer.apply(this)));
 	}
 
 	/**
@@ -8717,18 +8763,20 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * flux.transform(applySchedulers).map(v -> v * v).subscribe();
 	 * </pre></blockquote>
 	 * <p>
-	 * <img class="marble" src="doc-files/marbles/transformForFlux.svg" alt="">
+	 * <img class="marble" src="doc-files/marbles/composeNowForFlux.svg" alt="">
 	 *
 	 * @param transformer the {@link Function} to immediately map this {@link Flux} into a target {@link Flux}
 	 * instance.
 	 * @param <V> the item type in the returned {@link Flux}
 	 *
 	 * @return a new {@link Flux}
-	 * @see #compose(Function) for deferred composition of {@link Flux} for each {@link Subscriber}
+	 * @see #composeLater(Function) for deferred composition of {@link Flux} for each {@link Subscriber}
 	 * @see #as for a loose conversion to an arbitrary type
+	 * @deprecated will be removed in 3.4.0, use {@link #composeNow(Function)} instead
 	 */
+	@Deprecated
 	public final <V> Flux<V> transform(Function<? super Flux<T>, ? extends Publisher<V>> transformer) {
-		return onAssembly(from(transformer.apply(this)));
+		return composeNow(transformer);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -185,7 +185,7 @@ public abstract class Operators {
 	/**
 	 * Create a function that can be used to support a custom operator via
 	 * {@link CoreSubscriber} decoration. The function is compatible with
-	 * {@link Flux#transform(Function)}, {@link Mono#transform(Function)},
+	 * {@link Flux#composeNow(Function)}, {@link Mono#composeNow(Function)},
 	 * {@link Hooks#onEachOperator(Function)} and {@link Hooks#onLastOperator(Function)},
 	 * but requires that the original {@link Publisher} be {@link Scannable}.
 	 * <p>
@@ -213,7 +213,7 @@ public abstract class Operators {
 	/**
 	 * Create a function that can be used to support a custom operator via
 	 * {@link CoreSubscriber} decoration. The function is compatible with
-	 * {@link Flux#transform(Function)}, {@link Mono#transform(Function)},
+	 * {@link Flux#composeNow(Function)}, {@link Mono#composeNow(Function)},
 	 * {@link Hooks#onEachOperator(Function)} and {@link Hooks#onLastOperator(Function)},
 	 * but requires that the original {@link Publisher} be {@link Scannable}.
 	 * <p>
@@ -249,7 +249,7 @@ public abstract class Operators {
 	/**
 	 * Create a function that can be used to support a custom operator via
 	 * {@link CoreSubscriber} decoration. The function is compatible with
-	 * {@link Flux#transform(Function)}, {@link Mono#transform(Function)},
+	 * {@link Flux#composeNow(Function)}, {@link Mono#composeNow(Function)},
 	 * {@link Hooks#onEachOperator(Function)} and {@link Hooks#onLastOperator(Function)},
 	 * and works with the raw {@link Publisher} as input, which is useful if you need to
 	 * detect the precise type of the source (eg. instanceof checks to detect Mono, Flux,
@@ -273,7 +273,7 @@ public abstract class Operators {
 	/**
 	 * Create a function that can be used to support a custom operator via
 	 * {@link CoreSubscriber} decoration. The function is compatible with
-	 * {@link Flux#transform(Function)}, {@link Mono#transform(Function)},
+	 * {@link Flux#composeNow(Function)}, {@link Mono#composeNow(Function)},
 	 * {@link Hooks#onEachOperator(Function)} and {@link Hooks#onLastOperator(Function)},
 	 * and works with the raw {@link Publisher} as input, which is useful if you need to
 	 * detect the precise type of the source (eg. instanceof checks to detect Mono, Flux,

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -316,6 +316,20 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	}
 
 	/**
+	 * Allows composing operators, in assembly time, on top of this {@link ParallelFlux}
+	 * and returns another {@link ParallelFlux} with composed features.
+	 *
+	 * @param <U> the output value type
+	 * @param composer the composer function from {@link ParallelFlux} (this) to another
+	 * ParallelFlux
+	 *
+	 * @return the {@link ParallelFlux} returned by the function
+	 */
+	public final <U> ParallelFlux<U> composeNow(Function<? super ParallelFlux<T>, ParallelFlux<U>> composer) {
+		return onAssembly(as(composer));
+	}
+
+	/**
 	 * Generates and concatenates Publishers on each 'rail', signalling errors immediately
 	 * and generating 2 publishers upfront.
 	 *
@@ -1107,9 +1121,11 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 * ParallelFlux
 	 *
 	 * @return the {@link ParallelFlux} returned by the function
+	 * @deprecated will be removed in 3.4.0, use {@link #composeNow(Function)} instead
 	 */
+	@Deprecated
 	public final <U> ParallelFlux<U> transform(Function<? super ParallelFlux<T>, ParallelFlux<U>> composer) {
-		return onAssembly(as(composer));
+		return composeNow(composer);
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/composeLaterForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/composeLaterForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 11 536.68 424.76" width="536.68" height="424.76" id="svg138">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 11 579.51 424.76" width="579.51" height="424.76" id="svg138">
  <defs id="defs25">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>
@@ -383,9 +383,14 @@
     <path d="M8 0L0-3v6z" id="path14-7-1-0" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10037" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
-   <g id="g10035">
-    <path d="M8 0L0-3v6z" id="path10033" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37805" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g37803">
+    <path d="M8 0L0-3v6z" id="path37801" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37811" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g37809">
+    <path d="M8 0L0-3v6z" id="path37807" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker-7-3" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
@@ -398,80 +403,40 @@
     <path d="M8 0L0-3v6z" id="path7-2" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10049" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g10047">
-    <path d="M8 0L0-3v6z" id="path10045" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37823" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g37821">
+    <path d="M8 0L0-3v6z" id="path37819" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10055" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
-   <g id="g10053">
-    <path d="M8 0L0-3v6z" id="path10051" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10061" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
-   <g id="g10059">
-    <path d="M12 0L0-4v9z" id="path10057" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10067" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g10065">
-    <path d="M8 0L0-3v6z" id="path10063" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10073" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g10071">
-    <path d="M8 0L0-3v6z" id="path10069" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10079" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
-   <g id="g10077">
-    <path d="M12 0L0-4v9z" id="path10075" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10085" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g10083">
-    <path d="M8 0L0-3v6z" id="path10081" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37829" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g37827">
+    <path d="M12 0L0-4v9z" id="path37825" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
   <marker orient="auto" refY="0" refX="0" id="Arrow2Lend-6-2" overflow="visible">
    <path id="path5247-9-1" d="M-11-4L1 0l-12 4c2-2 2-6 0-8z" fill="#000" fill-opacity="1" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linejoin="round" stroke-opacity="1"/>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10093" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
-   <g id="g10091">
-    <path d="M8 0L0-3v6z" id="path10089" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37837" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g37835">
+    <path d="M8 0L0-3v6z" id="path37833" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10099" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g10097">
-    <path d="M8 0L0-3v6z" id="path10095" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37843" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g37841">
+    <path d="M8 0L0-3v6z" id="path37839" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10105" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g10103">
-    <path d="M8 0L0-3v6z" id="path10101" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37849" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g37847">
+    <path d="M8 0L0-3v6z" id="path37845" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10111" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g10109">
-    <path d="M8 0L0-3v6z" id="path10107" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
+  <marker orient="auto" refY="0" refX="0" id="marker37853" overflow="visible">
+   <path id="path37851" d="M-11-4L1 0l-12 4c2-2 2-6 0-8z" fill="#000" fill-opacity="1" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linejoin="round" stroke-opacity="1"/>
   </marker>
-  <marker orient="auto" refY="0" refX="0" id="marker10115" overflow="visible">
-   <path id="path10113" d="M-11-4L1 0l-12 4c2-2 2-6 0-8z" fill="#000" fill-opacity="1" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linejoin="round" stroke-opacity="1"/>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10121" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
-   <g id="g10119">
-    <path d="M12 0L0-4v9z" id="path10117" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10127" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g10125">
-    <path d="M8 0L0-3v6z" id="path10123" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10133" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g10131">
-    <path d="M8 0L0-3v6z" id="path10129" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker-7-0" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g4-9-4">
+    <path d="M12 0L0-4v9z" id="path2-0-9" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-3-3" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
@@ -479,29 +444,50 @@
     <path d="M8 0L0-3v6z" id="path7-20" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker11224" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g11222">
-    <path d="M8 0L0-3v6z" id="path11220" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37865" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g37863">
+    <path d="M8 0L0-3v6z" id="path37861" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker11230" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g11228">
-    <path d="M8 0L0-3v6z" id="path11226" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37871" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g37869">
+    <path d="M8 0L0-3v6z" id="path37867" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker11236" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g11234">
-    <path d="M8 0L0-3v6z" id="path11232" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37877" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g37875">
+    <path d="M8 0L0-3v6z" id="path37873" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker-7-0" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
-   <g id="g4-9-4">
-    <path d="M12 0L0-4v9z" id="path2-0-9" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37883" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g37881">
+    <path d="M12 0L0-4v9z" id="path37879" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37889" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g37887">
+    <path d="M8 0L0-3v6z" id="path37885" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37895" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g37893">
+    <path d="M8 0L0-3v6z" id="path37891" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37901" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g37899">
+    <path d="M8 0L0-3v6z" id="path37897" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37907" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g37905">
+    <path d="M8 0L0-3v6z" id="path37903" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
  </defs>
+ <path d="M363.1 243.4v-31.56H53.85" id="path9964" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000008,6.00000021" stroke-opacity="1"/>
  <path id="path9958" d="M54.66 243.4V59.76" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000008,6.00000021" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-5-0)"/>
- <path d="M29.43 125.55h520.31l.94.73v67.25l-.94 1.46H29.43l-.94-1.46v-67.25z" id="path67-7" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M29.5 125.55h555l1 .73v67.25l-1 1.46h-555l-1-1.46v-67.25z" id="path67-7" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
  <path d="M54.66 402.72v-94.66" id="line1366-6" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999999,5.99999995" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-5-0)"/>
  <text id="text1370-6" transform="rotate(-90)" x="-398.66" y="33.66" font-size="12" fill="#45b8de" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
   <tspan id="tspan1368-2" y="46.66" x="-398.66" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de" stroke-width="1">subscribe()</tspan>
@@ -514,31 +500,31 @@
  <path d="M46.05 405.71h106.23" id="path51694" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker-7-3)"/>
  <circle cx="98.49" cy="404.25" id="circle51696" r="23" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
  <path d="M137.1 380.25l2 2v44l-2 2-2-2v-44z" id="path51698" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
- <text id="text71-8" x="-52.33" y="148.18" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan font-size="24" font-weight="700" x="101.67" y="170.18" id="tspan69-5" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">transform(</tspan>
+ <text id="text71-8" x="-24.93" y="148.18" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="24" font-weight="700" x="70.07" y="170.18" id="tspan69-5" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">composeLater(</tspan>
  </text>
- <path id="path4954-6-4" d="M271.67 163.18h39" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" marker-end="url(#Arrow2Lend-6-2)"/>
- <text y="148.18" x="79.67" id="text41792-5" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan41790-6" y="170.18" x="233.67" font-weight="400" font-size="19" style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">flux</tspan>
+ <path id="path4954-6-4" d="M289.07 163.18h39" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" marker-end="url(#Arrow2Lend-6-2)"/>
+ <text y="148.18" x="97.07" id="text41792-5" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan41790-6" y="170.18" x="251.07" font-weight="400" font-size="19" style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">flux</tspan>
  </text>
- <text id="text41806-6" x="165.67" y="148.18" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-size="19" font-weight="400" x="319.67" y="170.18" id="tspan41804-0" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">flux.<tspan id="tspan50012" font-weight="700">take </tspan> <tspan id="tspan53138" font-weight="400">(</tspan> </tspan>
+ <text id="text41806-6" x="183.07" y="148.18" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-size="19" font-weight="400" x="337.07" y="170.18" id="tspan41804-0" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">flux.<tspan id="tspan50012" font-weight="700">take </tspan> <tspan id="tspan53142" font-weight="400">(</tspan> </tspan>
  </text>
- <text y="148.18" x="301.67" id="text41816-3" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan41814-8" y="170.18" x="455.67" font-weight="400" font-size="19" style="-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="sans-serif" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">)</tspan>
+ <text y="148.18" x="319.07" id="text41816-3" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan41814-8" y="170.18" x="473.07" font-weight="400" font-size="19" style="-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="sans-serif" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">)</tspan>
  </text>
- <text y="148.18" x="313.67" id="text41820-0" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan41818-9" y="170.18" x="467.67" font-weight="700" font-size="24" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">)</tspan>
+ <text y="148.18" x="331.07" id="text41820-0" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan41818-9" y="170.18" x="485.07" font-weight="700" font-size="24" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">)</tspan>
  </text>
- <path d="M31.3 246.1h515.8v43H31.3z" id="path9261" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <text font-size="12" id="text9269" x="70.26" y="252.9" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan font-size="24" font-weight="700" x="224.26" y="274.9" id="tspan9267" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">take(</tspan>
+ <path d="M31.5 246.1h247.02v43H31.5z" id="path9261" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <text font-size="12" id="text9269" x="-63.94" y="252.9" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="24" font-weight="700" x="90.06" y="274.9" id="tspan9267" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">take(</tspan>
  </text>
- <text font-size="12" id="text9273" x="190.3" y="252.9" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan font-size="24" font-weight="700" x="344.3" y="274.9" id="tspan9271" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">)</tspan>
+ <text font-size="12" id="text9273" x="56.11" y="252.9" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="24" font-weight="700" x="210.11" y="274.9" id="tspan9271" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">)</tspan>
  </text>
- <text y="45.11" x="170.69" id="text41792-1" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan41790-5" y="67.11" x="324.69" font-weight="400" font-size="19" style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">external shared state</tspan>
+ <text y="45.11" x="199.22" id="text41792-1" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan41790-5" y="67.11" x="353.22" font-weight="400" font-size="19" style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">external shared state</tspan>
  </text>
  <path id="path9926" d="M362.45 402.72v-94.66" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999999,5.99999995" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-5-0)"/>
  <text font-size="12" y="341.45" x="-398.66" transform="rotate(-90)" id="text9930" fill="#45b8de" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
@@ -546,8 +532,8 @@
  </text>
  <path d="M447.4 291.44v71.32" id="path9934" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-5)"/>
  <path id="path9936" d="M408.08 291.16v71.6" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-5)"/>
- <path d="M303.42 195.97v37.23" id="path9944" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="4" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
- <path d="M303.23 203.63v39" id="path9946" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" marker-end="url(#Arrow2Lend-6-2)"/>
+ <path d="M162.26 195.97v37.23" id="path9944" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="4" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M162.26 218.9v23.73" id="path9946" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" marker-end="url(#Arrow2Lend-6-2)"/>
  <path id="line32-0" d="M26.01 40.35h240.41" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker-7-0)"/>
  <circle r="23" id="ellipse37-1" cy="40" cx="98.33" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
  <circle r="23" id="ellipse42-0" cy="40" cx="157.33" fill="#e6ba31" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
@@ -557,8 +543,16 @@
  <path id="line56-5" d="M157.33 64v42" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-3)"/>
  <path id="line59-5" d="M217.33 64v42" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-3)"/>
  <path id="line62-5" d="M252.33 64l-1 42" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-3)"/>
- <path d="M363.94 243.73v-31.57H54.7" id="path9964" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000008,6.00000021" stroke-opacity="1"/>
- <g id="g52425" transform="translate(159.27 -49.9)" stroke-linejoin="miter" stroke-opacity="1">
+ <path id="path47084" d="M346.47 246.1h247.04v43H346.47z" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <text y="252.9" x="251.05" id="text47088" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan47086" y="274.9" x="405.05" font-weight="700" font-size="24" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">take(</tspan>
+ </text>
+ <text y="252.9" x="371.09" id="text47092" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan47090" y="274.9" x="525.09" font-weight="700" font-size="24" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">)</tspan>
+ </text>
+ <path id="path47120" d="M469.99 195.97v37.23" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="4" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path47122" d="M469.99 218.9v23.73" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" marker-end="url(#Arrow2Lend-6-2)"/>
+ <g id="g52425" transform="translate(185.04 -49.88)" stroke-linejoin="miter" stroke-opacity="1">
   <path id="rect52407" opacity="1" fill="#fff" fill-opacity="1" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0" d="M352 81h38v35h-38z"/>
   <text transform="scale(1.00072 .99929)" xml:space="preserve" style="line-height:125%" x="353.62" y="109.8" id="text52413" font-style="normal" font-weight="400" font-size="36.67" font-family="sans-serif" letter-spacing="0" word-spacing="0" fill="#000" fill-opacity="1" stroke="none" stroke-width="1" stroke-linecap="butt">
    <tspan id="tspan52411" x="353.62" y="109.8" style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-weight="400" font-stretch="normal" font-size="36.67" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" stroke-width="1">v</tspan>
@@ -569,7 +563,7 @@
   </g>
   <path d="M378.81 107.1h4.38" id="path52423" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt"/>
  </g>
- <g transform="translate(61.79 64.28)" id="g52445" stroke-linejoin="miter" stroke-opacity="1">
+ <g transform="translate(79.5 65.66)" id="g52445" stroke-linejoin="miter" stroke-opacity="1">
   <path id="rect52427" opacity="1" fill="#fff" fill-opacity="1" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0" d="M352 81h38v35h-38z"/>
   <text id="text52433" y="109.8" x="353.62" style="line-height:125%" xml:space="preserve" transform="scale(1.00072 .99929)" font-style="normal" font-weight="400" font-size="36.67" font-family="sans-serif" letter-spacing="0" word-spacing="0" fill="#000" fill-opacity="1" stroke="none" stroke-width="1" stroke-linecap="butt">
    <tspan style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" y="109.8" x="353.62" id="tspan52431" font-style="normal" font-variant="normal" font-weight="400" font-stretch="normal" font-size="36.67" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" stroke-width="1">v</tspan>
@@ -581,7 +575,7 @@
   </g>
   <path id="path52443" d="M378.81 107.1h4.38" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt"/>
  </g>
- <g transform="translate(1621.09 -545.4) scale(3.77953)" id="g52955" stroke-linejoin="miter" stroke-opacity="1">
+ <g transform="translate(1487.03 -545.4) scale(3.77953)" id="g52955" stroke-linejoin="miter" stroke-opacity="1">
   <path id="rect52475" opacity="1" fill="#fff" fill-opacity="1" stroke="#000" stroke-width=".53" stroke-linecap="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0" d="M-350.72 210.21h10.05v9.26h-10.05z"/>
   <rect ry=".65" rx=".86" y="210.74" x="-350.19" height="8.2" width="5.82" id="rect52477" opacity="1" fill="#1574e1" fill-opacity="1" stroke="none" stroke-width="1.06" stroke-linecap="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0"/>
   <g id="g52531" transform="translate(-496.59 188.78) scale(.26458)" stroke="#000" fill="none" fill-rule="evenodd" stroke-width="1" stroke-linecap="butt">
@@ -591,6 +585,18 @@
   <path d="M-343.63 217.12h1.16" id="path52491" fill="none" fill-rule="evenodd" stroke="#000" stroke-width=".26" stroke-linecap="butt"/>
   <text id="text51128-8" y="217.49" x="-349.39" style="line-height:125%" xml:space="preserve" transform="scale(1.00072 .99929)" font-style="normal" font-weight="400" font-size="7.89" font-family="sans-serif" letter-spacing="0" word-spacing="0" fill="#fff" fill-opacity="1" stroke="none" stroke-width=".26" stroke-linecap="butt">
    <tspan style="-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" y="217.49" x="-349.39" id="tspan51126-4" font-style="normal" font-variant="normal" font-weight="400" font-stretch="normal" font-size="7.18" font-family="sans-serif" writing-mode="lr-tb" text-anchor="start" fill="#fff" fill-opacity="1" stroke-width=".26">1</tspan>
+  </text>
+ </g>
+ <g transform="translate(1801.7 -544.7) scale(3.77953)" id="g52955-2" stroke-linejoin="miter" stroke-opacity="1">
+  <path id="rect52475-5" opacity="1" fill="#fff" fill-opacity="1" stroke="#000" stroke-width=".53" stroke-linecap="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0" d="M-350.72 210.21h10.05v9.26h-10.05z"/>
+  <rect ry=".65" rx=".86" y="210.74" x="-350.19" height="8.2" width="5.82" id="rect52477-2" opacity="1" fill="#1574e1" fill-opacity="1" stroke="none" stroke-width="1.06" stroke-linecap="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0"/>
+  <g id="g52531-1" transform="translate(-496.59 188.78) scale(.26458)" stroke="#000" fill="none" fill-rule="evenodd" stroke-width="1" stroke-linecap="butt">
+   <path d="M580.3 86.7v7" id="path52485-7"/>
+   <path d="M576.3 90.2h8" id="path52487-2"/>
+  </g>
+  <path d="M-343.63 217.12h1.16" id="path52491-8" fill="none" fill-rule="evenodd" stroke="#000" stroke-width=".26" stroke-linecap="butt"/>
+  <text id="text51128-8-8" y="217.49" x="-349.39" style="line-height:125%" xml:space="preserve" transform="scale(1.00072 .99929)" font-style="normal" font-weight="400" font-size="7.89" font-family="sans-serif" letter-spacing="0" word-spacing="0" fill="#fff" fill-opacity="1" stroke="none" stroke-width=".26" stroke-linecap="butt">
+   <tspan style="-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" y="217.49" x="-349.39" id="tspan51126-4-9" font-style="normal" font-variant="normal" font-weight="400" font-stretch="normal" font-size="7.18" font-family="sans-serif" writing-mode="lr-tb" text-anchor="start" fill="#fff" fill-opacity="1" stroke-width=".26">2</tspan>
   </text>
  </g>
 </svg>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/composeLaterForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/composeLaterForMono.svg
@@ -567,7 +567,7 @@
  <path d="M158.95 289.1v71.6" id="path51700" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-4)"/>
  <circle r="23" id="circle51702" cy="404.7" cx="158.95" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
  <text id="text71-4" x="-56.78" y="148.63" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan font-size="24" font-weight="700" x="97.22" y="170.63" id="tspan69-7" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">compose(</tspan>
+  <tspan font-size="24" font-weight="700" x="37.22" y="170.63" id="tspan69-7" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">composeLater(</tspan>
  </text>
  <path id="path4954-6-1" d="M269.47 163.63h39" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" marker-end="url(#Arrow2Lend-6-6)"/>
  <text y="148.63" x="61.47" id="text41792-7" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/composeNowForFlux.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/composeNowForFlux.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 11 593.65 422.7" width="593.65" height="422.7" id="svg138">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 11 536.68 424.76" width="536.68" height="424.76" id="svg138">
  <defs id="defs25">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>
@@ -290,49 +290,9 @@
     <path d="M8 0L0-3v6z" id="path2769" fill="#45b8de" fill-opacity="1" stroke="#45b8de" stroke-width="1" stroke-opacity="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-8-2-9" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g9-0-1-5">
-    <path d="M8 0L0-3v6z" id="path7-5-8-0" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-8-5" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g9-0-13">
-    <path d="M8 0L0-3v6z" id="path7-5-5" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-8-2" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g9-0-1">
-    <path d="M8 0L0-3v6z" id="path7-5-8" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-8" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g9-0">
-    <path d="M8 0L0-3v6z" id="path7-5" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_4" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g21">
-    <path d="M8 0L0-3v6z" id="path19" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37516" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g37514">
-    <path d="M8 0L0-3v6z" id="path37512" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37522" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g37520">
-    <path d="M8 0L0-3v6z" id="path37518" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37528" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g37526">
-    <path d="M8 0L0-3v6z" id="path37524" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-7" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
-   <g id="g16">
-    <path d="M12 0L0-4v9z" id="path14" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker-7" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g4-9">
+    <path d="M12 0L0-4v9z" id="path2-0" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-3" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
@@ -340,119 +300,265 @@
     <path d="M8 0L0-3v6z" id="path7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37540" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g37538">
-    <path d="M8 0L0-3v6z" id="path37536" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46246" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g46244">
+    <path d="M8 0L0-3v6z" id="path46242" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37546" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g37544">
-    <path d="M8 0L0-3v6z" id="path37542" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46252" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g46250">
+    <path d="M8 0L0-3v6z" id="path46248" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37552" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g37550">
-    <path d="M8 0L0-3v6z" id="path37548" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker-7" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
-   <g id="g4-9">
-    <path d="M12 0L0-4v9z" id="path2-0" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46258" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g46256">
+    <path d="M8 0L0-3v6z" id="path46254" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
   <marker orient="auto" refY="0" refX="0" id="Arrow2Lend-6" overflow="visible">
    <path id="path5247-9" d="M-11-4L1 0l-12 4c2-2 2-6 0-8z" fill="#000" fill-opacity="1" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linejoin="round" stroke-opacity="1"/>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46266" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g46264">
+    <path d="M8 0L0-3v6z" id="path46262" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46272" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g46270">
+    <path d="M8 0L0-3v6z" id="path46268" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
   </marker>
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3-5" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
    <g id="g16-6-9">
     <path d="M8 0L0-3v6z" id="path14-7-1" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-3-7" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g9-3">
-    <path d="M8 0L0-3v6z" id="path7-8" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46281" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g46279">
+    <path d="M8 0L0-3v6z" id="path46277" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker50037" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g50035">
-    <path d="M8 0L0-3v6z" id="path50033" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46287" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g46285">
+    <path d="M12 0L0-4v9z" id="path46283" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker50043" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g50041">
-    <path d="M8 0L0-3v6z" id="path50039" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46293" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g46291">
+    <path d="M12 0L0-4v9z" id="path46289" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker-7-4" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
-   <g id="g4-9-5">
-    <path d="M12 0L0-4v9z" id="path2-0-2" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46299" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g46297">
+    <path d="M8 0L0-3v6z" id="path46295" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-3-0" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g9-2">
-    <path d="M8 0L0-3v6z" id="path7-0" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46305" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g46303">
+    <path d="M8 0L0-3v6z" id="path46301" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46311" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g46309">
+    <path d="M8 0L0-3v6z" id="path46307" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46317" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g46315">
+    <path d="M8 0L0-3v6z" id="path46313" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46323" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g46321">
+    <path d="M8 0L0-3v6z" id="path46319" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46329" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g46327">
+    <path d="M8 0L0-3v6z" id="path46325" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3-5-0" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g16-6-9-6">
+    <path d="M8 0L0-3v6z" id="path14-7-1-0" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10037" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g10035">
+    <path d="M8 0L0-3v6z" id="path10033" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker-7-3" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g4-9-1">
+    <path d="M12 0L0-4v9z" id="path2-0-4" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-3-5" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g9-7">
+    <path d="M8 0L0-3v6z" id="path7-2" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10049" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g10047">
+    <path d="M8 0L0-3v6z" id="path10045" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10055" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g10053">
+    <path d="M8 0L0-3v6z" id="path10051" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10061" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g10059">
+    <path d="M12 0L0-4v9z" id="path10057" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10067" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g10065">
+    <path d="M8 0L0-3v6z" id="path10063" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10073" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g10071">
+    <path d="M8 0L0-3v6z" id="path10069" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10079" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g10077">
+    <path d="M12 0L0-4v9z" id="path10075" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10085" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g10083">
+    <path d="M8 0L0-3v6z" id="path10081" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" refY="0" refX="0" id="Arrow2Lend-6-2" overflow="visible">
+   <path id="path5247-9-1" d="M-11-4L1 0l-12 4c2-2 2-6 0-8z" fill="#000" fill-opacity="1" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linejoin="round" stroke-opacity="1"/>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10093" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g10091">
+    <path d="M8 0L0-3v6z" id="path10089" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10099" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g10097">
+    <path d="M8 0L0-3v6z" id="path10095" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10105" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g10103">
+    <path d="M8 0L0-3v6z" id="path10101" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10111" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g10109">
+    <path d="M8 0L0-3v6z" id="path10107" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" refY="0" refX="0" id="marker10115" overflow="visible">
+   <path id="path10113" d="M-11-4L1 0l-12 4c2-2 2-6 0-8z" fill="#000" fill-opacity="1" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linejoin="round" stroke-opacity="1"/>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10121" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g10119">
+    <path d="M12 0L0-4v9z" id="path10117" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10127" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g10125">
+    <path d="M8 0L0-3v6z" id="path10123" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker10133" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g10131">
+    <path d="M8 0L0-3v6z" id="path10129" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-3-3" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g9-8">
+    <path d="M8 0L0-3v6z" id="path7-20" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker11224" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g11222">
+    <path d="M8 0L0-3v6z" id="path11220" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker11230" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g11228">
+    <path d="M8 0L0-3v6z" id="path11226" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker11236" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g11234">
+    <path d="M8 0L0-3v6z" id="path11232" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker-7-0" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g4-9-4">
+    <path d="M12 0L0-4v9z" id="path2-0-9" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
  </defs>
- <path id="path9958" d="M52.17 243.85V60.21" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000008,6.00000021" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-5)"/>
- <path id="line32" d="M35.84 41.16h138.54" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker-7)"/>
- <circle r="23" id="ellipse37" cy="40" cx="116" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <path id="path50" d="M156 16l2 2v44l-2 2-2-2V18z" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
- <path id="line53" d="M116 63v43" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3)"/>
- <path id="line62" d="M156.98 64l-1 42" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3)"/>
- <path d="M27 126h555l1 .73v67.25l-1 1.46H27l-1-1.46v-67.25z" id="path67" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <path d="M52.17 403.17v-94.66" id="line1366" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999999,5.99999995" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-5)"/>
- <text id="text1370" transform="rotate(-90)" x="-399.11" y="31.17" font-size="12" fill="#45b8de" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan1368" y="44.17" x="-399.11" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de" stroke-width="1">subscribe()</tspan>
+ <path id="path9958" d="M54.66 243.4V59.76" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000008,6.00000021" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-5-0)"/>
+ <path d="M29.43 125.55h520.31l.94.73v67.25l-.94 1.46H29.43l-.94-1.46v-67.25z" id="path67-7" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M54.66 402.72v-94.66" id="line1366-6" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999999,5.99999995" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-5-0)"/>
+ <text id="text1370-6" transform="rotate(-90)" x="-398.66" y="33.66" font-size="12" fill="#45b8de" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan1368-2" y="46.66" x="-398.66" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de" stroke-width="1">subscribe()</tspan>
  </text>
- <path id="path46206" d="M385.47 405.7h176" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker-7)"/>
- <circle r="23" id="circle46208" cy="404.7" cx="437.47" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <path id="path46212" d="M536.47 380.7l2 2v44l-2 2-2-2v-44z" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
- <circle cx="497.47" cy="404.7" id="circle50020" r="23" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <path id="path51690" d="M96 289.1v71.6" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3)"/>
- <path id="path51692" d="M196 289.38v71.32" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3)"/>
- <path d="M44 405.7h176" id="path51694" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker-7)"/>
- <circle cx="96" cy="404.7" id="circle51696" r="23" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <path d="M195 380.7l2 2v44l-2 2-2-2v-44z" id="path51698" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
- <path d="M156 289.1v71.6" id="path51700" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3)"/>
- <circle r="23" id="circle51702" cy="404.7" cx="156" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <text id="text71" x="-66.42" y="148.63" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan font-size="24" font-weight="700" x="87.58" y="170.63" id="tspan69" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">transform(</tspan>
+ <path id="path46206-4" d="M352.82 407.89h105.27" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker-7-3)"/>
+ <path id="path46212-9" d="M447.08 382.76l2 2v44l-2 2-2-2v-44z" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="408.08" cy="406.76" id="circle50020" r="23" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path51690" d="M98.5 288.64v71.6" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-5)"/>
+ <path id="path51692" d="M138.1 288.93v71.32" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-5)"/>
+ <path d="M46.05 405.71h106.23" id="path51694" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker-7-3)"/>
+ <circle cx="98.49" cy="404.25" id="circle51696" r="23" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M137.1 380.25l2 2v44l-2 2-2-2v-44z" id="path51698" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <text id="text71-8" x="-52.33" y="148.18" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="24" font-weight="700" x="60.67" y="170.18" id="tspan69-5" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">composeNow(</tspan>
  </text>
- <path id="path4954-6" d="M273.58 163.63h39" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" marker-end="url(#Arrow2Lend-6)"/>
- <text y="148.63" x="65.58" id="text41792" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan41790" y="170.63" x="219.58" font-weight="400" font-size="19" style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">mono</tspan>
+ <path id="path4954-6-4" d="M271.67 163.18h39" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" marker-end="url(#Arrow2Lend-6-2)"/>
+ <text y="148.18" x="79.67" id="text41792-5" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan41790-6" y="170.18" x="233.67" font-weight="400" font-size="19" style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">flux</tspan>
  </text>
- <text id="text41806" x="167.58" y="148.63" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-size="19" font-weight="400" x="321.58" y="170.63" id="tspan41804" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">mono.<tspan id="tspan50012" font-weight="700">repeat</tspan> (</tspan>
+ <text id="text41806-6" x="165.67" y="148.18" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-size="19" font-weight="400" x="319.67" y="170.18" id="tspan41804-0" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">flux.<tspan id="tspan50012" font-weight="700">take </tspan> <tspan id="tspan53138" font-weight="400">(</tspan> </tspan>
  </text>
- <text y="148.63" x="345.58" id="text41816" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan41814" y="170.63" x="499.58" font-weight="400" font-size="19" style="-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="sans-serif" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">)</tspan>
+ <text y="148.18" x="301.67" id="text41816-3" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan41814-8" y="170.18" x="455.67" font-weight="400" font-size="19" style="-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="sans-serif" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">)</tspan>
  </text>
- <text y="148.63" x="357.58" id="text41820" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan41818" y="170.63" x="511.58" font-weight="700" font-size="24" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">)</tspan>
+ <text y="148.18" x="313.67" id="text41820-0" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan41818-9" y="170.18" x="467.67" font-weight="700" font-size="24" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">)</tspan>
  </text>
- <path d="M29 246.55h550.18v43H29z" id="path9261" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <text font-size="12" id="text9269" x="74.48" y="252.55" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan font-size="24" font-weight="700" x="228.48" y="274.55" id="tspan9267" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">repeat(</tspan>
+ <path d="M31.3 246.1h515.8v43H31.3z" id="path9261" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <text font-size="12" id="text9269" x="70.26" y="252.9" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="24" font-weight="700" x="224.26" y="274.9" id="tspan9267" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">take(</tspan>
  </text>
- <text font-size="12" id="text9273" x="214.53" y="252.55" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan font-size="24" font-weight="700" x="368.53" y="274.55" id="tspan9271" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">)</tspan>
+ <text font-size="12" id="text9273" x="190.3" y="252.9" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="24" font-weight="700" x="344.3" y="274.9" id="tspan9271" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">)</tspan>
  </text>
- <text y="45.92" x="131.9" id="text41792-1" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan41790-5" y="67.92" x="285.9" font-weight="400" font-size="19" style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">external shared state</tspan>
+ <text y="45.11" x="170.69" id="text41792-1" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan41790-5" y="67.11" x="324.69" font-weight="400" font-size="19" style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">external shared state</tspan>
  </text>
- <path id="path9926" d="M392.97 403.17v-94.66" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999999,5.99999995" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-5)"/>
- <text font-size="12" y="371.97" x="-399.11" transform="rotate(-90)" id="text9930" fill="#45b8de" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan font-size="14" font-weight="400" x="-399.11" y="384.97" id="tspan9928" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de" stroke-width="1">subscribe()</tspan>
+ <path id="path9926" d="M362.45 402.72v-94.66" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999999,5.99999995" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-5-0)"/>
+ <text font-size="12" y="341.45" x="-398.66" transform="rotate(-90)" id="text9930" fill="#45b8de" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="14" font-weight="400" x="-398.66" y="354.45" id="tspan9928" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de" stroke-width="1">subscribe()</tspan>
  </text>
- <path d="M436.8 289.1v71.6" id="path9932" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3)"/>
- <path d="M536.8 289.38v71.32" id="path9934" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3)"/>
- <path id="path9936" d="M497.47 289.1v71.6" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3)"/>
- <path d="M392.18 244.7v-31.57H51.71" id="path9964" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000006,6.00000014" stroke-opacity="1"/>
- <path d="M300.93 196.43v37.22" id="path9944" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="4" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
- <path d="M300.74 204.08v39" id="path9946" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" marker-end="url(#Arrow2Lend-6)"/>
- <g id="g52425" transform="translate(116.72 -47.4)" stroke-linejoin="miter" stroke-opacity="1">
+ <path d="M447.4 291.44v71.32" id="path9934" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-5)"/>
+ <path id="path9936" d="M408.08 291.16v71.6" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-5)"/>
+ <path d="M303.42 195.97v37.23" id="path9944" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="4" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M303.23 203.63v39" id="path9946" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" marker-end="url(#Arrow2Lend-6-2)"/>
+ <path id="line32-0" d="M26.01 40.35h240.41" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker-7-0)"/>
+ <circle r="23" id="ellipse37-1" cy="40" cx="98.33" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="23" id="ellipse42-0" cy="40" cx="157.33" fill="#e6ba31" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="23" id="ellipse47-5" cy="40" cx="217.33" fill="#45b8de" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path50-2" d="M251.33 16l2 2v44l-2 2-2-2V18z" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line53-9" d="M98.33 63v43" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-3)"/>
+ <path id="line56-5" d="M157.33 64v42" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-3)"/>
+ <path id="line59-5" d="M217.33 64v42" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-3)"/>
+ <path id="line62-5" d="M252.33 64l-1 42" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-3)"/>
+ <path d="M363.94 243.73v-31.57H54.7" id="path9964" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000008,6.00000021" stroke-opacity="1"/>
+ <g id="g52425" transform="translate(159.27 -49.9)" stroke-linejoin="miter" stroke-opacity="1">
   <path id="rect52407" opacity="1" fill="#fff" fill-opacity="1" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0" d="M352 81h38v35h-38z"/>
   <text transform="scale(1.00072 .99929)" xml:space="preserve" style="line-height:125%" x="353.62" y="109.8" id="text52413" font-style="normal" font-weight="400" font-size="36.67" font-family="sans-serif" letter-spacing="0" word-spacing="0" fill="#000" fill-opacity="1" stroke="none" stroke-width="1" stroke-linecap="butt">
    <tspan id="tspan52411" x="353.62" y="109.8" style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-weight="400" font-stretch="normal" font-size="36.67" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" stroke-width="1">v</tspan>
@@ -463,7 +569,7 @@
   </g>
   <path d="M378.81 107.1h4.38" id="path52423" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt"/>
  </g>
- <g transform="translate(102.01 64.75)" id="g52445" stroke-linejoin="miter" stroke-opacity="1">
+ <g transform="translate(61.79 64.28)" id="g52445" stroke-linejoin="miter" stroke-opacity="1">
   <path id="rect52427" opacity="1" fill="#fff" fill-opacity="1" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0" d="M352 81h38v35h-38z"/>
   <text id="text52433" y="109.8" x="353.62" style="line-height:125%" xml:space="preserve" transform="scale(1.00072 .99929)" font-style="normal" font-weight="400" font-size="36.67" font-family="sans-serif" letter-spacing="0" word-spacing="0" fill="#000" fill-opacity="1" stroke="none" stroke-width="1" stroke-linecap="butt">
    <tspan style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" y="109.8" x="353.62" id="tspan52431" font-style="normal" font-variant="normal" font-weight="400" font-stretch="normal" font-size="36.67" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" stroke-width="1">v</tspan>
@@ -475,7 +581,7 @@
   </g>
   <path id="path52443" d="M378.81 107.1h4.38" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt"/>
  </g>
- <g transform="translate(1648.79 -544.16) scale(3.77953)" id="g52955" stroke-linejoin="miter" stroke-opacity="1">
+ <g transform="translate(1621.09 -545.4) scale(3.77953)" id="g52955" stroke-linejoin="miter" stroke-opacity="1">
   <path id="rect52475" opacity="1" fill="#fff" fill-opacity="1" stroke="#000" stroke-width=".53" stroke-linecap="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0" d="M-350.72 210.21h10.05v9.26h-10.05z"/>
   <rect ry=".65" rx=".86" y="210.74" x="-350.19" height="8.2" width="5.82" id="rect52477" opacity="1" fill="#1574e1" fill-opacity="1" stroke="none" stroke-width="1.06" stroke-linecap="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0"/>
   <g id="g52531" transform="translate(-496.59 188.78) scale(.26458)" stroke="#000" fill="none" fill-rule="evenodd" stroke-width="1" stroke-linecap="butt">

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/composeNowForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/composeNowForMono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 11 579.51 424.76" width="579.51" height="424.76" id="svg138">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 11 593.65 422.7" width="593.65" height="422.7" id="svg138">
  <defs id="defs25">
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>
@@ -290,9 +290,49 @@
     <path d="M8 0L0-3v6z" id="path2769" fill="#45b8de" fill-opacity="1" stroke="#45b8de" stroke-width="1" stroke-opacity="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker-7" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
-   <g id="g4-9">
-    <path d="M12 0L0-4v9z" id="path2-0" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-8-2-9" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g9-0-1-5">
+    <path d="M8 0L0-3v6z" id="path7-5-8-0" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-8-5" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g9-0-13">
+    <path d="M8 0L0-3v6z" id="path7-5-5" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-8-2" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g9-0-1">
+    <path d="M8 0L0-3v6z" id="path7-5-8" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-8" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g9-0">
+    <path d="M8 0L0-3v6z" id="path7-5" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_4" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g21">
+    <path d="M8 0L0-3v6z" id="path19" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37516" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g37514">
+    <path d="M8 0L0-3v6z" id="path37512" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37522" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g37520">
+    <path d="M8 0L0-3v6z" id="path37518" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37528" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g37526">
+    <path d="M8 0L0-3v6z" id="path37524" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-7" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g16">
+    <path d="M12 0L0-4v9z" id="path14" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-3" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
@@ -300,259 +340,119 @@
     <path d="M8 0L0-3v6z" id="path7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46246" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g46244">
-    <path d="M8 0L0-3v6z" id="path46242" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37540" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g37538">
+    <path d="M8 0L0-3v6z" id="path37536" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46252" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g46250">
-    <path d="M8 0L0-3v6z" id="path46248" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37546" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g37544">
+    <path d="M8 0L0-3v6z" id="path37542" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46258" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g46256">
-    <path d="M8 0L0-3v6z" id="path46254" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37552" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g37550">
+    <path d="M8 0L0-3v6z" id="path37548" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker-7" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g4-9">
+    <path d="M12 0L0-4v9z" id="path2-0" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
   <marker orient="auto" refY="0" refX="0" id="Arrow2Lend-6" overflow="visible">
    <path id="path5247-9" d="M-11-4L1 0l-12 4c2-2 2-6 0-8z" fill="#000" fill-opacity="1" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linejoin="round" stroke-opacity="1"/>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46266" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g46264">
-    <path d="M8 0L0-3v6z" id="path46262" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46272" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g46270">
-    <path d="M8 0L0-3v6z" id="path46268" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
   </marker>
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3-5" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
    <g id="g16-6-9">
     <path d="M8 0L0-3v6z" id="path14-7-1" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46281" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
-   <g id="g46279">
-    <path d="M8 0L0-3v6z" id="path46277" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-3-7" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g9-3">
+    <path d="M8 0L0-3v6z" id="path7-8" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46287" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
-   <g id="g46285">
-    <path d="M12 0L0-4v9z" id="path46283" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker50037" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g50035">
+    <path d="M8 0L0-3v6z" id="path50033" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46293" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
-   <g id="g46291">
-    <path d="M12 0L0-4v9z" id="path46289" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker50043" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g50041">
+    <path d="M8 0L0-3v6z" id="path50039" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46299" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g46297">
-    <path d="M8 0L0-3v6z" id="path46295" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker-7-4" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g4-9-5">
+    <path d="M12 0L0-4v9z" id="path2-0-2" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46305" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g46303">
-    <path d="M8 0L0-3v6z" id="path46301" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46311" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g46309">
-    <path d="M8 0L0-3v6z" id="path46307" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46317" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g46315">
-    <path d="M8 0L0-3v6z" id="path46313" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46323" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g46321">
-    <path d="M8 0L0-3v6z" id="path46319" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker46329" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g46327">
-    <path d="M8 0L0-3v6z" id="path46325" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3-5-0" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
-   <g id="g16-6-9-6">
-    <path d="M8 0L0-3v6z" id="path14-7-1-0" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37805" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
-   <g id="g37803">
-    <path d="M8 0L0-3v6z" id="path37801" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37811" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
-   <g id="g37809">
-    <path d="M8 0L0-3v6z" id="path37807" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker-7-3" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
-   <g id="g4-9-1">
-    <path d="M12 0L0-4v9z" id="path2-0-4" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-3-5" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g9-7">
-    <path d="M8 0L0-3v6z" id="path7-2" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37823" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g37821">
-    <path d="M8 0L0-3v6z" id="path37819" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37829" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
-   <g id="g37827">
-    <path d="M12 0L0-4v9z" id="path37825" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" refY="0" refX="0" id="Arrow2Lend-6-2" overflow="visible">
-   <path id="path5247-9-1" d="M-11-4L1 0l-12 4c2-2 2-6 0-8z" fill="#000" fill-opacity="1" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linejoin="round" stroke-opacity="1"/>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37837" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
-   <g id="g37835">
-    <path d="M8 0L0-3v6z" id="path37833" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37843" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g37841">
-    <path d="M8 0L0-3v6z" id="path37839" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37849" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g37847">
-    <path d="M8 0L0-3v6z" id="path37845" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" refY="0" refX="0" id="marker37853" overflow="visible">
-   <path id="path37851" d="M-11-4L1 0l-12 4c2-2 2-6 0-8z" fill="#000" fill-opacity="1" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linejoin="round" stroke-opacity="1"/>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker-7-0" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
-   <g id="g4-9-4">
-    <path d="M12 0L0-4v9z" id="path2-0-9" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-3-3" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g9-8">
-    <path d="M8 0L0-3v6z" id="path7-20" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37865" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g37863">
-    <path d="M8 0L0-3v6z" id="path37861" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37871" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g37869">
-    <path d="M8 0L0-3v6z" id="path37867" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37877" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g37875">
-    <path d="M8 0L0-3v6z" id="path37873" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37883" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
-   <g id="g37881">
-    <path d="M12 0L0-4v9z" id="path37879" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37889" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g37887">
-    <path d="M8 0L0-3v6z" id="path37885" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37895" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g37893">
-    <path d="M8 0L0-3v6z" id="path37891" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37901" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g37899">
-    <path d="M8 0L0-3v6z" id="path37897" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker37907" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
-   <g id="g37905">
-    <path d="M8 0L0-3v6z" id="path37903" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-3-0" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g9-2">
+    <path d="M8 0L0-3v6z" id="path7-0" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
  </defs>
- <path d="M363.1 243.4v-31.56H53.85" id="path9964" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000008,6.00000021" stroke-opacity="1"/>
- <path id="path9958" d="M54.66 243.4V59.76" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000008,6.00000021" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-5-0)"/>
- <path d="M29.5 125.55h555l1 .73v67.25l-1 1.46h-555l-1-1.46v-67.25z" id="path67-7" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <path d="M54.66 402.72v-94.66" id="line1366-6" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999999,5.99999995" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-5-0)"/>
- <text id="text1370-6" transform="rotate(-90)" x="-398.66" y="33.66" font-size="12" fill="#45b8de" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan1368-2" y="46.66" x="-398.66" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de" stroke-width="1">subscribe()</tspan>
+ <path id="path9958" d="M52.17 243.85V60.21" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000008,6.00000021" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-5)"/>
+ <path id="line32" d="M35.84 41.16h138.54" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker-7)"/>
+ <circle r="23" id="ellipse37" cy="40" cx="116" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path50" d="M156 16l2 2v44l-2 2-2-2V18z" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line53" d="M116 63v43" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3)"/>
+ <path id="line62" d="M156.98 64l-1 42" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3)"/>
+ <path d="M27 126h555l1 .73v67.25l-1 1.46H27l-1-1.46v-67.25z" id="path67" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M52.17 403.17v-94.66" id="line1366" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999999,5.99999995" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-5)"/>
+ <text id="text1370" transform="rotate(-90)" x="-399.11" y="31.17" font-size="12" fill="#45b8de" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan1368" y="44.17" x="-399.11" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de" stroke-width="1">subscribe()</tspan>
  </text>
- <path id="path46206-4" d="M352.82 407.89h105.27" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker-7-3)"/>
- <path id="path46212-9" d="M447.08 382.76l2 2v44l-2 2-2-2v-44z" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
- <circle cx="408.08" cy="406.76" id="circle50020" r="23" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <path id="path51690" d="M98.5 288.64v71.6" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-5)"/>
- <path id="path51692" d="M138.1 288.93v71.32" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-5)"/>
- <path d="M46.05 405.71h106.23" id="path51694" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker-7-3)"/>
- <circle cx="98.49" cy="404.25" id="circle51696" r="23" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <path d="M137.1 380.25l2 2v44l-2 2-2-2v-44z" id="path51698" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
- <text id="text71-8" x="-24.93" y="148.18" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan font-size="24" font-weight="700" x="129.07" y="170.18" id="tspan69-5" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">compose(</tspan>
+ <path id="path46206" d="M385.47 405.7h176" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker-7)"/>
+ <circle r="23" id="circle46208" cy="404.7" cx="437.47" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path46212" d="M536.47 380.7l2 2v44l-2 2-2-2v-44z" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="497.47" cy="404.7" id="circle50020" r="23" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path51690" d="M96 289.1v71.6" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3)"/>
+ <path id="path51692" d="M196 289.38v71.32" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3)"/>
+ <path d="M44 405.7h176" id="path51694" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker-7)"/>
+ <circle cx="96" cy="404.7" id="circle51696" r="23" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M195 380.7l2 2v44l-2 2-2-2v-44z" id="path51698" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M156 289.1v71.6" id="path51700" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3)"/>
+ <circle r="23" id="circle51702" cy="404.7" cx="156" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <text id="text71" x="-66.42" y="148.63" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="24" font-weight="700" x="40.58" y="170.63" id="tspan69" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">composeNow(</tspan>
  </text>
- <path id="path4954-6-4" d="M289.07 163.18h39" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" marker-end="url(#Arrow2Lend-6-2)"/>
- <text y="148.18" x="97.07" id="text41792-5" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan41790-6" y="170.18" x="251.07" font-weight="400" font-size="19" style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">flux</tspan>
+ <path id="path4954-6" d="M273.58 163.63h39" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" marker-end="url(#Arrow2Lend-6)"/>
+ <text y="148.63" x="65.58" id="text41792" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan41790" y="170.63" x="219.58" font-weight="400" font-size="19" style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">mono</tspan>
  </text>
- <text id="text41806-6" x="183.07" y="148.18" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-size="19" font-weight="400" x="337.07" y="170.18" id="tspan41804-0" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">flux.<tspan id="tspan50012" font-weight="700">take </tspan> <tspan id="tspan53142" font-weight="400">(</tspan> </tspan>
+ <text id="text41806" x="167.58" y="148.63" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-size="19" font-weight="400" x="321.58" y="170.63" id="tspan41804" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">mono.<tspan id="tspan50012" font-weight="700">repeat</tspan> (</tspan>
  </text>
- <text y="148.18" x="319.07" id="text41816-3" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan41814-8" y="170.18" x="473.07" font-weight="400" font-size="19" style="-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="sans-serif" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">)</tspan>
+ <text y="148.63" x="345.58" id="text41816" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan41814" y="170.63" x="499.58" font-weight="400" font-size="19" style="-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="sans-serif" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">)</tspan>
  </text>
- <text y="148.18" x="331.07" id="text41820-0" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan41818-9" y="170.18" x="485.07" font-weight="700" font-size="24" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">)</tspan>
+ <text y="148.63" x="357.58" id="text41820" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan41818" y="170.63" x="511.58" font-weight="700" font-size="24" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">)</tspan>
  </text>
- <path d="M31.5 246.1h247.02v43H31.5z" id="path9261" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <text font-size="12" id="text9269" x="-63.94" y="252.9" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan font-size="24" font-weight="700" x="90.06" y="274.9" id="tspan9267" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">take(</tspan>
+ <path d="M29 246.55h550.18v43H29z" id="path9261" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <text font-size="12" id="text9269" x="74.48" y="252.55" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="24" font-weight="700" x="228.48" y="274.55" id="tspan9267" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">repeat(</tspan>
  </text>
- <text font-size="12" id="text9273" x="56.11" y="252.9" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan font-size="24" font-weight="700" x="210.11" y="274.9" id="tspan9271" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">)</tspan>
+ <text font-size="12" id="text9273" x="214.53" y="252.55" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="24" font-weight="700" x="368.53" y="274.55" id="tspan9271" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">)</tspan>
  </text>
- <text y="45.11" x="199.22" id="text41792-1" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan41790-5" y="67.11" x="353.22" font-weight="400" font-size="19" style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">external shared state</tspan>
+ <text y="45.92" x="131.9" id="text41792-1" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan41790-5" y="67.92" x="285.9" font-weight="400" font-size="19" style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-stretch="normal" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" fill="#34302c" stroke-width="1">external shared state</tspan>
  </text>
- <path id="path9926" d="M362.45 402.72v-94.66" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999999,5.99999995" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-5-0)"/>
- <text font-size="12" y="341.45" x="-398.66" transform="rotate(-90)" id="text9930" fill="#45b8de" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan font-size="14" font-weight="400" x="-398.66" y="354.45" id="tspan9928" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de" stroke-width="1">subscribe()</tspan>
+ <path id="path9926" d="M392.97 403.17v-94.66" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999999,5.99999995" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-5)"/>
+ <text font-size="12" y="371.97" x="-399.11" transform="rotate(-90)" id="text9930" fill="#45b8de" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="14" font-weight="400" x="-399.11" y="384.97" id="tspan9928" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de" stroke-width="1">subscribe()</tspan>
  </text>
- <path d="M447.4 291.44v71.32" id="path9934" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-5)"/>
- <path id="path9936" d="M408.08 291.16v71.6" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-5)"/>
- <path d="M162.26 195.97v37.23" id="path9944" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="4" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
- <path d="M162.26 218.9v23.73" id="path9946" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" marker-end="url(#Arrow2Lend-6-2)"/>
- <path id="line32-0" d="M26.01 40.35h240.41" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker-7-0)"/>
- <circle r="23" id="ellipse37-1" cy="40" cx="98.33" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <circle r="23" id="ellipse42-0" cy="40" cx="157.33" fill="#e6ba31" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <circle r="23" id="ellipse47-5" cy="40" cx="217.33" fill="#45b8de" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <path id="path50-2" d="M251.33 16l2 2v44l-2 2-2-2V18z" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1"/>
- <path id="line53-9" d="M98.33 63v43" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-3)"/>
- <path id="line56-5" d="M157.33 64v42" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-3)"/>
- <path id="line59-5" d="M217.33 64v42" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-3)"/>
- <path id="line62-5" d="M252.33 64l-1 42" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3-3)"/>
- <path id="path47084" d="M346.47 246.1h247.04v43H346.47z" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <text y="252.9" x="251.05" id="text47088" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan47086" y="274.9" x="405.05" font-weight="700" font-size="24" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">take(</tspan>
- </text>
- <text y="252.9" x="371.09" id="text47092" font-size="12" fill="#34302c" fill-opacity="1" stroke="none" stroke-width="1" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan47090" y="274.9" x="525.09" font-weight="700" font-size="24" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c" stroke-width="1">)</tspan>
- </text>
- <path id="path47120" d="M469.99 195.97v37.23" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="4" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
- <path id="path47122" d="M469.99 218.9v23.73" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" marker-end="url(#Arrow2Lend-6-2)"/>
- <g id="g52425" transform="translate(185.04 -49.88)" stroke-linejoin="miter" stroke-opacity="1">
+ <path d="M436.8 289.1v71.6" id="path9932" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3)"/>
+ <path d="M536.8 289.38v71.32" id="path9934" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3)"/>
+ <path id="path9936" d="M497.47 289.1v71.6" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000003,6.00000007" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2-3)"/>
+ <path d="M392.18 244.7v-31.57H51.71" id="path9964" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000006,6.00000014" stroke-opacity="1"/>
+ <path d="M300.93 196.43v37.22" id="path9944" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="4" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M300.74 204.08v39" id="path9946" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" marker-end="url(#Arrow2Lend-6)"/>
+ <g id="g52425" transform="translate(116.72 -47.4)" stroke-linejoin="miter" stroke-opacity="1">
   <path id="rect52407" opacity="1" fill="#fff" fill-opacity="1" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0" d="M352 81h38v35h-38z"/>
   <text transform="scale(1.00072 .99929)" xml:space="preserve" style="line-height:125%" x="353.62" y="109.8" id="text52413" font-style="normal" font-weight="400" font-size="36.67" font-family="sans-serif" letter-spacing="0" word-spacing="0" fill="#000" fill-opacity="1" stroke="none" stroke-width="1" stroke-linecap="butt">
    <tspan id="tspan52411" x="353.62" y="109.8" style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" font-style="normal" font-variant="normal" font-weight="400" font-stretch="normal" font-size="36.67" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" stroke-width="1">v</tspan>
@@ -563,7 +463,7 @@
   </g>
   <path d="M378.81 107.1h4.38" id="path52423" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt"/>
  </g>
- <g transform="translate(79.5 65.66)" id="g52445" stroke-linejoin="miter" stroke-opacity="1">
+ <g transform="translate(102.01 64.75)" id="g52445" stroke-linejoin="miter" stroke-opacity="1">
   <path id="rect52427" opacity="1" fill="#fff" fill-opacity="1" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0" d="M352 81h38v35h-38z"/>
   <text id="text52433" y="109.8" x="353.62" style="line-height:125%" xml:space="preserve" transform="scale(1.00072 .99929)" font-style="normal" font-weight="400" font-size="36.67" font-family="sans-serif" letter-spacing="0" word-spacing="0" fill="#000" fill-opacity="1" stroke="none" stroke-width="1" stroke-linecap="butt">
    <tspan style="-inkscape-font-specification:'Tahoma, Nimbus Sans L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" y="109.8" x="353.62" id="tspan52431" font-style="normal" font-variant="normal" font-weight="400" font-stretch="normal" font-size="36.67" font-family="Tahoma,'Nimbus Sans L'" writing-mode="lr-tb" text-anchor="start" stroke-width="1">v</tspan>
@@ -575,7 +475,7 @@
   </g>
   <path id="path52443" d="M378.81 107.1h4.38" fill="none" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linecap="butt"/>
  </g>
- <g transform="translate(1487.03 -545.4) scale(3.77953)" id="g52955" stroke-linejoin="miter" stroke-opacity="1">
+ <g transform="translate(1648.79 -544.16) scale(3.77953)" id="g52955" stroke-linejoin="miter" stroke-opacity="1">
   <path id="rect52475" opacity="1" fill="#fff" fill-opacity="1" stroke="#000" stroke-width=".53" stroke-linecap="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0" d="M-350.72 210.21h10.05v9.26h-10.05z"/>
   <rect ry=".65" rx=".86" y="210.74" x="-350.19" height="8.2" width="5.82" id="rect52477" opacity="1" fill="#1574e1" fill-opacity="1" stroke="none" stroke-width="1.06" stroke-linecap="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0"/>
   <g id="g52531" transform="translate(-496.59 188.78) scale(.26458)" stroke="#000" fill="none" fill-rule="evenodd" stroke-width="1" stroke-linecap="butt">
@@ -585,18 +485,6 @@
   <path d="M-343.63 217.12h1.16" id="path52491" fill="none" fill-rule="evenodd" stroke="#000" stroke-width=".26" stroke-linecap="butt"/>
   <text id="text51128-8" y="217.49" x="-349.39" style="line-height:125%" xml:space="preserve" transform="scale(1.00072 .99929)" font-style="normal" font-weight="400" font-size="7.89" font-family="sans-serif" letter-spacing="0" word-spacing="0" fill="#fff" fill-opacity="1" stroke="none" stroke-width=".26" stroke-linecap="butt">
    <tspan style="-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" y="217.49" x="-349.39" id="tspan51126-4" font-style="normal" font-variant="normal" font-weight="400" font-stretch="normal" font-size="7.18" font-family="sans-serif" writing-mode="lr-tb" text-anchor="start" fill="#fff" fill-opacity="1" stroke-width=".26">1</tspan>
-  </text>
- </g>
- <g transform="translate(1801.7 -544.7) scale(3.77953)" id="g52955-2" stroke-linejoin="miter" stroke-opacity="1">
-  <path id="rect52475-5" opacity="1" fill="#fff" fill-opacity="1" stroke="#000" stroke-width=".53" stroke-linecap="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0" d="M-350.72 210.21h10.05v9.26h-10.05z"/>
-  <rect ry=".65" rx=".86" y="210.74" x="-350.19" height="8.2" width="5.82" id="rect52477-2" opacity="1" fill="#1574e1" fill-opacity="1" stroke="none" stroke-width="1.06" stroke-linecap="round" stroke-miterlimit="4" stroke-dasharray="none" stroke-dashoffset="0"/>
-  <g id="g52531-1" transform="translate(-496.59 188.78) scale(.26458)" stroke="#000" fill="none" fill-rule="evenodd" stroke-width="1" stroke-linecap="butt">
-   <path d="M580.3 86.7v7" id="path52485-7"/>
-   <path d="M576.3 90.2h8" id="path52487-2"/>
-  </g>
-  <path d="M-343.63 217.12h1.16" id="path52491-8" fill="none" fill-rule="evenodd" stroke="#000" stroke-width=".26" stroke-linecap="butt"/>
-  <text id="text51128-8-8" y="217.49" x="-349.39" style="line-height:125%" xml:space="preserve" transform="scale(1.00072 .99929)" font-style="normal" font-weight="400" font-size="7.89" font-family="sans-serif" letter-spacing="0" word-spacing="0" fill="#fff" fill-opacity="1" stroke="none" stroke-width=".26" stroke-linecap="butt">
-   <tspan style="-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" y="217.49" x="-349.39" id="tspan51126-4-9" font-style="normal" font-variant="normal" font-weight="400" font-stretch="normal" font-size="7.18" font-family="sans-serif" writing-mode="lr-tb" text-anchor="start" fill="#fff" fill-opacity="1" stroke-width=".26">2</tspan>
   </text>
  </g>
 </svg>

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
@@ -205,7 +205,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
 	public void pairWise() {
 		AssertSubscriber<Tuple2<Integer, Integer>> ts = AssertSubscriber.create();
 
-		range(1, 9).transform(o -> zip(o, o.skip(1)))
+		range(1, 9).composeNow(o -> zip(o, o.skip(1)))
 		           .subscribe(ts);
 
 		ts.assertValues(Tuples.of(1, 2),

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
@@ -674,7 +674,7 @@ public class FluxSwitchOnFirstTest {
     @Test
     public void shouldPropagateErrorCorrectly() {
         Flux<String> switchTransformed = Flux.error(new RuntimeException("hello"))
-                                             .transform(flux -> new FluxSwitchOnFirst<>(
+                                             .composeNow(flux -> new FluxSwitchOnFirst<>(
                                                      flux,
                                                      (first, innerFlux) -> innerFlux.map(
                                                              String::valueOf)));

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSourceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSourceTest.java
@@ -248,8 +248,8 @@ public class MonoSourceTest {
 	}
 
 	@Test
-	public void transform() {
-		StepVerifier.create(Mono.just(1).transform(m -> Flux.just(1, 2, 3)))
+	public void composeNow() {
+		StepVerifier.create(Mono.just(1).composeNow(m -> Flux.just(1, 2, 3)))
 	                .expectNext(1)
 	                .verifyComplete();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
@@ -651,7 +651,7 @@ public class ParallelFluxTest {
 	@Test
 	public void transformChangesPrefetch() {
 		assertThat(ParallelFlux.from(Flux.range(1, 10), 3, 12, Queues.small())
-		                       .transform(pf -> pf.runOn(Schedulers.parallel(), 3)
+		                       .composeNow(pf -> pf.runOn(Schedulers.parallel(), 3)
 		                                          .log()
 		                                          .hide())
 		                       .getPrefetch())

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -894,7 +894,7 @@ public class FluxTests extends AbstractReactorTest {
 			final String source = "ASYNC_TEST " + i;
 
 			Flux.just(source)
-			    .transform(operationStream -> operationStream.publishOn(asyncGroup)
+			    .composeNow(operationStream -> operationStream.publishOn(asyncGroup)
 			                                          .delayElements(Duration.ofMillis(100))
 			                                          .map(s -> s + " MODIFIED")
 			                                          .map(s -> {

--- a/reactor-core/src/test/java/reactor/core/publisher/tck/AbstractFluxVerification.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/tck/AbstractFluxVerification.java
@@ -48,7 +48,7 @@ public abstract class AbstractFluxVerification
 			return Flux.range(1, (int) elements)
 			           .filter(integer -> true)
 			           .map(integer -> integer)
-			           .transform(this::transformFlux);
+			           .composeNow(this::transformFlux);
 		}
 		else {
 			final Random random = new Random();
@@ -56,14 +56,14 @@ public abstract class AbstractFluxVerification
 			return Mono.fromCallable(random::nextInt)
 			           .repeat()
 			           .map(Math::abs)
-			           .transform(this::transformFlux);
+			           .composeNow(this::transformFlux);
 		}
 	}
 
 	@Override
 	public Publisher<Integer> createFailedPublisher() {
 		return Flux.<Integer>error(new Exception("oops"))
-				.transform(this::transformFlux);
+				.composeNow(this::transformFlux);
 	}
 
 	protected void monitorThreadUse(Object val) {

--- a/reactor-core/src/test/java/reactor/guide/GuideDebuggingExtraTests.java
+++ b/reactor-core/src/test/java/reactor/guide/GuideDebuggingExtraTests.java
@@ -37,8 +37,8 @@ public class GuideDebuggingExtraTests {
 		try {
 			StringWriter sw = new StringWriter();
 			FakeRepository.findAllUserByName(Flux.just("pedro", "simon", "stephane"))
-			              .transform(FakeUtils1.applyFilters)
-			              .transform(FakeUtils2.enrichUser)
+			              .composeNow(FakeUtils1.applyFilters)
+			              .composeNow(FakeUtils2.enrichUser)
 			              .subscribe(System.out::println,
 					              t -> t.printStackTrace(new PrintWriter(sw))
 			              );
@@ -47,12 +47,12 @@ public class GuideDebuggingExtraTests {
 
 			assertThat(debugStack.substring(0, debugStack.indexOf("Stack trace:")))
 					.endsWith("Error has been observed at the following site(s):\n"
-							+ "\t|_       Flux.map ⇢ at reactor.guide.FakeRepository.findAllUserByName(FakeRepository.java:27)\n"
-							+ "\t|_       Flux.map ⇢ at reactor.guide.FakeRepository.findAllUserByName(FakeRepository.java:28)\n"
-							+ "\t|_    Flux.filter ⇢ at reactor.guide.FakeUtils1.lambda$static$1(FakeUtils1.java:29)\n"
-							+ "\t|_ Flux.transform ⇢ at reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:40)\n"
-							+ "\t|_   Flux.elapsed ⇢ at reactor.guide.FakeUtils2.lambda$static$0(FakeUtils2.java:30)\n"
-							+ "\t|_ Flux.transform ⇢ at reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:41)\n");
+							+ "\t|_        Flux.map ⇢ at reactor.guide.FakeRepository.findAllUserByName(FakeRepository.java:27)\n"
+							+ "\t|_        Flux.map ⇢ at reactor.guide.FakeRepository.findAllUserByName(FakeRepository.java:28)\n"
+							+ "\t|_     Flux.filter ⇢ at reactor.guide.FakeUtils1.lambda$static$1(FakeUtils1.java:29)\n"
+							+ "\t|_ Flux.composeNow ⇢ at reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:40)\n"
+							+ "\t|_    Flux.elapsed ⇢ at reactor.guide.FakeUtils2.lambda$static$0(FakeUtils2.java:30)\n"
+							+ "\t|_ Flux.composeNow ⇢ at reactor.guide.GuideDebuggingExtraTests.debuggingActivatedWithDeepTraceback(GuideDebuggingExtraTests.java:41)\n");
 		}
 		finally {
 			Hooks.resetOnOperatorDebug();

--- a/reactor-core/src/test/java/reactor/guide/GuideTests.java
+++ b/reactor-core/src/test/java/reactor/guide/GuideTests.java
@@ -156,19 +156,19 @@ public class GuideTests {
 	}
 
 	@Test
-	public void advancedCompose() {
+	public void advancedComposedNow() {
 		Function<Flux<String>, Flux<String>> filterAndMap =
 				f -> f.filter(color -> !color.equals("orange"))
 				      .map(String::toUpperCase);
 
 		Flux.fromIterable(Arrays.asList("blue", "green", "orange", "purple"))
 		    .doOnNext(System.out::println)
-		    .transform(filterAndMap)
+		    .composeNow(filterAndMap)
 		    .subscribe(d -> System.out.println("Subscriber to Transformed MapAndFilter: "+d));
 	}
 
 	@Test
-	public void advancedTransform() {
+	public void advancedComposedDefer() {
 		AtomicInteger ai = new AtomicInteger();
 		Function<Flux<String>, Flux<String>> filterAndMap = f -> {
 			if (ai.incrementAndGet() == 1) {
@@ -182,7 +182,7 @@ public class GuideTests {
 		Flux<String> composedFlux =
 				Flux.fromIterable(Arrays.asList("blue", "green", "orange", "purple"))
 				    .doOnNext(System.out::println)
-				    .compose(filterAndMap);
+				    .composeLater(filterAndMap);
 
 		composedFlux.subscribe(d -> System.out.println("Subscriber 1 to Composed MapAndFilter :"+d));
 		composedFlux.subscribe(d -> System.out.println("Subscriber 2 to Composed MapAndFilter: "+d));


### PR DESCRIPTION
This makes the relationship between the two clearer, while also better
showing their difference in behavior at a glance:
 - composeNow immediately applies the Function
 - composeDefer mixes defer and composeNow behaviors