### PR TITLE
Add doOnEach variant similar to doFirst&doOnCancel + Context

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -4386,14 +4386,18 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <ol>
 	 *     <li>
 	 *         when the {@link Flux} is subscribed to ({@link SignalType#SUBSCRIBE},
-	 *         see {@link #doFirst(Runnable)})
+	 *         see {@link #doFirst(Runnable)}).
+	 *         <br/>Executed BEFORE the previous operator in the chain is subscribed.
 	 *     </li>
 	 *     <li>
 	 *         when it establishes the {@link Subscription} with said {@link Subscriber} ({@link SignalType#ON_SUBSCRIBE},
-	 *         see {@link #doOnSubscribe(Consumer)})</li>
+	 *         see {@link #doOnSubscribe(Consumer)}).
+	 * 	       <br/>Executed BEFORE a similar onSubscribe signal is passed downstream.
+	 * 	   </li>
 	 *     <li>
 	 *         when said {@link Subscriber} cancels its {@link Subscription} ({@link SignalType#CANCEL},
-	 *         see {@link #doOnCancel(Runnable)})
+	 *         see {@link #doOnCancel(Runnable)}).
+	 *         <br/>Executed AFTER the upstream has been cancelled.
 	 *     </li>
 	 * </ol>
 	 * <p>

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -4376,9 +4376,41 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final Flux<T> doOnEach(Consumer<? super Signal<T>> signalConsumer) {
 		if (this instanceof Fuseable) {
-			return onAssembly(new FluxDoOnEachFuseable<>(this, signalConsumer));
+			return onAssembly(new FluxDoOnEachFuseable<>(this, signalConsumer, null));
 		}
-		return onAssembly(new FluxDoOnEach<>(this, signalConsumer));
+		return onAssembly(new FluxDoOnEach<>(this, signalConsumer, null));
+	}
+
+	/**
+	 * Add behavior triggered around events relative to subscriptions to this {@link Flux}:
+	 * <ol>
+	 *     <li>
+	 *         when the {@link Flux} is subscribed to ({@link SignalType#SUBSCRIBE},
+	 *         see {@link #doFirst(Runnable)})
+	 *     </li>
+	 *     <li>
+	 *         when it establishes the {@link Subscription} with said {@link Subscriber} ({@link SignalType#ON_SUBSCRIBE},
+	 *         see {@link #doOnSubscribe(Consumer)})</li>
+	 *     <li>
+	 *         when said {@link Subscriber} cancels its {@link Subscription} ({@link SignalType#CANCEL},
+	 *         see {@link #doOnCancel(Runnable)})
+	 *     </li>
+	 * </ol>
+	 * <p>
+	 * In each event, only the type of signal is notified, along with the {@link Context} attached to the {@link Subscriber}.
+	 *
+	 * @return a {@link Flux} with the {@link Subscription}-relative events observed within a single lambda
+	 * @see #doOnSubscribe(Consumer)
+	 * @see #doFinally(Consumer)
+	 * @see #doFirst(Runnable)
+	 * @see #doOnEach(Consumer)
+	 * @see SignalType
+	 */
+	public final Flux<T> doOnEachSubscriptionLifecyle(BiConsumer<SignalType, Context> subscriptionLifecycleListener) {
+		if (this instanceof Fuseable) {
+			return onAssembly(new FluxDoOnEachFuseable<>(this, ignored -> {}, subscriptionLifecycleListener));
+		}
+		return onAssembly(new FluxDoOnEach<>(this, ignored -> {}, subscriptionLifecycleListener));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDoOnEachFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDoOnEachFuseable.java
@@ -17,10 +17,13 @@
 package reactor.core.publisher;
 
 import java.util.Objects;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * Peek into the lifecycle events and signals of a sequence, {@link Fuseable} version of
@@ -32,16 +35,23 @@ import reactor.core.Fuseable;
  */
 final class FluxDoOnEachFuseable<T> extends InternalFluxOperator<T, T> implements Fuseable {
 
-	final Consumer<? super Signal<T>> onSignal;
+	final Consumer<? super Signal<T>>     onSignal;
+	@Nullable
+	final BiConsumer<SignalType, Context> onSubscriptionSignal;
 
-	FluxDoOnEachFuseable(Flux<? extends T> source, Consumer<? super Signal<T>> onSignal) {
+	FluxDoOnEachFuseable(Flux<? extends T> source, Consumer<? super Signal<T>> onSignal,
+			@Nullable BiConsumer<SignalType, Context> signal) {
 		super(source);
 		this.onSignal = Objects.requireNonNull(onSignal, "onSignal");
+		onSubscriptionSignal = signal;
 	}
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
-		return FluxDoOnEach.createSubscriber(actual, this.onSignal, true, false);
+		if (onSubscriptionSignal != null) {
+			onSubscriptionSignal.accept(SignalType.SUBSCRIBE, actual.currentContext());
+		}
+		return FluxDoOnEach.createSubscriber(actual, this.onSignal, this.onSubscriptionSignal,true, false);
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/ImmutableSignal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ImmutableSignal.java
@@ -82,49 +82,38 @@ final class ImmutableSignal<T> implements Signal<T>, Serializable {
 	}
 
 	@Override
-	public boolean equals(@Nullable Object o) {
+	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
 		}
-		if (o == null || !(o instanceof Signal)) {
+		if (o == null || getClass() != o.getClass()) {
 			return false;
 		}
 
-		Signal<?> signal = (Signal<?>) o;
+		ImmutableSignal<?> signal = (ImmutableSignal<?>) o;
 
 		if (getType() != signal.getType()) {
 			return false;
 		}
-		if (isOnComplete()) {
-			return true;
+		if (getThrowable() != null ? !getThrowable().equals(signal.getThrowable()) :
+				signal.getThrowable() != null) {
+			return false;
 		}
-		if (isOnSubscribe()) {
-			return Objects.equals(this.getSubscription(), signal.getSubscription());
+		if (value != null ? !value.equals(signal.value) : signal.value != null) {
+			return false;
 		}
-		if (isOnError()) {
-			return Objects.equals(this.getThrowable(), signal.getThrowable());
-		}
-		if (isOnNext()) {
-			return Objects.equals(this.get(), signal.get());
-		}
-		return false;
+		return getSubscription() != null ?
+				getSubscription().equals(signal.getSubscription()) :
+				signal.getSubscription() == null;
 	}
 
 	@Override
 	public int hashCode() {
 		int result = getType().hashCode();
-		if (isOnError()) {
-			return  31 * result + (getThrowable() != null ? getThrowable().hashCode() :
-					0);
-		}
-		if (isOnNext()) {
-			//noinspection ConstantConditions
-			return  31 * result + (get() != null ? get().hashCode() : 0);
-		}
-		if (isOnSubscribe()) {
-			return  31 * result + (getSubscription() != null ?
-					getSubscription().hashCode() : 0);
-		}
+		result = 31 * result + (getThrowable() != null ? getThrowable().hashCode() : 0);
+		result = 31 * result + (value != null ? value.hashCode() : 0);
+		result = 31 * result + (getSubscription() != null ? getSubscription().hashCode() :
+				0);
 		return result;
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ImmutableSignal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ImmutableSignal.java
@@ -82,38 +82,49 @@ final class ImmutableSignal<T> implements Signal<T>, Serializable {
 	}
 
 	@Override
-	public boolean equals(Object o) {
+	public boolean equals(@Nullable Object o) {
 		if (this == o) {
 			return true;
 		}
-		if (o == null || getClass() != o.getClass()) {
+		if (o == null || !(o instanceof Signal)) {
 			return false;
 		}
 
-		ImmutableSignal<?> signal = (ImmutableSignal<?>) o;
+		Signal<?> signal = (Signal<?>) o;
 
 		if (getType() != signal.getType()) {
 			return false;
 		}
-		if (getThrowable() != null ? !getThrowable().equals(signal.getThrowable()) :
-				signal.getThrowable() != null) {
-			return false;
+		if (isOnComplete()) {
+			return true;
 		}
-		if (value != null ? !value.equals(signal.value) : signal.value != null) {
-			return false;
+		if (isOnSubscribe()) {
+			return Objects.equals(this.getSubscription(), signal.getSubscription());
 		}
-		return getSubscription() != null ?
-				getSubscription().equals(signal.getSubscription()) :
-				signal.getSubscription() == null;
+		if (isOnError()) {
+			return Objects.equals(this.getThrowable(), signal.getThrowable());
+		}
+		if (isOnNext()) {
+			return Objects.equals(this.get(), signal.get());
+		}
+		return false;
 	}
 
 	@Override
 	public int hashCode() {
 		int result = getType().hashCode();
-		result = 31 * result + (getThrowable() != null ? getThrowable().hashCode() : 0);
-		result = 31 * result + (value != null ? value.hashCode() : 0);
-		result = 31 * result + (getSubscription() != null ? getSubscription().hashCode() :
-				0);
+		if (isOnError()) {
+			return  31 * result + (getThrowable() != null ? getThrowable().hashCode() :
+					0);
+		}
+		if (isOnNext()) {
+			//noinspection ConstantConditions
+			return  31 * result + (get() != null ? get().hashCode() : 0);
+		}
+		if (isOnSubscribe()) {
+			return  31 * result + (getSubscription() != null ?
+					getSubscription().hashCode() : 0);
+		}
 		return result;
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/OptimizableOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/OptimizableOperator.java
@@ -35,7 +35,13 @@ interface OptimizableOperator<IN, OUT> extends CorePublisher<IN> {
 
 	/**
 	 * Allow delegation of the subscription by returning a {@link CoreSubscriber}, or force
-	 * subscription encapsulation by returning null. This can be used in conjunction with {@link #nextOptimizableSource()}
+	 * subscription encapsulation by returning null.
+	 * <br/>
+	 * Caller MUST catch exceptions and report them to the most relevant {@link org.reactivestreams.Subscriber},
+	 * generally using {@link Operators#reportThrowInSubscribe(CoreSubscriber, Throwable)},
+	 * rather than letting them bubble up the call stack.
+	 * <p>
+	 * This can be used in conjunction with {@link #nextOptimizableSource()}
 	 * to perform subscription in a loop instead of by recursion.
 	 *
 	 * @return next {@link CoreSubscriber} or "null" if the subscription was already done inside the method

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelDoOnEach.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelDoOnEach.java
@@ -103,10 +103,13 @@ final class ParallelDoOnEach<T> extends ParallelFlux<T> implements Scannable {
 
 	private class DoOnEachSignalPeek implements SignalPeek<T> {
 
+		@Nullable
 		Consumer<? super T> onNextCall;
 
+		@Nullable
 		Consumer<? super Throwable> onErrorCall;
 
+		@Nullable
 		Runnable onCompleteCall;
 
 		public DoOnEachSignalPeek(Context ctx) {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDoOnEachTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDoOnEachTest.java
@@ -48,14 +48,14 @@ public class MonoDoOnEachTest {
 	@Test
 	public void nullSource() {
 		Assertions.assertThatNullPointerException()
-		          .isThrownBy(() -> new MonoDoOnEach<>(null, s -> {}))
+		          .isThrownBy(() -> new MonoDoOnEach<>(null, s -> {}, null))
 		          .withMessage(null);
 	}
 
 	@Test
 	public void nullConsumer() {
 		Assertions.assertThatNullPointerException()
-		          .isThrownBy(() -> new MonoDoOnEach<>(Mono.just("foo"), null))
+		          .isThrownBy(() -> new MonoDoOnEach<>(Mono.just("foo"), null, null))
 		          .withMessage("onSignal");
 	}
 
@@ -68,7 +68,7 @@ public class MonoDoOnEachTest {
 		Mono<String> source = Mockito.mock(Mono.class);
 
 		final MonoDoOnEach<String> test =
-				new MonoDoOnEach<>(source, s -> { });
+				new MonoDoOnEach<>(source, s -> { }, null);
 
 		test.subscribe();
 		Mockito.verify(source).subscribe(argumentCaptor.capture());
@@ -85,7 +85,7 @@ public class MonoDoOnEachTest {
 		                          .filter(t -> true);
 
 		final MonoDoOnEach<String> test =
-				new MonoDoOnEach<>(source, s -> { });
+				new MonoDoOnEach<>(source, s -> { }, null);
 
 		test.filter(t -> true)
 		    .subscribe();


### PR DESCRIPTION
This commit adds doOnEachSubscriptionLifecycle, a dual to doOnEach
that allows listening to SUBSCRIBE, ON_SUBSCRIBE and CANCEL events in a
single lambda.

Additionally, contrary to doFirst/doOnCancel/doOnSubscribe it exposes
the Context.

Extending Signal with these new SignalType could have induced breaking
of existing code that doesn't strictly check the Signal's type when
processing it and using its getters. So this new operator doesn't expose
a Signal but works with a `BiConsumer<SignalType, Context>`. This is
assumed sufficient, as the "data" associated to such signals is of
limited use (basically Subscription for ON_SUBSCRIBE).