### PR TITLE
[doc] Fix typo Retry.fromFunction instead of from

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -7340,7 +7340,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * the previous Context:
 	 * <blockquote><pre>
 	 * {@code
-	 * Retry customStrategy = Retry.fromFunction(companion -> companion.handle((retrySignal, sink) -> {
+	 * Retry customStrategy = Retry.from(companion -> companion.handle((retrySignal, sink) -> {
 	 * 	    Context ctx = sink.currentContext();
 	 * 	    int rl = ctx.getOrDefault("retriesLeft", 0);
 	 * 	    if (rl > 0) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -3763,7 +3763,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * <blockquote>
 	 * <pre>
 	 * {@code
-	 * Retry customStrategy = Retry.fromFunction(companion -> companion.handle((retrySignal, sink) -> {
+	 * Retry customStrategy = Retry.from(companion -> companion.handle((retrySignal, sink) -> {
 	 * 	    Context ctx = sink.currentContext();
 	 * 	    int rl = ctx.getOrDefault("retriesLeft", 0);
 	 * 	    if (rl > 0) {


### PR DESCRIPTION
Typo - on Retry class we don't have fromFunction