### PR TITLE
fix #1734 Change duration-based operator to have nanosecond precision

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDelaySequence.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDelaySequence.java
@@ -73,7 +73,7 @@ final class FluxDelaySequence<T> extends InternalFluxOperator<T, T> {
 			super();
 			this.actual = new SerializedSubscriber<>(actual);
 			this.w = w;
-			if (delay.compareTo(Duration.ofMinutes(1)) < 0) {
+			if (Operators.nanoPrecision(delay)) {
 				this.delay = delay.toNanos();
 				this.timeUnit = TimeUnit.NANOSECONDS;
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxInterval.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxInterval.java
@@ -15,6 +15,7 @@
  */
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -44,16 +45,22 @@ final class FluxInterval extends Flux<Long> implements SourceProducer<Long> {
 	final TimeUnit unit;
 
 	FluxInterval(
-			long initialDelay, 
-			long period, 
-			TimeUnit unit, 
+			Duration initialDelay,
+			Duration period,
 			Scheduler timedScheduler) {
-		if (period < 0L) {
+		if (period.isNegative()) {
 			throw new IllegalArgumentException("period >= 0 required but it was " + period);
 		}
-		this.initialDelay = initialDelay;
-		this.period = period;
-		this.unit = Objects.requireNonNull(unit, "unit");
+		if (Operators.nanoPrecision(initialDelay) && Operators.nanoPrecision(period)) {
+			this.unit = TimeUnit.NANOSECONDS;
+			this.initialDelay = initialDelay.toNanos();
+			this.period = period.toNanos();
+		}
+		else {
+			this.unit = TimeUnit.MILLISECONDS;
+			this.initialDelay = initialDelay.toMillis();
+			this.period = period.toMillis();
+		}
 		this.timedScheduler = Objects.requireNonNull(timedScheduler, "timedScheduler");
 	}
 	

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -249,7 +249,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return a new {@link Mono}
 	 */
 	public static Mono<Long> delay(Duration duration, Scheduler timer) {
-		return onAssembly(new MonoDelay(duration.toMillis(), TimeUnit.MILLISECONDS, timer));
+		return onAssembly(new MonoDelay(duration, timer));
 	}
 
 	/**
@@ -1535,7 +1535,12 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	public T block(Duration timeout) {
 		BlockingMonoSubscriber<T> subscriber = new BlockingMonoSubscriber<>();
 		subscribe((Subscriber<T>) subscriber);
-		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
+		if (Operators.nanoPrecision(timeout)) {
+			return subscriber.blockingGet(timeout.toNanos(), TimeUnit.NANOSECONDS);
+		}
+		else {
+			return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
+		}
 	}
 
 	/**
@@ -1581,7 +1586,12 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	public Optional<T> blockOptional(Duration timeout) {
 		BlockingOptionalMonoSubscriber<T> subscriber = new BlockingOptionalMonoSubscriber<>();
 		subscribe((Subscriber<T>) subscriber);
-		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
+		if (Operators.nanoPrecision(timeout)) {
+			return subscriber.blockingGet(timeout.toNanos(), TimeUnit.NANOSECONDS);
+		}
+		else {
+			return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
+		}
 	}
 
 	/**
@@ -1866,7 +1876,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return a delayed {@link Mono}
 	 */
 	public final Mono<T> delayElement(Duration delay, Scheduler timer) {
-		return onAssembly(new MonoDelayElement<>(this, delay.toMillis(), TimeUnit.MILLISECONDS, timer));
+		return onAssembly(new MonoDelayElement<>(this, delay, timer));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
@@ -15,6 +15,7 @@
  */
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -42,9 +43,16 @@ final class MonoDelay extends Mono<Long> implements Scannable,  SourceProducer<L
 
 	final TimeUnit unit;
 
-	MonoDelay(long delay, TimeUnit unit, Scheduler timedScheduler) {
-		this.delay = delay;
-		this.unit = Objects.requireNonNull(unit, "unit");
+	MonoDelay(Duration delay, Scheduler timedScheduler) {
+		if (Operators.nanoPrecision(delay)) {
+			this.delay = delay.toNanos();
+			this.unit = TimeUnit.NANOSECONDS;
+		}
+		else {
+			this.delay = delay.toMillis();
+			this.unit = TimeUnit.MILLISECONDS;
+		}
+
 		this.timedScheduler = Objects.requireNonNull(timedScheduler, "timedScheduler");
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -15,10 +15,12 @@
  */
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -93,6 +95,12 @@ public abstract class Operators {
 			}
 		}
 	}
+
+	public static boolean nanoPrecision(final Duration duration) {
+		final Duration MAX_NANOS = Duration.ofNanos(Long.MAX_VALUE);
+		return duration.compareTo(MAX_NANOS) < 0;
+	}
+
 	/**
 	 * Returns the subscription as QueueSubscription if possible or null.
 	 * @param <T> the value type of the QueueSubscription.

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -289,7 +290,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 			throw new IllegalArgumentException("size > 0 required but it was " + size);
 		}
 		return new ReplayProcessor<>(new FluxReplay.SizeAndTimeBoundReplayBuffer<>(size,
-				maxAge.toMillis(),
+				maxAge.toMillis(), TimeUnit.MILLISECONDS,
 				scheduler));
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/BlockingOptionalMonoSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BlockingOptionalMonoSubscriberTest.java
@@ -101,7 +101,7 @@ public class BlockingOptionalMonoSubscriberTest {
 
 		assertThatExceptionOfType(IllegalStateException.class)
 				.isThrownBy(() -> source.blockOptional(Duration.ofMillis(500)))
-				.withMessage("Timeout on blocking read for 500 MILLISECONDS");
+				.withMessageStartingWith("Timeout on blocking read for");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -108,7 +109,7 @@ public class FluxBufferTimeoutTest {
 		final Scheduler.Worker worker = Schedulers.elastic()
 		                                          .createWorker();
 		FluxBufferTimeout.BufferTimeoutSubscriber<String, List<String>> test = new FluxBufferTimeout.BufferTimeoutSubscriber<String, List<String>>(
-						actual, 123, 1000,
+						actual, 123, Duration.ofMillis(1000),
 				worker, ArrayList::new);
 
 		try {
@@ -152,7 +153,9 @@ public class FluxBufferTimeoutTest {
 		CoreSubscriber<List<String>> actual = new LambdaSubscriber<>(null, e -> {}, null, s -> subscriptionsHolder[0] = s);
 
 		FluxBufferTimeout.BufferTimeoutSubscriber<String, List<String>> test = new FluxBufferTimeout.BufferTimeoutSubscriber<String, List<String>>(
-				actual, 123, 1000, Schedulers.elastic().createWorker(), ArrayList::new);
+				actual, 123, Duration.ofMillis(1000),
+				Schedulers.elastic().createWorker(),
+				ArrayList::new);
 
 		Subscription subscription = Operators.emptySubscription();
 		test.onSubscribe(subscription);
@@ -168,7 +171,9 @@ public class FluxBufferTimeoutTest {
 		CoreSubscriber<List<String>> actual = new LambdaSubscriber<>(null, e -> {}, null, s -> subscriptionsHolder[0] = s);
 
 		FluxBufferTimeout.BufferTimeoutSubscriber<String, List<String>> test = new FluxBufferTimeout.BufferTimeoutSubscriber<String, List<String>>(
-				actual, 5, 1000, Schedulers.elastic().createWorker(), ArrayList::new);
+				actual, 5, Duration.ofMillis(1000),
+				Schedulers.elastic().createWorker(),
+				ArrayList::new);
 
 		Subscription subscription = Operators.emptySubscription();
 		test.onSubscribe(subscription);
@@ -189,7 +194,8 @@ public class FluxBufferTimeoutTest {
 
 		VirtualTimeScheduler timeScheduler = VirtualTimeScheduler.getOrSet();
 		FluxBufferTimeout.BufferTimeoutSubscriber<String, List<String>> test = new FluxBufferTimeout.BufferTimeoutSubscriber<String, List<String>>(
-				actual, 5, 100, timeScheduler.createWorker(), ArrayList::new);
+				actual, 5, Duration.ofMillis(100), timeScheduler.createWorker(),
+				ArrayList::new);
 
 		Subscription subscription = Operators.emptySubscription();
 		test.onSubscribe(subscription);
@@ -208,7 +214,9 @@ public class FluxBufferTimeoutTest {
 				actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 
 		FluxBufferTimeout.BufferTimeoutSubscriber<String, List<String>> test = new FluxBufferTimeout.BufferTimeoutSubscriber<String, List<String>>(
-						actual, 123, 1000, Schedulers.elastic().createWorker(), ArrayList::new);
+					actual, 123, Duration.ofMillis(1000),
+				Schedulers.elastic().createWorker(),
+				ArrayList::new);
 
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
 		assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
@@ -231,7 +239,9 @@ public class FluxBufferTimeoutTest {
 		CoreSubscriber<List<Integer>> actual = new LambdaSubscriber<>(consumer, null, null, null);
 
 		FluxBufferTimeout.BufferTimeoutSubscriber<Integer, List<Integer>> test = new FluxBufferTimeout.BufferTimeoutSubscriber<Integer, List<Integer>>(
-				actual, 3, 1000, Schedulers.elastic().createWorker(), ArrayList::new);
+				actual, 3, Duration.ofMillis(1000),
+				Schedulers.elastic().createWorker(),
+				ArrayList::new);
 		test.onSubscribe(Operators.emptySubscription());
 
 		AtomicInteger counter = new AtomicInteger();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDelaySequenceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDelaySequenceTest.java
@@ -178,7 +178,7 @@ public class FluxDelaySequenceTest {
 
 	@Test
 	public void longDelayInMillis() {
-		Duration longDelay = Duration.ofMinutes(1);
+		Duration longDelay = Duration.ofNanos(Long.MAX_VALUE).plusNanos(1);
 		long expected = longDelay.toMillis();
 
 		DelaySubscriber<String> subscriber = new DelaySubscriber<>(null, longDelay, null);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxReplayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxReplayTest.java
@@ -454,7 +454,8 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 	@Test
     public void scanMain() {
         Flux<Integer> parent = Flux.just(1).map(i -> i);
-        FluxReplay<Integer> test = new FluxReplay<>(parent, 25, 1000, Schedulers.single());
+        FluxReplay<Integer> test = new FluxReplay<>(parent, 25, Duration.ofMillis(1000),
+		        Schedulers.single());
 
         Assertions.assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
         Assertions.assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(25);
@@ -464,7 +465,9 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 	@Test
     public void scanInner() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
-        FluxReplay<Integer> main = new FluxReplay<>(Flux.just(1), 2, 1000, Schedulers.single());
+        FluxReplay<Integer> main = new FluxReplay<>(Flux.just(1), 2,
+		        Duration.ofMillis(1000),
+		        Schedulers.single());
         FluxReplay.ReplayInner<Integer> test = new FluxReplay.ReplayInner<>(actual);
         FluxReplay.ReplaySubscriber<Integer> parent = new FluxReplay.ReplaySubscriber<>(new FluxReplay.UnboundedReplayBuffer<>(10), main);
         parent.add(test);
@@ -490,7 +493,9 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 
 	@Test
     public void scanSubscriber() {
-		FluxReplay<Integer> parent = new FluxReplay<>(Flux.just(1), 2, 1000, Schedulers.single());
+		FluxReplay<Integer> parent = new FluxReplay<>(Flux.just(1), 2,
+				Duration.ofMillis(1000),
+				Schedulers.single());
         FluxReplay.ReplaySubscriber<Integer> test = new FluxReplay.ReplaySubscriber<>(new FluxReplay.UnboundedReplayBuffer<>(10), parent);
         Subscription sub = Operators.emptySubscription();
         test.onSubscribe(sub);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTimeoutTest.java
@@ -221,7 +221,8 @@ public class FluxWindowTimeoutTest {
 
 	@Test
 	public void scanOperator() {
-		FluxWindowTimeout<Integer> test = new FluxWindowTimeout<>(Flux.just(1), 123, 100, Schedulers.immediate());
+		FluxWindowTimeout<Integer> test = new FluxWindowTimeout<>(Flux.just(1), 123,
+				Duration.ofMillis(100),	Schedulers.immediate());
 
 		assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.immediate());
 	}
@@ -264,7 +265,7 @@ public class FluxWindowTimeoutTest {
 		Scheduler scheduler = new MyScheduler();
 		CoreSubscriber<Flux<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		FluxWindowTimeout.WindowTimeoutSubscriber<Integer> test = new FluxWindowTimeout.WindowTimeoutSubscriber<>(actual,
-				123, Long.MAX_VALUE, scheduler);
+				123, Duration.ofMillis(Long.MAX_VALUE), scheduler);
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
@@ -48,7 +48,8 @@ public class MonoDelayElementTest {
 	public void normalIsDelayed() {
 		Mono<String> source = Mono.just("foo").log().hide();
 
-		StepVerifier.withVirtualTime(() -> new MonoDelayElement<>(source, 2, TimeUnit.SECONDS,
+		StepVerifier.withVirtualTime(() -> new MonoDelayElement<>(source,
+				Duration.ofSeconds(2),
 				defaultSchedulerForDelay()).log())
 	                .expectSubscription()
 	                .expectNoEvent(Duration.ofSeconds(2))
@@ -64,7 +65,7 @@ public class MonoDelayElementTest {
 		Mono<String> source = Mono.just("foo").log().hide();
 
 		StepVerifier.withVirtualTime(
-				() -> new MonoDelayElement<>(source, 2, TimeUnit.SECONDS, vts)
+				() -> new MonoDelayElement<>(source, Duration.ofSeconds(2), vts)
 						.doOnCancel(() -> cancelled.set(true))
 						.log()
 						.doOnNext(n -> emitted.set(true)),
@@ -88,7 +89,7 @@ public class MonoDelayElementTest {
 		Mono<Long> source = Mono.delay(Duration.ofMillis(1000), vts);
 
 		StepVerifier.withVirtualTime(
-				() -> new MonoDelayElement<>(source, 2, TimeUnit.SECONDS, vts)
+				() -> new MonoDelayElement<>(source, Duration.ofSeconds(2), vts)
 						.doOnCancel(() -> cancelled.set(true))
 						.doOnNext(n -> emitted.set(true)),
 				() -> vts, Long.MAX_VALUE)
@@ -106,7 +107,8 @@ public class MonoDelayElementTest {
 	public void emptyIsImmediate() {
 		Mono<String> source = Mono.<String>empty().log().hide();
 
-		Duration d = StepVerifier.create(new MonoDelayElement<>(source, 10, TimeUnit.SECONDS,
+		Duration d = StepVerifier.create(new MonoDelayElement<>(source,
+				Duration.ofSeconds(10),
 				defaultSchedulerForDelay()).log())
 		            .expectSubscription()
 		            .verifyComplete();
@@ -118,7 +120,8 @@ public class MonoDelayElementTest {
 	public void errorIsImmediate() {
 		Mono<String> source = Mono.<String>error(new IllegalStateException("boom")).hide();
 
-		Duration d = StepVerifier.create(new MonoDelayElement<>(source, 10, TimeUnit.SECONDS, defaultSchedulerForDelay()).log())
+		Duration d = StepVerifier.create(new MonoDelayElement<>(source,
+				Duration.ofSeconds(10), defaultSchedulerForDelay()).log())
 		                         .expectSubscription()
 		                         .verifyErrorMessage("boom");
 
@@ -133,7 +136,8 @@ public class MonoDelayElementTest {
 
 		try {
 			StepVerifier.withVirtualTime(() ->
-					new MonoDelayElement<>(source.mono(), 2, TimeUnit.SECONDS, defaultSchedulerForDelay()))
+					new MonoDelayElement<>(source.mono(),
+							Duration.ofSeconds(2), defaultSchedulerForDelay()))
 			            .expectSubscription()
 			            .then(() -> source.next("foo").error(new IllegalStateException("boom")))
 			            .expectNoEvent(Duration.ofSeconds(2))
@@ -153,7 +157,8 @@ public class MonoDelayElementTest {
 		Mono<String> source = Mono.just("foo").hide();
 
 		try {
-			StepVerifier.create(new MonoDelayElement<>(source, 2, TimeUnit.SECONDS, scheduler))
+			StepVerifier.create(new MonoDelayElement<>(source,
+					Duration.ofSeconds(2), scheduler))
 			            .expectSubscription()
 			            .verifyComplete(); //complete not relevant
 			fail("expected exception here");
@@ -178,7 +183,7 @@ public class MonoDelayElementTest {
 				.doOnCancel(() -> upstreamCancelCount.incrementAndGet());
 
 		StepVerifier.withVirtualTime(
-				() -> new MonoDelayElement<>(source, 2, TimeUnit.SECONDS, vts),
+				() -> new MonoDelayElement<>(source, Duration.ofSeconds(2), vts),
 				() -> vts, Long.MAX_VALUE)
 		            .expectSubscription()
 		            .expectNoEvent(Duration.ofSeconds(1))
@@ -200,7 +205,7 @@ public class MonoDelayElementTest {
 
 		try {
 			StepVerifier.withVirtualTime(
-					() -> new MonoDelayElement<>(source, 2, TimeUnit.SECONDS, vts).log(),
+					() -> new MonoDelayElement<>(source, Duration.ofSeconds(2), vts).log(),
 					() -> vts, Long.MAX_VALUE)
 			            .expectSubscription()
 			            .verifyComplete();
@@ -258,8 +263,7 @@ public class MonoDelayElementTest {
 
 		try {
 			StepVerifier.withVirtualTime(() -> new MonoDelayElement<>(source,
-					2,
-					TimeUnit.SECONDS,
+					Duration.ofSeconds(2),
 					defaultSchedulerForDelay()))
 			            .expectSubscription()
 			            .expectNoEvent(Duration.ofSeconds(2))
@@ -281,8 +285,7 @@ public class MonoDelayElementTest {
 		});
 
 		StepVerifier.withVirtualTime(() -> new MonoDelayElement<>(source,
-				2,
-				TimeUnit.SECONDS,
+				Duration.ofSeconds(2),
 				defaultSchedulerForDelay()))
 		            .expectSubscription()
 		            .expectNoEvent(Duration.ofSeconds(2))
@@ -303,8 +306,7 @@ public class MonoDelayElementTest {
 
 		try {
 			StepVerifier.withVirtualTime(() -> new MonoDelayElement<>(source,
-					2,
-					TimeUnit.SECONDS,
+					Duration.ofSeconds(2),
 					defaultSchedulerForDelay()))
 			            .expectSubscription()
 			            .expectNoEvent(Duration.ofSeconds(2))
@@ -354,8 +356,7 @@ public class MonoDelayElementTest {
 
 
 		StepVerifier.withVirtualTime(() -> new MonoDelayElement<>(source,
-				2,
-				TimeUnit.SECONDS,
+				Duration.ofSeconds(2),
 				defaultSchedulerForDelay())
 				.doOnCancel(onCancel::incrementAndGet)
 				.doOnSuccessOrError((v, e) -> onTerminate.incrementAndGet()))
@@ -372,7 +373,8 @@ public class MonoDelayElementTest {
 
 	@Test
 	public void scanOperator() {
-		MonoDelayElement<String> test = new MonoDelayElement<>(Mono.empty(), 1, TimeUnit.SECONDS, Schedulers.immediate());
+		MonoDelayElement<String> test = new MonoDelayElement<>(Mono.empty(),
+				Duration.ofSeconds(1), Schedulers.immediate());
 
 		assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.immediate());
 	}
@@ -381,7 +383,7 @@ public class MonoDelayElementTest {
 	public void scanSubscriber() {
 		CoreSubscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
 		MonoDelayElement.DelayElementSubscriber<String> test = new MonoDelayElement.DelayElementSubscriber<>(
-				actual, Schedulers.single(), 10, TimeUnit.MILLISECONDS);
+				actual, Schedulers.single(), Duration.ofMillis(10));
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDelayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDelayTest.java
@@ -73,7 +73,7 @@ public class MonoDelayTest {
 
 	@Test
 	public void scanOperator() {
-		MonoDelay test = new MonoDelay(1, TimeUnit.SECONDS, Schedulers.immediate());
+		MonoDelay test = new MonoDelay(Duration.ofSeconds(1), Schedulers.immediate());
 
 		assertThat(test.scan(Scannable.Attr.RUN_ON)).isSameAs(Schedulers.immediate());
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
@@ -16,6 +16,7 @@
 
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -87,6 +88,14 @@ public class OperatorsTest {
 		assertThat(Operators.addCap(1, 2)).isEqualTo(3);
 		assertThat(Operators.addCap(1, Long.MAX_VALUE)).isEqualTo(Long.MAX_VALUE);
 		assertThat(Operators.addCap(0, -1)).isEqualTo(Long.MAX_VALUE);
+	}
+
+	@Test
+	public void nanoPrecision() {
+		final Duration MAX_NANOS = Duration.ofNanos(Long.MAX_VALUE);
+		assertThat(Operators.nanoPrecision(MAX_NANOS)).isFalse();
+		assertThat(Operators.nanoPrecision(MAX_NANOS.plusNanos(1))).isFalse();
+		assertThat(Operators.nanoPrecision(MAX_NANOS.minusNanos(1))).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
PR changes duration-based operators to use nanosecond precision, if the given `Duration `can be expressed in nanoseconds without exceeding `Long.MAX_VALUE`.

The conversion from `Duration` to `Long` is no longer done in the Flux class. The operator constructors were changed to accept a `Duration` instead of a `Long` + `TimeUnit`. This allows for the constructor to determine time precision.