### PR TITLE
Record executor service metrics to Micrometer

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
@@ -15,7 +15,6 @@
  */
 package reactor.core.scheduler;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -28,6 +27,7 @@ import java.util.function.BiFunction;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 import io.micrometer.core.instrument.internal.TimedExecutorService;
 import io.micrometer.core.instrument.search.Search;
@@ -72,7 +72,7 @@ final class SchedulerMetricDecorator
 				executorDifferentiator.computeIfAbsent(scheduler, key -> new AtomicInteger(0))
 				                      .getAndIncrement();
 
-		Iterable<Tag> tags = Collections.singleton(Tag.of(TAG_SCHEDULER_ID, schedulerId));
+		Tags tags = Tags.of(TAG_SCHEDULER_ID, schedulerId);
 
 		/*
 		Design note: we assume that a given Scheduler won't apply the decorator twice to the

--- a/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
@@ -15,15 +15,21 @@
  */
 package reactor.core.scheduler;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
+import io.micrometer.core.instrument.internal.TimedExecutorService;
 import io.micrometer.core.instrument.search.Search;
 
 import reactor.core.Disposable;
@@ -66,6 +72,8 @@ final class SchedulerMetricDecorator
 				executorDifferentiator.computeIfAbsent(scheduler, key -> new AtomicInteger(0))
 				                      .getAndIncrement();
 
+		Iterable<Tag> tags = Collections.singleton(Tag.of(TAG_SCHEDULER_ID, schedulerId));
+
 		/*
 		Design note: we assume that a given Scheduler won't apply the decorator twice to the
 		same ExecutorService. Even though, it would simply create an extraneous meter for
@@ -76,13 +84,12 @@ final class SchedulerMetricDecorator
 		to distinguish between two instances with the same name and configuration).
 		 */
 
+		ExecutorServiceMetrics.monitor(globalRegistry, service, executorId, tags);
+
 		// TODO return the result of ExecutorServiceMetrics#monitor
 		//  once ScheduledExecutorService gets supported by Micrometer
 		//  See https://github.com/micrometer-metrics/micrometer/issues/1021
-		ExecutorServiceMetrics.monitor(globalRegistry, service, executorId,
-				Tag.of(TAG_SCHEDULER_ID, schedulerId));
-
-		return service;
+		return new TimedScheduledExecutorService(globalRegistry, service, executorId, tags);
 	}
 
 	@Override
@@ -97,5 +104,36 @@ final class SchedulerMetricDecorator
 		this.seenSchedulers.clear();
 		this.schedulerDifferentiator.clear();
 		this.executorDifferentiator.clear();
+	}
+
+	static final class TimedScheduledExecutorService extends TimedExecutorService implements ScheduledExecutorService {
+
+		final ScheduledExecutorService delegate;
+
+		public TimedScheduledExecutorService(MeterRegistry registry, ScheduledExecutorService delegate, String executorServiceName, Iterable<Tag> tags) {
+			super(registry, delegate, executorServiceName, tags);
+
+			this.delegate = delegate;
+		}
+
+		@Override
+		public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+			return delegate.schedule(command, delay, unit);
+		}
+
+		@Override
+		public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+			return delegate.schedule(callable, delay, unit);
+		}
+
+		@Override
+		public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+			return delegate.scheduleAtFixedRate(command, initialDelay, period, unit);
+		}
+
+		@Override
+		public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+			return delegate.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+		}
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
@@ -84,6 +84,8 @@ final class SchedulerMetricDecorator
 		to distinguish between two instances with the same name and configuration).
 		 */
 
+		//the result of `monitor` below is ignored on purpose (the equivalent wrapping is done right after).
+		//calling this method is still useful, as it binds some gauges from the executor to the registry...
 		ExecutorServiceMetrics.monitor(globalRegistry, service, executorId, tags);
 
 		// TODO return the result of ExecutorServiceMetrics#monitor

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersMetricsTest.java
@@ -199,7 +199,7 @@ public class SchedulersMetricsTest {
 				.tag(TAG_SCHEDULER_ID, scheduler.toString())
 				.functionCounter();
 
-		// Use Awaitility instead of Phaser because "count" is reported "eventually"
+		// Use Awaitility because "count" is reported "eventually"
 		await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
 			assertThat(counter)
 					.isNotNull()
@@ -239,13 +239,16 @@ public class SchedulersMetricsTest {
 				.tag(TAG_SCHEDULER_ID, scheduler.toString())
 				.timer();
 
-		assertThat(timer)
-				.isNotNull()
-				.satisfies(it -> {
-					assertThat(it.count()).as("count").isEqualTo(taskCount);
-					assertThat(it.max(TimeUnit.MILLISECONDS))
-							.as("min")
-							.isEqualTo(60, offset(10.0d));
-				});
+		// Use Awaitility because "count" is reported "eventually"
+		await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+			assertThat(timer)
+					.isNotNull()
+					.satisfies(it -> {
+						assertThat(it.count()).as("count").isEqualTo(taskCount);
+						assertThat(it.max(TimeUnit.MILLISECONDS))
+								.as("min")
+								.isEqualTo(60, offset(10.0d));
+					});
+		});
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersMetricsTest.java
@@ -1,20 +1,30 @@
 package reactor.core.scheduler;
 
 import java.util.concurrent.Executors;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
-import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import reactor.core.Disposable;
+import reactor.core.Disposables;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+import static org.awaitility.Awaitility.await;
+import static reactor.core.scheduler.SchedulerMetricDecorator.TAG_SCHEDULER_ID;
 
 public class SchedulersMetricsTest {
 
 	final SimpleMeterRegistry simpleMeterRegistry = new SimpleMeterRegistry();
+
+	final Disposable.Composite disposables = Disposables.composite();
 
 	@Before
 	public void setUp() {
@@ -24,6 +34,7 @@ public class SchedulersMetricsTest {
 
 	@After
 	public void tearDown() {
+		disposables.dispose();
 		Schedulers.disableMetrics();
 		Metrics.globalRegistry.forEachMeter(Metrics.globalRegistry::remove);
 		Metrics.removeRegistry(simpleMeterRegistry);
@@ -58,7 +69,7 @@ public class SchedulersMetricsTest {
 
 		assertThat(simpleMeterRegistry.getMeters()
 		                              .stream()
-		                              .map(m -> m.getId().getTag(SchedulerMetricDecorator.TAG_SCHEDULER_ID))
+		                              .map(m -> m.getId().getTag(TAG_SCHEDULER_ID))
 		                              .distinct())
 				.containsOnly(
 						"parallel(4,\"A\")",
@@ -123,5 +134,72 @@ public class SchedulersMetricsTest {
 		                              .map(m -> m.getId().getName())
 		                              .distinct())
 				.containsExactly("foo");
+	}
+
+	@Test
+    public void shouldReportExecutorMetrics() {
+		Scheduler scheduler = Schedulers.newParallel("A", 1);
+		disposables.add(scheduler);
+
+		final int taskCount = 3;
+
+		for (int i = 0; i < taskCount; i++) {
+			scheduler.schedule(() -> {
+			});
+		}
+
+		FunctionCounter counter = simpleMeterRegistry
+				.find("executor.completed")
+				.tag(TAG_SCHEDULER_ID, scheduler.toString())
+				.functionCounter();
+
+		// Use Awaitility instead of Phaser because "count" is reported "eventually"
+		await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+			assertThat(counter)
+					.isNotNull()
+					.satisfies(it -> {
+						assertThat(it.count())
+								.as("count")
+								.isEqualTo(taskCount);
+					});
+		});
+    }
+
+	@Test(timeout = 10_000)
+	public void shouldReportExecutionTimes() {
+		Scheduler scheduler = Schedulers.newParallel("A", 1);
+		disposables.add(scheduler);
+
+		final int taskCount = 3;
+
+		Phaser phaser = new Phaser(1);
+		for (int i = 1; i <= taskCount; i++) {
+			phaser.register();
+			int delay = i * 20;
+			scheduler.schedule(() -> {
+				try {
+					Thread.sleep(delay);
+					phaser.arriveAndDeregister();
+				}
+				catch (InterruptedException e) {
+					throw new RuntimeException(e);
+				}
+			});
+		}
+		phaser.arriveAndAwaitAdvance();
+
+		Timer timer = simpleMeterRegistry
+				.find("executor")
+				.tag(TAG_SCHEDULER_ID, scheduler.toString())
+				.timer();
+
+		assertThat(timer)
+				.isNotNull()
+				.satisfies(it -> {
+					assertThat(it.count()).as("count").isEqualTo(taskCount);
+					assertThat(it.max(TimeUnit.MILLISECONDS))
+							.as("min")
+							.isEqualTo(60, offset(10.0d));
+				});
 	}
 }


### PR DESCRIPTION
Since we were ignoring the result of `ExecutorServiceMetrics.monitor`, we were not reporting the execution times of tasks submitted to `ExecutorService`s

These metrics are super helpful to detect thread starvation (by analysing `executor_seconds_max`, for instance)

Note the performance overhead of wrapping every `Runnable` submitted to the executor