### PR TITLE
[build] Follow-up to #2088 bump to Gradle 6.3 : 3.3 specifics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ plugins {
 	id 'org.asciidoctor.convert' version '1.5.11'
 	id "me.champeau.gradle.japicmp" version "0.2.6"
 	id "de.undercouch.download" version "3.4.3"
-	id "org.unbroken-dome.test-sets" version "2.1.1" apply false // 2.x version does not work with Gradle 4.10
-	id 'com.gradle.build-scan' version '2.4.2'
+	id "org.unbroken-dome.test-sets" version "3.0.0" apply false
+	//note: build scan plugin now must be applied in settings.gradle
 	id "com.jfrog.artifactory" version "4.9.8" apply false
 	id 'biz.aQute.bnd.builder' version '5.0.1' apply false
 }
@@ -60,7 +60,7 @@ ext {
   jsr166BackportVersion = '1.0.0.RELEASE'
 
   // Blockhound
-  blockhoundVersion = '1.0.0.RELEASE'
+  blockhoundVersion = '1.0.3.RELEASE'
 
   // Logging
   slf4jVersion = '1.7.12'
@@ -82,13 +82,15 @@ ext {
 //typically, for local usage, you would temporarily set the env with:
 // `GRADLE_ENTERPRISE_URL=https://myge.example.com/ gradle foo`
 if (System.getenv('GRADLE_ENTERPRISE_URL')) {
-	buildScan {
-		captureTaskInputFiles = true
-		obfuscation {
-			ipAddresses { addresses -> addresses.collect { '0.0.0.0' } }
+	gradleEnterprise {
+		buildScan {
+			captureTaskInputFiles = true
+			obfuscation {
+				ipAddresses { addresses -> addresses.collect { '0.0.0.0' } }
+			}
+			publishAlways()
+			server = System.getenv('GRADLE_ENTERPRISE_URL')
 		}
-		publishAlways()
-		server = System.getenv('GRADLE_ENTERPRISE_URL')
 	}
 }
 

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -24,14 +24,16 @@ ext {
 	bndOptions = [
 			"Export-Package": [
 					"!*internal*",
-					"reactor.*;-noimport:=true"
+					"!reactor.blockhound*",
+					"reactor.*"
 			].join(","),
 			"Import-Package": [
 					"!javax.annotation",
 					'org.slf4j;resolution:=optional;version="[1.5.4,2)"',
 					"kotlin.*;resolution:=optional",
 					"reactor.blockhound.*;resolution:=optional",
-					"io.micrometer.*;resolution:=optional","*"
+					"io.micrometer.*;resolution:=optional",
+					"*"
 			].join(","),
 			"Bundle-Name" : "reactor-core",
 			"Bundle-SymbolicName" : "io.projectreactor.reactor-core"

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
@@ -353,9 +353,8 @@ public class FluxDistinctUntilChangedTest extends FluxOperatorTest<String, Strin
 
 		System.gc();
 		await().untilAsserted(() -> {
-			assertThat(retainedDetector.finalizedCount())
-					.as("none retained after cancel")
-					.isEqualTo(50);
+			System.gc();
+			retainedDetector.assertAllFinalized();
 		});
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxUsingWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxUsingWhenTest.java
@@ -1160,8 +1160,8 @@ public class FluxUsingWhenTest {
 		});
 
 		Thread.sleep(300);
-		assertThat(cleanupCount.sum()).isEqualTo(1000);
-		assertThat(cancelled).as("source cancelled").isTrue();
+			          assertThat(cleanupCount.sum()).isEqualTo(1000);
+			          assertThat(cancelled).as("source cancelled").isTrue();
 	}
 
 	@Test

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-rootProject.name = 'reactor'
+plugins {
+	id "com.gradle.enterprise" version "3.2"
+}
 
+rootProject.name = 'reactor'
 
 include 'benchmarks', 'reactor-core', 'reactor-test', 'reactor-tools'


### PR DESCRIPTION
 - build-scan plugin (added in 3.3) has been upgraded but must now be
 applied in settings.gradle
 - unbroken-dome.test-sets plugin must be bumped to version 3.0.0 for
 Gradle 6.3 compatibility
 - Bump of blockhound to 1.0.3 to avoid `reactor.shaded` version of
 bytebuddy (which confuses BND)
 - Exclude blockhound in core's BDN Export-Package