### PR TITLE
Unify handling of errors thrown by `subscribeOrReturn`

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -8251,7 +8251,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 					subscriber = operator.subscribeOrReturn(subscriber);
 				}
 				catch (Throwable e) {
-					Operators.error(subscriber, Operators.onOperatorError(e,  subscriber.currentContext()));
+					Operators.error(subscriber, Operators.onOperatorError(e, subscriber.currentContext()));
 					return;
 				}
 				if (subscriber == null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -8247,7 +8247,13 @@ public abstract class Flux<T> implements CorePublisher<T> {
 		if (publisher instanceof OptimizableOperator) {
 			OptimizableOperator operator = (OptimizableOperator) publisher;
 			while (true) {
-				subscriber = operator.subscribeOrReturn(subscriber);
+				try {
+					subscriber = operator.subscribeOrReturn(subscriber);
+				}
+				catch (Throwable e) {
+					Operators.error(subscriber, Operators.onOperatorError(e,  subscriber.currentContext()));
+					return;
+				}
 				if (subscriber == null) {
 					// null means "I will subscribe myself", returning...
 					return;

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -8244,30 +8244,30 @@ public abstract class Flux<T> implements CorePublisher<T> {
 		CorePublisher publisher = Operators.onLastAssembly(this);
 		CoreSubscriber subscriber = Operators.toCoreSubscriber(actual);
 
-		if (publisher instanceof OptimizableOperator) {
-			OptimizableOperator operator = (OptimizableOperator) publisher;
-			while (true) {
-				try {
+		try {
+			if (publisher instanceof OptimizableOperator) {
+				OptimizableOperator operator = (OptimizableOperator) publisher;
+				while (true) {
 					subscriber = operator.subscribeOrReturn(subscriber);
+					if (subscriber == null) {
+						// null means "I will subscribe myself", returning...
+						return;
+					}
+					OptimizableOperator newSource = operator.nextOptimizableSource();
+					if (newSource == null) {
+						publisher = operator.source();
+						break;
+					}
+					operator = newSource;
 				}
-				catch (Throwable e) {
-					Operators.error(subscriber, Operators.onOperatorError(e, subscriber.currentContext()));
-					return;
-				}
-				if (subscriber == null) {
-					// null means "I will subscribe myself", returning...
-					return;
-				}
-				OptimizableOperator newSource = operator.nextOptimizableSource();
-				if (newSource == null) {
-					publisher = operator.source();
-					break;
-				}
-				operator = newSource;
 			}
-		}
 
-		publisher.subscribe(subscriber);
+			publisher.subscribe(subscriber);
+		}
+		catch (Throwable e) {
+			Operators.reportThrowInSubscribe(subscriber, e);
+			return;
+		}
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
@@ -61,16 +61,8 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super C> actual) {
-		C buffer;
-
-		try {
-			buffer = Objects.requireNonNull(bufferSupplier.get(),
-					"The bufferSupplier returned a null buffer");
-		}
-		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e,  actual.currentContext()));
-			return null;
-		}
+		C buffer = Objects.requireNonNull(bufferSupplier.get(),
+				"The bufferSupplier returned a null buffer");
 
 		BufferBoundaryMain<T, U, C> parent =
 				new BufferBoundaryMain<>(

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
@@ -81,16 +81,8 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super C> actual) {
-		C initialBuffer;
-
-		try {
-			initialBuffer = Objects.requireNonNull(bufferSupplier.get(),
-					"The bufferSupplier returned a null initial buffer");
-		}
-		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
-			return null;
-		}
+		C initialBuffer = Objects.requireNonNull(bufferSupplier.get(),
+				"The bufferSupplier returned a null initial buffer");
 
 		BufferPredicateSubscriber<T, C> parent = new BufferPredicateSubscriber<>(actual,
 				initialBuffer, bufferSupplier, predicate, mode);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxContextStart.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxContextStart.java
@@ -37,14 +37,7 @@ final class FluxContextStart<T> extends InternalFluxOperator<T, T> implements Fu
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
-		Context c;
-		try {
-			c = doOnContext.apply(actual.currentContext());
-		}
-		catch (Throwable t) {
-			Operators.error(actual, Operators.onOperatorError(t, actual.currentContext()));
-			return null;
-		}
+		Context c = doOnContext.apply(actual.currentContext());
 
 		return new ContextStartSubscriber<>(actual, c);
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDistinct.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDistinct.java
@@ -62,16 +62,8 @@ final class FluxDistinct<T, K, C> extends InternalFluxOperator<T, T> {
 	@Override
 	@SuppressWarnings("unchecked")
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
-		C collection;
-
-		try {
-			collection = Objects.requireNonNull(collectionSupplier.get(),
-					"The collectionSupplier returned a null collection");
-		}
-		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
-			return null;
-		}
+		C collection = Objects.requireNonNull(collectionSupplier.get(),
+				"The collectionSupplier returned a null collection");
 
 		if (actual instanceof ConditionalSubscriber) {
 			return new DistinctConditionalSubscriber<>((ConditionalSubscriber<? super T>) actual,

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDistinctFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDistinctFuseable.java
@@ -56,16 +56,8 @@ final class FluxDistinctFuseable<T, K, C>
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
-		C collection;
-
-		try {
-			collection = Objects.requireNonNull(collectionSupplier.get(),
-					"The collectionSupplier returned a null collection");
-		}
-		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
-			return null;
-		}
+		C collection = Objects.requireNonNull(collectionSupplier.get(),
+				"The collectionSupplier returned a null collection");
 
 		return new DistinctFuseableSubscriber<>(actual, collection, keyExtractor,
 				distinctPredicate, cleanupCallback);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDoFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDoFirst.java
@@ -44,14 +44,7 @@ final class FluxDoFirst<T> extends InternalFluxOperator<T, T> {
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
-
-		try {
-			onFirst.run();
-		}
-		catch (Throwable error) {
-			Operators.error(actual, error);
-			return null;
-		}
+		onFirst.run();
 		return actual;
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDoFirstFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDoFirstFuseable.java
@@ -45,13 +45,7 @@ final class FluxDoFirstFuseable<T> extends InternalFluxOperator<T, T> implements
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
-		try {
-			onFirst.run();
-		}
-		catch (Throwable error) {
-			Operators.error(actual, error);
-			return null;
-		}
+		onFirst.run();
 
 		return actual;
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
@@ -71,19 +71,10 @@ final class FluxFlattenIterable<T, R> extends InternalFluxOperator<T, R> impleme
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
+	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) throws Exception {
 
 		if (source instanceof Callable) {
-			T v;
-
-			try {
-				v = ((Callable<T>) source).call();
-			}
-			catch (Throwable ex) {
-				Operators.error(actual, Operators.onOperatorError(ex,
-						actual.currentContext()));
-				return null;
-			}
+			T v = ((Callable<T>) source).call();
 
 			if (v == null) {
 				Operators.complete(actual);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFromMonoOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFromMonoOperator.java
@@ -76,7 +76,7 @@ abstract class FluxFromMonoOperator<I, O> extends Flux<O> implements Scannable,
 				subscriber = operator.subscribeOrReturn(subscriber);
 			}
 			catch (Throwable e) {
-				Operators.error(subscriber, Operators.onOperatorError(e,  subscriber.currentContext()));
+				Operators.error(subscriber, Operators.onOperatorError(e, subscriber.currentContext()));
 				return;
 			}
 			if (subscriber == null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFromMonoOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFromMonoOperator.java
@@ -72,7 +72,13 @@ abstract class FluxFromMonoOperator<I, O> extends Flux<O> implements Scannable,
 	public final void subscribe(CoreSubscriber<? super O> subscriber) {
 		OptimizableOperator operator = this;
 		while (true) {
-			subscriber = operator.subscribeOrReturn(subscriber);
+			try {
+				subscriber = operator.subscribeOrReturn(subscriber);
+			}
+			catch (Throwable e) {
+				Operators.error(subscriber, Operators.onOperatorError(e,  subscriber.currentContext()));
+				return;
+			}
 			if (subscriber == null) {
 				// null means "I will subscribe myself", returning...
 				return;
@@ -88,7 +94,7 @@ abstract class FluxFromMonoOperator<I, O> extends Flux<O> implements Scannable,
 
 	@Override
 	@Nullable
-	public abstract CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual);
+	public abstract CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) throws Throwable;
 
 	@Override
 	public final CorePublisher<? extends I> source() {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFromMonoOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFromMonoOperator.java
@@ -71,24 +71,24 @@ abstract class FluxFromMonoOperator<I, O> extends Flux<O> implements Scannable,
 	@SuppressWarnings("unchecked")
 	public final void subscribe(CoreSubscriber<? super O> subscriber) {
 		OptimizableOperator operator = this;
-		while (true) {
-			try {
+		try {
+			while (true) {
 				subscriber = operator.subscribeOrReturn(subscriber);
+				if (subscriber == null) {
+					// null means "I will subscribe myself", returning...
+					return;
+				}
+				OptimizableOperator newSource = operator.nextOptimizableSource();
+				if (newSource == null) {
+					operator.source().subscribe(subscriber);
+					return;
+				}
+				operator = newSource;
 			}
-			catch (Throwable e) {
-				Operators.error(subscriber, Operators.onOperatorError(e, subscriber.currentContext()));
-				return;
-			}
-			if (subscriber == null) {
-				// null means "I will subscribe myself", returning...
-				return;
-			}
-			OptimizableOperator newSource = operator.nextOptimizableSource();
-			if (newSource == null) {
-				operator.source().subscribe(subscriber);
-				return;
-			}
-			operator = newSource;
+		}
+		catch (Throwable e) {
+			Operators.reportThrowInSubscribe(subscriber, e);
+			return;
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMergeOrdered.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMergeOrdered.java
@@ -60,6 +60,14 @@ final class FluxMergeOrdered<T> extends Flux<T> implements SourceProducer<T> {
 			throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
 		}
 		this.sources = Objects.requireNonNull(sources, "sources must be non-null");
+
+		for (int i = 0; i < sources.length; i++) {
+			Publisher<? extends T> source = sources[i];
+			if (source == null) {
+				throw new NullPointerException("sources[" + i + "] is null");
+			}
+		}
+
 		this.prefetch = prefetch;
 		this.queueSupplier = queueSupplier;
 		this.valueComparator = valueComparator;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
@@ -75,17 +75,8 @@ final class FluxPublishMulticast<T, R> extends InternalFluxOperator<T, R> implem
 				queueSupplier,
 				actual.currentContext());
 
-		Publisher<? extends R> out;
-
-		try {
-			out = Objects.requireNonNull(transform.apply(multicast),
-					"The transform returned a null Publisher");
-		}
-		catch (Throwable ex) {
-			Operators.error(actual,
-					Operators.onOperatorError(ex, actual.currentContext()));
-			return null;
-		}
+		Publisher<? extends R> out = Objects.requireNonNull(transform.apply(multicast),
+				"The transform returned a null Publisher");
 
 		if (out instanceof Fuseable) {
 			out.subscribe(new CancelFuseableMulticaster<>(actual, multicast));

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
@@ -83,16 +83,8 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 	@Override
 	@SuppressWarnings("unchecked")
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
-		Worker worker;
-
-		try {
-			worker = Objects.requireNonNull(scheduler.createWorker(),
-					"The scheduler returned a null worker");
-		}
-		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
-			return null;
-		}
+		Worker worker = Objects.requireNonNull(scheduler.createWorker(),
+				"The scheduler returned a null worker");
 
 		if (actual instanceof ConditionalSubscriber) {
 			ConditionalSubscriber<? super T> cs = (ConditionalSubscriber<? super T>) actual;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -1069,7 +1069,13 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 
 		cancelSupport.accept(s);
 		if (doConnect) {
-			source.subscribe(s);
+			try {
+				source.subscribe(s);
+			}
+			catch (Throwable e) {
+				Operators.reportThrowInSubscribe(connection, e);
+				return;
+			}
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -1076,15 +1076,21 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 	@Override
 	@SuppressWarnings("unchecked")
 	public void subscribe(CoreSubscriber<? super T> actual) {
-		CoreSubscriber nextSubscriber = subscribeOrReturn(actual);
-		if (nextSubscriber == null) {
+		try {
+			CoreSubscriber nextSubscriber = subscribeOrReturn(actual);
+			if (nextSubscriber == null) {
+				return;
+			}
+			source.subscribe(nextSubscriber);
+		}
+		catch (Throwable e) {
+			Operators.error(actual, Operators.onOperatorError(e,  actual.currentContext()));
 			return;
 		}
-		source.subscribe(nextSubscriber);
 	}
 
 	@Override
-	public final CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
+	public final CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) throws Throwable {
 		boolean expired;
 		for (; ; ) {
 			ReplaySubscriber<T> c = connection;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -1084,7 +1084,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 			source.subscribe(nextSubscriber);
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e,  actual.currentContext()));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSubscribeOn.java
@@ -50,15 +50,8 @@ final class FluxSubscribeOn<T> extends InternalFluxOperator<T, T> {
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
-		Worker worker;
-
-		try {
-			worker = Objects.requireNonNull(scheduler.createWorker(),
-					"The scheduler returned a null Function");
-		} catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
-			return null;
-		}
+		Worker worker = Objects.requireNonNull(scheduler.createWorker(),
+				"The scheduler returned a null Function");
 
 		SubscribeOnSubscriber<T> parent = new SubscribeOnSubscriber<>(source,
 				actual, worker, requestOnSeparateThread);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxZipIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxZipIterable.java
@@ -49,26 +49,10 @@ final class FluxZipIterable<T, U, R> extends InternalFluxOperator<T, R> {
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
-		Iterator<? extends U> it;
+		Iterator<? extends U> it = Objects.requireNonNull(other.iterator(),
+				"The other iterable produced a null iterator");
 
-		try {
-			it = Objects.requireNonNull(other.iterator(),
-					"The other iterable produced a null iterator");
-		}
-		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
-			return null;
-		}
-
-		boolean b;
-
-		try {
-			b = it.hasNext();
-		}
-		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
-			return null;
-		}
+		boolean b = it.hasNext();
 
 		if (!b) {
 			Operators.complete(actual);

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalConnectableFluxOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalConnectableFluxOperator.java
@@ -55,7 +55,7 @@ abstract class InternalConnectableFluxOperator<I, O> extends ConnectableFlux<O> 
 				subscriber = operator.subscribeOrReturn(subscriber);
 			}
 			catch (Throwable e) {
-				Operators.error(subscriber, Operators.onOperatorError(e,  subscriber.currentContext()));
+				Operators.error(subscriber, Operators.onOperatorError(e, subscriber.currentContext()));
 				return;
 			}
 			if (subscriber == null) {
@@ -73,7 +73,7 @@ abstract class InternalConnectableFluxOperator<I, O> extends ConnectableFlux<O> 
 
 	@Override
 	@Nullable
-	public abstract CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual);
+	public abstract CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) throws Throwable;
 
 	@Override
 	public final CorePublisher<? extends I> source() {

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalConnectableFluxOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalConnectableFluxOperator.java
@@ -51,7 +51,13 @@ abstract class InternalConnectableFluxOperator<I, O> extends ConnectableFlux<O> 
 	public final void subscribe(CoreSubscriber<? super O> subscriber) {
 		OptimizableOperator operator = this;
 		while (true) {
-			subscriber = operator.subscribeOrReturn(subscriber);
+			try {
+				subscriber = operator.subscribeOrReturn(subscriber);
+			}
+			catch (Throwable e) {
+				Operators.error(subscriber, Operators.onOperatorError(e,  subscriber.currentContext()));
+				return;
+			}
 			if (subscriber == null) {
 				// null means "I will subscribe myself", returning...
 				return;

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalConnectableFluxOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalConnectableFluxOperator.java
@@ -50,24 +50,24 @@ abstract class InternalConnectableFluxOperator<I, O> extends ConnectableFlux<O> 
 	@SuppressWarnings("unchecked")
 	public final void subscribe(CoreSubscriber<? super O> subscriber) {
 		OptimizableOperator operator = this;
-		while (true) {
-			try {
+		try {
+			while (true) {
 				subscriber = operator.subscribeOrReturn(subscriber);
+				if (subscriber == null) {
+					// null means "I will subscribe myself", returning...
+					return;
+				}
+				OptimizableOperator newSource = operator.nextOptimizableSource();
+				if (newSource == null) {
+					operator.source().subscribe(subscriber);
+					return;
+				}
+				operator = newSource;
 			}
-			catch (Throwable e) {
-				Operators.error(subscriber, Operators.onOperatorError(e, subscriber.currentContext()));
-				return;
-			}
-			if (subscriber == null) {
-				// null means "I will subscribe myself", returning...
-				return;
-			}
-			OptimizableOperator newSource = operator.nextOptimizableSource();
-			if (newSource == null) {
-				operator.source().subscribe(subscriber);
-				return;
-			}
-			operator = newSource;
+		}
+		catch (Throwable e) {
+			Operators.reportThrowInSubscribe(subscriber, e);
+			return;
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalFluxOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalFluxOperator.java
@@ -51,7 +51,13 @@ abstract class InternalFluxOperator<I, O> extends FluxOperator<I, O> implements 
 	public final void subscribe(CoreSubscriber<? super O> subscriber) {
 		OptimizableOperator operator = this;
 		while (true) {
-			subscriber = operator.subscribeOrReturn(subscriber);
+			try {
+				subscriber = operator.subscribeOrReturn(subscriber);
+			}
+			catch (Throwable e) {
+				Operators.error(subscriber, Operators.onOperatorError(e,  subscriber.currentContext()));
+				return;
+			}
 			if (subscriber == null) {
 				// null means "I will subscribe myself", returning...
 				return;
@@ -66,7 +72,7 @@ abstract class InternalFluxOperator<I, O> extends FluxOperator<I, O> implements 
 	}
 
 	@Nullable
-	public abstract CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual);
+	public abstract CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) throws Throwable;
 
 	@Override
 	public final CorePublisher<? extends I> source() {

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalFluxOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalFluxOperator.java
@@ -55,7 +55,7 @@ abstract class InternalFluxOperator<I, O> extends FluxOperator<I, O> implements 
 				subscriber = operator.subscribeOrReturn(subscriber);
 			}
 			catch (Throwable e) {
-				Operators.error(subscriber, Operators.onOperatorError(e,  subscriber.currentContext()));
+				Operators.error(subscriber, Operators.onOperatorError(e, subscriber.currentContext()));
 				return;
 			}
 			if (subscriber == null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalMonoOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalMonoOperator.java
@@ -52,24 +52,24 @@ abstract class InternalMonoOperator<I, O> extends MonoOperator<I, O> implements 
 	@SuppressWarnings("unchecked")
 	public final void subscribe(CoreSubscriber<? super O> subscriber) {
 		OptimizableOperator operator = this;
-		while (true) {
-			try {
+		try {
+			while (true) {
 				subscriber = operator.subscribeOrReturn(subscriber);
+				if (subscriber == null) {
+					// null means "I will subscribe myself", returning...
+					return;
+				}
+				OptimizableOperator newSource = operator.nextOptimizableSource();
+				if (newSource == null) {
+					operator.source().subscribe(subscriber);
+					return;
+				}
+				operator = newSource;
 			}
-			catch (Throwable e) {
-				Operators.error(subscriber, Operators.onOperatorError(e, subscriber.currentContext()));
-				return;
-			}
-			if (subscriber == null) {
-				// null means "I will subscribe myself", returning...
-				return;
-			}
-			OptimizableOperator newSource = operator.nextOptimizableSource();
-			if (newSource == null) {
-				operator.source().subscribe(subscriber);
-				return;
-			}
-			operator = newSource;
+		}
+		catch (Throwable e) {
+			Operators.reportThrowInSubscribe(subscriber, e);
+			return;
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalMonoOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalMonoOperator.java
@@ -57,7 +57,7 @@ abstract class InternalMonoOperator<I, O> extends MonoOperator<I, O> implements 
 				subscriber = operator.subscribeOrReturn(subscriber);
 			}
 			catch (Throwable e) {
-				Operators.error(subscriber, Operators.onOperatorError(e,  subscriber.currentContext()));
+				Operators.error(subscriber, Operators.onOperatorError(e, subscriber.currentContext()));
 				return;
 			}
 			if (subscriber == null) {
@@ -74,7 +74,7 @@ abstract class InternalMonoOperator<I, O> extends MonoOperator<I, O> implements 
 	}
 
 	@Nullable
-	public abstract CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual);
+	public abstract CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) throws Throwable;
 
 	@Override
 	public final CorePublisher<? extends I> source() {

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalMonoOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalMonoOperator.java
@@ -53,7 +53,13 @@ abstract class InternalMonoOperator<I, O> extends MonoOperator<I, O> implements 
 	public final void subscribe(CoreSubscriber<? super O> subscriber) {
 		OptimizableOperator operator = this;
 		while (true) {
-			subscriber = operator.subscribeOrReturn(subscriber);
+			try {
+				subscriber = operator.subscribeOrReturn(subscriber);
+			}
+			catch (Throwable e) {
+				Operators.error(subscriber, Operators.onOperatorError(e,  subscriber.currentContext()));
+				return;
+			}
 			if (subscriber == null) {
 				// null means "I will subscribe myself", returning...
 				return;

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -4192,7 +4192,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 		if (publisher instanceof OptimizableOperator) {
 			OptimizableOperator operator = (OptimizableOperator) publisher;
 			while (true) {
-				subscriber = operator.subscribeOrReturn(subscriber);
+				try {
+					subscriber = operator.subscribeOrReturn(subscriber);
+				}
+				catch (Throwable e) {
+					Operators.error(subscriber, Operators.onOperatorError(e,  subscriber.currentContext()));
+					return;
+				}
 				if (subscriber == null) {
 					// null means "I will subscribe myself", returning...
 					return;

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -4196,7 +4196,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 					subscriber = operator.subscribeOrReturn(subscriber);
 				}
 				catch (Throwable e) {
-					Operators.error(subscriber, Operators.onOperatorError(e,  subscriber.currentContext()));
+					Operators.error(subscriber, Operators.onOperatorError(e, subscriber.currentContext()));
 					return;
 				}
 				if (subscriber == null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -4189,31 +4189,31 @@ public abstract class Mono<T> implements CorePublisher<T> {
 		CorePublisher publisher = Operators.onLastAssembly(this);
 		CoreSubscriber subscriber = Operators.toCoreSubscriber(actual);
 
-		if (publisher instanceof OptimizableOperator) {
-			OptimizableOperator operator = (OptimizableOperator) publisher;
-			while (true) {
-				try {
+		try {
+			if (publisher instanceof OptimizableOperator) {
+				OptimizableOperator operator = (OptimizableOperator) publisher;
+				while (true) {
 					subscriber = operator.subscribeOrReturn(subscriber);
-				}
-				catch (Throwable e) {
-					Operators.error(subscriber, Operators.onOperatorError(e, subscriber.currentContext()));
-					return;
-				}
-				if (subscriber == null) {
-					// null means "I will subscribe myself", returning...
-					return;
-				}
+					if (subscriber == null) {
+						// null means "I will subscribe myself", returning...
+						return;
+					}
 
-				OptimizableOperator newSource = operator.nextOptimizableSource();
-				if (newSource == null) {
-					publisher = operator.source();
-					break;
+					OptimizableOperator newSource = operator.nextOptimizableSource();
+					if (newSource == null) {
+						publisher = operator.source();
+						break;
+					}
+					operator = newSource;
 				}
-				operator = newSource;
 			}
-		}
 
-		publisher.subscribe(subscriber);
+			publisher.subscribe(subscriber);
+		}
+		catch (Throwable e) {
+			Operators.reportThrowInSubscribe(subscriber, e);
+			return;
+		}
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollect.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollect.java
@@ -54,16 +54,8 @@ final class MonoCollect<T, R> extends MonoFromFluxOperator<T, R>
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
-		R container;
-
-		try {
-			container = Objects.requireNonNull(supplier.get(),
-					"The supplier returned a null container");
-		}
-		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
-			return null;
-		}
+		R container = Objects.requireNonNull(supplier.get(),
+				"The supplier returned a null container");
 
 		return new CollectSubscriber<>(actual, action, container);
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDefer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDefer.java
@@ -38,8 +38,16 @@ final class MonoDefer<T> extends Mono<T> implements SourceProducer<T> {
 
 	@SuppressWarnings("unchecked")
 	public void subscribe(CoreSubscriber<? super T> actual) {
-		Mono<? extends T> p = Objects.requireNonNull(supplier.get(),
-				"The Mono returned by the supplier is null");
+		Mono<? extends T> p;
+
+		try {
+			p = Objects.requireNonNull(supplier.get(),
+					"The Mono returned by the supplier is null");
+		}
+		catch (Throwable e) {
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
+			return;
+		}
 
 		p.subscribe(actual);
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDefer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDefer.java
@@ -38,16 +38,8 @@ final class MonoDefer<T> extends Mono<T> implements SourceProducer<T> {
 
 	@SuppressWarnings("unchecked")
 	public void subscribe(CoreSubscriber<? super T> actual) {
-		Mono<? extends T> p;
-
-		try {
-			p = Objects.requireNonNull(supplier.get(),
-					"The Mono returned by the supplier is null");
-		}
-		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
-			return;
-		}
+		Mono<? extends T> p = Objects.requireNonNull(supplier.get(),
+				"The Mono returned by the supplier is null");
 
 		p.subscribe(actual);
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDeferWithContext.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDeferWithContext.java
@@ -39,9 +39,17 @@ final class MonoDeferWithContext<T> extends Mono<T> implements SourceProducer<T>
 
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
+		Mono<? extends T> p;
+
 		Context ctx = actual.currentContext();
-		Mono<? extends T> p = Objects.requireNonNull(supplier.apply(ctx),
-				"The Mono returned by the supplier is null");
+		try {
+			p = Objects.requireNonNull(supplier.apply(ctx),
+					"The Mono returned by the supplier is null");
+		}
+		catch (Throwable e) {
+			Operators.error(actual, Operators.onOperatorError(e, ctx));
+			return;
+		}
 
 		p.subscribe(actual);
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDeferWithContext.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDeferWithContext.java
@@ -39,17 +39,9 @@ final class MonoDeferWithContext<T> extends Mono<T> implements SourceProducer<T>
 
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
-		Mono<? extends T> p;
-
 		Context ctx = actual.currentContext();
-		try {
-			p = Objects.requireNonNull(supplier.apply(ctx),
-					"The Mono returned by the supplier is null");
-		}
-		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e, ctx));
-			return;
-		}
+		Mono<? extends T> p = Objects.requireNonNull(supplier.apply(ctx),
+				"The Mono returned by the supplier is null");
 
 		p.subscribe(actual);
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
@@ -93,11 +93,17 @@ final class MonoDelayUntil<T> extends Mono<T> implements Scannable,
 
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
-		source.subscribe(subscribeOrReturn(actual));
+		try {
+			source.subscribe(subscribeOrReturn(actual));
+		}
+		catch (Throwable e) {
+			Operators.error(actual, Operators.onOperatorError(e,  actual.currentContext()));
+			return;
+		}
 	}
 
 	@Override
-	public final CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
+	public final CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) throws Throwable {
 		DelayUntilCoordinator<T> parent = new DelayUntilCoordinator<>(actual, otherGenerators);
 		actual.onSubscribe(parent);
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
@@ -97,7 +97,7 @@ final class MonoDelayUntil<T> extends Mono<T> implements Scannable,
 			source.subscribe(subscribeOrReturn(actual));
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e,  actual.currentContext()));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDoFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDoFirst.java
@@ -44,13 +44,7 @@ final class MonoDoFirst<T> extends InternalMonoOperator<T, T> {
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
-		try {
-			onFirst.run();
-		}
-		catch (Throwable error) {
-			Operators.error(actual, error);
-			return null;
-		}
+		onFirst.run();
 
 		return actual;
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDoFirstFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDoFirstFuseable.java
@@ -45,13 +45,7 @@ final class MonoDoFirstFuseable<T> extends InternalMonoOperator<T, T> implements
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
-		try {
-			onFirst.run();
-		}
-		catch (Throwable error) {
-			Operators.error(actual, error);
-			return null;
-		}
+		onFirst.run();
 
 		return actual;
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFlattenIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFlattenIterable.java
@@ -63,36 +63,18 @@ final class MonoFlattenIterable<T, R> extends FluxFromMonoOperator<T, R>
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
+	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) throws Exception {
 		if (source instanceof Callable) {
-			T v;
-
-			try {
-				v = ((Callable<T>) source).call();
-			}
-			catch (Throwable ex) {
-				Operators.error(actual, Operators.onOperatorError(ex,
-						actual.currentContext()));
-				return null;
-			}
+			T v = ((Callable<T>) source).call();
 
 			if (v == null) {
 				Operators.complete(actual);
 				return null;
 			}
 
-			Iterator<? extends R> it;
-			boolean itFinite;
-			try {
-				Iterable<? extends R> iter = mapper.apply(v);
-				it = iter.iterator();
-				itFinite = FluxIterable.checkFinite(iter);
-			}
-			catch (Throwable ex) {
-				Operators.error(actual, Operators.onOperatorError(ex,
-						actual.currentContext()));
-				return null;
-			}
+			Iterable<? extends R> iter = mapper.apply(v);
+			Iterator<? extends R>  it = iter.iterator();
+			boolean itFinite = FluxIterable.checkFinite(iter);
 
 			FluxIterable.subscribe(actual, it, itFinite);
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFromFluxOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFromFluxOperator.java
@@ -74,7 +74,7 @@ abstract class MonoFromFluxOperator<I, O> extends Mono<O> implements Scannable,
 				subscriber = operator.subscribeOrReturn(subscriber);
 			}
 			catch (Throwable e) {
-				Operators.error(subscriber, Operators.onOperatorError(e,  subscriber.currentContext()));
+				Operators.error(subscriber, Operators.onOperatorError(e, subscriber.currentContext()));
 				return;
 			}
 			if (subscriber == null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFromFluxOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFromFluxOperator.java
@@ -70,7 +70,13 @@ abstract class MonoFromFluxOperator<I, O> extends Mono<O> implements Scannable,
 	public final void subscribe(CoreSubscriber<? super O> subscriber) {
 		OptimizableOperator operator = this;
 		while (true) {
-			subscriber = operator.subscribeOrReturn(subscriber);
+			try {
+				subscriber = operator.subscribeOrReturn(subscriber);
+			}
+			catch (Throwable e) {
+				Operators.error(subscriber, Operators.onOperatorError(e,  subscriber.currentContext()));
+				return;
+			}
 			if (subscriber == null) {
 				// null means "I will subscribe myself", returning...
 				return;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFromFluxOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFromFluxOperator.java
@@ -69,24 +69,24 @@ abstract class MonoFromFluxOperator<I, O> extends Mono<O> implements Scannable,
 	@SuppressWarnings("unchecked")
 	public final void subscribe(CoreSubscriber<? super O> subscriber) {
 		OptimizableOperator operator = this;
-		while (true) {
-			try {
+		try {
+			while (true) {
 				subscriber = operator.subscribeOrReturn(subscriber);
+				if (subscriber == null) {
+					// null means "I will subscribe myself", returning...
+					return;
+				}
+				OptimizableOperator newSource = operator.nextOptimizableSource();
+				if (newSource == null) {
+					operator.source().subscribe(subscriber);
+					return;
+				}
+				operator = newSource;
 			}
-			catch (Throwable e) {
-				Operators.error(subscriber, Operators.onOperatorError(e, subscriber.currentContext()));
-				return;
-			}
-			if (subscriber == null) {
-				// null means "I will subscribe myself", returning...
-				return;
-			}
-			OptimizableOperator newSource = operator.nextOptimizableSource();
-			if (newSource == null) {
-				operator.source().subscribe(subscriber);
-				return;
-			}
-			operator = newSource;
+		}
+		catch (Throwable e) {
+			Operators.reportThrowInSubscribe(subscriber, e);
+			return;
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFromPublisher.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFromPublisher.java
@@ -55,15 +55,21 @@ final class MonoFromPublisher<T> extends Mono<T> implements Scannable,
 	@Override
 	@SuppressWarnings("unchecked")
 	public void subscribe(CoreSubscriber<? super T> actual) {
-		CoreSubscriber<? super T> subscriber = subscribeOrReturn(actual);
-		if (subscriber == null) {
+		try {
+			CoreSubscriber<? super T> subscriber = subscribeOrReturn(actual);
+			if (subscriber == null) {
+				return;
+			}
+			source.subscribe(subscriber);
+		}
+		catch (Throwable e) {
+			Operators.error(actual, Operators.onOperatorError(e,  actual.currentContext()));
 			return;
 		}
-		source.subscribe(subscriber);
 	}
 
 	@Override
-	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
+	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) throws Throwable {
 		return new MonoNext.NextSubscriber<>(actual);
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFromPublisher.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFromPublisher.java
@@ -63,7 +63,7 @@ final class MonoFromPublisher<T> extends Mono<T> implements Scannable,
 			source.subscribe(subscriber);
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e,  actual.currentContext()));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoIgnorePublisher.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoIgnorePublisher.java
@@ -56,7 +56,7 @@ final class MonoIgnorePublisher<T> extends Mono<T> implements Scannable,
 			source.subscribe(subscribeOrReturn(actual));
 		}
 		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e,  actual.currentContext()));
+			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
 			return;
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoIgnorePublisher.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoIgnorePublisher.java
@@ -52,11 +52,17 @@ final class MonoIgnorePublisher<T> extends Mono<T> implements Scannable,
 
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
-		source.subscribe(subscribeOrReturn(actual));
+		try {
+			source.subscribe(subscribeOrReturn(actual));
+		}
+		catch (Throwable e) {
+			Operators.error(actual, Operators.onOperatorError(e,  actual.currentContext()));
+			return;
+		}
 	}
 
 	@Override
-	public final CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
+	public final CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) throws Throwable {
 		return new MonoIgnoreElements.IgnoreElementsSubscriber<>(actual);
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPublishMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPublishMulticast.java
@@ -53,15 +53,8 @@ final class MonoPublishMulticast<T, R> extends InternalMonoOperator<T, R> implem
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
 		MonoPublishMulticaster<T> multicast = new MonoPublishMulticaster<>(actual.currentContext());
 
-		Mono<? extends R> out;
-		try {
-			out = Objects.requireNonNull(transform.apply(fromDirect(multicast)),
-					"The transform returned a null Mono");
-		}
-		catch (Throwable ex) {
-			Operators.error(actual, Operators.onOperatorError(ex, actual.currentContext()));
-			return null;
-		}
+		Mono<? extends R> out = Objects.requireNonNull(transform.apply(fromDirect(multicast)),
+				"The transform returned a null Mono");
 
 		if (out instanceof Fuseable) {
 			out.subscribe(new FluxPublishMulticast.CancelFuseableMulticaster<>(actual, multicast));

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoReduceSeed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoReduceSeed.java
@@ -51,16 +51,8 @@ final class MonoReduceSeed<T, R> extends MonoFromFluxOperator<T, R>
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
-		R initialValue;
-
-		try {
-			initialValue = Objects.requireNonNull(initialSupplier.get(),
-					"The initial value supplied is null");
-		}
-		catch (Throwable e) {
-			Operators.error(actual, Operators.onOperatorError(e, actual.currentContext()));
-			return null;
-		}
+		R initialValue = Objects.requireNonNull(initialSupplier.get(),
+				"The initial value supplied is null");
 
 		return new ReduceSeedSubscriber<>(actual, accumulator, initialValue);
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoStreamCollector.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoStreamCollector.java
@@ -51,22 +51,12 @@ final class MonoStreamCollector<T, A, R> extends MonoFromFluxOperator<T, R>
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
-		A container;
-		BiConsumer<? super A, ? super T> accumulator;
-		Function<? super A, ? extends R> finisher;
+		A container = collector.supplier()
+		                     .get();
 
-		try {
-			container = collector.supplier()
-			                     .get();
+		BiConsumer<? super A, ? super T>  accumulator = collector.accumulator();
 
-			accumulator = collector.accumulator();
-
-			finisher = collector.finisher();
-		}
-		catch (Throwable ex) {
-			Operators.error(actual, Operators.onOperatorError(ex, actual.currentContext()));
-			return null;
-		}
+		Function<? super A, ? extends R>  finisher = collector.finisher();
 
 		return new StreamCollectorSubscriber<>(actual, container, accumulator, finisher);
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSubscriberContext.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSubscriberContext.java
@@ -35,14 +35,7 @@ final class MonoSubscriberContext<T> extends InternalMonoOperator<T, T> implemen
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
-		Context c;
-		try {
-			c = doOnContext.apply(actual.currentContext());
-		}
-		catch (Throwable t) {
-			Operators.error(actual, Operators.onOperatorError(t, actual.currentContext()));
-			return null;
-		}
+		Context c = doOnContext.apply(actual.currentContext());
 
 		return new FluxContextStart.ContextStartSubscriber<>(actual, c);
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -185,6 +185,16 @@ public abstract class Operators {
 		s.onError(e);
 	}
 
+	public static void reportThrowInSubscribe(CoreSubscriber subscriber, Throwable e) {
+		try {
+			subscriber.onSubscribe(Operators.EmptySubscription.INSTANCE);
+		}
+		catch (Throwable onSubscribeError) {
+			e.addSuppressed(onSubscribeError);
+		}
+		subscriber.onError(onOperatorError(e, subscriber.currentContext()));
+	}
+
 	/**
 	 * Create a function that can be used to support a custom operator via
 	 * {@link CoreSubscriber} decoration. The function is compatible with

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -185,11 +185,12 @@ public abstract class Operators {
 		s.onError(e);
 	}
 
-	public static void reportThrowInSubscribe(CoreSubscriber subscriber, Throwable e) {
+	public static void reportThrowInSubscribe(CoreSubscriber<?> subscriber, Throwable e) {
 		try {
-			subscriber.onSubscribe(Operators.EmptySubscription.INSTANCE);
+			subscriber.onSubscribe(EmptySubscription.INSTANCE);
 		}
 		catch (Throwable onSubscribeError) {
+			Exceptions.throwIfFatal(onSubscribeError);
 			e.addSuppressed(onSubscribeError);
 		}
 		subscriber.onError(onOperatorError(e, subscriber.currentContext()));

--- a/reactor-core/src/main/java/reactor/core/publisher/OptimizableOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/OptimizableOperator.java
@@ -41,7 +41,7 @@ interface OptimizableOperator<IN, OUT> extends CorePublisher<IN> {
 	 * @return next {@link CoreSubscriber} or "null" if the subscription was already done inside the method
 	 */
 	@Nullable
-	CoreSubscriber<? super OUT> subscribeOrReturn(CoreSubscriber<? super IN> actual);
+	CoreSubscriber<? super OUT> subscribeOrReturn(CoreSubscriber<? super IN> actual) throws Throwable;
 
 	/**
 	 * @return {@link CorePublisher} to call {@link CorePublisher#subscribe(CoreSubscriber)} on

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
@@ -630,24 +630,14 @@ public class FluxMergeOrderedTest {
 
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
-	public void nullSecond() {
-		FluxMergeOrdered<Integer> test = new FluxMergeOrdered<>(2, Queues.small(),
-				Comparator.naturalOrder(),
-				Flux.just(1), null);
-
-		assertThatNullPointerException().isThrownBy(test::subscribe)
-		                                .withMessage("subscribed with a null source: sources[1]");
-	}
-
-	@Test
-	@SuppressWarnings("unchecked") //safe varargs
-	public void nullFirst() {
-		FluxMergeOrdered<Integer> test = new FluxMergeOrdered<>(2, Queues.small(),
-				Comparator.naturalOrder(),
-				null, Flux.just(1), null);
-
-		assertThatNullPointerException().isThrownBy(test::subscribe)
-		                                .withMessage("subscribed with a null source: sources[0]");
+	public void nullInSourceArray() {
+		assertThatNullPointerException()
+				.isThrownBy(() -> {
+					new FluxMergeOrdered<>(2, Queues.small(),
+							Comparator.naturalOrder(),
+							Flux.just(1), null);
+				})
+                .withMessage("sources[1] is null");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
@@ -637,7 +637,7 @@ public class FluxMergeOrderedTest {
 							Comparator.naturalOrder(),
 							Flux.just(1), null);
 				})
-                .withMessage("sources[1] is null");
+				.withMessage("sources[1] is null");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/test/publisher/BaseOperatorTest.java
+++ b/reactor-core/src/test/java/reactor/test/publisher/BaseOperatorTest.java
@@ -235,28 +235,23 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 			if (verifier == null) {
 				String m = exception().getMessage();
 				verifier = step -> {
-					try {
-						if (scenario.shouldHitDropErrorHookAfterTerminate() || scenario.shouldHitDropNextHookAfterTerminate()) {
-							StepVerifier.Assertions assertions =
-									scenario.applySteps(step)
-									        .expectErrorMessage(m)
-									        .verifyThenAssertThat();
-							if(scenario.shouldHitDropErrorHookAfterTerminate()){
-								assertions.hasDroppedErrorsSatisfying(c -> {
-									assertThat(c.stream().findFirst().get()).hasMessage(scenario.droppedError.getMessage());
-								});
-							}
-							if(scenario.shouldHitDropNextHookAfterTerminate()){
-								assertions.hasDropped(scenario.droppedItem);
-							}
+					if (scenario.shouldHitDropErrorHookAfterTerminate() || scenario.shouldHitDropNextHookAfterTerminate()) {
+						StepVerifier.Assertions assertions =
+								scenario.applySteps(step)
+								        .expectErrorMessage(m)
+								        .verifyThenAssertThat();
+						if(scenario.shouldHitDropErrorHookAfterTerminate()){
+							assertions.hasDroppedErrorsSatisfying(c -> {
+								assertThat(c.stream().findFirst().get()).hasMessage(scenario.droppedError.getMessage());
+							});
 						}
-						else {
-							scenario.applySteps(step)
-							        .verifyErrorMessage(m);
+						if(scenario.shouldHitDropNextHookAfterTerminate()){
+							assertions.hasDropped(scenario.droppedItem);
 						}
 					}
-					catch (Exception e) {
-						assertThat(Exceptions.unwrap(e)).hasMessage(m);
+					else {
+						scenario.applySteps(step)
+						        .verifyErrorMessage(m);
 					}
 				};
 			}

--- a/reactor-core/src/test/java/reactor/test/publisher/FluxFuseableExceptionOnPoll.java
+++ b/reactor-core/src/test/java/reactor/test/publisher/FluxFuseableExceptionOnPoll.java
@@ -76,6 +76,8 @@ final class FluxFuseableExceptionOnPoll<T> extends FluxOperator<T, T>
 
 		@Override
 		public boolean tryOnNext(T t) {
+			// Make it easier to debug
+			exception.addSuppressed(new Exception("thrown at"));
 			throw exception;
 		}
 
@@ -88,6 +90,8 @@ final class FluxFuseableExceptionOnPoll<T> extends FluxOperator<T, T>
 		@Override
 		public void onNext(T t) {
 			if (t != null) {
+				// Make it easier to debug
+				exception.addSuppressed(new Exception("thrown at"));
 				throw exception;
 			}
 			actual.onNext(null);
@@ -113,6 +117,8 @@ final class FluxFuseableExceptionOnPoll<T> extends FluxOperator<T, T>
 		public T poll() {
 			T t = qs.poll();
 			if (t != null) {
+				// Make it easier to debug
+				exception.addSuppressed(new Exception("thrown at"));
 				throw exception;
 			}
 			return null;


### PR DESCRIPTION
As we fully control `subscribeOrReturn` invocations, we can wrap them with `try {} catch {}`
and remove the error handling from `subscribeOrReturn` implementations.

During the change I've also discovered that some operators (like `MonoDoFirst`) were not
calling `onOperatorError`.