### PR TITLE
fix #2152 reportThrowInSubscribe triggers sneaky ClassCastException

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
@@ -1253,7 +1253,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	}
 
 	@Test
-    public void scanSubscriber() {
+    public void scanSubscriber() throws InterruptedException {
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxPublishOn.PublishOnSubscriber<Integer> test = new FluxPublishOn.PublishOnSubscriber<>(actual,
         		Schedulers.single(), Schedulers.single().createWorker(), true, 123, 123, Queues.unbounded());
@@ -1278,6 +1278,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 
         //once cancelled, there shouldn't be any draining left
         // => better place to test that BUFFERED reflects the size of the queue
+		Thread.sleep(50); //"hiccup" to ensure cancellation / draining is done
         test.queue.add(1);
         test.queue.add(1);
         assertThat(test.scan(Scannable.Attr.BUFFERED)).isEqualTo(2);

--- a/reactor-test/src/test/java/reactor/test/DefaultStepVerifierBuilderTests.java
+++ b/reactor-test/src/test/java/reactor/test/DefaultStepVerifierBuilderTests.java
@@ -23,6 +23,7 @@ import java.util.Queue;
 
 import org.junit.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Operators;
 import reactor.test.DefaultStepVerifierBuilder.DefaultVerifySubscriber;
 import reactor.test.DefaultStepVerifierBuilder.DescriptionEvent;
 import reactor.test.DefaultStepVerifierBuilder.Event;
@@ -55,6 +56,21 @@ public class DefaultStepVerifierBuilderTests {
 		assertThatExceptionOfType(AssertionError.class)
 				.isThrownBy(s::verify)
 				.withMessageStartingWith("expectation failed (an unexpected Subscription has been received");
+	}
+
+	@Test
+	public void subscribedTwiceDetectsSpecialSubscription() {
+		Flux<String> flux = Flux.never();
+
+		DefaultVerifySubscriber<String> s =
+				new DefaultStepVerifierBuilder<String>(StepVerifierOptions.create().initialRequest(Long.MAX_VALUE), null)
+						.expectErrorMessage("expected")
+				.toSubscriber();
+
+		flux.subscribe(s);
+		Operators.reportThrowInSubscribe(s, new RuntimeException("expected"));
+
+		s.verify(Duration.ofSeconds(1));
 	}
 
 	@Test(timeout = 4000)


### PR DESCRIPTION
This commit changes the Subscription set by reportThrowInSubscribe to
an instance compatible with QueueSubscription, preventing fused cases
where a ClassCastException would be thrown. The later would be
problematic with operators that make use of the Subscription when
receiving the onError signal, as said Subscription would be null at
that point due to the ClassCastException, sometimes causing hanging.