### PR TITLE
fix #1451 Dematerialize needs extra request(1) for terminal signals...

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDematerialize.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDematerialize.java
@@ -83,11 +83,11 @@ final class FluxDematerialize<T> extends FluxOperator<Signal<T>, T> {
 				s.cancel();
 				onComplete();
 			}
-			else if (t.isOnError() && t.getThrowable() != null) {
+			else if (t.isOnError()) {
 				s.cancel();
 				onError(t.getThrowable());
 			}
-			else if (t.isOnNext() && t.get() != null) {
+			else if (t.isOnNext()) {
 				actual.onNext(t.get());
 				if (completeAfterOnNext) {
 					onComplete();

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDematerialize.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDematerialize.java
@@ -38,7 +38,7 @@ final class FluxDematerialize<T> extends FluxOperator<Signal<T>, T> {
 	static final class DematerializeSubscriber<T> implements InnerOperator<Signal<T>, T> {
 
 		final CoreSubscriber<? super T> actual;
-		final boolean isMono;
+		final boolean                   completeAfterOnNext;
 
 		Subscription s;
 
@@ -46,9 +46,9 @@ final class FluxDematerialize<T> extends FluxOperator<Signal<T>, T> {
 
 		volatile boolean cancelled;
 
-		DematerializeSubscriber(CoreSubscriber<? super T> subscriber, boolean isMono) {
+		DematerializeSubscriber(CoreSubscriber<? super T> subscriber, boolean completeAfterOnNext) {
 			this.actual = subscriber;
-			this.isMono = isMono;
+			this.completeAfterOnNext = completeAfterOnNext;
 		}
 
 		@Override
@@ -89,7 +89,7 @@ final class FluxDematerialize<T> extends FluxOperator<Signal<T>, T> {
 			}
 			else if (t.isOnNext() && t.get() != null) {
 				actual.onNext(t.get());
-				if (isMono) {
+				if (completeAfterOnNext) {
 					onComplete();
 				}
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDematerialize.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDematerialize.java
@@ -28,6 +28,6 @@ final class MonoDematerialize<T> extends MonoOperator<Signal<T>, T> {
 
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
-		source.subscribe(new FluxDematerialize.DematerializeSubscriber<>(actual));
+		source.subscribe(new FluxDematerialize.DematerializeSubscriber<>(actual, true));
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDematerializeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDematerializeTest.java
@@ -15,19 +15,22 @@
  */
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.reactivestreams.Subscription;
+
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.util.function.Tuple2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 public class FluxDematerializeTest extends FluxOperatorTest<Signal<String>, String> {
 
@@ -41,52 +44,7 @@ public class FluxDematerializeTest extends FluxOperatorTest<Signal<String>, Stri
 
 				scenario(Flux::<String>dematerialize)
 						.producer(1, i -> Signal.subscribe(Operators.emptySubscription()))
-						.receiverEmpty(),
-
-				scenario(Flux::<String>dematerialize)
-						.receive(s -> assertThat(s).isEqualTo(item(0).get()),
-								s -> assertThat(s).isEqualTo(item(1).get()),
-								s -> assertThat(s).isEqualTo(item(2).get()))
-						.verifier(step -> step.expectNext("test")
-						                      .expectNext("test1")
-						                      .consumeSubscriptionWith(s -> {
-							                      if(s instanceof FluxDematerialize.DematerializeSubscriber) {
-								                      FluxDematerialize.DematerializeSubscriber m =
-										                      (FluxDematerialize.DematerializeSubscriber) s;
-
-								                      m.peek();
-								                      m.poll();
-								                      m.size();
-							                      }
-						                      })
-						                      .expectNext("test2")
-						                      .consumeSubscriptionWith(s -> {
-							                      if(s instanceof FluxDematerialize.DematerializeSubscriber){
-								                      FluxDematerialize.DematerializeSubscriber m =
-										                      (FluxDematerialize.DematerializeSubscriber)s;
-
-								                      m.peek();
-								                      m.poll();
-								                      m.size();
-
-								                      try{
-									                      m.offer(null);
-									                      Assert.fail();
-								                      }
-								                      catch (UnsupportedOperationException u){
-									                      //ignore
-								                      }
-
-								                      try{
-									                      m.iterator();
-									                      Assert.fail();
-								                      }
-								                      catch (UnsupportedOperationException u){
-									                      //ignore
-								                      }
-							                      }
-						                      })
-						                      .verifyComplete())
+						.receiverEmpty()
 		);
 	}
 
@@ -142,7 +100,7 @@ public class FluxDematerializeTest extends FluxOperatorTest<Signal<String>, Stri
 	}
 
 	@Test
-	public void immediateCompletion() {
+	public void immediateCompletionNeedsRequestOne() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
 		Flux<Integer> dematerialize = Flux.just(Signal.<Integer>complete()).dematerialize();
@@ -151,11 +109,14 @@ public class FluxDematerializeTest extends FluxOperatorTest<Signal<String>, Stri
 
 		ts.assertNoValues()
 		  .assertNoError()
-		  .assertComplete();
+		  .assertNotComplete();
+
+		ts.request(1);
+		ts.assertComplete();
 	}
 
 	@Test
-	public void immediateError() {
+	public void immediateErrorNeedsRequestOne() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
 		Flux<Integer> dematerialize = Flux.just(error).dematerialize();
@@ -163,12 +124,15 @@ public class FluxDematerializeTest extends FluxOperatorTest<Signal<String>, Stri
 		dematerialize.subscribe(ts);
 
 		ts.assertNoValues()
-		  .assertError(RuntimeException.class)
-		  .assertNotComplete();
+		  .assertNotComplete()
+		  .assertNoError();
+
+		ts.request(1);
+		ts.assertError(RuntimeException.class);
 	}
 
 	@Test
-	public void completeAfterSingleSignal() {
+	public void doesntCompleteWithoutRequest() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
 		Flux<Integer> dematerialize = Flux.just(Signal.next(1), Signal.<Integer>complete()).dematerialize();
@@ -183,11 +147,14 @@ public class FluxDematerializeTest extends FluxOperatorTest<Signal<String>, Stri
 
 		ts.assertValues(1)
 		  .assertNoError()
-		  .assertComplete();
+		  .assertNotComplete();
+
+		ts.request(1);
+		ts.assertComplete();
 	}
 
 	@Test
-	public void errorAfterSingleSignal() {
+	public void doesntErrorWithoutRequest() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
 		Flux<Integer> dematerialize = Flux.just(Signal.next(1), error).dematerialize();
@@ -201,62 +168,51 @@ public class FluxDematerializeTest extends FluxOperatorTest<Signal<String>, Stri
 		ts.request(1);
 
 		ts.assertValues(1)
-		  .assertError(RuntimeException.class)
+		  .assertNoError()
 		  .assertNotComplete();
+
+		ts.request(1);
+		ts.assertError(RuntimeException.class);
 	}
 
 	@Test
 	public void twoSignalsAndComplete() {
-		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
+		Flux<Integer> dematerialize = Flux.just(Signal.next(1), Signal.next(2), Signal.<Integer>complete())
+		                                  .dematerialize();
 
-		Flux<Integer> dematerialize = Flux.just(Signal.next(1), Signal.next(2), Signal.<Integer>complete()).dematerialize();
-
-		dematerialize.subscribe(ts);
-
-		ts.assertNoValues()
-		  .assertNoError()
-		  .assertNotComplete();
-
-		ts.request(1);
-
-		ts.assertValues(1)
-		  .assertNoError()
-		  .assertNotComplete();
-
-		ts.request(1);
-
-		ts.assertValues(1, 2)
-		  .assertNoError()
-		  .assertComplete();
+		StepVerifier.create(dematerialize, 0)
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofMillis(50))
+		            .thenRequest(1)
+		            .expectNext(1)
+		            .expectNoEvent(Duration.ofMillis(50))
+		            .thenRequest(1)
+		            .expectNext(2)
+		            .expectNoEvent(Duration.ofMillis(50))
+		            .thenRequest(1)
+		            .verifyComplete();
 	}
 
 	@Test
 	public void twoSignalsAndError() {
-		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
+		Flux<Integer> dematerialize = Flux.just(Signal.next(1), Signal.next(2), error)
+		                                  .dematerialize();
 
-		Flux<Integer> dematerialize = Flux.just(Signal.next(1), Signal.next(2), error).dematerialize();
-
-		dematerialize.subscribe(ts);
-
-		ts.assertNoValues()
-		  .assertNoError()
-		  .assertNotComplete();
-
-		ts.request(1);
-
-		ts.assertValues(1)
-		  .assertNoError()
-		  .assertNotComplete();
-
-		ts.request(1);
-
-		ts.assertValues(1, 2)
-		  .assertError(RuntimeException.class)
-		  .assertNotComplete();
+		StepVerifier.create(dematerialize, 0)
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofMillis(50))
+		            .thenRequest(1)
+		            .expectNext(1)
+		            .expectNoEvent(Duration.ofMillis(50))
+		            .thenRequest(1)
+		            .expectNext(2)
+		            .expectNoEvent(Duration.ofMillis(50))
+		            .thenRequest(1)
+		            .verifyError(error.getThrowable().getClass());
 	}
 
 	@Test
-	public void neverEnding() {
+	public void neverEndingSignalSourceWithCompleteSignal() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		Flux<Integer> dematerialize = Flux.just(Signal.next(1), Signal.next(2),
@@ -272,7 +228,7 @@ public class FluxDematerializeTest extends FluxOperatorTest<Signal<String>, Stri
 	}
 
 	@Test
-	public void dematerialize() {
+	public void dematerializeUnbounded() {
 		StepVerifier.create(Flux.just(Signal.next("Three"),
 				Signal.next("Two"),
 				Signal.next("One"),
@@ -285,29 +241,66 @@ public class FluxDematerializeTest extends FluxOperatorTest<Signal<String>, Stri
 	}
 
 	@Test
+	public void materializeDematerializeUnbounded() {
+		StepVerifier.create(Flux.just(1, 2, 3).materialize().dematerialize())
+		            .expectNext(1, 2, 3)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void materializeDematerializeRequestOneByOne() {
+		StepVerifier.create(Flux.just(1, 2, 3).materialize().dematerialize(), 0)
+		            .thenRequest(1)
+		            .expectNext(1)
+		            .thenRequest(1)
+		            .expectNext(2)
+		            .thenRequest(1)
+		            .expectNext(3)
+		            .expectNoEvent(Duration.ofMillis(50))
+		            .thenRequest(1)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void emissionTimingsAreGrouped() {
+		StepVerifier.withVirtualTime(() ->
+				Flux.interval(Duration.ofSeconds(1))
+				    .map(i -> "tick" + i)
+				    .take(5)
+				    .timestamp()
+				    .materialize()
+				    .<Tuple2<Long, String>>dematerialize()
+				    .timestamp()
+		)
+		            .thenAwait(Duration.ofSeconds(5))
+		            .thenConsumeWhile(tupleDematerialize -> {
+		            	long dematerializeTimestamp = tupleDematerialize.getT1();
+		            	long originalTimestamp = tupleDematerialize.getT2().getT1();
+
+			            System.out.println(tupleDematerialize.getT2().getT2() + ": " + originalTimestamp + ", " + dematerializeTimestamp);
+
+		            	return dematerializeTimestamp == originalTimestamp;
+		            })
+		            .verifyComplete();
+	}
+
+	@Test
 	public void scanSubscriber() {
 		CoreSubscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null,
 				sub -> sub.request(100));
 		FluxDematerialize.DematerializeSubscriber<String> test =
-				new FluxDematerialize.DematerializeSubscriber<>(actual);
+				new FluxDematerialize.DematerializeSubscriber<>(actual, false);
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
-
-		assertThat(test.scan(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(100L);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
 
-		assertThat(test.scan(Scannable.Attr.BUFFERED)).isEqualTo(0);
-		test.value = "foo";
-		assertThat(test.scan(Scannable.Attr.BUFFERED)).isEqualTo(1);
-
 		assertThat(test.scan(Scannable.Attr.ERROR)).isNull();
 		assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
 		test.onError(new IllegalStateException("boom"));
-		assertThat(test.scan(Scannable.Attr.ERROR)).hasMessage("boom");
+		assertThat(test.scan(Scannable.Attr.ERROR)).as("error is not retained").isNull();
 		assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
-
 
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
 		test.cancel();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDematerializeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDematerializeTest.java
@@ -277,8 +277,6 @@ public class FluxDematerializeTest extends FluxOperatorTest<Signal<String>, Stri
 		            	long dematerializeTimestamp = tupleDematerialize.getT1();
 		            	long originalTimestamp = tupleDematerialize.getT2().getT1();
 
-			            System.out.println(tupleDematerialize.getT2().getT2() + ": " + originalTimestamp + ", " + dematerializeTimestamp);
-
 		            	return dematerializeTimestamp == originalTimestamp;
 		            })
 		            .verifyComplete();

--- a/reactor-core/src/test/java/reactor/core/publisher/tck/AbstractFluxVerification.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/tck/AbstractFluxVerification.java
@@ -62,7 +62,7 @@ public abstract class AbstractFluxVerification
 
 	@Override
 	public Publisher<Integer> createFailedPublisher() {
-		return Flux.<Integer>error(new Exception("oops"))
+		return Flux.<Integer>error(new Exception("boom"))
 				.transform(this::transformFlux);
 	}
 


### PR DESCRIPTION
This commit reworks dematerialize so that it maps 1 request to 1 Signal
from upstream, immediately propagating that decoded signal.

As a consequence, when requested one by one, dematerialize now requires
one more request for the terminal signal to be pulled and propagated.

This also means that the requested signals won't be delayed until the
upstream emits the next signal (which was both problematic in terms of
timing consistency and in terms of getting the last `onNext` in the case
of a never ending source).