### PR TITLE
fix #1431 #2176 Avoid throwing in onErrorDropped & subscribe w/lambdas

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -101,7 +101,7 @@ dependencies {
 	testRuntime "org.junit.jupiter:junit-jupiter-engine:${jUnitJupiterVersion}"
 	testRuntime "org.junit.vintage:junit-vintage-engine:${jUnitJupiterVersion}"
 
-	testRuntime "ch.qos.logback:logback-classic:$logbackVersion"
+	testCompile "ch.qos.logback:logback-classic:$logbackVersion"
 	testRuntime "io.micrometer:micrometer-core:$micrometerVersion"
 	// Testing
 	testCompile(project(":reactor-test")) {

--- a/reactor-core/src/main/java/reactor/core/Exceptions.java
+++ b/reactor-core/src/main/java/reactor/core/Exceptions.java
@@ -16,7 +16,6 @@
 
 package reactor.core;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/reactor-core/src/main/java/reactor/core/publisher/LambdaMonoSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/LambdaMonoSubscriber.java
@@ -155,7 +155,7 @@ final class LambdaMonoSubscriber<T> implements InnerConsumer<T>, Disposable {
 			errorConsumer.accept(t);
 		}
 		else {
-			throw Exceptions.errorCallbackNotImplemented(t);
+			Operators.onErrorDropped(Exceptions.errorCallbackNotImplemented(t), this.initialContext);
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/LambdaSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/LambdaSubscriber.java
@@ -149,7 +149,7 @@ final class LambdaSubscriber<T>
 			errorConsumer.accept(t);
 		}
 		else {
-			throw Exceptions.errorCallbackNotImplemented(t);
+			Operators.onErrorDropped(Exceptions.errorCallbackNotImplemented(t), this.initialContext);
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -632,7 +632,7 @@ public abstract class Operators {
 		}
 		if (hook == null) {
 			log.error("Operator called default onErrorDropped", e);
-			throw Exceptions.bubble(e);
+			return;
 		}
 		hook.accept(e);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDoFinallyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDoFinallyTest.java
@@ -16,9 +16,6 @@
 
 package reactor.core.publisher;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
@@ -33,8 +30,9 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
+import reactor.test.LoggerUtils;
 import reactor.test.StepVerifier;
-import reactor.util.Loggers;
+import reactor.test.util.TestLogger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -496,14 +494,10 @@ public class FluxDoFinallyTest implements Consumer<SignalType> {
 
 	@Test
 	//see https://github.com/reactor/reactor-core/issues/951
-	public void gh951_withoutDoOnError() throws UnsupportedEncodingException {
-		PrintStream err = System.err;
-		PrintStream out = System.out;
+	public void gh951_withoutDoOnError() {
+		TestLogger testLogger = new TestLogger();
+		LoggerUtils.addAppender(testLogger, Operators.class);
 		try {
-			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			System.setErr(new PrintStream(outputStream));
-			System.setOut(new PrintStream(outputStream));
-			Loggers.useVerboseConsoleLoggers();
 			List<String> events = new ArrayList<>();
 
 			Mono.just(true)
@@ -514,14 +508,12 @@ public class FluxDoFinallyTest implements Consumer<SignalType> {
 			Assertions.assertThat(events)
 			          .as("withoutDoOnError")
 			          .containsExactly("doFinally onError");
-			Assertions.assertThat(outputStream.toString("utf-8"))
+			Assertions.assertThat(testLogger.getErrContent())
 			          .contains("Operator called default onErrorDropped")
 			          .contains("reactor.core.Exceptions$ErrorCallbackNotImplemented: java.lang.IllegalStateException: boom");
 		}
 		finally {
-			Loggers.resetLoggerFactory();
-			System.setErr(err);
-			System.setOut(out);
+			LoggerUtils.resetAppender(Operators.class);
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -15,6 +15,9 @@
  */
 package reactor.core.publisher;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,6 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -40,6 +44,7 @@ import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.test.util.RaceTestUtils;
+import reactor.util.Loggers;
 import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -671,52 +676,87 @@ public class FluxFlatMapTest {
 	}
 
 	@Test
-	public void failDoubleError() {
+	public void failDoubleError() throws UnsupportedEncodingException {
+		PrintStream err = System.err;
+		PrintStream out = System.out;
 		try {
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			System.setErr(new PrintStream(outputStream));
+			System.setOut(new PrintStream(outputStream));
+			Loggers.useVerboseConsoleLoggers();
 			StepVerifier.create(Flux.from(s -> {
 				s.onSubscribe(Operators.emptySubscription());
 				s.onError(new Exception("test"));
 				s.onError(new Exception("test2"));
-			}).flatMap(Flux::just))
+			})
+			                        .flatMap(Flux::just))
 			            .verifyErrorMessage("test");
-			Assert.fail();
-		}
-		catch (Exception e) {
-			assertThat(Exceptions.unwrap(e)).hasMessage("test2");
+
+			Assertions.assertThat(outputStream.toString("utf-8"))
+			          .contains("Operator called default onErrorDropped")
+			          .contains("java.lang.Exception: test2");
+		} finally {
+			Loggers.resetLoggerFactory();
+			System.setErr(err);
+			System.setOut(out);
 		}
 	}
 
 
 	@Test //FIXME use Violation.NO_CLEANUP_ON_TERMINATE
-	public void failDoubleErrorTerminated() {
+	public void failDoubleErrorTerminated() throws UnsupportedEncodingException {
+		PrintStream err = System.err;
+		PrintStream out = System.out;
 		try {
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			System.setErr(new PrintStream(outputStream));
+			System.setOut(new PrintStream(outputStream));
+			Loggers.useVerboseConsoleLoggers();
 			StepVerifier.create(Flux.from(s -> {
 				s.onSubscribe(Operators.emptySubscription());
 				Exceptions.terminate(FluxFlatMap.FlatMapMain.ERROR, (FluxFlatMap.FlatMapMain) s);
+				((FluxFlatMap.FlatMapMain) s).done = true;
+				((FluxFlatMap.FlatMapMain) s).drain(null);
 				s.onError(new Exception("test"));
-			}).flatMap(Flux::just))
-			            .verifyErrorMessage("test");
-			Assert.fail();
-		}
-		catch (Exception e) {
-			assertThat(Exceptions.unwrap(e)).hasMessage("test");
+			})
+			                        .flatMap(Flux::just))
+			            .verifyComplete();
+			Assertions.assertThat(outputStream.toString("utf-8"))
+			          .contains("Operator called default onErrorDropped")
+			          .contains("java.lang.Exception: test");
+		} finally {
+			Loggers.resetLoggerFactory();
+			System.setErr(err);
+			System.setOut(out);
 		}
 	}
 
 	@Test //FIXME use Violation.NO_CLEANUP_ON_TERMINATE
-	public void failDoubleErrorTerminatedInner() {
+	public void failDoubleErrorTerminatedInner() throws UnsupportedEncodingException {
+		PrintStream err = System.err;
+		PrintStream out = System.out;
 		try {
-			StepVerifier.create(Flux.just(1).hide().flatMap(f -> Flux.from(s -> {
-				s.onSubscribe(Operators.emptySubscription());
-				Exceptions.terminate(FluxFlatMap.FlatMapMain.ERROR,( (FluxFlatMap
-						.FlatMapInner) s).parent);
-				s.onError(new Exception("test"));
-			})))
-			            .verifyErrorMessage("test");
-			Assert.fail();
-		}
-		catch (Exception e) {
-			assertThat(Exceptions.unwrap(e)).hasMessage("test");
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			System.setErr(new PrintStream(outputStream));
+			System.setOut(new PrintStream(outputStream));
+			Loggers.useConsoleLoggers();
+			StepVerifier.create(Flux.just(1)
+			                        .hide()
+			                        .flatMap(f -> Flux.from(s -> {
+				                        s.onSubscribe(Operators.emptySubscription());
+				                        Exceptions.terminate(FluxFlatMap.FlatMapMain.ERROR,
+						                        ((FluxFlatMap.FlatMapInner) s).parent);
+				                        s.onError(new Exception("test"));
+			                        })))
+			            .verifyComplete();
+
+			Assertions.assertThat(outputStream.toString("utf-8"))
+			          .contains("Operator called default onErrorDropped")
+			          .contains("java.lang.Exception: test");
+		} finally {
+			Loggers.resetLoggerFactory();
+			System.setErr(err);
+			System.setOut(out);
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
@@ -16,6 +16,9 @@
 
 package reactor.core.publisher;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -27,6 +30,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.LongConsumer;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -43,6 +47,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.MockUtils;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
@@ -352,28 +357,47 @@ public class FluxPeekFuseableTest {
 	}
 
 	@Test
-	public void afterTerminateCallbackErrorDoesNotInvokeOnError() {
-		IllegalStateException err = new IllegalStateException("test");
-		AtomicReference<Throwable> errorCallbackCapture = new AtomicReference<>();
-
-		FluxPeekFuseable<String> flux = new FluxPeekFuseable<>(
-				Flux.empty(), null, null, errorCallbackCapture::set, null,
-				() -> { throw err; }, null, null);
-
-		AssertSubscriber<String> ts = AssertSubscriber.create();
-
+	public void afterTerminateCallbackErrorDoesNotInvokeOnError()
+			throws UnsupportedEncodingException {
+		PrintStream err = System.err;
+		PrintStream out = System.out;
 		try {
-			flux.subscribe(ts);
-			fail("expected thrown exception");
-		}
-		catch (Exception e) {
-			assertThat(e).hasCause(err);
-		}
-		ts.assertNoValues();
-		ts.assertComplete();
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			System.setErr(new PrintStream(outputStream));
+			System.setOut(new PrintStream(outputStream));
+			Loggers.useVerboseConsoleLoggers();
+			IllegalStateException error = new IllegalStateException("test");
+			AtomicReference<Throwable> errorCallbackCapture = new AtomicReference<>();
 
-		//the onError wasn't invoked:
-		assertThat(errorCallbackCapture.get()).isNull();
+			FluxPeekFuseable<String> flux = new FluxPeekFuseable<>(Flux.empty(),
+					null,
+					null,
+					errorCallbackCapture::set,
+					null,
+					() -> {
+						throw error;
+					},
+					null,
+					null);
+
+			AssertSubscriber<String> ts = AssertSubscriber.create();
+
+			flux.subscribe(ts);
+			ts.assertNoValues();
+			ts.assertComplete();
+
+			//the onError wasn't invoked:
+			assertThat(errorCallbackCapture.get()).isNull();
+
+			Assertions.assertThat(outputStream.toString("utf-8"))
+			          .contains("Operator called default onErrorDropped")
+			          .contains(error.getMessage());
+		}
+		finally {
+			Loggers.resetLoggerFactory();
+			System.setErr(err);
+			System.setOut(out);
+		}
 	}
 
 	@Test
@@ -421,61 +445,85 @@ public class FluxPeekFuseableTest {
 	}
 
 	@Test
-	public void afterTerminateCallbackErrorAndErrorCallbackError() {
-		IllegalStateException err = new IllegalStateException("expected afterTerminate");
-		IllegalArgumentException err2 = new IllegalArgumentException("error");
-
-		FluxPeekFuseable<String> flux = new FluxPeekFuseable<>(
-				Flux.empty(), null, null, e -> { throw err2; },
-				null,
-				() -> { throw err; }, null, null);
-
-		AssertSubscriber<String> ts = AssertSubscriber.create();
-
+	public void afterTerminateCallbackErrorAndErrorCallbackError()
+			throws UnsupportedEncodingException {
+		PrintStream err = System.err;
+		PrintStream out = System.out;
 		try {
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			System.setErr(new PrintStream(outputStream));
+			System.setOut(new PrintStream(outputStream));
+			Loggers.useVerboseConsoleLoggers();
+			IllegalStateException error = new IllegalStateException("expected afterTerminate");
+			IllegalArgumentException error2 = new IllegalArgumentException("error");
+
+			FluxPeekFuseable<String> flux =
+					new FluxPeekFuseable<>(Flux.empty(), null, null, e -> {
+						throw error2;
+					}, null, () -> {
+						throw error;
+					}, null, null);
+
+			AssertSubscriber<String> ts = AssertSubscriber.create();
+
 			flux.subscribe(ts);
-			fail("expected thrown exception");
+			Assertions.assertThat(outputStream.toString("utf-8"))
+			          .contains("Operator called default onErrorDropped")
+			          .contains(error.getMessage());
+			assertEquals(0, error2.getSuppressed().length);
+			//error2 is never thrown
+			ts.assertNoValues();
+			ts.assertComplete();
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-			assertSame(e.toString(), err, e.getCause());
-			assertEquals(0, err2.getSuppressed().length);
-			//err2 is never thrown
+		finally {
+			Loggers.resetLoggerFactory();
+			System.setErr(err);
+			System.setOut(out);
 		}
-		ts.assertNoValues();
-		ts.assertComplete();
 	}
 
 	@Test
-	public void afterTerminateCallbackErrorAndErrorCallbackError2() {
-		IllegalStateException afterTerminate = new IllegalStateException("afterTerminate");
-		IllegalArgumentException error = new IllegalArgumentException("error");
-		NullPointerException err = new NullPointerException();
-
-		FluxPeekFuseable<String> flux = new FluxPeekFuseable<>(
-				Flux.error(err),
-				null, null,
-				e -> { throw error; }, null, () -> { throw afterTerminate; },
-				null, null);
-
-		AssertSubscriber<String> ts = AssertSubscriber.create();
-
+	public void afterTerminateCallbackErrorAndErrorCallbackError2()
+			throws UnsupportedEncodingException {
+		PrintStream err = System.err;
+		PrintStream out = System.out;
 		try {
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			System.setErr(new PrintStream(outputStream));
+			System.setOut(new PrintStream(outputStream));
+			Loggers.useVerboseConsoleLoggers();
+			IllegalStateException afterTerminate = new IllegalStateException("afterTerminate");
+			IllegalArgumentException error = new IllegalArgumentException("error");
+			NullPointerException error2 = new NullPointerException();
+
+			FluxPeekFuseable<String> flux =
+					new FluxPeekFuseable<>(Flux.error(error2), null, null, e -> {
+						throw error;
+					}, null, () -> {
+						throw afterTerminate;
+					}, null, null);
+
+			AssertSubscriber<String> ts = AssertSubscriber.create();
+
 			flux.subscribe(ts);
-			fail("expected thrown exception");
-		}
-		catch (Exception e) {
-			assertSame(afterTerminate, e.getCause());
-			//afterTerminate suppressed error which itself suppressed original err
+			Assertions.assertThat(outputStream.toString("utf-8"))
+			          .contains("Operator called default onErrorDropped")
+			          .contains(afterTerminate.getMessage());
+			//afterTerminate suppressed error which itself suppressed original error2
 			assertEquals(1, afterTerminate.getSuppressed().length);
 			assertEquals(error, afterTerminate.getSuppressed()[0]);
 
 			assertEquals(1, error.getSuppressed().length);
-			assertEquals(err, error.getSuppressed()[0]);
+			assertEquals(error2, error.getSuppressed()[0]);
+			ts.assertNoValues();
+			//the subscriber still sees the 'error' message since actual.onError is called before the afterTerminate callback
+			ts.assertErrorMessage("error");
 		}
-		ts.assertNoValues();
-		//the subscriber still sees the 'error' message since actual.onError is called before the afterTerminate callback
-		ts.assertErrorMessage("error");
+		finally {
+			Loggers.resetLoggerFactory();
+			System.setErr(err);
+			System.setOut(out);
+		}
 	}
 
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
@@ -16,6 +16,9 @@
 
 package reactor.core.publisher;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -24,6 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.reactivestreams.Subscription;
@@ -35,6 +39,7 @@ import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.util.Loggers;
 import reactor.util.concurrent.Queues;
 
 import static java.lang.Thread.sleep;
@@ -106,31 +111,7 @@ public class FluxPeekTest extends FluxOperatorTest<String, String> {
 					throw exception();
 				})),
 
-				scenario(f -> Flux.doOnSignal(f, null, null, s -> {
-					if (s.getMessage()
-					     .equals(exception().getMessage())) {
-						throw Exceptions.propagate(s);
-					}
-				}, () -> {
-				}, () -> {
-					throw exception();
-				}, null, null)).producerEmpty(),
-
-				scenario(f -> Flux.doOnSignal(f, null, null, s -> {
-					if (s.getMessage()
-					     .equals(exception().getMessage())) {
-						throw exception();
-					}
-				}, () -> {
-				}, () -> {
-					throw exception();
-				}, null, null)).producerEmpty(),
-
 				scenario(f -> f.doOnComplete(() -> {
-					               throw exception();
-				               })).producerEmpty(),
-
-				scenario(f -> f.doAfterTerminate(() -> {
 					               throw exception();
 				               })).producerEmpty(),
 
@@ -571,34 +552,46 @@ public class FluxPeekTest extends FluxOperatorTest<String, String> {
 	}
 
 	@Test
-	public void afterTerminateCallbackErrorDoesNotInvokeOnError() {
-		IllegalStateException err = new IllegalStateException("test");
-		AtomicReference<Throwable> errorCallbackCapture = new AtomicReference<>();
-
-		FluxPeek<String> flux = new FluxPeek<>(Flux.empty(),
-				null,
-				null,
-				errorCallbackCapture::set,
-				null,
-				() -> {
-					throw err;
-				},
-				null,
-				null);
-
-		AssertSubscriber<String> ts = AssertSubscriber.create();
-
+	public void afterTerminateCallbackErrorDoesNotInvokeOnError()
+			throws UnsupportedEncodingException {
+		PrintStream err = System.err;
+		PrintStream out = System.out;
 		try {
-			flux.subscribe(ts);
-			fail("expected thrown exception");
-		}
-		catch (Exception e) {
-			assertThat(e).hasCause(err);
-		}
-		ts.assertNoValues();
-		ts.assertComplete();
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			System.setErr(new PrintStream(outputStream));
+			System.setOut(new PrintStream(outputStream));
+			Loggers.useVerboseConsoleLoggers();
+			IllegalStateException e = new IllegalStateException("test");
+			AtomicReference<Throwable> errorCallbackCapture = new AtomicReference<>();
 
-		assertThat(errorCallbackCapture.get()).isNull();
+			FluxPeek<String> flux = new FluxPeek<>(Flux.empty(),
+					null,
+					null,
+					errorCallbackCapture::set,
+					null,
+					() -> {
+						throw e;
+					},
+					null,
+					null);
+
+			AssertSubscriber<String> ts = AssertSubscriber.create();
+
+			flux.subscribe(ts);
+
+			ts.assertNoValues();
+			ts.assertComplete();
+
+			assertThat(errorCallbackCapture.get()).isNull();
+
+			Assertions.assertThat(outputStream.toString("utf-8"))
+			          .contains("Operator called default onErrorDropped")
+			          .contains(e.toString());
+		} finally {
+			Loggers.resetLoggerFactory();
+			System.setErr(err);
+			System.setOut(out);
+		}
 	}
 
 	@Test
@@ -659,62 +652,82 @@ public class FluxPeekTest extends FluxOperatorTest<String, String> {
 	}
 
 	@Test
-	public void afterTerminateCallbackErrorAndErrorCallbackError() {
-		IllegalStateException err = new IllegalStateException("afterTerminate");
-		IllegalArgumentException err2 = new IllegalArgumentException("error");
-
-		FluxPeek<String> flux = new FluxPeek<>(Flux.empty(), null, null, e -> {
-			throw err2;
-		}, null, () -> {
-			throw err;
-		}, null, null);
-
-		AssertSubscriber<String> ts = AssertSubscriber.create();
-
+	public void afterTerminateCallbackErrorAndErrorCallbackError()
+			throws UnsupportedEncodingException {
+		PrintStream err = System.err;
+		PrintStream out = System.out;
 		try {
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			System.setErr(new PrintStream(outputStream));
+			System.setOut(new PrintStream(outputStream));
+			Loggers.useVerboseConsoleLoggers();
+			IllegalStateException error1 = new IllegalStateException("afterTerminate");
+			IllegalArgumentException error2 = new IllegalArgumentException("error");
+
+			FluxPeek<String> flux = new FluxPeek<>(Flux.empty(), null, null, e -> {
+				throw error2;
+			}, null, () -> {
+				throw error1;
+			}, null, null);
+
+			AssertSubscriber<String> ts = AssertSubscriber.create();
+
 			flux.subscribe(ts);
-			fail("expected thrown exception");
+			Assertions.assertThat(outputStream.toString("utf-8"))
+			          .contains("Operator called default onErrorDropped")
+			          .contains(error1.getMessage());
+			assertEquals(0, error2.getSuppressed().length);
+			//error2 is never thrown
+			ts.assertNoValues();
+			ts.assertComplete();
 		}
-		catch (Exception e) {
-			assertSame(err, e.getCause());
-			assertEquals(0, err2.getSuppressed().length);
-			//err2 is never thrown
+		finally {
+			Loggers.resetLoggerFactory();
+			System.setErr(err);
+			System.setOut(out);
 		}
-		ts.assertNoValues();
-		ts.assertComplete();
 	}
 
 	@Test
-	public void afterTerminateCallbackErrorAndErrorCallbackError2() {
-		IllegalStateException afterTerminate =
-				new IllegalStateException("afterTerminate");
-		IllegalArgumentException error = new IllegalArgumentException("error");
-		NullPointerException err = new NullPointerException();
-
-		FluxPeek<String> flux = new FluxPeek<>(Flux.error(err), null, null, e -> {
-			throw error;
-		}, null, () -> {
-			throw afterTerminate;
-		}, null, null);
-
-		AssertSubscriber<String> ts = AssertSubscriber.create();
-
+	public void afterTerminateCallbackErrorAndErrorCallbackError2()
+			throws UnsupportedEncodingException {
+		PrintStream err = System.err;
+		PrintStream out = System.out;
 		try {
-			flux.subscribe(ts);
-			fail("expected thrown exception");
-		}
-		catch (Exception e) {
-			assertSame(afterTerminate, e.getCause());
-			//afterTerminate suppressed error which itself suppressed original err
-			assertEquals(1, afterTerminate.getSuppressed().length);
-			assertEquals(error, afterTerminate.getSuppressed()[0]);
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			System.setErr(new PrintStream(outputStream));
+			System.setOut(new PrintStream(outputStream));
+			Loggers.useVerboseConsoleLoggers();
+			IllegalStateException afterTerminate = new IllegalStateException("afterTerminate");
+			IllegalArgumentException error = new IllegalArgumentException("error");
+			NullPointerException ex = new NullPointerException();
 
-			assertEquals(1, error.getSuppressed().length);
-			assertEquals(err, error.getSuppressed()[0]);
+			FluxPeek<String> flux = new FluxPeek<>(Flux.error(ex), null, null, e -> {
+				throw error;
+			}, null, () -> {
+				throw afterTerminate;
+			}, null, null);
+
+			AssertSubscriber<String> ts = AssertSubscriber.create();
+
+				flux.subscribe(ts);
+			Assertions.assertThat(outputStream.toString("utf-8"))
+			          .contains("Operator called default onErrorDropped")
+			          .contains(afterTerminate.getMessage());
+				//afterTerminate suppressed error which itself suppressed original err
+				assertEquals(1, afterTerminate.getSuppressed().length);
+				assertEquals(error, afterTerminate.getSuppressed()[0]);
+
+				assertEquals(1, error.getSuppressed().length);
+				assertEquals(ex, error.getSuppressed()[0]);
+			ts.assertNoValues();
+			//the subscriber still sees the 'error' message since actual.onError is called before the afterTerminate callback
+			ts.assertErrorMessage("error");
+		}  finally {
+			Loggers.resetLoggerFactory();
+			System.setErr(err);
+			System.setOut(out);
 		}
-		ts.assertNoValues();
-		//the subscriber still sees the 'error' message since actual.onError is called before the afterTerminate callback
-		ts.assertErrorMessage("error");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -16,6 +16,9 @@
 
 package reactor.core.publisher;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -23,6 +26,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,6 +39,7 @@ import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.util.Loggers;
 import reactor.util.concurrent.Queues;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuple3;
@@ -708,24 +713,40 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 	}
 
 	@Test //FIXME use Violation.NO_CLEANUP_ON_TERMINATE
-	public void failDoubleError() {
+	public void failDoubleError() throws UnsupportedEncodingException {
+		PrintStream err = System.err;
+		PrintStream out = System.out;
 		try {
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			System.setErr(new PrintStream(outputStream));
+			System.setOut(new PrintStream(outputStream));
+			Loggers.useVerboseConsoleLoggers();
 			StepVerifier.create(Flux.zip(obj -> 0, Flux.just(1), Flux.never(), s -> {
 				s.onSubscribe(Operators.emptySubscription());
 				s.onError(new Exception("test"));
 				s.onError(new Exception("test2"));
 			}))
 			            .verifyErrorMessage("test");
-			Assert.fail();
-		}
-		catch (Exception e) {
-			assertThat(Exceptions.unwrap(e)).hasMessage("test2");
+
+			Assertions.assertThat(outputStream.toString("utf-8"))
+			          .contains("Operator called default onErrorDropped")
+			          .contains("test2");
+		} finally {
+			Loggers.resetLoggerFactory();
+			System.setErr(err);
+			System.setOut(out);
 		}
 	}
 
 	@Test //FIXME use Violation.NO_CLEANUP_ON_TERMINATE
-	public void failDoubleError3() {
+	public void failDoubleError3() throws UnsupportedEncodingException {
+		PrintStream err = System.err;
+		PrintStream out = System.out;
 		try {
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			System.setErr(new PrintStream(outputStream));
+			System.setOut(new PrintStream(outputStream));
+			Loggers.useVerboseConsoleLoggers();
 			StepVerifier.create(Flux.zip(obj -> 0,
 					Flux.just(1)
 					    .hide(),
@@ -736,10 +757,14 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 						s.onError(new Exception("test2"));
 					}))
 			            .verifyErrorMessage("test");
-			Assert.fail();
-		}
-		catch (Exception e) {
-			assertThat(Exceptions.unwrap(e)).hasMessage("test2");
+
+			Assertions.assertThat(outputStream.toString("utf-8"))
+			          .contains("Operator called default onErrorDropped")
+			          .contains("test2");
+		} finally {
+			Loggers.resetLoggerFactory();
+			System.setErr(err);
+			System.setOut(out);
 		}
 	}
 
@@ -756,8 +781,14 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 	}
 
 	@Test //FIXME use Violation.NO_CLEANUP_ON_TERMINATE
-	public void failDoubleErrorHide() {
+	public void failDoubleErrorHide() throws UnsupportedEncodingException {
+		PrintStream err = System.err;
+		PrintStream out = System.out;
 		try {
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			System.setErr(new PrintStream(outputStream));
+			System.setOut(new PrintStream(outputStream));
+			Loggers.useVerboseConsoleLoggers();
 			StepVerifier.create(Flux.zip(obj -> 0,
 					Flux.just(1)
 					    .hide(),
@@ -768,10 +799,14 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 						s.onError(new Exception("test2"));
 					}))
 			            .verifyErrorMessage("test");
-			Assert.fail();
-		}
-		catch (Exception e) {
-			assertThat(Exceptions.unwrap(e)).hasMessage("test2");
+
+			Assertions.assertThat(outputStream.toString("utf-8"))
+			          .contains("Operator called default onErrorDropped")
+			          .contains("test2");
+		} finally {
+			Loggers.resetLoggerFactory();
+			System.setErr(err);
+			System.setOut(out);
 		}
 	}
 
@@ -791,8 +826,14 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 	}
 
 	@Test //FIXME use Violation.NO_CLEANUP_ON_TERMINATE
-	public void failDoubleError2() {
+	public void failDoubleError2() throws UnsupportedEncodingException {
+		PrintStream err = System.err;
+		PrintStream out = System.out;
 		try {
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			System.setErr(new PrintStream(outputStream));
+			System.setOut(new PrintStream(outputStream));
+			Loggers.useVerboseConsoleLoggers();
 			StepVerifier.create(Flux.zip(obj -> 0,
 					Flux.just(1)
 					    .hide(),
@@ -803,10 +844,14 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 						s.onError(new Exception("test2"));
 					}))
 			            .verifyErrorMessage("test");
-			Assert.fail();
-		}
-		catch (Exception e) {
-			assertThat(Exceptions.unwrap(e)).hasMessage("test2");
+
+			Assertions.assertThat(outputStream.toString("utf-8"))
+			          .contains("Operator called default onErrorDropped")
+			          .contains("test2");
+		} finally {
+			Loggers.resetLoggerFactory();
+			System.setErr(err);
+			System.setOut(out);
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -16,9 +16,6 @@
 
 package reactor.core.publisher;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -34,12 +31,12 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.reactivestreams.Subscription;
 
 import reactor.core.CoreSubscriber;
-import reactor.core.Exceptions;
 import reactor.core.Scannable;
+import reactor.test.LoggerUtils;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.Loggers;
+import reactor.test.util.TestLogger;
 import reactor.util.concurrent.Queues;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuple3;
@@ -713,14 +710,10 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 	}
 
 	@Test //FIXME use Violation.NO_CLEANUP_ON_TERMINATE
-	public void failDoubleError() throws UnsupportedEncodingException {
-		PrintStream err = System.err;
-		PrintStream out = System.out;
+	public void failDoubleError() {
+		TestLogger testLogger = new TestLogger();
+		LoggerUtils.addAppender(testLogger, Operators.class);
 		try {
-			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			System.setErr(new PrintStream(outputStream));
-			System.setOut(new PrintStream(outputStream));
-			Loggers.useVerboseConsoleLoggers();
 			StepVerifier.create(Flux.zip(obj -> 0, Flux.just(1), Flux.never(), s -> {
 				s.onSubscribe(Operators.emptySubscription());
 				s.onError(new Exception("test"));
@@ -728,25 +721,19 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 			}))
 			            .verifyErrorMessage("test");
 
-			Assertions.assertThat(outputStream.toString("utf-8"))
+			Assertions.assertThat(testLogger.getErrContent())
 			          .contains("Operator called default onErrorDropped")
 			          .contains("test2");
 		} finally {
-			Loggers.resetLoggerFactory();
-			System.setErr(err);
-			System.setOut(out);
+			LoggerUtils.resetAppender(Operators.class);
 		}
 	}
 
 	@Test //FIXME use Violation.NO_CLEANUP_ON_TERMINATE
-	public void failDoubleError3() throws UnsupportedEncodingException {
-		PrintStream err = System.err;
-		PrintStream out = System.out;
+	public void failDoubleError3() {
+		TestLogger testLogger = new TestLogger();
+		LoggerUtils.addAppender(testLogger, Operators.class);
 		try {
-			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			System.setErr(new PrintStream(outputStream));
-			System.setOut(new PrintStream(outputStream));
-			Loggers.useVerboseConsoleLoggers();
 			StepVerifier.create(Flux.zip(obj -> 0,
 					Flux.just(1)
 					    .hide(),
@@ -758,13 +745,11 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 					}))
 			            .verifyErrorMessage("test");
 
-			Assertions.assertThat(outputStream.toString("utf-8"))
+			Assertions.assertThat(testLogger.getErrContent())
 			          .contains("Operator called default onErrorDropped")
 			          .contains("test2");
 		} finally {
-			Loggers.resetLoggerFactory();
-			System.setErr(err);
-			System.setOut(out);
+			LoggerUtils.resetAppender(Operators.class);
 		}
 	}
 
@@ -781,14 +766,10 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 	}
 
 	@Test //FIXME use Violation.NO_CLEANUP_ON_TERMINATE
-	public void failDoubleErrorHide() throws UnsupportedEncodingException {
-		PrintStream err = System.err;
-		PrintStream out = System.out;
+	public void failDoubleErrorHide() {
+		TestLogger testLogger = new TestLogger();
+		LoggerUtils.addAppender(testLogger, Operators.class);
 		try {
-			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			System.setErr(new PrintStream(outputStream));
-			System.setOut(new PrintStream(outputStream));
-			Loggers.useVerboseConsoleLoggers();
 			StepVerifier.create(Flux.zip(obj -> 0,
 					Flux.just(1)
 					    .hide(),
@@ -800,13 +781,11 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 					}))
 			            .verifyErrorMessage("test");
 
-			Assertions.assertThat(outputStream.toString("utf-8"))
+			Assertions.assertThat(testLogger.getErrContent())
 			          .contains("Operator called default onErrorDropped")
 			          .contains("test2");
 		} finally {
-			Loggers.resetLoggerFactory();
-			System.setErr(err);
-			System.setOut(out);
+			LoggerUtils.resetAppender(Operators.class);
 		}
 	}
 
@@ -826,14 +805,10 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 	}
 
 	@Test //FIXME use Violation.NO_CLEANUP_ON_TERMINATE
-	public void failDoubleError2() throws UnsupportedEncodingException {
-		PrintStream err = System.err;
-		PrintStream out = System.out;
+	public void failDoubleError2() {
+		TestLogger testLogger = new TestLogger();
+		LoggerUtils.addAppender(testLogger, Operators.class);
 		try {
-			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			System.setErr(new PrintStream(outputStream));
-			System.setOut(new PrintStream(outputStream));
-			Loggers.useVerboseConsoleLoggers();
 			StepVerifier.create(Flux.zip(obj -> 0,
 					Flux.just(1)
 					    .hide(),
@@ -845,13 +820,11 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 					}))
 			            .verifyErrorMessage("test");
 
-			Assertions.assertThat(outputStream.toString("utf-8"))
+			Assertions.assertThat(testLogger.getErrContent())
 			          .contains("Operator called default onErrorDropped")
 			          .contains("test2");
 		} finally {
-			Loggers.resetLoggerFactory();
-			System.setErr(err);
-			System.setOut(out);
+			LoggerUtils.resetAppender(Operators.class);
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
@@ -16,9 +16,6 @@
 
 package reactor.core.publisher;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -46,7 +43,6 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.Loggers;
 import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -781,18 +777,21 @@ public class HooksTest {
 		};
 		List<Integer> seen = new ArrayList<>();
 
-		Hooks.onNextDropped(dropHook::set);
-		Hooks.onNextDroppedFail();
+		try {
+			Hooks.onNextDropped(dropHook::set);
+			Hooks.onNextDroppedFail();
 
-		assertThatExceptionOfType(RuntimeException.class)
-				.isThrownBy(() -> Flux.from(p)
-				                      .take(2)
-				                      .subscribe(seen::add))
-				.isInstanceOf(RuntimeException.class)
-				.matches(Exceptions::isCancel);
+			assertThatExceptionOfType(RuntimeException.class)
+					.isThrownBy(() -> Flux.from(p).take(2).subscribe(seen::add))
+					.isInstanceOf(RuntimeException.class)
+					.matches(Exceptions::isCancel);
 
-		assertThat(seen).containsExactly(1, 2);
-		assertThat(dropHook.get()).isNull();
+			assertThat(seen).containsExactly(1, 2);
+			assertThat(dropHook.get()).isNull();
+		}
+		finally {
+			Hooks.resetOnNextDropped();
+		}
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
@@ -16,6 +16,9 @@
 
 package reactor.core.publisher;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,6 +46,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.util.Loggers;
 import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -777,21 +781,18 @@ public class HooksTest {
 		};
 		List<Integer> seen = new ArrayList<>();
 
-		try {
-			Hooks.onNextDropped(dropHook::set);
-			Hooks.onNextDroppedFail();
+		Hooks.onNextDropped(dropHook::set);
+		Hooks.onNextDroppedFail();
 
-			assertThatExceptionOfType(RuntimeException.class)
-					.isThrownBy(() -> Flux.from(p).take(2).subscribe(seen::add))
-					.isInstanceOf(RuntimeException.class)
-					.matches(Exceptions::isCancel);
+		assertThatExceptionOfType(RuntimeException.class)
+				.isThrownBy(() -> Flux.from(p)
+				                      .take(2)
+				                      .subscribe(seen::add))
+				.isInstanceOf(RuntimeException.class)
+				.matches(Exceptions::isCancel);
 
-			assertThat(seen).containsExactly(1, 2);
-			assertThat(dropHook.get()).isNull();
-		}
-		finally {
-			Hooks.resetOnNextDropped();
-		}
+		assertThat(seen).containsExactly(1, 2);
+		assertThat(dropHook.get()).isNull();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
@@ -16,9 +16,6 @@
 
 package reactor.core.publisher;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -28,9 +25,9 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.reactivestreams.Subscription;
 
-import reactor.core.Exceptions;
 import reactor.core.Scannable;
-import reactor.util.Loggers;
+import reactor.test.LoggerUtils;
+import reactor.test.util.TestLogger;
 import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -157,15 +154,10 @@ public class LambdaMonoSubscriberTest {
 	}
 
 	@Test
-	public void onNextConsumerExceptionBubblesUpDoesntTriggerCancellation()
-			throws UnsupportedEncodingException {
-		PrintStream err = System.err;
-		PrintStream out = System.out;
+	public void onNextConsumerExceptionBubblesUpDoesntTriggerCancellation() {
+		TestLogger testLogger = new TestLogger();
+		LoggerUtils.addAppender(testLogger, Operators.class);
 		try {
-			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			System.setErr(new PrintStream(outputStream));
-			System.setOut(new PrintStream(outputStream));
-			Loggers.useVerboseConsoleLoggers();
 			AtomicReference<Throwable> errorHolder = new AtomicReference<>(null);
 
 			LambdaMonoSubscriber<String> tested = new LambdaMonoSubscriber<>(value -> {
@@ -179,7 +171,7 @@ public class LambdaMonoSubscriberTest {
 			//as Mono is single-value, it cancels early on onNext. this leads to an exception
 			//during onNext to be bubbled up as a BubbledException, not propagated through onNext
 			tested.onNext("foo");
-			Assertions.assertThat(outputStream.toString("utf-8"))
+			Assertions.assertThat(testLogger.getErrContent())
 			          .contains("Operator called default onErrorDropped")
 			          .contains("IllegalArgumentException");
 
@@ -189,22 +181,15 @@ public class LambdaMonoSubscriberTest {
 			                                        .isFalse();
 		}
 		finally {
-			Loggers.resetLoggerFactory();
-			System.setErr(err);
-			System.setOut(out);
+			LoggerUtils.resetAppender(Operators.class);
 		}
 	}
 
 	@Test
-	public void onNextConsumerFatalDoesntTriggerCancellation()
-			throws UnsupportedEncodingException {
-		PrintStream err = System.err;
-		PrintStream out = System.out;
+	public void onNextConsumerFatalDoesntTriggerCancellation() {
+		TestLogger testLogger = new TestLogger();
+		LoggerUtils.addAppender(testLogger, Operators.class);
 		try {
-			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			System.setErr(new PrintStream(outputStream));
-			System.setOut(new PrintStream(outputStream));
-			Loggers.useVerboseConsoleLoggers();
 			AtomicReference<Throwable> errorHolder = new AtomicReference<>(null);
 
 			LambdaMonoSubscriber<String> tested = new LambdaMonoSubscriber<>(value -> {
@@ -217,7 +202,7 @@ public class LambdaMonoSubscriberTest {
 
 			//the error is expected to be thrown as it is fatal
 			tested.onNext("foo");
-			Assertions.assertThat(outputStream.toString("utf-8"))
+			Assertions.assertThat(testLogger.getErrContent())
 			          .contains("Operator called default onErrorDropped")
 			          .contains("OutOfMemoryError");
 
@@ -227,9 +212,7 @@ public class LambdaMonoSubscriberTest {
 			                                        .isFalse();
 		}
 		finally {
-			Loggers.resetLoggerFactory();
-			System.setErr(err);
-			System.setOut(out);
+			LoggerUtils.resetAppender(Operators.class);
 		}
 	}
 
@@ -281,28 +264,21 @@ public class LambdaMonoSubscriberTest {
 	}
 
 	@Test
-	public void noErrorHookThrowsCallbackNotImplemented()
-			throws UnsupportedEncodingException {
-		PrintStream err = System.err;
-		PrintStream out = System.out;
+	public void noErrorHookThrowsCallbackNotImplemented() {
+		TestLogger testLogger = new TestLogger();
+		LoggerUtils.addAppender(testLogger, Operators.class);
 		try {
-			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			System.setErr(new PrintStream(outputStream));
-			System.setOut(new PrintStream(outputStream));
-			Loggers.useVerboseConsoleLoggers();
 			RuntimeException boom = new IllegalArgumentException("boom");
 			Mono.error(boom)
 			    .subscribe(v -> {
 			    });
-			Assertions.assertThat(outputStream.toString("utf-8"))
+			Assertions.assertThat(testLogger.getErrContent())
 			          .contains("Operator called default onErrorDropped")
 			          .contains(
 					          "reactor.core.Exceptions$ErrorCallbackNotImplemented: java.lang.IllegalArgumentException: boom");
 		}
 		finally {
-			Loggers.resetLoggerFactory();
-			System.setErr(err);
-			System.setOut(out);
+			LoggerUtils.resetAppender(Operators.class);
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPeekAfterTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPeekAfterTest.java
@@ -16,9 +16,6 @@
 
 package reactor.core.publisher;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -30,7 +27,9 @@ import org.junit.Test;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.scheduler.Schedulers;
+import reactor.test.LoggerUtils;
 import reactor.test.StepVerifier;
+import reactor.test.util.TestLogger;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 
@@ -449,15 +448,10 @@ public class MonoPeekAfterTest {
 	}
 
 	@Test
-	public void afterSuccessOrErrorCallbackFailureInterruptsOnNextAndThrows()
-			throws UnsupportedEncodingException {
-		PrintStream err = System.err;
-		PrintStream out = System.out;
+	public void afterSuccessOrErrorCallbackFailureInterruptsOnNextAndThrows() {
+		TestLogger testLogger = new TestLogger();
+		LoggerUtils.addAppender(testLogger, Operators.class);
 		try {
-			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			System.setErr(new PrintStream(outputStream));
-			System.setOut(new PrintStream(outputStream));
-			Loggers.useVerboseConsoleLoggers();
 			LongAdder invoked = new LongAdder();
 			try {
 				@SuppressWarnings("deprecation")
@@ -478,28 +472,21 @@ public class MonoPeekAfterTest {
 			}
 
 			assertEquals(1, invoked.intValue());
-			Assertions.assertThat(outputStream.toString("utf-8"))
+			Assertions.assertThat(testLogger.getErrContent())
 			          .contains("Operator called default onErrorDropped")
 			          .contains("IllegalArgumentException")
 			          .contains("foo");
 		}
 		finally {
-			Loggers.resetLoggerFactory();
-			System.setErr(err);
-			System.setOut(out);
+			LoggerUtils.resetAppender(Operators.class);
 		}
 	}
 
 	@Test
-	public void afterTerminateCallbackFailureInterruptsOnNextAndThrows()
-			throws UnsupportedEncodingException {
-		PrintStream err = System.err;
-		PrintStream out = System.out;
+	public void afterTerminateCallbackFailureInterruptsOnNextAndThrows() {
+		TestLogger testLogger = new TestLogger();
+		LoggerUtils.addAppender(testLogger, Operators.class);
 		try {
-			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			System.setErr(new PrintStream(outputStream));
-			System.setOut(new PrintStream(outputStream));
-			Loggers.useVerboseConsoleLoggers();
 			LongAdder invoked = new LongAdder();
 			try {
 				@SuppressWarnings("deprecation")
@@ -521,15 +508,13 @@ public class MonoPeekAfterTest {
 
 			assertEquals(1, invoked.intValue());
 
-			Assertions.assertThat(outputStream.toString("utf-8"))
+			Assertions.assertThat(testLogger.getErrContent())
 			          .contains("Operator called default onErrorDropped")
 			          .contains("foo")
 			          .contains("IllegalArgumentException");
 		}
 		finally {
-			Loggers.resetLoggerFactory();
-			System.setErr(err);
-			System.setOut(out);
+			LoggerUtils.resetAppender(Operators.class);
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
@@ -15,9 +15,6 @@
  */
 package reactor.core.publisher;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.lang.ref.WeakReference;
 import java.time.Duration;
 import java.util.Date;
@@ -32,9 +29,10 @@ import org.junit.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Scannable;
+import reactor.test.LoggerUtils;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
-import reactor.util.Loggers;
+import reactor.test.util.TestLogger;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.function.Tuple2;
 
@@ -352,51 +350,39 @@ public class MonoProcessorTest {
 	}
 
 	@Test
-	public void MonoProcessorDoubleError() throws UnsupportedEncodingException {
-		PrintStream err = System.err;
-		PrintStream out = System.out;
+	public void MonoProcessorDoubleError() {
+		TestLogger testLogger = new TestLogger();
+		LoggerUtils.addAppender(testLogger, Operators.class);
 		try {
-			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			System.setErr(new PrintStream(outputStream));
-			System.setOut(new PrintStream(outputStream));
-			Loggers.useVerboseConsoleLoggers();
 			MonoProcessor<String> mp = MonoProcessor.create();
 
 			mp.onError(new Exception("test"));
 			mp.onError(new Exception("test2"));
-			Assertions.assertThat(outputStream.toString("utf-8"))
+			Assertions.assertThat(testLogger.getErrContent())
 			          .contains("Operator called default onErrorDropped")
 			          .contains("test2");
 		}
 		finally {
-			Loggers.resetLoggerFactory();
-			System.setErr(err);
-			System.setOut(out);
+			LoggerUtils.resetAppender(Operators.class);
 		}
 	}
 
 	@Test
-	public void MonoProcessorDoubleSignal() throws UnsupportedEncodingException {
-		PrintStream err = System.err;
-		PrintStream out = System.out;
+	public void MonoProcessorDoubleSignal() {
+		TestLogger testLogger = new TestLogger();
+		LoggerUtils.addAppender(testLogger, Operators.class);
 		try {
-			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			System.setErr(new PrintStream(outputStream));
-			System.setOut(new PrintStream(outputStream));
-			Loggers.useVerboseConsoleLoggers();
 			MonoProcessor<String> mp = MonoProcessor.create();
 
 			mp.onNext("test");
 			mp.onError(new Exception("test2"));
 
-			Assertions.assertThat(outputStream.toString("utf-8"))
+			Assertions.assertThat(testLogger.getErrContent())
 			          .contains("Operator called default onErrorDropped")
 			          .contains("test2");
 		}
 		finally {
-			Loggers.resetLoggerFactory();
-			System.setErr(err);
-			System.setOut(out);
+			LoggerUtils.resetAppender(Operators.class);
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
@@ -15,6 +15,9 @@
  */
 package reactor.core.publisher;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.lang.ref.WeakReference;
 import java.time.Duration;
 import java.util.Date;
@@ -31,6 +34,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
+import reactor.util.Loggers;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.function.Tuple2;
 
@@ -347,20 +351,53 @@ public class MonoProcessorTest {
 		            .verifyErrorMessage("test");
 	}
 
-	@Test(expected = Exception.class)
-	public void MonoProcessorDoubleError() {
-		MonoProcessor<String> mp = MonoProcessor.create();
+	@Test
+	public void MonoProcessorDoubleError() throws UnsupportedEncodingException {
+		PrintStream err = System.err;
+		PrintStream out = System.out;
+		try {
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			System.setErr(new PrintStream(outputStream));
+			System.setOut(new PrintStream(outputStream));
+			Loggers.useVerboseConsoleLoggers();
+			MonoProcessor<String> mp = MonoProcessor.create();
 
-		mp.onError(new Exception("test"));
-		mp.onError(new Exception("test"));
+			mp.onError(new Exception("test"));
+			mp.onError(new Exception("test2"));
+			Assertions.assertThat(outputStream.toString("utf-8"))
+			          .contains("Operator called default onErrorDropped")
+			          .contains("test2");
+		}
+		finally {
+			Loggers.resetLoggerFactory();
+			System.setErr(err);
+			System.setOut(out);
+		}
 	}
 
-	@Test(expected = Exception.class)
-	public void MonoProcessorDoubleSignal() {
-		MonoProcessor<String> mp = MonoProcessor.create();
+	@Test
+	public void MonoProcessorDoubleSignal() throws UnsupportedEncodingException {
+		PrintStream err = System.err;
+		PrintStream out = System.out;
+		try {
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			System.setErr(new PrintStream(outputStream));
+			System.setOut(new PrintStream(outputStream));
+			Loggers.useVerboseConsoleLoggers();
+			MonoProcessor<String> mp = MonoProcessor.create();
 
-		mp.onNext("test");
-		mp.onError(new Exception("test"));
+			mp.onNext("test");
+			mp.onError(new Exception("test2"));
+
+			Assertions.assertThat(outputStream.toString("utf-8"))
+			          .contains("Operator called default onErrorDropped")
+			          .contains("test2");
+		}
+		finally {
+			Loggers.resetLoggerFactory();
+			System.setErr(err);
+			System.setOut(out);
+		}
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -16,10 +16,7 @@
 
 package reactor.core.publisher.scenarios;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -71,8 +68,10 @@ import reactor.core.publisher.Processors;
 import reactor.core.publisher.Signal;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
+import reactor.test.LoggerUtils;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.test.util.TestLogger;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 import reactor.util.function.Tuple2;
@@ -1175,16 +1174,10 @@ public class FluxTests extends AbstractReactorTest {
 		assertThat("Not totally dispatched", latch.await(30, TimeUnit.SECONDS));
 	}
 	@Test
-	public void unimplementedErrorCallback()
-			throws UnsupportedEncodingException {
-		PrintStream err = System.err;
-		PrintStream out = System.out;
+	public void unimplementedErrorCallback() {
+		TestLogger testLogger = new TestLogger();
+		LoggerUtils.addAppender(testLogger, Operators.class);
 		try {
-			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			System.setErr(new PrintStream(outputStream));
-			System.setOut(new PrintStream(outputStream));
-			Loggers.useVerboseConsoleLoggers();
-
 			Flux.error(new Exception("forced1"))
 			    .log("error")
 			    .subscribe();
@@ -1192,14 +1185,12 @@ public class FluxTests extends AbstractReactorTest {
 			Flux.error(new Exception("forced2"))
 			    .subscribe();
 
-			Assertions.assertThat(outputStream.toString("utf-8"))
+			Assertions.assertThat(testLogger.getErrContent())
 			          .contains("Operator called default onErrorDropped")
 			          .contains("reactor.core.Exceptions$ErrorCallbackNotImplemented: java.lang.Exception: forced2");
 		}
 		finally {
-			Loggers.resetLoggerFactory();
-			System.setErr(err);
-			System.setOut(out);
+			LoggerUtils.resetAppender(Operators.class);
 		}
 	}
 
@@ -1421,15 +1412,10 @@ public class FluxTests extends AbstractReactorTest {
 	}
 
 	@Test
-	public void testThrowWithoutOnErrorShowsUpInSchedulerHandler()
-			throws UnsupportedEncodingException {
-		PrintStream err = System.err;
-		PrintStream out = System.out;
+	public void testThrowWithoutOnErrorShowsUpInSchedulerHandler() {
+		TestLogger testLogger = new TestLogger();
+		LoggerUtils.addAppender(testLogger, Operators.class);
 		try {
-			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			System.setErr(new PrintStream(outputStream));
-			System.setOut(new PrintStream(outputStream));
-			Loggers.useVerboseConsoleLoggers();
 			AtomicReference<String> failure = new AtomicReference<>(null);
 			AtomicBoolean handled = new AtomicBoolean(false);
 
@@ -1460,16 +1446,14 @@ public class FluxTests extends AbstractReactorTest {
 			assertThat(handled).as("Uncaught error handler")
 			                   .isFalse();
 			assertThat(failure).as("Uncaught error handler")
-			                   .isNull();
-			Assertions.assertThat(outputStream.toString("utf-8"))
+			                   .hasValue(null);
+			Assertions.assertThat(testLogger.getErrContent())
 			          .contains("Operator called default onErrorDropped")
 			          .contains(
 					          "reactor.core.Exceptions$ErrorCallbackNotImplemented: java.lang.IllegalArgumentException");
 		}
 		finally {
-			Loggers.resetLoggerFactory();
-			System.setErr(err);
-			System.setOut(out);
+			LoggerUtils.resetAppender(Operators.class);
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/test/LoggerUtils.java
+++ b/reactor-core/src/test/java/reactor/test/LoggerUtils.java
@@ -1,0 +1,59 @@
+package reactor.test;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.pattern.ThrowableProxyConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import org.slf4j.LoggerFactory;
+import reactor.test.util.TestLogger;
+
+public class LoggerUtils {
+	static final String TEST_APPENDER_NAME = "TestAppender";
+
+	public static void addAppender(TestLogger testLogger, Class<?> classWithLogger) {
+		org.slf4j.Logger slf4jLogger = LoggerFactory.getLogger(classWithLogger);
+		if (slf4jLogger instanceof Logger) {
+			Logger logbackLogger = (Logger) slf4jLogger;
+			TestAppender appender = new TestAppender(testLogger);
+			appender.start();
+			logbackLogger.addAppender(appender);
+		}
+	}
+
+	public static void resetAppender(Class<?> classWithLogger) {
+		org.slf4j.Logger slf4jLogger = LoggerFactory.getLogger(classWithLogger);
+		if (slf4jLogger instanceof Logger) {
+			Logger logbackLogger = (Logger) slf4jLogger;
+			logbackLogger.detachAppender(TEST_APPENDER_NAME);
+		}
+	}
+
+	static class TestAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
+
+		private final TestLogger testLogger;
+		private final ThrowableProxyConverter throwableProxyConverter = new ThrowableProxyConverter();
+
+		TestAppender(TestLogger testLogger) {
+			this.testLogger = testLogger;
+		}
+
+		@Override
+		protected void append(ILoggingEvent eventObject) {
+			if (eventObject.getLevel() == Level.ERROR) {
+				testLogger.error(eventObject.getFormattedMessage()
+				                            .concat("\n")
+				                            .concat(throwableProxyConverter.convert(eventObject)));
+
+			} else {
+				testLogger.info(eventObject.getFormattedMessage());
+			}
+		}
+
+		@Override
+		public String getName() {
+			return TEST_APPENDER_NAME;
+		}
+
+	}
+}


### PR DESCRIPTION
Draft PR to fix onErrorDropped which throws bubbling exception

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>