### PR TITLE
fix #2077 Support doOnDiscard in SerializedSubscriber

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3794,6 +3794,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/delaySequence.svg" alt="">
 	 *
+	 * @reactor.discard This operator discards elements currently being delayed
+	 * 	 * if the sequence is cancelled during the delay.
+	 *
 	 * @param delay {@link Duration} to shift the sequence by
 	 * @return an shifted {@link Flux} emitting at the same frequency as the source
 	 */
@@ -3820,6 +3823,9 @@ public abstract class Flux<T> implements Publisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/delaySequence.svg" alt="">
+	 *
+	 * @reactor.discard This operator discards elements currently being delayed
+	 * if the sequence is cancelled during the delay.
 	 *
 	 * @param delay {@link Duration} to shift the sequence by
 	 * @param timer a time-capable {@link Scheduler} instance to delay signals on
@@ -8574,9 +8580,10 @@ public abstract class Flux<T> implements Publisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/timeoutPublisherFunctionForFlux.svg" alt="">
 	 *
+	 * @reactor.discard This operator discards an element if it comes right after the timeout.
+	 *
 	 * @param firstTimeout the timeout {@link Publisher} that must not emit before the first signal from this {@link Flux}
 	 * @param nextTimeoutFactory the timeout {@link Publisher} factory for each next item
-	 *
 	 * @param <U> the type of the elements of the first timeout Publisher
 	 * @param <V> the type of the elements of the subsequent timeout Publishers
 	 *

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -172,6 +172,9 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 	 * Create a {@link FluxProcessor} that safely gates multi-threaded producer
 	 * {@link Subscriber#onNext(Object)}.
 	 *
+	 * @reactor.discard The resulting processor discards elements received from the source
+	 * {@link Publisher} (if any) when it cancels subscription to said source.
+	 *
 	 * @return a serializing {@link FluxProcessor}
 	 */
 	public final FluxProcessor<IN, OUT> serialize() {

--- a/reactor-core/src/main/java/reactor/core/publisher/SerializedSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SerializedSubscriber.java
@@ -68,14 +68,22 @@ final class SerializedSubscriber<T> implements InnerOperator<T, T> {
 
 	@Override
 	public void onNext(T t) {
-		if (cancelled || done) {
+		if (cancelled) {
 			Operators.onDiscard(t, actual.currentContext());
+			return;
+		}
+		if (done) {
+			Operators.onNextDropped(t, actual.currentContext());
 			return;
 		}
 
 		synchronized (this) {
-			if (cancelled || done) {
+			if (cancelled) {
 				Operators.onDiscard(t, actual.currentContext());
+				return;
+			}
+			if (done) {
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/SerializedSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SerializedSubscriber.java
@@ -223,10 +223,6 @@ final class SerializedSubscriber<T> implements InnerOperator<T, T> {
 
 				head = null;
 				tail = null;
-
-//				if (cancelled) {
-//					discardMultiple(n);
-//				}
 			}
 
 			while (n != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/SerializedSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SerializedSubscriber.java
@@ -260,7 +260,6 @@ final class SerializedSubscriber<T> implements InnerOperator<T, T> {
 	}
 
 	private void discardMultiple(LinkedArrayNode<T> head) {
-		synchronized (actual) {
 		LinkedArrayNode<T> originalHead = head;
 		LinkedArrayNode<T> h = head;
 		while (h != null) {
@@ -274,7 +273,6 @@ final class SerializedSubscriber<T> implements InnerOperator<T, T> {
 				originalHead = this.head;
 				h = originalHead;
 			}
-		}
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
@@ -85,12 +85,9 @@ public class SerializedSubscriberTest {
 	//direct transcription of test case exposed in https://github.com/reactor/reactor-core/issues/2077
 	@Test
 	public void testLeakWithRetryWhenImmediatelyCancelled() throws InterruptedException {
-
 		AtomicInteger counter = new AtomicInteger();
 		AtomicInteger discarded = new AtomicInteger();
 		AtomicInteger seen = new AtomicInteger();
-		AtomicInteger dropped = new AtomicInteger();
-		Hooks.onNextDropped(o -> dropped.incrementAndGet());
 
 		final CountDownLatch latch = new CountDownLatch(1);
 		Flux.<Integer>generate(s -> {
@@ -122,8 +119,8 @@ public class SerializedSubscriberTest {
 		      .untilAsserted(() -> {
 			      //counter now holds the next value it would have emitted, so total emitted == counter - 1
 			      assertThat(counter.get() - 1)
-					      .withFailMessage("counter not equal to seen+discarded+dropped: Expected <%s>, got <%s+%s+%s>=<%s>",
-							      counter, seen, discarded, dropped, dropped.get() + seen.get() + discarded.get())
+					      .withFailMessage("counter not equal to seen+discarded: Expected <%s>, got <%s+%s>=<%s>",
+							      counter, seen, discarded, seen.get() + discarded.get())
 					      .isEqualTo(seen.get() + discarded.get());
 		      });
 	}


### PR DESCRIPTION
TODO: document which operators better support `doOnDiscard` transitively.
Also test the specific case reported in the #2077 issue (retryWhen)﻿
