### PR TITLE
StepVerifier fix For Fusion and request after onNext

### DIFF
--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -1570,8 +1570,12 @@ final class DefaultStepVerifierBuilder<T>
 				try {
 					if (event instanceof SubscriptionTaskEvent) {
 						updateRequested(event);
+						((TaskEvent<T>) event).run(this);
+						serializeDrainAndSubscriptionEvent();
 					}
-					((TaskEvent<T>) event).run(this);
+					else {
+						((TaskEvent<T>) event).run(this);
+					}
 				}
 				catch (Throwable t) {
 					Exceptions.throwIfFatal(t);

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -36,6 +36,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import reactor.core.Fuseable;
 import reactor.core.publisher.DirectProcessor;
+import reactor.core.publisher.MonoProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.UnicastProcessor;
@@ -2100,5 +2101,35 @@ public class StepVerifierTests {
 						::verify)
 				.withMessage("Unexpected error during a no-event expectation: java.lang.IllegalStateException: boom")
 				.withCause(new IllegalStateException("boom"));
+	}
+
+	@Test
+	public void verifyDrainOnRequestInCaseOfFusion() {
+		MonoProcessor<Integer> processor = MonoProcessor.create();
+		StepVerifier.create(processor, 0)
+				.expectFusion(Fuseable.ANY)
+				.then(() -> processor.onNext(1))
+				.thenRequest(1)
+				.expectNext(1)
+				.verifyComplete();
+	}
+
+	@Test
+	public void verifyDrainOnRequestInCaseOfFusion2() {
+		ArrayList<Long> requests = new ArrayList<>();
+		UnicastProcessor<Integer> processor = UnicastProcessor.create();
+		StepVerifier.create(processor.doOnRequest(requests::add), 0)
+				.expectFusion(Fuseable.ANY)
+				.then(() -> {
+					processor.onNext(1);
+					processor.onComplete();
+				})
+				.thenRequest(1)
+				.thenRequest(1)
+				.thenRequest(1)
+				.expectNext(1)
+				.verifyComplete();
+
+		assertThat(requests).containsExactly(1L, 1L, 1L);
 	}
 }


### PR DESCRIPTION
# Expected 

When `StepVerifier` is used for verification of `Publisher` behavior in fusion mode as a User, I want to have it act identically to other operators in fusion mode with upstream. For example, let's consider the behavior of `FluxPublishOn` in ASYNC fusion with `UnicastProcessor` as the Upstream 

```
Event: unicastProcessor is subscribed by FluxPublishOnSubscriber
Event: FluxPublishOnSubscriber received onSubscribe (let's assume there is no prefetch)
Event: unicastProcessor.onNext(XXX)
Event: FluxPublishOnSubscriber is notified over onNext(null) there is an item in a queue
Event: request(XXX) appeared at FluxPublishOnSubscriber, so it called `drain` method in order to start draining elements from the fused queue
```

# Actual

In case of such events' order `StepVerifier` will hang until its timeout. 

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>