### PR TITLE
fix #2014 Cancel discards concatMapIterable/fromIterable's remainder …

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -30,6 +30,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
+import java.util.Spliterator;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -3654,7 +3655,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * Thus {@code flatMapIterable} and {@code concatMapIterable} are equivalent offered as a discoverability
 	 * improvement for users that explore the API with the concat vs flatMap expectation.
 	 *
-	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation.
+	 * @reactor.discard Upon cancellation, this operator discards {@code T} elements it prefetched and, in
+	 * some cases, attempts to discard remainder of the currently processed {@link Iterable} (if it can
+	 * safely assume the iterator is not infinite, see {@link Spliterator#getExactSizeIfKnown()}).
 	 *
 	 * @param mapper the {@link Function} to transform input sequence into N {@link Iterable}
 	 * @param <R> the merged output sequence type
@@ -3677,7 +3680,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * Thus {@code flatMapIterable} and {@code concatMapIterable} are equivalent offered as a discoverability
 	 * improvement for users that explore the API with the concat vs flatMap expectation.
 	 *
-	 * @reactor.discard This operator discards elements it internally queued for backpressure upon cancellation.
+	 * @reactor.discard Upon cancellation, this operator discards {@code T} elements it prefetched and, in
+	 * some cases, attempts to discard remainder of the currently processed {@link Iterable} (if it can
+	 * safely assume the iterator is not infinite, see {@link Spliterator#getExactSizeIfKnown()}).
 	 *
 	 * @param mapper the {@link Function} to transform input sequence into N {@link Iterable}
 	 * @param prefetch the maximum in-flight elements from each inner {@link Iterable} sequence
@@ -4925,7 +4930,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * Thus {@code flatMapIterable} and {@code concatMapIterable} are equivalent offered as a discoverability
 	 * improvement for users that explore the API with the concat vs flatMap expectation.
 	 *
-	 * @reactor.discard This operator discards elements internally queued for backpressure upon cancellation or error triggered by a data signal.
+	 * @reactor.discard Upon cancellation, this operator discards {@code T} elements it prefetched and, in
+	 * some cases, attempts to discard remainder of the currently processed {@link Iterable} (if it can
+	 * safely assume iterator is not infinite, see {@link Spliterator#getExactSizeIfKnown()}).
 	 *
 	 * @param mapper the {@link Function} to transform input sequence into N {@link Iterable}
 	 * @param <R> the merged output sequence type
@@ -4949,7 +4956,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * Thus {@code flatMapIterable} and {@code concatMapIterable} are equivalent offered as a discoverability
 	 * improvement for users that explore the API with the concat vs flatMap expectation.
 	 *
-	 * @reactor.discard This operator discards elements internally queued for backpressure upon cancellation or error triggered by a data signal.
+	 * @reactor.discard Upon cancellation, this operator discards {@code T} elements it prefetched and, in
+	 * some cases, attempts to discard remainder of the currently processed {@link Iterable} (if it can
+	 * safely assume the iterator is not infinite, see {@link Spliterator#getExactSizeIfKnown()}).
 	 *
 	 * @param mapper the {@link Function} to transform input sequence into N {@link Iterable}
 	 * @param prefetch the maximum in-flight elements from each inner {@link Iterable} sequence

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxIterable.java
@@ -19,16 +19,20 @@ package reactor.core.publisher;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Objects;
+import java.util.Spliterator;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import org.reactivestreams.Subscriber;
+
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.util.annotation.Nullable;
 import reactor.util.function.Tuple2;
 
 /**
- * Emits the contents of an Iterable source.
+ * Emits the contents of an Iterable source. Attempt to discard remainder of a source
+ * in case of error / cancellation, but uses the {@link Spliterator} API to try and detect
+ * infinite sources (so that said discarding doesn't loop infinitely).
  *
  * @param <T> the value type
  *
@@ -36,10 +40,27 @@ import reactor.util.function.Tuple2;
  */
 final class FluxIterable<T> extends Flux<T> implements Fuseable, SourceProducer<T> {
 
+	/**
+	 * Utility method to check that a given {@link Iterable} can be positively identified as
+	 * finite, which implies forEachRemaining type of iteration can be done to discard unemitted
+	 * values (in case of cancellation or error).
+	 * <p>
+	 * A {@link Collection} is assumed to be finite, and for other iterables the {@link Spliterator}
+	 * {@link Spliterator#SIZED} characteristic is looked for.
+	 *
+	 * @param iterable the {@link Iterable} to check.
+	 * @param <T>
+	 * @return true if the {@link Iterable} can confidently classified as finite, false if not finite/unsure
+	 */
+	static <T> boolean checkFinite(Iterable<T> iterable) {
+		return iterable instanceof Collection || iterable.spliterator().hasCharacteristics(Spliterator.SIZED);
+	}
+
 	final Iterable<? extends T> iterable;
+	@Nullable
 	private final Runnable      onClose;
 
-	FluxIterable(Iterable<? extends T> iterable, Runnable onClose) {
+	FluxIterable(Iterable<? extends T> iterable, @Nullable Runnable onClose) {
 		this.iterable = Objects.requireNonNull(iterable, "iterable");
 		this.onClose = onClose;
 	}
@@ -50,9 +71,11 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable, SourceProducer<
 
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
+		boolean knownToBeFinite;
 		Iterator<? extends T> it;
 
 		try {
+			knownToBeFinite = FluxIterable.checkFinite(iterable);
 			it = iterable.iterator();
 		}
 		catch (Throwable e) {
@@ -60,7 +83,7 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable, SourceProducer<
 			return;
 		}
 
-		subscribe(actual, it, onClose);
+		subscribe(actual, it, knownToBeFinite, onClose);
 	}
 
 	@Override
@@ -73,28 +96,27 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable, SourceProducer<
 	}
 
 	/**
-	 * Common method to take an Iterator as a source of values.
+	 * Common method to take an {@link Iterator} as a source of values.
 	 *
 	 * @param s the subscriber to feed this iterator to
-	 * @param it the iterator to use as a source of values
+	 * @param it the {@link Iterator} to use as a predictable source of values
 	 */
-	@SuppressWarnings("unchecked")
-	static <T> void subscribe(CoreSubscriber<? super T> s, Iterator<? extends T> it) {
-		subscribe(s, it, null);
+	static <T> void subscribe(CoreSubscriber<? super T> s, Iterator<? extends T> it, boolean knownToBeFinite) {
+		subscribe(s, it, knownToBeFinite, null);
 	}
 
 	/**
-	 * Common method to take an Iterator as a source of values.
+	 * Common method to take an {@link Iterator} as a source of values.
 	 *
 	 * @param s the subscriber to feed this iterator to
-	 * @param it the iterator to use as a source of values
+	 * @param it the {@link Iterator} to use as a source of values
 	 * @param onClose close handler to call once we're done with the iterator (provided it
 	 * is not null, this includes when the iteration errors or complete or the subscriber
 	 * is cancelled). Null to ignore.
 	 */
 	@SuppressWarnings("unchecked")
 	static <T> void subscribe(CoreSubscriber<? super T> s, Iterator<? extends T> it,
-			@Nullable Runnable onClose) {
+			boolean knownToBeFinite, @Nullable Runnable onClose) {
 		//noinspection ConstantConditions
 		if (it == null) {
 			Operators.error(s, new NullPointerException("The iterator is null"));
@@ -133,10 +155,10 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable, SourceProducer<
 
 		if (s instanceof ConditionalSubscriber) {
 			s.onSubscribe(new IterableSubscriptionConditional<>((ConditionalSubscriber<? super T>) s,
-					it, onClose));
+					it, knownToBeFinite, onClose));
 		}
 		else {
-			s.onSubscribe(new IterableSubscription<>(s, it, onClose));
+			s.onSubscribe(new IterableSubscription<>(s, it, knownToBeFinite, onClose));
 		}
 	}
 
@@ -146,6 +168,7 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable, SourceProducer<
 		final CoreSubscriber<? super T> actual;
 
 		final Iterator<? extends T> iterator;
+		final boolean               knownToBeFinite;
 		final Runnable              onClose;
 
 		volatile boolean cancelled;
@@ -179,15 +202,16 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable, SourceProducer<
 		T current;
 
 		IterableSubscription(CoreSubscriber<? super T> actual,
-				Iterator<? extends T> iterator, @Nullable Runnable onClose) {
+				Iterator<? extends T> iterator, boolean knownToBeFinite, @Nullable Runnable onClose) {
 			this.actual = actual;
 			this.iterator = iterator;
+			this.knownToBeFinite = knownToBeFinite;
 			this.onClose = onClose;
 		}
 
 		IterableSubscription(CoreSubscriber<? super T> actual,
-				Iterator<? extends T> iterator) {
-			this(actual, iterator, null);
+				Iterator<? extends T> iterator, boolean knownToBeFinite) {
+			this(actual, iterator, knownToBeFinite, null);
 		}
 
 		@Override
@@ -341,6 +365,7 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable, SourceProducer<
 		public void cancel() {
 			onCloseWithDropError();
 			cancelled = true;
+			Operators.onDiscardMultiple(this.iterator, this.knownToBeFinite, actual.currentContext());
 		}
 
 		@Override
@@ -360,6 +385,7 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable, SourceProducer<
 
 		@Override
 		public void clear() {
+			Operators.onDiscardMultiple(this.iterator, this.knownToBeFinite, actual.currentContext());
 			state = STATE_NO_NEXT;
 		}
 
@@ -418,6 +444,7 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable, SourceProducer<
 		final ConditionalSubscriber<? super T> actual;
 
 		final Iterator<? extends T> iterator;
+		final boolean               knownToBeFinite;
 		final Runnable              onClose;
 
 		volatile boolean cancelled;
@@ -451,15 +478,16 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable, SourceProducer<
 		T current;
 
 		IterableSubscriptionConditional(ConditionalSubscriber<? super T> actual,
-				Iterator<? extends T> iterator, @Nullable Runnable onClose) {
+				Iterator<? extends T> iterator, boolean knownToBeFinite, @Nullable Runnable onClose) {
 			this.actual = actual;
 			this.iterator = iterator;
+			this.knownToBeFinite = knownToBeFinite;
 			this.onClose = onClose;
 		}
 
 		IterableSubscriptionConditional(ConditionalSubscriber<? super T> actual,
-				Iterator<? extends T> iterator) {
-			this(actual, iterator, null);
+				Iterator<? extends T> iterator, boolean knownToBeFinite) {
+			this(actual, iterator, knownToBeFinite, null);
 		}
 
 		@Override
@@ -615,6 +643,7 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable, SourceProducer<
 		public void cancel() {
 			onCloseWithDropError();
 			cancelled = true;
+			Operators.onDiscardMultiple(this.iterator, this.knownToBeFinite, actual.currentContext());
 		}
 
 		@Override
@@ -634,6 +663,7 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable, SourceProducer<
 
 		@Override
 		public void clear() {
+			Operators.onDiscardMultiple(this.iterator, this.knownToBeFinite, actual.currentContext());
 			state = STATE_NO_NEXT;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -17,6 +17,7 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
@@ -2602,6 +2603,10 @@ public abstract class Mono<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/flatMapIterableForMono.svg" alt="">
+	 *
+	 * @reactor.discard Upon cancellation in some cases, this operator attempts to discard remainder of
+	 * the currently processed {@link Iterable} (if it can safely assume the iterator is not infinite,
+	 * see {@link Operators#onDiscardMultiple(Iterator, boolean, Context)}).
 	 *
 	 * @param mapper the {@link Function} to transform input item into a sequence {@link Iterable}
 	 * @param <R> the merged output sequence type

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFlattenIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFlattenIterable.java
@@ -82,11 +82,11 @@ final class MonoFlattenIterable<T, R> extends FluxFromMonoOperator<T, R>
 			}
 
 			Iterator<? extends R> it;
-
+			boolean itFinite;
 			try {
 				Iterable<? extends R> iter = mapper.apply(v);
-
 				it = iter.iterator();
+				itFinite = FluxIterable.checkFinite(iter);
 			}
 			catch (Throwable ex) {
 				Operators.error(actual, Operators.onOperatorError(ex,
@@ -94,7 +94,7 @@ final class MonoFlattenIterable<T, R> extends FluxFromMonoOperator<T, R>
 				return;
 			}
 
-			FluxIterable.subscribe(actual, it);
+			FluxIterable.subscribe(actual, it, itFinite);
 
 			return;
 		}

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
@@ -17,15 +17,22 @@
 package reactor.core.publisher;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -729,5 +736,215 @@ public class OperatorsTest {
 
 		Assertions.assertThat(Operators.toConditionalSubscriber(original))
 		          .isEqualTo(original);
+	}
+
+	@Test
+	public void discardQueueWithClearContinuesOnExtractionError() {
+		AtomicInteger discardedCount = new AtomicInteger();
+		Context hookContext = Operators.discardLocalAdapter(Integer.class, i -> {
+			if (i == 3) throw new IllegalStateException("boom");
+			discardedCount.incrementAndGet();
+		}).apply(Context.empty());
+
+		Queue<List<Integer>> q = new ArrayBlockingQueue<>(5);
+		q.add(Collections.singletonList(1));
+		q.add(Collections.singletonList(2));
+		q.add(Arrays.asList(3, 30));
+		q.add(Collections.singletonList(4));
+		q.add(Collections.singletonList(5));
+
+		Operators.onDiscardQueueWithClear(q, hookContext, o -> {
+			List<Integer> l = o;
+			if (l.size() == 2) throw new IllegalStateException("boom in extraction");
+			return l.stream();
+		});
+
+		assertThat(discardedCount).hasValue(4);
+	}
+
+	@Test
+	public void discardQueueWithClearContinuesOnExtractedElementNotDiscarded() {
+		AtomicInteger discardedCount = new AtomicInteger();
+		Context hookContext = Operators.discardLocalAdapter(Integer.class, i -> {
+			if (i == 3) throw new IllegalStateException("boom");
+			discardedCount.incrementAndGet();
+		}).apply(Context.empty());
+
+		Queue<List<Integer>> q = new ArrayBlockingQueue<>(5);
+		q.add(Collections.singletonList(1));
+		q.add(Collections.singletonList(2));
+		q.add(Collections.singletonList(3));
+		q.add(Collections.singletonList(4));
+		q.add(Collections.singletonList(5));
+
+		Operators.onDiscardQueueWithClear(q, hookContext, Collection::stream);
+
+		assertThat(discardedCount).as("discarded 1 2 4 5").hasValue(4);
+	}
+
+	@Test
+	public void discardQueueWithClearContinuesOnRawQueueElementNotDiscarded() {
+		AtomicInteger discardedCount = new AtomicInteger();
+		Context hookContext = Operators.discardLocalAdapter(Integer.class, i -> {
+			if (i == 3) throw new IllegalStateException("boom");
+			discardedCount.incrementAndGet();
+		}).apply(Context.empty());
+
+		Queue<Integer> q = new ArrayBlockingQueue<>(5);
+		q.add(1);
+		q.add(2);
+		q.add(3);
+		q.add(4);
+		q.add(5);
+
+		Operators.onDiscardQueueWithClear(q, hookContext, null);
+
+		assertThat(discardedCount).as("discarded 1 2 4 5").hasValue(4);
+	}
+
+	@Test
+	public void discardQueueWithClearStopsOnQueuePollingError() {
+		AtomicInteger discardedCount = new AtomicInteger();
+		@SuppressWarnings("unchecked") Queue<Integer> q = Mockito.mock(Queue.class);
+		Mockito.when(q.poll())
+		       .thenReturn(1, 2)
+		       .thenThrow(new IllegalStateException("poll boom"))
+		       .thenReturn(4, 5)
+		       .thenReturn(null);
+
+		Context hookContext = Operators.discardLocalAdapter(Integer.class, i -> discardedCount.incrementAndGet()).apply(Context.empty());
+
+		Operators.onDiscardQueueWithClear(q, hookContext, null);
+
+		assertThat(discardedCount).as("discarding stops").hasValue(2);
+	}
+
+	@Test
+	public void discardStreamContinuesWhenElementFailsToBeDiscarded() {
+		Stream<Integer> stream = Stream.of(1, 2, 3, 4, 5);
+		AtomicInteger discardedCount = new AtomicInteger();
+		Context hookContext = Operators.discardLocalAdapter(Integer.class, i -> {
+			if (i == 3) throw new IllegalStateException("boom");
+			discardedCount.incrementAndGet();
+		}).apply(Context.empty());
+
+		Operators.onDiscardMultiple(stream, hookContext);
+
+		assertThat(discardedCount).hasValue(4);
+	}
+
+	@Test
+	public void discardStreamStopsOnIterationError() {
+		Stream<Integer> stream = Stream.of(1, 2, 3, 4, 5);
+		//noinspection ResultOfMethodCallIgnored
+		stream.count(); //consumes the Stream on purpose
+
+		AtomicInteger discardedCount = new AtomicInteger();
+		Context hookContext = Operators.discardLocalAdapter(Integer.class, i -> discardedCount.incrementAndGet()).apply(Context.empty());
+
+		Operators.onDiscardMultiple(stream, hookContext);
+
+		assertThat(discardedCount).hasValue(0);
+	}
+
+	@Test
+	public void discardCollectionContinuesWhenIteratorElementFailsToBeDiscarded() {
+		List<Integer> elements = Arrays.asList(1, 2, 3, 4, 5);
+		AtomicInteger discardedCount = new AtomicInteger();
+		Context hookContext = Operators.discardLocalAdapter(Integer.class, i -> {
+			if (i == 3) throw new IllegalStateException("boom");
+			discardedCount.incrementAndGet();
+		}).apply(Context.empty());
+
+		Operators.onDiscardMultiple(elements, hookContext);
+
+		assertThat(discardedCount).hasValue(4);
+	}
+
+	@Test
+	public void discardCollectionStopsOnIterationError() {
+		List<Integer> elements = Arrays.asList(1, 2, 3, 4, 5);
+		Iterator<Integer> trueIterator = elements.iterator();
+		Iterator<Integer> failingIterator = new Iterator<Integer>() {
+			@Override
+			public boolean hasNext() {
+				return trueIterator.hasNext();
+			}
+
+			@Override
+			public Integer next() {
+				Integer n = trueIterator.next();
+				if (n >= 3) throw new IllegalStateException("Iterator boom");
+				return n;
+			}
+		};
+		List<Integer> mock = Mockito.mock(List.class);
+		Mockito.when(mock.iterator()).thenReturn(failingIterator);
+
+		AtomicInteger discardedCount = new AtomicInteger();
+		Context hookContext = Operators.discardLocalAdapter(Integer.class, i -> {
+			if (i == 3) throw new IllegalStateException("boom");
+			discardedCount.incrementAndGet();
+		}).apply(Context.empty());
+
+		Operators.onDiscardMultiple(mock, hookContext);
+
+		assertThat(discardedCount).hasValue(2);
+	}
+
+	@Test
+	public void discardCollectionStopsOnIsEmptyError() {
+		@SuppressWarnings("unchecked") List<Integer> mock = Mockito.mock(List.class);
+		Mockito.when(mock.isEmpty()).thenThrow(new IllegalStateException("isEmpty boom"));
+
+		AtomicInteger discardedCount = new AtomicInteger();
+		Context hookContext = Operators.discardLocalAdapter(Integer.class, i -> discardedCount.incrementAndGet())
+		                               .apply(Context.empty());
+
+		Operators.onDiscardMultiple(mock, hookContext);
+
+		assertThat(discardedCount).hasValue(0);
+	}
+
+	@Test
+	public void discardIteratorContinuesWhenIteratorElementFailsToBeDiscarded() {
+		List<Integer> elements = Arrays.asList(1, 2, 3, 4, 5);
+		AtomicInteger discardedCount = new AtomicInteger();
+		Context hookContext = Operators.discardLocalAdapter(Integer.class, i -> {
+			if (i == 3) throw new IllegalStateException("boom");
+			discardedCount.incrementAndGet();
+		}).apply(Context.empty());
+
+		Operators.onDiscardMultiple(elements.iterator(), true, hookContext);
+
+		assertThat(discardedCount).hasValue(4);
+	}
+
+	@Test
+	public void discardIteratorStopsOnIterationError() {
+		List<Integer> elements = Arrays.asList(1, 2, 3, 4, 5);
+		Iterator<Integer> trueIterator = elements.iterator();
+		Iterator<Integer> failingIterator = new Iterator<Integer>() {
+			@Override
+			public boolean hasNext() {
+				return trueIterator.hasNext();
+			}
+
+			@Override
+			public Integer next() {
+				Integer n = trueIterator.next();
+				if (n >= 3) throw new IllegalStateException("Iterator boom");
+				return n;
+			}
+		};
+		AtomicInteger discardedCount = new AtomicInteger();
+		Context hookContext = Operators.discardLocalAdapter(Integer.class, i -> {
+			if (i == 3) throw new IllegalStateException("boom");
+			discardedCount.incrementAndGet();
+		}).apply(Context.empty());
+
+		Operators.onDiscardMultiple(failingIterator, true, hookContext);
+
+		assertThat(discardedCount).hasValue(2);
 	}
 }


### PR DESCRIPTION
…from iterator

If both an Iterator and a Spliterator can be generated for each of the
processed Iterables, then the Spliterator is used to ensure the Iterable
is SIZED. This allows us to safely assume we can iterate over the
remainder of the iterator when cancelling, in order to discard its
elements that weren't emitted.

Not doing this check would likely cause trouble with infinite discarding
loops in the case of infinite Iterables (which is technically possible).

For Streams, since both the iterator() and spliterator() methods are
terminating the Stream we only generate the Spliterator. We use it to
check SIZED and then wrap it in an Iterator adapter for iteration (which
is what BaseStream does by default).

Note that using a Spliterator to drive the internal iteration doesn't
work that well, since the default Iterable#spliterator isn't SIZED and
its estimatedSize() method doesn't behave like hasNext().
Iterator#hasNext is far better suited for looking ahead of the emitted
element to trigger onComplete immediately after the last onNext.