### PR TITLE
Fix fused last(T) not delivering defaultValue

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTakeLastOne.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTakeLastOne.java
@@ -120,7 +120,7 @@ final class MonoTakeLastOne<T> extends MonoFromFluxOperator<T, T>
 
 		@Override
 		public void setValue(T value) {
-			// value is always in a field
+			this.value = value;
 		}
 	}
 }


### PR DESCRIPTION
This change fixes a bug in the `last(defaultValue)` operator which would not deliver the default value when used in combination with a `Flux.zip`. The issue would cause the `zip` to complete prematurely with a cancel all subscribers instead of pulling in the default value when the `last` subscription was completed without emitting an item.

The unit test included does produce the issue if the change for the `setValue` function is not included.

**Note:** This was the fix I included but a different solution could be proposed in the [`FluxZip`](https://github.com/reactor/reactor-core/blob/master/reactor-core/src/main/java/reactor/core/publisher/FluxZip.java#L681) code linked here which is where the trigger for the `cancelAll` and `onComplete` calls occur when they shouldn't.