### PR TITLE
fix #2184 Add scope operator to deal with Context manipulation

### DIFF
--- a/docs/asciidoc/advancedFeatures.adoc
+++ b/docs/asciidoc/advancedFeatures.adoc
@@ -831,10 +831,15 @@ its `ContextView`:
  - to access the context from data signals, use `doOnEach` and `Signal#getContext()`
  - alternatively, when dealing with an inner sequence (like inside a `flatMap`), the `ContextView`
  can be materialized using `Mono.deferWithContext(Mono::just)`
+ - to change the context of a subset of the operator chain and restore the original upstream of that subset,
+   use `scope`.
 
 TIP: In order to read from the `Context` without misleading users into thinking one can write to it
 while data is running through the pipeline, only the `ContextView` is exposed by the operators above.
 
+TIP: `scope` can also be used to locally tune the behavior of the sequence (discard hooks, continuing
+on errors, etc...). These are advanced configurations that go around the Reactive Streams spec a bit and
+only work on core Reactor operators (because they are based on storing a flag in the `Context`).
 
 === Simple `Context` Examples
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextTrackingFunctionWrapper.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextTrackingFunctionWrapper.java
@@ -33,6 +33,10 @@ class ContextTrackingFunctionWrapper<T, V> implements Function<CorePublisher<T>,
 
 	static final String CONTEXT_MARKER_PREFIX = "reactor.core.context.marker.";
 
+	static final String generateKey(CorePublisher<?> target) {
+		return CONTEXT_MARKER_PREFIX + System.identityHashCode(target);
+	}
+
 	final Function<? super Publisher<T>, ? extends Publisher<V>> transformer;
 
 	ContextTrackingFunctionWrapper(Function<? super Publisher<T>, ? extends Publisher<V>> transformer) {
@@ -41,7 +45,7 @@ class ContextTrackingFunctionWrapper<T, V> implements Function<CorePublisher<T>,
 
 	@Override
 	public CorePublisher<V> apply(CorePublisher<T> self) {
-		String key = CONTEXT_MARKER_PREFIX + System.identityHashCode(self);
+		String key = generateKey(self);
 
 		Publisher<V> newSource = Operators.<T, T>liftPublisher((p, actual) -> {
 			Context ctx = actual.currentContext();

--- a/reactor-core/src/main/java/reactor/core/publisher/ScopeContext.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ScopeContext.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import reactor.util.context.ContextView;
+
+/**
+ * @author Simon Baslé
+ */
+public interface ScopeContext {
+
+	ContextView contextOutsideScope();
+
+	ContextView contextInScope();
+
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/ScopeMutableSpec.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ScopeMutableSpec.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+import reactor.util.context.Context;
+import reactor.util.context.ContextView;
+
+/**
+ * Mutable options for the {@link Flux#scope(Consumer, BiFunction)} operator, mainly around handling
+ * {@link Context} and special hooks within the scope. Provided directly by the operator to a
+ * {@link Consumer} for further user configuration. The result is then exposed in the operator as
+ * a {@link ScopeContext} read-only object.
+ */
+public final class ScopeMutableSpec implements ScopeContext {
+
+	private static Context TOTALLY_RESET(ContextView original, Context inner) {
+		return Context.fromReadOnly(original);
+	}
+
+	/**
+	 * Create a {@link ScopeMutableSpec} to be passed to the {@link Consumer} of {@link Flux#scope(Consumer, BiFunction) a scope}
+	 * for further configuration.
+	 *
+	 * @return a new {@link ScopeMutableSpec} with no amends, total reset strategy, for the given original {@link Context}
+	 */
+	static final ScopeMutableSpec mutableSpec(ContextView original) {
+		return new ScopeMutableSpec(Context.fromReadOnly(original), Context.empty(), ScopeMutableSpec::TOTALLY_RESET);
+	}
+
+	final Context                             original; //needs to be Context to allow putAll of amends
+	Context                                   contextAmends;
+	BiFunction<ContextView, Context, Context> contextRestoreStrategy; //original, inScope, restored
+
+	private ScopeMutableSpec(final Context original, Context context, BiFunction<ContextView, Context, Context> contextRestoreStrategy) {
+		this.original = original;
+		this.contextAmends = context;
+		this.contextRestoreStrategy = contextRestoreStrategy;
+	}
+
+	@Override
+	public ContextView contextOutsideScope() {
+		return this.original;
+	}
+
+	@Override
+	public ContextView contextInScope() {
+		return fullContextInScope();
+	}
+
+	Context fullContextInScope() {
+		return this.original.putAll(this.contextAmends);
+	}
+
+	public ScopeContext readOnly() {
+		return this;
+	}
+
+	/**
+	 * Used for the simple strategy {@link #setRestoreStrategyToRemoveHooks()}.
+	 */
+	private Context removeHookKeys(ContextView original, Context inner) {
+		return inner.delete(Hooks.KEY_ON_DISCARD);
+	}
+
+	/**
+	 * Used for the intermediate strategy {@link #setRestoreStrategyToRemoveAllModifiedKeys()}.
+	 */
+	private Context removeAmendedKeys(ContextView original, Context inner) {
+		final Context[] result = {inner};
+		this.contextAmends.stream().forEach(e -> {
+			result[0] = result[0].delete(e.getKey());
+		});
+		return result[0];
+	}
+
+	Context restore(Context contextInScope) {
+		return this.contextRestoreStrategy.apply(original, contextInScope);
+	}
+
+	/**
+	 * Outside (upstream) of the scope, the whole {@link Context} is reset to the value
+	 * visible downstream of the scope. This includes discard hooks.
+	 *
+	 * @return this {@link ScopeMutableSpec} for further setup
+	 */
+	public ScopeMutableSpec setRestoreStrategyToReset() {
+		return setRestoreStrategyTo(ScopeMutableSpec::TOTALLY_RESET);
+	}
+
+	/**
+	 * Outside (upstream) of the scope, the {@link Context} is rewritten to have the
+	 * hooks set up in scope options removed. Free-form entries set via {@link #putInContext(Object, Object)}
+	 * and {@link #putAllInContext(Context)} are preserved.
+	 *
+	 * @return this {@link ScopeMutableSpec} for further setup
+	 */
+	public ScopeMutableSpec setRestoreStrategyToRemoveHooks() {
+		return setRestoreStrategyTo(this::removeHookKeys);
+	}
+
+	/**
+	 * Outside (upstream) of the scope, the whole {@link Context} is rewritten to <strong>remove</strong>
+	 * all entries modified via the options. This includes discard hooks, but also free-form entries
+	 * set via {@link #putInContext(Object, Object)} and {@link #putAllInContext(Context)}.
+	 *
+	 * @return this {@link ScopeMutableSpec} for further setup
+	 */
+	public ScopeMutableSpec setRestoreStrategyToRemoveAllModifiedKeys() {
+		return setRestoreStrategyTo(this::removeAmendedKeys);
+	}
+
+	/**
+	 * Outside (upstream) of the scope, the whole {@link Context} is rewritten according to the provided
+	 * {@link BiFunction}, which receives the original {@link ContextView} as visible downstream of the scope and the
+	 * modified {@link Context} as visible from within the scope.
+	 *
+	 * @return this {@link ScopeMutableSpec} for further setup
+	 */
+	public ScopeMutableSpec setRestoreStrategyTo(BiFunction<ContextView, Context, Context> strategyFromOriginalAndInner) {
+		this.contextRestoreStrategy = strategyFromOriginalAndInner;
+		return this;
+	}
+
+	/**
+	 * Augment the {@link Context} in this scope with an additional discard hook.
+	 * //TODO give more details on discard hooks and how they combine
+	 *
+	 * @param discardHook
+	 * @return this {@link ScopeMutableSpec} for further setup
+	 */
+	public ScopeMutableSpec addDiscardHandler(Consumer<?> discardHook) {
+		this.contextAmends = Operators.addOnDiscard(contextAmends, discardHook);
+		return this;
+	}
+
+	/**
+	 * Augment the {@link Context} in this scope with an additional type-safe discard hook.
+	 * //TODO give more details on discard hooks and how they combine
+	 *
+	 * @param clazz
+	 * @param discardHook
+	 * @return this {@link ScopeMutableSpec} for further setup
+	 */
+	public <T> ScopeMutableSpec addDiscardHandler(Class<T> clazz, Consumer<? super T> discardHook) {
+		this.contextAmends = Operators.discardLocalAdapter(clazz, discardHook).apply(contextAmends);
+		return this;
+	}
+
+	/**
+	 * Augment the {@link Context} in this scope with a custom entry, replacing any value that would
+	 * previously be set for the given key.
+	 *
+	 * @param key the key to add/replace
+	 * @param value the value for the key
+	 * @return this {@link ScopeMutableSpec} for further setup
+	 */
+	public ScopeMutableSpec putInContext(Object key, Object value) {
+		this.contextAmends = contextAmends.put(key, value);
+		return this;
+	}
+
+	/**
+	 * Augment the {@link Context} in this scope with custom entries, replacing any value that would
+	 * previously be set for the given keys.
+	 *
+	 * @param entries the {@link Context} from which to {@link Context#putAll(Context) add/replace all} entries
+	 * @return this {@link ScopeMutableSpec} for further setup
+	 */
+	public ScopeMutableSpec putAllInContext(Context entries) {
+		this.contextAmends = this.contextAmends.putAll(entries);
+		return this;
+	}
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/ContextLossDetectionTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ContextLossDetectionTest.java
@@ -70,6 +70,7 @@ public class ContextLossDetectionTest {
 						return Mono.deferWithContext(Mono::just).transformDeferred(f);
 					}
 				}
+				//TODO test scope?
 		);
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxScopeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxScopeTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.junit.Test;
+
+import reactor.util.context.Context;
+import reactor.util.context.ContextView;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Simon Baslé
+ */
+public class FluxScopeTest {
+
+	//TODO perform tests around non-reactor publishers/subscribers in the middle of the chain
+
+	@Test
+	public void smokeTest() {
+		Context downmost = Context.of("key1", "value1");
+		List<Object> discarded = new ArrayList<>();
+		List<Integer> discardedInts = new ArrayList<>();
+
+		Flux.range(1, 20)
+		    .hide()
+		    .filter(i -> i % 2 == 0)
+		    .scope(spec -> spec.addDiscardHandler(discarded::add)
+		                       .addDiscardHandler(Integer.class, discardedInts::add),
+				    (scopeCtx, f) -> f.filter(i -> i % 5 != 0))
+		    .log()
+		    .subscriberContext(downmost)
+		    .blockLast();
+
+		assertThat(discarded).containsExactly(10, 20);
+		assertThat(discardedInts).containsExactly(10, 20);
+	}
+
+	@Test
+	public void restoreByResetReturnsToOriginal() {
+		AtomicReference<ContextView> contextUpstreamRef = new AtomicReference<>();
+		AtomicReference<ContextView> contextDownstreamRef = new AtomicReference<>();
+
+		Flux.range(1, 20)
+		    .doOnEach(s -> {
+			    if (s.isOnComplete()) {
+				    contextUpstreamRef.set(s.getContext());
+			    }
+		    })
+		    .hide()
+		    .filter(i -> i % 2 == 0)
+		    .scope(spec -> spec.setRestoreStrategyToReset()
+		                       .putInContext("key1", "temp")
+		                       .putInContext("key2", "inner2"),
+				    (scopeCtx, f) -> f.filter(i -> i % 5 != 0))
+		    .doOnEach(s -> {
+			    if (s.isOnComplete()) {
+				    contextDownstreamRef.set(s.getContext());
+			    }
+		    })
+		    //NB: the Context provided below and the actual context (captured above) are different
+		    .subscriberContext(Context.of("key1", "value1"))
+		    .blockLast();
+
+		assertThat(contextUpstreamRef.get())
+				.isNotNull()
+				.isSameAs(contextDownstreamRef.get())
+				.matches(c -> c.size() == 1, "size(1)")
+				.matches(c -> c.getOrDefault("key1", "NOT SET").equals("value1"), "key1 back to value1");
+	}
+
+	@Test
+	public void restoreByRemovingAllKeysDiscardsOverwrittenKeysAndHooks() {
+		AtomicReference<ContextView> contextUpstreamRef = new AtomicReference<>();
+
+		Flux.range(1, 20)
+		    .doOnEach(s -> {
+			    if (s.isOnComplete()) {
+				    contextUpstreamRef.set(s.getContext());
+			    }
+		    })
+		    .hide()
+		    .filter(i -> i % 2 == 0)
+		    .scope(spec -> spec.setRestoreStrategyToRemoveAllModifiedKeys()
+		                       .putInContext("key1", "temp")
+		                       .putInContext("key2", "inner2"),
+				    (scopeCtx, f) -> f.filter(i -> i % 5 != 0))
+		    .subscriberContext(Context.of("key1", "value1"))
+		    .blockLast();
+
+		assertThat(contextUpstreamRef.get())
+				.isNotNull()
+				.matches(c -> c.size() == 0, "both key1 and key2 removed");
+	}
+
+	@Test
+	public void restoreByRemovingHooksKeepsInnerWrites() {
+		AtomicReference<ContextView> contextUpstreamRef = new AtomicReference<>();
+
+		Flux.range(1, 20)
+		    .doOnEach(s -> {
+			    if (s.isOnComplete()) {
+				    contextUpstreamRef.set(s.getContext());
+			    }
+		    })
+		    .hide()
+		    .filter(i -> i % 2 == 0)
+		    .scope(spec -> spec.setRestoreStrategyToRemoveHooks()
+		                       .putInContext("key1", "temp")
+		                       .putInContext("key2", "inner2"),
+				    (scopeCtx, f) -> f.filter(i -> i % 5 != 0))
+		    .subscriberContext(Context.of("key1", "value1"))
+		    .blockLast();
+
+		assertThat(contextUpstreamRef.get())
+				.isNotNull()
+				.matches(c -> c.size() == 2, "size(2)")
+				.matches(c -> c.getOrDefault("key1", "NOT SET").equals("temp"), "key1=temp")
+				.matches(c -> c.getOrDefault("key2", "NOT SET").equals("inner2"), "key2=inner2");
+	}
+
+	@Test
+	public void restoreByRemovingHooksRemovesDiscardKeyEntirely() {
+		Context ctx1 = Context.of("key1", "value1");
+		Consumer<Object> consumer1 = s -> {};
+		Consumer<Object> consumer2 = s -> {};
+
+		AtomicReference<ContextView> contextUpstreamRef = new AtomicReference<>();
+		AtomicReference<ContextView> contextInnerRef = new AtomicReference<>();
+
+		Flux.range(1, 20)
+		    .doOnEach(s -> {
+			    if (s.isOnComplete()) {
+				    contextUpstreamRef.set(s.getContext());
+			    }
+		    })
+		    .hide()
+		    .filter(i -> i % 2 == 0)
+		    .scope(spec -> spec.addDiscardHandler(consumer1)
+		                       .setRestoreStrategyToRemoveHooks(),
+				    (scopeCtx, f) -> f.doOnEach(s -> {
+					    if (s.isOnComplete()) {
+						    contextInnerRef.set(s.getContext());
+					    }
+				    })
+				                     .filter(i -> i % 5 != 0))
+		    .subscriberContext(c -> Operators.addOnDiscard(c, consumer2))
+		    .subscriberContext(ctx1)
+		    .blockLast();
+
+		assertThat(contextInnerRef.get())
+				.isNotNull()
+				.matches(c -> c.size() == 2, "size(2)")
+				.matches(c -> c.getOrDefault("key1", "NOT SET").equals("value1"), "key1=value1")
+				.matches(c -> c.get(Hooks.KEY_ON_DISCARD) == consumer1, "inner has discard hook from options");
+
+		assertThat(contextUpstreamRef.get())
+				.isNotNull()
+				.matches(c -> c.size() == 1, "size(1)")
+				.matches(c -> c.getOrDefault("key1", "NOT SET").equals("value1"), "key1=value1");
+	}
+
+	@Test
+	public void resetUpstreamDoesStillTriggerOuterDiscardHook() {
+		List<Object> discardedOuter = new ArrayList<>();
+		List<Object> discardedInner = new ArrayList<>();
+
+		Flux.range(1, 20)
+		    .hide()
+		    .filter(i -> i % 5 != 0)
+		    .scope(spec -> spec.addDiscardHandler(discardedInner::add)
+		                       .setRestoreStrategyToReset(),
+				    (scopeCtx, f) -> f)
+		    .doOnDiscard(Integer.class, discardedOuter::add)
+		    .blockLast();
+
+		assertThat(discardedInner).isEmpty();
+		assertThat(discardedOuter).containsExactly(5, 10, 15, 20);
+	}
+
+	@Test
+	public void performContextLoggingInMiddleOfChain() {
+		List<String> messages = new ArrayList<>();
+		Flux<Integer> flux = Flux
+				.range(1, 10)
+				.scope(
+						spec -> spec.putInContext("traceId", "EXAMPLE2"),
+						(scopeCtx, f) -> {
+							System.out.println("Original: " + scopeCtx.contextOutsideScope());
+							System.out.println("Scoped: " + scopeCtx.contextInScope());
+
+							return Flux.deferWithContext(ctx -> {
+								System.out.println("Defer inside scope:" + ctx);
+								String traceId = ctx.getOrDefault("traceId", "NO_SCOPED_TRACEID");
+								String oldTraceId = scopeCtx.contextOutsideScope().getOrDefault("traceId", "NO_ORIGINAL_TRACEID");
+								return f.doFirst(() -> messages.add("first " + traceId + " (formerly " + oldTraceId + ")"))
+								        .doOnNext(v -> {
+									        //there is no access to the contexts here, just the ContextView which only allow read operations
+									        messages.add("onNext(" + v + ") for " + traceId);
+								        })
+								        .doFinally(st -> messages.add(traceId + " (formerly " + oldTraceId + ") terminated with " + st));
+							});
+						})
+				.flatMap(i -> Flux.range(i * 10, i));
+
+		flux.subscriberContext(Context.of("traceId", "EXAMPLE1"))
+		    .blockLast();
+
+		assertThat(messages).containsExactly("first EXAMPLE2 (formerly EXAMPLE1)",
+				"onNext(1) for EXAMPLE2", "onNext(2) for EXAMPLE2",
+				"onNext(3) for EXAMPLE2", "onNext(4) for EXAMPLE2",
+				"onNext(5) for EXAMPLE2", "onNext(6) for EXAMPLE2",
+				"onNext(7) for EXAMPLE2", "onNext(8) for EXAMPLE2",
+				"onNext(9) for EXAMPLE2", "onNext(10) for EXAMPLE2",
+				"EXAMPLE2 (formerly EXAMPLE1) terminated with onComplete");
+
+		messages.clear();
+		flux.blockLast();
+
+		assertThat(messages).containsExactly("first EXAMPLE2 (formerly NO_ORIGINAL_TRACEID)",
+				"onNext(1) for EXAMPLE2", "onNext(2) for EXAMPLE2",
+				"onNext(3) for EXAMPLE2", "onNext(4) for EXAMPLE2",
+				"onNext(5) for EXAMPLE2", "onNext(6) for EXAMPLE2",
+				"onNext(7) for EXAMPLE2", "onNext(8) for EXAMPLE2",
+				"onNext(9) for EXAMPLE2", "onNext(10) for EXAMPLE2",
+				"EXAMPLE2 (formerly NO_ORIGINAL_TRACEID) terminated with onComplete");
+	}
+
+}


### PR DESCRIPTION
This is a work in progress still: a first pass at scoping `Context` manipulation, and notably errorContinue and discard hooks, to a subset of a sequence.
This would typically help with constraining the effect of `onErrorContinue` to the "scope" (which would probably fix issue #2145).