### PR TITLE
Fix #2023 by handling "empty `Callable`" case in `Flux#collectList`

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3184,25 +3184,25 @@ public abstract class Flux<T> implements Publisher<T> {
 				catch (Exception e) {
 					return Mono.error(e);
 				}
-				return Mono.fromCallable(() -> {
+				return Mono.onAssembly(new MonoCallable<>(() -> {
 					List<T> list = Flux.<T>listSupplier().get();
 					if (v != null) {
 						list.add(v);
 					}
 					return list;
-				});
+				}));
 
 			}
 			@SuppressWarnings("unchecked")
 			Callable<T> thiz = (Callable<T>)this;
-			return Mono.fromCallable(() -> {
+			return Mono.onAssembly(new MonoCallable<>(() -> {
 				List<T> list = Flux.<T>listSupplier().get();
 				T u = thiz.call();
 				if (u != null) {
 					list.add(u);
 				}
 				return list;
-			});
+			}));
 		}
 		return Mono.onAssembly(new MonoCollectList<>(this));
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3187,20 +3187,20 @@ public abstract class Flux<T> implements Publisher<T> {
 				if (v == null) {
 					return Mono.onAssembly(new MonoSupplier<>(listSupplier()));
 				}
-				return Mono.just(v).map(u -> {
-					List<T> list = Flux.<T>listSupplier().get();
-					list.add(u);
-					return list;
-				});
-
+				List<T> list = Flux.<T>listSupplier().get();
+				list.add(v);
+				return Mono.just(list);
 			}
 			@SuppressWarnings("unchecked")
 			Callable<T> thiz = (Callable<T>)this;
-			return Mono.onAssembly(new MonoCallable<>(thiz).map(u -> {
+			return Mono.fromCallable(() -> {
 				List<T> list = Flux.<T>listSupplier().get();
-				list.add(u);
+				T u = thiz.call();
+				if (u != null) {
+					list.add(u);
+				}
 				return list;
-			}));
+			});
 		}
 		return Mono.onAssembly(new MonoCollectList<>(this));
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3184,12 +3184,14 @@ public abstract class Flux<T> implements Publisher<T> {
 				catch (Exception e) {
 					return Mono.error(e);
 				}
-				if (v == null) {
-					return Mono.onAssembly(new MonoSupplier<>(listSupplier()));
-				}
-				List<T> list = Flux.<T>listSupplier().get();
-				list.add(v);
-				return Mono.just(list);
+				return Mono.fromCallable(() -> {
+					List<T> list = Flux.<T>listSupplier().get();
+					if (v != null) {
+						list.add(v);
+					}
+					return list;
+				});
+
 			}
 			@SuppressWarnings("unchecked")
 			Callable<T> thiz = (Callable<T>)this;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -255,6 +256,24 @@ public class MonoCollectListTest {
 			}
 		}
 		LOGGER.info("discarded twice or more: {}", doubleDiscardCounter.get());
+	}
+
+	@Test
+	public void emptyCallable() {
+		class EmptyFluxCallable extends Flux<Object> implements Callable<Object> {
+			@Override
+			public Object call() {
+				return null;
+			}
+
+			@Override
+			public void subscribe(CoreSubscriber<? super Object> actual) {
+				Flux.empty().subscribe(actual);
+			}
+		}
+		List<Object> result = new EmptyFluxCallable().collectList().block();
+
+		assertThat(result).isEmpty();
 	}
 
 }


### PR DESCRIPTION
It seems that we were handling `Callable` (but not `Fuseable.ScalarCallable`) incorrectly
and, instead of producing an empty list, were returning an empty `Mono` instead.

The change also simplifies handling of `Fuseable.ScalarCallable`