### PR TITLE
Fix early cancellation handling and improve switchOnFirst

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -8380,7 +8380,56 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @return a new {@link Flux} that transform the upstream once a signal is available
 	 */
 	public final <V> Flux<V> switchOnFirst(BiFunction<Signal<? extends T>, Flux<T>, Publisher<? extends V>> transformer) {
-		return onAssembly(new FluxSwitchOnFirst<>(this, transformer));
+		return switchOnFirst(transformer, true);
+	}
+
+	/**
+	 * Transform the current {@link Flux<T>} once it emits its first element, making a
+	 * conditional transformation possible. This operator first requests one element
+	 * from the source then applies a transformation derived from the first {@link Signal}
+	 * and the source. The whole source (including the first signal) is passed as second
+	 * argument to the {@link BiFunction} and it is very strongly advised to always build
+	 * upon with operators (see below).
+	 * <p>
+	 * Note that the source might complete or error immediately instead of emitting,
+	 * in which case the {@link Signal} would be onComplete or onError. It is NOT
+	 * necessarily an onNext Signal, and must be checked accordingly.
+	 * <p>
+	 * For example, this operator could be used to define a dynamic transformation that depends
+	 * on the first element (which could contain routing metadata for instance):
+	 *
+	 * <blockquote><pre>
+	 * {@code
+	 *  fluxOfIntegers.switchOnFirst((signal, flux) -> {
+	 *      if (signal.hasValue()) {
+	 *          ColoredShape firstColor = signal.get();
+	 *          return flux.filter(v -> !v.hasSameColorAs(firstColor))
+	 *      }
+	 *      return flux; //either early complete or error, this forwards the termination in any case
+	 *      //`return flux.onErrorResume(t -> Mono.empty());` instead would suppress an early error
+	 *      //`return Flux.just(1,2,3);` instead would suppress an early error and return 1, 2, 3.
+	 *      //It would also only cancel the original `flux` at the completion of `just`.
+	 *  })
+	 * }
+	 * </pre></blockquote>
+	 * <p>
+	 * <img class="marble" src="doc-files/marbles/switchOnFirst.svg" alt="">
+	 * <p>
+	 * It is advised to return a {@link Publisher} derived from the original {@link Flux}
+	 * in all cases, as not doing so would keep the original {@link Publisher} open and
+	 * hanging with a single request. In case the value of the {@code cancelSourceOnComplete} parameter is {@code true} the original publisher until the inner {@link Publisher} terminates or
+	 * the whole {@link Flux} is cancelled. Otherwise the original publisher will hang forever.
+	 *
+	 * @param transformer A {@link BiFunction} executed once the first signal is
+	 * available and used to transform the source conditionally. The whole source (including
+	 * first signal) is passed as second argument to the BiFunction.
+	 * @param <V> the item type in the returned {@link Flux}
+	 * @param cancelSourceOnComplete specify whether original publisher should be cancelled on {@code onComplete} from the derived one
+	 *
+	 * @return a new {@link Flux} that transform the upstream once a signal is available
+	 */
+	public final <V> Flux<V> switchOnFirst(BiFunction<Signal<? extends T>, Flux<T>, Publisher<? extends V>> transformer, boolean cancelSourceOnComplete) {
+		return onAssembly(new FluxSwitchOnFirst<>(this, transformer, cancelSourceOnComplete));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
@@ -109,7 +109,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
         @Override
         @Nullable
         public Object scanUnsafe(Attr key) {
-            final boolean isCancelled = this.inner == Operators.emptySubscriber();
+            final boolean isCancelled = this.inner == Operators.EMPTY_SUBSCRIBER;
 
             if (key == Attr.CANCELLED) return isCancelled && !this.done;
             if (key == Attr.TERMINATED) return this.done || isCancelled;
@@ -124,7 +124,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 
         @Override
         public void cancel() {
-            if (INNER.getAndSet(this, Operators.emptySubscriber()) != Operators.emptySubscriber()) {
+            if (INNER.getAndSet(this, Operators.EMPTY_SUBSCRIBER) != Operators.EMPTY_SUBSCRIBER) {
                 this.s.cancel();
 
                 if (WIP.getAndIncrement(this) == 0) {
@@ -142,7 +142,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
             if (Operators.validate(this.s, s)) {
                 this.s = s;
                 this.outer.sendSubscription();
-                if (this.inner != Operators.emptySubscriber()) {
+                if (this.inner != Operators.EMPTY_SUBSCRIBER) {
                     s.request(1);
                 }
             }
@@ -151,7 +151,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
         @Override
         public void onNext(T t) {
             final CoreSubscriber<? super T> i = this.inner;
-            if (this.done || i == Operators.emptySubscriber()) {
+            if (this.done || i == Operators.EMPTY_SUBSCRIBER) {
                 Operators.onNextDropped(t, currentContext());
                 return;
             }
@@ -183,7 +183,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
         @Override
         public void onError(Throwable t) {
             final CoreSubscriber<? super T> i = this.inner;
-            if (this.done || i == Operators.emptySubscriber()) {
+            if (this.done || i == Operators.EMPTY_SUBSCRIBER) {
                 Operators.onErrorDropped(t, currentContext());
                 return;
             }
@@ -220,7 +220,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
         @Override
         public void onComplete() {
             final CoreSubscriber<? super T> i = this.inner;
-            if (this.done || i == Operators.emptySubscriber()) {
+            if (this.done || i == Operators.EMPTY_SUBSCRIBER) {
                 return;
             }
 
@@ -318,7 +318,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
                 if (f != null) {
                     this.first = null;
 
-                    if (a == Operators.emptySubscriber()) {
+                    if (a == Operators.EMPTY_SUBSCRIBER) {
                         Operators.onDiscard(f, currentContext());
                         return false;
                     }
@@ -329,7 +329,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 
                 a = this.inner;
 
-                if (a == Operators.emptySubscriber()) {
+                if (a == Operators.EMPTY_SUBSCRIBER) {
                     return false;
                 }
 
@@ -340,7 +340,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
                     } else {
                         a.onComplete();
                     }
-                    INNER.lazySet(this, Operators.emptySubscriber());
+                    INNER.lazySet(this, Operators.EMPTY_SUBSCRIBER);
                     return true;
                 }
 
@@ -389,7 +389,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
             @SuppressWarnings("unchecked")
             final Fuseable.ConditionalSubscriber<? super T> i =
                     (Fuseable.ConditionalSubscriber<? super T>) this.inner;
-            if (this.done || i == Operators.emptySubscriber()) {
+            if (this.done || i == Operators.EMPTY_SUBSCRIBER) {
                 Operators.onNextDropped(t, currentContext());
                 return false;
             }
@@ -435,7 +435,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
                 if (f != null) {
                     this.first = null;
 
-                    if (a == Operators.emptySubscriber()) {
+                    if (a == Operators.EMPTY_SUBSCRIBER) {
                         Operators.onDiscard(f, currentContext());
                         return false;
                     }
@@ -446,7 +446,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 
                 a = (Fuseable.ConditionalSubscriber<? super T>) this.inner;
 
-                if (a == Operators.emptySubscriber()) {
+                if (a == Operators.EMPTY_SUBSCRIBER) {
                     return false;
                 }
 
@@ -457,7 +457,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
                     } else {
                         a.onComplete();
                     }
-                    INNER.lazySet(this, Operators.emptySubscriber());
+                    INNER.lazySet(this, Operators.EMPTY_SUBSCRIBER);
                     return sent;
                 }
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -1413,7 +1413,7 @@ public abstract class Operators {
 		}
 	}
 
-	static final CoreSubscriber<?> EMPTY_SUBSCRIBER = new CoreSubscriber<Object>() {
+	static final Fuseable.ConditionalSubscriber<?> EMPTY_SUBSCRIBER = new Fuseable.ConditionalSubscriber<Object>() {
 		@Override
 		public void onSubscribe(Subscription s) {
 			Throwable e = new IllegalStateException("onSubscribe should not be used");
@@ -1424,6 +1424,13 @@ public abstract class Operators {
 		public void onNext(Object o) {
 			Throwable e = new IllegalStateException("onNext should not be used, got " + o);
 			log.error("Unexpected call to Operators.emptySubscriber()", e);
+		}
+
+		@Override
+		public boolean tryOnNext(Object o) {
+			Throwable e = new IllegalStateException("tryOnNext should not be used, got " + o);
+			log.error("Unexpected call to Operators.emptySubscriber()", e);
+			return false;
 		}
 
 		@Override

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
@@ -757,6 +757,13 @@ public class FluxSwitchOnFirstTest {
         stepVerifier.verify(Duration.ofSeconds(10));
 
         Assertions.assertThat(latch2.await(1, TimeUnit.SECONDS)).isTrue();
+
+        Instant endTime = Instant.now().plusSeconds(5);
+        while (!publisher.wasCancelled()) {
+            if (endTime.isBefore(Instant.now())) {
+                break;
+            }
+        }
         publisher.assertCancelled();
         publisher.assertWasRequested();
     }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
@@ -16,6 +16,7 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
@@ -24,9 +25,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
@@ -36,6 +42,8 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
+import reactor.test.scheduler.VirtualTimeScheduler;
+import reactor.test.subscriber.AssertSubscriber;
 import reactor.test.util.RaceTestUtils;
 import reactor.util.context.Context;
 
@@ -445,7 +453,9 @@ public class FluxSwitchOnFirstTest {
         Flux<Long> switchTransformed = Flux.<Long>empty()
                 .switchOnFirst((f, innerFlux) -> {
                     first[0] = f;
-                    return innerFlux;
+                    innerFlux.subscribe();
+
+                    return Flux.<Long>empty();
                 })
                 .subscriberContext(Context.of("a", "c"))
                 .subscriberContext(Context.of("c", "d"));
@@ -459,6 +469,32 @@ public class FluxSwitchOnFirstTest {
                     .then()
                     .expectComplete()
                     .verify();
+
+        Assertions.assertThat(first).containsExactly(Signal.complete(Context.of("a", "c").put("c", "d")));
+    }
+
+    @Test
+    public void shouldReturnCorrectContextIfLoosingChain() {
+        @SuppressWarnings("unchecked")
+        Signal<? extends Long>[] first = new Signal[1];
+
+        Flux<Long> switchTransformed = Flux.<Long>empty()
+                .switchOnFirst((f, innerFlux) -> {
+                    first[0] = f;
+                    return innerFlux;
+                })
+                .subscriberContext(Context.of("a", "c"))
+                .subscriberContext(Context.of("c", "d"));
+
+        StepVerifier.create(switchTransformed, 0)
+                .expectSubscription()
+                .thenRequest(1)
+                .expectAccessibleContext()
+                .contains("a", "c")
+                .contains("c", "d")
+                .then()
+                .expectComplete()
+                .verify();
 
         Assertions.assertThat(first).containsExactly(Signal.complete(Context.of("a", "c").put("c", "d")));
     }
@@ -496,7 +532,9 @@ public class FluxSwitchOnFirstTest {
     }
 
     @Test
-    public void shouldBeAbleToAccessUpstreamContext() {
+    // Since context is immutable, with switchOnFirst it should not be mutable as well. Upstream should observe downstream
+    // Inner should be able to access downstreamContext but should not modify upstream context after the first element
+    public void shouldNotBeAbleToAccessUpstreamContext() {
         TestPublisher<Long> publisher = TestPublisher.createCold();
 
         Flux<String> switchTransformed = publisher.flux()
@@ -516,7 +554,7 @@ public class FluxSwitchOnFirstTest {
                     .then(() -> publisher.next(2L))
                     .expectNext("2")
                     .expectAccessibleContext()
-                    .contains("a", "b")
+                    .contains("a", "c")
                     .contains("c", "d")
                     .then()
                     .then(publisher::complete)
@@ -693,17 +731,32 @@ public class FluxSwitchOnFirstTest {
     }
 
     @Test
-    public void shouldBeAbleToBeCancelledProperly() {
+    public void shouldBeAbleToBeCancelledProperly() throws InterruptedException {
+        CountDownLatch latch1 = new CountDownLatch(1);
+        CountDownLatch latch2 = new CountDownLatch(1);
         TestPublisher<Integer> publisher = TestPublisher.createCold();
         Flux<String> switchTransformed = publisher.flux()
-                                                  .switchOnFirst((first, innerFlux) -> innerFlux.map(String::valueOf));
+                .doOnCancel(latch2::countDown)
+                .switchOnFirst((first, innerFlux) -> innerFlux.map(String::valueOf))
+                .doOnCancel(() -> {
+                    try {
+                        latch1.await();
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                })
+                .cancelOn(Schedulers.elastic());
 
         publisher.next(1);
 
-        StepVerifier.create(switchTransformed, 0)
-                    .thenCancel()
-                    .verify(Duration.ofSeconds(10));
+        StepVerifier stepVerifier = StepVerifier.create(switchTransformed, 0)
+                .thenCancel()
+                .verifyLater();
 
+        latch1.countDown();
+        stepVerifier.verify(Duration.ofSeconds(10));
+
+        Assertions.assertThat(latch2.await(1, TimeUnit.SECONDS)).isTrue();
         publisher.assertCancelled();
         publisher.assertWasRequested();
     }
@@ -777,24 +830,46 @@ public class FluxSwitchOnFirstTest {
     }
 
     @Test
-    public void shouldBeAbleToCatchDiscardedElementInCaseOfConditional() {
+    public void shouldBeAbleToCatchDiscardedElementInCaseOfConditional() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        CountDownLatch latch2 = new CountDownLatch(1);
         TestPublisher<Integer> publisher = TestPublisher.create();
-        Integer[] discarded = new Integer[1];
+        int[] discarded = new int[1];
         Flux<String> switchTransformed = publisher.flux()
-                                                  .switchOnFirst((first, innerFlux) -> innerFlux.map(String::valueOf))
-                                                  .filter(t -> true)
-                                                  .doOnDiscard(Integer.class, e -> discarded[0] = e);
+                .doOnCancel(latch2::countDown)
+                .switchOnFirst((first, innerFlux) -> innerFlux.map(String::valueOf))
+                .filter(t -> true)
+                .doOnDiscard(Integer.class, e -> discarded[0] = e)
+                .doOnCancel(() -> {
+                    try {
+                        latch.await();
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                })
+                .cancelOn(Schedulers.elastic());
 
-        StepVerifier.create(switchTransformed, 0)
-                    .expectSubscription()
-                    .then(() -> publisher.next(1))
-                    .thenCancel()
-                    .verify(Duration.ofSeconds(10));
+        StepVerifier stepVerifier = StepVerifier.create(switchTransformed, 0)
+                .expectSubscription()
+                .then(() -> publisher.next(1))
+                .thenCancel()
+                .verifyLater();
+
+        latch.countDown();
+        stepVerifier.verify(Duration.ofSeconds(1));
+        Assertions.assertThat(latch2.await(1, TimeUnit.SECONDS)).isTrue();
+
+        Instant endTime = Instant.now().plusSeconds(5);
+        while (discarded[0] == 0) {
+            if (endTime.isBefore(Instant.now())) {
+                break;
+            }
+        }
 
         publisher.assertCancelled();
         publisher.assertWasRequested();
 
-        Assertions.assertThat(discarded).contains(1);
+        Assertions.assertThat(discarded).containsExactly(1);
     }
 
     @Test
@@ -810,7 +885,8 @@ public class FluxSwitchOnFirstTest {
                 CountDownLatch latch = new CountDownLatch(1);
                 Flux<Long> switchTransformed = publisher.doOnRequest(requested::addAndGet)
                                                         .doOnCancel(latch::countDown)
-                                                        .switchOnFirst((first, innerFlux) -> innerFlux);
+                                                        .switchOnFirst((first, innerFlux) -> innerFlux)
+                                                        .doOnComplete(latch::countDown);
 
                 switchTransformed.subscribeWith(new LambdaSubscriber<>(
                     captureElement::set,
@@ -902,6 +978,79 @@ public class FluxSwitchOnFirstTest {
     }
 
     @Test
+    public void shouldReturnNormallyIfExceptionIsThrownOnNextDuringSwitchingConditional() {
+        @SuppressWarnings("unchecked")
+        Signal<? extends Integer>[] first = new Signal[1];
+        Optional<?> expectedCause = Optional.of(1);
+
+        StepVerifier
+            .create(
+                Flux.range(1, 100)
+                    .switchOnFirst((s, f) -> {
+                        first[0] = s;
+                        throw new NullPointerException();
+                    })
+                    .filter(__ -> true)
+            )
+            .expectSubscription()
+            .expectError(NullPointerException.class)
+            .verifyThenAssertThat()
+            .hasOperatorErrorsSatisfying(c ->
+                Assertions.assertThat(c)
+                        .hasOnlyOneElementSatisfying(t -> {
+                            Assertions.assertThat(t.getT1()).containsInstanceOf(NullPointerException.class);
+                            Assertions.assertThat(t.getT2()).isEqualTo(expectedCause);
+                        })
+            );
+
+
+        Assertions.assertThat((long) first[0].get()).isEqualTo(1L);
+    }
+
+    @Test
+    public void shouldReturnNormallyIfExceptionIsThrownOnErrorDuringSwitchingConditional() {
+        @SuppressWarnings("unchecked")
+        Signal<? extends Long>[] first = new Signal[1];
+
+        NullPointerException npe = new NullPointerException();
+        RuntimeException error = new RuntimeException();
+        StepVerifier.create(Flux.<Long>error(error)
+                .switchOnFirst((s, f) -> {
+                    first[0] = s;
+                    throw npe;
+                }).filter(__ -> true))
+                .expectSubscription()
+                .verifyError(NullPointerException.class);
+
+
+        Assertions.assertThat(first).containsExactly(Signal.error(error));
+    }
+
+    @Test
+    public void shouldReturnNormallyIfExceptionIsThrownOnCompleteDuringSwitchingConditional() {
+        @SuppressWarnings("unchecked")
+        Signal<? extends Long>[] first = new Signal[1];
+
+        StepVerifier.create(Flux.<Long>empty()
+                .switchOnFirst((s, f) -> {
+                    first[0] = s;
+                    throw new NullPointerException();
+                }).filter(__ -> true)
+        )
+                .expectSubscription()
+                .expectError(NullPointerException.class)
+                .verifyThenAssertThat()
+                .hasOperatorErrorMatching(t -> {
+                    Assertions.assertThat(t)
+                            .isInstanceOf(NullPointerException.class);
+                    return true;
+                });
+
+
+        Assertions.assertThat(first).containsExactly(Signal.complete());
+    }
+
+    @Test
     public void sourceSubscribedOnce() {
         AtomicInteger subCount = new AtomicInteger();
         Flux<Integer> source = Flux.range(1, 10)
@@ -953,6 +1102,19 @@ public class FluxSwitchOnFirstTest {
     }
 
     @Test
+    public void shouldNotCancelSourceOnUnrelatedPublisherComplete() {
+        EmitterProcessor<Long> testPublisher = EmitterProcessor.create();
+
+        testPublisher.onNext(1L);
+
+        StepVerifier.create(testPublisher.switchOnFirst((s, f) -> Flux.empty(), false))
+                .expectSubscription()
+                .verifyComplete();
+
+        Assertions.assertThat(testPublisher.isCancelled()).isFalse();
+    }
+
+    @Test
     public void shouldCancelSourceOnUnrelatedPublisherError() {
         EmitterProcessor<Long> testPublisher = EmitterProcessor.create();
 
@@ -998,6 +1160,100 @@ public class FluxSwitchOnFirstTest {
                     .verifyComplete();
 
         Assertions.assertThat(testPublisher.isCancelled()).isTrue();
+    }
+
+    @Test
+    public void shouldNotCancelSourceOnUnrelatedPublisherCompleteConditional() {
+        EmitterProcessor<Long> testPublisher = EmitterProcessor.create();
+
+        testPublisher.onNext(1L);
+
+        StepVerifier.create(testPublisher.switchOnFirst((s, f) -> Flux.empty().delaySubscription(Duration.ofMillis(10)), false).filter(__ -> true))
+                .then(() -> {
+                    FluxPublish.PubSubInner<Long>[] subs = testPublisher.subscribers;
+                    Assertions.assertThat(subs).hasSize(1);
+                    Assertions.assertThat(subs[0])
+                            .extracting(psi -> psi.actual)
+                            .isInstanceOf(Fuseable.ConditionalSubscriber.class);
+                })
+                .verifyComplete();
+
+        Assertions.assertThat(testPublisher.isCancelled()).isFalse();
+    }
+
+    @Test
+    public void shouldCancelInnerSubscriptionImmediatelyUpOnReceivingIfDownstreamIsAlreadyCancelledConditional() {
+        VirtualTimeScheduler virtualTimeScheduler = VirtualTimeScheduler.getOrSet();
+        TestPublisher<Long> testPublisher = TestPublisher.create();
+        TestPublisher<Long> testPublisherInner = TestPublisher.create();
+
+        try {
+            StepVerifier
+                .create(
+                    testPublisher
+                        .flux()
+                        .switchOnFirst((s, f) ->
+                            testPublisherInner
+                                .flux()
+                                .transform(Operators.lift((__, cs) -> new BaseSubscriber<Long>() {
+                                    @Override
+                                    protected void hookOnSubscribe(Subscription subscription) {
+                                        Schedulers.parallel().schedule(() -> cs.onSubscribe(this), 1, TimeUnit.SECONDS);
+                                    }
+                                })),
+                            false
+                        )
+                        .filter(__ -> true)
+                )
+                .expectSubscription()
+                .then(() -> testPublisher.next(1L))
+                .thenCancel()
+                .verify();
+
+            Assertions.assertThat(testPublisher.wasCancelled()).isTrue();
+            Assertions.assertThat(testPublisherInner.wasCancelled()).isFalse();
+            virtualTimeScheduler.advanceTimeBy(Duration.ofMillis(1000));
+            Assertions.assertThat(testPublisherInner.wasCancelled()).isTrue();
+        } finally {
+            VirtualTimeScheduler.reset();
+        }
+    }
+
+    @Test
+    public void shouldCancelInnerSubscriptionImmediatelyUpOnReceivingIfDownstreamIsAlreadyCancelled() {
+        VirtualTimeScheduler virtualTimeScheduler = VirtualTimeScheduler.getOrSet();
+        TestPublisher<Long> testPublisher = TestPublisher.create();
+        TestPublisher<Long> testPublisherInner = TestPublisher.create();
+
+        try {
+            StepVerifier
+                    .create(
+                            testPublisher
+                                    .flux()
+                                    .switchOnFirst((s, f) ->
+                                                    testPublisherInner
+                                                            .flux()
+                                                            .transform(Operators.lift((__, cs) -> new BaseSubscriber<Long>() {
+                                                                @Override
+                                                                protected void hookOnSubscribe(Subscription subscription) {
+                                                                    Schedulers.parallel().schedule(() -> cs.onSubscribe(this), 1, TimeUnit.SECONDS);
+                                                                }
+                                                            })),
+                                            false
+                                    )
+                    )
+                    .expectSubscription()
+                    .then(() -> testPublisher.next(1L))
+                    .thenCancel()
+                    .verify();
+
+            Assertions.assertThat(testPublisher.wasCancelled()).isTrue();
+            Assertions.assertThat(testPublisherInner.wasCancelled()).isFalse();
+            virtualTimeScheduler.advanceTimeBy(Duration.ofMillis(1000));
+            Assertions.assertThat(testPublisherInner.wasCancelled()).isTrue();
+        } finally {
+            VirtualTimeScheduler.reset();
+        }
     }
 
     @Test
@@ -1124,7 +1380,7 @@ public class FluxSwitchOnFirstTest {
             CoreSubscriber subscriber = subscribers[0];
             Subscription downstreamSubscription = downstreamSubscriptions[0];
             Subscription innerSubscription = innerSubscriptions[0];
-            innerSubscription.request(1);
+            downstreamSubscription.request(1);
 
             RaceTestUtils.race(() -> subscriber.onSubscribe(innerSubscription), () -> downstreamSubscription.request(1));
 
@@ -1183,13 +1439,177 @@ public class FluxSwitchOnFirstTest {
             CoreSubscriber subscriber = subscribers[0];
             Subscription downstreamSubscription = downstreamSubscriptions[0];
             Subscription innerSubscription = innerSubscriptions[0];
-            innerSubscription.request(1);
+            downstreamSubscription.request(1);
 
             RaceTestUtils.race(() -> subscriber.onSubscribe(innerSubscription), () -> downstreamSubscription.request(1));
 
             Assertions.assertThat(requested.get()).isEqualTo(2);
         }
     }
+
+    @Test
+    public void unitRacingTest() {
+        for (int i = 0; i < 10000; i++) {
+            FluxSwitchOnFirst.AbstractSwitchOnFirstMain mockParent = Mockito.mock(FluxSwitchOnFirst.AbstractSwitchOnFirstMain.class);
+            Mockito.doNothing().when(mockParent).request(Mockito.anyLong());
+            Mockito.doNothing().when(mockParent).cancel();
+            Subscription mockSubscription = Mockito.mock(Subscription.class);
+            ArgumentCaptor<Long> longArgumentCaptor = ArgumentCaptor.forClass(Long.class);
+            Mockito.doNothing().when(mockSubscription).request(longArgumentCaptor.capture());
+            Mockito.doNothing().when(mockSubscription).cancel();
+            AssertSubscriber<Object> subscriber = AssertSubscriber.create(0);
+            FluxSwitchOnFirst.SwitchOnFirstControlSubscriber switchOnFirstControlSubscriber = new FluxSwitchOnFirst.SwitchOnFirstControlSubscriber<>(mockParent, subscriber, true);
+
+            switchOnFirstControlSubscriber.request(10);
+            RaceTestUtils.race(() -> switchOnFirstControlSubscriber.request(10), () -> switchOnFirstControlSubscriber.onSubscribe(mockSubscription), Schedulers.parallel());
+
+            Assertions.assertThat(longArgumentCaptor.getAllValues().size()).isBetween(1, 2);
+            if (longArgumentCaptor.getAllValues().size() == 1) {
+                Assertions.assertThat(longArgumentCaptor.getValue()).isEqualTo(20L);
+            } else if (longArgumentCaptor.getAllValues().size() == 2) {
+                Assertions.assertThat(longArgumentCaptor.getAllValues()).containsExactly(10L, 10L);
+            } else {
+                Assertions.fail("Unexpected number of calls");
+            }
+        }
+    }
+
+    @Test
+    public void onCompleteAndRequestRacingTest() {
+        Long signal = 1L;
+        Function<CoreSubscriber, FluxSwitchOnFirst.AbstractSwitchOnFirstMain>[] factories = new Function[] {
+                (assertSubscriber) -> new FluxSwitchOnFirst.SwitchOnFirstMain((CoreSubscriber)assertSubscriber, (s, f) -> f, true),
+                (assertSubscriber) -> new FluxSwitchOnFirst.SwitchOnFirstConditionalMain((Fuseable.ConditionalSubscriber) assertSubscriber, (s, f) -> f, true)
+        };
+        for (Function<CoreSubscriber, FluxSwitchOnFirst.AbstractSwitchOnFirstMain> factory : factories) {
+            for (int i = 0; i < 1000; i++) {
+                Subscription mockSubscription = Mockito.mock(Subscription.class);
+                ArgumentCaptor<Long> requestCaptor = ArgumentCaptor.forClass(Long.class);
+                Mockito.doNothing().when(mockSubscription).request(requestCaptor.capture());
+                Mockito.doNothing().when(mockSubscription).cancel();
+                AssertSubscriber<Object> assertSubscriber = AssertSubscriber.create(0);
+                FluxSwitchOnFirst.AbstractSwitchOnFirstMain<Object, Object> switchOnFirstMain = factory.apply(Operators.toConditionalSubscriber(assertSubscriber));
+
+                switchOnFirstMain.onSubscribe(mockSubscription);
+                Mockito.verify(mockSubscription).request(Mockito.longThat(argument -> argument.equals(1L)));
+                Mockito.clearInvocations(mockSubscription);
+                switchOnFirstMain.onNext(signal);
+                RaceTestUtils.race(() -> switchOnFirstMain.onComplete(), () -> switchOnFirstMain.request(55));
+                Mockito.verify(mockSubscription).request(Mockito.longThat(argument -> argument.equals(54L)));
+                assertSubscriber.assertSubscribed()
+                        .awaitAndAssertNextValues(signal)
+                        .assertComplete();
+            }
+        }
+    }
+
+    @Test
+    public void onErrorAndRequestRacingTest() {
+        Long signal = 1L;
+        RuntimeException ex = new RuntimeException();
+        Function<CoreSubscriber, FluxSwitchOnFirst.AbstractSwitchOnFirstMain>[] factories = new Function[] {
+                (assertSubscriber) -> new FluxSwitchOnFirst.SwitchOnFirstMain((CoreSubscriber)assertSubscriber, (s, f) -> f, true),
+                (assertSubscriber) -> new FluxSwitchOnFirst.SwitchOnFirstConditionalMain((Fuseable.ConditionalSubscriber) assertSubscriber, (s, f) -> f, true)
+        };
+        for (Function<CoreSubscriber, FluxSwitchOnFirst.AbstractSwitchOnFirstMain> factory : factories) {
+            for (int i = 0; i < 1000; i++) {
+                Subscription mockSubscription = Mockito.mock(Subscription.class);
+                ArgumentCaptor<Long> requestCaptor = ArgumentCaptor.forClass(Long.class);
+                Mockito.doNothing().when(mockSubscription).request(requestCaptor.capture());
+                Mockito.doNothing().when(mockSubscription).cancel();
+                AssertSubscriber<Object> assertSubscriber = AssertSubscriber.create(0);
+                FluxSwitchOnFirst.AbstractSwitchOnFirstMain<Object, Object> switchOnFirstMain = factory.apply(Operators.toConditionalSubscriber(assertSubscriber));
+
+                switchOnFirstMain.onSubscribe(mockSubscription);
+                Mockito.verify(mockSubscription).request(Mockito.longThat(argument -> argument.equals(1L)));
+                Mockito.clearInvocations(mockSubscription);
+                switchOnFirstMain.onNext(signal);
+                RaceTestUtils.race(() -> switchOnFirstMain.onError(ex), () -> switchOnFirstMain.request(55));
+                Mockito.verify(mockSubscription).request(Mockito.longThat(argument -> argument.equals(54L)));
+                assertSubscriber.assertSubscribed()
+                        .awaitAndAssertNextValues(signal)
+                        .assertErrorWith(t -> Assertions.assertThat(t).isEqualTo(ex));
+            }
+        }
+    }
+
+    @Test
+    public void сancelAndRequestRacingWithOnCompleteAfterTest() {
+        Long signal = 1L;
+        Function<CoreSubscriber, FluxSwitchOnFirst.AbstractSwitchOnFirstMain>[] factories = new Function[] {
+                (assertSubscriber) -> new FluxSwitchOnFirst.SwitchOnFirstMain((CoreSubscriber)assertSubscriber, (s, f) -> f, true),
+                (assertSubscriber) -> new FluxSwitchOnFirst.SwitchOnFirstConditionalMain((Fuseable.ConditionalSubscriber) assertSubscriber, (s, f) -> f, true)
+        };
+        for (Function<CoreSubscriber, FluxSwitchOnFirst.AbstractSwitchOnFirstMain> factory : factories){
+            for (int i = 0; i < 1000; i++) {
+                Subscription mockSubscription = Mockito.mock(Subscription.class);
+                ArgumentCaptor<Long> requestCaptor = ArgumentCaptor.forClass(Long.class);
+                AtomicReference<Object> discarded = new AtomicReference<>();
+                Mockito.doNothing().when(mockSubscription).request(requestCaptor.capture());
+                Mockito.doNothing().when(mockSubscription).cancel();
+                AssertSubscriber assertSubscriber = new AssertSubscriber<>(Context.of(Hooks.KEY_ON_DISCARD, (Consumer<Object>) o -> Assertions.assertThat(discarded.getAndSet(o)).isNull()), 0L);
+                FluxSwitchOnFirst.AbstractSwitchOnFirstMain<Object, Object> switchOnFirstMain = factory.apply(Operators.toConditionalSubscriber(assertSubscriber));
+
+                switchOnFirstMain.onSubscribe(mockSubscription);
+                Mockito.verify(mockSubscription).request(Mockito.longThat(argument -> argument.equals(1L)));
+                Mockito.clearInvocations(mockSubscription);
+                switchOnFirstMain.onNext(signal);
+                RaceTestUtils.race(() -> switchOnFirstMain.cancel(), () -> switchOnFirstMain.request(55));
+                switchOnFirstMain.onComplete();
+                assertSubscriber.assertNotTerminated();
+                Object discardedValue = discarded.get();
+                if (discardedValue == null) {
+                    assertSubscriber.awaitAndAssertNextValues(signal);
+                } else {
+                    Assertions.assertThat(discardedValue).isEqualTo(signal);
+                }
+
+                Mockito.verify(mockSubscription).request(Mockito.longThat(argument -> argument.equals(54L) || argument.equals(55L)));
+            }
+        }
+    }
+
+    @Test
+    public void cancelAndRequestRacingOnErrorAfterTest() {
+        Long signal = 1L;
+        Function<CoreSubscriber, FluxSwitchOnFirst.AbstractSwitchOnFirstMain>[] factories = new Function[] {
+                (assertSubscriber) -> new FluxSwitchOnFirst.SwitchOnFirstMain((CoreSubscriber)assertSubscriber, (s, f) -> f, true),
+                (assertSubscriber) -> new FluxSwitchOnFirst.SwitchOnFirstConditionalMain((Fuseable.ConditionalSubscriber) assertSubscriber, (s, f) -> f, true)
+        };
+        for (Function<CoreSubscriber, FluxSwitchOnFirst.AbstractSwitchOnFirstMain> factory : factories) {
+            for (int i = 0; i < 1000; i++) {
+                Subscription mockSubscription = Mockito.mock(Subscription.class);
+                ArgumentCaptor<Long> requestCaptor = ArgumentCaptor.forClass(Long.class);
+                AtomicReference<Object> discarded = new AtomicReference<>();
+                AtomicReference<Object> discardedError = new AtomicReference<>();
+                Mockito.doNothing().when(mockSubscription).request(requestCaptor.capture());
+                Mockito.doNothing().when(mockSubscription).cancel();
+                AssertSubscriber<Object> assertSubscriber = new AssertSubscriber<>(Context.of(
+                        Hooks.KEY_ON_DISCARD, (Consumer<Object>) o -> Assertions.assertThat(discarded.getAndSet(o)).isNull(),
+                        Hooks.KEY_ON_ERROR_DROPPED, (Consumer<Object>) o -> Assertions.assertThat(discardedError.getAndSet(o)).isNull()
+                ), 0L);
+                FluxSwitchOnFirst.AbstractSwitchOnFirstMain<Object, Object> switchOnFirstMain = factory.apply(Operators.toConditionalSubscriber(assertSubscriber));
+
+                switchOnFirstMain.onSubscribe(mockSubscription);
+                Mockito.verify(mockSubscription).request(Mockito.longThat(argument -> argument.equals(1L)));
+                Mockito.clearInvocations(mockSubscription);
+                switchOnFirstMain.onNext(signal);
+                RaceTestUtils.race(() -> switchOnFirstMain.cancel(), () -> switchOnFirstMain.request(55));
+                switchOnFirstMain.onError(new NullPointerException());
+                assertSubscriber.assertNotTerminated();
+                Assertions.assertThat(discardedError.get()).isInstanceOf(NullPointerException.class);
+                Object discardedValue = discarded.get();
+                if (discardedValue == null) {
+                    assertSubscriber.awaitAndAssertNextValues(signal);
+                } else {
+                    Assertions.assertThat(discardedValue).isEqualTo(signal);
+                }
+
+                Mockito.verify(mockSubscription).request(Mockito.longThat(argument -> argument.equals(54L) || argument.equals(55L)));
+            }
+        }
+    }
+
 
     private static final class NoOpsScheduler implements Scheduler {
 


### PR DESCRIPTION
This PR provides a couple of non-breaking changes in the behavior of SwitchOnFirst operator:

1) Applies Name changes in internal class naming
2) Provides additional parameter which allows canceling the source `Publisher` or continuing it work regardless derived `Publisher` completion
3) Provides the ability to cancel source if there are no elements but downstream has already been canceled (actually this was a bug, cuz in case of `Flux.never` or  Fluxes which require much time to produce an element it was impossible to cancel execution in a timely manner. Imagine the case -> `Flux.just(1).delayElement(Durations.ofHour(1)).switchOnFirst(...).timeout(Duration.ofSeconds(1))`).

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>