### PR TITLE
Fix the "Threading and Schedulers" sample code

### DIFF
--- a/docs/asciidoc/coreFeatures.adoc
+++ b/docs/asciidoc/coreFeatures.adoc
@@ -155,15 +155,17 @@ example runs a `Mono` in a new thread:
 ====
 [source,java]
 ----
-public static void main(String[] args) {
+public static void main(String[] args) throws InterruptedException {
   final Mono<String> mono = Mono.just("hello "); //<1>
 
-  new Thread(() -> mono
+  Thread t = new Thread(() -> mono
       .map(msg -> msg + "thread ")
       .subscribe(v -> //<2>
           System.out.println(v + Thread.currentThread().getName()) //<3>
       )
-  ).join();
+  )
+  t.start();
+  t.join();
 
 }
 ----


### PR DESCRIPTION
The code used to illustrate the section is incomplete: the thread it creates is never actually started, so the subscription never happens. Fix by explicitly starting it before join()-ing on it. Also add "throws InterruptedException" to make the code actually compile.