### PR TITLE
Align MonoCollect with MonoList

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
@@ -42,9 +42,9 @@ final class MonoCollectList<T> extends MonoFromFluxOperator<T, List<T>> implemen
 
 	static final class MonoCollectListSubscriber<T> extends Operators.MonoSubscriber<T, List<T>> {
 
-		Subscription s;
-
 		List<T> list;
+
+		Subscription s;
 
 		boolean done;
 
@@ -92,7 +92,7 @@ final class MonoCollectList<T> extends MonoFromFluxOperator<T, List<T>> implemen
 
 		@Override
 		public void onError(Throwable t) {
-			if(done) {
+			if (done) {
 				Operators.onErrorDropped(t, actual.currentContext());
 				return;
 			}
@@ -102,7 +102,7 @@ final class MonoCollectList<T> extends MonoFromFluxOperator<T, List<T>> implemen
 				l = list;
 				list = null;
 			}
-			Operators.onDiscardMultiple(l, actual.currentContext());
+			discard(l);
 			actual.onError(t);
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCollectTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCollectTest.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;


### PR DESCRIPTION
This change aligns the implementation of `MonoCollect` to be comparable to that of `MonoList` in order to address #2186. `MonoList` seems better protected against competing upstream and downstream signals and the two should not be different as far as I can see. A `MonoList` is essentially a `MonoCollect` with an `ArrayList` as the container.

