### PR TITLE
fix #1797 Explicitly reject null keys/values in Context constructors

### DIFF
--- a/reactor-core/src/main/java/reactor/util/context/Context.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context.java
@@ -56,6 +56,7 @@ public interface Context {
 	 * @param key the key to initialize.
 	 * @param value the value for the key.
 	 * @return a {@link Context} with a single entry.
+	 * @throws NullPointerException if either key or value are null
 	 */
 	static Context of(Object key, Object value) {
 		return new Context1(key, value);
@@ -69,6 +70,7 @@ public interface Context {
 	 * @param key2 the second key to initialize.
 	 * @param value2 the value for the second key.
 	 * @return a {@link Context} with two entries.
+	 * @throws NullPointerException if any key or value is null
 	 */
 	static Context of(Object key1, Object value1,
 			Object key2, Object value2) {
@@ -85,6 +87,7 @@ public interface Context {
 	 * @param key3 the third key to initialize.
 	 * @param value3 the value for the third key.
 	 * @return a {@link Context} with three entries.
+	 * @throws NullPointerException if any key or value is null
 	 */
 	static Context of(Object key1, Object value1,
 			Object key2, Object value2,
@@ -104,6 +107,7 @@ public interface Context {
 	 * @param key4 the fourth key to initialize.
 	 * @param value4 the value for the fourth key.
 	 * @return a {@link Context} with four entries.
+	 * @throws NullPointerException if any key or value is null
 	 */
 	static Context of(Object key1, Object value1,
 			Object key2, Object value2,
@@ -126,6 +130,7 @@ public interface Context {
 	 * @param key5 the fifth key to initialize.
 	 * @param value5 the value for the fifth key.
 	 * @return a {@link Context} with five entries.
+	 * @throws NullPointerException if any key or value is null
 	 */
 	static Context of(Object key1, Object value1,
 			Object key2, Object value2,
@@ -140,7 +145,6 @@ public interface Context {
 	 * a {@link NoSuchElementException} if the key is not present.
 	 *
 	 * @param key a lookup key to resolve the value within the context
-	 *
 	 * @param <T> an unchecked casted generic for fluent typing convenience
 	 *
 	 * @return the value resolved for this key (throws if key not found)
@@ -230,6 +234,7 @@ public interface Context {
 	 * @param value the value to associate to the key in the new {@link Context}
 	 *
 	 * @return a new {@link Context} including the provided key/value
+	 * @throws NullPointerException if either the key or value are null
 	 */
 	Context put(Object key, Object value);
 
@@ -242,6 +247,7 @@ public interface Context {
 	 * @param valueOrNull the value to associate to the key in the new {@link Context}, null to ignore the operation
 	 *
 	 * @return a new {@link Context} including the provided key/value, or the same {@link Context} if value is null
+	 * @throws NullPointerException if the key is null
 	 */
 	default Context putNonNull(Object key, @Nullable Object valueOrNull) {
 		if (valueOrNull != null) {

--- a/reactor-core/src/main/java/reactor/util/context/Context1.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context1.java
@@ -26,8 +26,8 @@ final class Context1 implements Context, Map.Entry<Object, Object> {
 	final Object value;
 
 	Context1(Object key, Object value) {
-		this.key = key;
-		this.value = value;
+		this.key = Objects.requireNonNull(key, "key");
+		this.value = Objects.requireNonNull(value, "value");
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/util/context/Context2.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context2.java
@@ -29,10 +29,10 @@ final class Context2 implements Context {
 	final Object value2;
 
 	Context2(Object key1, Object value1, Object key2, Object value2) {
-		this.key1 = key1;
-		this.value1 = value1;
-		this.key2 = key2;
-		this.value2 = value2;
+		this.key1 = Objects.requireNonNull(key1, "key1");
+		this.value1 = Objects.requireNonNull(value1, "value1");
+		this.key2 = Objects.requireNonNull(key2, "key2");
+		this.value2 = Objects.requireNonNull(value2, "value2");
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/util/context/Context3.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context3.java
@@ -33,12 +33,12 @@ final class Context3 implements Context {
 	Context3(Object key1, Object value1,
 			Object key2, Object value2,
 			Object key3, Object value3) {
-		this.key1 = key1;
-		this.value1 = value1;
-		this.key2 = key2;
-		this.value2 = value2;
-		this.key3 = key3;
-		this.value3 = value3;
+		this.key1 = Objects.requireNonNull(key1, "key1");
+		this.value1 = Objects.requireNonNull(value1, "value1");
+		this.key2 = Objects.requireNonNull(key2, "key2");
+		this.value2 = Objects.requireNonNull(value2, "value2");
+		this.key3 = Objects.requireNonNull(key3, "key3");
+		this.value3 = Objects.requireNonNull(value3, "value3");
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/util/context/Context4.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context4.java
@@ -36,14 +36,14 @@ final class Context4 implements Context {
 			Object key2, Object value2,
 			Object key3, Object value3,
 			Object key4, Object value4) {
-		this.key1 = key1;
-		this.value1 = value1;
-		this.key2 = key2;
-		this.value2 = value2;
-		this.key3 = key3;
-		this.value3 = value3;
-		this.key4 = key4;
-		this.value4 = value4;
+		this.key1 = Objects.requireNonNull(key1, "key1");
+		this.value1 = Objects.requireNonNull(value1, "value1");
+		this.key2 = Objects.requireNonNull(key2, "key2");
+		this.value2 = Objects.requireNonNull(value2, "value2");
+		this.key3 = Objects.requireNonNull(key3, "key3");
+		this.value3 = Objects.requireNonNull(value3, "value3");
+		this.key4 = Objects.requireNonNull(key4, "key4");
+		this.value4 = Objects.requireNonNull(value4, "value4");
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/util/context/Context5.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context5.java
@@ -39,16 +39,16 @@ final class Context5 implements Context {
 			Object key3, Object value3,
 			Object key4, Object value4,
 			Object key5, Object value5) {
-		this.key1 = key1;
-		this.value1 = value1;
-		this.key2 = key2;
-		this.value2 = value2;
-		this.key3 = key3;
-		this.value3 = value3;
-		this.key4 = key4;
-		this.value4 = value4;
-		this.key5 = key5;
-		this.value5 = value5;
+		this.key1 = Objects.requireNonNull(key1, "key1");
+		this.value1 = Objects.requireNonNull(value1, "value1");
+		this.key2 = Objects.requireNonNull(key2, "key2");
+		this.value2 = Objects.requireNonNull(value2, "value2");
+		this.key3 = Objects.requireNonNull(key3, "key3");
+		this.value3 = Objects.requireNonNull(value3, "value3");
+		this.key4 = Objects.requireNonNull(key4, "key4");
+		this.value4 = Objects.requireNonNull(value4, "value4");
+		this.key5 = Objects.requireNonNull(key5, "key5");
+		this.value5 = Objects.requireNonNull(value5, "value5");
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/util/context/ContextN.java
+++ b/reactor-core/src/main/java/reactor/util/context/ContextN.java
@@ -16,11 +16,11 @@
 package reactor.util.context;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -28,31 +28,42 @@ import java.util.stream.Stream;
 import reactor.util.annotation.Nullable;
 
 @SuppressWarnings("unchecked")
-final class ContextN extends ConcurrentHashMap<Object, Object>
+final class ContextN extends HashMap<Object, Object>
 		implements Context, Function<Entry<Object, Object>, Entry<Object, Object>> {
 
 	ContextN(Object key1, Object value1, Object key2, Object value2,
 			Object key3, Object value3, Object key4, Object value4,
 			Object key5, Object value5, Object key6, Object value6) {
 		super(6, 1f);
-		super.put(key1, value1);
-		super.put(key2, value2);
-		super.put(key3, value3);
-		super.put(key4, value4);
-		super.put(key5, value5);
-		super.put(key6, value6);
+		innerPut(key1, value1);
+		innerPut(key2, value2);
+		innerPut(key3, value3);
+		innerPut(key4, value4);
+		innerPut(key5, value5);
+		innerPut(key6, value6);
 	}
 
 	ContextN(Map<Object, Object> map, Object key, Object value) {
 		super(map.size() + 1, 1f);
-		super.putAll(map);
-		super.put(key, value);
+		innerPutAll(map);
+		innerPut(key, value);
 	}
 
 	ContextN(Map<Object, Object> sourceMap, Map<?, ?> other) {
 		super(sourceMap.size() + other.size(), 1f);
-		super.putAll(sourceMap);
-		super.putAll(other);
+		innerPutAll(sourceMap);
+		innerPutAll(other);
+	}
+
+	private void innerPut(Object key, Object value) {
+		super.put(Objects.requireNonNull(key, "null key passed to constructor"),
+				Objects.requireNonNull(value, "null value passed to constructor"));
+	}
+
+	private void innerPutAll(Map<?, ?> map) {
+		Objects.requireNonNull(map, "map in constructor")
+		       .forEach((k,v) -> super.put(Objects.requireNonNull(k, "map in constructor contains null key"),
+				       Objects.requireNonNull(v, "map in constructor contains null value")));
 	}
 
 	@Override
@@ -94,8 +105,7 @@ final class ContextN extends ConcurrentHashMap<Object, Object>
 
 	@Override
 	public boolean hasKey(Object key) {
-		//explicitly duplicate what ConcurrentHashMap does
-		return super.get(key) != null;
+		return super.containsKey(key);
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/util/context/ContextN.java
+++ b/reactor-core/src/main/java/reactor/util/context/ContextN.java
@@ -56,14 +56,13 @@ final class ContextN extends HashMap<Object, Object>
 	}
 
 	private void innerPut(Object key, Object value) {
-		super.put(Objects.requireNonNull(key, "null key passed to constructor"),
-				Objects.requireNonNull(value, "null value passed to constructor"));
+		super.put(Objects.requireNonNull(key, "key"),
+				Objects.requireNonNull(value, "value"));
 	}
 
 	private void innerPutAll(Map<?, ?> map) {
-		Objects.requireNonNull(map, "map in constructor")
-		       .forEach((k,v) -> super.put(Objects.requireNonNull(k, "map in constructor contains null key"),
-				       Objects.requireNonNull(v, "map in constructor contains null value")));
+		Objects.requireNonNull(map, "map")
+		       .forEach(this::innerPut);
 	}
 
 	@Override

--- a/reactor-core/src/test/java/reactor/util/context/ContextNTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextNTest.java
@@ -16,6 +16,8 @@
 
 package reactor.util.context;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -23,8 +25,7 @@ import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.*;
 import static reactor.util.context.ContextTest.*;
 
 public class ContextNTest {
@@ -35,6 +36,74 @@ public class ContextNTest {
 	public void initContext() {
 		c = new ContextN(1, "A", 2, "B", 3, "C",
 			4, "D", 5, "E", 6, "F");
+	}
+
+	@Test
+	public void constructFromPairsRejectsNulls() {
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(null, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(1, null, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(1, 1, null, 2, 3, 3, 4, 4, 5, 5, 6, 6));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(1, 1, 2, null, 3, 3, 4, 4, 5, 5, 6, 6));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(1, 1, 2, 2, null, 3, 4, 4, 5, 5, 6, 6));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(1, 1, 2, 2, 3, null, 4, 4, 5, 5, 6, 6));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(1, 1, 2, 2, 3, 3, null, 4, 5, 5, 6, 6));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(1, 1, 2, 2, 3, 3, 4, null, 5, 5, 6, 6));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(1, 1, 2, 2, 3, 3, 4, 4, null, 5, 6, 6));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(1, 1, 2, 2, 3, 3, 4, 4, 5, null, 6, 6));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(1, 1, 2, 2, 3, 3, 4, 4, 5, 5, null, 6));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, null));
+	}
+
+	@Test
+	public void constructFromMapWithNullKey() {
+		Map<Object, Object> map = new HashMap<>(1);
+		map.put(null, 0);
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(map, "foo", 1));
+	}
+
+	@Test
+	public void constructFromMapWithNullValue() {
+		Map<Object, Object> map = new HashMap<>(1);
+		map.put("key", null);
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(map, "foo", 1));
+	}
+
+	@Test
+	public void constructFromMapWithAdditionalNullKey() {
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(Collections.emptyMap(), null, 1));
+	}
+
+	@Test
+	public void constructFromMapWithAdditionalNullValue() {
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(Collections.emptyMap(), "foo", null));
+	}
+
+	@Test
+	public void constructFromMapsWithLeftNullKey() {
+		Map<Object, Object> leftMap = new HashMap<>(1);
+		leftMap.put(null, "foo");
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(leftMap, Collections.emptyMap()));
+	}
+
+	@Test
+	public void constructFromMapsWithLeftNullValue() {
+		Map<Object, Object> leftMap = new HashMap<>(1);
+		leftMap.put("key", null);
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(leftMap, Collections.emptyMap()));
+	}
+
+	@Test
+	public void constructFromMapsWithRightNullKey() {
+		Map<Object, Object> rightMap = new HashMap<>(1);
+		rightMap.put(null, "foo");
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(Collections.emptyMap(), rightMap));
+	}
+
+	@Test
+	public void constructFromMapsWithRightNullValue() {
+		Map<Object, Object> rightMap = new HashMap<>(1);
+		rightMap.put("key", null);
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(Collections.emptyMap(), rightMap));
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/context/ContextTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextTest.java
@@ -20,6 +20,7 @@ import org.assertj.core.api.Condition;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 public class ContextTest {
 
@@ -106,6 +107,86 @@ public class ContextTest {
 		assertThat(c).isInstanceOf(Context5.class);
 		assertThat(c.isEmpty()).as("isEmpty").isFalse();
 		assertThat(c.stream()).hasSize(5);
+	}
+	
+	@Test
+	public void of1NullChecks() {
+		assertThatNullPointerException().as("key1").isThrownBy(() -> Context.of(null, 1))
+		                                .withMessage("key");
+		assertThatNullPointerException().as("value1").isThrownBy(() -> Context.of(1, null))
+		                                .withMessage("value");
+	}
+	
+	@Test
+	public void of2NullChecks() {
+		assertThatNullPointerException().as("key1").isThrownBy(() -> Context.of(null, 2, 2, 2))
+		                                .withMessage("key1");
+		assertThatNullPointerException().as("value1").isThrownBy(() -> Context.of(2, null, 2, 2))
+		                                .withMessage("value1");
+		assertThatNullPointerException().as("key2").isThrownBy(() -> Context.of(2, 2, null, 2))
+		                                .withMessage("key2");
+		assertThatNullPointerException().as("value2").isThrownBy(() -> Context.of(2, 2, 2, null))
+		                                .withMessage("value2");
+	}
+	
+	@Test
+	public void of3NullChecks() {
+		assertThatNullPointerException().as("key1").isThrownBy(() -> Context.of(null, 3, 3, 3, 3, 3))
+		                                .withMessage("key1");
+		assertThatNullPointerException().as("value1").isThrownBy(() -> Context.of(3, null, 3, 3, 3, 3))
+		                                .withMessage("value1");
+		assertThatNullPointerException().as("key2").isThrownBy(() -> Context.of(3, 3, null, 3, 3, 3))
+		                                .withMessage("key2");
+		assertThatNullPointerException().as("value2").isThrownBy(() -> Context.of(3, 3, 3, null, 3, 3))
+		                                .withMessage("value2");
+		assertThatNullPointerException().as("key3").isThrownBy(() -> Context.of(3, 3, 3, 3, null, 3))
+		                                .withMessage("key3");
+		assertThatNullPointerException().as("value3").isThrownBy(() -> Context.of(3, 3, 3, 3, 3, null))
+		                                .withMessage("value3");
+	}
+	
+	@Test
+	public void of4NullChecks() {
+		assertThatNullPointerException().as("key1").isThrownBy(() -> Context.of(null, 4, 4, 4, 4, 4, 4, 4))
+		                                .withMessage("key1");
+		assertThatNullPointerException().as("value1").isThrownBy(() -> Context.of(4, null, 4, 4, 4, 4, 4, 4))
+		                                .withMessage("value1");
+		assertThatNullPointerException().as("key2").isThrownBy(() -> Context.of(4, 4, null, 4, 4, 4, 4, 4))
+		                                .withMessage("key2");
+		assertThatNullPointerException().as("value2").isThrownBy(() -> Context.of(4, 4, 4, null, 4, 4, 4, 4))
+		                                .withMessage("value2");
+		assertThatNullPointerException().as("key3").isThrownBy(() -> Context.of(4, 4, 4, 4, null, 4, 4, 4))
+		                                .withMessage("key3");
+		assertThatNullPointerException().as("value3").isThrownBy(() -> Context.of(4, 4, 4, 4, 4, null, 4, 4))
+		                                .withMessage("value3");
+		assertThatNullPointerException().as("key4").isThrownBy(() -> Context.of(4, 4, 4, 4, 4, 4, null, 4))
+		                                .withMessage("key4");
+		assertThatNullPointerException().as("value4").isThrownBy(() -> Context.of(4, 4, 4, 4, 4, 4, 4, null))
+		                                .withMessage("value4");
+	}
+	
+	@Test
+	public void of5NullChecks() {
+		assertThatNullPointerException().as("key1").isThrownBy(() -> Context.of(null, 5, 5, 5, 5, 5, 5, 5, 5, 5))
+		                                .withMessage("key1");
+		assertThatNullPointerException().as("value1").isThrownBy(() -> Context.of(5, null, 5, 5, 5, 5, 5, 5, 5, 5))
+		                                .withMessage("value1");
+		assertThatNullPointerException().as("key2").isThrownBy(() -> Context.of(5, 5, null, 5, 5, 5, 5, 5, 5, 5))
+		                                .withMessage("key2");
+		assertThatNullPointerException().as("value2").isThrownBy(() -> Context.of(5, 5, 5, null, 5, 5, 5, 5, 5, 5))
+		                                .withMessage("value2");
+		assertThatNullPointerException().as("key3").isThrownBy(() -> Context.of(5, 5, 5, 5, null, 5, 5, 5, 5, 5))
+		                                .withMessage("key3");
+		assertThatNullPointerException().as("value3").isThrownBy(() -> Context.of(5, 5, 5, 5, 5, null, 5, 5, 5, 5))
+		                                .withMessage("value3");
+		assertThatNullPointerException().as("key4").isThrownBy(() -> Context.of(5, 5, 5, 5, 5, 5, null, 5, 5, 5))
+		                                .withMessage("key4");
+		assertThatNullPointerException().as("value4").isThrownBy(() -> Context.of(5, 5, 5, 5, 5, 5, 5, null, 5, 5))
+		                                .withMessage("value4");
+		assertThatNullPointerException().as("key5").isThrownBy(() -> Context.of(5, 5, 5, 5, 5, 5, 5, 5, null, 5))
+		                                .withMessage("key5");
+		assertThatNullPointerException().as("value5").isThrownBy(() -> Context.of(5, 5, 5, 5, 5, 5, 5, 5, 5, null))
+		                                .withMessage("value5");
 	}
 
 }


### PR DESCRIPTION
This commit better enforces non-null nature of the various Context
implementations by throwing a NullPointerException whenever a null key
or null value is passed to one of the implementations' constructors.

This aligns with the `put` behavior, which already throws NPE.

To that end, ContextN now extends ConcurrentHashMap: this flavor
naturally rejects nulls, contrary to HashMap and LinkedHashMap.