### PR TITLE
fix #1911 Instrument ScheduledExecutorService via Micrometer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
   }
 
   // Metrics
-  micrometerVersion = 'latest.release' //TODO specify a version of micrometer?
+  micrometerVersion = '1.3.0' //optional, should be compatible with any 1.3.x, but 1.3.0 is now a baseline
 
   // Logging
   slf4jVersion = '1.7.12'

--- a/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
@@ -18,18 +18,12 @@ package reactor.core.scheduler;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.WeakHashMap;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
-import io.micrometer.core.instrument.internal.TimedExecutorService;
 import io.micrometer.core.instrument.search.Search;
 
 import reactor.core.Disposable;
@@ -84,14 +78,7 @@ final class SchedulerMetricDecorator
 		to distinguish between two instances with the same name and configuration).
 		 */
 
-		//the result of `monitor` below is ignored on purpose (the equivalent wrapping is done right after).
-		//calling this method is still useful, as it binds some gauges from the executor to the registry...
-		ExecutorServiceMetrics.monitor(globalRegistry, service, executorId, tags);
-
-		// TODO return the result of ExecutorServiceMetrics#monitor
-		//  once ScheduledExecutorService gets supported by Micrometer
-		//  See https://github.com/micrometer-metrics/micrometer/issues/1021
-		return new TimedScheduledExecutorService(globalRegistry, service, executorId, tags);
+		return ExecutorServiceMetrics.monitor(globalRegistry, service, executorId, tags);
 	}
 
 	@Override
@@ -106,36 +93,5 @@ final class SchedulerMetricDecorator
 		this.seenSchedulers.clear();
 		this.schedulerDifferentiator.clear();
 		this.executorDifferentiator.clear();
-	}
-
-	static final class TimedScheduledExecutorService extends TimedExecutorService implements ScheduledExecutorService {
-
-		final ScheduledExecutorService delegate;
-
-		public TimedScheduledExecutorService(MeterRegistry registry, ScheduledExecutorService delegate, String executorServiceName, Iterable<Tag> tags) {
-			super(registry, delegate, executorServiceName, tags);
-
-			this.delegate = delegate;
-		}
-
-		@Override
-		public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-			return delegate.schedule(command, delay, unit);
-		}
-
-		@Override
-		public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
-			return delegate.schedule(callable, delay, unit);
-		}
-
-		@Override
-		public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
-			return delegate.scheduleAtFixedRate(command, initialDelay, period, unit);
-		}
-
-		@Override
-		public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
-			return delegate.scheduleWithFixedDelay(command, initialDelay, delay, unit);
-		}
 	}
 }


### PR DESCRIPTION
I have removed the `TimedScheduledExecutorService` that was there within the reactor-core and instead returned the one from `ExecutorServiceMetrics.monitor` call.

fixes #1911