### PR TITLE
fix #1848 StepVerifier API to subscribe to source and verify it later

### DIFF
--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -49,6 +49,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
@@ -185,6 +186,7 @@ final class DefaultStepVerifierBuilder<T>
 	final         MessageFormatter                           messageFormatter;
 	final         long                                       initialRequest;
 	final         Supplier<? extends VirtualTimeScheduler>   vtsLookup;
+	@Nullable
 	final         Supplier<? extends Publisher<? extends T>> sourceSupplier;
 	private final StepVerifierOptions                        options;
 
@@ -756,6 +758,11 @@ final class DefaultStepVerifierBuilder<T>
 		}
 
 		@Override
+		public StepVerifier deferred() {
+			return toVerifierAndSubscribe();
+		}
+
+		@Override
 		public Assertions verifyThenAssertThat() {
 			return verifyThenAssertThat(defaultVerifyTimeout);
 		}
@@ -785,46 +792,52 @@ final class DefaultStepVerifierBuilder<T>
 		@Override
 		public Duration verify(Duration duration) {
 			Objects.requireNonNull(duration, "duration");
-			if (parent.sourceSupplier != null) {
-				VirtualTimeScheduler vts = null;
-				if (parent.vtsLookup != null) {
-					vtsLock.lock(); //wait for other virtualtime verifies to finish
-					vts = parent.vtsLookup.get();
-					//this works even for the default case where StepVerifier has created
-					// a vts through enable(false), because the CURRENT will already be that vts
-					VirtualTimeScheduler.set(vts);
-				}
-				try {
-					Publisher<? extends T> publisher = parent.sourceSupplier.get();
-					Instant now = Instant.now();
+			Instant now = Instant.now();
 
-					DefaultVerifySubscriber<T> newVerifier = new DefaultVerifySubscriber<>(
-							this.parent.script,
-							this.parent.messageFormatter,
-							this.parent.initialRequest,
-							this.requestedFusionMode,
-							this.expectedFusionMode,
-							this.debugEnabled,
-							this.parent.options.getInitialContext(),
-							vts);
+			DefaultVerifySubscriber<T> newVerifier = toVerifierAndSubscribe();
+			newVerifier.verify(duration);
 
-					publisher.subscribe(newVerifier);
-					newVerifier.verify(duration);
+			return Duration.between(now, Instant.now());
+		}
 
-					return Duration.between(now, Instant.now());
-				}
-				finally {
-					if (vts != null) {
-						vts.dispose();
-						//explicitly reset the factory, rather than rely on vts shutdown doing so
-						// because it could have been eagerly shut down in a test.
-						VirtualTimeScheduler.reset();
-						vtsLock.unlock();
-					}
-				}
-			} else {
-				return toSubscriber().verify(duration);
+		DefaultVerifySubscriber<T> toVerifierAndSubscribe() {
+			if (parent.sourceSupplier == null) {
+				throw new IllegalArgumentException("no source to automatically subscribe to for verification");
 			}
+			final VirtualTimeScheduler vts;
+			if (parent.vtsLookup != null) {
+				vtsLock.lock(); //wait for other virtualtime verifies to finish
+				vts = parent.vtsLookup.get();
+				//this works even for the default case where StepVerifier has created
+				// a vts through enable(false), because the CURRENT will already be that vts
+				VirtualTimeScheduler.set(vts);
+			}
+			else {
+				vts = null;
+			}
+			Publisher<? extends T> publisher = parent.sourceSupplier.get();
+
+			DefaultVerifySubscriber<T> newVerifier = new DefaultVerifySubscriber<>(
+					this.parent.script,
+					this.parent.messageFormatter,
+					this.parent.initialRequest,
+					this.requestedFusionMode,
+					this.expectedFusionMode,
+					this.debugEnabled,
+					this.parent.options.getInitialContext(),
+					vts,
+					() -> {
+						if (vts != null) {
+							vts.dispose();
+							//explicitly reset the factory, rather than rely on vts shutdown doing so
+							// because it could have been eagerly shut down in a test.
+							VirtualTimeScheduler.reset();
+							vtsLock.unlock();
+						}
+					});
+
+			publisher.subscribe(newVerifier);
+			return newVerifier;
 		}
 
 		/**
@@ -854,7 +867,8 @@ final class DefaultStepVerifierBuilder<T>
 					this.expectedFusionMode,
 					this.debugEnabled,
 					this.parent.options.getInitialContext(),
-					vts);
+					vts,
+					null);
 		}
 
 	}
@@ -871,6 +885,7 @@ final class DefaultStepVerifierBuilder<T>
 		final int                  expectedFusionMode;
 		final long                 initialRequest;
 		final VirtualTimeScheduler virtualTimeScheduler;
+		final Disposable           postVerifyCleanup;
 
 		Context                       initialContext;
 		@Nullable
@@ -910,7 +925,8 @@ final class DefaultStepVerifierBuilder<T>
 				int expectedFusionMode,
 				boolean debugEnabled,
 				@Nullable Context initialContext,
-				@Nullable VirtualTimeScheduler vts) {
+				@Nullable VirtualTimeScheduler vts,
+				@Nullable Disposable postVerifyCleanup) {
 			this.virtualTimeScheduler = vts;
 			this.requestedFusionMode = requestedFusionMode;
 			this.expectedFusionMode = expectedFusionMode;
@@ -935,6 +951,7 @@ final class DefaultStepVerifierBuilder<T>
 			this.requested = initialRequest;
 			this.initialContext = initialContext == null ? Context.empty() : initialContext;
 			this.messageFormatter = messageFormatter;
+			this.postVerifyCleanup = postVerifyCleanup;
 		}
 
 		@Override
@@ -1166,6 +1183,12 @@ final class DefaultStepVerifierBuilder<T>
 		}
 
 		@Override
+		public StepVerifier deferred() {
+			//intentionally NO-OP
+			return this;
+		}
+
+		@Override
 		public Assertions verifyThenAssertThat() {
 			return verifyThenAssertThat(defaultVerifyTimeout);
 		}
@@ -1195,17 +1218,24 @@ final class DefaultStepVerifierBuilder<T>
 
 		@Override
 		public Duration verify(Duration duration) {
-			Objects.requireNonNull(duration, "duration");
-			Instant now = Instant.now();
 			try {
-				pollTaskEventOrComplete(duration);
+				Objects.requireNonNull(duration, "duration");
+				Instant now = Instant.now();
+				try {
+					pollTaskEventOrComplete(duration);
+				}
+				catch (InterruptedException ex) {
+					Thread.currentThread()
+					      .interrupt();
+				}
+				validate();
+				return Duration.between(now, Instant.now());
 			}
-			catch (InterruptedException ex) {
-				Thread.currentThread()
-				      .interrupt();
+			finally {
+				if (postVerifyCleanup != null) {
+					postVerifyCleanup.dispose();
+				}
 			}
-			validate();
-			return Duration.between(now, Instant.now());
 		}
 
 		/**

--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -758,7 +758,7 @@ final class DefaultStepVerifierBuilder<T>
 		}
 
 		@Override
-		public StepVerifier deferred() {
+		public StepVerifier verifyLater() {
 			return toVerifierAndSubscribe();
 		}
 
@@ -1183,7 +1183,7 @@ final class DefaultStepVerifierBuilder<T>
 		}
 
 		@Override
-		public StepVerifier deferred() {
+		public StepVerifier verifyLater() {
 			//intentionally NO-OP
 			return this;
 		}

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -306,10 +306,13 @@ public interface StepVerifier {
 	 * Trigger the subscription and prepare for verifications but doesn't block. Calling one
 	 * of the {@link #verify()} methods afterwards will block until the sequence is validated
 	 * and throw if assertions fail.
+	 * <p>
+	 * Calling this method more than once in a row should be a NO-OP, returning the same
+	 * instance as the first call.
 	 *
-	 * @return
+	 * @return a {@link StepVerifier} that is in progress but on which one can chose to block later.
 	 */
-	StepVerifier deferred();
+	StepVerifier verifyLater();
 
 	/**
 	 * Verify the signals received by this subscriber. Unless a default timeout has been

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -303,6 +303,15 @@ public interface StepVerifier {
 	StepVerifier log();
 
 	/**
+	 * Trigger the subscription and prepare for verifications but doesn't block. Calling one
+	 * of the {@link #verify()} methods afterwards will block until the sequence is validated
+	 * and throw if assertions fail.
+	 *
+	 * @return
+	 */
+	StepVerifier deferred();
+
+	/**
 	 * Verify the signals received by this subscriber. Unless a default timeout has been
 	 * set before construction of the {@link StepVerifier} via {@link StepVerifier#setDefaultTimeout(Duration)},
 	 * this method will <strong>block</strong> until the stream has been terminated

--- a/reactor-test/src/test/java/reactor/test/DefaultStepVerifierBuilderTests.java
+++ b/reactor-test/src/test/java/reactor/test/DefaultStepVerifierBuilderTests.java
@@ -33,8 +33,7 @@ import reactor.test.DefaultStepVerifierBuilder.TaskEvent;
 import reactor.test.DefaultStepVerifierBuilder.WaitEvent;
 import reactor.test.scheduler.VirtualTimeScheduler;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Stephane Maldini
@@ -109,6 +108,14 @@ public class DefaultStepVerifierBuilderTests {
 		catch (IllegalStateException e) {
 			assertThat(e).hasMessageContaining("VirtualTimeScheduler");
 		}
+	}
+
+	@Test
+	public void noSourceSupplierFailsFastWhenAttemptingVerify() {
+		StepVerifier stepVerifier = new DefaultStepVerifierBuilder<String>(StepVerifierOptions.create(), null).expectComplete();
+
+		assertThatIllegalArgumentException().isThrownBy(stepVerifier::verify)
+		                                    .withMessage("no source to automatically subscribe to for verification");
 	}
 
 	@Test

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -35,7 +35,6 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import reactor.core.Fuseable;
-import reactor.core.publisher.ConnectableFlux;
 import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -2213,13 +2212,13 @@ public class StepVerifierTests {
 	}
 
 	@Test
-	public void deferredVerifyCanVerifyConnectableFlux() {
+	public void verifyLaterCanVerifyConnectableFlux() {
 		Flux<Integer> autoconnectableFlux = Flux.just(1, 2, 3).publish().autoConnect(2);
 
 		StepVerifier deferred1 = StepVerifier.create(autoconnectableFlux)
 		                                     .expectNext(1, 2, 3)
 		                                     .expectComplete()
-		                                     .deferred();
+		                                     .verifyLater();
 
 		assertThatExceptionOfType(AssertionError.class)
 				.isThrownBy(() -> deferred1.verify(Duration.ofSeconds(1)))
@@ -2228,28 +2227,28 @@ public class StepVerifierTests {
 		StepVerifier deferred2 = StepVerifier.create(autoconnectableFlux)
 		                                     .expectNext(1, 2, 3)
 		                                     .expectComplete()
-		                                     .deferred()
-		                                     .deferred()
-		                                     .deferred()
-		                                     .deferred();
+		                                     .verifyLater()
+		                                     .verifyLater()
+		                                     .verifyLater()
+		                                     .verifyLater();
 
 		deferred1.verify(Duration.ofSeconds(1));
 		deferred2.verify(Duration.ofSeconds(1));
 	}
 
 	@Test
-	public void deferredVerifyCanVerifyConnectableFlux_withAssertionErrors() {
+	public void verifyLaterCanVerifyConnectableFlux_withAssertionErrors() {
 		Flux<Integer> autoconnectableFlux = Flux.just(1, 2, 3).publish().autoConnect(2);
 
 		StepVerifier deferred1 = StepVerifier.create(autoconnectableFlux)
 		                                     .expectNext(1, 2, 4)
 		                                     .expectComplete()
-		                                     .deferred();
+		                                     .verifyLater();
 
 		StepVerifier deferred2 = StepVerifier.create(autoconnectableFlux)
 		                                     .expectNext(1, 2, 5)
 		                                     .expectComplete()
-		                                     .deferred();
+		                                     .verifyLater();
 
 		assertThatExceptionOfType(AssertionError.class)
 				.isThrownBy(() -> deferred1.verify(Duration.ofSeconds(10)))


### PR DESCRIPTION
This commit introduces `StepVerifier#deferred()`: a way to defer the
verification of a source while still triggering a subscription to it.
This is especially useful in scenarios where a source will only emit
after having received several subscription, like an `autoConnect(2)`
ConnectableFlux.