### PR TITLE
Polish ContextN null checks

### DIFF
--- a/reactor-core/src/main/java/reactor/util/context/Context.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context.java
@@ -19,6 +19,7 @@ package reactor.util.context;
 import java.util.Collections;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -150,7 +151,7 @@ public interface Context {
 	 * when map size is less than 6.
 	 */
 	static Context of(Map<?, ?> map) {
-		int size = map.size();
+		int size = Objects.requireNonNull(map, "map").size();
 		if (size == 0) return Context.empty();
 		if (size <= 5) {
 			Map.Entry[] entries = map.entrySet().toArray(new Map.Entry[size]);

--- a/reactor-core/src/main/java/reactor/util/context/ContextN.java
+++ b/reactor-core/src/main/java/reactor/util/context/ContextN.java
@@ -47,18 +47,17 @@ final class ContextN extends HashMap<Object, Object>
 	}
 
 	ContextN(Map<Object, Object> map, Object key, Object value) {
-		super(map.size() + 1, 1f);
-		Objects.requireNonNull(map, "map")
-		       .forEach(this);
+		super(Objects.requireNonNull(map, "map").size() + 1, 1f);
+		map.forEach(this);
 		accept(key, value); //innerPut
 	}
 
 	ContextN(Map<Object, Object> sourceMap, Map<?, ?> other) {
-		super(sourceMap.size() + other.size(), 1f);
-		Objects.requireNonNull(sourceMap, "sourceMap")
-		       .forEach(this);
-		Objects.requireNonNull(other, "other")
-		       .forEach(this);
+		super(Objects.requireNonNull(sourceMap, "sourceMap").size()
+						+ Objects.requireNonNull(other, "other").size(),
+				1f);
+		sourceMap.forEach(this);
+		other.forEach(this);
 	}
 
 	//this performs an inner put to the actual hashmap, and also allows passing `this` directly to

--- a/reactor-core/src/test/java/reactor/util/context/ContextNTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextNTest.java
@@ -55,55 +55,81 @@ public class ContextNTest {
 	}
 
 	@Test
+	public void constructFromMapNull() {
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(null, "foo", 1))
+		                                .withMessage("map");
+	}
+
+	@Test
 	public void constructFromMapWithNullKey() {
 		Map<Object, Object> map = new HashMap<>(1);
 		map.put(null, 0);
-		assertThatNullPointerException().isThrownBy(() -> new ContextN(map, "foo", 1));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(map, "foo", 1))
+		                                .withMessage("key");
 	}
 
 	@Test
 	public void constructFromMapWithNullValue() {
 		Map<Object, Object> map = new HashMap<>(1);
 		map.put("key", null);
-		assertThatNullPointerException().isThrownBy(() -> new ContextN(map, "foo", 1));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(map, "foo", 1))
+		                                .withMessage("value");
 	}
 
 	@Test
 	public void constructFromMapWithAdditionalNullKey() {
-		assertThatNullPointerException().isThrownBy(() -> new ContextN(Collections.emptyMap(), null, 1));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(Collections.emptyMap(), null, 1))
+		                                .withMessage("key");
 	}
 
 	@Test
 	public void constructFromMapWithAdditionalNullValue() {
-		assertThatNullPointerException().isThrownBy(() -> new ContextN(Collections.emptyMap(), "foo", null));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(Collections.emptyMap(), "foo", null))
+		                                .withMessage("value");
+	}
+
+	@Test
+	public void constructFromMapsLeftNull() {
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(null, Collections.emptyMap()))
+		                                .withMessage("sourceMap");
+	}
+
+	@Test
+	public void constructFromMapsRightNull() {
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(Collections.emptyMap(), null))
+		                                .withMessage("other");
 	}
 
 	@Test
 	public void constructFromMapsWithLeftNullKey() {
 		Map<Object, Object> leftMap = new HashMap<>(1);
 		leftMap.put(null, "foo");
-		assertThatNullPointerException().isThrownBy(() -> new ContextN(leftMap, Collections.emptyMap()));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(leftMap, Collections.emptyMap()))
+		                                .withMessage("key");
 	}
 
 	@Test
 	public void constructFromMapsWithLeftNullValue() {
 		Map<Object, Object> leftMap = new HashMap<>(1);
 		leftMap.put("key", null);
-		assertThatNullPointerException().isThrownBy(() -> new ContextN(leftMap, Collections.emptyMap()));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(leftMap, Collections.emptyMap()))
+		                                .withMessage("value");
 	}
 
 	@Test
 	public void constructFromMapsWithRightNullKey() {
 		Map<Object, Object> rightMap = new HashMap<>(1);
 		rightMap.put(null, "foo");
-		assertThatNullPointerException().isThrownBy(() -> new ContextN(Collections.emptyMap(), rightMap));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(Collections.emptyMap(), rightMap))
+		                                .withMessage("key");
 	}
 
 	@Test
 	public void constructFromMapsWithRightNullValue() {
 		Map<Object, Object> rightMap = new HashMap<>(1);
 		rightMap.put("key", null);
-		assertThatNullPointerException().isThrownBy(() -> new ContextN(Collections.emptyMap(), rightMap));
+		assertThatNullPointerException().isThrownBy(() -> new ContextN(Collections.emptyMap(), rightMap))
+		                                .withMessage("value");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/context/ContextTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextTest.java
@@ -236,6 +236,13 @@ public class ContextTest {
 	}
 
 	@Test
+	public void ofMapNull() {
+		Map<String, Integer> nullMap = null;
+		assertThatNullPointerException().isThrownBy(() -> Context.of(nullMap))
+		                                .withMessage("map");
+	}
+
+	@Test
 	public void ofMapOne() {
 		Map<String, Integer> map = new HashMap<>(1);
 		map.put("k1", 1);


### PR DESCRIPTION
This commit polishes null checks introduced to ContextN in #1800 and
and #1794 by moving the checks to the `super` calls (since they already
make use of the potentially null input parameters).