### PR TITLE
fix #2143 Use ZoneId.of(String) to avoid blocking disk load

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -192,6 +192,12 @@ task testNoMicrometer(type: Test, group: 'verification') {
   }
 }
 
+blockHoundTest {
+	// Creates a JVM per test because the agent can be installed only once
+	forkEvery = 1
+	maxParallelForks = 1
+}
+
 tasks.withType(Test).all {
   useJUnitPlatform()
 }

--- a/reactor-core/src/blockHoundTest/java/reactor/core/scheduler/BoundedElasticSchedulerBlockhoundTest.java
+++ b/reactor-core/src/blockHoundTest/java/reactor/core/scheduler/BoundedElasticSchedulerBlockhoundTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.scheduler;
+
+import java.util.concurrent.FutureTask;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import reactor.blockhound.BlockHound;
+import reactor.core.Disposable;
+
+public class BoundedElasticSchedulerBlockhoundTest {
+
+	@BeforeClass
+	public static void setup() {
+		BlockHound.install();
+	}
+
+	//see https://github.com/reactor/reactor-core/issues/2143
+	@Test
+	public void shouldNotReportBlockingCallWithZoneIdUsage() throws Throwable {
+		FutureTask<Disposable> testTask = new FutureTask<>(() -> new BoundedElasticScheduler(1, 1, Thread::new, 1));
+		Schedulers.single().schedule(testTask);
+		//automatically re-throw in case of blocking call, in which case the scheduler hasn't been created so there is no leak.
+		testTask.get().dispose();
+	}
+
+}

--- a/reactor-core/src/test/java/reactor/core/scheduler/BoundedElasticSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/BoundedElasticSchedulerTest.java
@@ -27,7 +27,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -97,6 +96,8 @@ public class BoundedElasticSchedulerTest extends AbstractSchedulerTest {
 		LOGGER.debug("Remaining threads after test class:");
 		LOGGER.debug(dumpThreadNames().collect(Collectors.joining(", ")));
 	}
+
+	//note: blocking behavior is also tested in BoundedElasticSchedulerBlockhoundTest (separate sourceset)
 
 	@Override
 	protected BoundedElasticScheduler scheduler() {


### PR DESCRIPTION
The former use of ZoneId.systemDefault() would trigger a file read from
disk (configuration read for the sytem's default timezone), despite the
timezone not being that important for the Scheduler. Using of(String)
factory method avoids that disk read. The ZoneId is frontloaded as a
constant anyway, since it is used by the SHUTDOWN constant as well.