### PR TITLE
Fix #1937 use local requested value to avoid extra emit

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
@@ -293,7 +293,7 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 			long r = REQUESTED.getAndDecrement(this);
 			if(r > 0){
 				actual.onNext(b);
-				return requested > 0;
+				return r > 1;
 			}
 			cancel();
 			actual.onError(Exceptions.failWithOverflow("Could not emit buffer due to lack of requests"));

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
@@ -148,6 +148,7 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 					s.request(Long.MAX_VALUE);
 				}
 				else {
+					long r = REQUESTED.get(this);
 					// Requesting from source may have been interrupted if downstream
 					// received enough buffer (requested == 0), so this new request for
 					// buffer should resume progressive filling from upstream. We can
@@ -160,7 +161,9 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 							REQUESTED,
 							this,
 							this)) {
-						s.request(1);
+						if (r == 0L) {
+							s.request(1L);
+						}
 					}
 				}
 			}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
@@ -741,4 +741,20 @@ public class FluxBufferPredicateTest {
 		            .verifyThenAssertThat()
 		            .hasDiscardedExactly(1, 2, 3);
 	}
+
+	@Test
+	public void testBufferUntilNoExtraRequestFromEmit() {
+		Flux<List<Integer>> numbers = Flux.just(1, 2, 3)
+				.bufferUntil(val -> true)
+				.log();
+
+		StepVerifier.create(numbers, 1)
+				.expectNext(Collections.singletonList(1))
+				.thenRequest(1)
+				.expectNext(Collections.singletonList(2))
+				.thenAwait()
+				.thenRequest(1)
+				.expectNext(Collections.singletonList(3))
+				.verifyComplete();
+	}
 }


### PR DESCRIPTION
if subscriber has finite demand and requests data from onNext()
then FluxBufferPredicate.request() adds it to `FluxBufferPredicate.requested`
and propagates it to the parent subscription. FluxBufferPredicate.emit() used
mutated `requested` to check if more request is needed
which leads to the extra request