### PR TITLE
fixes elements leaks on cancel and onXXX racing

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -1024,20 +1024,20 @@ final class FluxFlatMap<T, R> extends InternalFluxOperator<T, R> {
 
 		@Override
 		public void onNext(R t) {
-			if (done) {
-				Operators.onNextDropped(t, parent.currentContext());
-				return;
-			}
-
-			if (s == Operators.cancelledSubscription()) {
-				Operators.onDiscard(t, parent.currentContext());
-				return;
-			}
-
 			if (sourceMode == Fuseable.ASYNC) {
 				parent.drain();
 			}
 			else {
+				if (done) {
+					Operators.onNextDropped(t, parent.currentContext());
+					return;
+				}
+
+				if (s == Operators.cancelledSubscription()) {
+					Operators.onDiscard(t, parent.currentContext());
+					return;
+				}
+
 				parent.tryEmit(this, t);
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -352,23 +352,10 @@ final class FluxFlatMap<T, R> extends InternalFluxOperator<T, R> {
 
 				if (WIP.getAndIncrement(this) == 0) {
 					Queue<R> sq = this.scalarQueue;
-					FlatMapInner<R>[] as = this.array;
 					this.scalarQueue = null;
 					s.cancel();
 					unsubscribe();
-					int m = 1;
-					for (;;) {
-						for (FlatMapInner<R> fmi : as) {
-							if (fmi != null) {
-								Operators.onDiscardQueueWithClear(fmi.queue, actual.currentContext(), null);
-							}
-						}
-						Operators.onDiscardQueueWithClear(sq, actual.currentContext(), null);
-						m = WIP.addAndGet(this, -m);
-						if (m == 0) {
-							return;
-						}
-					}
+					Operators.onDiscardQueueWithClear(sq, actual.currentContext(), null);
 				}
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -529,6 +529,8 @@ final class FluxFlatMap<T, R> extends InternalFluxOperator<T, R> {
 			}
 		}
 
+		// 1 case - we dont have any quue at all
+
 		void tryEmit(FlatMapInner<R> inner, R v) {
 			if (wip == 0 && WIP.compareAndSet(this, 0, 1)) {
 				long r = requested;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
@@ -240,14 +240,14 @@ final class FluxFlattenIterable<T, R> extends InternalFluxOperator<T, R> impleme
 					return;
 				}
 			}
-			drain();
+			drain(t);
 		}
 
 		@Override
 		public void onError(Throwable t) {
 			if (Exceptions.addThrowable(ERROR, this, t)) {
 				done = true;
-				drain();
+				drain(null);
 			}
 			else {
 				Operators.onErrorDropped(t, actual.currentContext());
@@ -257,14 +257,14 @@ final class FluxFlattenIterable<T, R> extends InternalFluxOperator<T, R> impleme
 		@Override
 		public void onComplete() {
 			done = true;
-			drain();
+			drain(null);
 		}
 
 		@Override
 		public void request(long n) {
 			if (Operators.validate(n)) {
 				Operators.addCap(REQUESTED, this, n);
-				drain();
+				drain(null);
 			}
 		}
 
@@ -277,15 +277,8 @@ final class FluxFlattenIterable<T, R> extends InternalFluxOperator<T, R> impleme
 
 				if (WIP.getAndIncrement(this) == 0) {
 					Context context = actual.currentContext();
-					int m = 0;
-					for (;;) {
-						Operators.onDiscardQueueWithClear(queue, context, null);
-						Operators.onDiscardMultiple(current, currentKnownToBeFinite, context);
-						m = WIP.addAndGet(this, -m);
-						if (m == 0) {
-							return;
-						}
-					}
+					Operators.onDiscardQueueWithClear(queue, context, null);
+					Operators.onDiscardMultiple(current, currentKnownToBeFinite, context);
 				}
 			}
 		}
@@ -671,8 +664,11 @@ final class FluxFlattenIterable<T, R> extends InternalFluxOperator<T, R> impleme
 			}
 		}
 
-		void drain() {
+		void drain(@Nullable T dataSignal) {
 			if (WIP.getAndIncrement(this) != 0) {
+				if (dataSignal != null && cancelled) {
+					Operators.onDiscard(dataSignal, actual.currentContext());
+				}
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlattenIterable.java
@@ -277,8 +277,15 @@ final class FluxFlattenIterable<T, R> extends InternalFluxOperator<T, R> impleme
 
 				if (WIP.getAndIncrement(this) == 0) {
 					Context context = actual.currentContext();
-					Operators.onDiscardQueueWithClear(queue, context, null);
-					Operators.onDiscardMultiple(current, currentKnownToBeFinite, context);
+					int m = 0;
+					for (;;) {
+						Operators.onDiscardQueueWithClear(queue, context, null);
+						Operators.onDiscardMultiple(current, currentKnownToBeFinite, context);
+						m = WIP.addAndGet(this, -m);
+						if (m == 0) {
+							return;
+						}
+					}
 				}
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
@@ -265,7 +265,15 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 			worker.dispose();
 
 			if (WIP.getAndIncrement(this) == 0) {
-				Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
+				int m = 1;
+				for (;;) {
+					Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
+
+					m = WIP.addAndGet(this, -m);
+					if (m == 0) {
+						return;
+					}
+				}
 			}
 		}
 
@@ -312,6 +320,7 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 					}
 
 					if (cancelled) {
+						Operators.onDiscard(v, actual.currentContext());
 						Operators.onDiscardQueueWithClear(q, actual.currentContext(), null);
 						return;
 					}
@@ -379,7 +388,7 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 
 					boolean empty = v == null;
 
-					if (checkTerminated(d, empty, a)) {
+					if (checkTerminated(d, empty, a, v)) {
 						return;
 					}
 
@@ -399,7 +408,7 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 					}
 				}
 
-				if (e == r && checkTerminated(done, q.isEmpty(), a)) {
+				if (e == r && checkTerminated(done, q.isEmpty(), a, null)) {
 					return;
 				}
 
@@ -477,8 +486,9 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 			}
 		}
 
-		boolean checkTerminated(boolean d, boolean empty, Subscriber<?> a) {
+		boolean checkTerminated(boolean d, boolean empty, Subscriber<?> a, @Nullable T v) {
 			if (cancelled) {
+				Operators.onDiscard(v, actual.currentContext());
 				Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
 				return true;
 			}
@@ -498,6 +508,7 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 				else {
 					Throwable e = error;
 					if (e != null) {
+						Operators.onDiscard(v, actual.currentContext());
 						Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
 						doError(a, e);
 						return true;
@@ -735,7 +746,15 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 			worker.dispose();
 
 			if (WIP.getAndIncrement(this) == 0) {
-				Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
+				int m = 1;
+				for (;;) {
+					Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
+
+					m = WIP.addAndGet(this, -m);
+					if (m == 0) {
+						return;
+					}
+				}
 			}
 		}
 
@@ -781,6 +800,7 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 					}
 
 					if (cancelled) {
+						Operators.onDiscard(v, actual.currentContext());
 						Operators.onDiscardQueueWithClear(q, actual.currentContext(), null);
 						return;
 					}
@@ -847,7 +867,7 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 					}
 					boolean empty = v == null;
 
-					if (checkTerminated(d, empty, a)) {
+					if (checkTerminated(d, empty, a, v)) {
 						return;
 					}
 
@@ -867,7 +887,7 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 					}
 				}
 
-				if (emitted == r && checkTerminated(done, q.isEmpty(), a)) {
+				if (emitted == r && checkTerminated(done, q.isEmpty(), a, null)) {
 					return;
 				}
 
@@ -967,8 +987,9 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 			}
 		}
 
-		boolean checkTerminated(boolean d, boolean empty, Subscriber<?> a) {
+		boolean checkTerminated(boolean d, boolean empty, Subscriber<?> a, @Nullable T v) {
 			if (cancelled) {
+				Operators.onDiscard(v, actual.currentContext());
 				Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
 				return true;
 			}
@@ -988,6 +1009,7 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 				else {
 					Throwable e = error;
 					if (e != null) {
+						Operators.onDiscard(v, actual.currentContext());
 						Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
 						doError(a, e);
 						return true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
@@ -215,6 +215,12 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
+
+			if (cancelled) {
+				Operators.onDiscard(t, actual.currentContext());
+				return;
+			}
+
 			if (!queue.offer(t)) {
 				error = Operators.onOperatorError(s,
 						Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL),
@@ -265,15 +271,7 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 			worker.dispose();
 
 			if (WIP.getAndIncrement(this) == 0) {
-				int m = 1;
-				for (;;) {
-					Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
-
-					m = WIP.addAndGet(this, -m);
-					if (m == 0) {
-						return;
-					}
-				}
+				Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
 			}
 		}
 
@@ -282,6 +280,9 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 				@Nullable Throwable suppressed,
 				@Nullable Object dataSignal) {
 			if (WIP.getAndIncrement(this) != 0) {
+				if (dataSignal != null && cancelled) {
+					Operators.onDiscard(dataSignal, actual.currentContext());
+				}
 				return;
 			}
 
@@ -746,15 +747,7 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 			worker.dispose();
 
 			if (WIP.getAndIncrement(this) == 0) {
-				int m = 1;
-				for (;;) {
-					Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
-
-					m = WIP.addAndGet(this, -m);
-					if (m == 0) {
-						return;
-					}
-				}
+				Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
 			}
 		}
 
@@ -763,6 +756,9 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 				@Nullable Throwable suppressed,
 				@Nullable Object dataSignal) {
 			if (WIP.getAndIncrement(this) != 0) {
+				if (dataSignal != null && cancelled) {
+					Operators.onDiscard(dataSignal, actual.currentContext());
+				}
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
@@ -639,7 +639,7 @@ final class FluxWindowPredicate<T> extends InternalFluxOperator<T, Flux<T>>
 					T t = q.poll();
 					boolean empty = t == null;
 
-					if (checkTerminated(d, empty, a, q)) {
+					if (checkTerminated(d, empty, a, q, t)) {
 						return;
 					}
 
@@ -653,7 +653,7 @@ final class FluxWindowPredicate<T> extends InternalFluxOperator<T, Flux<T>>
 				}
 
 				if (r == e) {
-					if (checkTerminated(done, q.isEmpty(), a, q)) {
+					if (checkTerminated(done, q.isEmpty(), a, q, null)) {
 						return;
 					}
 				}
@@ -730,8 +730,9 @@ final class FluxWindowPredicate<T> extends InternalFluxOperator<T, Flux<T>>
 			}
 		}
 
-		boolean checkTerminated(boolean d, boolean empty, Subscriber<?> a, Queue<?> q) {
+		boolean checkTerminated(boolean d, boolean empty, Subscriber<?> a, Queue<?> q, @Nullable T t) {
 			if (cancelled) {
+				Operators.onDiscard(t, ctx);
 				Operators.onDiscardQueueWithClear(q, ctx, null);
 				ctx = Context.empty();
 				actual = null;
@@ -757,6 +758,7 @@ final class FluxWindowPredicate<T> extends InternalFluxOperator<T, Flux<T>>
 			Subscriber<? super T> a = actual;
 
 			if (!queue.offer(t)) {
+				Operators.onDiscard(t, ctx);
 				onError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t,
 						ctx));
 				return;
@@ -837,7 +839,16 @@ final class FluxWindowPredicate<T> extends InternalFluxOperator<T, Flux<T>>
 
 			if (!enableOperatorFusion) {
 				if (WIP.getAndIncrement(this) == 0) {
-					Operators.onDiscardQueueWithClear(queue, ctx, null);
+					int m = 1;
+					for (;;) {
+						Operators.onDiscardQueueWithClear(queue, ctx, null);
+
+						m = WIP.addAndGet(this, -m);
+
+						if (m == 0) {
+							return;
+						}
+					}
 				}
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -17,6 +17,7 @@ package reactor.core.publisher;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.Spliterator;
@@ -30,6 +31,9 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import com.sun.org.apache.bcel.internal.generic.RET;
+import org.jetbrains.annotations.NotNull;
+import org.omg.CORBA.PUBLIC_MEMBER;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -1480,6 +1484,107 @@ public abstract class Operators {
 		}
 	};
 	//
+
+	static class DiscardingQueue<T> implements Queue<T> {
+		String NOT_SUPPORTED_MESSAGE = "Although DiscardingQueue extends Queue it is purely internal" +
+				" and only guarantees support for offer/poll/clear/size/isEmpty." +
+				" Instances shouldn't be used/exposed as Queue outside of Reactor operators.";
+
+		Context context() {
+			return Context.empty();
+		}
+
+		@Override
+		public boolean offer(T t) {
+			Operators.onDiscard(t, context());
+			return true;
+		}
+
+		@Override
+		public boolean add(T t) {
+			return offer(t);
+		}
+
+		@Override
+		public int size() {
+			return 0;
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return true;
+		}
+
+		@Override
+		public boolean contains(Object o) {
+			return false;
+		}
+
+		@Override
+		public Iterator<T> iterator() {
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
+		}
+
+		@Override
+		public Object[] toArray() {
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
+		}
+
+		@NotNull
+		@Override
+		public <T1> T1[] toArray(@NotNull T1[] a) {
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
+		}
+
+		@Override
+		public boolean remove(Object o) {
+			return false;
+		}
+
+		@Override
+		public boolean containsAll(@NotNull Collection<?> c) {
+			return false;
+		}
+
+		@Override
+		public boolean addAll(@NotNull Collection<? extends T> c) {
+			return false;
+		}
+
+		@Override
+		public boolean removeAll(@NotNull Collection<?> c) {
+			return false;
+		}
+
+		@Override
+		public boolean retainAll(@NotNull Collection<?> c) {
+			return false;
+		}
+
+		@Override
+		public void clear() {
+		}
+
+		@Override
+		public T remove() {
+			throw new NoSuchElementException();
+		}
+
+		@Override
+		public T poll() {
+			return null;
+		}
+
+		@Override
+		public T element() {
+			throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
+		}
+
+		@Override
+		public T peek() {
+			return null;
+		}
+	}
 
 	final static class CancelledSubscription implements Subscription, Scannable {
 		static final CancelledSubscription INSTANCE = new CancelledSubscription();

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -229,7 +229,7 @@ public final class UnicastProcessor<T>
 				T t = q.poll();
 				boolean empty = t == null;
 
-				if (checkTerminated(d, empty, a, q)) {
+				if (checkTerminated(d, empty, a, q, t)) {
 					return;
 				}
 
@@ -243,7 +243,7 @@ public final class UnicastProcessor<T>
 			}
 
 			if (r == e) {
-				if (checkTerminated(done, q.isEmpty(), a, q)) {
+				if (checkTerminated(done, q.isEmpty(), a, q, null)) {
 					return;
 				}
 			}
@@ -321,8 +321,9 @@ public final class UnicastProcessor<T>
 		}
 	}
 
-	boolean checkTerminated(boolean d, boolean empty, CoreSubscriber<? super T> a, Queue<T> q) {
+	boolean checkTerminated(boolean d, boolean empty, CoreSubscriber<? super T> a, Queue<T> q, @Nullable T t) {
 		if (cancelled) {
+			Operators.onDiscard(t, a.currentContext());
 			Operators.onDiscardQueueWithClear(q, a.currentContext(), null);
 			actual = null;
 			return true;
@@ -371,7 +372,7 @@ public final class UnicastProcessor<T>
 		if (!queue.offer(t)) {
 			Throwable ex = Operators.onOperatorError(null,
 					Exceptions.failWithOverflow(), t, currentContext());
-			if(onOverflow != null) {
+			if (onOverflow != null) {
 				try {
 					onOverflow.accept(t);
 				}
@@ -380,7 +381,8 @@ public final class UnicastProcessor<T>
 					ex.initCause(e);
 				}
 			}
-			onError(Operators.onOperatorError(null, ex, t, currentContext()));
+			Operators.onDiscard(t, currentContext());
+			onError(ex);
 			return;
 		}
 		drain();
@@ -450,7 +452,17 @@ public final class UnicastProcessor<T>
 		doTerminate();
 
 		if (WIP.getAndIncrement(this) == 0) {
-			Operators.onDiscardQueueWithClear(queue, currentContext(), null);
+			int m = 1;
+
+			// possible racing between offer and clear, so we need to ensure all offered elements are drained
+			for (;;) {
+				Operators.onDiscardQueueWithClear(queue, currentContext(), null);
+				m = WIP.addAndGet(this, -m);
+
+				if (m == 0) {
+					break;
+				}
+			}
 			actual = null;
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -298,18 +298,8 @@ public final class UnicastProcessor<T>
 
 	void drain(@Nullable T dataSignal) {
 		if (WIP.getAndIncrement(this) != 0) {
-			CoreSubscriber<? super T> a = this.actual;
-
 			if (dataSignal != null && cancelled) {
-				if (a != null) {
-					Operators.onDiscard(dataSignal, a.currentContext());
-				} else {
-					T v;
-					while ((v = queue.poll()) != null) {
-						Operators.onNextDropped(v, Context.empty());
-					}
-					return;
-				}
+				Operators.onDiscard(dataSignal, a.currentContext());
 			}
 			return;
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -203,6 +203,7 @@ public final class UnicastProcessor<T>
 	@Override
 	public Object scanUnsafe(Attr key) {
 		if (Attr.BUFFERED == key) return queue.size();
+		if (Attr.PREFETCH == key) return Integer.MAX_VALUE;
 		return super.scanUnsafe(key);
 	}
 
@@ -310,6 +311,14 @@ public final class UnicastProcessor<T>
 					drainFused(a);
 				} else {
 					drainRegular(a);
+				}
+				return;
+			}
+
+			if (cancelled) {
+				T v;
+				while ((v = queue.poll()) != null) {
+					Operators.onNextDropped(v, Context.empty());
 				}
 				return;
 			}

--- a/reactor-core/src/test/java/reactor/core/publisher/AbstractOnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/AbstractOnDiscardShouldNotLeakTest.java
@@ -1,0 +1,102 @@
+package reactor.core.publisher;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import reactor.test.subscriber.AssertSubscriber;
+import reactor.test.util.RaceTestUtils;
+
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+
+public abstract class AbstractOnDiscardShouldNotLeakTest {
+
+    abstract Publisher<Tracked<?>> transform(Flux<Tracked<?>> upstream);
+
+    @Test
+    public void ensureNoLeaksOnCancelOnNext() {
+        for (int i = 0; i < 10000; i++) {
+            FluxSink<Tracked<?>> sink[] = new FluxSink[1];
+            Publisher<Tracked<?>> source = transform(Flux.create(s -> {
+                sink[0] = s;
+            }, FluxSink.OverflowStrategy.IGNORE));
+
+            AssertSubscriber<Tracked<?>> assertSubscriber = new AssertSubscriber<>(Operators.enableOnDiscard(null, Tracked::safeRelease));
+            source.subscribe(assertSubscriber);
+
+            Tracked<Integer> value = new Tracked<>(1);
+
+            RaceTestUtils.race(assertSubscriber::cancel, () -> sink[0].next(value));
+
+            List<Tracked<?>> values = assertSubscriber.values();
+            values.forEach(Tracked::release);
+
+            Tracked.assertNoLeaks();
+        }
+    }
+
+    public static final class Tracked<T> extends AtomicBoolean {
+
+        static final Queue<Tracked<?>> tracked = new ConcurrentLinkedQueue<>();
+
+
+        static void safeRelease(Object t) {
+            if (t instanceof Tracked) {
+                ((Tracked<?>) t).release();
+            }
+        }
+
+        static void assertNoLeaks() {
+            try {
+                Assertions.assertThat(tracked)
+                        .allMatch(Tracked::isReleased);
+            } finally {
+                tracked.clear();
+            }
+        }
+
+        final T value;
+
+        public Tracked(T value) {
+            this.value = value;
+
+            // track value
+            tracked.add(this);
+        }
+
+        public Tracked<T> release() {
+            set(true);
+            return this;
+        }
+
+        public boolean isReleased() {
+            return get();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Tracked<?> tracked = (Tracked<?>) o;
+
+            return value != null ? value.equals(tracked.value) : tracked.value == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return value != null ? value.hashCode() : 0;
+        }
+
+        @Override
+        public String toString() {
+            return "Tracked{" +
+                    " value=" + value +
+                    " released=" + get() +
+                    " }";
+        }
+    }
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/AbstractOnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/AbstractOnDiscardShouldNotLeakTest.java
@@ -1,8 +1,12 @@
 package reactor.core.publisher;
 
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Assumptions;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
+import reactor.core.Scannable;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.test.util.RaceTestUtils;
 
@@ -16,20 +20,147 @@ public abstract class AbstractOnDiscardShouldNotLeakTest {
 
     abstract Publisher<Tracked<?>> transform(Flux<Tracked<?>> upstream);
 
+    int subscriptionsNumber() {
+        return 1;
+    }
+
     @Test
-    public void ensureNoLeaksOnCancelOnNext() {
-        for (int i = 0; i < 10000; i++) {
-            FluxSink<Tracked<?>> sink[] = new FluxSink[1];
+    public void ensureNoLeaksOnCancelOnNext1() {
+        Hooks.onNextDropped(Tracked::safeRelease);
+        Scheduler scheduler = Schedulers.newParallel("testScheduler", subscriptionsNumber());
+        scheduler.start();
+        for (int i = 0; i < 100000; i++) {
+            int[] index = new int[] { 0 };
+            FluxSink<Tracked<?>> sink[] = new FluxSink[subscriptionsNumber()];
             Publisher<Tracked<?>> source = transform(Flux.create(s -> {
-                sink[0] = s;
+                sink[index[0]++] = s;
             }, FluxSink.OverflowStrategy.IGNORE));
 
             AssertSubscriber<Tracked<?>> assertSubscriber = new AssertSubscriber<>(Operators.enableOnDiscard(null, Tracked::safeRelease));
             source.subscribe(assertSubscriber);
 
-            Tracked<Integer> value = new Tracked<>(1);
+            if (subscriptionsNumber() == 1) {
+                Tracked<Integer> value = new Tracked<>(1);
+                RaceTestUtils.race(assertSubscriber::cancel, () -> sink[0].next(value), scheduler);
+            } else {
+                int startIndex = --index[0];
+                Tracked<Integer> value1 = new Tracked<>(startIndex);
+                int secondIndex = --index[0];
+                Tracked<Integer> value2 = new Tracked<>(secondIndex);
+                Runnable action = () -> RaceTestUtils.race(() -> sink[startIndex].next(value1), () -> sink[secondIndex].next(value2), scheduler);
 
-            RaceTestUtils.race(assertSubscriber::cancel, () -> sink[0].next(value));
+                while (index[0] > 0) {
+                    int nextIndex = --index[0];
+                    Tracked<Integer> nextValue = new Tracked<>(nextIndex);
+                    Runnable nextAction = action;
+                    action = () -> RaceTestUtils.race(nextAction, () -> sink[nextIndex].next(nextValue), scheduler);
+                }
+                RaceTestUtils.race(assertSubscriber::cancel, action, scheduler);
+            }
+
+            List<Tracked<?>> values = assertSubscriber.values();
+            values.forEach(Tracked::release);
+
+            Tracked.assertNoLeaks();
+        }
+    }
+
+    @Test
+    public void ensureNoLeaksOnCancelOnNext2() {
+        Assumptions.assumeThat(subscriptionsNumber())
+                .isOne();
+        Hooks.onNextDropped(Tracked::safeRelease);
+        for (int i = 0; i < 100000; i++) {
+            FluxSink<Tracked<?>> sink[] = new FluxSink[1];
+            Publisher<Tracked<?>> source = transform(Flux.create(s -> {
+                sink[0] = s;
+            }, FluxSink.OverflowStrategy.IGNORE));
+
+            Scannable scannable = Scannable.from(source);
+            Integer prefetch = scannable.scan(Scannable.Attr.PREFETCH);
+
+            Assumptions.assumeThat(prefetch)
+                    .isNotZero();
+
+            AssertSubscriber<Tracked<?>> assertSubscriber = new AssertSubscriber<>(Operators.enableOnDiscard(null, Tracked::safeRelease), 0);
+            source.subscribe(assertSubscriber);
+
+            sink[0].next(new Tracked<>(1));
+            sink[0].next(new Tracked<>(2));
+            sink[0].next(new Tracked<>(3));
+            sink[0].next(new Tracked<>(4));
+
+            Tracked<Integer> value5 = new Tracked<>(5);
+
+            RaceTestUtils.race(assertSubscriber::cancel, () -> sink[0].next(value5));
+
+            List<Tracked<?>> values = assertSubscriber.values();
+            values.forEach(Tracked::release);
+
+            Tracked.assertNoLeaks();
+        }
+    }
+
+    @Test
+    public void ensureNoLeaksOnCancelOnNext3() {
+        Assumptions.assumeThat(subscriptionsNumber())
+                .isOne();
+        Hooks.onNextDropped(Tracked::safeRelease);
+        for (int i = 0; i < 100000; i++) {
+            FluxSink<Tracked<?>> sink[] = new FluxSink[1];
+            Publisher<Tracked<?>> source = transform(Flux.create(s -> {
+                sink[0] = s;
+            }, FluxSink.OverflowStrategy.IGNORE));
+
+            Scannable scannable = Scannable.from(source);
+            Integer prefetch = scannable.scan(Scannable.Attr.PREFETCH);
+
+            Assumptions.assumeThat(prefetch)
+                    .isNotZero();
+
+            AssertSubscriber<Tracked<?>> assertSubscriber = new AssertSubscriber<>(Operators.enableOnDiscard(null, Tracked::safeRelease), 0);
+            source.subscribe(assertSubscriber);
+
+            sink[0].next(new Tracked<>(1));
+            sink[0].next(new Tracked<>(2));
+            sink[0].next(new Tracked<>(3));
+            sink[0].next(new Tracked<>(4));
+
+            RaceTestUtils.race(assertSubscriber::cancel, () -> sink[0].complete());
+
+            List<Tracked<?>> values = assertSubscriber.values();
+            values.forEach(Tracked::release);
+
+            Tracked.assertNoLeaks();
+        }
+    }
+
+    @Test
+    public void ensureNoLeaksOnCancelOnNext4() {
+        Assumptions.assumeThat(subscriptionsNumber())
+                .isOne();
+        Hooks.onNextDropped(Tracked::safeRelease);
+        for (int i = 0; i < 100000; i++) {
+            FluxSink<Tracked<?>> sink[] = new FluxSink[1];
+            Publisher<Tracked<?>> source = transform(Flux.create(s -> {
+                sink[0] = s;
+            }, FluxSink.OverflowStrategy.IGNORE));
+
+            Scannable scannable = Scannable.from(source);
+            Integer prefetch = scannable.scan(Scannable.Attr.PREFETCH);
+
+            Assumptions.assumeThat(prefetch)
+                    .isNotZero();
+
+            AssertSubscriber<Tracked<?>> assertSubscriber = new AssertSubscriber<>(Operators.enableOnDiscard(null, Tracked::safeRelease), 0);
+            source.subscribe(assertSubscriber);
+
+            sink[0].next(new Tracked<>(1));
+            sink[0].next(new Tracked<>(2));
+            sink[0].next(new Tracked<>(3));
+            sink[0].next(new Tracked<>(4));
+
+            RaceTestUtils.race(assertSubscriber::cancel, () -> assertSubscriber.request(Long.MAX_VALUE));
 
             List<Tracked<?>> values = assertSubscriber.values();
             values.forEach(Tracked::release);

--- a/reactor-core/src/test/java/reactor/core/publisher/AbstractOnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/AbstractOnDiscardShouldNotLeakTest.java
@@ -29,7 +29,7 @@ public abstract class AbstractOnDiscardShouldNotLeakTest {
         Hooks.onNextDropped(Tracked::safeRelease);
         Scheduler scheduler = Schedulers.newParallel("testScheduler", subscriptionsNumber());
         scheduler.start();
-        for (int i = 0; i < 100000; i++) {
+        for (int i = 0; i < 10000; i++) {
             int[] index = new int[] { 0 };
             FluxSink<Tracked<?>> sink[] = new FluxSink[subscriptionsNumber()];
             Publisher<Tracked<?>> source = transform(Flux.create(s -> {
@@ -70,7 +70,7 @@ public abstract class AbstractOnDiscardShouldNotLeakTest {
         Assumptions.assumeThat(subscriptionsNumber())
                 .isOne();
         Hooks.onNextDropped(Tracked::safeRelease);
-        for (int i = 0; i < 100000; i++) {
+        for (int i = 0; i < 10000; i++) {
             FluxSink<Tracked<?>> sink[] = new FluxSink[1];
             Publisher<Tracked<?>> source = transform(Flux.create(s -> {
                 sink[0] = s;
@@ -106,7 +106,7 @@ public abstract class AbstractOnDiscardShouldNotLeakTest {
         Assumptions.assumeThat(subscriptionsNumber())
                 .isOne();
         Hooks.onNextDropped(Tracked::safeRelease);
-        for (int i = 0; i < 100000; i++) {
+        for (int i = 0; i < 10000; i++) {
             FluxSink<Tracked<?>> sink[] = new FluxSink[1];
             Publisher<Tracked<?>> source = transform(Flux.create(s -> {
                 sink[0] = s;
@@ -140,7 +140,7 @@ public abstract class AbstractOnDiscardShouldNotLeakTest {
         Assumptions.assumeThat(subscriptionsNumber())
                 .isOne();
         Hooks.onNextDropped(Tracked::safeRelease);
-        for (int i = 0; i < 100000; i++) {
+        for (int i = 0; i < 10000; i++) {
             FluxSink<Tracked<?>> sink[] = new FluxSink[1];
             Publisher<Tracked<?>> source = transform(Flux.create(s -> {
                 sink[0] = s;

--- a/reactor-core/src/test/java/reactor/core/publisher/AbstractOnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/AbstractOnDiscardShouldNotLeakTest.java
@@ -52,7 +52,7 @@ public abstract class AbstractOnDiscardShouldNotLeakTest {
         Hooks.onNextDropped(Tracked::safeRelease);
         Scheduler scheduler = Schedulers.newParallel("testScheduler", subscriptionsNumber());
         scheduler.start();
-        for (int i = 0; i < 1000000; i++) {
+        for (int i = 0; i < 10000; i++) {
             int[] index = new int[] { 0 };
             FluxSink<Tracked<?>> sink[] = new FluxSink[subscriptionsNumber()];
             Flux<Tracked<?>> source = transform(Flux.create(s -> {
@@ -100,7 +100,7 @@ public abstract class AbstractOnDiscardShouldNotLeakTest {
         Assumptions.assumeThat(subscriptionsNumber())
                 .isOne();
         Hooks.onNextDropped(Tracked::safeRelease);
-        for (int i = 0; i < 1000000; i++) {
+        for (int i = 0; i < 10000; i++) {
             FluxSink<Tracked<?>> sink[] = new FluxSink[1];
             Flux<Tracked<?>> source = transform(Flux.create(s -> sink[0] = s, FluxSink.OverflowStrategy.IGNORE));
 
@@ -141,7 +141,7 @@ public abstract class AbstractOnDiscardShouldNotLeakTest {
         Assumptions.assumeThat(subscriptionsNumber())
                 .isOne();
         Hooks.onNextDropped(Tracked::safeRelease);
-        for (int i = 0; i < 1000000; i++) {
+        for (int i = 0; i < 10000; i++) {
             FluxSink<Tracked<?>> sink[] = new FluxSink[1];
             Flux<Tracked<?>> source = transform(Flux.create(s -> {
                 sink[0] = s;
@@ -182,7 +182,7 @@ public abstract class AbstractOnDiscardShouldNotLeakTest {
         Assumptions.assumeThat(subscriptionsNumber())
                 .isOne();
         Hooks.onNextDropped(Tracked::safeRelease);
-        for (int i = 0; i < 1000000; i++) {
+        for (int i = 0; i < 10000; i++) {
             FluxSink<Tracked<?>> sink[] = new FluxSink[1];
             Flux<Tracked<?>> source = transform(Flux.create(s -> {
                 sink[0] = s;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapIterableOnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapIterableOnDiscardShouldNotLeakTest.java
@@ -1,0 +1,16 @@
+package reactor.core.publisher;
+
+import java.util.Arrays;
+
+public class FluxFlatMapIterableOnDiscardShouldNotLeakTest extends AbstractOnDiscardShouldNotLeakTest {
+
+    public FluxFlatMapIterableOnDiscardShouldNotLeakTest(boolean conditional, boolean fused) {
+        super(conditional, fused);
+    }
+
+    @Override
+    Flux<Tracked<?>> transform(Flux<Tracked<?>> upstream) {
+        return upstream
+                .flatMapIterable(Arrays::asList);
+    }
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapOnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapOnDiscardShouldNotLeakTest.java
@@ -1,14 +1,13 @@
 package reactor.core.publisher;
 
-import org.reactivestreams.Publisher;
-import reactor.core.scheduler.Schedulers;
-
-import java.time.Duration;
-
 public class FluxFlatMapOnDiscardShouldNotLeakTest extends AbstractOnDiscardShouldNotLeakTest {
 
+    public FluxFlatMapOnDiscardShouldNotLeakTest(boolean conditional, boolean fused) {
+        super(conditional, fused);
+    }
+
     @Override
-    Publisher<Tracked<?>> transform(Flux<Tracked<?>> upstream) {
+    Flux<Tracked<?>> transform(Flux<Tracked<?>> upstream) {
         return upstream
                 .flatMap(f -> Mono.just(f).hide().flux());
     }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapOnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapOnDiscardShouldNotLeakTest.java
@@ -1,0 +1,15 @@
+package reactor.core.publisher;
+
+import org.reactivestreams.Publisher;
+import reactor.core.scheduler.Schedulers;
+
+import java.time.Duration;
+
+public class FluxFlatMapOnDiscardShouldNotLeakTest extends AbstractOnDiscardShouldNotLeakTest {
+
+    @Override
+    Publisher<Tracked<?>> transform(Flux<Tracked<?>> upstream) {
+        return upstream
+                .flatMap(f -> Mono.just(f).hide().flux());
+    }
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOnDiscardShouldNotLeakTest.java
@@ -1,12 +1,15 @@
 package reactor.core.publisher;
 
-import org.reactivestreams.Publisher;
 import reactor.util.concurrent.Queues;
 
 public class FluxMergeOnDiscardShouldNotLeakTest extends AbstractOnDiscardShouldNotLeakTest {
 
+    public FluxMergeOnDiscardShouldNotLeakTest(boolean conditional, boolean fused) {
+        super(conditional, fused);
+    }
+
     @Override
-    Publisher<Tracked<?>> transform(Flux<Tracked<?>> upstream) {
+    Flux<Tracked<?>> transform(Flux<Tracked<?>> upstream) {
         Flux<Tracked<?>>[] inners = new Flux[subscriptionsNumber()];
         for (int i = 0; i < subscriptionsNumber(); i++) {
             inners[i] = upstream;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOnDiscardShouldNotLeakTest.java
@@ -1,0 +1,21 @@
+package reactor.core.publisher;
+
+import org.reactivestreams.Publisher;
+import reactor.util.concurrent.Queues;
+
+public class FluxMergeOnDiscardShouldNotLeakTest extends AbstractOnDiscardShouldNotLeakTest {
+
+    @Override
+    Publisher<Tracked<?>> transform(Flux<Tracked<?>> upstream) {
+        Flux<Tracked<?>>[] inners = new Flux[subscriptionsNumber()];
+        for (int i = 0; i < subscriptionsNumber(); i++) {
+            inners[i] = upstream;
+        }
+        return Flux.merge(inners);
+    }
+
+    @Override
+    int subscriptionsNumber() {
+        return Queues.XS_BUFFER_SIZE;
+    }
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferOnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferOnDiscardShouldNotLeakTest.java
@@ -1,0 +1,14 @@
+package reactor.core.publisher;
+
+public class FluxOnBackpressureBufferOnDiscardShouldNotLeakTest extends AbstractOnDiscardShouldNotLeakTest {
+
+    public FluxOnBackpressureBufferOnDiscardShouldNotLeakTest(boolean conditional, boolean fused) {
+        super(conditional, fused);
+    }
+
+    @Override
+    Flux<Tracked<?>> transform(Flux<Tracked<?>> upstream) {
+        return upstream
+                .onBackpressureBuffer();
+    }
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnOnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnOnDiscardShouldNotLeakTest.java
@@ -1,0 +1,13 @@
+package reactor.core.publisher;
+
+import org.reactivestreams.Publisher;
+import reactor.core.scheduler.Schedulers;
+
+public class FluxPublishOnOnDiscardShouldNotLeakTest extends AbstractOnDiscardShouldNotLeakTest {
+
+    @Override
+    Publisher<Tracked<?>> transform(Flux<Tracked<?>> upstream) {
+        return upstream
+                .publishOn(Schedulers.immediate());
+    }
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnOnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnOnDiscardShouldNotLeakTest.java
@@ -1,12 +1,15 @@
 package reactor.core.publisher;
 
-import org.reactivestreams.Publisher;
 import reactor.core.scheduler.Schedulers;
 
 public class FluxPublishOnOnDiscardShouldNotLeakTest extends AbstractOnDiscardShouldNotLeakTest {
 
+    public FluxPublishOnOnDiscardShouldNotLeakTest(boolean conditional, boolean fused) {
+        super(conditional, fused);
+    }
+
     @Override
-    Publisher<Tracked<?>> transform(Flux<Tracked<?>> upstream) {
+    Flux<Tracked<?>> transform(Flux<Tracked<?>> upstream) {
         return upstream
                 .publishOn(Schedulers.immediate());
     }

--- a/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorOnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorOnDiscardShouldNotLeakTest.java
@@ -1,12 +1,13 @@
 package reactor.core.publisher;
 
-import org.reactivestreams.Publisher;
-import reactor.core.scheduler.Schedulers;
-
 public class UnicastProcessorOnDiscardShouldNotLeakTest extends AbstractOnDiscardShouldNotLeakTest {
 
+    public UnicastProcessorOnDiscardShouldNotLeakTest(boolean conditional, boolean fused) {
+        super(conditional, fused);
+    }
+
     @Override
-    Publisher<Tracked<?>> transform(Flux<Tracked<?>> upstream) {
+    Flux<Tracked<?>> transform(Flux<Tracked<?>> upstream) {
         return upstream
                 .subscribeWith(UnicastProcessor.create());
     }

--- a/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorOnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorOnDiscardShouldNotLeakTest.java
@@ -1,0 +1,13 @@
+package reactor.core.publisher;
+
+import org.reactivestreams.Publisher;
+import reactor.core.scheduler.Schedulers;
+
+public class UnicastProcessorOnDiscardShouldNotLeakTest extends AbstractOnDiscardShouldNotLeakTest {
+
+    @Override
+    Publisher<Tracked<?>> transform(Flux<Tracked<?>> upstream) {
+        return upstream
+                .subscribeWith(UnicastProcessor.create());
+    }
+}


### PR DESCRIPTION
While testing RSocket ByteBuf leaks issue https://github.com/rsocket/rsocket-java/pull/777 I found that Reactor may leak an element (so it will not be sent to `onDiscard` and `onNextDropped` hooks at all) in case there is `cancel` and `onNext` racing.

Not that obvious leaks
case 1
```
                while (r != e) {
					boolean d = done;
					T t = q.poll();
					boolean empty = t == null;
                    
// t element has been polled (so it is not in the queue anymore) == it is not discarded == leak
					if (checkTerminated(d, empty, a)) {
						return;
					}
				}
```
case 2

```
void onNext(T t) {
   if (canceled) {
      ...
   }
   queue.offer(t);
   drain();
}
void cancel() {
  canceled = true
  ...
  if (WIP.getAndIncrement(this) == 0) {
	Operators.onDiscardQueueWithClear(queue, actual.currentContext(), null);
  }
}
```
1) 
    - Thread 1 entering `onNext`
    - Thread 2 entering `cancel`
2) 
    - Thread 1 bypassing `if(canceled)`
    - Thread 2 sets `canceled = true`
3) 
    - Thread 1 idle for some reasons 
    - Thread 2 incrementing `WIP` to 1
4) 
    - Thread 1 idle for some reasons
    - Thread 2 clear the queue
5) 
    - Thread 1 offers an element into the `queue`
    - Thread 2 exists the `cancel` method
6) 
    - Thread 1 increments `WIP` and sees 1, so it just returns the execution 

Pabaaam, we have one element in the queue which is not discarded 


I have not added any tests yet but I can cover that in this PR as well in order to ensure that we don't have that leaks anymore in the fixed operators

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>