### PR TITLE
Ensure DeferredSubscription makes requests serially

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxUsingWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxUsingWhen.java
@@ -247,7 +247,7 @@ final class FluxUsingWhen<T, S> extends Flux<T> implements SourceProducer<T> {
 				super.cancel();
 			}
 			else {
-				Operators.terminate(S, this);
+				super.terminate();
 				if (closureSubscriber != null) {
 					closureSubscriber.cancel();
 				}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoUsingWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoUsingWhen.java
@@ -243,7 +243,7 @@ final class MonoUsingWhen<T, S> extends Mono<T> implements SourceProducer<T> {
 				super.cancel();
 			}
 			else {
-				Operators.terminate(S, this);
+				super.terminate();
 				if (closureSubscriber != null) {
 					closureSubscriber.cancel();
 				}

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -1548,7 +1548,7 @@ public abstract class Operators {
 				if (toRequest > 0) { // if there is something,
 					s.request(toRequest); // then we do a request on the given subscription
 				}
-				accumulated = r;
+				accumulated += toRequest;
 
 				if (REQUESTED.compareAndSet(this, r, STATE_SUBSCRIBED)) {
 					return true;

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -1444,29 +1444,38 @@ public abstract class Operators {
 	public static class DeferredSubscription
 			implements Subscription, Scannable {
 
-		volatile Subscription s;
+		static final int STATE_CANCELLED = -2;
+		static final int STATE_SUBSCRIBED = -1;
+
+		Subscription s;
 		volatile long requested;
 
 		protected boolean isCancelled(){
-			return s == cancelledSubscription();
+			return requested == STATE_CANCELLED;
 		}
 
 		@Override
 		public void cancel() {
-			Subscription a = s;
-			if (a != cancelledSubscription()) {
-				a = S.getAndSet(this, cancelledSubscription());
-				if (a != null && a != cancelledSubscription()) {
-					a.cancel();
-				}
+			final long state = REQUESTED.getAndSet(this, STATE_CANCELLED);
+			if (state == STATE_CANCELLED) {
+				return;
 			}
+
+			if (state == STATE_SUBSCRIBED) {
+				this.s.cancel();
+			}
+		}
+
+		protected void terminate() {
+			REQUESTED.getAndSet(this, STATE_CANCELLED);
 		}
 
 		@Override
 		@Nullable
 		public Object scanUnsafe(Attr key) {
+			long requested = this.requested; // volatile read to see subscription
 			if (key == Attr.PARENT) return s;
-			if (key == Attr.REQUESTED_FROM_DOWNSTREAM) return requested;
+			if (key == Attr.REQUESTED_FROM_DOWNSTREAM) return requested < 0 ? 0 : requested;
 			if (key == Attr.CANCELLED) return isCancelled();
 
 			return null;
@@ -1474,23 +1483,33 @@ public abstract class Operators {
 
 		@Override
 		public void request(long n) {
-			Subscription a = s;
-			if (a != null) {
-				a.request(n);
-			}
-			else {
-				addCap(REQUESTED, this, n);
+			long r = this.requested; // volatile read beforehand
 
-				a = s;
+			if (r > STATE_SUBSCRIBED) { // works only in case onSubscribe has not happened
+				long u;
+				for (;;) { // normal CAS loop with overflow protection
+					if (r == Long.MAX_VALUE) { // if r == Long.MAX_VALUE then we dont care and we can loose this request just in case of racing
+						return;
+					}
+					u = Operators.addCap(r, n);
+					if (REQUESTED.compareAndSet(this, r, u)) { // Means increment happened before onSubscribe
+						return;
+					}
+					else { // Means increment happened after onSubscribe
+						r = this.requested; // update new state to see what exactly happened (onSubscribe | cancel | requestN)
 
-				if (a != null) {
-					long r = REQUESTED.getAndSet(this, 0L);
-
-					if (r != 0L) {
-						a.request(r);
+						if (r < 0) { // check state (expect -1 | -2 to exit, otherwise repeat)
+							break;
+						}
 					}
 				}
 			}
+
+			if (r == STATE_CANCELLED) { // if canceled, just exit
+				return;
+			}
+
+			this.s.request(n); // if onSubscribe -> subscription exists (and we sure of that because volatile read after volatile write) so we can execute requestN on the subscription
 		}
 
 		/**
@@ -1501,8 +1520,9 @@ public abstract class Operators {
 		 */
 		public final boolean set(Subscription s) {
 			Objects.requireNonNull(s, "s");
+			final long state = this.requested;
 			Subscription a = this.s;
-			if (a == cancelledSubscription()) {
+			if (state == STATE_CANCELLED) {
 				s.cancel();
 				return false;
 			}
@@ -1512,30 +1532,30 @@ public abstract class Operators {
 				return false;
 			}
 
-			if (S.compareAndSet(this, null, s)) {
+			long r;
+			long accomulated = 0;
+			for (;;) {
+				r = this.requested;
 
-				long r = REQUESTED.getAndSet(this, 0L);
-
-				if (r != 0L) {
-					s.request(r);
+				if (r == STATE_CANCELLED || r == STATE_SUBSCRIBED) {
+					s.cancel();
+					return false;
 				}
 
-				return true;
+				this.s = s;
+
+				long toRequest = r - accomulated;
+				if (toRequest > 0) { // if there is something,
+					s.request(toRequest); // then we do a request on the given subscription
+				}
+				accomulated = r;
+
+				if (REQUESTED.compareAndSet(this, r, STATE_SUBSCRIBED)) {
+					return true;
+				}
 			}
-
-			a = this.s;
-
-			if (a != cancelledSubscription()) {
-				s.cancel();
-				reportSubscriptionSet();
-				return false;
-			}
-
-			return false;
 		}
 
-		static final AtomicReferenceFieldUpdater<DeferredSubscription, Subscription> S =
-				AtomicReferenceFieldUpdater.newUpdater(DeferredSubscription.class, Subscription.class, "s");
 		static final AtomicLongFieldUpdater<DeferredSubscription> REQUESTED =
 				AtomicLongFieldUpdater.newUpdater(DeferredSubscription.class, "requested");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -1533,7 +1533,7 @@ public abstract class Operators {
 			}
 
 			long r;
-			long accomulated = 0;
+			long accumulated = 0;
 			for (;;) {
 				r = this.requested;
 
@@ -1544,11 +1544,11 @@ public abstract class Operators {
 
 				this.s = s;
 
-				long toRequest = r - accomulated;
+				long toRequest = r - accumulated;
 				if (toRequest > 0) { // if there is something,
 					s.request(toRequest); // then we do a request on the given subscription
 				}
-				accomulated = r;
+				accumulated = r;
 
 				if (REQUESTED.compareAndSet(this, r, STATE_SUBSCRIBED)) {
 					return true;

--- a/reactor-core/src/main/java/reactor/core/publisher/StrictSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/StrictSubscriber.java
@@ -72,9 +72,22 @@ final class StrictSubscriber<T> implements Scannable, CoreSubscriber<T>, Subscri
 			actual.onSubscribe(this);
 
 			if (Operators.setOnce(S, this, s)) {
-				long r = REQUESTED.getAndSet(this, 0L);
-				if (r != 0L) {
+				for (;;) {
+					long r = this.requested;
+
+					if (r == 0) {
+						return;
+					}
+
 					s.request(r);
+
+					if (r == Long.MAX_VALUE) {
+						return;
+					}
+
+					if (REQUESTED.addAndGet(this, -r) == 0) {
+						return;
+					}
 				}
 			}
 		}
@@ -135,7 +148,20 @@ final class StrictSubscriber<T> implements Scannable, CoreSubscriber<T>, Subscri
 		}
 		Subscription a = s;
 		if (a != null) {
-			a.request(n);
+			for (;;) {
+				long r = this.requested;
+
+				if (r == 0) {
+					a.request(n);
+					return;
+				}
+
+				long u = Operators.addCap(r, n);
+				if (REQUESTED.compareAndSet(this, r, u)) {
+					// if there is racing between onSubscribe and request
+					return;
+				}
+			}
 		}
 		else {
 			Operators.addCap(REQUESTED, this, n);

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
@@ -202,6 +202,30 @@ public class OperatorsTest {
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
 	}
 
+
+	@Test
+	public void shouldBeSerialIfRacy() {
+		for (int i = 0; i < 10000; i++) {
+			long[] requested = new long[] { 0 };
+			Subscription mockSubscription = Mockito.mock(Subscription.class);
+			Mockito.doAnswer(a -> requested[0] += (long) a.getArgument(0)).when(mockSubscription).request(Mockito.anyLong());
+			DeferredSubscription deferredSubscription = new DeferredSubscription();
+
+			deferredSubscription.request(5);
+
+			RaceTestUtils.race(() -> deferredSubscription.set(mockSubscription),
+					() -> {
+						deferredSubscription.request(10);
+						deferredSubscription.request(10);
+						deferredSubscription.request(10);
+					});
+
+			deferredSubscription.request(15);
+
+			Assertions.assertThat(requested[0]).isEqualTo(50L);
+		}
+	}
+
 	@Test
 	public void scanDeferredSubscription() {
 		DeferredSubscription test = new DeferredSubscription();


### PR DESCRIPTION
This PR ensures that DefferedSubscription makes requests serially if there is racing between set / requestN (according to RS spec Rule 2.7)
Signed-off-by: Oleh Dokuka <shadowgun@i.ua>