### PR TITLE
fix #1962 Avoid extending Entry in Context1

### DIFF
--- a/reactor-core/src/main/java/reactor/util/context/Context1.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context1.java
@@ -15,12 +15,13 @@
  */
 package reactor.util.context;
 
+import java.util.AbstractMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-final class Context1 implements Context, Map.Entry<Object, Object> {
+final class Context1 implements Context {
 
 	final Object key;
 	final Object value;
@@ -67,22 +68,7 @@ final class Context1 implements Context, Map.Entry<Object, Object> {
 
 	@Override
 	public Stream<Map.Entry<Object, Object>> stream() {
-		return Stream.of(this);
-	}
-
-	@Override
-	public Object getKey() {
-		return key;
-	}
-
-	@Override
-	public Object getValue() {
-		return value;
-	}
-
-	@Override
-	public Object setValue(Object value) {
-		throw new UnsupportedOperationException("Does not support in-place update");
+		return Stream.of(new AbstractMap.SimpleImmutableEntry<>(key, value));
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/util/context/ContextN.java
+++ b/reactor-core/src/main/java/reactor/util/context/ContextN.java
@@ -15,6 +15,7 @@
  */
 package reactor.util.context;
 
+import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -30,8 +31,7 @@ import reactor.util.annotation.Nullable;
 
 @SuppressWarnings("unchecked")
 final class ContextN extends HashMap<Object, Object>
-		implements Context, Function<Entry<Object, Object>, Entry<Object, Object>>,
-		           BiConsumer<Object, Object> {
+		implements Context, BiConsumer<Object, Object> {
 
 	ContextN(Object key1, Object value1, Object key2, Object value2,
 			Object key3, Object value3, Object key4, Object value4,
@@ -131,12 +131,7 @@ final class ContextN extends HashMap<Object, Object>
 
 	@Override
 	public Stream<Entry<Object, Object>> stream() {
-		return entrySet().stream().map(this);
-	}
-
-	@Override
-	public Entry<Object, Object> apply(Entry<Object, Object> o) {
-		return new Context1(o.getKey(), o.getValue());
+		return entrySet().stream().map(AbstractMap.SimpleImmutableEntry::new);
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/util/context/ContextN.java
+++ b/reactor-core/src/main/java/reactor/util/context/ContextN.java
@@ -17,20 +17,19 @@ package reactor.util.context;
 
 import java.util.AbstractMap;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import reactor.util.annotation.Nullable;
 
 @SuppressWarnings("unchecked")
-final class ContextN extends HashMap<Object, Object>
+final class ContextN extends LinkedHashMap<Object, Object>
 		implements Context, BiConsumer<Object, Object> {
 
 	ContextN(Object key1, Object value1, Object key2, Object value2,

--- a/reactor-core/src/test/java/reactor/util/context/Context1Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context1Test.java
@@ -18,6 +18,7 @@ package reactor.util.context;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
@@ -103,23 +104,6 @@ public class Context1Test {
 	}
 
 	@Test
-	public void getKey() throws Exception {
-		assertThat(c.getKey()).isEqualTo(1);
-	}
-
-	@Test
-	public void getValue() throws Exception {
-		assertThat(c.getValue()).isEqualTo("A");
-	}
-
-	@Test
-	public void setValue() throws Exception {
-		assertThatExceptionOfType(UnsupportedOperationException.class)
-				.isThrownBy(() -> c.setValue("BOOM"))
-				.withMessage("Does not support in-place update");
-	}
-
-	@Test
 	public void string() throws Exception {
 		assertThat(c.toString()).isEqualTo("Context1{1=A}");
 	}
@@ -138,6 +122,15 @@ public class Context1Test {
 
 		assertThat(put).isInstanceOf(Context4.class)
 		               .hasToString("Context4{1=A, A=1, B=2, C=3}");
+	}
+
+	@Test
+	public void putAllReplaces() {
+		Context m = Context.of(c.key, "replaced", "A", 1);
+		Context put = c.putAll(m);
+
+		assertThat(put).isInstanceOf(Context2.class)
+		               .hasToString("Context2{1=replaced, A=1}");
 	}
 
 	@Test
@@ -165,6 +158,17 @@ public class Context1Test {
 	@Test
 	public void size() {
 		assertThat(c.size()).isOne();
+	}
+
+	@Test
+	public void streamHasCleanToString() {
+		Context1 context1 = new Context1("key", "value");
+
+		assertThat(context1.toString()).as("toString").isEqualTo("Context1{key=value}");
+
+		assertThat(context1.stream().map(Objects::toString).collect(Collectors.joining(", ")))
+				.as("stream elements representation")
+				.isEqualTo("key=value");
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/util/context/Context2Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context2Test.java
@@ -146,6 +146,15 @@ public class Context2Test {
 	}
 
 	@Test
+	public void putAllReplaces() {
+		Context m = Context.of(c.key1, "replaced", "A", 1);
+		Context put = c.putAll(m);
+
+		assertThat(put).isInstanceOf(Context3.class)
+		               .hasToString("Context3{1=replaced, 2=B, A=1}");
+	}
+
+	@Test
 	public void putAllOfEmpty() {
 		Context m = Context.empty();
 		Context put = c.putAll(m);

--- a/reactor-core/src/test/java/reactor/util/context/Context3Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context3Test.java
@@ -171,6 +171,15 @@ public class Context3Test {
 	}
 
 	@Test
+	public void putAllReplaces() {
+		Context m = Context.of(c.key1, "replaced", "A", 1);
+		Context put = c.putAll(m);
+
+		assertThat(put).isInstanceOf(Context4.class)
+		               .hasToString("Context4{1=replaced, 2=B, 3=C, A=1}");
+	}
+
+	@Test
 	public void putAllOfEmpty() {
 		Context m = Context.empty();
 		Context put = c.putAll(m);

--- a/reactor-core/src/test/java/reactor/util/context/Context4Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context4Test.java
@@ -197,6 +197,15 @@ public class Context4Test {
 	}
 
 	@Test
+	public void putAllReplaces() {
+		Context m = Context.of(c.key1, "replaced", "A", 1);
+		Context put = c.putAll(m);
+
+		assertThat(put).isInstanceOf(Context5.class)
+		               .hasToString("Context5{1=replaced, 2=B, 3=C, 4=D, A=1}");
+	}
+
+	@Test
 	public void putAllOfEmpty() {
 		Context m = Context.empty();
 		Context put = c.putAll(m);

--- a/reactor-core/src/test/java/reactor/util/context/Context5Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context5Test.java
@@ -229,6 +229,15 @@ public class Context5Test {
 	}
 
 	@Test
+	public void putAllReplaces() {
+		Context m = Context.of(c.key1, "replaced", "A", 1);
+		Context put = c.putAll(m);
+
+		assertThat(put).isInstanceOf(ContextN.class)
+		               .hasToString("ContextN{1=replaced, 2=B, 3=C, 4=D, 5=E, A=1}");
+	}
+
+	@Test
 	public void putAllOfEmpty() {
 		Context m = Context.empty();
 		Context put = c.putAll(m);

--- a/reactor-core/src/test/java/reactor/util/context/ContextNTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextNTest.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.junit.Before;
@@ -384,6 +385,15 @@ public class ContextNTest {
 	}
 
 	@Test
+	public void putAllReplaces() {
+		Context m = Context.of(1, "replaced", "A", 1);
+		Context put = c.putAll(m);
+
+		assertThat(put).isInstanceOf(ContextN.class)
+		               .hasToString("ContextN{1=replaced, 2=B, 3=C, 4=D, 5=E, 6=F, A=1}");
+	}
+
+	@Test
 	public void putAllOfEmpty() {
 		Context m = Context.empty();
 		Context put = c.putAll(m);
@@ -415,6 +425,16 @@ public class ContextNTest {
 		assertThat(c.size()).isEqualTo(6);
 
 		assertThat(c.put("sizeGrows", "yes").size()).isEqualTo(7);
+	}
+
+
+	@Test
+	public void streamHasCleanToString() {
+		assertThat(c.toString()).as("toString").isEqualTo("ContextN{1=A, 2=B, 3=C, 4=D, 5=E, 6=F}");
+
+		assertThat(c.stream().map(Objects::toString).collect(Collectors.joining(", ")))
+				.as("stream elements representation")
+				.isEqualTo("1=A, 2=B, 3=C, 4=D, 5=E, 6=F");
 	}
 
 }


### PR DESCRIPTION
The motivation for this change is that this drives two implementations
of `Context#stream()` to use the `Context1` as an immutable map entry.

In turn, this proves problematic when the `stream()` is converted to a
string representation (eg. by loggers or assertions): the stream entries
use `Context1{k=v}` format, which is fine in a standalone toString but
less so in a representation of the whole stream.

`AbstractMap.SimpleImmutableEntry` can be leveraged instead, and it
has a proper `key=value` string representation by default.