### PR TITLE
Rework linking between check, japicmp and downloadBaseline tasks

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -101,32 +101,30 @@ jmh {
 	resultFormat = 'JSON'
 }
 
-task downloadBaseline {
-	if (project.gradle.startParameter.isOffline()) {
-		println "Offline: skipping downloading of baseline and JAPICMP"
-	}
-	else if ("$compatibleVersion" == "SKIP") {
-		println "SKIP: Instructed to skip the baseline comparison"
-	}
-	else {
-		println "Will download and perform baseline comparison with ${compatibleVersion}"
-		finalizedBy { doDownloadBaseline }
-	}
-}
-
-task doDownloadBaseline(type: Download) {
+task downloadBaseline(type: Download) {
 	onlyIfNewer true
 	compress true
 
 	src "${repositories.jcenter().url}io/projectreactor/reactor-core/$compatibleVersion/reactor-core-${compatibleVersion}.jar"
 	dest "${buildDir}/baselineLibs/reactor-core-${compatibleVersion}.jar"
-
-	finalizedBy { japicmp }
 }
 
 task japicmp(type: JapicmpTask) {
+	if (project.gradle.startParameter.isOffline()) {
+		println "Offline: skipping downloading of baseline and JAPICMP"
+	  	enabled = false
+	}
+	else if ("$compatibleVersion" == "SKIP") {
+		println "SKIP: Instructed to skip the baseline comparison"
+	  	enabled = false
+	}
+	else {
+		println "Will download and perform baseline comparison with ${compatibleVersion}"
+	  	dependsOn(downloadBaseline)
+	}
+
 	oldClasspath = files("${buildDir}/baselineLibs/reactor-core-${compatibleVersion}.jar")
-	newClasspath = files(jar.archivePath)
+	newClasspath = files(jar.archiveFile)
 	onlyBinaryIncompatibleModified = true
 	failOnModification = true
 	failOnSourceIncompatibility = true
@@ -250,7 +248,7 @@ jar {
 
 jacocoTestReport.dependsOn test
 check.dependsOn jacocoTestReport
-jar.finalizedBy(downloadBaseline)
+check.dependsOn japicmp
 
 if (JavaVersion.current().java9Compatible) {
 	sourceSets {

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -49,20 +49,7 @@ dependencies {
 	testCompile "org.mockito:mockito-core:$mockitoVersion"
 }
 
-task downloadBaseline {
-	if (project.gradle.startParameter.isOffline()) {
-		println "Offline: skipping downloading of baseline and JAPICMP"
-	}
-	else if ("$compatibleVersion" == "SKIP") {
-		println "SKIP: Instructed to skip the baseline comparison"
-	}
-	else {
-		println "Will download and perform baseline comparison with ${compatibleVersion}"
-		finalizedBy { doDownloadBaseline }
-	}
-}
-
-task doDownloadBaseline(type: Download) {
+task downloadBaseline(type: Download) {
 	onlyIfNewer true
 	compress true
 
@@ -73,8 +60,21 @@ task doDownloadBaseline(type: Download) {
 }
 
 task japicmp(type: JapicmpTask) {
+	if (project.gradle.startParameter.isOffline()) {
+		println "Offline: skipping downloading of baseline and JAPICMP"
+	  	enabled = false
+	}
+	else if ("$compatibleVersion" == "SKIP") {
+		println "SKIP: Instructed to skip the baseline comparison"
+	  	enabled = false
+	}
+	else {
+		println "Will download and perform baseline comparison with ${compatibleVersion}"
+	  	dependsOn(downloadBaseline)
+	}
+
 	oldClasspath = files("${buildDir}/baselineLibs/reactor-test-${compatibleVersion}.jar")
-	newClasspath = files(jar.archivePath)
+	newClasspath = files(jar.archiveFile)
 	onlyBinaryIncompatibleModified = true
 	failOnModification = true
 	failOnSourceIncompatibility = true
@@ -138,7 +138,7 @@ jar {
 	bnd(bndOptions)
 }
 
-jar.finalizedBy(downloadBaseline)
+check.dependsOn japicmp
 
 //add kdoc to the publication
 publishing.publications.mavenJava.artifact(kdocZip)


### PR DESCRIPTION
Extracted from #2202 and backported to `3.2.x`