### PR TITLE
fix #1949 Avoid race between request handler setup and first requests

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -736,7 +736,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @see #create(Consumer)
 	 */
 	public static <T> Flux<T> push(Consumer<? super FluxSink<T>> emitter) {
-		return onAssembly(new FluxCreate<>(emitter, OverflowStrategy.BUFFER, FluxCreate.CreateMode.PUSH_ONLY));
+		return push(emitter, OverflowStrategy.BUFFER);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -223,7 +223,7 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 			strategy = FluxSink.OverflowStrategy.IGNORE;
 		}
 
-		FluxCreate.BaseSink<IN> s = FluxCreate.createSink(this, strategy);
+		FluxCreate.BaseSink<IN> s = FluxCreate.createSink(this, strategy, FluxCreate.CreateMode.PUSH_PULL);
 		onSubscribe(s);
 
 		if(s.isCancelled() ||


### PR DESCRIPTION
When the request handler is being set up in the create/push lambda,
one or several concurrent request can occur. In that case, the
consumer might miss requests.

This commit fixes the situation by tracking requests made before the
consumer could be registered, with a special flag of `-1` when it is
about to be registered. In the later case, in `#request(long)`, we
wait until we see the `Consumer` and we directly pass the request
amount to it.

cc @DRayX