### PR TITLE
provides stats operators and supporting utility

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableFluxStats.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableFluxStats.java
@@ -1,0 +1,107 @@
+package reactor.core.publisher;
+
+import java.util.function.Consumer;
+
+import org.reactivestreams.Publisher;
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+import reactor.core.Fuseable;
+import reactor.core.Scannable;
+import reactor.util.stats.StatsMarker;
+import reactor.util.stats.StatsReporter;
+
+public class ConnectableFluxStats<T> extends InternalConnectableFluxOperator<T, T> {
+
+	final FluxOnAssembly.AssemblySnapshot assemblySnapshot;
+	final StatsReporter                   statsReporter;
+	final StatsMarker[]                   statsMarkers;
+
+	protected ConnectableFluxStats(ConnectableFlux<T> source,
+			FluxOnAssembly.AssemblySnapshot assemblySnapshot,
+			StatsReporter statsReporter,
+			StatsMarker[] statsMarkers) {
+		super(source);
+		this.assemblySnapshot = assemblySnapshot;
+		this.statsReporter = statsReporter;
+		this.statsMarkers = statsMarkers;
+	}
+
+	@Override
+	public void connect(Consumer<? super Disposable> cancelSupport) {
+		source.connect(cancelSupport);
+	}
+
+	@Override
+	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
+
+		if (nextOptimizableSource() == null) {
+			return new ConnectableStatsInner<>(actual,
+					assemblySnapshot,
+					source,
+					statsReporter,
+					statsMarkers);
+		}
+		else {
+			return new FluxStats.StatsOperator<>(actual,
+					assemblySnapshot,
+					source,
+					statsReporter,
+					statsMarkers);
+		}
+	}
+
+	static class ConnectableStatsInner<T> extends FluxStats.StatsOperator<T>
+			implements InnerOperator<T, T>, Fuseable.QueueSubscription<T> {
+
+		ConnectableStatsInner(CoreSubscriber<? super T> actual,
+				FluxOnAssembly.AssemblySnapshot snapshotStack,
+				Publisher<?> parent,
+				StatsReporter statsReporter,
+				StatsMarker[] statsMarkers) {
+
+			super(actual, snapshotStack, parent, statsReporter, statsMarkers);
+		}
+
+		@Override
+		public void onNext(T t) {
+			resolveUpstream();
+			super.onNext(t);
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			resolveUpstream();
+			super.onError(t);
+		}
+
+		@Override
+		public void onComplete() {
+			resolveUpstream();
+			super.onComplete();
+		}
+
+		@Override
+		public void cancel() {
+			resolveUpstream();
+			FluxStats.StatsOperator<?> connectableStatsOperator = this.upstreamNode;
+			if (connectableStatsOperator instanceof FluxStats.MultiConsumersStatsOperator) {
+				((FluxStats.MultiConsumersStatsOperator<?>) connectableStatsOperator).disconnect();
+			}
+			super.cancel();
+		}
+
+		void resolveUpstream() {
+			if (this.upstreamNode == null) {
+				FluxStats.MultiConsumersStatsOperator<?>
+						multiConsumersStatsOperator = (FluxStats.MultiConsumersStatsOperator<?>) Scannable.from(s)
+						                                                                                  .parents()
+						                                                                                  .filter(FluxStats.MultiConsumersStatsOperator.class::isInstance)
+						                                                                                  .findFirst()
+						                                                                                  .orElse(null);
+
+				this.upstreamNode = multiConsumersStatsOperator;
+				multiConsumersStatsOperator.connect();
+			}
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableFluxStats.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableFluxStats.java
@@ -10,13 +10,13 @@ import reactor.core.Scannable;
 import reactor.util.stats.StatsMarker;
 import reactor.util.stats.StatsReporter;
 
-public class ConnectableFluxStats<T> extends InternalConnectableFluxOperator<T, T> {
+final class ConnectableFluxStats<T> extends InternalConnectableFluxOperator<T, T> {
 
 	final FluxOnAssembly.AssemblySnapshot assemblySnapshot;
 	final StatsReporter                   statsReporter;
 	final StatsMarker[]                   statsMarkers;
 
-	protected ConnectableFluxStats(ConnectableFlux<T> source,
+	ConnectableFluxStats(ConnectableFlux<T> source,
 			FluxOnAssembly.AssemblySnapshot assemblySnapshot,
 			StatsReporter statsReporter,
 			StatsMarker[] statsMarkers) {
@@ -50,7 +50,7 @@ public class ConnectableFluxStats<T> extends InternalConnectableFluxOperator<T, 
 		}
 	}
 
-	static class ConnectableStatsInner<T> extends FluxStats.StatsOperator<T>
+	static final class ConnectableStatsInner<T> extends FluxStats.StatsOperator<T>
 			implements InnerOperator<T, T>, Fuseable.QueueSubscription<T> {
 
 		ConnectableStatsInner(CoreSubscriber<? super T> actual,

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxStats.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxStats.java
@@ -1,0 +1,367 @@
+package reactor.core.publisher;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
+import reactor.core.Fuseable;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+import reactor.util.stats.StatsMarker;
+import reactor.util.stats.StatsNode;
+import reactor.util.stats.StatsReporter;
+
+import static reactor.core.Fuseable.SYNC;
+
+public class FluxStats<T> extends InternalFluxOperator<T, T> {
+
+	final FluxOnAssembly.AssemblySnapshot assemblySnapshot;
+	final StatsReporter        statsReporter;
+	final StatsMarker[]        statsMarkers;
+
+	protected FluxStats(Flux<? extends T> source,
+			FluxOnAssembly.AssemblySnapshot assemblySnapshot,
+			StatsReporter statsReporter,
+			StatsMarker[] statsMarkers) {
+		super(source);
+		this.assemblySnapshot = assemblySnapshot;
+		this.statsReporter = statsReporter;
+		this.statsMarkers = statsMarkers;
+	}
+
+	@Override
+	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
+		return wrapSubscriber(actual,
+				source,
+				assemblySnapshot,
+				statsReporter,
+				statsMarkers);
+	}
+
+
+	static <T> CoreSubscriber<? super T> wrapSubscriber(CoreSubscriber<? super T> actual,
+			Flux<? extends T> source,
+			FluxOnAssembly.AssemblySnapshot snapshotStack,
+			StatsReporter statsReporter,
+			StatsMarker[] statsMarkers) {
+
+		if (actual instanceof FluxPublish.PublishSubscriber) {
+			return new MultiConsumersStatsOperator<>(actual,
+					snapshotStack,
+					source,
+					statsReporter,
+					statsMarkers
+			);
+		}
+		else {
+			return new StatsOperator<>(actual,
+					snapshotStack,
+					source,
+					statsReporter,
+					statsMarkers
+			);
+		}
+	}
+
+	static class StatsOperator<T> extends StatsNode<StatsOperator<?>>
+			implements InnerOperator<T, T>, Fuseable.QueueSubscription<T> {
+		@SuppressWarnings("rawtypes")
+		static final Class<StatsOperator> KEY = StatsOperator.class;
+
+		final FluxOnAssembly.AssemblySnapshot snapshotStack;
+		final Publisher<?>                    parent;
+		final CoreSubscriber<? super T>       actual;
+		final Context                         currentContext;
+		final boolean                         reportOnTerminal;
+
+		final StatsReporter statsReporter;
+		final StatsMarker[] statsMarkers;
+
+		Fuseable.QueueSubscription<T> qs;
+		Subscription                  s;
+		int                           fusionMode;
+
+		StatsOperator(CoreSubscriber<? super T> actual,
+				FluxOnAssembly.AssemblySnapshot snapshotStack,
+				Publisher<?> parent,
+				StatsReporter statsReporter,
+				StatsMarker[] statsMarkers) {
+
+			this.snapshotStack = snapshotStack;
+			this.parent = parent;
+			this.actual = actual;
+			this.statsReporter = statsReporter;
+			this.statsMarkers = statsMarkers;
+
+			Context context = actual.currentContext();
+			StatsOperator<?> downstreamStatsOperator = context.getOrDefault(KEY, null);
+
+			if (downstreamStatsOperator != null) {
+				this.reportOnTerminal = false;
+				this.attachTo(downstreamStatsOperator);
+			}
+			else {
+				this.reportOnTerminal = true;
+			}
+
+			this.currentContext = context.put(KEY, this);
+		}
+
+		@Override
+		public void attachTo(StatsOperator<?> downstreamNode) {
+			Publisher<?> parent = downstreamNode.parent;
+			if ((!(parent instanceof OptimizableOperator) || ((OptimizableOperator<?,
+					?>) parent).nextOptimizableSource() == null) && !(parent instanceof MonoIgnoreThen || parent instanceof ConnectableFlux || parent instanceof ParallelSource || this.parent instanceof ConnectableFlux)) {
+				this.downstreamNode = downstreamNode;
+				this.isInner = true;
+				downstreamNode.add(this);
+				return;
+			}
+
+			super.attachTo(downstreamNode);
+		}
+
+		@Override
+		public final CoreSubscriber<? super T> actual() {
+			return actual;
+		}
+
+		@Override
+		@Nullable
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) return s;
+			if (key == Attr.ACTUAL_METADATA) return !snapshotStack.checkpointed;
+
+			return InnerOperator.super.scanUnsafe(key);
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.validate(this.s, s)) {
+				this.s = s;
+				this.qs = Operators.as(s);
+
+				this.recordSignal(SignalType.ON_SUBSCRIBE);
+
+				this.actual.onSubscribe(this);
+			}
+		}
+
+		@Override
+		final public int requestFusion(int requestedMode) {
+			Fuseable.QueueSubscription<T> qs = this.qs;
+			if (qs != null) {
+				int m = qs.requestFusion(requestedMode);
+				if (m != Fuseable.NONE) {
+					this.fusionMode = m;
+					if (m == SYNC) {
+						recordRequest(Long.MAX_VALUE);
+					}
+				}
+				return m;
+			}
+			return Fuseable.NONE;
+		}
+
+		@Override
+		public void onNext(T t) {
+
+			this.recordProduced();
+			this.recordSignal(SignalType.ON_NEXT);
+
+			this.actual.onNext(t);
+
+			// workaround to measure of the source publisher speed rather than source
+			// and the whole pipeline
+			if (this.upstreamNode == null) {
+				this.lastElapsedOnNextNanos = System.nanoTime();
+			}
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			this.error = t;
+			this.recordSignal(SignalType.ON_ERROR);
+
+			if (this.reportOnTerminal()) {
+				this.statsReporter.report(this, statsMarkers);
+			}
+
+			this.actual.onError(t);
+		}
+
+		@Override
+		public void onComplete() {
+			this.recordSignal(SignalType.ON_COMPLETE);
+
+			if (this.reportOnTerminal()) {
+				this.statsReporter.report(this, statsMarkers);
+			}
+
+			this.detachIfInner();
+
+			this.actual.onComplete();
+		}
+
+		@Override
+		public void request(long n) {
+			this.recordSignal(SignalType.REQUEST);
+			this.recordRequest(n);
+
+			this.s.request(n);
+		}
+
+		@Override
+		public void cancel() {
+			this.recordSignal(SignalType.CANCEL);
+
+			if (this.reportOnTerminal()) {
+				this.statsReporter.report(this, this.statsMarkers);
+			}
+
+			this.s.cancel();
+		}
+
+		boolean reportOnTerminal() {
+			return reportOnTerminal;
+		}
+
+		@Override
+		final public Context currentContext() {
+			return this.currentContext;
+		}
+
+		@Override
+		final public int size() {
+			return qs.size();
+		}
+
+		@Override
+		final public boolean isEmpty() {
+			try {
+				return qs.isEmpty();
+			}
+			catch (Throwable ex) {
+				Exceptions.throwIfFatal(ex);
+				throw Exceptions.propagate(ex);
+			}
+		}
+
+		@Override
+		final public void clear() {
+			qs.clear();
+		}
+
+		@Override
+		@Nullable
+		final public T poll() {
+			try {
+				T element = qs.poll();
+
+				if (element != null) {
+					this.recordProduced();
+					this.recordSignal(SignalType.ON_NEXT);
+				} else {
+					if (this.fusionMode == SYNC) {
+						this.done = true;
+
+						this.recordSignal(SignalType.ON_COMPLETE);
+
+						if (this.reportOnTerminal) {
+							this.statsReporter.report(this, statsMarkers);
+						}
+					}
+				}
+
+				return element;
+			}
+			catch (final Throwable ex) {
+				this.error = ex;
+				this.done = true;
+
+				this.recordSignal(SignalType.ON_ERROR);
+
+				if (this.reportOnTerminal) {
+					this.statsReporter.report(this, statsMarkers);
+				}
+
+				Exceptions.throwIfFatal(ex);
+				throw Exceptions.propagate(ex);
+			}
+		}
+
+		@Override
+		final public String toString() {
+			return this.snapshotStack.operatorAssemblyInformation();
+		}
+
+		@Override
+		final public String stepName() {
+			return toString();
+		}
+
+		String[] cachedParts;
+		@Override
+		public String operatorName() {
+			String[] parts = cachedParts;
+
+			if (parts == null) {
+				parts = Traces.extractOperatorAssemblyInformationParts(this.snapshotStack.toAssemblyInformation());
+				cachedParts = parts;
+			}
+
+			return parts.length > 1 ? parts[0] : "";
+		}
+
+		@Override
+		public String line() {
+			String[] parts = cachedParts;
+
+			if (parts == null) {
+				parts = Traces.extractOperatorAssemblyInformationParts(this.snapshotStack.toAssemblyInformation());
+				cachedParts = parts;
+			}
+
+			return parts[parts.length - 1];
+		}
+	}
+
+	static class MultiConsumersStatsOperator<T> extends StatsOperator<T>
+			implements InnerOperator<T, T>, Fuseable.QueueSubscription<T> {
+
+		volatile int consumers;
+		@SuppressWarnings("rawtypes")
+		static final AtomicIntegerFieldUpdater<MultiConsumersStatsOperator> CONSUMERS =
+				AtomicIntegerFieldUpdater.newUpdater(MultiConsumersStatsOperator.class, "consumers");
+
+		MultiConsumersStatsOperator(CoreSubscriber<? super T> actual,
+				FluxOnAssembly.AssemblySnapshot snapshotStack,
+				Publisher<?> parent,
+				StatsReporter statsReporter,
+				StatsMarker[] statsMarkers) {
+
+			super(actual, snapshotStack, parent, statsReporter, statsMarkers);
+		}
+
+		@Override
+		public void attachTo(StatsOperator<?> downstreamNode) {
+			// do nothing here
+		}
+
+		void connect() {
+			CONSUMERS.getAndIncrement(this);
+		}
+
+
+		void disconnect() {
+			CONSUMERS.decrementAndGet(this);
+		}
+
+		@Override
+		boolean reportOnTerminal() {
+			return this.consumers == 0;
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxStats.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxStats.java
@@ -15,13 +15,13 @@ import reactor.util.stats.StatsReporter;
 
 import static reactor.core.Fuseable.SYNC;
 
-public class FluxStats<T> extends InternalFluxOperator<T, T> {
+final class FluxStats<T> extends InternalFluxOperator<T, T> {
 
 	final FluxOnAssembly.AssemblySnapshot assemblySnapshot;
 	final StatsReporter        statsReporter;
 	final StatsMarker[]        statsMarkers;
 
-	protected FluxStats(Flux<? extends T> source,
+	FluxStats(Flux<? extends T> source,
 			FluxOnAssembly.AssemblySnapshot assemblySnapshot,
 			StatsReporter statsReporter,
 			StatsMarker[] statsMarkers) {
@@ -328,7 +328,7 @@ public class FluxStats<T> extends InternalFluxOperator<T, T> {
 		}
 	}
 
-	static class MultiConsumersStatsOperator<T> extends StatsOperator<T>
+	static final class MultiConsumersStatsOperator<T> extends StatsOperator<T>
 			implements InnerOperator<T, T>, Fuseable.QueueSubscription<T> {
 
 		volatile int consumers;

--- a/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
@@ -518,14 +518,13 @@ public abstract class Hooks {
 	}
 
 	/**
-	 * Globally enables the {@link Context} loss detection in operators like
-	 * {@link Flux#transform} or {@link Mono#transformDeferred} when non-Reactor types are used.
+	 * Enable operator stats recorder that captures all signals that goes through each
+	 * operator.
 	 *
-	 * An exception will be thrown upon applying the transformation if the original {@link Context} isn't reachable
-	 * (ie. it has been replaced by a totally different {@link Context}, or no {@link Context} at all)
+	 * When the terminal signal is observed later on, the last operator in the chain
+	 * will invoke stats reporting for the whole pipeline.
 	 */
-	public static void enableStatsTracking() {
-		log.debug("Enabling stacktrace debugging with statistic via onOperatorDebug");
+	public static void enableStatsRecording() {
 		GLOBAL_STATS_TRACE = true;
 	}
 
@@ -534,7 +533,7 @@ public abstract class Hooks {
 	 * enabled by {@link #enableContextLossTracking()}.
 	 *
 	 */
-	public static void disableStatsTracking() {
+	public static void disableStatsRecording() {
 		GLOBAL_STATS_TRACE = false;
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
@@ -26,6 +26,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.jetbrains.annotations.NotNull;
 import org.reactivestreams.Publisher;
 
 import reactor.core.Exceptions;
@@ -684,36 +685,51 @@ public abstract class Hooks {
 
 	static <T, P extends Publisher<T>> Publisher<T> addAssemblyInfo(P publisher, AssemblySnapshot stacktrace) {
 		if (GLOBAL_STATS_TRACE) {
-			if (publisher instanceof Mono) {
-				return new MonoStats<>((Mono<T>) publisher, stacktrace, Stats.getStatsReporter(), Stats.getStatsMarkers());
-			}
-			if (publisher instanceof ParallelFlux) {
-				return new ParallelFluxStats<>((ParallelFlux<T>) publisher, stacktrace, Stats.getStatsReporter(), Stats.getStatsMarkers());
-			}
-			if (publisher instanceof ConnectableFlux) {
-				return new ConnectableFluxStats<>((ConnectableFlux<T>) publisher, stacktrace, Stats.getStatsReporter(), Stats.getStatsMarkers());
-			}
-			return new FluxStats<>((Flux<T>) publisher, stacktrace, Stats.getStatsReporter(), Stats.getStatsMarkers());
+			return addOperatorStatsInfo(publisher, stacktrace);
 		}
 		else {
-			if (publisher instanceof Callable) {
-				if (publisher instanceof Mono) {
-					return new MonoCallableOnAssembly<>((Mono<T>) publisher, stacktrace);
-				}
-				return new FluxCallableOnAssembly<>((Flux<T>) publisher, stacktrace);
-			}
-			if (publisher instanceof Mono) {
-				return new MonoOnAssembly<>((Mono<T>) publisher, stacktrace);
-			}
-			if (publisher instanceof ParallelFlux) {
-				return new ParallelFluxOnAssembly<>((ParallelFlux<T>) publisher,
-						stacktrace);
-			}
-			if (publisher instanceof ConnectableFlux) {
-				return new ConnectableFluxOnAssembly<>((ConnectableFlux<T>) publisher,
-						stacktrace);
-			}
-			return new FluxOnAssembly<>((Flux<T>) publisher, stacktrace);
+			return addOperatorStacktraceInfo(publisher, stacktrace);
 		}
+	}
+
+	static <T, P extends Publisher<T>> Publisher<T> addOperatorStacktraceInfo(P publisher,
+			AssemblySnapshot stacktrace) {
+
+		if (publisher instanceof Callable) {
+			if (publisher instanceof Mono) {
+				return new MonoCallableOnAssembly<>((Mono<T>) publisher, stacktrace);
+			}
+			return new FluxCallableOnAssembly<>((Flux<T>) publisher, stacktrace);
+		}
+		if (publisher instanceof Mono) {
+			return new MonoOnAssembly<>((Mono<T>) publisher, stacktrace);
+		}
+		if (publisher instanceof ParallelFlux) {
+			return new ParallelFluxOnAssembly<>((ParallelFlux<T>) publisher, stacktrace);
+		}
+		if (publisher instanceof ConnectableFlux) {
+			return new ConnectableFluxOnAssembly<>((ConnectableFlux<T>) publisher,
+					stacktrace);
+		}
+		return new FluxOnAssembly<>((Flux<T>) publisher, stacktrace);
+	}
+
+	static <T, P extends Publisher<T>> Publisher<T> addOperatorStatsInfo(P publisher,
+			AssemblySnapshot stacktrace) {
+
+		if (publisher instanceof Mono) {
+			return new MonoStats<>((Mono<T>) publisher,
+					stacktrace, Stats.getStatsReporter(), Stats.getStatsMarkers());
+		}
+		if (publisher instanceof ParallelFlux) {
+			return new ParallelFluxStats<>((ParallelFlux<T>) publisher,
+					stacktrace, Stats.getStatsReporter(), Stats.getStatsMarkers());
+		}
+		if (publisher instanceof ConnectableFlux) {
+			return new ConnectableFluxStats<>((ConnectableFlux<T>) publisher,
+					stacktrace, Stats.getStatsReporter(), Stats.getStatsMarkers());
+		}
+		return new FluxStats<>((Flux<T>) publisher,
+				stacktrace, Stats.getStatsReporter(), Stats.getStatsMarkers());
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoStats.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoStats.java
@@ -1,0 +1,52 @@
+package reactor.core.publisher;
+
+import org.reactivestreams.Publisher;
+import reactor.core.CoreSubscriber;
+import reactor.util.stats.StatsMarker;
+import reactor.util.stats.StatsReporter;
+
+public class MonoStats<T> extends InternalMonoOperator<T, T> {
+
+	final FluxOnAssembly.AssemblySnapshot assemblySnapshot;
+	final StatsReporter                   statsReporter;
+	final StatsMarker[]                   statsMarkers;
+
+	protected MonoStats(Mono<? extends T> source,
+			FluxOnAssembly.AssemblySnapshot assemblySnapshot,
+			StatsReporter statsReporter,
+			StatsMarker[] statsMarkers) {
+		super(source);
+		this.assemblySnapshot = assemblySnapshot;
+		this.statsReporter = statsReporter;
+		this.statsMarkers = statsMarkers;
+	}
+
+	@Override
+	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
+		return new MonoStatsOperator<>(actual,
+				assemblySnapshot,
+				source,
+				statsReporter,
+				statsMarkers);
+	}
+
+	static class MonoStatsOperator<T> extends FluxStats.StatsOperator<T> {
+
+		MonoStatsOperator(CoreSubscriber<? super T> actual,
+				FluxOnAssembly.AssemblySnapshot snapshotStack,
+				Publisher<?> parent,
+				StatsReporter statsReporter,
+				StatsMarker[] statsMarkers) {
+			super(actual, snapshotStack, parent, statsReporter, statsMarkers);
+		}
+
+		@Override
+		public void onNext(T t) {
+			// specific mono case
+			this.recordSignal(SignalType.ON_COMPLETE);
+			this.detachIfInner();
+
+			super.onNext(t);
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoStats.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoStats.java
@@ -5,13 +5,13 @@ import reactor.core.CoreSubscriber;
 import reactor.util.stats.StatsMarker;
 import reactor.util.stats.StatsReporter;
 
-public class MonoStats<T> extends InternalMonoOperator<T, T> {
+final class MonoStats<T> extends InternalMonoOperator<T, T> {
 
 	final FluxOnAssembly.AssemblySnapshot assemblySnapshot;
 	final StatsReporter                   statsReporter;
 	final StatsMarker[]                   statsMarkers;
 
-	protected MonoStats(Mono<? extends T> source,
+	MonoStats(Mono<? extends T> source,
 			FluxOnAssembly.AssemblySnapshot assemblySnapshot,
 			StatsReporter statsReporter,
 			StatsMarker[] statsMarkers) {
@@ -30,7 +30,7 @@ public class MonoStats<T> extends InternalMonoOperator<T, T> {
 				statsMarkers);
 	}
 
-	static class MonoStatsOperator<T> extends FluxStats.StatsOperator<T> {
+	static final class MonoStatsOperator<T> extends FluxStats.StatsOperator<T> {
 
 		MonoStatsOperator(CoreSubscriber<? super T> actual,
 				FluxOnAssembly.AssemblySnapshot snapshotStack,

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxStats.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxStats.java
@@ -47,7 +47,7 @@ final class ParallelFluxStats<T> extends ParallelFlux<T> implements Scannable {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	protected void subscribe(CoreSubscriber<? super T>[] subscribers) {
+	public void subscribe(CoreSubscriber<? super T>[] subscribers) {
 		if (!validate(subscribers)) {
 			return;
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxStats.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxStats.java
@@ -1,0 +1,163 @@
+package reactor.core.publisher;
+
+import org.reactivestreams.Publisher;
+import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
+import reactor.core.Scannable;
+import reactor.util.annotation.Nullable;
+import reactor.util.stats.StatsMarker;
+import reactor.util.stats.StatsReporter;
+
+public class ParallelFluxStats<T> extends ParallelFlux<T> implements Scannable {
+
+	final ParallelFlux<T>                 source;
+	final FluxOnAssembly.AssemblySnapshot assemblySnapshot;
+	final StatsReporter                   statsReporter;
+	final StatsMarker[]                   statsMarkers;
+
+	ParallelFluxStats(ParallelFlux<T> source,
+			FluxOnAssembly.AssemblySnapshot assemblySnapshot,
+			StatsReporter statsReporter,
+			StatsMarker[] statsMarkers) {
+
+		this.source = source;
+		this.assemblySnapshot = assemblySnapshot;
+		this.statsReporter = statsReporter;
+		this.statsMarkers = statsMarkers;
+	}
+
+	@Override
+	public int parallelism() {
+		return source.parallelism();
+	}
+
+	@Override
+	public int getPrefetch() {
+		return source.getPrefetch();
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PARENT) return source;
+		if (key == Attr.PREFETCH) return getPrefetch();
+
+		return null;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected void subscribe(CoreSubscriber<? super T>[] subscribers) {
+		if (!validate(subscribers)) {
+			return;
+		}
+
+		int n = subscribers.length;
+		CoreSubscriber<? super T>[] parents = new CoreSubscriber[n];
+
+		for (int i = 0; i < n; i++) {
+			parents[i] = new ParallelStatsInner<>(subscribers[i],
+					assemblySnapshot,
+					source,
+					statsReporter,
+					statsMarkers);
+		}
+
+		source.subscribe(parents);
+	}
+
+	static class ParallelStatsInner<T> extends FluxStats.StatsOperator<T>
+			implements InnerOperator<T, T>, Fuseable.QueueSubscription<T> {
+
+		FluxStats.StatsOperator<?> serialDownstreamNode;
+
+		boolean resolved;
+
+		ParallelStatsInner(CoreSubscriber<? super T> actual,
+				FluxOnAssembly.AssemblySnapshot snapshotStack,
+				Publisher<?> parent,
+				StatsReporter statsReporter,
+				StatsMarker[] statsMarkers) {
+
+			super(actual, snapshotStack, parent, statsReporter, statsMarkers);
+		}
+
+		@Override
+		public void onNext(T t) {
+			resolveChain();
+			super.onNext(t);
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			resolveChain();
+			super.onError(t);
+		}
+
+		@Override
+		public void onComplete() {
+			resolveChain();
+			super.onComplete();
+		}
+
+		@Override
+		public void cancel() {
+			resolveChain();
+			super.cancel();
+		}
+
+		@Override
+		public void attachTo(FluxStats.StatsOperator<?> downstreamNode) {
+			if (downstreamNode instanceof ParallelStatsInner) {
+				this.downstreamNode = downstreamNode;
+
+				if (downstreamNode.upstreamNode != null) {
+					downstreamNode.add(this);
+				}
+				else {
+					downstreamNode.upstreamNode = this;
+				}
+				this.serialDownstreamNode = ((ParallelStatsInner<?>) downstreamNode).serialDownstreamNode;
+			}
+			else {
+				this.isInner = true;
+				this.serialDownstreamNode = downstreamNode;
+			}
+		}
+
+		@Override
+		public void detachIfInner() {
+			// no-ops since parallel inner should not be detached
+		}
+
+		void resolveChain() {
+			if (!resolved && !(this.upstreamNode instanceof ParallelStatsInner<?>)) {
+				this.resolved = true;
+				FluxStats.StatsOperator<?> upstreamNode =
+						(FluxStats.StatsOperator<?>) Scannable.from(s)
+						                                      .parents()
+						                                      .filter(FluxStats.StatsOperator.class::isInstance)
+						                                      .findFirst()
+						                                      .orElse(null);
+				ParallelStatsInner<?> tailNode = this.resolveTail();
+
+				this.upstreamNode = null;
+				this.serialDownstreamNode.upstreamNode = upstreamNode;
+
+				tailNode.downstreamNode = upstreamNode;
+				upstreamNode.downstreamNode = this.serialDownstreamNode;
+				upstreamNode.add(tailNode);
+			}
+		}
+
+		ParallelStatsInner<?> resolveTail() {
+			if (this.downstreamNode instanceof ParallelFluxStats.ParallelStatsInner) {
+				return ((ParallelStatsInner<?>) this.downstreamNode).resolveTail();
+			}
+
+			return this;
+		}
+
+	}
+
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxStats.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxStats.java
@@ -8,7 +8,7 @@ import reactor.util.annotation.Nullable;
 import reactor.util.stats.StatsMarker;
 import reactor.util.stats.StatsReporter;
 
-public class ParallelFluxStats<T> extends ParallelFlux<T> implements Scannable {
+final class ParallelFluxStats<T> extends ParallelFlux<T> implements Scannable {
 
 	final ParallelFlux<T>                 source;
 	final FluxOnAssembly.AssemblySnapshot assemblySnapshot;
@@ -66,7 +66,7 @@ public class ParallelFluxStats<T> extends ParallelFlux<T> implements Scannable {
 		source.subscribe(parents);
 	}
 
-	static class ParallelStatsInner<T> extends FluxStats.StatsOperator<T>
+	static final class ParallelStatsInner<T> extends FluxStats.StatsOperator<T>
 			implements InnerOperator<T, T>, Fuseable.QueueSubscription<T> {
 
 		FluxStats.StatsOperator<?> serialDownstreamNode;

--- a/reactor-core/src/main/java/reactor/util/stats/LoggerStatsReporter.java
+++ b/reactor-core/src/main/java/reactor/util/stats/LoggerStatsReporter.java
@@ -1,0 +1,286 @@
+package reactor.util.stats;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import reactor.util.Logger;
+import reactor.util.Loggers;
+import reactor.util.function.Tuple8;
+import reactor.util.function.Tuples;
+
+class LoggerStatsReporter implements StatsReporter {
+
+	static final LoggerStatsReporter INSTANCE = new LoggerStatsReporter();
+
+	static final Logger logger = Loggers.getLogger(LoggerStatsReporter.class);
+
+	static final String                PROBE_CALL_SITE_GLUE = " ↳ ";
+	static final String                CALL_SITE_GLUE       = " ⇢ ";
+	static final Map<TimeUnit, String> TIME_UNIT_SYMBOLS    =
+			new EnumMap<TimeUnit, String>(TimeUnit.class) {
+				{
+					put(TimeUnit.NANOSECONDS, "ns");
+					put(TimeUnit.MICROSECONDS, "μs");
+					put(TimeUnit.MILLISECONDS, "ms");
+					put(TimeUnit.SECONDS, " s");
+				}
+			};
+
+	private LoggerStatsReporter() {}
+
+	@Override
+	public void report(StatsNode<?> statsNode, StatsMarker... markers) {
+		logger.info("The following stats are collected:\n" + buildReport(statsNode, markers));
+	}
+
+	static String buildReport(StatsNode<?> statsNode, StatsMarker... markers) {
+		int minAvgProcessingTimeWidth = minAvgProcessingTimeWidth(statsNode);
+		TimeUnit timeUnit = TimeUnit.NANOSECONDS;
+		TimeUnit[] timeUnitValues = TimeUnit.values();
+		int k = 0;
+		while (minAvgProcessingTimeWidth > 3 && k < 3) {
+			k++;
+			minAvgProcessingTimeWidth -= 3;
+			timeUnit = timeUnitValues[k];
+		}
+
+
+		return buildReport(statsNode, "  \t", timeUnit, -1, markers);
+	}
+
+
+	static int minAvgProcessingTimeWidth(StatsNode<?> statsNode) {
+		int minAvgProcessingTimeWidth = Integer.MAX_VALUE;
+
+		while (statsNode != null) {
+			long value = avgProcessingTime(statsNode);
+			String avgProcessingTime = String.valueOf(value);
+
+			int length = avgProcessingTime.length();
+			if (length < minAvgProcessingTimeWidth && value != 0L) {
+				minAvgProcessingTimeWidth = length;
+			}
+
+			for (StatsNode<?> innerStatsNode : statsNode.innerNodes) {
+				length = minAvgProcessingTimeWidth(innerStatsNode);
+
+				if (length < minAvgProcessingTimeWidth) {
+					minAvgProcessingTimeWidth = length;
+				}
+			}
+
+			statsNode = statsNode.upstreamNode;
+		}
+
+		return minAvgProcessingTimeWidth;
+	}
+
+
+	static String requested(StatsNode<?> node) {
+		return node.requested == Long.MAX_VALUE ? "∞" : String.valueOf(node.requested);
+	}
+
+	static String produced(StatsNode<?> node) {
+		return String.valueOf(node.produced);
+	}
+
+	static long avgProcessingTime(StatsNode<?> node) {
+		return node.produced != 0 ? node.totalSumProcessingTimeInNanos / node.produced : 0;
+	}
+
+	static String lastObservedSignal(StatsNode<?> node) {
+		return node.lastObservedSignal.toString();
+	}
+
+	static String state(StatsNode<?> node) {
+		return node.cancelled
+				? "canceled"
+				: node.done
+				? node.error == null
+				? "completed"
+				: "errored"
+				: "none";
+	}
+
+
+	static String buildReport(StatsNode<?> statsNode, String indentContent,
+			TimeUnit timeUnit, int id, StatsMarker... markers) {
+		ArrayList<Tuple8<StatsNode<?>, String, String, String, String, Long, String, String>> chainOrder = new ArrayList<>();
+		StringBuilder sb = new StringBuilder();
+
+		while (statsNode != null) {
+			String operator = statsNode.operatorName();
+			String line = statsNode.line();
+			String requested = requested(statsNode);
+			String produced = produced(statsNode);
+			long avgProcessingTime = avgProcessingTime(statsNode);
+			String lastSignal = lastObservedSignal(statsNode);
+			String state = state(statsNode);
+			chainOrder.add(0, Tuples.of(statsNode, operator, line, requested, produced, avgProcessingTime, lastSignal, state));
+			statsNode = statsNode.upstreamNode;
+		}
+
+		int maxOperatorWidth = 0;
+		int maxRequestWidth = 0;
+		int maxProduceWidth = 0;
+		int maxAvgProcessingTimeWidth = 0;
+		int maxLastSignalWidth = 0;
+		int maxStateWidth = 0;
+		for (Tuple8<StatsNode<?>, String, String, String, String, Long, String, String> t : chainOrder) {
+			int length = t.getT2().length();
+			if (length > maxOperatorWidth) {
+				maxOperatorWidth = length;
+			}
+
+			length = t.getT4().length();
+			if (length > maxRequestWidth) {
+				maxRequestWidth = length;
+			}
+
+			length = t.getT5().length();
+			if (length > maxProduceWidth) {
+				maxProduceWidth = length;
+			}
+
+			Long value = t.getT6();
+			length = String.valueOf(value).length();
+			if (length > maxAvgProcessingTimeWidth) {
+				maxAvgProcessingTimeWidth = length;
+			}
+
+			length = t.getT7().length();
+			if (length > maxLastSignalWidth) {
+				maxLastSignalWidth = length;
+			}
+
+			length = t.getT8().length();
+			if (length > maxStateWidth) {
+				maxStateWidth = length;
+			}
+		}
+
+		maxAvgProcessingTimeWidth -= timeUnit.ordinal() * 3;
+
+		for (int i = 0; i < chainOrder.size(); i++) {
+			Tuple8<StatsNode<?>, String, String, String, String, Long, String, String> t = chainOrder.get(i);
+			StatsNode<?> statsOperator = t.getT1();
+			String operator = t.getT2();
+			String message = t.getT3();
+			String requested = t.getT4();
+			String produced = t.getT5();
+			Long avgProcessingTime = t.getT6();
+			String lastSignal = t.getT7();
+			String state = t.getT8();
+
+			String marker = null;
+
+			for (StatsMarker statsMarker : markers) {
+				marker = statsMarker.mark(statsOperator);
+				if (marker != null) {
+					break;
+				}
+			}
+			sb.append(indentContent);
+
+			if (id < 0 || i > 0) {
+				sb.append("| ");
+			}
+			else {
+				String idString = String.valueOf(id);
+				sb.replace(indentContent.length() - 1 - idString.length(), indentContent.length() - 1, idString)
+				  .append("| ");
+			}
+
+			if (marker != null) {
+				sb.replace(sb.length() - 5,
+						sb.length() - 3, marker);
+			}
+
+			int indent = maxOperatorWidth - operator.length();
+			StringBuilder indentSpace = new StringBuilder();
+			for (int j = 0; j < indent; j++) {
+				indentSpace.append(' ');
+			}
+			sb.append(' ');
+			sb.append(operator);
+			sb.append(indentSpace);
+			sb.append(CALL_SITE_GLUE);
+			sb.append(message);
+			sb.append("\n");
+
+			boolean hasInners = statsOperator.innerNodes.length > 0;
+			if (hasInners) {
+				sb.append(indentContent).append("| ");
+			}
+			else {
+				sb.append(indentContent).append("|_");
+			}
+
+			for (int j = indent; j < maxOperatorWidth + 1; j++) {
+				indentSpace.append(' ');
+			}
+			sb.append(indentSpace);
+
+			sb.append(PROBE_CALL_SITE_GLUE);
+			sb.append("Stats(Requested: ");
+
+			for (int j = 0; j < maxRequestWidth - requested.length(); j++) {
+				sb.append(' ');
+			}
+			sb.append(requested);
+			sb.append(';');
+
+			sb.append(" Produced: ");
+			for (int j = 0; j < maxProduceWidth - produced.length(); j++) {
+				sb.append(' ');
+			}
+			sb.append(produced);
+			sb.append(';');
+
+			sb.append(" OnNext ~Time: ");
+			String processingTime = String.valueOf(timeUnit.convert(avgProcessingTime, TimeUnit.NANOSECONDS));
+			for (int j = 0; j < maxAvgProcessingTimeWidth - processingTime.length(); j++) {
+				sb.append(' ');
+			}
+			sb.append(processingTime);
+			sb.append(TIME_UNIT_SYMBOLS.get(timeUnit));
+			sb.append(';');
+
+			sb.append(" Last Signal: ");
+			for (int j = 0; j < maxLastSignalWidth - lastSignal.length(); j++) {
+				sb.append(' ');
+			}
+			sb.append(lastSignal);
+			sb.append(';');
+
+			sb.append(" State: ");
+			for (int j = 0; j < maxStateWidth - state.length(); j++) {
+				sb.append(' ');
+			}
+			sb.append(state);
+			sb.append(')');
+
+			if (hasInners) {
+				sb.append("\n");
+
+				int length = statsOperator.innerNodes.length;
+				for (int j = 0; j < length; j++) {
+					StatsNode<?> innerNode = statsOperator.innerNodes[j];
+					sb.append(indentContent).append("|\n");
+					sb.append(buildReport(innerNode, indentContent + "|  " + indentSpace.toString(), timeUnit, j, markers));
+					sb.append("\n");
+				}
+
+				sb.append(indentContent).append("|_");
+			}
+
+			if (i != chainOrder.size() - 1) {
+				sb.append("\n");
+			}
+		}
+
+		return sb.toString();
+	}
+}

--- a/reactor-core/src/main/java/reactor/util/stats/LoggerStatsReporter.java
+++ b/reactor-core/src/main/java/reactor/util/stats/LoggerStatsReporter.java
@@ -10,7 +10,7 @@ import reactor.util.Loggers;
 import reactor.util.function.Tuple8;
 import reactor.util.function.Tuples;
 
-class LoggerStatsReporter implements StatsReporter {
+final class LoggerStatsReporter implements StatsReporter {
 
 	static final LoggerStatsReporter INSTANCE = new LoggerStatsReporter();
 

--- a/reactor-core/src/main/java/reactor/util/stats/Stats.java
+++ b/reactor-core/src/main/java/reactor/util/stats/Stats.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.util.stats;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.ServiceLoader;
+
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+public class Stats {
+
+	static Logger logger = Loggers.getLogger(Stats.class);
+
+	static StatsReporter defaultStatsReporter;
+
+	static StatsMarker[] statsMarkers;
+
+	static {
+		loadDefaultStatsReporter();
+		loadMarkers();
+	}
+
+	static void loadDefaultStatsReporter() {
+		String className = System.getProperty("reactor.trace.operatorStatsReporter");
+
+		if (className != null) {
+			className = className.trim();
+
+			if (!className.isEmpty()) {
+				try {
+					Class<?> aClass = Stats.class.getClassLoader()
+					                             .loadClass(className);
+					Constructor<?> constructor = aClass.getConstructor();
+					defaultStatsReporter = (StatsReporter) constructor.newInstance();
+					return;
+				} catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+					logger.error("Custom StatsPrinter instantiation has failed", e);
+				}
+			}
+		}
+
+		defaultStatsReporter = LoggerStatsReporter.INSTANCE;
+	}
+
+	static void loadMarkers() {
+		ServiceLoader<StatsMarker> statsMarkerServiceLoader =
+				ServiceLoader.load(StatsMarker.class);
+		ArrayList<StatsMarker> statsMarkerArrayList = new ArrayList<>();
+		for (StatsMarker statsMarker : statsMarkerServiceLoader) {
+			statsMarkerArrayList.add(statsMarker);
+		}
+
+		statsMarkers = statsMarkerArrayList.toArray(new StatsMarker[0]);
+	}
+
+	public static StatsReporter getStatsReporter() {
+		return defaultStatsReporter;
+	}
+
+	public static StatsMarker[] getStatsMarkers() {
+		return statsMarkers;
+	}
+
+	public static void setStatsReporter(StatsReporter statsReporter) {
+		defaultStatsReporter = statsReporter;
+	}
+
+	public static void useLoggerStatsReporter() {
+		defaultStatsReporter = LoggerStatsReporter.INSTANCE;
+	}
+
+	public static void addMarker(StatsMarker statsMarker) {
+		StatsMarker[] newStatsMarkers = Arrays.copyOf(statsMarkers, statsMarkers.length + 1);
+
+		newStatsMarkers[statsMarkers.length] = statsMarker;
+		statsMarkers = newStatsMarkers;
+	}
+}

--- a/reactor-core/src/main/java/reactor/util/stats/StatsMarker.java
+++ b/reactor-core/src/main/java/reactor/util/stats/StatsMarker.java
@@ -1,0 +1,10 @@
+package reactor.util.stats;
+
+import reactor.util.annotation.Nullable;
+
+@FunctionalInterface
+public interface StatsMarker {
+
+	@Nullable
+	String mark(StatsNode<?> stats);
+}

--- a/reactor-core/src/main/java/reactor/util/stats/StatsNode.java
+++ b/reactor-core/src/main/java/reactor/util/stats/StatsNode.java
@@ -1,0 +1,158 @@
+package reactor.util.stats;
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import reactor.core.publisher.SignalType;
+import reactor.util.annotation.Nullable;
+
+public abstract class StatsNode<SELF extends StatsNode<SELF>> {
+
+	@Nullable
+	public SELF upstreamNode;
+	@Nullable
+	public SELF downstreamNode;
+
+	static final StatsNode<?>[] EMPTY = new StatsNode[0];
+
+	public volatile SELF[] innerNodes;
+	@SuppressWarnings("rawtypes")
+	static final AtomicReferenceFieldUpdater<StatsNode, StatsNode[]> INNER_NODES
+		= AtomicReferenceFieldUpdater.newUpdater(StatsNode.class, StatsNode[].class, "innerNodes");
+
+	public SignalType lastObservedSignal;
+
+	public long lastElapsedOnNextNanos;
+
+	public long totalSumProcessingTimeInNanos;
+
+	public long produced;
+	public long requested;
+
+	public Throwable error;
+	public boolean   done;
+	public boolean   cancelled;
+
+	public boolean isInner;
+
+	protected StatsNode() {
+		INNER_NODES.lazySet(this, EMPTY);
+	}
+
+	public void recordSignal(SignalType signalType) {
+		long currentNanoTime;
+
+		switch (signalType) {
+			case ON_SUBSCRIBE:
+				this.lastObservedSignal = signalType;
+				break;
+			case ON_NEXT:
+				currentNanoTime = System.nanoTime();
+				if (this.upstreamNode == null) {
+					this.totalSumProcessingTimeInNanos += (currentNanoTime - this.lastElapsedOnNextNanos);
+				}
+				else {
+					this.totalSumProcessingTimeInNanos += (currentNanoTime - this.upstreamNode.lastElapsedOnNextNanos);
+				}
+				this.lastElapsedOnNextNanos = currentNanoTime;
+				this.lastObservedSignal = signalType;
+				break;
+			case REQUEST:
+				currentNanoTime = System.nanoTime();
+				if (this.produced == this.requested) {
+					this.lastElapsedOnNextNanos = currentNanoTime;
+				}
+				this.lastObservedSignal = signalType;
+				break;
+			case CANCEL:
+				this.cancelled = true;
+				break;
+			case ON_ERROR:
+			case ON_COMPLETE:
+				this.done = true;
+				break;
+		}
+	}
+
+	public void recordRequest(long requested) {
+		this.requested += requested;
+	}
+
+	public void recordProduced() {
+		this.produced++;
+	}
+
+	public void attachTo(SELF downstreamNode) {
+		this.downstreamNode = downstreamNode;
+
+		if (downstreamNode.upstreamNode != null) {
+			this.isInner = true;
+			downstreamNode.add(this);
+		}
+		else {
+			//noinspection unchecked
+			downstreamNode.upstreamNode = (SELF) this;
+		}
+	}
+
+	public void detachIfInner() {
+		if (this.isInner) {
+			//noinspection ConstantConditions
+			this.downstreamNode.remove(this);
+		}
+	}
+
+	public void add(StatsNode<?> uip) {
+		for (;;) {
+			StatsNode<?>[] a = innerNodes;
+
+			int n = a.length;
+			StatsNode<?>[] b = new StatsNode[n + 1];
+			System.arraycopy(a, 0, b, 0, n);
+			b[n] = uip;
+
+			if (INNER_NODES.compareAndSet(this, a, b)) {
+				return;
+			}
+		}
+	}
+
+	public void remove(StatsNode<?> uip) {
+		for (;;) {
+			StatsNode<?>[] a = innerNodes;
+			int n = a.length;
+			if (n == 0) {
+				return;
+			}
+
+			int j = -1;
+			for (int i = 0; i < n; i++) {
+				if (a[i] == uip) {
+					j = i;
+					break;
+				}
+			}
+
+			if (j < 0) {
+				return;
+			}
+
+			StatsNode<?>[] b;
+
+			if (n == 1) {
+				b = EMPTY;
+			} else {
+				b = new StatsNode[n - 1];
+				System.arraycopy(a, 0, b, 0, j);
+				System.arraycopy(a, j + 1, b, j, n - j - 1);
+			}
+			if (INNER_NODES.compareAndSet(this, a, b)) {
+				return;
+			}
+		}
+	}
+
+	public abstract String operatorName();
+
+	public abstract String line();
+
+}

--- a/reactor-core/src/main/java/reactor/util/stats/StatsNode.java
+++ b/reactor-core/src/main/java/reactor/util/stats/StatsNode.java
@@ -81,6 +81,7 @@ public abstract class StatsNode<SELF extends StatsNode<SELF>> {
 		this.produced++;
 	}
 
+	@SuppressWarnings("unchecked")
 	public void attachTo(SELF downstreamNode) {
 		this.downstreamNode = downstreamNode;
 
@@ -89,7 +90,6 @@ public abstract class StatsNode<SELF extends StatsNode<SELF>> {
 			downstreamNode.add(this);
 		}
 		else {
-			//noinspection unchecked
 			downstreamNode.upstreamNode = (SELF) this;
 		}
 	}

--- a/reactor-core/src/main/java/reactor/util/stats/StatsReporter.java
+++ b/reactor-core/src/main/java/reactor/util/stats/StatsReporter.java
@@ -1,0 +1,6 @@
+package reactor.util.stats;
+
+public interface StatsReporter {
+
+	void report(StatsNode<?> statsNode, StatsMarker... markers);
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxStatsReportTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxStatsReportTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Iterator;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.util.Loggers;
+import reactor.util.stats.Stats;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class FluxStatsReportTest {
+
+	static final ByteArrayOutputStream overriddenOut   = new ByteArrayOutputStream();
+	static final PrintStream           overriddenPrint = new PrintStream(overriddenOut);
+
+	@BeforeAll
+	public static void initLoggerOnce() {
+		PrintStream originalOut = System.out;
+		System.setOut(overriddenPrint);
+		Loggers.useConsoleLoggers();
+		Stats.useLoggerStatsReporter();
+		System.setOut(originalOut);
+	}
+
+	@AfterAll
+	public static void resetLoggerOnce() {
+		Loggers.resetLoggerFactory();
+	}
+
+	@BeforeEach
+	public void resetOut() {
+		overriddenOut.reset();
+		Hooks.onOperatorDebug();
+		Hooks.enableStatsTracking();
+	}
+
+	@Test
+	public void shouldAddStatsInfo() {
+		int baseline = getBaseline();
+		Flux.just(1)
+		    .map(i -> i < 3 ? i : null)
+		    .as(this::methodReturningFlux)
+		    .blockLast();
+
+		String debugStack = overriddenOut.toString();
+
+		Iterator<String> lines = Stream.of(debugStack.split("\n"))
+		                               .iterator();
+
+		while (lines.hasNext()) {
+			String line = lines.next();
+			if (line.endsWith("The following stats are collected:")) {
+				break;
+			}
+		}
+
+		assertThat(lines.next())
+			.as("first backtrace line")
+			.isEqualTo(
+				"  \t|  Flux.just ⇢ at reactor.core.publisher.FluxStatsReportTest.shouldAddStatsInfo(FluxStatsReportTest.java:" + (baseline + 1) + ")");
+		assertThat(lines.next())
+			.as("first stats-trace line")
+			.matches(Pattern.compile(
+				"  \t\\|_           ↳ Stats\\(Requested: ∞; Produced: 1; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal: onNext; State: completed\\)"
+			));
+
+		assertThat(lines.next())
+			.as("second backtrace line")
+			.endsWith(
+				"  \t|  Flux.map  ⇢ at reactor.core.publisher.FluxStatsReportTest.shouldAddStatsInfo(FluxStatsReportTest.java:" + (baseline + 2) + ")");
+		assertThat(lines.next())
+			.as("second stats-trace line")
+			.matches(Pattern.compile(
+				"  \t\\|_           ↳ Stats\\(Requested: ∞; Produced: 1; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal: onNext; State: completed\\)"
+			));
+
+		assertThat(lines.hasNext())
+			.as("should have no extra lines")
+			.isFalse();
+	}
+
+	@Test
+	public void shouldAddStatsInfoConcatMap() {
+		int baseline = getBaseline();
+		Flux.just(1)
+		    .concatMap(i -> Flux.just(i)
+		                        .map(k -> k < 3 ? k : null))
+		    .as(this::methodReturningFlux)
+		    .blockLast();
+
+		String debugStack = overriddenOut.toString();
+
+		Iterator<String> lines = Stream.of(debugStack.split("\n"))
+		                               .iterator();
+
+		while (lines.hasNext()) {
+			String line = lines.next();
+			if (line.endsWith("The following stats are collected:")) {
+				break;
+			}
+		}
+
+		assertThat(lines.next())
+				.as("first backtrace line")
+				.isEqualTo(
+						"  \t|  Flux.just      ⇢ at reactor.core.publisher.FluxStatsReportTest.shouldAddStatsInfoConcatMap(FluxStatsReportTest.java:" + (baseline + 1) + ")");
+		assertThat(lines.next())
+				.as("first stats-trace line")
+				.matches(Pattern.compile(
+						"  \t\\|_                ↳ Stats\\(Requested: ∞; Produced: 1; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal: onNext; State: completed\\)"
+				));
+
+		assertThat(lines.next())
+				.as("second backtrace line")
+				.endsWith(
+						"  \t|  Flux.concatMap ⇢ at reactor.core.publisher" +
+								".FluxStatsReportTest.shouldAddStatsInfoConcatMap(FluxStatsReportTest.java:" + (baseline + 2) + ")");
+		assertThat(lines.next())
+				.as("second stats-trace line")
+				.matches(Pattern.compile(
+						"  \t\\|_                ↳ Stats\\(Requested: ∞; Produced: 1; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal: onNext; State: completed\\)"
+				));
+
+		assertThat(lines.hasNext())
+				.as("should have no extra lines")
+				.isFalse();
+	}
+
+	@Test
+	public void shouldAddStatsInfoWhenError() {
+		int baseline = 0;
+		try {
+			baseline = getBaseline();
+			Flux.just(5)
+			    .map(i -> i < 3 ? i : null)
+			    .as(this::methodReturningFlux)
+			    .blockLast();
+			fail("Should not complete successfully");
+		} catch (Exception e) {
+			// ignored
+		}
+
+		String debugStack = overriddenOut.toString();
+
+		Iterator<String> lines = Stream.of(debugStack.split("\n"))
+		                               .iterator();
+
+		while (lines.hasNext()) {
+			String line = lines.next();
+			if (line.endsWith("The following stats are collected:")) {
+				break;
+			}
+		}
+
+		assertThat(lines.next())
+				.as("first backtrace line")
+				.isEqualTo(
+						"  \t|  Flux.just ⇢ at reactor.core.publisher.FluxStatsReportTest.shouldAddStatsInfoWhenError(FluxStatsReportTest.java:" + (baseline + 1) + ")");
+		assertThat(lines.next())
+				.as("first stats-trace line")
+				.matches(Pattern.compile(
+						"  \t\\|_           ↳ Stats\\(Requested: ∞; Produced: 1; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal:  onNext; State: canceled\\)"
+				));
+
+		assertThat(lines.next())
+				.as("second backtrace line")
+				.isEqualTo(
+						"  \t|  Flux.map  ⇢ at reactor.core.publisher.FluxStatsReportTest.shouldAddStatsInfoWhenError(FluxStatsReportTest.java:" + (baseline + 2) + ")");
+		assertThat(lines.next())
+				.as("second stats-trace line")
+				.matches(Pattern.compile(
+						"  \t\\|_           ↳ Stats\\(Requested: ∞; Produced: 0; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal: request; State:  errored\\)"
+				));
+
+		assertThat(lines.hasNext())
+				.as("should have no extra lines")
+				.isFalse();
+	}
+
+	@Test
+	public void shouldAddStatsInfoWhenConcatMapError() {
+		int baseline = 0;
+		try {
+			baseline = getBaseline();
+			Flux.just(5)
+			    .concatMap(v -> Flux.just(v)
+			                      .map(i -> i < 3 ? i : null))
+			    .as(this::methodReturningFlux)
+			    .blockLast();
+			fail("Should not complete successfully");
+		} catch (Exception e) {
+			// ignored
+		}
+
+		String debugStack = overriddenOut.toString();
+
+		Iterator<String> lines = Stream.of(debugStack.split("\n"))
+		                               .iterator();
+
+		while (lines.hasNext()) {
+			String line = lines.next();
+			if (line.endsWith("The following stats are collected:")) {
+				break;
+			}
+		}
+
+		assertThat(lines.next())
+				.as("first backtrace line")
+				.isEqualTo(
+						"  \t|  Flux.just      ⇢ at reactor.core.publisher.FluxStatsReportTest.shouldAddStatsInfoWhenConcatMapError(FluxStatsReportTest.java:" + (baseline + 1) + ")");
+		assertThat(lines.next())
+				.as("first stats-trace line")
+				.matches(Pattern.compile(
+						"  \t\\|_                ↳ Stats\\(Requested: ∞; Produced: 1; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal:  onNext; State: canceled\\)"
+				));
+
+		assertThat(lines.next())
+				.as("second backtrace line")
+				.isEqualTo(
+						"  \t|  Flux.concatMap ⇢ at reactor.core.publisher.FluxStatsReportTest.shouldAddStatsInfoWhenConcatMapError(FluxStatsReportTest.java:" + (baseline + 2) + ")");
+		assertThat(lines.next())
+				.as("second stats-trace line")
+				.matches(Pattern.compile(
+						"  \t\\|                 ↳ Stats\\(Requested: ∞; Produced: 0; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal: request; State:  errored\\)"
+				));
+
+		assertThat(lines.next())
+				.as("second blank separator with inner line")
+				.isEqualTo(
+						"  \t|");
+
+		assertThat(lines.next())
+				.as("first inner backtrace line")
+				.matches(
+						"  \t\\|               0 \\|  Flux.just ⇢ at reactor.core.publisher.FluxStatsReportTest.lambda\\$shouldAddStatsInfoWhenConcatMapError\\$[0-9]\\(FluxStatsReportTest.java:" + (baseline + 2) + "\\)");
+		assertThat(lines.next())
+				.as("first inner stats-trace line")
+				.matches(Pattern.compile(
+						"  \t\\|                 \\|_           ↳ Stats\\(Requested: ∞; Produced: 1; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal:  onNext; State: canceled\\)"
+				));
+
+		assertThat(lines.next())
+				.as("second inner backtrace line")
+				.matches(
+						"  \t\\|                 \\|  Flux.map  ⇢ at reactor.core.publisher.FluxStatsReportTest.lambda\\$shouldAddStatsInfoWhenConcatMapError\\$[0-9]\\(FluxStatsReportTest.java:" + (baseline + 3) + "\\)");;
+		assertThat(lines.next())
+				.as("second inner stats-trace line")
+				.matches(Pattern.compile(
+						"  \t\\|                 \\|_           ↳ Stats\\(Requested: ∞; Produced: 0; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal: request; State:  errored\\)"
+				));
+
+		assertThat(lines.next())
+				.as("second blank separator after inner line")
+				.isEqualTo(
+						"  \t|_");
+
+		assertThat(lines.hasNext())
+				.as("should have no extra lines")
+				.isFalse();
+	}
+
+	static final int methodReturningFluxBaseline = getBaseline();
+	private Flux<Integer> methodReturningFlux(Flux<Integer> flux) {
+		return flux;
+	}
+
+	private static int getBaseline() {
+		return new Exception().getStackTrace()[1].getLineNumber();
+	}
+
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxStatsReportTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxStatsReportTest.java
@@ -34,28 +34,22 @@ import static org.assertj.core.api.Assertions.fail;
 
 public class FluxStatsReportTest {
 
-	static final ByteArrayOutputStream overriddenOut   = new ByteArrayOutputStream();
-	static final PrintStream           overriddenPrint = new PrintStream(overriddenOut);
-
 	@BeforeAll
 	public static void initLoggerOnce() {
-		PrintStream originalOut = System.out;
-		System.setOut(overriddenPrint);
-		Loggers.useConsoleLoggers();
-		Stats.useLoggerStatsReporter();
-		System.setOut(originalOut);
+		Hooks.enableStatsRecording();
 	}
 
 	@AfterAll
 	public static void resetLoggerOnce() {
 		Loggers.resetLoggerFactory();
+		Hooks.resetOnOperatorDebug();
+		Hooks.disableStatsRecording();
 	}
 
 	@BeforeEach
 	public void resetOut() {
-		overriddenOut.reset();
+		StatsTestSupport.overriddenOut.reset();
 		Hooks.onOperatorDebug();
-		Hooks.enableStatsTracking();
 	}
 
 	@Test
@@ -66,7 +60,7 @@ public class FluxStatsReportTest {
 		    .as(this::methodReturningFlux)
 		    .blockLast();
 
-		String debugStack = overriddenOut.toString();
+		String debugStack = StatsTestSupport.overriddenOut.toString();
 
 		Iterator<String> lines = Stream.of(debugStack.split("\n"))
 		                               .iterator();
@@ -112,7 +106,7 @@ public class FluxStatsReportTest {
 		    .as(this::methodReturningFlux)
 		    .blockLast();
 
-		String debugStack = overriddenOut.toString();
+		String debugStack = StatsTestSupport.overriddenOut.toString();
 
 		Iterator<String> lines = Stream.of(debugStack.split("\n"))
 		                               .iterator();
@@ -164,7 +158,7 @@ public class FluxStatsReportTest {
 			// ignored
 		}
 
-		String debugStack = overriddenOut.toString();
+		String debugStack = StatsTestSupport.overriddenOut.toString();
 
 		Iterator<String> lines = Stream.of(debugStack.split("\n"))
 		                               .iterator();
@@ -216,7 +210,7 @@ public class FluxStatsReportTest {
 			// ignored
 		}
 
-		String debugStack = overriddenOut.toString();
+		String debugStack = StatsTestSupport.overriddenOut.toString();
 
 		Iterator<String> lines = Stream.of(debugStack.split("\n"))
 		                               .iterator();
@@ -290,6 +284,21 @@ public class FluxStatsReportTest {
 
 	private static int getBaseline() {
 		return new Exception().getStackTrace()[1].getLineNumber();
+	}
+
+
+	static class StatsTestSupport {
+
+		static final ByteArrayOutputStream overriddenOut   = new ByteArrayOutputStream();
+		static final PrintStream           overriddenPrint = new PrintStream(overriddenOut);
+
+		static {
+			PrintStream originalOut = System.out;
+			System.setOut(overriddenPrint);
+			Loggers.useConsoleLoggers();
+			Stats.useLoggerStatsReporter();
+			System.setOut(originalOut);
+		}
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoStatsReportTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoStatsReportTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Iterator;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.util.Loggers;
+import reactor.util.stats.Stats;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class MonoStatsReportTest {
+
+	static final ByteArrayOutputStream overriddenOut   = new ByteArrayOutputStream();
+	static final PrintStream           overriddenPrint = new PrintStream(overriddenOut);
+
+	@BeforeAll
+	public static void initLoggerOnce() {
+		PrintStream originalOut = System.out;
+		System.setOut(overriddenPrint);
+		Loggers.useConsoleLoggers();
+		Stats.useLoggerStatsReporter();
+		System.setOut(originalOut);
+	}
+
+	@AfterAll
+	public static void resetLoggerOnce() {
+		Loggers.resetLoggerFactory();
+
+		Hooks.resetOnOperatorDebug();
+		Hooks.disableStatsTracking();
+	}
+
+	@BeforeEach
+	public void resetOut() {
+		overriddenOut.reset();
+		Hooks.onOperatorDebug();
+		Hooks.enableStatsTracking();
+	}
+
+	@Test
+	public void shouldAddStatsInfo() {
+		int baseline = getBaseline();
+		Mono.just(1)
+		    .map(i -> i < 3 ? i : null)
+		    .as(this::methodReturningMono)
+		    .block();
+
+		String debugStack = overriddenOut.toString();
+
+		Iterator<String> lines = Stream.of(debugStack.split("\n"))
+		                               .iterator();
+
+		while (lines.hasNext()) {
+			String line = lines.next();
+			if (line.endsWith("The following stats are collected:")) {
+				break;
+			}
+		}
+
+		assertThat(lines.next())
+			.as("first backtrace line")
+			.isEqualTo(
+				"  \t|  Mono.just ⇢ at reactor.core.publisher.MonoStatsReportTest.shouldAddStatsInfo(MonoStatsReportTest.java:" + (baseline + 1) + ")");
+		assertThat(lines.next())
+			.as("first stats-trace line")
+			.matches(Pattern.compile(
+				"  \t\\|_           ↳ Stats\\(Requested: ∞; Produced: 1; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal: onNext; State: completed\\)"
+			));
+
+		assertThat(lines.next())
+			.as("second backtrace line")
+			.endsWith(
+				"  \t|  Mono.map  ⇢ at reactor.core.publisher.MonoStatsReportTest.shouldAddStatsInfo(MonoStatsReportTest.java:" + (baseline + 2) + ")");
+		assertThat(lines.next())
+			.as("second stats-trace line")
+			.matches(Pattern.compile(
+				"  \t\\|_           ↳ Stats\\(Requested: ∞; Produced: 1; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal: onNext; State: completed\\)"
+			));
+
+		assertThat(lines.hasNext())
+			.as("should have no extra lines")
+			.isFalse();
+	}
+
+	@Test
+	public void shouldAddStatsInfoConcatMap() {
+		int baseline = getBaseline();
+		Mono.just(1)
+		    .flatMap(i -> Mono.just(i)
+		                      .map(k -> k < 3 ? k : null))
+		    .as(this::methodReturningMono)
+		    .block();
+
+		String debugStack = overriddenOut.toString();
+
+		Iterator<String> lines = Stream.of(debugStack.split("\n"))
+		                               .iterator();
+
+		while (lines.hasNext()) {
+			String line = lines.next();
+			if (line.endsWith("The following stats are collected:")) {
+				break;
+			}
+		}
+
+		assertThat(lines.next())
+				.as("first backtrace line")
+				.isEqualTo(
+						"  \t|  Mono.just    ⇢ at reactor.core.publisher.MonoStatsReportTest.shouldAddStatsInfoConcatMap(MonoStatsReportTest.java:" + (baseline + 1) + ")");
+		assertThat(lines.next())
+				.as("first stats-trace line")
+				.matches(Pattern.compile(
+						"  \t\\|_              ↳ Stats\\(Requested: ∞; Produced: 1; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal: onNext; State: completed\\)"
+				));
+
+		assertThat(lines.next())
+				.as("second backtrace line")
+				.endsWith(
+						"  \t|  Mono.flatMap ⇢ at reactor.core.publisher.MonoStatsReportTest.shouldAddStatsInfoConcatMap(MonoStatsReportTest.java:" + (baseline + 2) + ")");
+		assertThat(lines.next())
+				.as("second stats-trace line")
+				.matches(Pattern.compile(
+						"  \t\\|_              ↳ Stats\\(Requested: ∞; Produced: 1; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal: onNext; State: completed\\)"
+				));
+
+		assertThat(lines.hasNext())
+				.as("should have no extra lines")
+				.isFalse();
+	}
+
+	@Test
+	public void shouldAddStatsInfoWhenError() {
+		int baseline = 0;
+		try {
+			baseline = getBaseline();
+			Mono.just(5)
+			    .map(i -> i < 3 ? i : null)
+			    .as(this::methodReturningMono)
+			    .block();
+			fail("Should not complete successfully");
+		} catch (Exception e) {
+			// ignored
+		}
+
+		String debugStack = overriddenOut.toString();
+
+		Iterator<String> lines = Stream.of(debugStack.split("\n"))
+		                               .iterator();
+
+		while (lines.hasNext()) {
+			String line = lines.next();
+			if (line.endsWith("The following stats are collected:")) {
+				break;
+			}
+		}
+
+		assertThat(lines.next())
+				.as("first backtrace line")
+				.isEqualTo(
+						"  \t|  Mono.just ⇢ at reactor.core.publisher.MonoStatsReportTest.shouldAddStatsInfoWhenError(MonoStatsReportTest.java:" + (baseline + 1) + ")");
+		assertThat(lines.next())
+				.as("first stats-trace line")
+				.matches(Pattern.compile(
+						"  \t\\|_           ↳ Stats\\(Requested: ∞; Produced: 1; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal:  onNext; State: canceled\\)"
+				));
+
+		assertThat(lines.next())
+				.as("second backtrace line")
+				.isEqualTo(
+						"  \t|  Mono.map  ⇢ at reactor.core.publisher.MonoStatsReportTest.shouldAddStatsInfoWhenError(MonoStatsReportTest.java:" + (baseline + 2) + ")");
+		assertThat(lines.next())
+				.as("second stats-trace line")
+				.matches(Pattern.compile(
+						"  \t\\|_           ↳ Stats\\(Requested: ∞; Produced: 0; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal: request; State:  errored\\)"
+				));
+
+		assertThat(lines.hasNext())
+				.as("should have no extra lines")
+				.isFalse();
+	}
+
+	@Test
+	public void shouldAddStatsInfoWhenConcatMapError() {
+		int baseline = 0;
+		try {
+			baseline = getBaseline();
+			Mono.just(5)
+			    .flatMap(v -> Mono.just(v)
+			                      .map(i -> i < 3 ? i : null))
+			    .as(this::methodReturningMono)
+			    .block();
+			fail("Should not complete successfully");
+		} catch (Exception e) {
+			// ignored
+		}
+
+		String debugStack = overriddenOut.toString();
+
+		Iterator<String> lines = Stream.of(debugStack.split("\n"))
+		                               .iterator();
+
+		while (lines.hasNext()) {
+			String line = lines.next();
+			if (line.endsWith("The following stats are collected:")) {
+				break;
+			}
+		}
+
+		assertThat(lines.next())
+				.as("first backtrace line")
+				.isEqualTo(
+						"  \t|  Mono.just    ⇢ at reactor.core.publisher.MonoStatsReportTest.shouldAddStatsInfoWhenConcatMapError(MonoStatsReportTest.java:" + (baseline + 1) + ")");
+		assertThat(lines.next())
+				.as("first stats-trace line")
+				.matches(Pattern.compile(
+						"  \t\\|_              ↳ Stats\\(Requested: ∞; Produced: 1; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal:  onNext; State: completed\\)"
+				));
+
+		assertThat(lines.next())
+				.as("second backtrace line")
+				.isEqualTo(
+						"  \t|  Mono.flatMap ⇢ at reactor.core.publisher.MonoStatsReportTest.shouldAddStatsInfoWhenConcatMapError(MonoStatsReportTest.java:" + (baseline + 2) + ")");
+		assertThat(lines.next())
+				.as("second stats-trace line")
+				.matches(Pattern.compile(
+						"  \t\\|               ↳ Stats\\(Requested: ∞; Produced: 0; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal: request; State:   errored\\)"
+				));
+
+		assertThat(lines.next())
+				.as("second blank separator with inner line")
+				.isEqualTo(
+						"  \t|");
+
+		assertThat(lines.next())
+				.as("first inner backtrace line")
+				.matches(
+						"  \t\\|             0 \\|  Mono.just ⇢ at reactor.core.publisher.MonoStatsReportTest.lambda\\$shouldAddStatsInfoWhenConcatMapError\\$[0-9]\\(MonoStatsReportTest.java:" + (baseline + 2) + "\\)");
+		assertThat(lines.next())
+				.as("first inner stats-trace line")
+				.matches(Pattern.compile(
+						"  \t\\|               \\|_           ↳ Stats\\(Requested: ∞; Produced: 1; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal:  onNext; State: canceled\\)"
+				));
+
+		assertThat(lines.next())
+				.as("second inner backtrace line")
+				.matches(
+						"  \t\\|               \\|  Mono.map  ⇢ at reactor.core.publisher.MonoStatsReportTest.lambda\\$shouldAddStatsInfoWhenConcatMapError\\$[0-9]\\(MonoStatsReportTest.java:" + (baseline + 3) + "\\)");;
+		assertThat(lines.next())
+				.as("second inner stats-trace line")
+				.matches(Pattern.compile(
+						"  \t\\|               \\|_           ↳ Stats\\(Requested: ∞; Produced: 0; OnNext ~Time: [\\s0-9]+[nμm\\s]s; Last Signal: request; State:  errored\\)"
+				));
+
+		assertThat(lines.next())
+				.as("second blank separator after inner line")
+				.isEqualTo(
+						"  \t|_");
+
+		assertThat(lines.hasNext())
+				.as("should have no extra lines")
+				.isFalse();
+	}
+
+	static final int methodReturningMonoBaseline = getBaseline();
+	private Mono<Integer> methodReturningMono(Mono<Integer> mono) {
+		return mono;
+	}
+
+	private static int getBaseline() {
+		return new Exception().getStackTrace()[1].getLineNumber();
+	}
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoStatsReportTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoStatsReportTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.FluxStatsReportTest.StatsTestSupport;
 import reactor.util.Loggers;
 import reactor.util.stats.Stats;
 
@@ -34,31 +35,22 @@ import static org.assertj.core.api.Assertions.fail;
 
 public class MonoStatsReportTest {
 
-	static final ByteArrayOutputStream overriddenOut   = new ByteArrayOutputStream();
-	static final PrintStream           overriddenPrint = new PrintStream(overriddenOut);
-
 	@BeforeAll
 	public static void initLoggerOnce() {
-		PrintStream originalOut = System.out;
-		System.setOut(overriddenPrint);
-		Loggers.useConsoleLoggers();
-		Stats.useLoggerStatsReporter();
-		System.setOut(originalOut);
+		Hooks.enableStatsRecording();
 	}
 
 	@AfterAll
 	public static void resetLoggerOnce() {
 		Loggers.resetLoggerFactory();
-
 		Hooks.resetOnOperatorDebug();
-		Hooks.disableStatsTracking();
+		Hooks.disableStatsRecording();
 	}
 
 	@BeforeEach
 	public void resetOut() {
-		overriddenOut.reset();
+		StatsTestSupport.overriddenOut.reset();
 		Hooks.onOperatorDebug();
-		Hooks.enableStatsTracking();
 	}
 
 	@Test
@@ -69,7 +61,7 @@ public class MonoStatsReportTest {
 		    .as(this::methodReturningMono)
 		    .block();
 
-		String debugStack = overriddenOut.toString();
+		String debugStack = StatsTestSupport.overriddenOut.toString();
 
 		Iterator<String> lines = Stream.of(debugStack.split("\n"))
 		                               .iterator();
@@ -115,7 +107,7 @@ public class MonoStatsReportTest {
 		    .as(this::methodReturningMono)
 		    .block();
 
-		String debugStack = overriddenOut.toString();
+		String debugStack = StatsTestSupport.overriddenOut.toString();
 
 		Iterator<String> lines = Stream.of(debugStack.split("\n"))
 		                               .iterator();
@@ -166,7 +158,7 @@ public class MonoStatsReportTest {
 			// ignored
 		}
 
-		String debugStack = overriddenOut.toString();
+		String debugStack = StatsTestSupport.overriddenOut.toString();
 
 		Iterator<String> lines = Stream.of(debugStack.split("\n"))
 		                               .iterator();
@@ -218,7 +210,7 @@ public class MonoStatsReportTest {
 			// ignored
 		}
 
-		String debugStack = overriddenOut.toString();
+		String debugStack = StatsTestSupport.overriddenOut.toString();
 
 		Iterator<String> lines = Stream.of(debugStack.split("\n"))
 		                               .iterator();


### PR DESCRIPTION
This PR introduces a Stats utility that allows stats reporting to a logger

## Motivation 

Usually, it is challenging to analyze what is going on within your data pipeline. Metrics are useful to get general "performance" insights for your stream. Debug hooks allow detecting the root cause operator. However, there is a gap in detecting general issues, like timeouts, which operator underperform, etc.

## Solution

In order to simplify the process of the mentioned problems detections, this PR introduces an extra `StatsOperator` which builds a graph from the whole execution pipeline and then collect all important information like:

1. The Number of produced items.
1. The Number of requested items.
1. The average execution time of that particular operator (is different from one provided by metrics).
1. The Last Observed signal (e.g. what happened last before `cancel | error | complete`)
1. The Current State of that operator (e.g. `canceled` | `completed` | `errored` | `none`)

All this information is printed after the execution in the well-formed stack trace like output which looks like the following 

```
10:43:19.381 [parallel-1] INFO  r.c.publisher.DefaultStatsReporter - The following stats are collected:
  	|  Flux.range       ⇢ at reactor.examples.ReportRootHangingTest.timeoutNightmare(ReportRootHangingTest.java:23)
  	|_                  ↳ Stats(Requested: 256; Produced: 100; OnNext ~Time: 450ns; Last Signal:  onNext; State: canceled)
  	|  Flux.map         ⇢ at reactor.examples.ReportRootHangingTest.timeoutNightmare(ReportRootHangingTest.java:24)
  	|_                  ↳ Stats(Requested: 256; Produced: 100; OnNext ~Time: 728ns; Last Signal:  onNext; State: canceled)
 	|  Flux.transform   ⇢ at reactor.examples.ReportRootHangingTest.timeoutNightmare(ReportRootHangingTest.java:25)
  	|_                  ↳ Stats(Requested: 256; Produced:   0; OnNext ~Time:   0ns; Last Signal: request; State: canceled)
  	|  Flux.map         ⇢ at reactor.examples.ReportRootHangingTest.timeoutNightmare(ReportRootHangingTest.java:29)
  	|_                  ↳ Stats(Requested: 256; Produced:   0; OnNext ~Time:   0ns; Last Signal: request; State: canceled)
  	|  Flux.subscribeOn ⇢ at reactor.examples.ReportRootHangingTest.timeoutNightmare(ReportRootHangingTest.java:30)
  	|_                  ↳ Stats(Requested: 256; Produced:   0; OnNext ~Time:   0ns; Last Signal: request; State: canceled)
  	|  Flux.filter      ⇢ at reactor.examples.ReportRootHangingTest.timeoutNightmare(ReportRootHangingTest.java:31)
  	|_                  ↳ Stats(Requested: 256; Produced:   0; OnNext ~Time:   0ns; Last Signal: request; State: canceled)
  	|  Flux.publishOn   ⇢ at reactor.examples.ReportRootHangingTest.timeoutNightmare(ReportRootHangingTest.java:33)
  	|_                  ↳ Stats(Requested:   ∞; Produced:   0; OnNext ~Time:   0ns; Last Signal: request; State: canceled)
  	|  Flux.timeout     ⇢ at reactor.examples.ReportRootHangingTest.timeoutNightmare(ReportRootHangingTest.java:34)
  	|_                  ↳ Stats(Requested:   ∞; Produced:   0; OnNext ~Time:   0ns; Last Signal: request; State:  errored)
  	|  Flux.metrics     ⇢ at reactor.examples.ReportRootHangingTest.timeoutNightmare(ReportRootHangingTest.java:35)
  	|_                  ↳ Stats(Requested:   ∞; Produced:   0; OnNext ~Time:   0ns; Last Signal: request; State:  errored)

```

In order to print such an output, `StatsOperator` uses `AssemblySnapshot`. Also, there is an abstract utility like `StatsReporter` which allows configuring where such output should be printed and what is the format of the output (e.g. one might want to see such an out as Graphviz diagram).

Also, this PR introduced output analyzers, called `StatsMarkers` which can add an extra marker to the output to say that this particular operator is the source of, for instance, timeout:


```
10:43:19.381 [parallel-1] INFO  r.c.publisher.DefaultStatsReporter - The following stats are collected:
...
🔎	|  Flux.transform   ⇢ at reactor.examples.ReportRootHangingTest.timeoutNightmare(ReportRootHangingTest.java:25)
  	|_                  ↳ Stats(Requested: 256; Produced:   0; OnNext ~Time:   0ns; Last Signal: request; State: canceled)
...

```

## HowTo Use 

In order to track advanced debug information and collect reports, you just need to use `Hook` API and enable the following 2 properties:

```java
Hooks.enableStatsRecording();
Hooks.onOperatorDebug();
```

Having that enabled, you may run your app, and if an exception occurs, you will see a detailed report which has extra info on what might cause the error 

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>