### PR TITLE
fix #2008 Add onErrorContinue support to FluxFlattenIterable

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -5066,6 +5066,12 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @param mapper the {@link Function} to transform input sequence into N {@link Iterable}
 	 * @param <R> the merged output sequence type
 	 *
+	 * @reactor.errorMode This operator supports {@link #onErrorContinue(BiConsumer) resuming on errors}
+	 * (including when fusion is enabled). Exceptions thrown by the consumer are passed to
+	 * the {@link #onErrorContinue(BiConsumer)} error consumer (the value consumer
+	 * is not invoked, as the source element will be part of the sequence). The onNext
+	 * signal is then propagated as normal.
+	 *
 	 * @return a concatenation of the values from the Iterables obtained from each element in this {@link Flux}
 	 */
 	public final <R> Flux<R> flatMapIterable(Function<? super T, ? extends Iterable<? extends R>> mapper) {
@@ -5090,6 +5096,12 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @param mapper the {@link Function} to transform input sequence into N {@link Iterable}
 	 * @param prefetch the maximum in-flight elements from each inner {@link Iterable} sequence
 	 * @param <R> the merged output sequence type
+	 *
+	 * @reactor.errorMode This operator supports {@link #onErrorContinue(BiConsumer) resuming on errors}
+	 * (including when fusion is enabled). Exceptions thrown by the consumer are passed to
+	 * the {@link #onErrorContinue(BiConsumer)} error consumer (the value consumer
+	 * is not invoked, as the source element will be part of the sequence). The onNext
+	 * signal is then propagated as normal.
 	 *
 	 * @return a concatenation of the values from the Iterables obtained from each element in this {@link Flux}
 	 */

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
@@ -98,8 +98,14 @@ final class FluxFlattenIterable<T, R> extends InternalFluxOperator<T, R> impleme
 			}
 			catch (Throwable ex) {
 				Context ctx = actual.currentContext();
-				Operators.error(actual, Operators.onOperatorError(ex, ctx));
+				Throwable e_ = Operators.onNextError(v, ex, ctx);
 				Operators.onDiscard(v, ctx);
+				if (e_ != null) {
+					Operators.error(actual, e_);
+				}
+				else {
+					Operators.complete(actual);
+				}
 				return null;
 			}
 
@@ -532,8 +538,9 @@ final class FluxFlattenIterable<T, R> extends InternalFluxOperator<T, R> impleme
 							Operators.onDiscard(t, ctx);
 							if (e_ != null) {
 								a.onError(e_);
+								return;
 							}
-							return;
+							continue;
 						}
 
 						if (!b) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
@@ -341,8 +341,11 @@ final class FluxFlattenIterable<T, R> extends InternalFluxOperator<T, R> impleme
 						catch (Throwable exc) {
 							it = null;
 							Context ctx = actual.currentContext();
-							onError(Operators.onOperatorError(s, exc, t, ctx));
+							Throwable e_ = Operators.onNextError(t, exc, ctx, s);
 							Operators.onDiscard(t, ctx);
+							if (e_ != null) {
+								onError(e_);
+							}
 							continue;
 						}
 
@@ -525,8 +528,11 @@ final class FluxFlattenIterable<T, R> extends InternalFluxOperator<T, R> impleme
 						catch (Throwable exc) {
 							current = null;
 							Context ctx = actual.currentContext();
-							a.onError(Operators.onOperatorError(s, exc, t, ctx));
+							Throwable e_ = Operators.onNextError(t, exc, ctx, s);
 							Operators.onDiscard(t, ctx);
+							if (e_ != null) {
+								a.onError(e_);
+							}
 							return;
 						}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
@@ -396,4 +396,48 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
 	                .expectErrorMessage("boom")
 	                .verify(Duration.ofSeconds(1));
     }
+
+	@Test
+	public void errorModeContinueNullPublisher() {
+		Flux<Integer> test = Flux
+				.just(1, 2)
+				.hide()
+				.flatMapIterable(f -> {
+					if (f == 1) {
+						return null;
+					}
+					return Arrays.asList(f);
+				})
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
+
+		StepVerifier.create(test)
+				.expectNoFusionSupport()
+				.expectNext(2)
+				.expectComplete()
+				.verifyThenAssertThat()
+				.hasDropped(1)
+				.hasDroppedErrors(1);
+	}
+
+    @Test
+	public void errorModeContinueInternalError() {
+	    Flux<Integer> test = Flux
+			    .just(1, 2)
+			    .hide()
+			    .flatMapIterable(f -> {
+            if (f == 1) {
+              throw new IllegalStateException("boom");
+            }
+            return Arrays.asList(f);
+			    })
+			    .onErrorContinue(OnNextFailureStrategyTest::drop);
+
+	    StepVerifier.create(test)
+			    .expectNoFusionSupport()
+			    .expectNext(2)
+			    .expectComplete()
+			    .verifyThenAssertThat()
+			    .hasDropped(1)
+			    .hasDroppedErrors(1);
+    }
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
@@ -397,7 +397,7 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
     }
 
 	@Test
-	public void errorModeContinueNullPublisherAsync() {
+	public void errorModeContinueNullPublisherNotFused() {
 		Flux<Integer> test = Flux
 				.just(1, 2)
 				.hide()
@@ -419,7 +419,7 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
 	}
 
     @Test
-	public void errorModeContinueInternalErrorAsync() {
+	public void errorModeContinueInternalErrorNotFused() {
 	    Flux<Integer> test = Flux
 			    .just(1, 2)
 			    .hide()
@@ -441,7 +441,7 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
     }
 
 	@Test
-	public void errorModeContinueSingleElementAsync() {
+	public void errorModeContinueSingleElementNotFused() {
 		Flux<Integer> test = Flux
 				.just(1)
 				.hide()
@@ -462,7 +462,7 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
 	}
 	
     @Test
-	public void errorModeContinueNullPublisherSync() {
+	public void errorModeContinueNullPublisherFused() {
 		Flux<Integer> test = Flux
 				.just(1, 2)
 				.flatMapIterable(f -> {
@@ -482,7 +482,7 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
 	}
 
     @Test
-	public void errorModeContinueInternalErrorSync() {
+	public void errorModeContinueInternalErrorFused() {
 	    Flux<Integer> test = Flux
 			    .just(1, 2)
 			    .flatMapIterable(f -> {
@@ -502,7 +502,7 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
     }
 
     @Test
-	public void errorModeContinueSingleElementSync() {
+	public void errorModeContinueSingleElementFused() {
 	    Flux<Integer> test = Flux
 			    .just(1)
 			    .flatMapIterable(f -> {


### PR DESCRIPTION
As opposed to many other operators, the FluxFlattenIterable does not
support `onErrorContinue` handling.

Attempted to add that support in this PR, together with a test verifying
the behaviour.

This would fix issue https://github.com/reactor/reactor-core/issues/2008