### PR TITLE
Fix input package rule for OSGi metadata generator

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -29,6 +29,7 @@ ext {
 		].join(","),
 		"Import-Package": [
 			"!javax.annotation",
+			"!javax.annotation.meta",
 			'org.slf4j;resolution:=optional;version="[1.5.4,2)"',
 			"kotlin.*;resolution:=optional",
 			"io.micrometer.*;resolution:=optional",


### PR DESCRIPTION
In feature https://github.com/reactor/reactor-core/pull/2088/files a refactoring relocated OSGi metadata generation from the base build file to the respective modules, this is fine. In the current bundle, the package javax.annotation.meta gets defined as an import package, see Manifest.MF of the reactor-core jar file. The change made is probably a typo and not intentional because javax.annotation.meta was next to javax.annotation excluded from the import, see the previous version from the commit mentioned.

Please consider the pull request as reasonable because otherwise, this current version of reactor-core does not run in OSGi environments because the import package rule gets not fulfilled.