### PR TITLE
fix #1706 again: bufferUntilChanged now uses defer to avoid shared state

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -2865,9 +2865,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final <V> Flux<List<T>> bufferUntilChanged(Function<? super T, ? extends V> keySelector,
 			BiPredicate<? super V, ? super V> keyComparator) {
-		Predicate<? super T> changed = new FluxBufferPredicate.ChangedPredicate<T, V>(keySelector,
-				keyComparator);
-		return bufferUntil(changed, true);
+		return Flux.defer(() -> bufferUntil(new FluxBufferPredicate.ChangedPredicate<T, V>(keySelector,
+				keyComparator), true));
 	}
 
 	/**


### PR DESCRIPTION
in #1846, it was overlooked that the stateful predicate was instantiated in the operator method (at assembly time), which makes it shared between subsequent subscribers. This PR fixes that issue by wrapping the predicate instantiation and `bufferUntil` call inside a `Flux.defer` scope.