### PR TITLE
see #1804 Enforce 100K task cap on Schedulers.boundedElastic()

### DIFF
--- a/docs/asciidoc/coreFeatures.adoc
+++ b/docs/asciidoc/coreFeatures.adoc
@@ -204,7 +204,7 @@ problems and lead to too many threads (see below).
 * A bounded elastic thread pool (`Schedulers.boundedElastic()`). Like its predecessor `elastic()`, it
 creates new worker pools as needed and reuses idle ones. Worker pools that stay idle for too long (the default is 60s) are
 also disposed. Unlike its `elastic()` predecessor, it has a cap on the number of backing threads it can create (default is number of CPU cores x 10).
-Tasks submitted after the cap has been reached are enqueued and will be re-scheduled when a thread becomes available
+Up to 100 000 tasks submitted after the cap has been reached are enqueued and will be re-scheduled when a thread becomes available
 (when scheduling with a delay, the delay starts when the thread becomes available). This is a better choice for I/O blocking work.
 `Schedulers.boundedElastic()` is a handy way to give a blocking process its own thread so that
 it does not tie up other resources. See <<faq.wrap-blocking>>, but doesn't pressure the system too much with new threads.

--- a/docs/asciidoc/faq.adoc
+++ b/docs/asciidoc/faq.adoc
@@ -35,7 +35,8 @@ from `Schedulers.boundedElastic()`.
 You should use a `Mono`, because the source returns one value. You should use
 `Schedulers.boundedElastic`, because it creates a dedicated thread to wait for the
 blocking resource without impacting other non-blocking processing, while also ensuring
-that there is a limit to the amount of threads that can be created.
+that there is a limit to the amount of threads that can be created, and blocking tasks
+that can be enqueued and deferred during a spike.
 
 Note that `subscribeOn` does not subscribe to the `Mono`. It specifies what
 kind of `Scheduler` to use when a subscribe call happens.

--- a/reactor-core/src/test/java/reactor/core/scheduler/BoundedElasticSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/BoundedElasticSchedulerTest.java
@@ -615,7 +615,7 @@ public class BoundedElasticSchedulerTest extends AbstractSchedulerTest {
 		//unbounded task queueing
 		assertThat(boundedElastic.deferredTaskCap)
 				.as("default unbounded task queueing")
-				.isEqualTo(Integer.MAX_VALUE)
+				.isEqualTo(100_000)
 				.isEqualTo(Schedulers.DEFAULT_BOUNDED_ELASTIC_QUEUESIZE);
 	}
 


### PR DESCRIPTION
Another late change, but if we introduce the `boundedElastic()` singleton version of the scheduler, we might as well make it truly bounded, including in the number of task submissions it can "absorb" during a spike. Used to be unbounded, now bounded to 100K tasks.

This is also more likely to uncover problematic scheduling of blocking tasks. Users switching from `elastic()` to `boundedElastic()` and seeing `RejectedExecutionException`s should challenge why their Reactor app schedules so many blocking tasks, and if still legitimate and necessary, use a `newBoundedElastic` instance that is better tuned to their workload.