### PR TITLE
fix #1251 Make `defer` opt-in in `VirtualTimeScheduler.create`

### DIFF
--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -219,7 +219,7 @@ public interface StepVerifier {
 	 */
 	static <T> FirstStep<T> withVirtualTime(Supplier<? extends Publisher<? extends T>> scenarioSupplier,
 			long n) {
-		return withVirtualTime(scenarioSupplier, VirtualTimeScheduler::getOrSet, n);
+		return withVirtualTime(scenarioSupplier, () -> VirtualTimeScheduler.create(true), n);
 	}
 
 	/**

--- a/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
+++ b/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
@@ -38,7 +38,7 @@ import reactor.util.concurrent.Queues;
 
 /**
  * A {@link Scheduler} that uses a virtual clock, allowing to manipulate time
- * (eg. in tests). Can replace the default reactor schedulers by using 
+ * (eg. in tests). Can replace the default reactor schedulers by using
  * the {@link #getOrSet} / {@link #set(VirtualTimeScheduler)} methods.
  *
  * @author Stephane Maldini
@@ -54,7 +54,21 @@ public class VirtualTimeScheduler implements Scheduler {
 	 * {@link Schedulers} factories.
 	 */
 	public static VirtualTimeScheduler create() {
-		return new VirtualTimeScheduler();
+		return create(false);
+	}
+
+	/**
+	 * Create a new {@link VirtualTimeScheduler} without enabling it. Call
+	 * {@link #getOrSet(VirtualTimeScheduler)} to enable it on
+	 * {@link reactor.core.scheduler.Schedulers.Factory} factories.
+	 *
+	 * @param defer true to defer all clock move operations until there are tasks in queue
+	 *
+	 * @return a new {@link VirtualTimeScheduler} intended for timed-only
+	 * {@link Schedulers} factories.
+	 */
+	public static VirtualTimeScheduler create(boolean defer) {
+		return new VirtualTimeScheduler(defer);
 	}
 
 	/**
@@ -65,7 +79,7 @@ public class VirtualTimeScheduler implements Scheduler {
 	 * @return the VirtualTimeScheduler that was created and set through the factory
 	 */
 	public static VirtualTimeScheduler getOrSet() {
-		return enable(VirtualTimeScheduler::new, false);
+		return enable(VirtualTimeScheduler::create, false);
 	}
 
 	/**
@@ -195,9 +209,12 @@ public class VirtualTimeScheduler implements Scheduler {
 
 	volatile boolean shutdown;
 
+	final boolean defer;
+
 	final VirtualTimeWorker directWorker;
 
-	protected VirtualTimeScheduler() {
+	protected VirtualTimeScheduler(boolean defer) {
+		this.defer = defer;
 		directWorker = createWorker();
 	}
 
@@ -319,7 +336,7 @@ public class VirtualTimeScheduler implements Scheduler {
 			return;
 		}
 		for(;;) {
-			if (!queue.isEmpty()) {
+			if (!defer || !queue.isEmpty()) {
 				//resetting for the first time a delayed schedule is called after a deferredNanoTime is set
 				long targetNanoTime = nanoTime + DEFERRED_NANO_TIME.getAndSet(this, 0);
 

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -2131,7 +2131,7 @@ public class StepVerifierTests {
 		}
 	}
 
-	@Test
+	@Test(timeout = 5000)
 	public void gh783() {
 		int size = 1;
 		Scheduler parallel = Schedulers.newParallel("gh-783");
@@ -2150,7 +2150,7 @@ public class StepVerifierTests {
 		            .verifyComplete();
 	}
 
-	@Test
+	@Test(timeout = 5000)
 	public void gh783_deferredAdvanceTime() {
 		int size = 61;
 		Scheduler parallel = Schedulers.newParallel("gh-783");

--- a/reactor-test/src/test/java/reactor/test/scheduler/VirtualTimeSchedulerTests.java
+++ b/reactor-test/src/test/java/reactor/test/scheduler/VirtualTimeSchedulerTests.java
@@ -127,7 +127,7 @@ public class VirtualTimeSchedulerTests {
 
 	@Test
 	public void captureNowInScheduledTask() {
-		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create(true);
 		List<Long> singleExecutionsTimestamps = new ArrayList<>();
 		List<Long> periodicExecutionTimestamps = new ArrayList<>();
 
@@ -192,6 +192,10 @@ public class VirtualTimeSchedulerTests {
 				assertThat(vts.now(TimeUnit.MILLISECONDS))
 						.as("iteration " + i)
 						.isEqualTo(13_000 * i);
+
+				assertThat(vts.nanoTime)
+						.as("now() == nanoTime in iteration " + i)
+						.isEqualTo(vts.now(TimeUnit.NANOSECONDS));
 			}
 		}
 		finally {
@@ -225,7 +229,7 @@ public class VirtualTimeSchedulerTests {
 
 	@Test
 	public void racingAdvanceTimeOnVaryingQueue() {
-		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create(true);
 		AtomicInteger count = new AtomicInteger();
 		try {
 			for (int i = 1; i <= 100; i++) {


### PR DESCRIPTION
See https://github.com/reactor/reactor-core/issues/1251

See also conversation in https://github.com/reactor/reactor-core/pull/2012