### PR TITLE
Decorate executors in start() rather than constructor (see #1778)

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
@@ -129,12 +129,7 @@ final class BoundedElasticScheduler implements Scheduler, Scannable {
 		this.clock = Objects.requireNonNull(clock, "A Clock must be provided");
 		this.ttlMillis = ttlMillis;
 
-		this.boundedServices = new BoundedServices(this);
-		this.evictor = Executors.newScheduledThreadPool(1, EVICTOR_FACTORY);
-		evictor.scheduleAtFixedRate(boundedServices::eviction,
-				ttlMillis,
-				ttlMillis,
-				TimeUnit.MILLISECONDS);
+		this.boundedServices = SHUTDOWN; //initially disposed, EVICTOR is also null
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
@@ -74,7 +74,7 @@ final class ElasticScheduler implements Scheduler, Scannable {
 
 	final Queue<CachedService> all;
 
-	final ScheduledExecutorService evictor;
+	ScheduledExecutorService evictor;
 
 
 	volatile boolean shutdown;
@@ -87,11 +87,8 @@ final class ElasticScheduler implements Scheduler, Scannable {
 		this.factory = factory;
 		this.cache = new ConcurrentLinkedDeque<>();
 		this.all = new ConcurrentLinkedQueue<>();
-		this.evictor = Executors.newScheduledThreadPool(1, EVICTOR_FACTORY);
-		this.evictor.scheduleAtFixedRate(this::eviction,
-				ttlSeconds,
-				ttlSeconds,
-				TimeUnit.SECONDS);
+		//evictor is now started in `start()`. make it look like it is constructed shutdown
+		this.shutdown = true;
 	}
 
 	/**
@@ -107,8 +104,15 @@ final class ElasticScheduler implements Scheduler, Scannable {
 
 	@Override
 	public void start() {
-		// NO-OP, executors are initialized on task submission
-		// no exception is thrown if shutdown, but this operation is also a no-op
+		if (!shutdown) {
+			return;
+		}
+		this.evictor = Executors.newScheduledThreadPool(1, EVICTOR_FACTORY);
+		this.evictor.scheduleAtFixedRate(this::eviction,
+				ttlSeconds,
+				ttlSeconds,
+				TimeUnit.SECONDS);
+		this.shutdown = false;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
@@ -107,7 +107,8 @@ final class ElasticScheduler implements Scheduler, Scannable {
 
 	@Override
 	public void start() {
-		throw new UnsupportedOperationException("Restarting not supported yet");
+		// NO-OP, executors are initialized on task submission
+		// no exception is thrown if shutdown, but this operation is also a no-op
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/ImmediateScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ImmediateScheduler.java
@@ -30,14 +30,18 @@ import reactor.core.Scannable;
  */
 final class ImmediateScheduler implements Scheduler, Scannable {
 
-    private static final ImmediateScheduler INSTANCE = new ImmediateScheduler();
-    
+    private static final ImmediateScheduler INSTANCE;
+
+    static {
+        INSTANCE = new ImmediateScheduler();
+        INSTANCE.start();
+    }
+
     public static Scheduler instance() {
         return INSTANCE;
     }
     
     private ImmediateScheduler() {
-        
     }
     
     static final Disposable FINISHED = Disposables.disposed();

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -61,6 +61,7 @@ import static reactor.core.Exceptions.unwrap;
  * <p>
  * Factories prefixed with {@code new} (eg. {@link #newBoundedElastic(int, int, String)} return a new instance of their flavor of {@link Scheduler},
  * while other factories like {@link #boundedElastic()} return a shared instance - which is the one used by operators requiring that flavor as their default Scheduler.
+ * All instances are returned in a {@link Scheduler#start() started} state.
  *
  * @author Stephane Maldini
  */
@@ -138,7 +139,9 @@ public abstract class Schedulers {
 		if(!trampoline && executor instanceof ExecutorService){
 			return fromExecutorService((ExecutorService) executor);
 		}
-		return new ExecutorScheduler(executor, trampoline);
+		final ExecutorScheduler scheduler = new ExecutorScheduler(executor, trampoline);
+		scheduler.start();
+		return scheduler;
 	}
 
 	/**
@@ -166,7 +169,9 @@ public abstract class Schedulers {
 	 * @return a new {@link Scheduler}
 	 */
 	public static Scheduler fromExecutorService(ExecutorService executorService, String executorName) {
-		return new DelegateServiceScheduler(executorName, executorService);
+		final DelegateServiceScheduler scheduler = new DelegateServiceScheduler(executorName, executorService);
+		scheduler.start();
+		return scheduler;
 	}
 
 	/**
@@ -332,7 +337,9 @@ public abstract class Schedulers {
 	 */
 	@Deprecated
 	public static Scheduler newElastic(int ttlSeconds, ThreadFactory threadFactory) {
-		return factory.newElastic(ttlSeconds, threadFactory);
+		final Scheduler fromFactory = factory.newElastic(ttlSeconds, threadFactory);
+		fromFactory.start();
+		return fromFactory;
 	}
 
 
@@ -482,7 +489,12 @@ public abstract class Schedulers {
 	 * that reuses threads and evict idle ones
 	 */
 	public static Scheduler newBoundedElastic(int threadCap, int queuedTaskCap, ThreadFactory threadFactory, int ttlSeconds) {
-		return factory.newBoundedElastic(threadCap, queuedTaskCap, threadFactory, ttlSeconds);
+		Scheduler fromFactory = factory.newBoundedElastic(threadCap,
+				queuedTaskCap,
+				threadFactory,
+				ttlSeconds);
+		fromFactory.start();
+		return fromFactory;
 	}
 
 	/**
@@ -545,7 +557,9 @@ public abstract class Schedulers {
 	 * ExecutorService-based workers and is suited for parallel work
 	 */
 	public static Scheduler newParallel(int parallelism, ThreadFactory threadFactory) {
-		return factory.newParallel(parallelism, threadFactory);
+		final Scheduler fromFactory = factory.newParallel(parallelism, threadFactory);
+		fromFactory.start();
+		return fromFactory;
 	}
 
 	/**
@@ -590,7 +604,9 @@ public abstract class Schedulers {
 	 * worker
 	 */
 	public static Scheduler newSingle(ThreadFactory threadFactory) {
-		return factory.newSingle(threadFactory);
+		final Scheduler fromFactory = factory.newSingle(threadFactory);
+		fromFactory.start();
+		return fromFactory;
 	}
 
 	/**
@@ -895,7 +911,9 @@ public abstract class Schedulers {
 	/**
 	 * Wraps a single {@link reactor.core.scheduler.Scheduler.Worker} from some other
 	 * {@link Scheduler} and provides {@link reactor.core.scheduler.Scheduler.Worker}
-	 * services on top of it.
+	 * services on top of it. Unlike with other factory methods in this class, the delegate
+	 * is assumed to be {@link Scheduler#start() started} and won't be implicitly started
+	 * by this method.
 	 * <p>
 	 * Use the {@link Scheduler#dispose()} to release the wrapped worker.
 	 *

--- a/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
@@ -55,7 +55,6 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 
 	SingleScheduler(ThreadFactory factory) {
 		this.factory = factory;
-		init();
 	}
 
 	/**
@@ -70,10 +69,6 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 		return e;
 	}
 
-	private void init() {
-		EXECUTORS.lazySet(this, Schedulers.decorateExecutorService(this, this.get()));
-	}
-
 	@Override
 	public boolean isDisposed() {
 		return executor == TERMINATED;
@@ -85,7 +80,7 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 		ScheduledExecutorService b = null;
 		for (; ; ) {
 			ScheduledExecutorService a = executor;
-			if (a != TERMINATED) {
+			if (a != TERMINATED && a != null) {
 				if (b != null) {
 					b.shutdownNow();
 				}
@@ -107,7 +102,7 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 		ScheduledExecutorService a = executor;
 		if (a != TERMINATED) {
 			a = EXECUTORS.getAndSet(this, TERMINATED);
-			if (a != TERMINATED) {
+			if (a != TERMINATED && a != null) {
 				a.shutdownNow();
 			}
 		}

--- a/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
@@ -40,6 +40,9 @@ public abstract class AbstractSchedulerTest {
 	@Rule
 	public AutoDisposingRule afterTest = new AutoDisposingRule();
 
+	/**
+	 * @return the {@link Scheduler} to be tested, {@link Scheduler#start() started}
+	 */
 	protected abstract Scheduler scheduler();
 
 	protected boolean shouldCheckInterrupted(){
@@ -80,6 +83,17 @@ public abstract class AbstractSchedulerTest {
 		else {
 			assertThat(s.isDisposed()).as("restart not supported").isTrue();
 		}
+	}
+
+	@Test
+	public void acceptTaskAfterStartStopStart() {
+		Assumptions.assumeThat(shouldCheckSupportRestart()).as("scheduler supports restart").isTrue();
+
+		Scheduler scheduler = scheduler();
+		scheduler.dispose();
+
+		scheduler.start();
+		assertThatCode(() -> scheduler.schedule(() -> {})).doesNotThrowAnyException();
 	}
 
 	@Test(timeout = 10000)

--- a/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
@@ -18,10 +18,11 @@ package reactor.core.scheduler;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.After;
+import org.assertj.core.api.Assumptions;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,11 +58,28 @@ public abstract class AbstractSchedulerTest {
 
 	protected boolean shouldCheckWorkerTimeScheduling() { return true; }
 
+	protected boolean shouldCheckSupportRestart() { return true; }
+
 	protected Scheduler schedulerNotCached() {
 		Scheduler s = scheduler();
 		assertThat(s).as("common scheduler tests should not use a CachedScheduler")
 		             .isNotInstanceOf(Schedulers.CachedScheduler.class);
 		return s;
+	}
+
+	@Test
+	public void restartSupport() {
+		boolean supportsRestart = shouldCheckSupportRestart();
+		Scheduler s = scheduler();
+		s.dispose();
+		s.start();
+
+		if (supportsRestart) {
+			assertThat(s.isDisposed()).as("restart supported").isFalse();
+		}
+		else {
+			assertThat(s.isDisposed()).as("restart not supported").isTrue();
+		}
 	}
 
 	@Test(timeout = 10000)

--- a/reactor-core/src/test/java/reactor/core/scheduler/DelegateServiceSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/DelegateServiceSchedulerTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.pivovarit.function.ThrowingRunnable;
 import org.junit.Test;
 
 import reactor.core.Exceptions;
@@ -67,7 +68,7 @@ public class DelegateServiceSchedulerTest extends AbstractSchedulerTest {
 
 		assertThat(decorationCount).as("before schedule").hasValue(0);
 		//first scheduled task implicitly starts the scheduler and thus creates the executor service
-		scheduler.schedule(() -> {});
+		scheduler.schedule(ThrowingRunnable.unchecked(() -> Thread.sleep(100)));
 		assertThat(decorationCount).as("after schedule").hasValue(1);
 		//second scheduled task runs on a started scheduler and doesn't create further executors
 		scheduler.schedule(() -> {});

--- a/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
@@ -62,31 +62,12 @@ public class ElasticSchedulerTest extends AbstractSchedulerTest {
 	}
 
 	@Test
-	public void bothStartAndRestartAreNoOp() {
-		Scheduler scheduler = scheduler();
+	public void bothStartAndRestartDoNotThrow() {
+		Scheduler scheduler = afterTest.autoDispose(scheduler());
 		assertThatCode(scheduler::start).as("start").doesNotThrowAnyException();
 
 		scheduler.dispose();
 		assertThatCode(scheduler::start).as("restart").doesNotThrowAnyException();
-	}
-
-	@Test
-	public void startAndDecorationImplicit() {
-		AtomicInteger decorationCount = new AtomicInteger();
-		Schedulers.setExecutorServiceDecorator("startAndDecorationImplicit", (s, srv) -> {
-			decorationCount.incrementAndGet();
-			return srv;
-		});
-		final Scheduler scheduler = afterTest.autoDispose(new ElasticScheduler(Thread::new, 10));
-		afterTest.autoDispose(() -> Schedulers.removeExecutorServiceDecorator("startAndDecorationImplicit"));
-
-		assertThat(decorationCount).as("before schedule").hasValue(0);
-		//first scheduled task implicitly starts one worker and thus creates one executor service
-		scheduler.schedule(ThrowingRunnable.unchecked(() -> Thread.sleep(100)));
-		assertThat(decorationCount).as("after schedule").hasValue(1);
-		//second scheduled task also implicitly starts one worker and thus creates a second executor service
-		scheduler.schedule(() -> {});
-		assertThat(decorationCount).as("after 2nd schedule").hasValue(2);
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
@@ -82,7 +82,7 @@ public class ElasticSchedulerTest extends AbstractSchedulerTest {
 
 		assertThat(decorationCount).as("before schedule").hasValue(0);
 		//first scheduled task implicitly starts one worker and thus creates one executor service
-		scheduler.schedule(() -> {});
+		scheduler.schedule(ThrowingRunnable.unchecked(() -> Thread.sleep(100)));
 		assertThat(decorationCount).as("after schedule").hasValue(1);
 		//second scheduled task also implicitly starts one worker and thus creates a second executor service
 		scheduler.schedule(() -> {});

--- a/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
@@ -58,7 +58,7 @@ public class ElasticSchedulerTest extends AbstractSchedulerTest {
 
 	@Override
 	protected boolean shouldCheckSupportRestart() {
-		return false;
+		return true;
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTest.java
@@ -55,6 +55,11 @@ public class ExecutorSchedulerTest extends AbstractSchedulerTest {
 	}
 
 	@Override
+	protected boolean shouldCheckSupportRestart() {
+		return false;
+	}
+
+	@Override
 	protected Scheduler scheduler() {
 		return Schedulers.fromExecutor(Runnable::run);
 	}

--- a/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTrampolineTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTrampolineTest.java
@@ -47,6 +47,11 @@ public class ExecutorSchedulerTrampolineTest extends AbstractSchedulerTest {
 		return false;
 	}
 
+	@Override
+	protected boolean shouldCheckSupportRestart() {
+		return false;
+	}
+
 	@Test
 	public void scanParent() {
 		Executor plainExecutor = new ExecutorSchedulerTest.PlainExecutor();

--- a/reactor-core/src/test/java/reactor/core/scheduler/ImmediateSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ImmediateSchedulerTest.java
@@ -18,6 +18,7 @@ package reactor.core.scheduler;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import org.assertj.core.api.Assumptions;
 import org.junit.Test;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
@@ -54,6 +55,17 @@ public class ImmediateSchedulerTest extends AbstractSchedulerTest {
 	@Override
 	protected boolean shouldCheckWorkerTimeScheduling() {
 		return false;
+	}
+
+	@Override
+	protected boolean shouldCheckSupportRestart() {
+		return false;
+	}
+
+	@Override
+	public void restartSupport() {
+		//immediate is a bit weird: disposing doesn't make sense any more than restarting
+		Assumptions.assumeThat(false).as("immediate cannot be either disposed nor restarted").isFalse();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/scheduler/ParallelSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ParallelSchedulerTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.pivovarit.function.ThrowingRunnable;
 import org.junit.Test;
 
 import reactor.core.Scannable;
@@ -59,7 +60,7 @@ public class ParallelSchedulerTest extends AbstractSchedulerTest {
 
 		assertThat(decorationCount).as("before schedule").hasValue(0);
 		//first scheduled task implicitly starts the scheduler and thus creates _parallelism_ workers/executorServices
-		scheduler.schedule(() -> {});
+		scheduler.schedule(ThrowingRunnable.unchecked(() -> Thread.sleep(100)));
 		assertThat(decorationCount).as("after schedule").hasValue(4);
 		//second scheduled task runs on a started scheduler and doesn't create further executors
 		scheduler.schedule(() -> {});

--- a/reactor-core/src/test/java/reactor/core/scheduler/ParallelSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ParallelSchedulerTest.java
@@ -55,16 +55,19 @@ public class ParallelSchedulerTest extends AbstractSchedulerTest {
 			decorationCount.incrementAndGet();
 			return srv;
 		});
-		final Scheduler scheduler = afterTest.autoDispose(new ParallelScheduler(4, Thread::new));
+
+		final int parallelismAndExpectedImplicitStart = 4;
+
+		final Scheduler scheduler = afterTest.autoDispose(new ParallelScheduler(parallelismAndExpectedImplicitStart, Thread::new));
 		afterTest.autoDispose(() -> Schedulers.removeExecutorServiceDecorator("startAndDecorationImplicit"));
 
 		assertThat(decorationCount).as("before schedule").hasValue(0);
 		//first scheduled task implicitly starts the scheduler and thus creates _parallelism_ workers/executorServices
 		scheduler.schedule(ThrowingRunnable.unchecked(() -> Thread.sleep(100)));
-		assertThat(decorationCount).as("after schedule").hasValue(4);
+		assertThat(decorationCount).as("after schedule").hasValue(parallelismAndExpectedImplicitStart);
 		//second scheduled task runs on a started scheduler and doesn't create further executors
 		scheduler.schedule(() -> {});
-		assertThat(decorationCount).as("after 2nd schedule").hasValue(4);
+		assertThat(decorationCount).as("after 2nd schedule").hasValue(parallelismAndExpectedImplicitStart);
 	}
 
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -1119,6 +1119,11 @@ public class SchedulersTest {
 	}
 
 	@Test
+	public void restartBoundedElastic() {
+		restart(Schedulers.newBoundedElastic(1, 10, "test"));
+	}
+
+	@Test
 	public void restartSingle(){
 		restart(Schedulers.newSingle("test"));
 	}

--- a/reactor-core/src/test/java/reactor/core/scheduler/SingleWorkerAroundTimerSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SingleWorkerAroundTimerSchedulerTest.java
@@ -21,11 +21,6 @@ package reactor.core.scheduler;
 public class SingleWorkerAroundTimerSchedulerTest extends AbstractSchedulerTest {
 
 	@Override
-	protected Scheduler scheduler() {
-		return Schedulers.single(Schedulers.newSingle("singleWorkerTimer"));
-	}
-
-	@Override
 	protected boolean shouldCheckDisposeTask() {
 		return false;
 	}
@@ -33,5 +28,15 @@ public class SingleWorkerAroundTimerSchedulerTest extends AbstractSchedulerTest 
 	@Override
 	protected boolean shouldCheckWorkerTimeScheduling() {
 		return false;
+	}
+
+	@Override
+	protected boolean shouldCheckSupportRestart() {
+		return false;
+	}
+
+	@Override
+	protected Scheduler scheduler() {
+		return Schedulers.single(Schedulers.newSingle("singleWorkerTimer"));
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/scheduler/SingleWorkerSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SingleWorkerSchedulerTest.java
@@ -45,6 +45,11 @@ public class SingleWorkerSchedulerTest extends AbstractSchedulerTest {
 		return false;
 	}
 
+	@Override
+	protected boolean shouldCheckSupportRestart() {
+		return false;
+	}
+
 	@Test
 	public void scanName() {
 		Scheduler withNamedFactory = Schedulers.single(Schedulers.newSingle("scanName"));

--- a/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
+++ b/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
@@ -68,7 +68,9 @@ public class VirtualTimeScheduler implements Scheduler {
 	 * {@link Schedulers} factories.
 	 */
 	public static VirtualTimeScheduler create(boolean defer) {
-		return new VirtualTimeScheduler(defer);
+		VirtualTimeScheduler instance = new VirtualTimeScheduler(defer);
+		instance.start();
+		return instance;
 	}
 
 	/**
@@ -163,7 +165,7 @@ public class VirtualTimeScheduler implements Scheduler {
 			}
 			VirtualTimeScheduler newS = schedulerSupplier.get();
 			if (newS == CURRENT.get()) {
-				return newS; //nothing to do, it has already been set in the past
+				return newS; //nothing to do, it has already been set and started in the past
 			}
 
 			if (CURRENT.compareAndSet(s, newS)) {


### PR DESCRIPTION
WIP:
 - [x] `Schedulers` API calls `start()` implicitly after calling the `Factory` + mention the implicit calling of `start()`.
 - [x] Scheduler concrete implementations move their initialization of executors to the `start()` method
 - [x] Update and add tests
 - [x] Double check reactor downstream projects for other implementations of schedulers that might need the same change, and probably align anyway
  - [x] eg. `VirtualTimeScheduler` has a few factories that need to be similarly changed