### PR TITLE
Update a link to Micrometer's docs for the executor metrics

### DIFF
--- a/docs/asciidoc/metrics.adoc
+++ b/docs/asciidoc/metrics.adoc
@@ -27,7 +27,7 @@ TIP: If you're using Spring Boot, it is a good idea to place the invocation befo
 
 Once scheduler metrics are enabled and provided it is on the classpath, Reactor will use Micrometer's support for instrumenting the executors that back most schedulers.
 
-Please refer to http://micrometer.io/docs[Micrometer's documentation] for the exposed metrics, such as:
+Please refer to http://micrometer.io/docs/ref/jvm[Micrometer's documentation] for the exposed metrics, such as:
 
 - executor_active_threads
 - executor_completed_tasks_total


### PR DESCRIPTION
Since https://github.com/micrometer-metrics/micrometer-docs/issues/97 is closed now,
We should point the users that page.