### PR TITLE
fix #2002 Implement Mono.cache() as MonoCacheTime without TTL

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1590,7 +1590,7 @@ public abstract class Mono<T> implements Publisher<T> {
 	 * @return a replaying {@link Mono}
 	 */
 	public final Mono<T> cache() {
-		return onAssembly(new MonoProcessor<>(this));
+		return onAssembly(new MonoCacheTime<>(this));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
@@ -26,6 +26,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
@@ -38,6 +39,8 @@ import reactor.util.context.Context;
  * @author Simon Baslé
  */
 class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
+
+	private static final Duration DURATION_INFINITE = Duration.ofMillis(Long.MAX_VALUE);
 
 	private static final Logger LOGGER = Loggers.getLogger(MonoCacheTime.class);
 
@@ -56,6 +59,10 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
 		this.clock = clock;
 		//noinspection unchecked
 		this.state = (Signal<T>) EMPTY;
+	}
+
+	MonoCacheTime(Mono<? extends T> source) {
+		this(source, sig -> DURATION_INFINITE, Schedulers.immediate());
 	}
 
 	MonoCacheTime(Mono<? extends T> source, Function<? super Signal<T>, Duration> ttlGenerator,
@@ -354,7 +361,6 @@ class MonoCacheTime<T> extends MonoOperator<T, T> implements Runnable {
 
 		private static final Operators.MonoSubscriber[] TERMINATED        = new Operators.MonoSubscriber[0];
 		private static final Operators.MonoSubscriber[] EMPTY             = new Operators.MonoSubscriber[0];
-		private static final Duration                   DURATION_INFINITE = Duration.ofMillis(Long.MAX_VALUE);
 	}
 
 	static final class CacheMonoSubscriber<T> extends Operators.MonoSubscriber<T, T> {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
@@ -835,4 +835,20 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 		assertThat(virtualTimeScheduler.getScheduledTaskCount()).isZero().as("once cache skipped scheduled count");
 	}
 
+	@Test
+	public void noTtlCancelDoesntCancelSource() {
+		AtomicInteger cancelled = new AtomicInteger();
+		Mono<Object> cached = new MonoCacheTime<>(Mono.never()
+		                          .doOnCancel(cancelled::incrementAndGet));
+
+		Disposable d1 = cached.subscribe();
+		Disposable d2 = cached.subscribe();
+
+		d1.dispose();
+		assertThat(cancelled.get()).as("when cancelling d1").isEqualTo(0);
+
+		d2.dispose();
+		assertThat(cancelled.get()).as("when both cancelled").isEqualTo(0);
+	}
+
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
@@ -47,7 +47,7 @@ public class MonoProcessorTest {
 		WeakReference<CompletableFuture<Date>> refFuture = new WeakReference<>(future);
 
 		Mono<Date> source = Mono.fromFuture(future);
-		Mono<String> data = source.map(Date::toString).log().cache().log();
+		Mono<String> data = source.map(Date::toString).as(MonoProcessor::new);
 
 		future.complete(date);
 		assertThat(data.block()).isEqualTo(date.toString());
@@ -76,7 +76,7 @@ public class MonoProcessorTest {
 		WeakReference<CompletableFuture<Date>> refFuture = new WeakReference<>(future);
 
 		Mono<Date> source = Mono.fromFuture(future);
-		Mono<String> data = source.map(Date::toString).cache();
+		Mono<String> data = source.map(Date::toString).as(MonoProcessor::new);
 
 		future.completeExceptionally(new IllegalStateException());
 
@@ -105,7 +105,7 @@ public class MonoProcessorTest {
 		WeakReference<CompletableFuture<Date>> refFuture = new WeakReference<>(future);
 
 		Mono<Date> source = Mono.fromFuture(future);
-		Mono<String> data = source.map(Date::toString).cache();
+		Mono<String> data = source.map(Date::toString).as(MonoProcessor::new);
 
 		future = null;
 		source = null;
@@ -594,7 +594,6 @@ public class MonoProcessorTest {
 		AtomicInteger subscriptionCount = new AtomicInteger();
 		Mono<String> coldToHot = Mono.just("foo")
 		                             .doOnSubscribe(sub -> subscriptionCount.incrementAndGet())
-		                             .cache()
 		                             .toProcessor() //this actually subscribes
 		                             .filter(s -> s.length() < 4);
 


### PR DESCRIPTION
This fixes an issue where direct disposal of the .cache() instance would
cause the source to be cancelled, which is not the case for the Flux
version.

This commit avoids coalescing infinite caching with MonoProcessor,
fixing the issue.