### PR TITLE
1734 use nanos

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -2851,7 +2851,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final  <C extends Collection<? super T>> Flux<C> bufferTimeout(int maxSize, Duration maxTime,
 			Scheduler timer, Supplier<C> bufferSupplier) {
-		return onAssembly(new FluxBufferTimeout<>(this, maxSize, maxTime.toMillis(), timer, bufferSupplier));
+		return onAssembly(new FluxBufferTimeout<>(this, maxSize, maxTime.toNanos(), TimeUnit.NANOSECONDS, timer, bufferSupplier));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -2472,7 +2472,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	public final T blockFirst(Duration timeout) {
 		BlockingFirstSubscriber<T> subscriber = new BlockingFirstSubscriber<>();
 		subscribe((Subscriber<T>) subscriber);
-		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
+		return subscriber.blockingGet(timeout.toNanos(), TimeUnit.NANOSECONDS);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -9052,10 +9052,10 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * the emitted data (as a {@code T}), for each item from this {@link Flux}.
 	 *
 	 * <p>The provider {@link Scheduler} will be asked to {@link Scheduler#now(TimeUnit) provide time}
-	 * with a granularity of {@link TimeUnit#MILLISECONDS} and, should return results that can be
-	 * interpreted as unix timestamps.</p>
-	 *
+	 * with a granularity of {@link TimeUnit#MILLISECONDS}. In order for this operator to work as advertised, the
+	 * provided Scheduler should thus return results that can be interpreted as unix timestamps.</p>
 	 * <p>
+	 *
 	 * <img class="marble" src="doc-files/marbles/timestampForFlux.svg" alt="">
 	 *
 	 * @param scheduler the {@link Scheduler} to read time from

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -9444,7 +9444,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @return a {@link Flux} of {@link Flux} windows based on element count and duration
 	 */
 	public final Flux<Flux<T>> windowTimeout(int maxSize, Duration maxTime, Scheduler timer) {
-		return onAssembly(new FluxWindowTimeout<>(this, maxSize, maxTime.toMillis(), timer));
+		return onAssembly(new FluxWindowTimeout<>(this, maxSize, maxTime.toNanos(), TimeUnit.NANOSECONDS, timer));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -2518,7 +2518,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	public final T blockLast(Duration timeout) {
 		BlockingLastSubscriber<T> subscriber = new BlockingLastSubscriber<>();
 		subscribe((Subscriber<T>) subscriber);
-		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
+		return subscriber.blockingGet(timeout.toNanos(), TimeUnit.NANOSECONDS);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -7197,7 +7197,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final ConnectableFlux<T> replay(int history, Duration ttl, Scheduler timer) {
 		Objects.requireNonNull(timer, "timer");
-		return onAssembly(new FluxReplay<>(this, history, ttl.toMillis(), timer));
+		return onAssembly(new FluxReplay<>(this, history, ttl.toNanos(), timer));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -9051,11 +9051,16 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * millis (as a {@link Long} measured by the provided {@link Scheduler}) and T2
 	 * the emitted data (as a {@code T}), for each item from this {@link Flux}.
 	 *
+	 * <p>The provider {@link Scheduler} will be asked to {@link Scheduler#now(TimeUnit) provide time}
+	 * with a granularity of {@link TimeUnit#MILLISECONDS} and, should return results that can be
+	 * interpreted as unix timestamps.</p>
+	 *
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/timestampForFlux.svg" alt="">
 	 *
 	 * @param scheduler the {@link Scheduler} to read time from
 	 * @return a timestamped {@link Flux}
+	 * @see Scheduler#now(TimeUnit)
 	 */
 	public final Flux<Tuple2<Long, T>> timestamp(Scheduler scheduler) {
 		Objects.requireNonNull(scheduler, "scheduler");

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -1162,7 +1162,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @return a new {@link Flux} emitting increasing numbers at regular intervals
 	 */
 	public static Flux<Long> interval(Duration period, Scheduler timer) {
-		return onAssembly(new FluxInterval(period.toMillis(), period.toMillis(), TimeUnit.MILLISECONDS, timer));
+		return interval(period, period, timer);
 	}
 
 	/**
@@ -1182,7 +1182,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @return a new {@link Flux} emitting increasing numbers at regular intervals
 	 */
 	public static Flux<Long> interval(Duration delay, Duration period, Scheduler timer) {
-		return onAssembly(new FluxInterval(delay.toMillis(), period.toMillis(), TimeUnit.MILLISECONDS, timer));
+		return onAssembly(new FluxInterval(delay.toNanos(), period.toNanos(), TimeUnit.NANOSECONDS, timer));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDelaySequence.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDelaySequence.java
@@ -73,14 +73,8 @@ final class FluxDelaySequence<T> extends InternalFluxOperator<T, T> {
 			super();
 			this.actual = new SerializedSubscriber<>(actual);
 			this.w = w;
-			if (delay.compareTo(Duration.ofMinutes(1)) < 0) {
-				this.delay = delay.toNanos();
-				this.timeUnit = TimeUnit.NANOSECONDS;
-			}
-			else {
-				this.delay = delay.toMillis();
-				this.timeUnit = TimeUnit.MILLISECONDS;
-			}
+			this.delay = delay.toNanos();
+			this.timeUnit = TimeUnit.NANOSECONDS;
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferTimeout.java
@@ -224,12 +224,12 @@ final class FluxOnBackpressureBufferTimeout<O> extends InternalFluxOperator<O, O
 					this.poll();
 					evicted = (T) this.poll();
 				}
-				this.offer(ttlScheduler.now(TimeUnit.MILLISECONDS));
+				this.offer(ttlScheduler.now(TimeUnit.NANOSECONDS));
 				this.offer(t);
 			}
 			evict(evicted);
 			try {
-				worker.schedule(this, ttl.toMillis(), TimeUnit.MILLISECONDS);
+				worker.schedule(this, ttl.toNanos(), TimeUnit.NANOSECONDS);
 			}
 			catch (RejectedExecutionException re) {
 				done = true;
@@ -268,7 +268,7 @@ final class FluxOnBackpressureBufferTimeout<O> extends InternalFluxOperator<O, O
 					Long ts = (Long) this.peek();
 					empty = ts == null;
 					if (!empty) {
-						if (ts <= ttlScheduler.now(TimeUnit.MILLISECONDS) - ttl.toMillis()) {
+						if (ts <= ttlScheduler.now(TimeUnit.NANOSECONDS) - ttl.toNanos()) {
 							this.poll();
 							evicted = (T) this.poll();
 						}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
@@ -124,7 +124,7 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 		}
 
 		if (replaceTimer) {
-			sd.replace(scheduler.schedule(rc, gracePeriod.toMillis(), TimeUnit.MILLISECONDS));
+			sd.replace(scheduler.schedule(rc, gracePeriod.toNanos(), TimeUnit.NANOSECONDS));
 		} else if (dispose != null) {
 			dispose.dispose();
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -158,7 +158,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 		@Override
 		public boolean isExpired() {
 			long done = this.done;
-			return done != NOT_DONE && scheduler.now(TimeUnit.MILLISECONDS) - maxAge > done;
+			return done != NOT_DONE && scheduler.now(TimeUnit.NANOSECONDS) - maxAge > done;
 		}
 
 		@SuppressWarnings("unchecked")
@@ -173,7 +173,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 					node = head;
 					if (done == NOT_DONE) {
 						// skip old entries
-						long limit = scheduler.now(TimeUnit.MILLISECONDS) - maxAge;
+						long limit = scheduler.now(TimeUnit.NANOSECONDS) - maxAge;
 						TimedNode<T> next = node;
 						while (next != null) {
 							long ts = next.time;
@@ -294,7 +294,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 
 		@Override
 		public void onError(Throwable ex) {
-			done = scheduler.now(TimeUnit.MILLISECONDS);
+			done = scheduler.now(TimeUnit.NANOSECONDS);
 			error = ex;
 		}
 
@@ -306,7 +306,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 
 		@Override
 		public void onComplete() {
-			done = scheduler.now(TimeUnit.MILLISECONDS);
+			done = scheduler.now(TimeUnit.NANOSECONDS);
 		}
 
 		@Override
@@ -316,7 +316,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 
 		@SuppressWarnings("unchecked")
 		TimedNode<T> latestHead(ReplaySubscription<T> rs) {
-			long now = scheduler.now(TimeUnit.MILLISECONDS) - maxAge;
+			long now = scheduler.now(TimeUnit.NANOSECONDS) - maxAge;
 
 			TimedNode<T> h = (TimedNode<T>) rs.node();
 			if (h == null) {
@@ -337,7 +337,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 		public T poll(ReplaySubscription<T> rs) {
 			TimedNode<T> node = latestHead(rs);
 			TimedNode<T> next;
-			long now = scheduler.now(TimeUnit.MILLISECONDS) - maxAge;
+			long now = scheduler.now(TimeUnit.NANOSECONDS) - maxAge;
 			while ((next = node.get()) != null) {
 				if (next.time > now) {
 					node = next;
@@ -400,7 +400,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 
 		@Override
 		public void add(T value) {
-			TimedNode<T> n = new TimedNode<>(value, scheduler.now(TimeUnit.MILLISECONDS));
+			TimedNode<T> n = new TimedNode<>(value, scheduler.now(TimeUnit.NANOSECONDS));
 			tail.set(n);
 			tail = n;
 			int s = size;
@@ -410,7 +410,7 @@ final class FluxReplay<T> extends ConnectableFlux<T> implements Scannable, Fusea
 			else {
 				size = s + 1;
 			}
-			long limit = scheduler.now(TimeUnit.MILLISECONDS) - maxAge;
+			long limit = scheduler.now(TimeUnit.NANOSECONDS) - maxAge;
 
 			TimedNode<T> h = head;
 			TimedNode<T> next;

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -255,7 +255,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return a new {@link Mono}
 	 */
 	public static Mono<Long> delay(Duration duration, Scheduler timer) {
-		return onAssembly(new MonoDelay(duration.toMillis(), TimeUnit.MILLISECONDS, timer));
+		return onAssembly(new MonoDelay(duration.toNanos(), TimeUnit.NANOSECONDS, timer));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1701,7 +1701,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	public T block(Duration timeout) {
 		BlockingMonoSubscriber<T> subscriber = new BlockingMonoSubscriber<>();
 		subscribe((Subscriber<T>) subscriber);
-		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
+		return subscriber.blockingGet(timeout.toNanos(), TimeUnit.NANOSECONDS);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -4634,11 +4634,16 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * T1 the current clock time in millis (as a {@link Long} measured by the
 	 * provided {@link Scheduler}) and T2 the emitted data (as a {@code T}).
 	 *
+	 * <p>The provider {@link Scheduler} will be asked to {@link Scheduler#now(TimeUnit) provide time}
+	 * with a granularity of {@link TimeUnit#MILLISECONDS} and, should return results that can be
+	 * interpreted as unix timestamps.</p>
 	 * <p>
+	 *
 	 * <img class="marble" src="doc-files/marbles/timestampForMono.svg" alt="">
 	 *
 	 * @param scheduler a {@link Scheduler} instance to read time from
 	 * @return a timestamped {@link Mono}
+	 * @see Scheduler#now(TimeUnit)
 	 */
 	public final Mono<Tuple2<Long, T>> timestamp(Scheduler scheduler) {
 		Objects.requireNonNull(scheduler, "scheduler");

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -4635,8 +4635,8 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * provided {@link Scheduler}) and T2 the emitted data (as a {@code T}).
 	 *
 	 * <p>The provider {@link Scheduler} will be asked to {@link Scheduler#now(TimeUnit) provide time}
-	 * with a granularity of {@link TimeUnit#MILLISECONDS} and, should return results that can be
-	 * interpreted as unix timestamps.</p>
+	 * with a granularity of {@link TimeUnit#MILLISECONDS}. In order for this operator to work as advertised, the
+	 * provided Scheduler should thus return results that can be interpreted as unix timestamps.</p>
 	 * <p>
 	 *
 	 * <img class="marble" src="doc-files/marbles/timestampForMono.svg" alt="">

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1747,7 +1747,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	public Optional<T> blockOptional(Duration timeout) {
 		BlockingOptionalMonoSubscriber<T> subscriber = new BlockingOptionalMonoSubscriber<>();
 		subscribe((Subscriber<T>) subscriber);
-		return subscriber.blockingGet(timeout.toMillis(), TimeUnit.MILLISECONDS);
+		return subscriber.blockingGet(timeout.toNanos(), TimeUnit.NANOSECONDS);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -2050,7 +2050,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return a delayed {@link Mono}
 	 */
 	public final Mono<T> delayElement(Duration delay, Scheduler timer) {
-		return onAssembly(new MonoDelayElement<>(this, delay.toMillis(), TimeUnit.MILLISECONDS, timer));
+		return onAssembly(new MonoDelayElement<>(this, delay.toNanos(), TimeUnit.NANOSECONDS, timer));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
@@ -300,7 +300,7 @@ class MonoCacheTime<T> extends InternalMonoOperator<T, T> implements Runnable {
 						main.run();
 					}
 					else if (!ttl.equals(DURATION_INFINITE)) {
-						main.clock.schedule(main, ttl.toMillis(), TimeUnit.MILLISECONDS);
+						main.clock.schedule(main, ttl.toNanos(), TimeUnit.NANOSECONDS);
 					}
 					//else TTL is Long.MAX_VALUE, schedule nothing but still cache
 				}

--- a/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -91,11 +91,22 @@ public interface Scheduler extends Disposable {
 
 	/**
 	 * Returns the "current time" notion of this scheduler.
+	 *
+	 * <p>
+	 *     <strong>Implementation Note:</strong> The default implementation uses {@link System#currentTimeMillis()}
+	 *     when requested with a {@code TimeUnit} of {@link TimeUnit#MILLISECONDS milliseconds} or coarser, and
+	 *     {@link System#nanoTime()} otherwise. As a consequence, results should not be interpreted as absolute timestamps
+	 *     in the latter case, only monotonicity inside the current JVM can be expected.
+	 * </p>
 	 * @param unit the target unit of the current time
 	 * @return the current time value in the target unit of measure
 	 */
 	default long now(TimeUnit unit) {
-		return unit.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
+		if (unit.compareTo(TimeUnit.MILLISECONDS) >= 0) {
+			return unit.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+		} else {
+			return unit.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
+		}
 	}
 	
 	/**

--- a/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -95,7 +95,7 @@ public interface Scheduler extends Disposable {
 	 * @return the current time value in the target unit of measure
 	 */
 	default long now(TimeUnit unit) {
-		return unit.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+		return unit.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
 	}
 	
 	/**

--- a/reactor-core/src/test/java/reactor/core/publisher/BlockingOptionalMonoSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BlockingOptionalMonoSubscriberTest.java
@@ -97,11 +97,12 @@ public class BlockingOptionalMonoSubscriberTest {
 
 	@Test
 	public void timeoutOptionalTimingOut() {
-		Mono<Long> source = Mono.delay(Duration.ofSeconds(1));
+		Mono<Long> source = Mono.delay(Duration.ofMillis(500));
 
+		// Using sub-millis timeouts after gh-1734
 		assertThatExceptionOfType(IllegalStateException.class)
-				.isThrownBy(() -> source.blockOptional(Duration.ofMillis(500)))
-				.withMessage("Timeout on blocking read for 500 MILLISECONDS");
+				.isThrownBy(() -> source.blockOptional(Duration.ofNanos(100)))
+				.withMessage("Timeout on blocking read for 100 NANOSECONDS");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/BlockingTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BlockingTests.java
@@ -102,9 +102,17 @@ public class BlockingTests {
 	}
 
 	@Test
-	public void blockingLastTimeout() {
+	public void blockingLastEarlyComplete() {
 		assertThat(Flux.empty()
 		               .blockLast(Duration.ofMillis(1))).isNull();
+	}
+
+	@Test
+	public void blockingLastTimeout() {
+		Assertions.assertThatIllegalStateException().isThrownBy(() ->
+				Flux.just(1).delayElements(Duration.ofNanos(100))
+						.blockLast(Duration.ofNanos(50)))
+				.withMessage("Timeout on blocking read for 50 NANOSECONDS");
 	}
 
 	@Test(expected = RuntimeException.class)

--- a/reactor-core/src/test/java/reactor/core/publisher/BlockingTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BlockingTests.java
@@ -36,6 +36,7 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 
 public class BlockingTests {
@@ -79,7 +80,7 @@ public class BlockingTests {
 
 	@Test
 	public void blockingFirstTimeout() {
-		Assertions.assertThatIllegalStateException().isThrownBy(() ->
+		assertThatIllegalStateException().isThrownBy(() ->
 				Flux.just(1).delayElements(Duration.ofNanos(100))
 				.blockFirst(Duration.ofNanos(50)))
 			.withMessage("Timeout on blocking read for 50 NANOSECONDS");
@@ -109,7 +110,7 @@ public class BlockingTests {
 
 	@Test
 	public void blockingLastTimeout() {
-		Assertions.assertThatIllegalStateException().isThrownBy(() ->
+		assertThatIllegalStateException().isThrownBy(() ->
 				Flux.just(1).delayElements(Duration.ofNanos(100))
 						.blockLast(Duration.ofNanos(50)))
 				.withMessage("Timeout on blocking read for 50 NANOSECONDS");
@@ -248,6 +249,12 @@ public class BlockingTests {
 	        .blockOptional();
 
 		assertThat(cancelCount.get()).isEqualTo(0);
+	}
+
+	@Test
+	public void monoBlockSupportsNanos() {
+		assertThatIllegalStateException().isThrownBy(() -> Mono.never().block(Duration.ofNanos(9_000L)))
+				.withMessage("Timeout on blocking read for 9000 NANOSECONDS");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/BlockingTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BlockingTests.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -71,9 +72,17 @@ public class BlockingTests {
 	}
 
 	@Test
-	public void blockingFirstTimeout() {
+	public void blockingFirstEarlyComplete() {
 		assertThat(Flux.empty()
 		               .blockFirst(Duration.ofMillis(1))).isNull();
+	}
+
+	@Test
+	public void blockingFirstTimeout() {
+		Assertions.assertThatIllegalStateException().isThrownBy(() ->
+				Flux.just(1).delayElements(Duration.ofNanos(100))
+				.blockFirst(Duration.ofNanos(50)))
+			.withMessage("Timeout on blocking read for 50 NANOSECONDS");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDelaySequenceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDelaySequenceTest.java
@@ -177,18 +177,7 @@ public class FluxDelaySequenceTest {
 	}
 
 	@Test
-	public void longDelayInMillis() {
-		Duration longDelay = Duration.ofMinutes(1);
-		long expected = longDelay.toMillis();
-
-		DelaySubscriber<String> subscriber = new DelaySubscriber<>(null, longDelay, null);
-
-		assertThat(subscriber.delay).isEqualTo(expected);
-		assertThat(subscriber.timeUnit).isSameAs(TimeUnit.MILLISECONDS);
-	}
-
-	@Test
-	public void smallDelayInNanos() {
+	public void allDelayInNanos() {
 		Duration longDelay = Duration.ofMillis(59_999);
 		long expected = longDelay.toNanos();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxIntervalTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxIntervalTest.java
@@ -136,10 +136,27 @@ public class FluxIntervalTest {
 		StepVerifier.withVirtualTime(this::scenario4)
 		            .thenAwait(Duration.ofMillis(1500))
 		            .expectNext(0L)
-		            .thenAwait(Duration.ofSeconds(4))
+		            .thenAwait(Duration.ofSeconds(3))
 		            .expectNextCount(4)
 		            .thenCancel()
 		            .verify();
+	}
+
+	Flux<Long> scenario5(){
+		return Flux.interval(Duration.ofNanos(0), Duration.ofNanos(1_000));
+	}
+
+	@Test
+	public void normal5() {
+		// Prior to gh-1734, sub millis period would round to 0 and this would fail.
+		Duration period = Duration.ofNanos(1_000);
+		Duration timespan = Duration.ofSeconds(1);
+		StepVerifier.withVirtualTime(() ->
+			Flux.interval(Duration.ofNanos(0), period).take(timespan).count()
+		)
+				.thenAwait(timespan)
+				.expectNext(timespan.toNanos() / period.toNanos())
+				.verifyComplete();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferTimeoutTest.java
@@ -286,15 +286,16 @@ public class FluxOnBackpressureBufferTimeoutTest implements Consumer<Object> {
 		TestPublisher<Integer> tp = TestPublisher.create();
 
 		StepVerifier.withVirtualTime(() -> tp.flux()
-		                                     .onBackpressureBuffer(Duration.ofMillis(600),
+											// Note: using sub-millis durations after gh-1734
+		                                     .onBackpressureBuffer(Duration.ofNanos(600),
 				                                     5, this).log(),
 				0)
 		            .expectSubscription()
 		            .then(() -> tp.next(1,2, 3, 4, 5, 6, 7)) //evict 2 elements
 		            .then(() -> assertThat(evicted).containsExactly(1, 2))
-		            .thenAwait(Duration.ofMillis(500))
+		            .thenAwait(Duration.ofNanos(500))
 		            .then(() -> tp.emit(8, 9, 10))
-		            .thenAwait(Duration.ofMillis(100)) // evict elements older than 8
+		            .thenAwait(Duration.ofNanos(100)) // evict elements older than 8
 		            .then(() -> assertThat(evicted).containsExactly(1, 2, 3, 4, 5, 6, 7))
 		            .thenRequest(10)
 		            .expectNext(8, 9, 10)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxReplayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxReplayTest.java
@@ -228,6 +228,31 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 	}
 
 	@Test
+	public void cacheFluxTTLNanos() {
+		Flux<Integer> source = Flux.just(1, 2, 3)
+		                                         .delayElements(Duration.ofNanos(1000))
+		                                         .replay(Duration.ofNanos(2000), vts)
+		                                         .hide()
+		                                         .autoConnect()
+												 .hide();
+
+		StepVerifier.create(source)
+		            .expectNoFusionSupport()
+		            .then(() -> vts.advanceTimeBy(Duration.ofNanos(3000)))
+		            .expectNext(1)
+		            .expectNext(2)
+		            .expectNext(3)
+		            .verifyComplete();
+
+		StepVerifier.create(source)
+		            .then(() -> vts.advanceTimeBy(Duration.ofNanos(3000)))
+		            .expectNext(2)
+		            .expectNext(3)
+		            .verifyComplete();
+
+	}
+
+	@Test
 	public void cacheFluxHistoryTTL() {
 
 		Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
@@ -58,6 +58,17 @@ public class MonoDelayElementTest {
 	}
 
 	@Test
+	public void subMillisDelay() {
+		Mono<String> source = Mono.just("foo");
+
+		StepVerifier.withVirtualTime(() -> source.delayElement(Duration.ofNanos(5000L)).log())
+	                .expectSubscription()
+	                .expectNoEvent(Duration.ofNanos(5000L))
+	                .expectNext("foo")
+	                .verifyComplete();
+	}
+
+	@Test
 	public void cancelDuringDelay() {
 		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 		AtomicBoolean emitted = new AtomicBoolean();

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -1158,13 +1158,14 @@ public class SchedulersTest {
 		EmptyTimedScheduler.EmptyTimedWorker tw = ts.createWorker();
 		tw.dispose();
 
-		long before = System.nanoTime();
+		long beforeInNanos = System.nanoTime();
+		long beforeInMillis = System.currentTimeMillis();
 
-		assertThat(ts.now(TimeUnit.NANOSECONDS)).isGreaterThanOrEqualTo(before)
+		assertThat(ts.now(TimeUnit.NANOSECONDS)).isGreaterThanOrEqualTo(beforeInNanos)
 		                                         .isLessThanOrEqualTo(System.nanoTime());
 
-//		assertThat(tw.now(TimeUnit.MILLISECONDS)).isGreaterThanOrEqualTo(before)
-//		                                        .isLessThanOrEqualTo(System.currentTimeMillis());
+		assertThat(ts.now(TimeUnit.MILLISECONDS)).isGreaterThanOrEqualTo(beforeInMillis)
+		                                        .isLessThanOrEqualTo(System.currentTimeMillis());
 
 		//noop
 		new Schedulers(){

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -1158,10 +1158,10 @@ public class SchedulersTest {
 		EmptyTimedScheduler.EmptyTimedWorker tw = ts.createWorker();
 		tw.dispose();
 
-		long before = System.currentTimeMillis();
+		long before = System.nanoTime();
 
-		assertThat(ts.now(TimeUnit.MILLISECONDS)).isGreaterThanOrEqualTo(before)
-		                                         .isLessThanOrEqualTo(System.currentTimeMillis());
+		assertThat(ts.now(TimeUnit.NANOSECONDS)).isGreaterThanOrEqualTo(before)
+		                                         .isLessThanOrEqualTo(System.nanoTime());
 
 //		assertThat(tw.now(TimeUnit.MILLISECONDS)).isGreaterThanOrEqualTo(before)
 //		                                        .isLessThanOrEqualTo(System.currentTimeMillis());


### PR DESCRIPTION
Fix #1734: use nanoseconds wherever possible instead of milliseconds currently.

This PR tries to bring changes one after another, each commit containing a change and a test in one particular operator/area. The most controversial change IMO is 7c7a6b2 which may change semantics if callers expect an absolute representation of time. Scheduler.now() still returns monotonic values though, which is the implicit expectation I think.