### PR TITLE
see #1855 Add isCompleteEmpty getter to Signal for doOnEach

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDoOnEach.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDoOnEach.java
@@ -197,7 +197,7 @@ final class FluxDoOnEach<T> extends InternalFluxOperator<T, T> {
 			state = STATE_DONE;
 			if (oldState < STATE_SKIP_HANDLER) {
 				try {
-					onSignal.accept(Signal.complete(cachedContext));
+					onSignal.accept(Signal.complete(cachedContext, this.t == null));
 				}
 				catch (Throwable e) {
 					state = oldState;
@@ -240,6 +240,11 @@ final class FluxDoOnEach<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public SignalType getType() {
 			return SignalType.ON_NEXT;
+		}
+
+		@Override
+		public boolean isOnEmptyComplete() {
+			return false; //default to false, this is used for onNext anyway
 		}
 
 		@Override
@@ -291,7 +296,7 @@ final class FluxDoOnEach<T> extends InternalFluxOperator<T, T> {
 			if (v == null && syncFused) {
 				state = STATE_DONE;
 				try {
-					onSignal.accept(Signal.complete(cachedContext));
+					onSignal.accept(Signal.complete(cachedContext, this.t == null));
 				}
 				catch (Throwable e) {
 					throw e;

--- a/reactor-core/src/main/java/reactor/core/publisher/ImmutableSignal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ImmutableSignal.java
@@ -40,17 +40,29 @@ final class ImmutableSignal<T> implements Signal<T>, Serializable {
 
 	private final SignalType type;
 	private final Throwable  throwable;
+	private final boolean    markEmptySource;
 
 	private final T value;
 
 	private transient final Subscription subscription;
 
-	ImmutableSignal(Context context, SignalType type, @Nullable T value, @Nullable Throwable e, @Nullable Subscription subscription) {
+	ImmutableSignal(Context context, SignalType type, @Nullable T value, @Nullable Throwable e, @Nullable Subscription subscription,
+			boolean markEmptySource) {
 		this.context = context;
 		this.value = value;
 		this.subscription = subscription;
 		this.throwable = e;
 		this.type = type;
+		this.markEmptySource = markEmptySource;
+	}
+
+	ImmutableSignal(Context context, SignalType type, @Nullable T value, @Nullable Throwable e, @Nullable Subscription subscription) {
+		this(context, type, value, e, subscription, false);
+	}
+
+	@Override
+	public boolean isOnEmptyComplete() {
+		return this.type == SignalType.ON_COMPLETE && this.markEmptySource;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
@@ -207,6 +207,11 @@ class MonoCacheTime<T> extends InternalMonoOperator<T, T> implements Runnable {
 			throw new UnsupportedOperationException("illegal signal use: getContext");
 		}
 
+		@Override
+		public boolean isOnEmptyComplete() {
+			throw new UnsupportedOperationException("illegal signal use: isOnEmptyComplete");
+		}
+
 		final boolean add(Operators.MonoSubscriber<T, T> toAdd) {
 			for (; ; ) {
 				Operators.MonoSubscriber<T, T>[] a = subscribers;

--- a/reactor-core/src/main/java/reactor/core/publisher/Signal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Signal.java
@@ -66,6 +66,13 @@ public interface Signal<T> extends Supplier<T>, Consumer<Subscriber<? super T>> 
 		return new ImmutableSignal<>(context, SignalType.ON_COMPLETE, null, null, null);
 	}
 
+	static <T> Signal<T> complete(Context context, boolean markEmptySource) {
+		if (context.isEmpty() && !markEmptySource) {
+			return (Signal<T>) ImmutableSignal.ON_COMPLETE;
+		}
+		return new ImmutableSignal<>(context, SignalType.ON_COMPLETE, null, null, null, markEmptySource);
+	}
+
 	/**
 	 * Creates and returns a {@code Signal} of variety {@code Type.FAILED}, which holds
 	 * the error.
@@ -256,6 +263,8 @@ public interface Signal<T> extends Supplier<T>, Consumer<Subscriber<? super T>> 
 	default boolean isOnComplete() {
 		return getType() == SignalType.ON_COMPLETE;
 	}
+
+	boolean isOnEmptyComplete();
 
 	/**
 	 * Indicates whether this signal represents an {@code onSubscribe} event.

--- a/reactor-core/src/test/java/reactor/core/publisher/SignalTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SignalTest.java
@@ -352,6 +352,11 @@ public class SignalTest {
 			public SignalType getType() {
 				return SignalType.AFTER_TERMINATE;
 			}
+
+			@Override
+			public boolean isOnEmptyComplete() {
+				return false;
+			}
 		})).isFalse();
 	}
 


### PR DESCRIPTION
I explored this alternative to #1855 where we don't provide a `doOnEmpty` new side effect, but rather expose a getter in the `Signal`. Said getter would only be guaranteed to be relevant within `doOnEach`, which is my main beef with this alternative.

(eg. `Signals` created by `materialize()` wouldn't meaningfully implement the method, with a default to `false`).

wdyt @smaldini @bsideup ?