### PR TITLE
fix #1913 expectTimeout as an alternative to expectNoEvent.thenCancel

### DIFF
--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -31,6 +31,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReference;
@@ -58,6 +59,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;
+import reactor.core.publisher.ParallelFlux;
 import reactor.core.publisher.Signal;
 import reactor.test.scheduler.VirtualTimeScheduler;
 import reactor.util.Logger;
@@ -182,15 +184,15 @@ final class DefaultStepVerifierBuilder<T>
 		return new DefaultStepVerifierBuilder<>(options, scenarioSupplier);
 	}
 
-	final         SignalEvent<T>                             defaultFirstStep;
-	final         List<Event<T>>                             script;
-	final         MessageFormatter                           messageFormatter;
-	final         long                                       initialRequest;
-	final         Supplier<? extends VirtualTimeScheduler>   vtsLookup;
-	@Nullable
-	final         Supplier<? extends Publisher<? extends T>> sourceSupplier;
-	private final StepVerifierOptions                        options;
+	final SignalEvent<T>                           defaultFirstStep;
+	final List<Event<T>>                           script;
+	final MessageFormatter                         messageFormatter;
+	final long                                     initialRequest;
+	final Supplier<? extends VirtualTimeScheduler> vtsLookup;
+	final StepVerifierOptions                      options;
 
+	@Nullable
+	Supplier<? extends Publisher<? extends T>> sourceSupplier;
 	long hangCheckRequested;
 	int  requestedFusionMode = -1;
 	int  expectedFusionMode  = -1;
@@ -624,6 +626,42 @@ final class DefaultStepVerifierBuilder<T>
 	@Override
 	public DefaultStepVerifier<T> thenCancel() {
 		this.script.add(new SubscriptionEvent<>("thenCancel"));
+		return build();
+	}
+
+	@Override
+	public DefaultStepVerifier<T> expectTimeout(Duration duration) {
+		if (sourceSupplier == null) {
+			throw new IllegalStateException("Attempting to call expectTimeout() without a Supplier<Publisher>");
+		}
+		Supplier<? extends Publisher<? extends T>> originalSupplier = sourceSupplier;
+		this.sourceSupplier = () -> {
+			Publisher<? extends T> p = originalSupplier.get();
+
+			if (p instanceof Flux) {
+				return ((Flux<T>) p).timeout(duration);
+			}
+			else if (p instanceof ParallelFlux) {
+				return ((ParallelFlux<T>) p).sequential().timeout(duration);
+			}
+			else if (p instanceof Mono) {
+				return ((Mono<T>) p).timeout(duration);
+			}
+			else return Flux.from(p).timeout(duration);
+		};
+
+		WaitEvent<T> timeout = new WaitEvent<>(duration, "expectTimeout-wait");
+		SignalEvent<T> timeoutVerification = new SignalEvent<>((signal, se) -> {
+			if (signal.isOnError() && signal.getThrowable() instanceof TimeoutException) {
+				return Optional.empty();
+			}
+			else {
+				return messageFormatter.failOptional(se, "expected: timeout(%s); actual: %s",
+						ValueFormatters.DURATION_CONVERTER.apply(duration), signal);
+			}
+		}, "expectTimeout");
+		this.script.add(timeout);
+		this.script.add(timeoutVerification);
 		return build();
 	}
 

--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -635,20 +635,7 @@ final class DefaultStepVerifierBuilder<T>
 			throw new IllegalStateException("Attempting to call expectTimeout() without a Supplier<Publisher>");
 		}
 		Supplier<? extends Publisher<? extends T>> originalSupplier = sourceSupplier;
-		this.sourceSupplier = () -> {
-			Publisher<? extends T> p = originalSupplier.get();
-
-			if (p instanceof Flux) {
-				return ((Flux<T>) p).timeout(duration);
-			}
-			else if (p instanceof ParallelFlux) {
-				return ((ParallelFlux<T>) p).sequential().timeout(duration);
-			}
-			else if (p instanceof Mono) {
-				return ((Mono<T>) p).timeout(duration);
-			}
-			else return Flux.from(p).timeout(duration);
-		};
+		this.sourceSupplier = () -> Flux.from(originalSupplier.get()).timeout(duration);
 
 		WaitEvent<T> timeout = new WaitEvent<>(duration, "expectTimeout-wait");
 		SignalEvent<T> timeoutVerification = new SignalEvent<>((signal, se) -> {

--- a/reactor-test/src/main/java/reactor/test/ValueFormatters.java
+++ b/reactor-test/src/main/java/reactor/test/ValueFormatters.java
@@ -53,8 +53,10 @@ public final class ValueFormatters {
 	 * Default {@link Duration#toString() Duration} {@link ToStringConverter} that removes the PT prefix and
 	 * switches {@link String#toLowerCase() to lower case}.
 	 */
-	public static final ToStringConverter DURATION_CONVERTER = new ClassBasedToStringConverter<Duration>(
-			Duration.class, d -> true, d -> d.toString().replaceFirst("PT", "").toLowerCase());
+	public static final ToStringConverter DURATION_CONVERTER = new ClassBasedToStringConverter<>(
+			Duration.class,
+			d -> true,
+			d -> d.toString().replaceFirst("PT", "").toLowerCase());
 
 	/**
 	 * A generic {@link Object} to {@link String} conversion {@link Function} which is

--- a/reactor-test/src/main/java/reactor/test/ValueFormatters.java
+++ b/reactor-test/src/main/java/reactor/test/ValueFormatters.java
@@ -16,6 +16,7 @@
 
 package reactor.test;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Spliterator;
 import java.util.function.BiFunction;
@@ -47,6 +48,13 @@ import reactor.util.annotation.Nullable;
 public final class ValueFormatters {
 
 	private ValueFormatters() {}
+
+	/**
+	 * Default {@link Duration#toString() Duration} {@link ToStringConverter} that removes the PT prefix and
+	 * switches {@link String#toLowerCase() to lower case}.
+	 */
+	public static final ToStringConverter DURATION_CONVERTER = new ClassBasedToStringConverter<Duration>(
+			Duration.class, d -> true, d -> d.toString().replaceFirst("PT", "").toLowerCase());
 
 	/**
 	 * A generic {@link Object} to {@link String} conversion {@link Function} which is

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -1258,14 +1258,28 @@ public class StepVerifierTests {
 	public void expectTimeoutSmokeTest() {
 		Mono<String> neverMono = Mono.never();
 		Mono<String> completingMono = Mono.empty();
-		Function<Mono<String>, Duration> f = m -> StepVerifier.create(m)
-		                                                      .expectTimeout(Duration.ofSeconds(1))
-		                                                      .verify();
 
-		f.apply(neverMono); //verification should pass
+		StepVerifier.create(neverMono, StepVerifierOptions.create().scenarioName("neverMono should pass"))
+				.expectTimeout(Duration.ofSeconds(1))
+				.verify();
+
+		StepVerifier shouldFail = StepVerifier.create(completingMono).expectTimeout(Duration.ofSeconds(1));
 
 		assertThatExceptionOfType(AssertionError.class)
-				.isThrownBy(() -> f.apply(completingMono))
+				.isThrownBy(shouldFail::verify)
+				.withMessage("expectation \"expectTimeout\" failed (expected: timeout(1s); actual: onComplete())");
+	}
+
+	@Test
+	public void verifyTimeoutSmokeTest() {
+		Mono<String> neverMono = Mono.never();
+		Mono<String> completingMono = Mono.empty();
+
+		StepVerifier.create(neverMono, StepVerifierOptions.create().scenarioName("neverMono should pass"))
+				.verifyTimeout(Duration.ofSeconds(1));
+
+		assertThatExceptionOfType(AssertionError.class)
+				.isThrownBy(() -> StepVerifier.create(completingMono).verifyTimeout(Duration.ofSeconds(1)))
 				.withMessage("expectation \"expectTimeout\" failed (expected: timeout(1s); actual: onComplete())");
 	}
 


### PR DESCRIPTION
The `expectTimeout(d)` method is a preferred alternative to the
`expectNoEvent(d).thenCancel()` combination. It should do a better job
at avoiding false positives, and is more expressive of the expectation
that a Publisher "never ends" (although it is impossible to meaningfully
assert that without waiting for the heat death of the universe).