### PR TITLE
fix #1916 Interpret MAX_VALUEms as indefinite caching in MonoCacheTime

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1797,6 +1797,9 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	/**
 	 * Turn this {@link Mono} into a hot source and cache last emitted signal for further
 	 * {@link Subscriber}, with an expiry timeout (TTL) that depends on said signal.
+	 * An TTL of {@link Long#MAX_VALUE} milliseconds is interpreted as indefinite caching of
+	 * the signal (no cache cleanup is scheduled, so the signal is retained as long as this
+	 * {@link Mono} is not garbage collected).
 	 * <p>
 	 * Empty completion and Error will also be replayed according to their respective TTL,
 	 * so transient errors can be "retried" by letting the {@link Function} return

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
@@ -292,7 +292,7 @@ class MonoCacheTime<T> extends InternalMonoOperator<T, T> implements Runnable {
 						//immediate cache clear
 						main.run();
 					}
-					else if (ttl.toMillis() < Long.MAX_VALUE) {
+					else if (!ttl.equals(DURATION_INFINITE)) {
 						main.clock.schedule(main, ttl.toMillis(), TimeUnit.MILLISECONDS);
 					}
 					//else TTL is Long.MAX_VALUE, schedule nothing but still cache
@@ -355,8 +355,9 @@ class MonoCacheTime<T> extends InternalMonoOperator<T, T> implements Runnable {
 			return null;
 		}
 
-		private static final Operators.MonoSubscriber[] TERMINATED = new Operators.MonoSubscriber[0];
-		private static final Operators.MonoSubscriber[] EMPTY = new Operators.MonoSubscriber[0];
+		private static final Operators.MonoSubscriber[] TERMINATED        = new Operators.MonoSubscriber[0];
+		private static final Operators.MonoSubscriber[] EMPTY             = new Operators.MonoSubscriber[0];
+		private static final Duration                   DURATION_INFINITE = Duration.ofMillis(Long.MAX_VALUE);
 	}
 
 	static final class CacheMonoSubscriber<T> extends Operators.MonoSubscriber<T, T> {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
@@ -287,12 +287,15 @@ class MonoCacheTime<T> extends InternalMonoOperator<T, T> implements Runnable {
 					}
 				}
 
-				if (ttl != null && ttl.isZero()) {
-					//immediate cache clear
-					main.run();
-				}
-				else if (ttl != null) {
-					main.clock.schedule(main, ttl.toMillis(), TimeUnit.MILLISECONDS);
+				if (ttl != null) {
+					if (ttl.isZero()) {
+						//immediate cache clear
+						main.run();
+					}
+					else if (ttl.toMillis() < Long.MAX_VALUE) {
+						main.clock.schedule(main, ttl.toMillis(), TimeUnit.MILLISECONDS);
+					}
+					//else TTL is Long.MAX_VALUE, schedule nothing but still cache
 				}
 				else {
 					//error during TTL generation, signal != updatedSignal, aka dropped


### PR DESCRIPTION
This results in no invalidation task being scheduled, avoiding
potential small leaks. The corresponding signal is cached until
the MonoCacheTime publisher is garbage collected.