### PR TITLE
fix #1798 Use bounded wildcard in #error methods

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -846,7 +846,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 *
 	 * @return a new failing {@link Flux}
 	 */
-	public static <T> Flux<T> error(Supplier<Throwable> errorSupplier) {
+	public static <T> Flux<T> error(Supplier<? extends Throwable> errorSupplier) {
 		return onAssembly(new FluxErrorSupplied<>(errorSupplier));
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxErrorSupplied.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxErrorSupplied.java
@@ -49,9 +49,9 @@ import reactor.core.Fuseable;
  */
 final class FluxErrorSupplied<T> extends Flux<T> implements Fuseable.ScalarCallable, SourceProducer<T> {
 
-	final Supplier<Throwable> errorSupplier;
+	final Supplier<? extends Throwable> errorSupplier;
 
-	FluxErrorSupplied(Supplier<Throwable> errorSupplier) {
+	FluxErrorSupplied(Supplier<? extends Throwable> errorSupplier) {
 		this.errorSupplier = Objects.requireNonNull(errorSupplier, "errorSupplier");
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -275,7 +275,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 *
 	 * @return a failing {@link Mono}
 	 */
-	public static <T> Mono<T> error(Supplier<Throwable> errorSupplier) {
+	public static <T> Mono<T> error(Supplier<? extends Throwable> errorSupplier) {
 		return onAssembly(new MonoErrorSupplied<>(errorSupplier));
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoErrorSupplied.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoErrorSupplied.java
@@ -47,9 +47,9 @@ import reactor.core.Fuseable;
  */
 final class MonoErrorSupplied<T> extends Mono<T> implements Fuseable.ScalarCallable, SourceProducer<T> {
 
-	final Supplier<Throwable> errorSupplier;
+	final Supplier<? extends Throwable> errorSupplier;
 
-	MonoErrorSupplied(Supplier<Throwable> errorSupplier) {
+	MonoErrorSupplied(Supplier<? extends Throwable> errorSupplier) {
 		this.errorSupplier = Objects.requireNonNull(errorSupplier, "errorSupplier");
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxErrorSuppliedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxErrorSuppliedTest.java
@@ -34,6 +34,7 @@ package reactor.core.publisher;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import java.util.function.Supplier;
 import org.junit.Test;
 import reactor.test.StepVerifier;
 
@@ -80,5 +81,15 @@ public class FluxErrorSuppliedTest {
 				.withMessage("boom1");
 
 		assertThat(count).as("after call").hasValue(1);
+	}
+
+	@Test
+	public void supplierMethod() {
+		StepVerifier.create(Flux.error(illegalStateExceptionSupplier()))
+				.verifyErrorMessage("boom");
+	}
+
+	private Supplier<IllegalStateException> illegalStateExceptionSupplier() {
+		return () -> new IllegalStateException("boom");
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxErrorSuppliedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxErrorSuppliedTest.java
@@ -86,7 +86,8 @@ public class FluxErrorSuppliedTest {
 	@Test
 	public void supplierMethod() {
 		StepVerifier.create(Flux.error(illegalStateExceptionSupplier()))
-				.verifyErrorMessage("boom");
+				.verifyErrorSatisfies(e -> assertThat(e).isInstanceOf(IllegalStateException.class)
+						.hasMessage("boom"));
 	}
 
 	private Supplier<IllegalStateException> illegalStateExceptionSupplier() {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoErrorSuppliedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoErrorSuppliedTest.java
@@ -116,11 +116,9 @@ public class MonoErrorSuppliedTest {
 
 	@Test
 	public void supplierMethod() {
-		Mono<Object> error = Mono.error(illegalStateExceptionSupplier());
-
-		assertThatExceptionOfType(IllegalStateException.class)
-				.isThrownBy(() -> error.block(Duration.ofMillis(100)))
-				.withMessage("boom");
+		StepVerifier.create(Mono.error(illegalStateExceptionSupplier()))
+				.verifyErrorSatisfies(e -> assertThat(e).isInstanceOf(IllegalStateException.class)
+						.hasMessage("boom"));
 	}
 
 	private Supplier<IllegalStateException> illegalStateExceptionSupplier() {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoErrorSuppliedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoErrorSuppliedTest.java
@@ -19,6 +19,7 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import java.util.function.Supplier;
 import org.junit.Test;
 import reactor.test.StepVerifier;
 
@@ -111,5 +112,18 @@ public class MonoErrorSuppliedTest {
 				.withMessage("boom1");
 
 		assertThat(count).as("after call").hasValue(1);
+	}
+
+	@Test
+	public void supplierMethod() {
+		Mono<Object> error = Mono.error(illegalStateExceptionSupplier());
+
+		assertThatExceptionOfType(IllegalStateException.class)
+				.isThrownBy(() -> error.block(Duration.ofMillis(100)))
+				.withMessage("boom");
+	}
+
+	private Supplier<IllegalStateException> illegalStateExceptionSupplier() {
+		return () -> new IllegalStateException("boom");
 	}
 }


### PR DESCRIPTION
Please refer https://github.com/reactor/reactor-core/issues/1798