### PR TITLE
fix #1899 Document Flux#next() behavior for an empty Flux

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -6033,6 +6033,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 
 	/**
 	 * Emit only the first item emitted by this {@link Flux}, into a new {@link Mono}.
+	 * If called on an empty {@link Flux}, emits an empty {@link Mono}.
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/next.svg" alt="">
 	 *


### PR DESCRIPTION
Only `JavaDoc` is updated since as it seems the only reasonable place to add this information in the `Reference Docs` is the [appendix](https://projectreactor.io/docs/core/release/reference/#which.filtering), however, all the phrases there are placed at one line with only general information, that is why it seems for me as not an appropriate place after all.

Fixes #1899