### PR TITLE
fix #1937 Account for requests made to upstream in FluxBufferPredicate

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
@@ -114,12 +114,19 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 
 		volatile boolean fastpath;
 
-		volatile long requested;
+		volatile long requestedBuffers;
 
 		@SuppressWarnings("rawtypes")
-		static final AtomicLongFieldUpdater<BufferPredicateSubscriber> REQUESTED =
+		static final AtomicLongFieldUpdater<BufferPredicateSubscriber> REQUESTED_BUFFERS =
 				AtomicLongFieldUpdater.newUpdater(BufferPredicateSubscriber.class,
-						"requested");
+						"requestedBuffers");
+
+		volatile long requestedFromSource;
+
+		@SuppressWarnings("rawtypes")
+		static final AtomicLongFieldUpdater<BufferPredicateSubscriber> REQUESTED_FROM_SOURCE =
+				AtomicLongFieldUpdater.newUpdater(BufferPredicateSubscriber.class,
+						"requestedFromSource");
 
 		volatile Subscription s;
 
@@ -144,7 +151,8 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 					// here we request everything from the source. switching to
 					// fastpath will avoid unnecessary request(1) during filling
 					fastpath = true;
-					requested = Long.MAX_VALUE;
+					requestedBuffers = Long.MAX_VALUE;
+					requestedFromSource = Long.MAX_VALUE;
 					s.request(Long.MAX_VALUE);
 				}
 				else {
@@ -156,11 +164,11 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 					// we'll continue requesting one by one)
 					if (!DrainUtils.postCompleteRequest(n,
 							actual,
-							this,
-							REQUESTED,
+							this, REQUESTED_BUFFERS,
 							this,
 							this)) {
-						s.request(1);
+						Operators.addCap(REQUESTED_FROM_SOURCE, this, n);
+						s.request(n);
 					}
 				}
 			}
@@ -205,25 +213,33 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 				return true;
 			}
 
-			boolean requestMore;
 			if (mode == Mode.UNTIL && match) {
 				b.add(t);
-				requestMore = onNextNewBuffer();
+				onNextNewBuffer();
 			}
 			else if (mode == Mode.UNTIL_CUT_BEFORE && match) {
-				requestMore = onNextNewBuffer();
+				onNextNewBuffer();
 				b = buffer;
 				b.add(t);
 			}
 			else if (mode == Mode.WHILE && !match) {
-				requestMore = onNextNewBuffer();
+				onNextNewBuffer();
 			}
 			else {
 				b.add(t);
-				return !(!fastpath && requested != 0);
 			}
 
-			return !requestMore;
+			if (fastpath) {
+				return true;
+			}
+
+			boolean isNotExpectingFromSource = REQUESTED_FROM_SOURCE.decrementAndGet(this) == 0;
+			boolean isStillExpectingBuffer = REQUESTED_BUFFERS.get(this) > 0;
+			if (isNotExpectingFromSource && isStillExpectingBuffer
+					&& REQUESTED_FROM_SOURCE.compareAndSet(this, 0, 1)) {
+				return false; //explicitly mark as "needing more", either in attached conditional or onNext()
+			}
+			return true;
 		}
 
 		@Nullable
@@ -251,12 +267,21 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 			return b;
 		}
 
-		private boolean onNextNewBuffer() {
+		private void onNextNewBuffer() {
 			C b = triggerNewBuffer();
 			if (b != null) {
-				return emit(b);
+				if (fastpath) {
+					actual.onNext(b);
+					return;
+				}
+				long r = REQUESTED_BUFFERS.getAndDecrement(this);
+				if (r > 0) {
+					actual.onNext(b);
+					return;
+				}
+				cancel();
+				actual.onError(Exceptions.failWithOverflow("Could not emit buffer due to lack of requests"));
 			}
-			return true;
 		}
 
 		@Override
@@ -282,22 +307,7 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 				return;
 			}
 			done = true;
-			DrainUtils.postComplete(actual, this, REQUESTED, this, this);
-		}
-
-		boolean emit(C b) {
-			if (fastpath) {
-				actual.onNext(b);
-				return false;
-			}
-			long r = REQUESTED.getAndDecrement(this);
-			if(r > 0){
-				actual.onNext(b);
-				return requested > 0;
-			}
-			cancel();
-			actual.onError(Exceptions.failWithOverflow("Could not emit buffer due to lack of requests"));
-			return false;
+			DrainUtils.postComplete(actual, this, REQUESTED_BUFFERS, this, this);
 		}
 
 		@Override
@@ -309,7 +319,7 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 				C b = buffer;
 				return b != null ? b.size() : 0;
 			}
-			if (key == Attr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == Attr.REQUESTED_FROM_DOWNSTREAM) return requestedBuffers;
 
 			return InnerOperator.super.scanUnsafe(key);
 		}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
@@ -21,15 +21,23 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Supplier;
+import java.util.stream.StreamSupport;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
 import reactor.core.Scannable;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import static org.hamcrest.Matchers.contains;
@@ -472,12 +480,32 @@ public class FluxBufferPredicateTest {
 		            .expectComplete()
 		            .verify();
 
-		assertThat(requestCallCount.intValue(), is(11)); //10 elements then the completion
-		assertThat(totalRequest.longValue(), is(11L)); //ignores the main requests
+		/*
+			request pattern expected:
+
+			BUF 1 => 1 buffer wanted
+			  UP 1 => 1/3 1st buffer, propagated from above
+			UP 1 => 2/3 1st buffer
+			UP 1 => EMIT 1st buffer
+			--- pause
+			BUF 2 => 2 more buffers wanted
+			  UP 2 => 2/3 2nd buffer
+			UP 1 => EMIT 2nd buffer
+			UP 1 => 1/3 3rd buffer
+			UP 1 => 2/3 3rd buffer
+			UP 1 => EMIT 3rd buffer
+			--- pause
+			BUF 3
+			  UP 3 => 1/3 4th buffer then COMPLETED
+			COMPLETED
+
+			hence 9 request calls and request(12) total (2 extraneous due to last request(3))
+		 */
+		assertThat(requestCallCount.intValue(), is(9));
+		assertThat(totalRequest.longValue(), is(12L));
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void requestBoundedSeveralInitial() {
 		LongAdder requestCallCount = new LongAdder();
 		LongAdder totalRequest = new LongAdder();
@@ -497,12 +525,29 @@ public class FluxBufferPredicateTest {
 		            .expectComplete()
 		            .verify(Duration.ofSeconds(1));
 
-		assertThat(requestCallCount.intValue(), is(11)); //10 elements then the completion
-		assertThat(totalRequest.longValue(), is(11L)); //ignores the main requests
+		/*
+			upstream requesting pattern:
+			2 => initial request, wants 2 buffers, upstream request propagated
+			  up 2 => 2/3 1st buffer
+			up 1 => EMIT 1st buffer
+			up 1 => 1/3 2nd buffer
+			up 1 => 2/3 2nd buffer
+			up 1 => EMIT 2nd buffer
+			--- pause
+			2 => wants 2 more buffers, up 2
+			 up 2 => 2/3 3rd buffer
+			up 1 => EMIT 3rd buffer
+			up 1 => 1/3 4th buffer
+			up 1 => COMPLETED
+
+			so 9 total upstream requests calls
+			and 11 total requested
+		 */
+		assertThat(requestCallCount.intValue(), is(9));
+		assertThat(totalRequest.longValue(), is(11L));
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void requestRemainingBuffersAfterBufferEmission() {
 		LongAdder requestCallCount = new LongAdder();
 		LongAdder totalRequest = new LongAdder();
@@ -521,8 +566,26 @@ public class FluxBufferPredicateTest {
 		            .expectComplete()
 		            .verify(Duration.ofSeconds(1));
 
-		assertThat(requestCallCount.intValue(), is(11)); //10 elements then the completion
-		assertThat(totalRequest.longValue(), is(11L)); //ignores the main requests
+		/*
+			upstream requesting pattern:
+			3 => initial request, wants 3 buffers, upstream request propagated
+			  up 3 => 3/3, EMIT 1st buffer
+			up 1 => 1/3 2nd buffer
+			up 1 => 2/3 2nd buffer
+			up 1 => EMIT 2nd buffer
+			up 1 => 1/3 3rd buffer
+			up 1 => 2/3 3rd buffer
+			up 1 => EMIT 3rd buffer
+			--- pause
+			1 => want 1 more buffer
+			  up 1 => 1/3 2nd buffer
+			up 1 => COMPLETED
+
+			so 9 total upstream requests calls
+			and 11 total requested
+		 */
+		assertThat(requestCallCount.intValue(), is(9));
+		assertThat(totalRequest.longValue(), is(11L));
 	}
 
 	@Test
@@ -740,5 +803,87 @@ public class FluxBufferPredicateTest {
 		            .expectErrorMessage("boom")
 		            .verifyThenAssertThat()
 		            .hasDiscardedExactly(1, 2, 3);
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/1937
+	@Test
+	public void testBufferUntilNoExtraRequestFromEmit() {
+		Flux<List<Integer>> numbers = Flux.just(1, 2, 3)
+		                                  .hide()
+		                                  .bufferUntil(val -> true);
+
+		StepVerifier.create(numbers, 1)
+				.expectNext(Collections.singletonList(1))
+				.thenRequest(1)
+				.expectNext(Collections.singletonList(2))
+				.thenAwait()
+				.thenRequest(1)
+				.expectNext(Collections.singletonList(3))
+				.verifyComplete();
+	}
+
+	//see https://github.com/reactor/reactor-core/pull/2027
+	@Test
+	public void testBufferUntilNoExtraRequestFromConcurrentEmitAndRequest() {
+		AtomicReference<Throwable> errorOrComplete = new AtomicReference<>();
+		ConcurrentLinkedQueue<List<Integer>> buffers = new ConcurrentLinkedQueue<>();
+		final BaseSubscriber<List<Integer>> subscriber = new BaseSubscriber<List<Integer>>() {
+			@Override
+			protected void hookOnSubscribe(Subscription subscription) {
+				request(1);
+			}
+			@Override
+			protected void hookOnNext(List<Integer> value) {
+				buffers.add(value);
+				if (value.equals(Collections.singletonList(0))) {
+					request(1);
+				}
+			}
+
+			@Override
+			protected void hookOnError(Throwable throwable) {
+				errorOrComplete.set(throwable);
+			}
+
+			@Override
+			protected void hookFinally(SignalType type) {
+				if (type != SignalType.ON_ERROR) {
+					errorOrComplete.set(new IllegalArgumentException("Terminated with signal type " + type));
+				}
+			}
+		};
+		final CountDownLatch emitLatch = new CountDownLatch(1);
+		Flux.just(0, 1, 2, 3, 4)
+		    .bufferUntil(s -> {
+			    if (s == 1) {
+				    try {
+					    Mono.fromRunnable(() -> {
+						    subscriber.request(1);
+						    emitLatch.countDown();
+					    })
+					        .subscribeOn(Schedulers.single())
+					        .subscribe();
+					    emitLatch.await();
+				    } catch (InterruptedException e) {
+					    throw Exceptions.propagate(e);
+				    }
+			    }
+			    return true;
+		    })
+		    .subscribe((Subscriber<? super List<Integer>>) subscriber); //sync subscriber, no need to sleep/latch
+
+		Assertions.assertThat(buffers).hasSize(3)
+		          .allMatch(b -> b.size() == 1, "size one");
+		//total requests: 3
+		Assertions.assertThat(buffers.stream().flatMapToInt(l -> l.stream().mapToInt(Integer::intValue)))
+		          .containsExactly(0,1,2);
+
+		Assertions.assertThat(errorOrComplete.get()).isNull();
+
+		//request the rest
+		subscriber.requestUnbounded();
+
+		Assertions.assertThat(errorOrComplete.get()).isInstanceOf(IllegalArgumentException.class)
+		          .hasMessage("Terminated with signal type onComplete");
 	}
 }

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -1702,7 +1702,6 @@ public class StepVerifierTests {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void requestBufferDoesntOverflow() {
 		LongAdder requestCallCount = new LongAdder();
 		LongAdder totalRequest = new LongAdder();
@@ -1723,8 +1722,9 @@ public class StepVerifierTests {
 		            .expectComplete()
 		            .verify();
 
-		assertThat(requestCallCount.intValue()).isEqualTo(11); //10 elements then the completion
-		assertThat(totalRequest.longValue()).isEqualTo(11L); //ignores the main requests
+		//see same pattern in reactor.core.publisher.FluxBufferPredicateTest.requestBounded
+		assertThat(requestCallCount.intValue()).isEqualTo(9L);
+		assertThat(totalRequest.longValue()).isEqualTo(12L);
 	}
 
 	@Test(timeout = 1000L)


### PR DESCRIPTION
This commit adds additional request accounting to FluxBufferPredicate,
allowing it to keep track of when there is remaining upstream request
and when there is not. In turn, this allows the "just add to buffer"
case to perform an additional `request(1)` ONLY if necessary (to further
fill the current buffer).

supersedes #2027 cc @UgiR @robotmrv