### PR TITLE
fix #1945 Avoid unnecessary wrapping of exceptions in scalar flatMap

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
@@ -761,17 +761,17 @@ final class FluxConcatMap<T, R> extends FluxOperator<T, R> {
 								}
 								catch (Throwable e) {
 									//does the strategy apply? if so, short-circuit the delayError. In any case, don't cancel
-									Throwable e_ = Operators.onNextPollError(v, e,
+									Throwable e_ = Operators.onNextError(v, e,
 											this.ctx);
 									if (e_ == null) {
 										continue;
 									}
 									//now if error mode strategy doesn't apply, let delayError play
-									if (veryEnd && Exceptions.addThrowable(ERROR, this, e)) {
+									if (veryEnd && Exceptions.addThrowable(ERROR, this, e_)) {
 										continue;
 									}
 									else {
-										actual.onError(Operators.onOperatorError(s, e, v,
+										actual.onError(Operators.onOperatorError(s, e_, v,
 												this.ctx));
 										return;
 									}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -129,7 +129,7 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 			catch (Throwable e) {
 				Context ctx = s.currentContext();
 				Throwable e_ = errorContinueExpected ?
-					Operators.onNextPollError(null, e, ctx) :
+					Operators.onNextError(null, e, ctx) :
 					Operators.onOperatorError(e, ctx);
 				if (e_ != null) {
 					Operators.error(s, e_);
@@ -155,7 +155,7 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 			catch (Throwable e) {
 				Context ctx = s.currentContext();
 				Throwable e_ = errorContinueExpected ?
-						Operators.onNextPollError(t, e, ctx) :
+						Operators.onNextError(t, e, ctx) :
 						Operators.onOperatorError(null, e, t, ctx);
 				if (e_ != null) {
 					Operators.error(s, e_);
@@ -176,7 +176,7 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 				catch (Throwable e) {
 					Context ctx = s.currentContext();
 					Throwable e_ = errorContinueExpected ?
-							Operators.onNextPollError(t, e, ctx) :
+							Operators.onNextError(t, e, ctx) :
 							Operators.onOperatorError(null, e, t, ctx);
 					if (e_ != null) {
 						Operators.error(s, e_);
@@ -401,13 +401,13 @@ final class FluxFlatMap<T, R> extends FluxOperator<T, R> {
 				catch (Throwable e) {
 					Context ctx = actual.currentContext();
 					//does the strategy apply? if so, short-circuit the delayError. In any case, don't cancel
-					Throwable e_ = Operators.onNextPollError(t, e, ctx);
+					Throwable e_ = Operators.onNextError(t, e, ctx);
 					if (e_ == null) {
 						return;
 					}
 					//now if error mode strategy doesn't apply, let delayError play
-					if (!delayError || !Exceptions.addThrowable(ERROR, this, e)) {
-						onError(Operators.onOperatorError(s, e, t, ctx));
+					if (!delayError || !Exceptions.addThrowable(ERROR, this, e_)) {
+						onError(Operators.onOperatorError(s, e_, t, ctx));
 					}
 					Operators.onDiscard(t, ctx);
 					return;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
@@ -266,9 +266,9 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 							handler.accept(v, this);
 						}
 						catch (Throwable error){
-							Throwable e_ = Operators.onNextPollError(v, error, actual.currentContext());
+							RuntimeException e_ = Operators.onNextPollError(v, error, actual.currentContext());
 							if (e_ != null) {
-								throw Exceptions.propagate(e_);
+								throw e_;
 							}
 							else {
 								reset();
@@ -279,10 +279,10 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 						data = null;
 						if (stop) {
 							if (error != null) {
-								Throwable e_ = Operators.onNextPollError(v, error, actual.currentContext());
+								RuntimeException e_ = Operators.onNextPollError(v, error, actual.currentContext());
 								if (e_ != null) {
 									done = true; //set done because we throw or go through `actual` directly
-									throw Exceptions.propagate(e_);
+									throw e_;
 								}
 								//else continue
 							}
@@ -315,9 +315,9 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 							handler.accept(v, this);
 						}
 						catch (Throwable error){
-							Throwable e_ = Operators.onNextPollError(v, error, actual.currentContext());
+							RuntimeException e_ = Operators.onNextPollError(v, error, actual.currentContext());
 							if (e_ != null) {
-								throw Exceptions.propagate(e_);
+								throw e_;
 							}
 							else {
 								reset();
@@ -328,10 +328,10 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 						data = null;
 						if (stop) {
 							if (error != null) {
-								Throwable e_ = Operators.onNextPollError(v, error, actual.currentContext());
+								RuntimeException e_ = Operators.onNextPollError(v, error, actual.currentContext());
 								if (e_ != null) {
 									done = true; //set done because we throw or go through `actual` directly
-									throw Exceptions.propagate(e_);
+									throw e_;
 								}
 								else {
 									reset();
@@ -653,9 +653,9 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 							handler.accept(v, this);
 						}
 						catch (Throwable error){
-							Throwable e_ = Operators.onNextPollError(v, error, actual.currentContext());
+							RuntimeException e_ = Operators.onNextPollError(v, error, actual.currentContext());
 							if (e_ != null) {
-								throw Exceptions.propagate(e_);
+								throw e_;
 							}
 							else {
 								reset();
@@ -705,9 +705,9 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 							handler.accept(v, this);
 						}
 						catch (Throwable error){
-							Throwable e_ = Operators.onNextPollError(v, error, actual.currentContext());
+							RuntimeException e_ = Operators.onNextPollError(v, error, actual.currentContext());
 							if (e_ != null) {
-								throw Exceptions.propagate(e_);
+								throw e_;
 							}
 							else {
 								reset();
@@ -719,9 +719,9 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 						if (stop) {
 							done = true; //set done because we throw or go through `actual` directly
 							if (error != null) {
-								Throwable e_ = Operators.onNextPollError(v, error, actual.currentContext());
+								RuntimeException e_ = Operators.onNextPollError(v, error, actual.currentContext());
 								if (e_ != null) {
-									throw Exceptions.propagate(e_);
+									throw e_;
 								}
 								else{
 									reset();

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -681,15 +681,18 @@ public abstract class Operators {
 	 *     return {@code false} to indicate value was not consumed and more must be
 	 *     tried.</li>
 	 *
-	 *     <li>{@code poll}: use {@link #onNextPollError(Object, Throwable, Context)} instead.</li>
+	 *     <li>any of the above where the error is going to be propagated through onError but the
+	 *     subscription shouldn't be cancelled: use {@link #onNextError(Object, Throwable, Context)} instead.</li>
+	 *
+	 *     <li>{@code poll} (where the error will be thrown): use {@link #onNextPollError(Object, Throwable, Context)} instead.</li>
 	 * </ul>
 	 *
-	 * @param value The onNext value that caused an error.
+	 * @param value The onNext value that caused an error. Can be null.
 	 * @param error The error.
 	 * @param context The most significant {@link Context} in which to look for an {@link OnNextFailureStrategy}.
-	 * @param subscriptionForCancel The {@link Subscription} that should be cancelled if the
-	 * strategy is terminal. Not null, use {@link #onNextPollError(Object, Throwable, Context)}
-	 * when unsubscribing is undesirable (eg. for poll()).
+	 * @param subscriptionForCancel The mandatory {@link Subscription} that should be cancelled if the
+	 * strategy is terminal. See also {@link #onNextError(Object, Throwable, Context)} and
+	 * {@link #onNextPollError(Object, Throwable, Context)} for alternatives that don't cancel a subscription
 	 * @param <T> The type of the value causing the error.
 	 * @return a {@link Throwable} to propagate through onError if the strategy is
 	 * terminal and cancelled the subscription, null if not.
@@ -710,6 +713,35 @@ public abstract class Operators {
 		else {
 			//falls back to operator errors
 			return onOperatorError(subscriptionForCancel, error, value, context);
+		}
+	}
+
+	/**
+	 * Find the {@link OnNextFailureStrategy} to apply to the calling async operator (which could be
+	 * a local error mode defined in the {@link Context}) and apply it.
+	 * <p>
+	 * This variant never cancels a {@link Subscription}. It returns a {@link Throwable} if the error is
+	 * fatal for the error mode, in which case the operator should call onError with the
+	 * returned error. On the contrary, if the error mode allows the sequence to
+	 * continue, this method returns {@code null}.
+	 *
+	 * @param value The onNext value that caused an error.
+	 * @param error The error.
+	 * @param context The most significant {@link Context} in which to look for an {@link OnNextFailureStrategy}.
+	 * @param <T> The type of the value causing the error.
+	 * @return a {@link Throwable} to propagate through onError if the strategy is terminal, null if not.
+	 * @see #onNextError(Object, Throwable, Context, Subscription)
+	 */
+	@Nullable
+	public static <T> Throwable onNextError(@Nullable T value, Throwable error, Context context) {
+		error = unwrapOnNextError(error);
+		OnNextFailureStrategy strategy = onNextErrorStrategy(context);
+		if (strategy.test(error, value)) {
+			//some strategies could still return an exception, eg. if the consumer throws
+			return strategy.process(error, value, context);
+		}
+		else {
+			return onOperatorError(null, error, value, context);
 		}
 	}
 
@@ -746,17 +778,23 @@ public abstract class Operators {
 	 * Find the {@link OnNextFailureStrategy} to apply to the calling async operator (which could be
 	 * a local error mode defined in the {@link Context}) and apply it.
 	 * <p>
-	 * Returns a {@link RuntimeException} if errors are fatal for the error mode, in which
+	 * Returns a {@link RuntimeException} if the error is fatal for the error mode, in which
 	 * case the operator poll should throw the returned error. On the contrary if the
 	 * error mode allows the sequence to continue, returns {@code null} in which case
 	 * the operator should retry the {@link Queue#poll() poll()}.
+	 * <p>
+	 * Note that this method {@link Exceptions#propagate(Throwable) wraps} checked exceptions in order to
+	 * return a {@link RuntimeException} that can be thrown from an arbitrary method. If you don't want to
+	 * throw the returned exception and this wrapping behavior is undesirable, but you still don't want to
+	 * cancel a subscription, you can use {@link #onNextError(Object, Throwable, Context)} instead.
 	 *
 	 * @param value The onNext value that caused an error.
 	 * @param error The error.
 	 * @param context The most significant {@link Context} in which to look for an {@link OnNextFailureStrategy}.
 	 * @param <T> The type of the value causing the error.
-	 * @return a {@link Throwable} to propagate through onError if the strategy is
-	 * terminal and cancelled the subscription, null if not.
+	 * @return a {@link RuntimeException} to be thrown (eg. within {@link Queue#poll()} if the error is terminal in
+	 * the strategy, null if not.
+	 * @see #onNextError(Object, Throwable, Context)
 	 */
 	@Nullable
 	public static <T> RuntimeException onNextPollError(@Nullable T value, Throwable error, Context context) {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -1688,4 +1688,36 @@ public class FluxFlatMapTest {
 
 		assertThat(msg).contains("42 skipped, reason: boom");
 	}
+
+	@Test
+	public void noWrappingOfCheckedExceptions() {
+		Flux.just("single")
+		    .flatMap(x -> Mono.error(new NoSuchMethodException()))
+		    .as(StepVerifier::create)
+		    .expectError(NoSuchMethodException.class)
+		    .verify();
+
+		Flux.just("a", "b")
+		    .flatMap(x -> Mono.error(new NoSuchMethodException()))
+		    .as(StepVerifier::create)
+		    .expectError(NoSuchMethodException.class)
+		    .verify();
+	}
+
+	@Test
+	public void noWrappingOfCheckedExceptions_hide() {
+		Flux.just("single")
+		    .hide()
+		    .flatMap(x -> Mono.error(new NoSuchMethodException()))
+		    .as(StepVerifier::create)
+		    .expectError(NoSuchMethodException.class)
+		    .verify();
+
+		Flux.just("a", "b")
+		    .hide()
+		    .flatMap(x -> Mono.error(new NoSuchMethodException()))
+		    .as(StepVerifier::create)
+		    .expectError(NoSuchMethodException.class)
+		    .verify();
+	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFlatMapTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
+import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 
@@ -92,5 +93,24 @@ public class MonoFlatMapTest {
 
 		test.cancel();
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
+	}
+
+	@Test
+	public void noWrappingOfCheckedExceptions() {
+		Mono.just("single")
+		    .flatMap(x -> Mono.error(new NoSuchMethodException()))
+		    .as(StepVerifier::create)
+		    .expectError(NoSuchMethodException.class)
+		    .verify();
+	}
+
+	@Test
+	public void noWrappingOfCheckedExceptions_hide() {
+		Mono.just("single")
+		    .hide()
+		    .flatMap(x -> Mono.error(new NoSuchMethodException()))
+		    .as(StepVerifier::create)
+		    .expectError(NoSuchMethodException.class)
+		    .verify();
 	}
 }


### PR DESCRIPTION
Due to the usage of Operators.onNextPollError for the purpose of error
mode with scalar sources, which returns a RuntimeException, the original
errors can be wrapped in a ReactiveException (provided they're not a
RuntimeException already).

This is problematic, since this occurs even if no error mode strategy
is in place.

This change introduces a new Operators.onNextError variant that doesn't
wrap the exception nor cancels a Subscription. It merely returns the
original error to be passed to onError.