### PR TITLE
[build] Backport last relevant build changes from 3.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,92 +13,95 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 buildscript {
+  //we define kotlin version for benefit of both core and test (see kotlin-gradle-plugin below)
   ext.kotlinVersion = '1.3.71'
   repositories {
 	maven { url "https://repo.spring.io/plugins-release" }
   }
   dependencies {
-	classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
-	classpath 'io.spring.gradle:spring-io-plugin:0.0.4.RELEASE'
-	classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.0'
+	classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7' //still uses the old ways
 	classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
   }
 }
 
 
 plugins {
-	id 'org.asciidoctor.convert' version '1.5.9.2'
+	id "com.github.johnrengelman.shadow" version "4.0.2"
+	id 'org.asciidoctor.convert' version '1.5.11'
 	id "me.champeau.gradle.jmh" version "0.4.7" apply false
 	id "org.jetbrains.dokka" version "0.9.18" apply false
 	id "me.champeau.gradle.japicmp" version "0.2.6"
 	id "de.undercouch.download" version "3.4.3"
+	//note: build scan plugin now must be applied in settings.gradle
 	id "com.jfrog.artifactory" version "4.9.8" apply false
 	id 'biz.aQute.bnd.builder' version '5.0.1' apply false
 }
 
-apply from: "gradle/doc.gradle"
+apply plugin: "io.reactor.gradle.detect-ci"
+apply from: "gradle/asciidoc.gradle" //asciidoc (which is generated from root dir)
 apply from: "gradle/releaser.gradle"
 
 ext {
-  //also set up the special version at root, for refguide
-  if (project.hasProperty('versionBranch') && version.toString().endsWith(".BUILD-SNAPSHOT")) {
-	versionBranch = versionBranch.replaceAll("\"", "").trim()
-	if (!versionBranch.isEmpty()) {
-	  realVersion = version.toString().replace("BUILD-SNAPSHOT", versionBranch + ".BUILD-SNAPSHOT")
-	  project.version = realVersion
+	jdk = JavaVersion.current().majorVersion
+	jdkJavadoc = "https://docs.oracle.com/javase/$jdk/docs/api/"
+	if (JavaVersion.current().isJava11Compatible()) {
+		jdkJavadoc = "https://docs.oracle.com/en/java/javase/$jdk/docs/api/"
 	}
-  }
+	println "JDK Javadoc link for this build is ${rootProject.jdkJavadoc}"
 
-  // Metrics
-  micrometerVersion = 'latest.release' //TODO specify a version of micrometer?
+  /*
+   * Note that some versions can be bumped by a script.
+   * These are found in `gradle.properties`...
+   *
+   * Versions not necessarily bumped by a script (testing, etc...) below:
+   */
+  // Misc not often upgraded
+  jsr305Version = '3.0.2'
+  jsr166BackportVersion = '1.0.0.RELEASE'
 
   // Logging
   slf4jVersion = '1.7.12'
   logbackVersion = '1.1.2'
 
   // Testing
+  jUnitVersion = '4.13'
   assertJVersion = '3.11.1'
   mockitoVersion = '2.23.0'
   jUnitParamsVersion = '1.1.1'
+  awaitilityVersion = '3.1.2'
+  javaObjectLayoutVersion = '0.9'
+  testNgVersion = '6.8.5'
+}
 
-  jdk = JavaVersion.current().majorVersion
-  jdkJavadoc = "https://docs.oracle.com/javase/$jdk/docs/api/"
-  if (JavaVersion.current().isJava11Compatible()) {
-	jdkJavadoc = "https://docs.oracle.com/en/java/javase/$jdk/docs/api/"
-  }
-
-  javadocLinks = [jdkJavadoc,
-				  "https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/"] as String[]
+//only publish scan if a specific gradle entreprise server is passed
+//typically, for local usage, you would temporarily set the env with:
+// `GRADLE_ENTERPRISE_URL=https://myge.example.com/ gradle foo`
+if (System.getenv('GRADLE_ENTERPRISE_URL')) {
+	gradleEnterprise {
+		buildScan {
+			captureTaskInputFiles = true
+			obfuscation {
+				ipAddresses { addresses -> addresses.collect { '0.0.0.0' } }
+			}
+			publishAlways()
+			server = System.getenv('GRADLE_ENTERPRISE_URL')
+		}
+	}
 }
 
 configure(subprojects) { p ->
 	apply plugin: 'java'
-	apply plugin: 'kotlin'
 	apply plugin: 'jacoco'
-	apply plugin: 'propdeps'
+	apply plugin: 'propdeps' //TODO replace with a simpler local plugin?
 	apply from: "${rootDir}/gradle/setup.gradle"
 
 	description = 'Non-Blocking Reactive Foundation for the JVM'
 	group = 'io.projectreactor'
 
-	ext {
-		//set up special version per sub-project
-		//(the root level configuration doesn't seem to propagate)
-		if (project.hasProperty('versionBranch') && version.toString().endsWith(".BUILD-SNAPSHOT")) {
-			versionBranch = versionBranch.replaceAll("\"", "").trim()
-			if (!versionBranch.isEmpty()) {
-				realVersion = p.version.toString().replace("BUILD-SNAPSHOT", versionBranch + ".BUILD-SNAPSHOT")
-				p.version = realVersion
-				println "Building special ${project} snapshot ${p.version}"
-			}
-		}
-	}
-
   repositories {
 	mavenLocal()
-	if (version.endsWith('BUILD-SNAPSHOT') || project.hasProperty('platformVersion')) {
+	if (version.endsWith('BUILD-SNAPSHOT')) {
 	  maven { url 'https://repo.spring.io/libs-snapshot' }
 	}
 
@@ -120,55 +123,6 @@ configure(subprojects) { p ->
 	}
   }
 
-  [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
-  [compileJava, compileTestJava]*.options*.compilerArgs =
-		  ["-Xlint:-varargs", // intentionally disabled
-		   "-Xlint:cast",
-		   "-Xlint:classfile",
-		   "-Xlint:dep-ann",
-		   "-Xlint:divzero",
-		   "-Xlint:empty",
-		   "-Xlint:finally",
-		   "-Xlint:overrides",
-		   "-Xlint:path",
-		   "-Xlint:processing",
-		   "-Xlint:static",
-		   "-Xlint:try",
-		   "-Xlint:deprecation",
-		   "-Xlint:unchecked",
-		   "-Xlint:-serial",      // intentionally disabled
-		   "-Xlint:-options",     // intentionally disabled
-		   "-Xlint:-fallthrough", // intentionally disabled
-		   "-Xlint:-rawtypes"     // TODO enable and fix warnings
-		  ]
-
-  compileJava {
-	sourceCompatibility = 1.8
-	targetCompatibility = 1.8
-  }
-
-  compileTestJava {
-	sourceCompatibility = 1.8
-	targetCompatibility = 1.8
-  }
-
-  compileKotlin {
-	kotlinOptions.jvmTarget = "1.8"
-	kotlinOptions.freeCompilerArgs = ["-Xjsr305=strict"]
-  }
-
-  compileTestKotlin {
-	kotlinOptions.jvmTarget = "1.8"
-	kotlinOptions.freeCompilerArgs = ["-Xjsr305=strict"]
-  }
-
-  if (JavaVersion.current().isJava8Compatible()) {
-	compileTestJava.options.compilerArgs += "-parameters"
-	p.tasks.withType(Javadoc) {
-	  options.addStringOption('Xdoclint:none', '-quiet')
-	}
-  }
-
   //includes for base test task (see below for additional common configurations)
   test {
 	include '**/*Tests.*'
@@ -187,14 +141,33 @@ configure(subprojects) { p ->
 	  maxGranularity 3
 	}
 
+	if (isCiServer) {
+	  def stdout = new LinkedList<TestOutputEvent>()
+	  beforeTest { TestDescriptor td ->
+		stdout.clear()
+	  }
+	  onOutput { TestDescriptor td, TestOutputEvent toe ->
+		stdout.add(toe)
+	  }
+	  afterTest { TestDescriptor td, TestResult tr ->
+		if (tr.resultType == TestResult.ResultType.FAILURE && stdout.size() > 0) {
+		  def stdOutput = stdout.collect {
+			it.getDestination().name() == "StdErr"
+					? "STD_ERR: ${it.getMessage()}"
+					: "STD_OUT: ${it.getMessage()}"
+		  }
+				  .join()
+		  println "This is the console output of the failing test below:\n$stdOutput"
+		}
+	  }
+	}
+
 	if (JavaVersion.current().isJava9Compatible()) {
 	  println "Java 9+: lowering MaxGCPauseMillis to 20ms in ${project.name} ${name}"
 	  jvmArgs = ["-XX:MaxGCPauseMillis=20"]
 	}
 
 	systemProperty("java.awt.headless", "true")
-	systemProperty("reactor.trace.cancel", "true")
-	systemProperty("reactor.trace.nocapacity", "true")
 	systemProperty("testGroups", p.properties.get("testGroups"))
 	scanForTestClasses = false
 	exclude '**/*Abstract*.*'
@@ -211,25 +184,31 @@ configure(subprojects) { p ->
 	  }
 	}
   }
-
-  // now that kotlin-gradle-plugin 1.1.60 is out with fix for https://youtrack.jetbrains.com/issue/KT-17564
-  // be wary and fail if the issue of source file duplication in jar comes up again
-  sourcesJar {
-	duplicatesStrategy = DuplicatesStrategy.FAIL
-  }
-
 }
 
-if (project.hasProperty('platformVersion')) {
-  apply plugin: 'spring-io'
+assemble.dependsOn docsZip
 
-  dependencyManagement {
-	springIoTestRuntime {
-	  imports {
-		mavenBom "io.spring.platform:platform-bom:$platformVersion"
+gradle.allprojects() { p ->
+  apply plugin: "io.reactor.gradle.custom-version"
+}
+
+configure(subprojects) { p ->
+  //these apply once the above configure is done, but before project-specific build.gradle have applied
+  apply plugin: "io.reactor.gradle.java-conventions"
+  apply from: "${rootDir}/gradle/javadoc.gradle"
+
+  //these apply AFTER project-specific build.gradle have applied
+  afterEvaluate {
+	if (p.plugins.hasPlugin("kotlin")) {
+	  println "Applying Kotlin conventions to ${p.name}"
+	  compileKotlin {
+		kotlinOptions.jvmTarget = "1.8"
+		kotlinOptions.freeCompilerArgs = ["-Xjsr305=strict"]
+	  }
+	  compileTestKotlin {
+		kotlinOptions.jvmTarget = "1.8"
+		kotlinOptions.freeCompilerArgs = ["-Xjsr305=strict"]
 	  }
 	}
   }
 }
-
-assemble.dependsOn docsZip

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ buildscript {
 
 
 plugins {
-	id "com.github.johnrengelman.shadow" version "4.0.2"
 	id 'org.asciidoctor.convert' version '1.5.11'
 	id "me.champeau.gradle.jmh" version "0.4.7" apply false
 	id "org.jetbrains.dokka" version "0.9.18" apply false

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+  id 'java-gradle-plugin'
+}
+
+repositories {
+  mavenCentral()
+  jcenter()
+  gradlePluginPortal()
+}
+
+dependencies {
+  testImplementation("org.assertj:assertj-core:3.11.1")
+  testImplementation("org.junit.jupiter:junit-jupiter-api:5.5.2")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.5.2")
+}
+
+test {
+  useJUnitPlatform()
+  testLogging {
+	showStackTraces = true
+	exceptionFormat = "FULL"
+  }
+}
+
+gradlePlugin {
+  plugins {
+	customVersionPlugin {
+	  id = "io.reactor.gradle.custom-version"
+	  implementationClass = "io.reactor.gradle.CustomVersionPlugin"
+	}
+	detectCIPlugin {
+	  id = "io.reactor.gradle.detect-ci"
+	  implementationClass = "io.reactor.gradle.DetectCiPlugin"
+	}
+	javaConventionsPlugin {
+	  id = "io.reactor.gradle.java-conventions"
+	  implementationClass = "io.reactor.gradle.JavaConventions"
+	}
+  }
+}

--- a/buildSrc/src/main/java/io/reactor/gradle/CustomVersionPlugin.java
+++ b/buildSrc/src/main/java/io/reactor/gradle/CustomVersionPlugin.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactor.gradle;
+
+import java.util.regex.Pattern;
+
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+/**
+ * Looks for a {@code -PversionBranch=foo} type of property and uses that as an additional
+ * suffix between the patch number and the snapshot qualifier ({@code .BUILD-SNAPSHOT}), in
+ * order to generate branch-specific snapshots that can be used to eg. validate a PR.
+ * <p>
+ * The custom suffix must only contain alphanumeric characters.
+ *
+ * @author Simon Baslé
+ */
+public class CustomVersionPlugin implements Plugin<Project> {
+
+	private static final String CUSTOM_VERSION_PROPERTY = "versionBranch";
+	private static final String SNAPSHOT_SUFFIX         = ".BUILD-SNAPSHOT";
+
+	private static final Pattern ONLY_ALPHANUMERIC_PATTERN = Pattern.compile("[A-Za-z0-9]+");
+
+	@Override
+	public void apply(Project project) {
+		String version = project.getVersion().toString();
+		Object versionBranchProperty = project.getProperties().get(CUSTOM_VERSION_PROPERTY);
+		if (versionBranchProperty == null) {
+			return;
+		}
+
+		String versionBranch = versionBranchProperty.toString();
+		//consider an empty string as "no custom version"
+		if (versionBranch.isEmpty()) {
+			return;
+		}
+		if (!ONLY_ALPHANUMERIC_PATTERN.matcher(versionBranch).matches()) {
+			throw new InvalidUserDataException("Custom version for project passed through -PversionBranch must be alphanumeric chars only: " + versionBranch);
+		}
+
+		if (!version.endsWith(SNAPSHOT_SUFFIX)) {
+			return;
+		}
+
+		String realVersion = version.replace(SNAPSHOT_SUFFIX, "." + versionBranch + SNAPSHOT_SUFFIX);
+		project.setVersion(realVersion);
+		System.out.println("Building custom snapshot for " + project + ": '" + project.getVersion());
+	}
+
+}

--- a/buildSrc/src/main/java/io/reactor/gradle/DetectCiPlugin.java
+++ b/buildSrc/src/main/java/io/reactor/gradle/DetectCiPlugin.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactor.gradle;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.inject.Inject;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+/**
+ * @author Simon Baslé
+ */
+public class DetectCiPlugin implements Plugin<Project> {
+
+	public static final List<String> CI_SERVERS = Arrays.asList("CI", "CONTINUOUS_INTEGRATION", "TRAVIS", "CIRCLECI", "bamboo_planKey", "GITHUB_ACTION");
+	public static final String FLAG_EXTENSION = "isCiServer";
+	public static final String DETECTED_EXTENSION = "detectedCiServers";
+
+	public final Supplier<? extends Collection<String>> environmentSupplier;
+
+	@Inject
+	public DetectCiPlugin() {
+		environmentSupplier = () -> System.getenv().keySet();
+	}
+
+	protected DetectCiPlugin(Collection<String> testEnvironment) {
+		environmentSupplier = () -> testEnvironment;
+	}
+
+	@Override
+	public void apply(Project project) {
+		//ignore subprojects
+		if (project.getParent() != null) {
+			return;
+		}
+
+		Set<String> detected = new HashSet<>(CI_SERVERS);
+		detected.retainAll(environmentSupplier.get());
+
+		boolean isCiServer = !detected.isEmpty();
+		if (isCiServer) {
+			System.out.println("Detected CI environment: " + detected);
+		}
+
+		project.getExtensions().add(FLAG_EXTENSION, isCiServer);
+		project.getExtensions().add(DETECTED_EXTENSION, detected);
+	}
+}

--- a/buildSrc/src/main/java/io/reactor/gradle/JavaConventions.java
+++ b/buildSrc/src/main/java/io/reactor/gradle/JavaConventions.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactor.gradle;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.gradle.api.JavaVersion;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.compile.JavaCompile;
+
+/**
+ * @author Simon Baslé
+ */
+public class JavaConventions implements Plugin<Project> {
+
+	@Override
+	public void apply(Project project) {
+		project.getPlugins().withType(JavaPlugin.class, plugin -> applyJavaConvention(project));
+	}
+
+	private void applyJavaConvention(Project project) {
+		JavaPluginConvention java = project.getConvention().getPlugin(JavaPluginConvention.class);
+		java.setSourceCompatibility(JavaVersion.VERSION_1_8);
+		java.setTargetCompatibility(JavaVersion.VERSION_1_8);
+
+		project.getTasks()
+		       .withType(JavaCompile.class)
+		       .forEach(compileTask -> {
+			       compileTask.getOptions().setEncoding("UTF-8");
+			       compileTask.getOptions().setCompilerArgs(Arrays.asList(
+					       "-Xlint:-varargs", // intentionally disabled
+					       "-Xlint:cast",
+					       "-Xlint:classfile",
+					       "-Xlint:dep-ann",
+					       "-Xlint:divzero",
+					       "-Xlint:empty",
+					       "-Xlint:finally",
+					       "-Xlint:overrides",
+					       "-Xlint:path",
+					       "-Xlint:processing",
+					       "-Xlint:static",
+					       "-Xlint:try",
+					       "-Xlint:deprecation",
+					       "-Xlint:unchecked",
+					       "-Xlint:-serial",      // intentionally disabled
+					       "-Xlint:-options",     // intentionally disabled
+					       "-Xlint:-fallthrough", // intentionally disabled
+					       "-Xlint:-rawtypes"     // TODO enable and fix warnings
+			       ));
+		       });
+
+		if (JavaVersion.current().isJava8Compatible()) {
+			project.getTasks().withType(JavaCompile.class, t -> {
+				if (t.getName().equalsIgnoreCase("testcompile")) {
+					List<String> args = new ArrayList<>(t.getOptions().getCompilerArgs());
+					args.add("-parameters");
+					t.getOptions().setCompilerArgs(args);
+				}
+			});
+		}
+
+	}
+}

--- a/buildSrc/src/test/java/io/reactor/gradle/CustomVersionPluginTest.java
+++ b/buildSrc/src/test/java/io/reactor/gradle/CustomVersionPluginTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactor.gradle;
+
+import io.reactor.gradle.CustomVersionPlugin;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * @author Simon Baslé
+ */
+public class CustomVersionPluginTest {
+
+	@Test
+	void noCustomVersionPropertyDoesNothing() {
+		CustomVersionPlugin plugin = new CustomVersionPlugin();
+		Project project = ProjectBuilder.builder().withName("foo").build();
+		project.setVersion("1.2.3.BUILD-SNAPSHOT");
+
+		plugin.apply(project);
+
+		assertThat(project.getVersion()).hasToString("1.2.3.BUILD-SNAPSHOT");
+	}
+
+	@Test
+	void acceptsEmptyStringAsNoCustomVersion() {
+		CustomVersionPlugin plugin = new CustomVersionPlugin();
+		Project project = ProjectBuilder.builder().withName("foo").build();
+		project.setVersion("1.2.3.BUILD-SNAPSHOT");
+		project.getExtensions().add("versionBranch", "");
+
+		assertThatCode(() -> plugin.apply(project)).doesNotThrowAnyException();
+		assertThat(project.getVersion()).hasToString("1.2.3.BUILD-SNAPSHOT");
+	}
+
+	@Test
+	void rejectSpace() {
+		CustomVersionPlugin plugin = new CustomVersionPlugin();
+		Project project = ProjectBuilder.builder().withName("foo").build();
+		project.setVersion("1.2.3.BUILD-SNAPSHOT");
+		project.getExtensions().add("versionBranch", "custom one");
+
+		assertThatExceptionOfType(InvalidUserDataException.class)
+				.isThrownBy(() -> plugin.apply(project))
+				.withMessage("Custom version for project passed through -PversionBranch must be alphanumeric chars only: custom one");
+
+		assertThat(project.getVersion()).hasToString("1.2.3.BUILD-SNAPSHOT");
+	}
+
+	@Test
+	void rejectDash() {
+		CustomVersionPlugin plugin = new CustomVersionPlugin();
+		Project project = ProjectBuilder.builder().withName("foo").build();
+		project.setVersion("1.2.3.BUILD-SNAPSHOT");
+		project.getExtensions().add("versionBranch", "custom-one");
+
+		assertThatExceptionOfType(InvalidUserDataException.class)
+				.isThrownBy(() -> plugin.apply(project))
+				.withMessage("Custom version for project passed through -PversionBranch must be alphanumeric chars only: custom-one");
+
+		assertThat(project.getVersion()).hasToString("1.2.3.BUILD-SNAPSHOT");
+	}
+
+	@Test
+	void rejectUnderscore() {
+		CustomVersionPlugin plugin = new CustomVersionPlugin();
+		Project project = ProjectBuilder.builder().withName("foo").build();
+		project.setVersion("1.2.3.BUILD-SNAPSHOT");
+		project.getExtensions().add("versionBranch", "custom_one");
+
+		assertThatExceptionOfType(InvalidUserDataException.class)
+				.isThrownBy(() -> plugin.apply(project))
+				.withMessage("Custom version for project passed through -PversionBranch must be alphanumeric chars only: custom_one");
+
+		assertThat(project.getVersion()).hasToString("1.2.3.BUILD-SNAPSHOT");
+	}
+
+	@Test
+	void rejectSpaceEvenIfNotSnapshot() {
+		CustomVersionPlugin plugin = new CustomVersionPlugin();
+		Project project = ProjectBuilder.builder().withName("foo").build();
+		project.setVersion("1.2.3.RELEASE");
+		project.getExtensions().add("versionBranch", "custom one");
+
+		assertThatExceptionOfType(InvalidUserDataException.class)
+				.isThrownBy(() -> plugin.apply(project))
+				.withMessage("Custom version for project passed through -PversionBranch must be alphanumeric chars only: custom one");
+
+		assertThat(project.getVersion()).hasToString("1.2.3.RELEASE");
+	}
+
+	@Test
+	void rejectDashEvenIfNotSnapshot() {
+		CustomVersionPlugin plugin = new CustomVersionPlugin();
+		Project project = ProjectBuilder.builder().withName("foo").build();
+		project.setVersion("1.2.3.RELEASE");
+		project.getExtensions().add("versionBranch", "custom-one");
+
+		assertThatExceptionOfType(InvalidUserDataException.class)
+				.isThrownBy(() -> plugin.apply(project))
+				.withMessage("Custom version for project passed through -PversionBranch must be alphanumeric chars only: custom-one");
+
+		assertThat(project.getVersion()).hasToString("1.2.3.RELEASE");
+	}
+
+	@Test
+	void rejectUnderscoreEvenIfNotSnapshot() {
+		CustomVersionPlugin plugin = new CustomVersionPlugin();
+		Project project = ProjectBuilder.builder().withName("foo").build();
+		project.setVersion("1.2.3.RELEASE");
+		project.getExtensions().add("versionBranch", "custom_one");
+
+		assertThatExceptionOfType(InvalidUserDataException.class)
+				.isThrownBy(() -> plugin.apply(project))
+				.withMessage("Custom version for project passed through -PversionBranch must be alphanumeric chars only: custom_one");
+
+		assertThat(project.getVersion()).hasToString("1.2.3.RELEASE");
+	}
+
+	@Test
+	void doNothingIfPropertyVersionBranchButNotSnapshot() {
+		CustomVersionPlugin plugin = new CustomVersionPlugin();
+		Project project = ProjectBuilder.builder().withName("foo").build();
+		project.setVersion("1.2.3.M1");
+		project.getExtensions().add("versionBranch", "custom");
+
+		plugin.apply(project);
+
+		assertThat(project.getVersion()).hasToString("1.2.3.M1");
+	}
+
+	@Test
+	void changesVersionIfPropertyVersionBranchAndSnapshot() {
+		CustomVersionPlugin plugin = new CustomVersionPlugin();
+		Project project = ProjectBuilder.builder().withName("foo").build();
+		project.setVersion("1.2.3.BUILD-SNAPSHOT");
+		project.getExtensions().add("versionBranch", "custom");
+
+		plugin.apply(project);
+
+		assertThat(project.getVersion()).hasToString("1.2.3.custom.BUILD-SNAPSHOT");
+	}
+
+}

--- a/buildSrc/src/test/java/io/reactor/gradle/DetectCiPluginTest.java
+++ b/buildSrc/src/test/java/io/reactor/gradle/DetectCiPluginTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactor.gradle;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+import static io.reactor.gradle.DetectCiPlugin.DETECTED_EXTENSION;
+import static io.reactor.gradle.DetectCiPlugin.FLAG_EXTENSION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Simon Baslé
+ */
+class DetectCiPluginTest {
+
+	@Test
+	void ignoresSubprojects() {
+		DetectCiPlugin plugin = new DetectCiPlugin(Arrays.asList("CI", "CONTINUOUS_INTEGRATION", "TRAVIS", "CIRCLECI", "bamboo_planKey", "GITHUB_ACTION"));
+		Project root = ProjectBuilder.builder().withName("root").build();
+		Project sub = ProjectBuilder.builder().withName("sub").withParent(root).build();
+
+		plugin.apply(sub);
+
+		assertThat(sub.getExtensions().findByName(FLAG_EXTENSION)).as(FLAG_EXTENSION).isNull();
+		assertThat(sub.getExtensions().findByName(DETECTED_EXTENSION)).as(DETECTED_EXTENSION).isNull();
+	}
+
+	@Test
+	void detectsGenericCi() {
+		DetectCiPlugin plugin = new DetectCiPlugin(Arrays.asList("CI", "NOISE"));
+		Project root = ProjectBuilder.builder().withName("root").build();
+
+		plugin.apply(root);
+
+		assertThat(root.getExtensions().getByName(FLAG_EXTENSION))
+				.as(FLAG_EXTENSION)
+				.isInstanceOfSatisfying(Boolean.class, b -> assertThat(b).isTrue());
+		assertThat(root.getExtensions().getByName(DETECTED_EXTENSION))
+				.as(DETECTED_EXTENSION)
+				.isInstanceOfSatisfying(Set.class, s -> assertThat(s).containsExactly("CI"));
+	}
+
+	@Test
+	void detectsGenericContinuousIntegration() {
+		DetectCiPlugin plugin = new DetectCiPlugin(Arrays.asList("CONTINUOUS_INTEGRATION", "NOISE"));
+		Project root = ProjectBuilder.builder().withName("root").build();
+
+		plugin.apply(root);
+
+		assertThat(root.getExtensions().getByName(FLAG_EXTENSION))
+				.as(FLAG_EXTENSION)
+				.isInstanceOfSatisfying(Boolean.class, b -> assertThat(b).isTrue());
+		assertThat(root.getExtensions().getByName(DETECTED_EXTENSION))
+				.as(DETECTED_EXTENSION)
+				.isInstanceOfSatisfying(Set.class, s -> assertThat(s).containsExactly("CONTINUOUS_INTEGRATION"));
+	}
+
+	@Test
+	void detectsTravis() {
+		DetectCiPlugin plugin = new DetectCiPlugin(Arrays.asList("TRAVIS", "NOISE"));
+		Project root = ProjectBuilder.builder().withName("root").build();
+
+		plugin.apply(root);
+
+		assertThat(root.getExtensions().getByName(FLAG_EXTENSION))
+				.as(FLAG_EXTENSION)
+				.isInstanceOfSatisfying(Boolean.class, b -> assertThat(b).isTrue());
+		assertThat(root.getExtensions().getByName(DETECTED_EXTENSION))
+				.as(DETECTED_EXTENSION)
+				.isInstanceOfSatisfying(Set.class, s -> assertThat(s).containsExactly("TRAVIS"));
+	}
+
+	@Test
+	void detectsCircleCi() {
+		DetectCiPlugin plugin = new DetectCiPlugin(Arrays.asList("CIRCLECI", "NOISE"));
+		Project root = ProjectBuilder.builder().withName("root").build();
+
+		plugin.apply(root);
+
+		assertThat(root.getExtensions().getByName(FLAG_EXTENSION))
+				.as(FLAG_EXTENSION)
+				.isInstanceOfSatisfying(Boolean.class, b -> assertThat(b).isTrue());
+		assertThat(root.getExtensions().getByName(DETECTED_EXTENSION))
+				.as(DETECTED_EXTENSION)
+				.isInstanceOfSatisfying(Set.class, s -> assertThat(s).containsExactly("CIRCLECI"));
+	}
+
+	@Test
+	void detectsBamboo() {
+		DetectCiPlugin plugin = new DetectCiPlugin(Arrays.asList("bamboo_planKey", "NOISE"));
+		Project root = ProjectBuilder.builder().withName("root").build();
+
+		plugin.apply(root);
+
+		assertThat(root.getExtensions().getByName(FLAG_EXTENSION))
+				.as(FLAG_EXTENSION)
+				.isInstanceOfSatisfying(Boolean.class, b -> assertThat(b).isTrue());
+		assertThat(root.getExtensions().getByName(DETECTED_EXTENSION))
+				.as(DETECTED_EXTENSION)
+				.isInstanceOfSatisfying(Set.class, s -> assertThat(s).containsExactly("bamboo_planKey"));
+	}
+
+	@Test
+	void detectsGithubActions() {
+		DetectCiPlugin plugin = new DetectCiPlugin(Arrays.asList("GITHUB_ACTION", "NOISE"));
+		Project root = ProjectBuilder.builder().withName("root").build();
+
+		plugin.apply(root);
+
+		assertThat(root.getExtensions().getByName(FLAG_EXTENSION))
+				.as(FLAG_EXTENSION)
+				.isInstanceOfSatisfying(Boolean.class, b -> assertThat(b).isTrue());
+		assertThat(root.getExtensions().getByName(DETECTED_EXTENSION))
+				.as(DETECTED_EXTENSION)
+				.isInstanceOfSatisfying(Set.class, s -> assertThat(s).containsExactly("GITHUB_ACTION"));
+	}
+
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
+micrometerVersion=1.3.0
 version=3.2.18.BUILD-SNAPSHOT
+reactiveStreamsVersion=1.0.2
 compatibleVersion=3.2.0.RELEASE

--- a/gradle/asciidoc.gradle
+++ b/gradle/asciidoc.gradle
@@ -16,15 +16,18 @@
 configure(rootProject) {
 	apply plugin: 'org.asciidoctor.convert'
 
-  configure(subprojects) { p ->
-	p.tasks.withType(Javadoc).all {
-	  afterEvaluate {
-		println "JDK Javadoc link for ${p.name} is ${rootProject.jdkJavadoc}"
-	  }
-	}
-  }
-
 	asciidoctor {
+	  inputs.dir("docs/asciidoc/")
+			.withPropertyName("asciidocFiles")
+			.withPathSensitivity(PathSensitivity.RELATIVE)
+
+	  if (isCiServer || !rootProject.version.toString().endsWith(".BUILD-SNAPSHOT")) {
+		backends = ["html5", "pdf"]
+	  }
+	  else {
+		backends = ["html5"]
+	  }
+
 	  sourceDir "$rootDir/docs/asciidoc/"
 	  sources {
 		include "index.asciidoc"
@@ -35,8 +38,7 @@ configure(rootProject) {
 		  include 'highlight/**/*'
 		}
 	  }
-	  outputDir file("$buildDir/reactor-code/build/asciidoc")
-	  backends = ['html5', 'pdf']
+	  outputDir file("$buildDir/docs/asciidoc")
 		logDocuments = true
 		options = [
 				doctype: 'book'
@@ -45,7 +47,6 @@ configure(rootProject) {
 				imagesdir: "images/",
 				stylesdir: "stylesheets/",
 				stylesheet: 'reactor.css',
-				appversion: version,
 				'source-highlighter': 'highlightjs',
 				'highlightjsdir': "./highlight",
 				'highlightjs-theme': 'railscasts'
@@ -61,14 +62,14 @@ configure(rootProject) {
 		archiveClassifier.set('docs')
 		afterEvaluate() {
 			//we copy the pdf late, when a potential customVersion has been applied to rootProject
-			from("$buildDir/reactor-code/build/asciidoc/pdf/index.pdf") {
+			from("$buildDir/docs/asciidoc/pdf/index.pdf") {
 				into ("docs/")
 				rename("index.pdf", "reactor-core-reference-guide-${rootProject.version}.pdf")
 			}
 		}
-	  from("$buildDir/reactor-code/build/asciidoc/html5/index.html") { into("docs/") }
-	  from("$buildDir/reactor-code/build/asciidoc/html5/images") { into("docs/images/") }
-	  from("$buildDir/reactor-code/build/asciidoc/html5/highlight") { into("docs/highlight/") }
+		from("$buildDir/docs/asciidoc/html5/index.html") { into("docs/") }
+		from("$buildDir/docs/asciidoc/html5/images") { into("docs/images/") }
+		from("$buildDir/docs/asciidoc/html5/highlight") { into("docs/highlight/") }
 	}
 }
 

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+javadoc {
+	dependsOn jar
+	group = "documentation"
+	description = "Generates aggregated Javadoc API documentation."
+
+	title = "${project.name} $version"
+	options.addStringOption('charSet', 'UTF-8')
+	options.author = true
+	options.header = "$project.name"
+	options.stylesheetFile = file("$rootDir/docs/api/stylesheet.css")
+
+	options.memberLevel = JavadocMemberLevel.PROTECTED
+
+	if (project.name.contains("core")) {
+	  options.links([rootProject.jdkJavadoc, "https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/"] as String[])
+	  options.tags = [ "apiNote:a:API Note:", "implSpec:a:Implementation Requirements:",
+					   "implNote:a:Implementation Note:", "reactor.errorMode:m:Error Mode Support",
+					   "reactor.discard:m:onDiscard Support"]
+	}
+	else {
+	  options.links([rootProject.jdkJavadoc,
+					 "https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/",
+					 "https://projectreactor.io/docs/core/release/api/"] as String[]);
+	  options.tags = [ "apiNote:a:API Note:", "implSpec:a:Implementation Requirements:",
+					   "implNote:a:Implementation Note:" ]
+	}
+
+	// In Java 9, javadoc generator will complain if it finds invalid class files in the classpath
+	// And Kotlin produces such classes, plus kotlin plugin puts them in the main sourceSet
+	classpath = sourceSets.main.output.filter { !it.absolutePath.contains("kotlin") }
+	classpath += sourceSets.main.compileClasspath
+
+	maxMemory = "1024m"
+	destinationDir = new File(project.buildDir, "docs/javadoc")
+
+	if (JavaVersion.current().isJava8Compatible()) {
+	  options.addStringOption("Xdoclint:none", "-quiet")
+	}
+  }

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -121,5 +121,7 @@ publishing {
 }
 
 artifactoryPublish {
+	//don't activate the onlyIf clause below yet, so that Bamboo builds will publish stuff...
+	//onlyIf { project.hasProperty("artifactory_publish_password")") }
 	publications(publishing.publications.mavenJava)
 }

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -17,20 +17,22 @@ import me.champeau.gradle.japicmp.JapicmpTask
 
 apply plugin: 'idea' //needed to avoid IDEA seeing the jmh folder as source
 apply plugin: 'me.champeau.gradle.jmh'
-apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'biz.aQute.bnd.builder'
+apply plugin: 'kotlin'
+apply plugin: 'org.jetbrains.dokka'
 
 ext {
 	bndOptions = [
 			"Export-Package": [
 					"!*internal*",
-					"reactor.*;-noimport:=true"
+					"reactor.*"
 			].join(","),
 			"Import-Package": [
 					"!javax.annotation",
 					'org.slf4j;resolution:=optional;version="[1.5.4,2)"',
 					"kotlin.*;resolution:=optional",
-					"io.micrometer.*;resolution:=optional","*"
+					"io.micrometer.*;resolution:=optional",
+					"*"
 			].join(","),
 			"Bundle-Name" : "reactor-core",
 			"Bundle-SymbolicName" : "io.projectreactor.reactor-core"
@@ -55,11 +57,11 @@ configurations {
 
 dependencies {
   // Reactive Streams
-  compile "org.reactivestreams:reactive-streams:1.0.2"
-  testCompile "org.reactivestreams:reactive-streams-tck:1.0.2"
+  compile "org.reactivestreams:reactive-streams:${reactiveStreamsVersion}"
+  testCompile "org.reactivestreams:reactive-streams-tck:${reactiveStreamsVersion}"
 
   // JSR-305 annotations
-  optional "com.google.code.findbugs:jsr305:3.0.2"
+  optional "com.google.code.findbugs:jsr305:$jsr305Version"
 
   //Optional Logging Operator
   optional "org.slf4j:slf4j-api:$slf4jVersion"
@@ -70,9 +72,9 @@ dependencies {
   optional("org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}")
 
   //Optional JDK 9 Converter
-  jsr166backport "io.projectreactor:jsr166:1.0.0.RELEASE"
+  jsr166backport "io.projectreactor:jsr166:$jsr166BackportVersion"
 
-  testCompile 'junit:junit:4.12'
+  testCompile "junit:junit:$jUnitVersion"
 
   testRuntime "ch.qos.logback:logback-classic:$logbackVersion"
   testRuntime "io.micrometer:micrometer-core:$micrometerVersion"
@@ -81,13 +83,12 @@ dependencies {
 	exclude module: 'reactor-core'
   }
 
-  testCompile "org.hamcrest:hamcrest-library:1.3",
-		  "org.testng:testng:6.8.5",
-		  "org.assertj:assertj-core:$assertJVersion",
-		  "org.mockito:mockito-core:$mockitoVersion",
-		  "org.openjdk.jol:jol-core:0.9",
-		  "pl.pragmatists:JUnitParams:$jUnitParamsVersion",
-		  "org.awaitility:awaitility:3.1.2"
+  testCompile "org.assertj:assertj-core:$assertJVersion",
+    "org.testng:testng:$testNgVersion",
+    "org.mockito:mockito-core:$mockitoVersion",
+    "org.openjdk.jol:jol-core:$javaObjectLayoutVersion",
+    "pl.pragmatists:JUnitParams:$jUnitParamsVersion",
+    "org.awaitility:awaitility:$awaitilityVersion"
 
   noMicrometerTestCompile sourceSets.main.output
   noMicrometerTestCompile sourceSets.test.output
@@ -138,31 +139,10 @@ task japicmp(type: JapicmpTask) {
 //	methodExcludes = ["reactor.core.Scannable#operatorName()"]
 }
 
+//complements the javadoc.gradle common configuration
 javadoc {
-  dependsOn jar
-  group = "documentation"
-  description = "Generates aggregated Javadoc API documentation."
-  title = "Reactor Core $version"
-
-  options.addStringOption('charSet', 'UTF-8')
-
-  options.memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PROTECTED
-  options.author = true
-  options.header = "$project.name"
+  options.addBooleanOption('nodeprecated', true)
   options.overview = "$rootDir/docs/api/overview.html"
-  options.stylesheetFile = file("$rootDir/docs/api/stylesheet.css")
-  options.links(rootProject.ext.javadocLinks )
-  options.tags = [ "apiNote:a:API Note:", "implSpec:a:Implementation Requirements:",
-				   "implNote:a:Implementation Note:", "reactor.errorMode:m:Error Mode Support",
-				   "reactor.discard:m:onDiscard Support"]
-
-  // In Java 9, javadoc generator will complain if it finds invalid class files in the classpath
-  // And Kotlin produces such classes, plus kotlin plugin puts them in the main sourceSet
-  classpath = sourceSets.main.output.filter { !it.absolutePath.contains("kotlin") }
-  classpath += sourceSets.main.compileClasspath
-
-  maxMemory = "1024m"
-  destinationDir = new File(project.buildDir, "docs/javadoc")
 
   doLast {
 	// work around https://github.com/gradle/gradle/issues/4046
@@ -241,9 +221,9 @@ task testNoMicrometer(type: Test, group: 'verification') {
 //inherit basic test task + common configuration in root
 //always depend on testNoMicrometer, skip testNG on Travis, skip loops when not releasing
 //note that this way the tasks can be run individually
-test {
+check {
   dependsOn testNoMicrometer
-  if (System.env.TRAVIS != "true") {
+  if (!detectedCiServers.contains("TRAVIS")) {
 	dependsOn testNG
   }
   if (!version.endsWith('BUILD-SNAPSHOT')) {
@@ -251,6 +231,7 @@ test {
   }
 }
 
+//TODO all java9 / stubs / java-specific stuff should go in a convention plugin ?
 if (!JavaVersion.current().isJava9Compatible()) {
   test {
 	jvmArgs = ["-Xbootclasspath/p:" + configurations.jsr166backport.asPath]
@@ -260,7 +241,8 @@ if (!JavaVersion.current().isJava9Compatible()) {
 jar {
   manifest {
 	attributes 'Implementation-Title': 'reactor-core',
-			'Implementation-Version': version
+			'Implementation-Version': project.version,
+			'Automatic-Module-Name': 'reactor.core'
   }
 	bnd(bndOptions)
 }

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -17,6 +17,7 @@ import me.champeau.gradle.japicmp.JapicmpTask
 
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'biz.aQute.bnd.builder'
+apply plugin: 'kotlin'
 
 description = 'Reactor Test support'
 
@@ -38,13 +39,12 @@ ext {
 dependencies {
   compile project(":reactor-core")
 
-  testCompile 'junit:junit:4.12'
+  testCompile "junit:junit:$jUnitVersion"
 
   testRuntime "ch.qos.logback:logback-classic:$logbackVersion"
 
-  testCompile "org.hamcrest:hamcrest-library:1.3",
-		  "org.assertj:assertj-core:$assertJVersion",
-		  "org.mockito:mockito-core:$mockitoVersion"
+  testCompile "org.assertj:assertj-core:$assertJVersion",
+    "org.mockito:mockito-core:$mockitoVersion"
 }
 
 task downloadBaseline {
@@ -83,31 +83,7 @@ task japicmp(type: JapicmpTask) {
   //TODO after a release, remove the reactor-test exclusions below if any
 }
 
-javadoc {
-  dependsOn jar
-  group = "documentation"
-  description = "Generates aggregated Javadoc API documentation."
-  title = "Reactor Test $version"
-
-  options.addStringOption('charSet', 'UTF-8')
-
-  options.memberLevel = JavadocMemberLevel.PROTECTED
-  options.author = true
-  options.header = "$project.name"
-  options.stylesheetFile = file("$rootDir/docs/api/stylesheet.css")
-  options.links(rootProject.ext.javadocLinks
-		  .plus("https://projectreactor.io/docs/core/release/api/") as String[])
-  options.tags = [ "apiNote:a:API Note:", "implSpec:a:Implementation Requirements:",
-				   "implNote:a:Implementation Note:" ]
-
-  // In Java 9, javadoc generator will complain if it finds invalid class files in the classpath
-  // And Kotlin produces such classes, plus kotlin plugin puts them in the main sourceSet
-  classpath = sourceSets.main.output.filter { !it.absolutePath.contains("kotlin") }
-  classpath += sourceSets.main.compileClasspath
-
-  maxMemory = "1024m"
-  destinationDir = new File(project.buildDir, "docs/javadoc")
-}
+//javadoc is configured in gradle/javadoc.gradle
 
 // Need https://github.com/Kotlin/dokka/issues/184 to be fixed to avoid "Can't find node by signature" log spam
 dokka {
@@ -154,7 +130,8 @@ task kdocZip(type: Zip, dependsOn: dokka) {
 jar {
   manifest {
     attributes 'Implementation-Title': 'reactor-test',
-            'Implementation-Version': version
+            'Implementation-Version': project.version,
+            'Automatic-Module-Name': 'reactor.test'
   }
   bnd(bndOptions)
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+	id "com.gradle.enterprise" version "3.2"
+}
+
 rootProject.name = 'reactor'
 
 


### PR DESCRIPTION
This includes:
 - using local buildSrc plugins rather than adhoc code blocks (detecting
 ci, java conventions, custom version)
 - splitting out javadoc/asciidoc gradle files
 - fixing the directory into which asciidocs are built
 - avoid building pdf reference guide locally (unless release)
 - remove spring-io-plugin / platform
 - bump asciidoctor.convert plugin
 - micrometer version defined in gradle.properties and pinned
 - reactiveStream version defined in gradle.properties
 - junit, awaitility, jol and testNg versions defined in properties
 rather than inline
 - use gradle enterprise plugin for buildScan
 - removed hamcrest-library dependency
 - automatic module names (see #1692)