### PR TITLE
fix #2160 Accommodate ASYNC fusion in Mono.metrics()

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
@@ -124,7 +124,7 @@ final class MonoMetrics<T> extends InternalMonoOperator<T, T> {
 		}
 
 		@Override
-		final public void onNext(T t) {
+		public void onNext(T t) {
 			if (done) {
 				FluxMetrics.recordMalformed(commonTags, registry);
 				Operators.onNextDropped(t, actual.currentContext());

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
@@ -102,7 +102,7 @@ final class MonoMetrics<T> extends InternalMonoOperator<T, T> {
 		}
 
 		@Override
-		final public void onComplete() {
+		public void onComplete() {
 			if (done) {
 				return;
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMetricsFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMetricsFuseable.java
@@ -103,6 +103,21 @@ final class MonoMetricsFuseable<T> extends InternalMonoOperator<T, T> implements
 		}
 
 		@Override
+		public void onComplete() {
+			if (mode == ASYNC) {
+				actual.onComplete();
+			}
+			else {
+				if (done) {
+					return;
+				}
+				done = true;
+				FluxMetrics.recordOnComplete(commonTags, registry, subscribeToTerminateSample);
+				actual.onComplete();
+			}
+		}
+
+		@Override
 		public void onNext(T t) {
 			if (mode == ASYNC) {
 				actual.onNext(null);

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMetricsFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMetricsFuseable.java
@@ -103,6 +103,27 @@ final class MonoMetricsFuseable<T> extends InternalMonoOperator<T, T> implements
 		}
 
 		@Override
+		public void onNext(T t) {
+			if (mode == ASYNC) {
+				actual.onNext(null);
+			}
+			else {
+				if (done) {
+					FluxMetrics.recordMalformed(commonTags, registry);
+					Operators.onNextDropped(t, actual.currentContext());
+					return;
+				}
+				done = true;
+				//TODO looks like we don't count onNext: `Mono.empty()` vs `Mono.just("foo")`
+				FluxMetrics.recordOnComplete(commonTags,
+						registry,
+						subscribeToTerminateSample);
+				actual.onNext(t);
+				actual.onComplete();
+			}
+		}
+
+		@Override
 		public boolean isEmpty() {
 			return qs == null || qs.isEmpty();
 		}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsTest.java
@@ -468,7 +468,7 @@ public class FluxMetricsTest {
 		    .as(StepVerifier::create)
 		    .expectNext(1, 2, 3)
 		    .expectComplete()
-		    .verify(Duration.ofMillis(1));
+		    .verify(Duration.ofMillis(500));
 	}
 
 	@Test
@@ -482,6 +482,6 @@ public class FluxMetricsTest {
 		    .as(StepVerifier::create)
 		    .expectNext(1, 2, 3)
 		    .expectComplete()
-		    .verify(Duration.ofMillis(1));
+		    .verify(Duration.ofMillis(500));
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsTest.java
@@ -17,9 +17,11 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import io.micrometer.core.instrument.Counter;
@@ -36,6 +38,7 @@ import org.junit.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
+import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -455,5 +458,30 @@ public class FluxMetricsTest {
 				.collect(Collectors.toSet());
 
 		assertThat(uniqueTagKeySets).hasSize(1);
+	}
+
+	@Test
+	public void ensureFuseablePropagateOnComplete_inCaseOfAsyncFusion() {
+		Flux.fromIterable(Arrays.asList(1, 2, 3))
+		    .metrics()
+		    .flatMapIterable(Arrays::asList)
+		    .as(StepVerifier::create)
+		    .expectNext(1, 2, 3)
+		    .expectComplete()
+		    .verify(Duration.ofMillis(1));
+	}
+
+	@Test
+	public void ensureOnNextInAsyncModeIsCapableToPropagateNulls() {
+		Flux.using(() -> "irrelevant",
+				irrelevant -> Mono.fromSupplier(() -> Arrays.asList(1, 2, 3)),
+				irrelevant -> {
+				})
+		    .metrics()
+		    .flatMapIterable(Function.identity())
+		    .as(StepVerifier::create)
+		    .expectNext(1, 2, 3)
+		    .expectComplete()
+		    .verify(Duration.ofMillis(1));
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsTest.java
@@ -400,7 +400,7 @@ public class MonoMetricsTest {
 		    .as(StepVerifier::create)
 		    .expectNext(1, 2, 3)
 		    .expectComplete()
-		    .verify(Duration.ofMillis(1));
+		    .verify(Duration.ofMillis(500));
 	}
 
 	@Test
@@ -414,6 +414,6 @@ public class MonoMetricsTest {
 		    .as(StepVerifier::create)
 		    .expectNext(1, 2, 3)
 		    .expectComplete()
-		    .verify(Duration.ofMillis(1));
+		    .verify(Duration.ofMillis(500));
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsTest.java
@@ -17,9 +17,12 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import io.micrometer.core.instrument.Counter;
@@ -33,13 +36,16 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Scannable;
 import reactor.core.publisher.MonoMetrics.MetricsSubscriber;
+import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static reactor.core.publisher.FluxMetrics.*;
 import static reactor.test.publisher.TestPublisher.Violation.CLEANUP_ON_TERMINATE;
@@ -389,4 +395,29 @@ public class MonoMetricsTest {
 		assertThat(uniqueTagKeySets).hasSize(1);
 	}
 
+	@Test
+	@Timeout(value = 1, unit = SECONDS)
+	public void this_hangs() {
+		StepVerifier.create(
+				Mono.fromSupplier(() -> Arrays.asList(1, 2, 3))
+				    .metrics()
+				    .flatMapIterable(Function.identity()))
+		            .expectNext(1, 2, 3)
+		            .verifyComplete();
+	}
+
+	@Test
+	@Timeout(value = 1, unit = SECONDS)
+	public void this_throws_NPE() {
+		StepVerifier.create(
+				Mono.using(
+						() -> "irrelevant",
+						irrelevant -> Mono.fromSupplier(() -> Arrays.asList(1, 2, 3)),
+						irrelevant -> {})
+				    .metrics()
+				    .flatMapIterable(Function.identity()))
+		            .expectNext(1, 2, 3)
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(1));
+	}
 }


### PR DESCRIPTION
Closes #2160