### PR TITLE
[Docs] Fix block titles for FAQ examples

### DIFF
--- a/docs/asciidoc/faq.adoc
+++ b/docs/asciidoc/faq.adoc
@@ -53,7 +53,7 @@ operators is to _chain_ the calls.
 
 Compare the following two examples:
 
-====
+
 .without chaining (incorrect)
 ====
 [source,java]
@@ -65,7 +65,6 @@ flux.subscribe(next -> System.out.println("Received: " + next));
 <1> The mistake is here. The result is not attached to the `flux` variable.
 ====
 
-====
 .without chaining (correct)
 ====
 [source,java]
@@ -78,7 +77,6 @@ flux.subscribe(next -> System.out.println("Received: " + next));
 
 The following sample is even better (because it is simpler):
 
-====
 .with chaining (best)
 ====
 [source,java]
@@ -145,7 +143,7 @@ which could help avoid some of these situations. Note that this does not apply t
 `Flux<Void>`/`Mono<Void>` sources, as you can only switch to another `Publisher<Void>`,
 which is still guaranteed to be empty. The following example uses `defaultIfEmpty`:
 
-====
+
 .use `defaultIfEmpty` before `zipWhen`
 ====
 [source,java]


### PR DESCRIPTION
Currently some blocks have invalid title defined, which causes issues with page rendering.

![image](https://user-images.githubusercontent.com/1116309/77810987-a4a40d80-7054-11ea-896c-d04b1fdf1f18.png)

See: https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#more-delimited-blocks