### PR TITLE
#1888 propagate context in `transformDeferred`

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -28,6 +28,7 @@ sourceSets {
 
 testSets {
   blockHoundTest
+  reactiveStreamsInteropTest
 }
 
 configurations {
@@ -82,6 +83,8 @@ dependencies {
   noMicrometerTestCompile sourceSets.main.output
   noMicrometerTestCompile sourceSets.test.output
   noMicrometerTestCompile configurations.testCompile
+
+  reactiveStreamsInteropTestImplementation "io.reactivex.rxjava2:rxjava:2.2.12"
 }
 
 task downloadBaseline {
@@ -216,6 +219,8 @@ task testNoMicrometer(type: Test, group: 'verification') {
 check {
   dependsOn testStaticInit
   dependsOn testNoMicrometer
+  dependsOn reactiveStreamsInteropTest
+
   if (System.env.TRAVIS != "true") {
 	dependsOn testNG
   }

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -8924,6 +8924,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * </pre></blockquote>
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/transformForFlux.svg" alt="">
+	 * <p>
+	 * Note that when composing {@link Publisher} that are NOT from Reactor, it is preferable to
+	 * A) use {@link #transformDeferred(Function)} and B) isolate the part of the subchain that switches
+	 * to the non-Reactor library. If you do so, {@link Context} propagation will be possible
+	 * (see {@link #transformDeferred(Function)} for details).
 	 *
 	 * @param transformer the {@link Function} to immediately map this {@link Flux} into a target {@link Flux}
 	 * instance.
@@ -8945,6 +8950,10 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * </pre></blockquote>
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/transformDeferredForFlux.svg" alt="">
+	 * <p>
+	 * Note that when composing {@link Publisher} that are NOT from Reactor, it is preferable to
+	 * isolate the part of the subchain that switches to the non-Reactor library in a dedicated {@link #transformDeferred(Function)}.
+	 * Doing so will allow this operator to detect the "alien" {@link Subscriber} and short-circuit it when propagating the {@link Context}.
 	 *
 	 * @param transformer the {@link Function} to lazily map this {@link Flux} into a target {@link Publisher}
 	 * instance for each new subscriber
@@ -8961,6 +8970,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 			if (!ctx.isEmpty()) {
 				BiFunction<Publisher, CoreSubscriber<? super T>, CoreSubscriber<? super T>> lifter = (pub, actual) -> {
 					if (actual instanceof StrictSubscriber) {
+						//this is ok with Fuseable too, it is a QueueSubscription
 						return new FluxContextStart.ContextStartSubscriber<>(actual, ctx);
 					}
 					else {

--- a/reactor-core/src/reactiveStreamsInteropTest/java/reactor/util/context/ReactiveStreamsContextPropagationTest.java
+++ b/reactor-core/src/reactiveStreamsInteropTest/java/reactor/util/context/ReactiveStreamsContextPropagationTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.context;
+
+import io.reactivex.Flowable;
+import junitparams.JUnitParamsRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnitParamsRunner.class)
+public class ReactiveStreamsContextPropagationTest {
+
+	//this test is here to demonstrate a limitation of the transformDeferred Context propagation:
+	//if the topmost SUBSCRIBER is a core subscriber, itself propagating to a non-reactor Subscriber,
+	//the outer Context will be lost.
+	@Test
+	public void transformDeferredWithFlowableWrappingCoreLosesContext() {
+		Flux<String> source = Flux.deferWithContext(Flux::just)
+		                          .map(ctx -> ctx.getOrDefault("foo", "NO CONTEXT"));
+		Context c = Context.of("foo", "bar");
+
+		String extracted = source.transformDeferred(f -> Flowable.fromPublisher(f.map(v -> "EXTRACTED " + v+ " FROM FLUX")))
+		                         .subscriberContext(c)
+		                         .blockLast();
+
+		assertThat(extracted).isEqualTo("EXTRACTED NO CONTEXT FROM FLUX");
+
+		Mono<String> monoSource = Mono.subscriberContext()
+				.map(ctx -> ctx.getOrDefault("foo", "NO CONTEXT"));
+
+		extracted = monoSource.transformDeferred(f -> Flowable.fromPublisher(f.map(v -> "EXTRACTED " + v + " FROM MONO")))
+		                      .subscriberContext(c)
+		                      .block();
+
+		assertThat(extracted).isEqualTo("EXTRACTED NO CONTEXT FROM MONO");
+	}
+
+	@Test
+	public void transformDeferredWithFlowableIsolatedWorks() {
+		Flux<String> source = Flux.deferWithContext(Flux::just)
+		                          .map(ctx -> ctx.getOrDefault("foo", "NO CONTEXT"));
+		Context c = Context.of("foo", "bar");
+
+		String extracted = source.transformDeferred(f -> f.map(v -> "EXTRACTED " + v + " FROM FLUX"))
+		                         .transformDeferred(Flowable::fromPublisher)
+		                         .subscriberContext(c)
+		                         .blockLast();
+
+		assertThat(extracted).isEqualTo("EXTRACTED bar FROM FLUX");
+
+		Mono<String> sourceMono = Mono.subscriberContext()
+		                              .map(ctx -> ctx.getOrDefault("foo", "NO CONTEXT"));
+
+		extracted = sourceMono.transformDeferred(f -> f.map(v -> "EXTRACTED " + v + " FROM MONO"))
+		                         .transformDeferred(Flowable::fromPublisher)
+		                         .subscriberContext(c)
+		                         .block();
+
+		assertThat(extracted).isEqualTo("EXTRACTED bar FROM MONO");
+	}
+
+}

--- a/reactor-core/src/test/java/reactor/util/context/ContextPropagationTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextPropagationTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.context;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.CorePublisher;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.*;
+
+@RunWith(JUnitParamsRunner.class)
+public class ContextPropagationTest {
+
+	public static List<TransformDeferredSourceFactory> transformDeferredSources() {
+		return Arrays.asList(
+				new TransformDeferredSourceFactory("Flux") {
+					@Override
+					public CorePublisher<Context> apply(Function<CorePublisher<Context>, Publisher<Context>> f) {
+						return Flux.deferWithContext(Flux::just).transformDeferred(f);
+					}
+				},
+				new TransformDeferredSourceFactory("Mono") {
+					@Override
+					public CorePublisher<Context> apply(Function<CorePublisher<Context>, Publisher<Context>> f) {
+						return Mono.subscriberContext().transformDeferred(f);
+					}
+				}
+		);
+	}
+
+	@Test
+	@Parameters(method = "transformDeferredSources")
+	public void transformDeferredPreservesContext(TransformDeferredSourceFactory fn) {
+		Function<CorePublisher<Context>, Publisher<Context>> lifter = source -> {
+			return actual -> source.subscribe(new ForwardingSubscriber<>(actual));
+		};
+
+		Context c = Context.of("foo", "bar");
+		Context ctx = Flux.from(fn.apply(lifter))
+		                  .subscriberContext(c)
+		                  .blockLast();
+
+		assertThat(ctx.getOrEmpty("foo")).hasValue("bar");
+	}
+
+	/**
+	 * TODO consider throwing an error when the context is overridden instead of changing the current one
+	 */
+	@Test
+	@Parameters(method = "transformDeferredSources")
+	public void transformDeferredDoesNotOverrideContext(
+			Function<Function<CorePublisher<Context>, Publisher<Context>>, CorePublisher<Context>> fn
+	) {
+		Function<CorePublisher<Context>, Publisher<Context>> lifter = source -> {
+			return actual -> source.subscribe(new ForwardingCoreSubscriber<Context>(actual) {
+				@Override
+				public Context currentContext() {
+					return Context.of("foo", "baz");
+				}
+			});
+		};
+
+		Context c = Context.of("foo", "bar");
+		Context ctx = Flux.from(fn.apply(lifter)).subscriberContext(c).blockLast();
+
+		assertThat(ctx.getOrEmpty("foo")).hasValue("baz");
+	}
+
+	/**
+	 * TODO consider throwing an error when the context is reset
+	 *  to the default value of {@link CoreSubscriber#currentContext()}
+	 */
+	@Test
+	@Parameters(method = "transformDeferredSources")
+	public void transformDeferredDoesRespectsEmptyContext(
+			Function<Function<CorePublisher<Context>, Publisher<Context>>, CorePublisher<Context>> fn
+	) {
+		Function<CorePublisher<Context>, Publisher<Context>> lifter = source -> {
+			return actual -> source.subscribe(new ForwardingCoreSubscriber<Context>(actual) {
+				@Override
+				public Context currentContext() {
+					return Context.empty();
+				}
+			});
+		};
+
+		Context c = Context.of("foo", "bar");
+		Context ctx = Flux.from(fn.apply(lifter)).subscriberContext(c).blockLast();
+
+		assertThat(ctx.isEmpty()).as("context is empty").isTrue();
+	}
+
+	static abstract class TransformDeferredSourceFactory implements Function<Function<CorePublisher<Context>, Publisher<Context>>, CorePublisher<Context>> {
+
+		final String name;
+
+		TransformDeferredSourceFactory(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+	}
+
+	static class ForwardingSubscriber<T> implements Subscriber<T> {
+
+		final Subscriber<? super T> actual;
+
+		ForwardingSubscriber(Subscriber<? super T> actual) {
+			this.actual = actual;
+		}
+
+		@Override
+		public void onComplete() {
+			actual.onComplete();
+		}
+
+		@Override
+		public void onError(Throwable throwable) {
+			actual.onError(throwable);
+		}
+
+		@Override
+		public void onNext(T context) {
+			actual.onNext(context);
+		}
+
+		@Override
+		public void onSubscribe(Subscription subscription) {
+			actual.onSubscribe(subscription);
+		}
+	}
+
+	static class ForwardingCoreSubscriber<T> extends ForwardingSubscriber<T> implements CoreSubscriber<T> {
+
+		ForwardingCoreSubscriber(Subscriber<? super T> actual) {
+			super(actual);
+		}
+	}
+
+}


### PR DESCRIPTION
See #1888.

Currently (see `transformDeferredPreservesContext` test) `transform` or `transformDeferred` returns a publisher that is not Reactor Core type, the context is lost.
Although it is not possible to ensure 100% propagation (see comments on `transformDeferredDoesNotOverrideContext` and `transformDeferredDoesRespectsEmptyContext`), we can at least do it for the publishers that are not Context aware (interop case).

We could also detect non-core type returned from `transform` and warn the user, but I decided to not do it in this PR to keep it small and focused