### PR TITLE
fix #1684 Flux#flatMap with scalar source now supports onErrorContinue

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
@@ -114,7 +114,7 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 	@Override
 	public void subscribe(CoreSubscriber<? super R> actual) {
 
-		if (FluxFlatMap.trySubscribeScalarMap(source, actual, mapper, false)) {
+		if (FluxFlatMap.trySubscribeScalarMap(source, actual, mapper, false, true)) {
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -90,7 +90,7 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 	@Override
 	public void subscribe(CoreSubscriber<? super R> actual) {
 
-		if (trySubscribeScalarMap(source, actual, mapper, false)) {
+		if (trySubscribeScalarMap(source, actual, mapper, false, true)) {
 			return;
 		}
 
@@ -118,7 +118,8 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 	static <T, R> boolean trySubscribeScalarMap(Publisher<? extends T> source,
 			CoreSubscriber<? super R> s,
 			Function<? super T, ? extends Publisher<? extends R>> mapper,
-			boolean fuseableExpected) {
+			boolean fuseableExpected,
+			boolean errorContinueExpected) {
 		if (source instanceof Callable) {
 			T t;
 
@@ -126,7 +127,17 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 				t = ((Callable<? extends T>) source).call();
 			}
 			catch (Throwable e) {
-				Operators.error(s, Operators.onOperatorError(e, s.currentContext()));
+				Context ctx = s.currentContext();
+				Throwable e_ = errorContinueExpected ?
+					Operators.onNextPollError(null, e, ctx) :
+					Operators.onOperatorError(e, ctx);
+				if (e_ != null) {
+					Operators.error(s, e_);
+				}
+				else {
+					//the error was recovered but we know there won't be any more value
+					Operators.complete(s);
+				}
 				return true;
 			}
 
@@ -142,7 +153,17 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 						"The mapper returned a null Publisher");
 			}
 			catch (Throwable e) {
-				Operators.error(s, Operators.onOperatorError(null, e, t, s.currentContext()));
+				Context ctx = s.currentContext();
+				Throwable e_ = errorContinueExpected ?
+						Operators.onNextPollError(t, e, ctx) :
+						Operators.onOperatorError(null, e, t, ctx);
+				if (e_ != null) {
+					Operators.error(s, e_);
+				}
+				else {
+					//the error was recovered but we know there won't be any more value
+					Operators.complete(s);
+				}
 				return true;
 			}
 
@@ -153,7 +174,17 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 					v = ((Callable<R>) p).call();
 				}
 				catch (Throwable e) {
-					Operators.error(s, Operators.onOperatorError(null, e, t, s.currentContext()));
+					Context ctx = s.currentContext();
+					Throwable e_ = errorContinueExpected ?
+							Operators.onNextPollError(t, e, ctx) :
+							Operators.onOperatorError(null, e, t, ctx);
+					if (e_ != null) {
+						Operators.error(s, e_);
+					}
+					else {
+						//the error was recovered but we know there won't be any more value
+						Operators.complete(s);
+					}
 					return true;
 				}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMergeSequential.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMergeSequential.java
@@ -86,7 +86,8 @@ final class FluxMergeSequential<T, R> extends FluxOperator<T, R> {
 
 	@Override
 	public void subscribe(CoreSubscriber<? super R> actual) {
-		if (FluxFlatMap.trySubscribeScalarMap(source, actual, mapper, false)) {
+		//for now mergeSequential doesn't support onErrorContinue, so the scalar version shouldn't either
+		if (FluxFlatMap.trySubscribeScalarMap(source, actual, mapper, false, false)) {
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
@@ -77,7 +77,8 @@ final class FluxSwitchMap<T, R> extends FluxOperator<T, R> {
 
 	@Override
 	public void subscribe(CoreSubscriber<? super R> actual) {
-		if (FluxFlatMap.trySubscribeScalarMap(source, actual, mapper, false)) {
+		//for now switchMap doesn't support onErrorContinue, so the scalar version shouldn't either
+		if (FluxFlatMap.trySubscribeScalarMap(source, actual, mapper, false, false)) {
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -2982,7 +2982,10 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * <p>
 	 * Note that this error handling mode is not necessarily implemented by all operators
 	 * (look for the {@code Error Mode Support} javadoc section to find operators that
-	 * support it).
+	 * support it). In particular, this operator is offered on {@link Mono} mainly as a
+	 * way to propagate the configuration to upstream {@link Flux}. The mode doesn't really
+	 * make sense on a {@link Mono}, since we're sure there will be no further value to
+	 * continue with: {@link #onErrorResume(Function)} is a more classical fit then.
 	 *
 	 * @param type the {@link Class} of {@link Exception} that are resumed from.
 	 * @param errorConsumer a {@link BiConsumer} fed with errors matching the {@link Class}
@@ -3004,7 +3007,10 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * <p>
 	 * Note that this error handling mode is not necessarily implemented by all operators
 	 * (look for the {@code Error Mode Support} javadoc section to find operators that
-	 * support it).
+	 * support it). In particular, this operator is offered on {@link Mono} mainly as a
+	 * way to propagate the configuration to upstream {@link Flux}. The mode doesn't really
+	 * make sense on a {@link Mono}, since we're sure there will be no further value to
+	 * continue with: {@link #onErrorResume(Function)} is a more classical fit then.
 	 *
 	 * @param errorPredicate a {@link Predicate} used to filter which errors should be resumed from.
 	 * This MUST be idempotent, as it can be used several times.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMap.java
@@ -49,8 +49,8 @@ final class MonoFlatMap<T, R> extends MonoOperator<T, R> implements Fuseable {
 
 	@Override
 	public void subscribe(CoreSubscriber<? super R> actual) {
-
-		if (FluxFlatMap.trySubscribeScalarMap(source, actual, mapper, true)) {
+		//for now Mono in general doesn't support onErrorContinue, so the scalar version shouldn't either
+		if (FluxFlatMap.trySubscribeScalarMap(source, actual, mapper, true, false)) {
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMapMany.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMapMany.java
@@ -43,7 +43,10 @@ final class MonoFlatMapMany<T, R> extends FluxFromMonoOperator<T, R> {
 
 	@Override
 	public void subscribe(CoreSubscriber<? super R> actual) {
-		if (FluxFlatMap.trySubscribeScalarMap(source, actual, mapper, false)) {
+		//for now Mono in general doesn't support onErrorContinue, so the scalar version shouldn't either
+		//even if the result is a Flux. once the mapper is applied, onErrorContinue will be taken care of by
+		//the mapped Flux if relevant.
+		if (FluxFlatMap.trySubscribeScalarMap(source, actual, mapper, false, false)) {
 			return;
 		}
 		source.subscribe(new FlatMapManyMain<T, R>(actual, mapper));
@@ -154,6 +157,7 @@ final class MonoFlatMapMany<T, R> extends FluxFromMonoOperator<T, R> {
 						"The mapper returned a null Publisher.");
 			}
 			catch (Throwable ex) {
+				//if the mapping fails, then there is nothing to be continued, since the source is a Mono
 				actual.onError(Operators.onOperatorError(this, ex, t,
 						actual.currentContext()));
 				return;

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -759,7 +759,7 @@ public abstract class Operators {
 	 * terminal and cancelled the subscription, null if not.
 	 */
 	@Nullable
-	public static <T> RuntimeException onNextPollError(T value, Throwable error, Context context) {
+	public static <T> RuntimeException onNextPollError(@Nullable T value, Throwable error, Context context) {
 		error = unwrapOnNextError(error);
 		OnNextFailureStrategy strategy = onNextErrorStrategy(context);
 		if (strategy.test(error, value)) {


### PR DESCRIPTION
Since the code for a scalar (aka Callable) source is shared among a few
operators other than Flux#flatMap (mergeSequential, switchMap and Mono
flatMap/flatMapMany), a new boolean is introduced as an opt-in to the
onErrorContinue support, to keep these operators consistent in how they
deal with scalar sources vs classic sources.