### PR TITLE
fix #1924 Discard elements of Collection in collect(), cover more cases

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3121,7 +3121,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param containerSupplier the supplier of the container instance for each Subscriber
 	 * @param collector a consumer of both the container instance and the value being currently collected
 	 *
-	 * @reactor.discard This operator discards the buffer upon cancellation or error triggered by a data signal.
+	 * @reactor.discard This operator discards the container upon cancellation or error triggered by a data signal.
+	 * Either the container type is a {@link Collection} (in which case individual elements are discarded)
+	 * or not (in which case the entire container is discarded). In case the collector {@link BiConsumer} fails
+	 * to accumulate an element, the container is discarded as above and the triggering element is also discarded.
 	 *
 	 * @return a {@link Mono} of the collected container on complete
 	 *
@@ -3142,6 +3145,13 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * @param <A> The mutable accumulation type
 	 * @param <R> the container type
 	 *
+	 * @reactor.discard This operator discards the intermediate container (see {@link Collector#supplier()} upon
+	 * cancellation, error or exception while applying the {@link Collector#finisher()}. Either the container type
+	 * is a {@link Collection} (in which case individual elements are discarded) or not (in which case the entire
+	 * container is discarded). In case the accumulator {@link BiConsumer} of the collector fails to accumulate
+	 * an element into the intermediate container, the container is discarded as above and the triggering element
+	 * is also discarded.
+	 *
 	 * @return a {@link Mono} of the collected container on complete
 	 *
 	 */
@@ -3156,7 +3166,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/collectList.svg" alt="">
 	 *
-	 * @reactor.discard This operator discards the buffer upon cancellation or error triggered by a data signal.
+	 * @reactor.discard This operator discards the elements in the {@link List} upon
+	 * cancellation or error triggered by a data signal.
 	 *
 	 * @return a {@link Mono} of a {@link List} of all values from this {@link Flux}
 	 */
@@ -3204,7 +3215,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/collectMapWithKeyExtractor.svg" alt="">
 	 *
-	 * @reactor.discard This operator discards the buffer upon cancellation or error triggered by a data signal.
+	 * @reactor.discard This operator discards the whole {@link Map} upon cancellation or error
+	 * triggered by a data signal, so discard handlers will have to unpack the map.
 	 *
 	 * @param keyExtractor a {@link Function} to map elements to a key for the {@link Map}
 	 * @param <K> the type of the key extracted from each source element
@@ -3227,7 +3239,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/collectMapWithKeyAndValueExtractors.svg" alt="">
 	 *
-	 * @reactor.discard This operator discards the buffer upon cancellation or error triggered by a data signal.
+	 * @reactor.discard This operator discards the whole {@link Map} upon cancellation or error
+	 * triggered by a data signal, so discard handlers will have to unpack the map.
 	 *
 	 * @param keyExtractor a {@link Function} to map elements to a key for the {@link Map}
 	 * @param valueExtractor a {@link Function} to map elements to a value for the {@link Map}
@@ -3254,7 +3267,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/collectMapWithKeyAndValueExtractors.svg" alt="">
 	 *
-	 * @reactor.discard This operator discards the buffer upon cancellation or error triggered by a data signal.
+	 * @reactor.discard This operator discards the whole {@link Map} upon cancellation or error
+	 * triggered by a data signal, so discard handlers will have to unpack the map.
 	 *
 	 * @param keyExtractor a {@link Function} to map elements to a key for the {@link Map}
 	 * @param valueExtractor a {@link Function} to map elements to a value for the {@link Map}
@@ -3286,7 +3300,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/collectMultiMapWithKeyExtractor.svg" alt="">
 	 *
-	 * @reactor.discard This operator discards the buffer upon cancellation or error triggered by a data signal.
+	 * @reactor.discard This operator discards the whole {@link Map} upon cancellation or error
+	 * triggered by a data signal, so discard handlers will have to unpack the list values in the map.
 	 *
 	 * @param keyExtractor a {@link Function} to map elements to a key for the {@link Map}
 	 *
@@ -3308,7 +3323,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/collectMultiMapWithKeyAndValueExtractors.svg" alt="">
 	 *
-	 * @reactor.discard This operator discards the buffer upon cancellation or error triggered by a data signal.
+	 * @reactor.discard This operator discards the whole {@link Map} upon cancellation or error
+	 * triggered by a data signal, so discard handlers will have to unpack the list values in the map.
 	 *
 	 * @param keyExtractor a {@link Function} to map elements to a key for the {@link Map}
 	 * @param valueExtractor a {@link Function} to map elements to a value for the {@link Map}
@@ -3334,7 +3350,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/collectMultiMapWithKeyAndValueExtractors.svg" alt="">
 	 *
-	 * @reactor.discard This operator discards the buffer upon cancellation or error triggered by a data signal.
+	 * @reactor.discard This operator discards the whole {@link Map} upon cancellation or error
+	 * triggered by a data signal, so discard handlers will have to unpack the list values in the map.
 	 *
 	 * @param keyExtractor a {@link Function} to map elements to a key for the {@link Map}
 	 * @param valueExtractor a {@link Function} to map elements to a value for the {@link Map}
@@ -3369,7 +3386,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/collectSortedList.svg" alt="">
 	 *
-	 * @reactor.discard This operator discards the buffer upon cancellation or error triggered by a data signal.
+	 * @reactor.discard This operator is based on {@link #collectList()}, and as such discards the
+	 * elements in the {@link List} individually upon cancellation or error triggered by a data signal.
 	 *
 	 * @return a {@link Mono} of a sorted {@link List} of all values from this {@link Flux}, in natural order
 	 */
@@ -3385,7 +3403,8 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/collectSortedListWithComparator.svg" alt="">
 	 *
-	 * @reactor.discard This operator discards the buffer upon cancellation or error triggered by a data signal.
+	 * @reactor.discard This operator is based on {@link #collectList()}, and as such discards the
+	 * elements in the {@link List} individually upon cancellation or error triggered by a data signal.
 	 *
 	 * @param comparator a {@link Comparator} to sort the items of this sequences
 	 *

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollect.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollect.java
@@ -71,7 +71,6 @@ final class MonoCollect<T, R> extends MonoFromFluxOperator<T, R>
 	static final class CollectSubscriber<T, R> extends Operators.MonoSubscriber<T, R>  {
 
 		final BiConsumer<? super R, ? super T> action;
-		final boolean canDiscard;
 
 		Subscription s;
 
@@ -83,7 +82,6 @@ final class MonoCollect<T, R> extends MonoFromFluxOperator<T, R>
 			super(actual);
 			this.action = action;
 			this.value = container;
-			this.canDiscard = container instanceof Collection;
 		}
 
 		@Override
@@ -103,7 +101,7 @@ final class MonoCollect<T, R> extends MonoFromFluxOperator<T, R>
 
 		@Override
 		protected void discard(R v) {
-			if (canDiscard && v instanceof Collection) {
+			if (v instanceof Collection) {
 				Collection<?> c = (Collection<?>) v;
 				Operators.onDiscardMultiple(c, actual.currentContext());
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
@@ -144,7 +144,7 @@ final class MonoCollectList<T> extends MonoFromFluxOperator<T, List<T>> implemen
 			}
 			if (l != null) {
 				s.cancel();
-				Operators.onDiscardMultiple(l, actual.currentContext());
+				discard(l);
 			}
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -1496,8 +1496,9 @@ public abstract class Operators {
 
 		@Override
 		public void cancel() {
+			O v = value;
 			if (STATE.getAndSet(this, CANCELLED) <= HAS_REQUEST_NO_VALUE) {
-				Operators.onDiscard(value, currentContext());
+				discard(v);
 			}
 			value = null;
 		}
@@ -1543,6 +1544,7 @@ public abstract class Operators {
 
 				// if state is >= HAS_CANCELLED or bit zero is set (*_HAS_VALUE) case, return
 				if ((state & ~HAS_REQUEST_NO_VALUE) != 0) {
+					this.value = null;
 					discard(v);
 					return;
 				}
@@ -1561,8 +1563,14 @@ public abstract class Operators {
 			}
 		}
 
+		/**
+		 * Discard the given value, generally this.value field. Lets derived subscriber with further knowledge about
+		 * the possible types of the value discard such values in a specific way. Note that fields should generally be
+		 * nulled out along the discard call.
+		 *
+		 * @param v the value to discard
+		 */
 		protected void discard(O v) {
-			this.value = null;
 			Operators.onDiscard(v, actual.currentContext());
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoStreamCollectorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoStreamCollectorTest.java
@@ -15,12 +15,20 @@
  */
 package reactor.core.publisher;
 
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
@@ -28,11 +36,51 @@ import org.junit.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
+import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoStreamCollectorTest {
+
+
+	static class TestCollector<T, A, R> implements Collector<T, A, R> {
+
+		private final Supplier<A>      supplier;
+		private final BiConsumer<A, T> accumulator;
+		private final Function<A, R>   finisher;
+
+		TestCollector(Supplier<A> supplier, BiConsumer<A, T> accumulator, Function<A, R> finisher) {
+			this.supplier = supplier;
+			this.accumulator = accumulator;
+			this.finisher = finisher;
+		}
+
+		@Override
+		public Supplier<A> supplier() {
+			return this.supplier;
+		}
+
+		@Override
+		public BiConsumer<A, T> accumulator() {
+			return this.accumulator;
+		}
+
+		@Override
+		public BinaryOperator<A> combiner() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Function<A, R> finisher() {
+			return this.finisher;
+		}
+
+		@Override
+		public Set<Characteristics> characteristics() {
+			return Collections.emptySet();
+		}
+	}
 
 	@Test
 	public void collectToList() {
@@ -90,6 +138,162 @@ public class MonoStreamCollectorTest {
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
 		test.cancel();
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
+	}
+
+	@Test
+	public void discardValueAndIntermediateListElementsOnAccumulatorFailure() {
+		Collector<Integer, List<Integer>, Set<Integer>> collector = new TestCollector<>(ArrayList::new, (l, i) -> {
+			if (i == 2) throw new IllegalStateException("accumulator: boom");
+			l.add(i);
+		}, HashSet::new);
+
+		Flux.range(1, 4)
+		    .collect(collector)
+		    .as(StepVerifier::create)
+		    .expectErrorMessage("accumulator: boom")
+		    .verifyThenAssertThat()
+		    .hasDiscardedExactly(1, 2);
+	}
+
+	@Test
+	public void discardValueAndIntermediateMapOnAccumulatorFailure() {
+		Collector<Integer, Map<Integer, String>, Set<Integer>> collector = new TestCollector<>(HashMap::new, (m, i) -> {
+			if (i == 2) throw new IllegalStateException("accumulator: boom");
+			m.put(i, String.valueOf(i));
+		}, Map::keySet);
+
+		Flux.range(1, 4)
+		    .collect(collector)
+		    .as(StepVerifier::create)
+		    .expectErrorMessage("accumulator: boom")
+		    .verifyThenAssertThat()
+		    .hasDiscardedExactly(Collections.singletonMap(1, "1"), 2);
+	}
+
+	@Test
+	public void discardIntermediateListElementsOnError() {
+		final Collector<Integer, ?, Collection<Integer>> collector = Collectors.toCollection(ArrayList::new);
+
+		Mono<Collection<Integer>> test =
+				Flux.range(1, 10)
+				    .hide()
+				    .map(i -> {
+					    if (i == 5) {
+						    throw new IllegalStateException("boom");
+					    }
+					    return i;
+				    })
+				    .collect(collector);
+
+		StepVerifier.create(test)
+		            .expectErrorMessage("boom")
+		            .verifyThenAssertThat()
+		            .hasDiscardedExactly(1, 2, 3, 4);
+	}
+
+	@Test
+	public void discardIntermediateListElementsOnCancel() {
+		final Collector<Long, ?, Collection<Long>> collector = Collectors.toCollection(ArrayList::new);
+
+		StepVerifier.withVirtualTime(() ->
+				Flux.interval(Duration.ofMillis(100))
+				    .take(10)
+				    .collect(collector)
+		)
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofMillis(210))
+		            .thenCancel()
+		            .verifyThenAssertThat()
+		            .hasDiscardedExactly(0L, 1L);
+	}
+
+	@Test
+	public void discardIntermediateListElementsOnFinisherFailure() {
+		Collector<Integer, List<Integer>, Set<Integer>> collector = new TestCollector<>(ArrayList::new, List::add, m -> { throw new IllegalStateException("finisher: boom"); });
+
+		Mono<Set<Integer>> test =
+				Flux.range(1, 4)
+				    .hide()
+				    .collect(collector);
+
+		StepVerifier.create(test)
+		            .expectErrorMessage("finisher: boom")
+		            .verifyThenAssertThat()
+		            .hasDiscardedExactly(1, 2, 3, 4);
+	}
+
+	@Test
+	public void discardIntermediateMapOnError() {
+		Collector<Integer, ?, Map<Integer, String>> collector = Collectors.toMap(Function.identity(), String::valueOf);
+		List<Object> discarded = new ArrayList<>();
+
+		Mono<Map<Integer, String>> test =
+				Flux.range(1, 10)
+				    .hide()
+				    .map(i -> {
+					    if (i == 5) {
+						    throw new IllegalStateException("boom");
+					    }
+					    return i;
+				    })
+				    .collect(collector)
+				    .doOnDiscard(Object.class, discarded::add);
+
+		StepVerifier.create(test)
+		            .expectErrorMessage("boom")
+		            .verify();
+
+		assertThat(discarded).doesNotHaveAnyElementsOfTypes(Integer.class)
+		                     .hasOnlyElementsOfType(Map.class)
+		                     .hasSize(1);
+		//noinspection unchecked
+		assertThat(((Map) discarded.get(0)).keySet()).containsExactly(1, 2, 3, 4);
+	}
+
+	@Test
+	public void discardIntermediateMapOnCancel() {
+		Collector<Long, Map<Long, String>, Set<Long>> collector = new TestCollector<>(HashMap::new,
+				(m, i) -> m.put(i, String.valueOf(i)), Map::keySet);
+		List<Object> discarded = new ArrayList<>();
+
+		StepVerifier.withVirtualTime(() ->
+				Flux.interval(Duration.ofMillis(100))
+				    .take(10)
+				    .collect(collector)
+				    .doOnDiscard(Object.class, discarded::add))
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofMillis(210))
+		            .thenCancel()
+		            .verify();
+
+		assertThat(discarded).doesNotHaveAnyElementsOfTypes(Long.class)
+		                     .hasOnlyElementsOfType(Map.class)
+		                     .hasSize(1);
+		//noinspection unchecked
+		assertThat((Map) discarded.get(0)).containsOnlyKeys(0L, 1L);
+	}
+
+	@Test
+	public void discardIntermediateMapOnFinisherFailure() {
+		Collector<Integer, Map<Integer, String>, Set<Integer>> collector = new TestCollector<>(HashMap::new,
+				(m, i) -> m.put(i, String.valueOf(i)), m -> { throw new IllegalStateException("finisher: boom"); });
+		List<Object> discarded = new ArrayList<>();
+
+		Mono<Set<Integer>> test =
+				Flux.range(1, 4)
+				    .hide()
+				    .collect(collector)
+				    .doOnDiscard(Object.class, discarded::add);
+
+		StepVerifier.create(test)
+		            .expectErrorMessage("finisher: boom")
+		            .verify();
+
+		assertThat(discarded).doesNotHaveAnyElementsOfTypes(Integer.class, Set.class)
+		                     .hasOnlyElementsOfType(Map.class)
+		                     .hasSize(1);
+		//noinspection unchecked
+		assertThat(((Map) discarded.get(0))).containsOnlyKeys(1, 2, 3, 4);
 	}
 
 }


### PR DESCRIPTION
 - `Flux.collect(Supplier, BiConsumer)` now detects if the
 container is of type `Collection`, in which case it discards each element
 in the collection when appropriate
 - the operator also now additionally discard the element T along the
 container when the collector function fails
 - `Flux.collect(Collector)` now also discards elements in a similar
 fashion to `Flux.collect(Supplier, BiConsumer)`. The accumulator failure
 case and finisher `Function` failure case are taken into account. The
 discarding of individual elements inside a `Collection` is applied to
 the intermediate container, not the result of the `finisher()`

Behavior change: if you extend `Operators.MonoSubscriber`, keep the
following in mind: `discard(O v)` no longer nulls out the `this.value`
field. Calling methods now need to do that themselves instead.