### PR TITLE
Explicit `currentContext()`

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -76,7 +76,8 @@ dependencies {
 		  "org.openjdk.jol:jol-core:$javaObjectLayoutVersion",
 		  "pl.pragmatists:JUnitParams:$jUnitParamsVersion",
 		  "org.awaitility:awaitility:$awaitilityVersion",
-		  "com.pivovarit:throwing-function:$throwingFunctionVersion"
+		  "com.pivovarit:throwing-function:$throwingFunctionVersion",
+		  'com.tngtech.archunit:archunit:0.12.0'
 
   noMicrometerTestCompile sourceSets.main.output
   noMicrometerTestCompile sourceSets.test.output

--- a/reactor-core/src/main/java/reactor/core/publisher/BlockingIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/BlockingIterable.java
@@ -36,6 +36,7 @@ import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * An iterable that consumes a Publisher in a blocking fashion.
@@ -146,6 +147,11 @@ final class BlockingIterable<T> implements Iterable<T>, Scannable {
 			this.limit = Operators.unboundedOrLimit(batchSize);
 			this.lock = new ReentrantLock();
 			this.condition = lock.newCondition();
+		}
+
+		@Override
+		public Context currentContext() {
+			return Context.empty();
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/BlockingOptionalMonoSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/BlockingOptionalMonoSubscriber.java
@@ -41,6 +41,7 @@ import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * Blocks assuming the upstream is a Mono, until it signals its value or completes.
@@ -91,6 +92,11 @@ final class BlockingOptionalMonoSubscriber<T> extends CountDownLatch
 	@Override
 	public final void onComplete() {
 		countDown();
+	}
+
+	@Override
+	public Context currentContext() {
+		return Context.empty();
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/BlockingSingleSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/BlockingSingleSubscriber.java
@@ -24,6 +24,7 @@ import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * @see <a href="https://github.com/reactor/reactive-streams-commons">https://github.com/reactor/reactive-streams-commons</a>
@@ -53,6 +54,11 @@ abstract class BlockingSingleSubscriber<T> extends CountDownLatch
 	@Override
 	public final void onComplete() {
 		countDown();
+	}
+
+	@Override
+	public Context currentContext() {
+		return Context.empty();
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferWhen.java
@@ -442,6 +442,11 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 		}
 
 		@Override
+		public Context currentContext() {
+			return parent.currentContext();
+		}
+
+		@Override
 		public void onSubscribe(Subscription s) {
 			if (Operators.setOnce(SUBSCRIPTION, this, s)) {
 				subscription.request(Long.MAX_VALUE);
@@ -501,6 +506,11 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 		BufferWhenCloseSubscriber(BufferWhenMainSubscriber<T, ?, ?, BUFFER> parent, long index) {
 			this.parent = parent;
 			this.index = index;
+		}
+
+		@Override
+		public Context currentContext() {
+			return parent.currentContext();
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -27,6 +27,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * A base processor that exposes {@link Flux} API for {@link Processor}.
@@ -165,6 +166,11 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 		if (key == Attr.CAPACITY) return getBufferSize();
 
 		return null;
+	}
+
+	@Override
+	public Context currentContext() {
+		return Context.empty();
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTimeout.java
@@ -27,6 +27,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * Signals a timeout (or switches to another sequence) in case a per-item
@@ -306,6 +307,11 @@ final class FluxTimeout<T, U, V> extends InternalFluxOperator<T, T> {
 				Operators.MultiSubscriptionSubscriber<T, T> arbiter) {
 			this.actual = actual;
 			this.arbiter = arbiter;
+		}
+
+		@Override
+		public Context currentContext() {
+			return actual.currentContext();
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoToCompletableFuture.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoToCompletableFuture.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
+import reactor.util.context.Context;
 
 /**
  * @author Stephane Maldini
@@ -74,5 +75,10 @@ final class MonoToCompletableFuture<T> extends CompletableFuture<T> implements C
 		if (ref.getAndSet(null) != null) {
 			complete(null);
 		}
+	}
+
+	@Override
+	public Context currentContext() {
+		return Context.empty();
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -1368,6 +1368,11 @@ public abstract class Operators {
 			Throwable e = new IllegalStateException("onComplete should not be used");
 			log.error("Unexpected call to Operators.emptySubscriber()", e);
 		}
+
+		@Override
+		public Context currentContext() {
+			return Context.empty();
+		}
 	};
 	//
 
@@ -2231,6 +2236,11 @@ public abstract class Operators {
 		@Override
 		public void onComplete() {
 
+		}
+
+		@Override
+		public Context currentContext() {
+			return Context.empty();
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/StrictSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/StrictSubscriber.java
@@ -174,4 +174,9 @@ final class StrictSubscriber<T> implements Scannable, CoreSubscriber<T>, Subscri
 
 		return null;
 	}
+
+	@Override
+	public Context currentContext() {
+		return Context.empty();
+	}
 }

--- a/reactor-core/src/test/java/reactor/core/CoreSubscriberArchTest.java
+++ b/reactor-core/src/test/java/reactor/core/CoreSubscriberArchTest.java
@@ -42,7 +42,7 @@ public class CoreSubscriberArchTest {
 	public static Object[][] scanClasses() {
 		JavaClasses classes = new ClassFileImporter()
 				.withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
-                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_ARCHIVES)
+				.withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_ARCHIVES)
 				.importPackagesOf(CoreSubscriber.class);
 
 		return classes.stream()

--- a/reactor-core/src/test/java/reactor/core/CoreSubscriberArchTest.java
+++ b/reactor-core/src/test/java/reactor/core/CoreSubscriberArchTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core;
+
+import java.util.Comparator;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+@RunWith(Parameterized.class)
+public class CoreSubscriberArchTest {
+
+	@Parameterized.Parameters(name = "{index}: {1}")
+	public static Object[][] scanClasses() {
+		JavaClasses classes = new ClassFileImporter()
+				.withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_ARCHIVES)
+				.importPackagesOf(CoreSubscriber.class);
+
+		return classes.stream()
+		              .sorted(Comparator.comparing(JavaClass::getName))
+		              .map(it -> new Object[] {
+		              		classes.that(DescribedPredicate.equalTo(it)),
+				            it.getName()
+				                .replace("reactor.", "r.")
+				                .replace("r.core.", "r.c.")
+				                .replace("r.c.publisher.", "r.c.p.")
+				                .replace("r.c.scheduler.", "r.c.s.")
+		              })
+		              .toArray(Object[][]::new);
+	}
+
+	final JavaClasses clazz;
+
+	public CoreSubscriberArchTest(JavaClasses clazz, String className) {
+		this.clazz = clazz;
+	}
+
+	@Test
+	public void shouldNotUseDefaultCurrentContext() {
+		AtomicBoolean checked = new AtomicBoolean(false);
+		classes()
+				.that().implement(CoreSubscriber.class)
+				.and().doNotHaveModifier(JavaModifier.ABSTRACT)
+				.should(new ArchCondition<JavaClass>("not use the default currentContext()") {
+					@Override
+					public void check(JavaClass item, ConditionEvents events) {
+						checked.set(true);
+						boolean overriddenMethod = item
+								.getAllMethods()
+								.stream()
+								.filter(it -> "currentContext".equals(it.getName()))
+								.filter(it -> it.getRawParameterTypes().isEmpty())
+								.anyMatch(it -> !it.getOwner().isEquivalentTo(CoreSubscriber.class));
+
+						if (!overriddenMethod) {
+							events.add(SimpleConditionEvent.violated(item, "currentContext() is not overridden"));
+						}
+					}
+				})
+				.check(clazz);
+
+		Assume.assumeTrue(checked.get());
+	}
+}

--- a/reactor-core/src/test/java/reactor/core/CoreSubscriberArchTest.java
+++ b/reactor-core/src/test/java/reactor/core/CoreSubscriberArchTest.java
@@ -74,14 +74,14 @@ public class CoreSubscriberArchTest {
 					@Override
 					public void check(JavaClass item, ConditionEvents events) {
 						checked.set(true);
-						boolean overriddenMethod = item
+						boolean overridesMethod = item
 								.getAllMethods()
 								.stream()
 								.filter(it -> "currentContext".equals(it.getName()))
 								.filter(it -> it.getRawParameterTypes().isEmpty())
 								.anyMatch(it -> !it.getOwner().isEquivalentTo(CoreSubscriber.class));
 
-						if (!overriddenMethod) {
+						if (!overridesMethod) {
 							events.add(SimpleConditionEvent.violated(item, "currentContext() is not overridden"));
 						}
 					}


### PR DESCRIPTION
As seen in issues like https://github.com/reactor/reactor-core/issues/1114,
due to the default `currentContext()` in `CoreSubscriber`,
we sometimes forget to delegate the context to the actual one.

To prevent it, this PR adds an ArchUnit rule to check that we always
explicitly implement `currentContext()`.

After running the check I noticed a few potentially buggy places:
- `FluxBufferWhen`
- `FluxTimeout`