### PR TITLE
Fix volatile read & conditionalSub classcast in switchOnFirst

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
@@ -161,8 +161,8 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
         @Override
         public void onError(Throwable t) {
             // read of the first should occur before the read of inner since otherwise
-            // first may be nulled while the previous read shew that inner is still null
-            // hence double invocation of transformer occurs
+            // first may be nulled while the previous read has shown that inner is still
+            // null hence double invocation of transformer occurs
             final T f = this.first;
             final CoreSubscriber<? super T> i = this.inner;
             if (this.done || i == Operators.EMPTY_SUBSCRIBER) {
@@ -198,8 +198,8 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
         @Override
         public void onComplete() {
             // read of the first should occur before the read of inner since otherwise
-            // first may be nulled while the previous read shew that inner is still null
-            // hence double invocation of transformer occurs
+            // first may be nulled while the previous read has shown that inner is still
+            // null hence double invocation of transformer occurs
             final T f = this.first;
             final CoreSubscriber<? super T> i = this.inner;
             if (this.done || i == Operators.EMPTY_SUBSCRIBER) {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
@@ -318,22 +318,23 @@ public class FluxSwitchOnFirstTest {
 
     @Test
     public void shouldSendOnNextAsyncSignal() {
-        @SuppressWarnings("unchecked")
-        Signal<? extends Long>[] first = new Signal[1];
+        for (int i = 0; i < 10000; i++) {
+            @SuppressWarnings("unchecked") Signal<? extends Long>[] first = new Signal[1];
 
-        StepVerifier.create(Flux.just(1L)
-                                .switchOnFirst((s, f) -> {
-                                    first[0] = s;
+            StepVerifier.create(Flux.just(1L)
+                                    .switchOnFirst((s, f) -> {
+                                        first[0] = s;
 
-                                    return f.subscribeOn(Schedulers.elastic());
-                                }))
-                    .expectSubscription()
-                    .expectNext(1L)
-                    .expectComplete()
-                    .verify(Duration.ofSeconds(5));
+                                        return f.subscribeOn(Schedulers.elastic());
+                                    }))
+                        .expectSubscription()
+                        .expectNext(1L)
+                        .expectComplete()
+                        .verify(Duration.ofSeconds(5));
 
-
-        Assertions.assertThat((long) first[0].get()).isEqualTo(1L);
+            Assertions.assertThat((long) first[0].get())
+                      .isEqualTo(1L);
+        }
     }
 
     @Test


### PR DESCRIPTION
This PR bugfix double writing on actual in case of conditional which led to ClassCastException when there is racing between setting actual and draining first element.

This PR bugfix double transformer invocation which might happen when first element is read after the volatile inner. That said that conditions like the following may happen

`Thread 1`: inner is read (`inner == null`) 
`Thread 2`: inner is set (`inner == Subscriber`)
`Thread 2`: drain method is called
`Thread 2`: first is set to null in the drain method
`Thread 2`: volatile write occurred on WIP var
`Thread 1`: reading first may or may not observer that `first == null`
`Thread 1`: if first is null then transforms is invoked for the second time since stored inner was observed as null at that time  

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>