### PR TITLE
Fix RetrySpec doc: throwablePredicate is actually filter

### DIFF
--- a/reactor-core/src/main/java/reactor/util/retry/RetryBackoffSpec.java
+++ b/reactor-core/src/main/java/reactor/util/retry/RetryBackoffSpec.java
@@ -204,7 +204,7 @@ public final class RetryBackoffSpec extends Retry {
 	 * <pre><code>
 	 * //given
 	 * RetrySpec retryTwiceIllegalArgument = Retry.max(2)
-	 *     .throwablePredicate(e -> e instanceof IllegalArgumentException);
+	 *     .filter(e -> e instanceof IllegalArgumentException);
 	 *
 	 * RetrySpec retryTwiceIllegalArgWithCause = retryTwiceIllegalArgument.modifyErrorFilter(old ->
 	 *     old.and(e -> e.getCause() != null));

--- a/reactor-core/src/main/java/reactor/util/retry/RetrySpec.java
+++ b/reactor-core/src/main/java/reactor/util/retry/RetrySpec.java
@@ -160,7 +160,7 @@ public final class RetrySpec extends Retry {
 	 * <pre><code>
 	 * //given
 	 * RetrySpec retryTwiceIllegalArgument = Retry.max(2)
-	 *     .throwablePredicate(e -> e instanceof IllegalArgumentException);
+	 *     .filter(e -> e instanceof IllegalArgumentException);
 	 *
 	 * RetrySpec retryTwiceIllegalArgWithCause = retryTwiceIllegalArgument.modifyErrorFilter(old ->
 	 *     old.and(e -> e.getCause() != null));


### PR DESCRIPTION
The Javadocs use `throwablePredicate` in a couple of code snippets. This method does not exist, I believe `filter` should be used instead.