### PR TITLE
fix jCenter to all lowercase

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -98,7 +98,7 @@ task doDownloadBaseline(type: Download) {
   onlyIfNewer true
   compress true
 
-  src "${repositories.jCenter().url}io/projectreactor/reactor-core/$compatibleVersion/reactor-core-${compatibleVersion}.jar"
+  src "${repositories.jcenter().url}io/projectreactor/reactor-core/$compatibleVersion/reactor-core-${compatibleVersion}.jar"
   dest "${buildDir}/baselineLibs/reactor-core-${compatibleVersion}.jar"
 
   finalizedBy { japicmp }

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -48,7 +48,7 @@ task doDownloadBaseline(type: Download) {
   onlyIfNewer true
   compress true
 
-  src "${repositories.jCenter().url}io/projectreactor/reactor-test/$compatibleVersion/reactor-test-${compatibleVersion}.jar"
+  src "${repositories.jcenter().url}io/projectreactor/reactor-test/$compatibleVersion/reactor-test-${compatibleVersion}.jar"
   dest "${buildDir}/baselineLibs/reactor-test-${compatibleVersion}.jar"
 
   finalizedBy { japicmp }


### PR DESCRIPTION
Shouldn't have manually re-done the `doDownloadBaseline` in text editor without actually testing it. Capitalized `jCenter` instead of `jcenter` for the fail 🤦‍♂ 