### PR TITLE
fix #2050 Use stream().sequential() for Context default putAll

### DIFF
--- a/reactor-core/src/main/java/reactor/util/context/Context.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context.java
@@ -348,8 +348,8 @@ public interface Context {
 		}
 
 		ContextN newContext = new ContextN(this.size() + other.size());
-		this.stream().forEach(newContext);
-		other.stream().forEach(newContext);
+		this.stream().sequential().forEach(newContext);
+		other.stream().sequential().forEach(newContext);
 		if (newContext.size() <= 5) {
 			// make it return Context{1-5}
 			return Context.of(newContext);

--- a/reactor-core/src/main/java/reactor/util/context/ContextN.java
+++ b/reactor-core/src/main/java/reactor/util/context/ContextN.java
@@ -177,7 +177,7 @@ final class ContextN extends LinkedHashMap<Object, Object>
 		}
 		else {
 			// avoid Collector to reduce the allocations
-			other.stream().forEach(newContext);
+			other.stream().sequential().forEach(newContext);
 		}
 
 		return newContext;

--- a/reactor-core/src/main/java/reactor/util/context/CoreContext.java
+++ b/reactor-core/src/main/java/reactor/util/context/CoreContext.java
@@ -40,7 +40,7 @@ interface CoreContext extends Context {
 
 		ContextN newContext = new ContextN(this.size() + other.size());
 		this.unsafePutAllInto(newContext);
-		other.stream().forEach(newContext);
+		other.stream().sequential().forEach(newContext);
 		if (newContext.size() <= 5) {
 			// make it return Context{1-5}
 			return Context.of(newContext);

--- a/reactor-core/src/test/java/reactor/util/context/ContextTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextTest.java
@@ -489,13 +489,16 @@ public class ContextTest {
 			}
 		};
 
-		Context combined = left.putAll(right);
-		assertThat(combined).isInstanceOf(ContextN.class);
-		ContextN combinedN = (ContextN) combined;
+		//this test proved flaky in the past, due to the parallelization
+		for (int i = 0; i < 1000; i++) {
+			Context combined = left.putAll(right);
+			assertThat(combined).isInstanceOf(ContextN.class);
+			ContextN combinedN = (ContextN) combined;
 
-		assertThat(combinedN)
-				.containsKeys(1, 2, 3, 4, 5, 10, 11, 12, 13)
-				.containsValues("A", "B", "C", "D", "E", "A10", "A11", "A12", "A13");
+			assertThat(combinedN)
+					.containsKeys(1, 2, 3, 4, 5, 10, 11, 12, 13)
+					.containsValues("A", "B", "C", "D", "E", "A10", "A11", "A12", "A13");
+		}
 	}
 
 	@Test


### PR DESCRIPTION
In case an external `Context` implementation returns a parallel Stream,
default `putAll` can fail due to `ContextN` not being thread-safe.

This commit ensures that when such operations are performed over the
`stream()`, it is forced to be `sequential()`.