### PR TITLE
Polish flux metrics

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
@@ -256,7 +256,6 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 
 	static final BiFunction<Tags, Tuple2<String, String>, Tags> TAG_ACCUMULATOR =
 			(prev, tuple) -> prev.and(Tag.of(tuple.getT1(), tuple.getT2()));
-	static final BinaryOperator<Tags> TAG_COMBINER = (a, b) -> b;
 
 	/**
 	 * Extract the name from the upstream, and detect if there was an actual name (ie. distinct from {@link
@@ -298,7 +297,10 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 
 		if (scannable.isScanAvailable()) {
 			return scannable.tags()
-			                .reduce(tags, TAG_ACCUMULATOR, TAG_COMBINER);
+			                //Note the combiner below is for parallel streams, which won't be used
+			                //For the identity, `commonTags` should be ok (even if reduce uses it multiple times)
+			                //since it deduplicates
+			                .reduce(tags, TAG_ACCUMULATOR, Tags::and);
 		}
 
 		return tags;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
@@ -256,6 +256,7 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 
 	static final BiFunction<Tags, Tuple2<String, String>, Tags> TAG_ACCUMULATOR =
 			(prev, tuple) -> prev.and(Tag.of(tuple.getT1(), tuple.getT2()));
+	static final BinaryOperator<Tags> TAG_COMBINER = Tags::and;
 
 	/**
 	 * Extract the name from the upstream, and detect if there was an actual name (ie. distinct from {@link
@@ -300,7 +301,7 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 			                //Note the combiner below is for parallel streams, which won't be used
 			                //For the identity, `commonTags` should be ok (even if reduce uses it multiple times)
 			                //since it deduplicates
-			                .reduce(tags, TAG_ACCUMULATOR, Tags::and);
+			                .reduce(tags, TAG_ACCUMULATOR, TAG_COMBINER);
 		}
 
 		return tags;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
@@ -244,8 +244,8 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 	 * Tag bearing the sequence's name, as given by the {@link Flux#name(String)} operator.
 	 */
 	static final String TAG_SEQUENCE_NAME = "flow";
-	static final Tags   DEFAULT_TAGS_FLUX = Tags.of(Tag.of("type", "Flux"));
-	static final Tags   DEFAULT_TAGS_MONO = Tags.of(Tag.of("type", "Mono"));
+	static final Tags   DEFAULT_TAGS_FLUX = Tags.of("type", "Flux");
+	static final Tags   DEFAULT_TAGS_MONO = Tags.of("type", "Mono");
 
 	// === Operator ===
 	static final Tag  TAG_ON_ERROR    = Tag.of("status", "error");

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
@@ -306,6 +306,12 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 		return tags;
 	}
 
+	/*
+	 * This method calls the registry, which can be costly. However the cancel signal is only expected
+	 * once per Subscriber. So the net effect should be that the registry is only called once, which
+	 * is equivalent to registering the meter as a final field, with the added benefit of paying that
+	 * cost only in case of cancellation.
+	 */
 	static void recordCancel(Tags commonTags, MeterRegistry registry, Timer.Sample flowDuration) {
 		Timer timer = Timer.builder(METER_FLOW_DURATION)
 		                   .tags(commonTags.and(TAG_CANCEL))
@@ -316,11 +322,23 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 		flowDuration.stop(timer);
 	}
 
+	/*
+	 * This method calls the registry, which can be costly. However a malformed signal is generally
+	 * not expected, or at most once per Subscriber. So the net effect should be that the registry
+	 * is only called once, which is equivalent to registering the meter as a final field,
+	 * with the added benefit of paying that cost only in case of onNext/onError after termination.
+	 */
 	static void recordMalformed(Tags commonTags, MeterRegistry registry) {
 		registry.counter(FluxMetrics.METER_MALFORMED, commonTags)
 		        .increment();
 	}
 
+	/*
+	 * This method calls the registry, which can be costly. However the onError signal is expected
+	 * at most once per Subscriber. So the net effect should be that the registry is only called once,
+	 * which is equivalent to registering the meter as a final field, with the added benefit of paying
+	 * that cost only in case of error.
+	 */
 	static void recordOnError(Tags commonTags, MeterRegistry registry, Timer.Sample flowDuration, Throwable e) {
 		Timer timer = Timer.builder(METER_FLOW_DURATION)
 		                   .tags(commonTags.and(TAG_ON_ERROR))
@@ -334,6 +352,12 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 		flowDuration.stop(timer);
 	}
 
+	/*
+	 * This method calls the registry, which can be costly. However the onComplete signal is expected
+	 * at most once per Subscriber. So the net effect should be that the registry is only called once,
+	 * which is equivalent to registering the meter as a final field, with the added benefit of paying
+	 * that cost only in case of completion (which is not always occurring).
+	 */
 	static void recordOnComplete(Tags commonTags, MeterRegistry registry, Timer.Sample flowDuration) {
 		Timer timer = Timer.builder(METER_FLOW_DURATION)
 		                   .tags(commonTags.and(TAG_ON_COMPLETE))
@@ -344,6 +368,12 @@ final class FluxMetrics<T> extends FluxOperator<T, T> {
 		flowDuration.stop(timer);
 	}
 
+	/*
+	 * This method calls the registry, which can be costly. However the onSubscribe signal is expected
+	 * at most once per Subscriber. So the net effect should be that the registry is only called once,
+	 * which is equivalent to registering the meter as a final field, with the added benefit of paying
+	 * that cost only in case of subscription.
+	 */
 	static void recordOnSubscribe(Tags commonTags, MeterRegistry registry) {
 		Counter.builder(METER_SUBSCRIBED)
 		       .tags(commonTags)

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
@@ -131,6 +131,7 @@ final class MonoMetrics<T> extends MonoOperator<T, T> {
 				return;
 			}
 			done = true;
+			//TODO looks like we don't count onNext: `Mono.empty()` vs `Mono.just("foo")`
 			FluxMetrics.recordOnComplete(commonTags, registry, subscribeToTerminateSample);
 			actual.onNext(t);
 			actual.onComplete();

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
@@ -41,7 +41,6 @@ final class MonoMetrics<T> extends MonoOperator<T, T> {
 
 	final String        name;
 	final Tags          tags;
-	@Nullable
 	final MeterRegistry meterRegistry;
 
 	MonoMetrics(Mono<? extends T> mono) {


### PR DESCRIPTION
Reviewing commits a9cc14e2e9907d8f7b46c8f0aa678ffed90a1e92, f478ab30c1ba810d97ed31570829adb953406209, 610a77025b131fa66e8d1f27262ac92d372a2bb7, d1d45c69960df03baa1f5f3848d43abacf1d76ed and 6897e3f94041c4a7bf57014312b244f3d6aa1c37 I came across a few polish points summarized below:

 - [x] Use the `Tags::and` combiner for reduce, even though it is only useful for parallel streams (do the right thing, `(a,b)->b` would totally break things if the stream was parallelized)
 - [x] Tags.of(k, v) is even leaner on allocations than Tags.of(Tag.of(k,v))
 - [x] Explicitly comment record* methods are special and can call registry
 - [x] Align all 4 implementations to make registryCandidate non-null in ctor 


