### PR TITLE
fix #2189 Ensure tools fat jar is the one published

### DIFF
--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -37,6 +37,12 @@ task javadocJar(type: Jar) {
 }
 
 publishing {
+    repositories {
+        maven {
+           name = "mock"
+           url = "${rootProject.buildDir}/repo"
+        }
+    }
 	publications {
 		mavenJava(MavenPublication) {
 			from components.java

--- a/reactor-tools/build.gradle
+++ b/reactor-tools/build.gradle
@@ -186,5 +186,14 @@ tasks.withType(Test).all {
     useJUnitPlatform()
 }
 
-//add jar and original jar to the publication
-publishing.publications.mavenJava.artifact(shadowJar)
+// make the shadow jar the default artifact
+['apiElements', 'runtimeElements'].each {
+    configurations.getByName(it).outgoing {
+        artifacts.clear()
+        artifact(shadowJar)
+    }
+}
+configurations.runtime.outgoing.artifacts.clear()
+
+//add original jar to the publication
+publishing.publications.mavenJava.artifact(jar)


### PR DESCRIPTION
The `reactor-tools` subproject is using the shadow plugin to create
a fat jar, and wants this fat jar to replace the main jar. To do so,
the normal jar that Gradle produces is replaced with a classifier,
`original`, and the shadow jar is produced without classifier.

The publication is then configured to add the "shadow" jar to the
normal publication. However, this is incorrect: the Gradle component
model describes that the "apiElements" and "runtimeElements" use
the output of the `jar` task as the main artifact. As a consequence,
when publishing Gradle module metadata, the module file says that
the file to be fetched is the one produced by the `jar` task, which
has the `original` classifier.

Instead, if the API and runtime of the `reactor-tools` project need
to use the shadow jar, then the shadow jar needs to be set as the
main artifact.

This is what this commit does:

- it replaces the default artifact that Gradle uses publication with
the "shadow" jar
- it adds the "original" jar as an extra, out of context, artifact
to upload alongside the shadow jar

In addition, it configures a dummy repository which can be used to
"see" what Gradle would publish. By running the:

`publishMavenJavaPublicationToMockRepository` task, Gradle will
create a dummy repository in <rootDir>/build/repo which contains
what it would upload to Artifactory. This way you can quickly
check what is produced before actually releasing. In particular,
you can check the module files.

Note that this problem doesn't happen with Maven consumers because
Maven doesn't care about variants. Therefore, it only looks for the
"main" jar based on its name. Gradle, on the other hand, is variant
aware, meaning that it will select an artifact based on the variant
information found in the module file.

This file tells it to fetch the "original" file for the API, so it
does.

Last but not least, Gradle can actually model that both variants,
the "shadow" and the "original" ones are published, and let the
consumers choose which one they need.

This can be fixed in a separate PR if you are interested.

Fixes #2189