### PR TITLE
fix #1037 Enforce serialized `Sink` in `Flux.create`, add `tryNext`

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -643,7 +643,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @return a {@link Flux}
 	 * @see #push(Consumer)
 	 */
-    public static <T> Flux<T> create(Consumer<? super FluxSink<T>> emitter) {
+    public static <T> Flux<T> create(Consumer<? super SerializedFluxSink<T>> emitter) {
 	    return create(emitter, OverflowStrategy.BUFFER);
     }
 
@@ -691,8 +691,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @return a {@link Flux}
 	 * @see #push(Consumer, reactor.core.publisher.FluxSink.OverflowStrategy)
 	 */
-	public static <T> Flux<T> create(Consumer<? super FluxSink<T>> emitter, OverflowStrategy backpressure) {
-		return onAssembly(new FluxCreate<>(emitter, backpressure, FluxCreate.CreateMode.PUSH_PULL));
+	public static <T> Flux<T> create(Consumer<? super SerializedFluxSink<T>> emitter, OverflowStrategy backpressure) {
+		return onAssembly(new FluxCreate<>(emitter, backpressure));
 	}
 
 	/**
@@ -736,7 +736,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @see #create(Consumer)
 	 */
 	public static <T> Flux<T> push(Consumer<? super FluxSink<T>> emitter) {
-		return onAssembly(new FluxCreate<>(emitter, OverflowStrategy.BUFFER, FluxCreate.CreateMode.PUSH_ONLY));
+		return onAssembly(new FluxCreatePush<>(emitter, OverflowStrategy.BUFFER));
 	}
 
 	/**
@@ -784,7 +784,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @see #create(Consumer, reactor.core.publisher.FluxSink.OverflowStrategy)
 	 */
 	public static <T> Flux<T> push(Consumer<? super FluxSink<T>> emitter, OverflowStrategy backpressure) {
-		return onAssembly(new FluxCreate<>(emitter, backpressure, FluxCreate.CreateMode.PUSH_ONLY));
+		return onAssembly(new FluxCreatePush<>(emitter, backpressure));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
@@ -222,7 +222,7 @@ final class FluxCreate<T> extends Flux<T> implements SourceProducer<T> {
 				}
 			}
 			finally {
-				if (!transitioned) {
+				if (transitioned) {
 					EMITTING_STATE.set(this, State.READY_TO_EMIT);
 				}
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCreatePush.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCreatePush.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
+import reactor.core.publisher.FluxCreate.BaseSink;
+import reactor.core.publisher.FluxSink.OverflowStrategy;
+
+/**
+ * Provides a multi-valued sink API for a callback that is called for each individual
+ * Subscriber, in a single-threaded producer fashion.
+ *
+ * @param <T> the value type
+ */
+final class FluxCreatePush<T> extends Flux<T> implements SourceProducer<T> {
+
+	final Consumer<? super FluxSink<T>> source;
+
+	final OverflowStrategy backpressure;
+
+	FluxCreatePush(Consumer<? super FluxSink<T>> source,
+			OverflowStrategy backpressure) {
+		this.source = Objects.requireNonNull(source, "source");
+		this.backpressure = Objects.requireNonNull(backpressure, "backpressure");
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super T> actual) {
+		BaseSink<T> sink = FluxCreate.createSink(actual, backpressure);
+
+		actual.onSubscribe(sink);
+		try {
+			source.accept(sink);
+		}
+		catch (Throwable ex) {
+			Exceptions.throwIfFatal(ex);
+			sink.error(Operators.onOperatorError(ex, actual.currentContext()));
+		}
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		return null; //no particular key to be represented, still useful in hooks
+	}
+
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -217,6 +217,7 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 	 * available strategies
 	 * @return a serializing {@link FluxSink}
 	 */
+	// TODO return `SerializedFluxSink`?
 	public final FluxSink<IN> sink(FluxSink.OverflowStrategy strategy) {
 		Objects.requireNonNull(strategy, "strategy");
 		if (getBufferSize() == Integer.MAX_VALUE){

--- a/reactor-core/src/main/java/reactor/core/publisher/SerializedFluxSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SerializedFluxSink.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+/**
+ * A {@link FluxSink} that is serialized, making it suitable for multi-threaded producers,
+ * and has a method to quickly try to emit data or fail fast (see {@link #tryNext(Object)}).
+ *
+ * @param <T> the value type
+ */
+public interface SerializedFluxSink<T> extends FluxSink<T> {
+
+	/**
+	 * Attempt to emit the value if there is enough request.
+	 * Returns {@code false} if the sink is either terminated/cancelled, has not enough request
+	 * or if there is a concurrent call to {@link #next(Object)}.
+	 *
+	 * @param value the value to attempt emitting
+	 * @return true if the value was directly emitted downstream, false otherwise
+	 */
+	boolean tryNext(T value);
+
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -923,4 +923,17 @@ public class EmitterProcessorTest {
 		processor.remove(inner);
 		assertThat(processor.subscribers).as("post remove inner").isEmpty();
 	}
+
+	@Test(timeout = 5_000)
+	public void tryNextShouldNotBlock() {
+		EmitterProcessor<String> processor = EmitterProcessor.create(1);
+
+		assertThat(processor.tryOnNext("foo")).as("tryNext()").isTrue();
+		assertThat(processor.tryOnNext("foo")).as("tryNext() on full").isFalse();
+
+		StepVerifier.create(processor, 1).expectNextCount(1).thenCancel().verify();
+
+		assertThat(processor.tryOnNext("foo")).as("tryNext()").isTrue();
+		assertThat(processor.tryOnNext("foo")).as("tryNext() on full").isFalse();
+	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCreatePushTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCreatePushTest.java
@@ -1,0 +1,816 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import reactor.core.Exceptions;
+import reactor.core.publisher.FluxSink.OverflowStrategy;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnitParamsRunner.class)
+public class FluxCreatePushTest {
+
+	@Test
+	public void fluxPush() {
+		Flux<String> created = Flux.push(s -> {
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		});
+
+		assertThat(created.getPrefetch()).isEqualTo(-1);
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushOnRequest() {
+		AtomicInteger index = new AtomicInteger(1);
+		AtomicInteger onRequest = new AtomicInteger();
+		Flux<Integer> created = Flux.push(s -> {
+			s.onRequest(n -> {
+				onRequest.incrementAndGet();
+				assertThat(n).isEqualTo(Long.MAX_VALUE);
+				for (int i = 0; i < 5; i++) {
+					s.next(index.getAndIncrement());
+				}
+				s.complete();
+			});
+		}, OverflowStrategy.BUFFER);
+
+		StepVerifier.create(created, 0)
+		            .expectSubscription()
+		            .thenAwait()
+		            .thenRequest(1)
+		            .expectNext(1)
+		            .thenRequest(2)
+		            .expectNext(2, 3)
+		            .thenRequest(2)
+		            .expectNext(4, 5)
+		            .expectComplete()
+		            .verify();
+		assertThat(onRequest.get()).isEqualTo(1);
+	}
+
+	@Test
+	public void contextTestPush() {
+		StepVerifier.create(Flux.push(s -> IntStream.range(0, 10).forEach(i -> s.next(s
+				.currentContext()
+				.get(AtomicInteger.class)
+				.incrementAndGet())))
+		                        .take(10)
+		                        .subscriberContext(ctx -> ctx.put(AtomicInteger.class,
+				                        new AtomicInteger())))
+		            .expectNext(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+		            .verifyComplete();
+	}
+	
+	
+	//mirror tests in FluxCreate
+
+	@Test
+	public void normalBuffered() {
+		AssertSubscriber<Integer> ts = AssertSubscriber.create();
+		Flux<Integer> source = Flux.<Signal<Integer>>push(e -> {
+			e.next(Signal.next(1));
+			e.next(Signal.next(2));
+			e.next(Signal.next(3));
+			e.next(Signal.complete());
+		}).dematerialize();
+
+		source.subscribe(ts);
+
+		ts.assertValues(1, 2, 3)
+		  .assertNoError()
+		  .assertComplete();
+	}
+
+	@Test
+	public void fluxPushBuffered() {
+		AtomicInteger onDispose = new AtomicInteger();
+		AtomicInteger onCancel = new AtomicInteger();
+		Flux<String> created = Flux.push(s -> {
+			s.onDispose(onDispose::getAndIncrement)
+			 .onCancel(onCancel::getAndIncrement);
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		});
+
+		assertThat(created.getPrefetch()).isEqualTo(-1);
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .verifyComplete();
+
+		assertThat(onDispose.get()).isEqualTo(1);
+		assertThat(onCancel.get()).isEqualTo(0);
+	}
+
+	@Test
+	public void fluxPushBuffered2() {
+		AtomicInteger cancellation = new AtomicInteger();
+		AtomicInteger onCancel = new AtomicInteger();
+		StepVerifier.create(Flux.push(s -> {
+			s.onDispose(cancellation::getAndIncrement);
+			s.onCancel(onCancel::getAndIncrement);
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}).publishOn(Schedulers.parallel()))
+		            .expectNext("test1", "test2", "test3")
+		            .verifyComplete();
+
+		assertThat(cancellation.get()).isEqualTo(1);
+		assertThat(onCancel.get()).isEqualTo(0);
+	}
+
+	@Test
+	public void fluxPushBufferedError() {
+		Flux<String> created = Flux.push(s -> {
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.error(new Exception("test"));
+		});
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void fluxPushBufferedError2() {
+		Flux<String> created = Flux.push(s -> {
+			s.error(new Exception("test"));
+		});
+
+		StepVerifier.create(created)
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void fluxPushBufferedEmpty() {
+		Flux<String> created = Flux.push(FluxSink::complete);
+
+		StepVerifier.create(created)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushDisposables() {
+		AtomicInteger dispose1 = new AtomicInteger();
+		AtomicInteger dispose2 = new AtomicInteger();
+		AtomicInteger cancel1 = new AtomicInteger();
+		AtomicInteger cancel2 = new AtomicInteger();
+		AtomicInteger cancellation = new AtomicInteger();
+		Flux<String> created = Flux.push(s -> {
+			s.onDispose(dispose1::getAndIncrement)
+			 .onCancel(cancel1::getAndIncrement);
+			s.onDispose(dispose2::getAndIncrement);
+			assertThat(dispose2.get()).isEqualTo(1);
+			s.onCancel(cancel2::getAndIncrement);
+			assertThat(cancel2.get()).isEqualTo(1);
+			s.onDispose(cancellation::getAndIncrement);
+			assertThat(cancellation.get()).isEqualTo(1);
+			assertThat(dispose1.get()).isEqualTo(0);
+			assertThat(cancel1.get()).isEqualTo(0);
+			s.next("test1");
+			s.complete();
+		});
+
+		StepVerifier.create(created)
+		            .expectNext("test1")
+		            .verifyComplete();
+
+		assertThat(dispose1.get()).isEqualTo(1);
+		assertThat(cancel1.get()).isEqualTo(0);
+	}
+
+	@Test
+	public void fluxPushBufferedCancelled() {
+		AtomicInteger onDispose = new AtomicInteger();
+		AtomicInteger onCancel = new AtomicInteger();
+		Flux<String> created = Flux.push(s -> {
+			s.onDispose(() -> {
+				onDispose.getAndIncrement();
+				assertThat(s.isCancelled()).isTrue();
+			});
+			s.onCancel(() -> {
+				onCancel.getAndIncrement();
+				assertThat(s.isCancelled()).isTrue();
+			});
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		});
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .thenCancel()
+		            .verify();
+
+		assertThat(onDispose.get()).isEqualTo(1);
+		assertThat(onCancel.get()).isEqualTo(1);
+	}
+
+	@Test
+	public void fluxPushBufferedBackpressured() {
+		Flux<String> created = Flux.push(s -> {
+			assertThat(s.requestedFromDownstream()).isEqualTo(1);
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		});
+
+		StepVerifier.create(created, 1)
+		            .expectNext("test1")
+		            .thenAwait()
+		            .thenRequest(2)
+		            .expectNext("test2", "test3")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushSerialized() {
+		Flux<String> created = Flux.push(s -> {
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		});
+
+		assertThat(created.getPrefetch()).isEqualTo(-1);
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushSerialized2(){
+		StepVerifier.create(Flux.push(s -> {
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}).publishOn(Schedulers.parallel()))
+		            .expectNext("test1", "test2", "test3")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushSerializedError() {
+		Flux<String> created = Flux.push(s -> {
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.error(new Exception("test"));
+		});
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void fluxPushSerializedError2() {
+		Flux<String> created = Flux.push(s -> {
+			s.error(new Exception("test"));
+		});
+
+		StepVerifier.create(created)
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void fluxPushSerializedEmpty() {
+		Flux<String> created = Flux.push(s ->{
+			s.complete();
+		});
+
+		StepVerifier.create(created)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushSerializedCancelled() {
+		AtomicInteger onDispose = new AtomicInteger();
+		AtomicInteger onCancel = new AtomicInteger();
+		Flux<String> created = Flux.push(s -> {
+			s.onDispose(onDispose::getAndIncrement)
+			 .onCancel(onCancel::getAndIncrement);
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			assertThat(s.isCancelled()).isTrue();
+			s.complete();
+		});
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .thenCancel()
+		            .verify();
+
+		assertThat(onDispose.get()).isEqualTo(1);
+		assertThat(onCancel.get()).isEqualTo(1);
+	}
+
+	@Test
+	public void fluxPushSerializedBackpressured() {
+		Flux<String> created = Flux.push(s -> {
+			assertThat(s.requestedFromDownstream()).isEqualTo(1);
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		});
+
+		StepVerifier.create(created, 1)
+		            .expectNext("test1")
+		            .thenAwait()
+		            .thenRequest(2)
+		            .expectNext("test2", "test3")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushLatest() {
+		Flux<String> created = Flux.push(s -> {
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}, OverflowStrategy.LATEST);
+
+		assertThat(created.getPrefetch()).isEqualTo(-1);
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushLatest2(){
+		StepVerifier.create(Flux.push(s -> {
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}, OverflowStrategy.LATEST).publishOn(Schedulers.parallel()))
+		            .expectNext("test1", "test2", "test3")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushLatestError() {
+		Flux<String> created = Flux.push(s -> {
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.error(new Exception("test"));
+		}, OverflowStrategy.LATEST);
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void fluxPushLatestError2() {
+		Flux<String> created = Flux.push(s -> {
+			s.error(new Exception("test"));
+		}, OverflowStrategy.LATEST);
+
+		StepVerifier.create(created)
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void fluxPushLatestEmpty() {
+		Flux<String> created =
+				Flux.push(FluxSink::complete, OverflowStrategy.LATEST);
+
+		StepVerifier.create(created)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushLatestCancelled() {
+		AtomicInteger onDispose = new AtomicInteger();
+		AtomicInteger onCancel = new AtomicInteger();
+		Flux<String> created = Flux.push(s -> {
+			s.onDispose(() -> {
+				onDispose.getAndIncrement();
+				assertThat(s.isCancelled()).isTrue();
+			});
+			s.onCancel(() -> {
+				onCancel.getAndIncrement();
+				assertThat(s.isCancelled()).isTrue();
+			});
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}, OverflowStrategy.LATEST);
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .thenCancel()
+		            .verify();
+
+		assertThat(onDispose.get()).isEqualTo(1);
+		assertThat(onCancel.get()).isEqualTo(1);
+	}
+
+	@Test
+	public void fluxPushLatestBackpressured() {
+		Flux<String> created = Flux.push(s -> {
+			assertThat(s.requestedFromDownstream()).isEqualTo(1);
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}, OverflowStrategy.LATEST);
+
+		StepVerifier.create(created, 1)
+		            .expectNext("test1")
+		            .thenAwait()
+		            .thenRequest(2)
+		            .expectNext("test3")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushDrop() {
+		Flux<String> created = Flux.push(s -> {
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}, OverflowStrategy.DROP);
+
+		assertThat(created.getPrefetch()).isEqualTo(-1);
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushDrop2(){
+		StepVerifier.create(Flux.push(s -> {
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}, OverflowStrategy.DROP).publishOn(Schedulers.parallel()))
+		            .expectNext("test1", "test2", "test3")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushDropError() {
+		Flux<String> created = Flux.push(s -> {
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.error(new Exception("test"));
+		}, OverflowStrategy.DROP);
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void fluxPushDropError2() {
+		Flux<String> created = Flux.push(s -> {
+			s.error(new Exception("test"));
+		}, OverflowStrategy.DROP);
+
+		StepVerifier.create(created)
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void fluxPushDropEmpty() {
+		Flux<String> created =
+				Flux.push(FluxSink::complete, OverflowStrategy.DROP);
+
+		StepVerifier.create(created)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushDropCancelled() {
+		AtomicInteger onDispose = new AtomicInteger();
+		AtomicInteger onCancel = new AtomicInteger();
+		Flux<String> created = Flux.push(s -> {
+			s.onDispose(() -> {
+				onDispose.getAndIncrement();
+				assertThat(s.isCancelled()).isTrue();
+			});
+			s.onCancel(() -> {
+				onCancel.getAndIncrement();
+				assertThat(s.isCancelled()).isTrue();
+			});
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}, OverflowStrategy.DROP);
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .thenCancel()
+		            .verify();
+
+		assertThat(onDispose.get()).isEqualTo(1);
+		assertThat(onCancel.get()).isEqualTo(1);
+	}
+
+	@Test
+	public void fluxPushDropBackpressured() {
+		Flux<String> created = Flux.push(s -> {
+			assertThat(s.requestedFromDownstream()).isEqualTo(1);
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}, OverflowStrategy.DROP);
+
+		StepVerifier.create(created, 1)
+		            .expectNext("test1")
+		            .thenAwait()
+		            .thenRequest(2)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushError() {
+		Flux<String> created = Flux.push(s -> {
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}, OverflowStrategy.ERROR);
+
+		assertThat(created.getPrefetch()).isEqualTo(-1);
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushError2(){
+		StepVerifier.create(Flux.push(s -> {
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}, OverflowStrategy.ERROR).publishOn(Schedulers.parallel()))
+		            .expectNext("test1", "test2", "test3")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushErrorError() {
+		Flux<String> created = Flux.push(s -> {
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.error(new Exception("test"));
+		}, OverflowStrategy.ERROR);
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void fluxPushErrorError2() {
+		Flux<String> created = Flux.push(s -> {
+			s.error(new Exception("test"));
+		}, OverflowStrategy.ERROR);
+
+		StepVerifier.create(created)
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void fluxPushErrorEmpty() {
+		Flux<String> created =
+				Flux.push(FluxSink::complete, OverflowStrategy.ERROR);
+
+		StepVerifier.create(created)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushErrorCancelled() {
+		AtomicInteger onDispose = new AtomicInteger();
+		AtomicInteger onCancel = new AtomicInteger();
+		Flux<String> created = Flux.push(s -> {
+			s.onDispose(() -> {
+				onDispose.getAndIncrement();
+				assertThat(s.isCancelled()).isTrue();
+			});
+			s.onCancel(() -> {
+				onCancel.getAndIncrement();
+				assertThat(s.isCancelled()).isTrue();
+			});
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}, OverflowStrategy.ERROR);
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .thenCancel()
+		            .verify();
+
+		assertThat(onDispose.get()).isEqualTo(1);
+		assertThat(onCancel.get()).isEqualTo(1);
+	}
+
+	@Test
+	public void fluxPushErrorBackpressured() {
+		Flux<String> created = Flux.push(s -> {
+			assertThat(s.requestedFromDownstream()).isEqualTo(1);
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}, OverflowStrategy.ERROR);
+
+		StepVerifier.create(created, 1)
+		            .expectNext("test1")
+		            .thenAwait()
+		            .thenRequest(2)
+		            .verifyErrorMatches(Exceptions::isOverflow);
+	}
+
+	@Test
+	public void fluxPushIgnore() {
+		Flux<String> created = Flux.push(s -> {
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}, OverflowStrategy.IGNORE);
+
+		assertThat(created.getPrefetch()).isEqualTo(-1);
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushIgnore2(){
+		StepVerifier.create(Flux.push(s -> {
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}, OverflowStrategy.IGNORE).publishOn(Schedulers.parallel()))
+		            .expectNext("test1", "test2", "test3")
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushIgnoreError() {
+		Flux<String> created = Flux.push(s -> {
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.error(new Exception("test"));
+		}, OverflowStrategy.IGNORE);
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void fluxPushIgnoreError2() {
+		Flux<String> created = Flux.push(s -> {
+			s.error(new Exception("test"));
+		}, OverflowStrategy.IGNORE);
+
+		StepVerifier.create(created)
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	public void fluxPushIgnoreEmpty() {
+		Flux<String> created =
+				Flux.push(FluxSink::complete, OverflowStrategy.IGNORE);
+
+		StepVerifier.create(created)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void fluxPushIgnoreCancelled() {
+		AtomicInteger onDispose = new AtomicInteger();
+		AtomicInteger onCancel = new AtomicInteger();
+		Flux<String> created = Flux.push(s -> {
+			s.onDispose(() -> {
+				onDispose.getAndIncrement();
+				assertThat(s.isCancelled()).isTrue();
+			});
+			s.onCancel(() -> {
+				onCancel.getAndIncrement();
+				assertThat(s.isCancelled()).isTrue();
+			});
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}, OverflowStrategy.IGNORE);
+
+		StepVerifier.create(created)
+		            .expectNext("test1", "test2", "test3")
+		            .thenCancel()
+		            .verify();
+
+		assertThat(onDispose.get()).isEqualTo(1);
+		assertThat(onCancel.get()).isEqualTo(1);
+	}
+
+	@Test
+	public void fluxPushIgnoreBackpressured() {
+		Flux<String> created = Flux.push(s -> {
+			assertThat(s.requestedFromDownstream()).isEqualTo(1);
+			s.next("test1");
+			s.next("test2");
+			s.next("test3");
+			s.complete();
+		}, OverflowStrategy.IGNORE);
+
+		try {
+			StepVerifier.create(created, 1)
+			            .expectNext("test1")
+			            .thenAwait()
+			            .thenRequest(2)
+			            .verifyComplete();
+			Assert.fail();
+		}
+		catch (AssertionError error){
+			assertThat(error).hasMessageContaining(
+					"request overflow (expected production of at most 1; produced: 2; request overflown by signal: onNext(test2))");
+		}
+	}
+
+	@Test
+	@Parameters(source = OverflowStrategy.class)
+	public void sinkToString(OverflowStrategy strategy) {
+		StepVerifier.create(Flux.push(sink -> {
+			if (sink instanceof FluxCreate.SerializedSink) {
+				sink.error(new IllegalArgumentException("expected no SerializedSink"));
+			}
+			else {
+				sink.next(sink.toString());
+				sink.complete();
+			}
+		}, strategy))
+		            .expectNext("FluxSink(" + strategy + ")")
+		            .verifyComplete();
+	}
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCreateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCreateTest.java
@@ -1431,8 +1431,9 @@ public class FluxCreateTest {
 			.limitRate(1)
 			.subscribeOn(Schedulers.boundedElastic());
 
-		StepVerifier.create(flux, 5)
-			.expectNextCount(5)
+		StepVerifier
+			.create(flux, 5)
+            .expectNextCount(5)
 			.thenCancel()
 			.verify(Duration.ofSeconds(1));
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCreateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCreateTest.java
@@ -26,11 +26,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.custom.combined.CombinedParameters;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
@@ -48,6 +51,7 @@ import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(JUnitParamsRunner.class)
 public class FluxCreateTest {
 
 	@Test
@@ -333,22 +337,6 @@ public class FluxCreateTest {
 		            .thenAwait()
 		            .thenRequest(2)
 		            .expectNext("test2", "test3")
-		            .verifyComplete();
-	}
-
-	@Test
-	public void fluxPush() {
-		Flux<String> created = Flux.push(s -> {
-			s.next("test1");
-			s.next("test2");
-			s.next("test3");
-			s.complete();
-		});
-
-		assertThat(created.getPrefetch()).isEqualTo(-1);
-
-		StepVerifier.create(created)
-		            .expectNext("test1", "test2", "test3")
 		            .verifyComplete();
 	}
 
@@ -944,35 +932,6 @@ public class FluxCreateTest {
 	}
 
 	@Test
-	public void fluxPushOnRequest() {
-		AtomicInteger index = new AtomicInteger(1);
-		AtomicInteger onRequest = new AtomicInteger();
-		Flux<Integer> created = Flux.push(s -> {
-			s.onRequest(n -> {
-				onRequest.incrementAndGet();
-				assertThat(n).isEqualTo(Long.MAX_VALUE);
-				for (int i = 0; i < 5; i++) {
-					s.next(index.getAndIncrement());
-				}
-				s.complete();
-			});
-		}, OverflowStrategy.BUFFER);
-
-		StepVerifier.create(created, 0)
-		            .expectSubscription()
-		            .thenAwait()
-		            .thenRequest(1)
-		            .expectNext(1)
-		            .thenRequest(2)
-		            .expectNext(2, 3)
-		            .thenRequest(2)
-		            .expectNext(4, 5)
-		            .expectComplete()
-		            .verify();
-		assertThat(onRequest.get()).isEqualTo(1);
-	}
-
-	@Test
 	public void fluxCreateGenerateOnRequest() {
 		AtomicInteger index = new AtomicInteger(1);
 		Flux<Integer> created = Flux.create(s -> {
@@ -995,13 +954,8 @@ public class FluxCreateTest {
 	}
 
 	@Test
-	public void fluxCreateOnRequestSingleThread() {
-		for (OverflowStrategy overflowStrategy : OverflowStrategy.values()) {
-			testFluxCreateOnRequestSingleThread(overflowStrategy);
-		}
-	}
-
-	private void testFluxCreateOnRequestSingleThread(OverflowStrategy overflowStrategy) {
+	@Parameters(source = OverflowStrategy.class)
+	public void fluxCreateOnRequestSingleThread(OverflowStrategy overflowStrategy) {
 		RequestTrackingTestQueue queue = new RequestTrackingTestQueue();
 		Flux<Integer> created = Flux.create(pushPullSink -> {
 			assertThat(pushPullSink instanceof SerializedSink).isTrue();
@@ -1044,20 +998,8 @@ public class FluxCreateTest {
 	}
 
 	@Test
-	public void fluxCreateOnRequestMultipleThreadsSlowProducer() {
-		for (OverflowStrategy overflowStrategy : OverflowStrategy.values()) {
-			testFluxCreateOnRequestMultipleThreads(overflowStrategy, true);
-		}
-	}
-
-	@Test
-	public void fluxCreateOnRequestMultipleThreadsFastProducer() {
-		for (OverflowStrategy overflowStrategy : OverflowStrategy.values()) {
-			testFluxCreateOnRequestMultipleThreads(overflowStrategy, false);
-		}
-	}
-
-	private void testFluxCreateOnRequestMultipleThreads(OverflowStrategy overflowStrategy, boolean slowProducer) {
+	@CombinedParameters({"BUFFER,DROP,IGNORE,ERROR,LATEST","true,false"})
+	public void testFluxCreateOnRequesMultipleThreads(OverflowStrategy overflowStrategy, boolean slowProducer) {
 		int count = 10_000;
 		TestQueue queue;
 		if (overflowStrategy == OverflowStrategy.ERROR || overflowStrategy == OverflowStrategy.IGNORE)
@@ -1256,19 +1198,6 @@ public class FluxCreateTest {
 	@Test
 	public void contextTest() {
 		StepVerifier.create(Flux.create(s -> IntStream.range(0, 10).forEach(i -> s.next(s
-				.currentContext()
-		                                                       .get(AtomicInteger.class)
-		                                                       .incrementAndGet())))
-		                        .take(10)
-		                        .subscriberContext(ctx -> ctx.put(AtomicInteger.class,
-				                        new AtomicInteger())))
-		            .expectNext(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-		            .verifyComplete();
-	}
-
-	@Test
-	public void contextTestPush() {
-		StepVerifier.create(Flux.push(s -> IntStream.range(0, 10).forEach(i -> s.next(s
 				.currentContext()
 		                                                       .get(AtomicInteger.class)
 		                                                       .incrementAndGet())))

--- a/reactor-core/src/test/java/reactor/core/publisher/SerializedSinkTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SerializedSinkTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import reactor.test.subscriber.AssertSubscriber;
+import reactor.test.util.RaceTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnitParamsRunner.class)
+public class SerializedSinkTest {
+
+	@Test
+	public void raceBetweenNext() {
+		for (int i = 0; i < 1000; i++) {
+
+			AssertSubscriber<String> ts = AssertSubscriber.create();
+			FluxCreate.BaseSink<String> baseSink = FluxCreate.createSink(ts, FluxSink.OverflowStrategy.BUFFER);
+			FluxCreate.SerializedSink<String> sink = new FluxCreate.SerializedSink<>(baseSink);
+
+			baseSink.request(Long.MAX_VALUE);
+
+			sink.next("foo");
+			RaceTestUtils.race(
+					() -> sink.next("bar"),
+					() -> sink.next("baz")
+			);
+
+			sink.complete();
+
+			Set<String> expected = new HashSet<String>() {{
+				add("foo");
+				add("bar");
+				add("baz");
+			}};
+
+			ts.assertContainValues(expected);
+			ts.assertComplete();
+		}
+	}
+
+	@Test
+	@Parameters(source = FluxSink.OverflowStrategy.class)
+	public void raceBetweenNextAndTryNext(FluxSink.OverflowStrategy STRATEGY) {
+		final int NUM_LOOPS = 1000;
+		final AtomicInteger trySuccess = new AtomicInteger();
+		final AtomicInteger tryRejected = new AtomicInteger();
+
+		int overflowAccepted = 0;
+		int overflowRejected = 0;
+
+		for (int i = 0; i < NUM_LOOPS; i++) {
+			AssertSubscriber<String> ts = AssertSubscriber.create();
+			FluxCreate.BaseSink<String> baseSink = FluxCreate.createSink(ts, STRATEGY);
+			FluxCreate.SerializedSink<String> sink = new FluxCreate.SerializedSink<>(baseSink);
+
+			AtomicBoolean bazAccepted = new AtomicBoolean();
+
+			baseSink.request(3);
+
+			sink.next("foo");
+			RaceTestUtils.race(
+					() -> {
+						boolean tried = sink.tryNext("baz");
+						if (tried) {
+							trySuccess.incrementAndGet();
+						}
+						else {
+							tryRejected.incrementAndGet();
+						}
+						bazAccepted.set(tried);
+					},
+					() -> sink.next("bar")
+			);
+
+			boolean overflow1 = sink.tryNext("overflow1");
+			boolean overflow2 = sink.tryNext("overflow2");
+
+			sink.complete();
+
+			if (bazAccepted.get()) {
+				assertThat(overflow1).isFalse();
+			}
+			else {
+				assertThat(overflow1).isTrue();
+			}
+			assertThat(overflow2).isFalse();
+
+			if (overflow1) overflowAccepted++;
+			else overflowRejected++;
+
+			if (overflow2) overflowAccepted++;
+			else overflowRejected++;
+
+			Set<String> expected = new HashSet<String>() {{
+				add("foo");
+				add("bar");
+			}};
+			if (bazAccepted.get()) {
+				expected.add("baz");
+			}
+
+			ts.assertContainValues(expected);
+			ts.assertComplete();
+		}
+
+		String racingDesc = "racing tryNext(" + STRATEGY + ")[accepted=" + trySuccess.get() + ", rejected=" + tryRejected.get() + "]";
+		String overflowDesc = "overflow tryNext(" + STRATEGY + ")[accepted=" + overflowAccepted + ", rejected=" + overflowRejected + "]";
+		System.out.println(racingDesc + "\t" + overflowDesc) ;
+
+		assertThat(trySuccess.get() + tryRejected.get())
+				.as(racingDesc)
+				.isEqualTo(NUM_LOOPS);
+
+		assertThat(overflowAccepted + overflowRejected)
+				.as(overflowDesc)
+				.isEqualTo(NUM_LOOPS * 2);
+	}
+
+}


### PR DESCRIPTION
This allows to have a `tryNext` method that fails fast if there is a
concurrent `next` call or there is not enough downstream request.
See #1037.

The change is based on https://github.com/reactor/reactor-core/commit/51ef961d6e376d218125d4fb4ff074ec04d39cc6 by @simonbasle

I also added `EmitterProcessor#tryNext` to avoid always-blocking
behaviour of `EmitterProcessor#onNext`, see #1936