### PR TITLE
fix #1968 Make FluxPublish propagate 1st subscriber context

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * A connectable publisher which shares an underlying source and dispatches source values
@@ -534,6 +535,11 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 		@Override
 		public Stream<? extends Scannable> inners() {
 			return Stream.of(subscribers);
+		}
+
+		@Override
+		public Context currentContext() {
+			return Operators.multiSubscribersContext(subscribers);
 		}
 
 		@Override


### PR DESCRIPTION
According to issue #1114, it looks like the FluxPublish operator should propagate the first subscriber context too.

This PR is a fix for #1968.

I will rebase the branch over the earliest relevant maintenance branch when it is decided.