### PR TITLE
fix #1778 Deprecate BiFunction scheduler decorators, change metrics

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
@@ -51,7 +51,9 @@ final class DelegateServiceScheduler implements Scheduler, Scannable {
 	DelegateServiceScheduler(String executorName, ExecutorService executorService) {
 			this.executorName = executorName;
 			ScheduledExecutorService exec = convert(executorService);
-			this.executor = Schedulers.decorateExecutorService(this, exec);
+			exec = Schedulers.decorateExecutorService(this, exec);
+			exec = Schedulers.decorateExecutorService(Schedulers.FROM_EXECUTOR_SERVICE, executorName, exec);
+			this.executor = exec;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
@@ -45,14 +45,15 @@ import reactor.util.annotation.Nullable;
  */
 final class DelegateServiceScheduler implements Scheduler, Scannable {
 
-	final String executorName;
+	final String schedulerName;
 	final ScheduledExecutorService executor;
 
 	DelegateServiceScheduler(String executorName, ExecutorService executorService) {
-			this.executorName = executorName;
+			this.schedulerName = Schedulers.FROM_EXECUTOR_SERVICE + '(' + executorName + ')';
+			String schedulerId = schedulerName + '@' + Integer.toHexString(System.identityHashCode(this));
 			ScheduledExecutorService exec = convert(executorService);
 			exec = Schedulers.decorateExecutorService(this, exec);
-			exec = Schedulers.decorateExecutorService(Schedulers.FROM_EXECUTOR_SERVICE, executorName, exec);
+			exec = Schedulers.decorateExecutorService(Schedulers.FROM_EXECUTOR_SERVICE, schedulerId, exec);
 			this.executor = exec;
 	}
 
@@ -104,14 +105,14 @@ final class DelegateServiceScheduler implements Scheduler, Scannable {
 	@Override
 	public Object scanUnsafe(Attr key) {
 		if (key == Attr.TERMINATED || key == Attr.CANCELLED) return isDisposed();
-		if (key == Attr.NAME) return toString();
+		if (key == Attr.NAME) return schedulerName;
 
 		return Schedulers.scanExecutor(executor, key);
 	}
 
 	@Override
 	public String toString() {
-		return Schedulers.FROM_EXECUTOR_SERVICE + '(' + executorName + ')';
+		return schedulerName;
 	}
 
 	static final class UnsupportedScheduledExecutorService

--- a/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
@@ -199,6 +199,11 @@ final class ElasticScheduler implements Scheduler, Supplier<ScheduledExecutorSer
 	}
 
 	@Override
+	public String name() {
+		return this.toString();
+	}
+
+	@Override
 	public Object scanUnsafe(Attr key) {
 		if (key == Attr.TERMINATED || key == Attr.CANCELLED) return isDisposed();
 		if (key == Attr.CAPACITY) return Integer.MAX_VALUE;
@@ -242,8 +247,9 @@ final class ElasticScheduler implements Scheduler, Supplier<ScheduledExecutorSer
 			this.parent = parent;
 			if (parent != null) {
 				ScheduledExecutorService exec = parent.get();
+				String schedulerId = parent.name() + '@' + Integer.toHexString(System.identityHashCode(this));
 				exec = Schedulers.decorateExecutorService(parent, exec);
-				exec = Schedulers.decorateExecutorService(Schedulers.ELASTIC, parent.name(), exec);
+				exec = Schedulers.decorateExecutorService(Schedulers.ELASTIC, schedulerId, exec);
 				this.exec = exec;
 			}
 			else {

--- a/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
@@ -241,7 +241,10 @@ final class ElasticScheduler implements Scheduler, Supplier<ScheduledExecutorSer
 		CachedService(@Nullable ElasticScheduler parent) {
 			this.parent = parent;
 			if (parent != null) {
-				this.exec = Schedulers.decorateExecutorService(parent, parent.get());
+				ScheduledExecutorService exec = parent.get();
+				exec = Schedulers.decorateExecutorService(parent, exec);
+				exec = Schedulers.decorateExecutorService(Schedulers.ELASTIC, parent.name(), exec);
+				this.exec = exec;
 			}
 			else {
 				this.exec = Executors.newSingleThreadScheduledExecutor();

--- a/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
@@ -83,7 +83,10 @@ final class ParallelScheduler implements Scheduler, Supplier<ScheduledExecutorSe
     void init(int n) {
         ScheduledExecutorService[] a = new ScheduledExecutorService[n];
         for (int i = 0; i < n; i++) {
-            a[i] = Schedulers.decorateExecutorService(this, this.get());
+            ScheduledExecutorService exec = this.get();
+            exec = Schedulers.decorateExecutorService(this, exec);
+            exec = Schedulers.decorateExecutorService(Schedulers.PARALLEL, this.name(), exec);
+            a[i] = exec;
         }
         EXECUTORS.lazySet(this, a);
     }
@@ -110,7 +113,10 @@ final class ParallelScheduler implements Scheduler, Supplier<ScheduledExecutorSe
             if (b == null) {
                 b = new ScheduledExecutorService[n];
                 for (int i = 0; i < n; i++) {
-                    b[i] = Schedulers.decorateExecutorService(this, this.get());
+                    ScheduledExecutorService exec = this.get();
+                    exec = Schedulers.decorateExecutorService(this, exec);
+                    exec = Schedulers.decorateExecutorService(Schedulers.PARALLEL, this.name(), exec);
+                    b[i] = exec;
                 }
             }
             

--- a/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
@@ -81,11 +81,12 @@ final class ParallelScheduler implements Scheduler, Supplier<ScheduledExecutorSe
     }
     
     void init(int n) {
+        String schedulerId = this.name() + '@' + Integer.toHexString(System.identityHashCode(this));
         ScheduledExecutorService[] a = new ScheduledExecutorService[n];
         for (int i = 0; i < n; i++) {
             ScheduledExecutorService exec = this.get();
             exec = Schedulers.decorateExecutorService(this, exec);
-            exec = Schedulers.decorateExecutorService(Schedulers.PARALLEL, this.name(), exec);
+            exec = Schedulers.decorateExecutorService(Schedulers.PARALLEL, schedulerId, exec);
             a[i] = exec;
         }
         EXECUTORS.lazySet(this, a);
@@ -111,11 +112,12 @@ final class ParallelScheduler implements Scheduler, Supplier<ScheduledExecutorSe
             }
 
             if (b == null) {
+                String schedulerId = this.name() + '@' + Integer.toHexString(System.identityHashCode(this));
                 b = new ScheduledExecutorService[n];
                 for (int i = 0; i < n; i++) {
                     ScheduledExecutorService exec = this.get();
                     exec = Schedulers.decorateExecutorService(this, exec);
-                    exec = Schedulers.decorateExecutorService(Schedulers.PARALLEL, this.name(), exec);
+                    exec = Schedulers.decorateExecutorService(Schedulers.PARALLEL, schedulerId, exec);
                     b[i] = exec;
                 }
             }
@@ -186,6 +188,11 @@ final class ParallelScheduler implements Scheduler, Supplier<ScheduledExecutorSe
         }
         ts.append(')');
         return ts.toString();
+    }
+
+    @Override
+    public String name() {
+        return this.toString();
     }
 
     @Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -15,7 +15,6 @@
  */
 package reactor.core.scheduler;
 
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -29,7 +28,7 @@ import reactor.core.Exceptions;
  * <p>
  * Implementations that use an underlying {@link ExecutorService} or
  * {@link ScheduledExecutorService} should decorate it with the relevant {@link Schedulers} hook
- * ({@link Schedulers#decorateExecutorService(Scheduler, ScheduledExecutorService)}.
+ * ({@link Schedulers#decorateExecutorService(String, String, ScheduledExecutorService)}.
  *
  * @author Stephane Maldini
  * @author Simon Baslé

--- a/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
@@ -33,54 +33,33 @@ import reactor.core.Scannable.Attr;
 import static io.micrometer.core.instrument.Metrics.globalRegistry;
 
 final class SchedulerMetricDecorator
-			implements BiFunction<Scheduler, ScheduledExecutorService, ScheduledExecutorService>,
-			           Disposable {
+		implements Schedulers.SchedulerExecutorDecorator,
+		           Disposable {
 
+	static final String TAG_SCHEDULER_TYPE = "reactor.scheduler.type";
 	static final String TAG_SCHEDULER_ID = "reactor.scheduler.id";
 	static final String METRICS_DECORATOR_KEY = "reactor.metrics.decorator";
 
-	final WeakHashMap<Scheduler, String>        seenSchedulers          = new WeakHashMap<>();
-	final Map<String, AtomicInteger>            schedulerDifferentiator = new HashMap<>();
-	final WeakHashMap<Scheduler, AtomicInteger> executorDifferentiator  = new WeakHashMap<>();
+	final Map<String, AtomicInteger> executorDifferentiator  = new HashMap<>();
 
 	@Override
-	public synchronized ScheduledExecutorService apply(Scheduler scheduler, ScheduledExecutorService service) {
-		//this is equivalent to `toString`, a detailed name like `parallel("foo", 3)`
-		String schedulerName = Scannable
-				.from(scheduler)
-				.scanOrDefault(Attr.NAME, scheduler.getClass().getName());
+	public synchronized ScheduledExecutorService apply(String schedulerType, String schedulerName, ScheduledExecutorService service) {
+		//with https://github.com/reactor/reactor-core/issues/1778 we no longer see the instance
+		//(which was problematic due to reference escaping the constructor most of the time)
+		//so we can only rely on the NAME, potentially aggregating executors from different instances if their Schedulers
+		//are similarly named (eg. parallel using the same parallelism and thread prefix).
+		//We can only hope that each NAME is unique enough. Applying the decorator twice will always create duplicate meters.
 
-		//we hope that each NAME is unique enough, but we'll differentiate by Scheduler
-		String schedulerId =
-				seenSchedulers.computeIfAbsent(scheduler, s -> {
-					int schedulerDifferentiator = this.schedulerDifferentiator
-							.computeIfAbsent(schedulerName, k -> new AtomicInteger(0))
-							.getAndIncrement();
-
-					return (schedulerDifferentiator == 0) ? schedulerName
-							: schedulerName + "#" + schedulerDifferentiator;
-				});
-
-		//we now want an executorId unique to a given scheduler
-		String executorId = schedulerId + "-" +
-				executorDifferentiator.computeIfAbsent(scheduler, key -> new AtomicInteger(0))
+		String executorId = schedulerName + "-" +
+				executorDifferentiator.computeIfAbsent(schedulerName, key -> new AtomicInteger(0))
 				                      .getAndIncrement();
-
-		/*
-		Design note: we assume that a given Scheduler won't apply the decorator twice to the
-		same ExecutorService. Even though, it would simply create an extraneous meter for
-		that ExecutorService, which we think is not that bad (compared to paying the price
-		upfront of also tracking executors instances to deduplicate). The main goal is to
-		detect Scheduler instances that have already started decorating their executors,
-		in order to avoid consider two calls in a row as duplicates (yet still being able
-		to distinguish between two instances with the same name and configuration).
-		 */
 
 		// TODO return the result of ExecutorServiceMetrics#monitor
 		//  once ScheduledExecutorService gets supported by Micrometer
 		//  See https://github.com/micrometer-metrics/micrometer/issues/1021
 		ExecutorServiceMetrics.monitor(globalRegistry, service, executorId,
-				Tag.of(TAG_SCHEDULER_ID, schedulerId));
+				Tag.of(TAG_SCHEDULER_ID, schedulerName),
+				Tag.of(TAG_SCHEDULER_TYPE, schedulerType));
 
 		return service;
 	}
@@ -94,8 +73,6 @@ final class SchedulerMetricDecorator
 
 		//note default isDisposed (returning false) is good enough, since the cleared
 		//collections can always be reused even though they probably won't
-		this.seenSchedulers.clear();
-		this.schedulerDifferentiator.clear();
 		this.executorDifferentiator.clear();
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
@@ -71,9 +71,10 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 	}
 
 	private void init() {
+		String schedulerId = this.name() + '@' + Integer.toHexString(System.identityHashCode(this));
 		ScheduledExecutorService exec = this.get();
 		exec = Schedulers.decorateExecutorService(this, exec);
-		exec = Schedulers.decorateExecutorService(Schedulers.SINGLE, this.name(), exec);
+		exec = Schedulers.decorateExecutorService(Schedulers.SINGLE, schedulerId, exec);
 		EXECUTORS.lazySet(this, exec);
 	}
 
@@ -96,9 +97,10 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 			}
 
 			if (b == null) {
+				String schedulerId = this.name() + '@' + Integer.toHexString(System.identityHashCode(this));
 				b = this.get();
 				b = Schedulers.decorateExecutorService(this, b);
-				b = Schedulers.decorateExecutorService(Schedulers.SINGLE, this.name(), b);
+				b = Schedulers.decorateExecutorService(Schedulers.SINGLE, schedulerId, b);
 			}
 
 			if (EXECUTORS.compareAndSet(this, a, b)) {
@@ -147,7 +149,12 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 		if (factory instanceof ReactorThreadFactory) {
 			ts.append('\"').append(((ReactorThreadFactory) factory).get()).append('\"');
 		}
-		return ts.append(')').toString();
+		return ts.toString();
+	}
+
+	@Override
+	public String name() {
+		return this.toString();
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
@@ -71,7 +71,10 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 	}
 
 	private void init() {
-		EXECUTORS.lazySet(this, Schedulers.decorateExecutorService(this, this.get()));
+		ScheduledExecutorService exec = this.get();
+		exec = Schedulers.decorateExecutorService(this, exec);
+		exec = Schedulers.decorateExecutorService(Schedulers.SINGLE, this.name(), exec);
+		EXECUTORS.lazySet(this, exec);
 	}
 
 	@Override
@@ -93,7 +96,9 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 			}
 
 			if (b == null) {
-				b = Schedulers.decorateExecutorService(this, this.get());
+				b = this.get();
+				b = Schedulers.decorateExecutorService(this, b);
+				b = Schedulers.decorateExecutorService(Schedulers.SINGLE, this.name(), b);
 			}
 
 			if (EXECUTORS.compareAndSet(this, a, b)) {

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersMetricsTest.java
@@ -91,10 +91,10 @@ public class SchedulersMetricsTest {
 		                              .stream()
 		                              .map(m -> m.getId().getTag("name"))
 		                              .distinct())
-				.containsOnly(
-						"parallel(1,\"A\")-0",
-						"parallel(1,\"A\")-1",
-						"parallel(1,\"A\")-2"
+				.hasSize(3)
+				.allSatisfy(name -> assertThat(name)
+						.startsWith("parallel(1,\"A\")@")
+						.endsWith("-0")
 				);
 	}
 

--- a/reactor-core/src/test/java/reactor/util/MetricsNoMicrometerTest.java
+++ b/reactor-core/src/test/java/reactor/util/MetricsNoMicrometerTest.java
@@ -22,6 +22,7 @@ import org.assertj.core.api.Assumptions;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import reactor.core.Scannable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
@@ -81,7 +82,7 @@ public class MetricsNoMicrometerTest {
 			assertThatCode(() -> {
 				Schedulers.enableMetrics();
 				Scheduler s = Schedulers.newSingle("foo");
-				Schedulers.decorateExecutorService(s,
+				Schedulers.decorateExecutorService("SINGLE", Scannable.from(s).name(),
 						Executors.newSingleThreadScheduledExecutor());
 				s.schedule(() -> System.out.println("schedulers instrumentation no micrometer"));
 			})


### PR DESCRIPTION
Since the BiFunction took the Scheduler reference, but was mostly
applied from inside said Scheduler constructor, it would imply dealing
with a not fully constructed object.

Switching to a decorator interface that takes two Strings (scheduler
type and soft id) allows for a more reliable (yet more restricted)
mechanism.

The two approaches cannot be sharing the same underlying implementation,
which has the unfortunate consequence that implementors MUST apply the
two sets of decorators explicitly.

The Schedulers.enableMetrics() also need to change in the new approach,
removing the capacity to detect executors that are attached to a common
instance, and instead aggregating all similarly configured Schedulers
under their common schedulerId. On the other hand, the meters can now
be tagged with the more generic Scheduler type (eg. all PARALLELs).