### PR TITLE
fix #2237 remove some compilation warnings

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -4930,9 +4930,8 @@ public abstract class Mono<T> implements CorePublisher<T> {
 		}
 		if (source instanceof FluxSourceMono
 				|| source instanceof FluxSourceMonoFuseable) {
-			FluxFromMonoOperator<T, T> wrapper = (FluxFromMonoOperator<T,T>) source;
 			@SuppressWarnings("unchecked")
-			Mono<T> extracted = (Mono<T>) wrapper.source;
+			Mono<T> extracted = (Mono<T>) ((FluxFromMonoOperator<T,T>) source).source;
 			return extracted;
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
@@ -135,15 +135,16 @@ public class OnDiscardShouldNotLeakTest {
 		for (int i = 0; i < 10000; i++) {
 			tracker.reset();
 			int[] index = new int[]{subscriptionsNumber};
-			TestPublisher<Tracked>[] testPublishers = new TestPublisher[subscriptionsNumber];
+			List<TestPublisher<Tracked>> testPublishers = new ArrayList<>(subscriptionsNumber);
 
 			for (int i1 = 0; i1 < subscriptionsNumber; i1++) {
-				testPublishers[i1] = TestPublisher.createNoncompliant(
+				testPublishers.add(TestPublisher.createNoncompliant(
 						TestPublisher.Violation.DEFER_CANCELLATION,
-						TestPublisher.Violation.REQUEST_OVERFLOW);
+						TestPublisher.Violation.REQUEST_OVERFLOW)
+				);
 			}
 
-			Publisher<Tracked> source = discardScenario.producePublisherFromSources(testPublishers[0], Arrays.copyOfRange(testPublishers, 1, testPublishers.length));
+			Publisher<Tracked> source = discardScenario.producePublisherFromSources(testPublishers.get(0), testPublishers.subList(1, testPublishers.size()));
 
 			if (conditional) {
 				if (source instanceof Flux) {
@@ -167,7 +168,7 @@ public class OnDiscardShouldNotLeakTest {
 								assertSubscriber::cancel,
 								() -> assertSubscriber.request(Long.MAX_VALUE),
 								scheduler),
-						() -> testPublishers[0].next(value),
+						() -> testPublishers.get(0).next(value),
 						scheduler);
 			}
 			else {
@@ -176,8 +177,8 @@ public class OnDiscardShouldNotLeakTest {
 				int secondIndex = --index[0];
 				Tracked value2 = tracker.track(secondIndex);
 				Runnable action = () -> RaceTestUtils.race(
-						() -> testPublishers[startIndex].next(value1),
-						() -> testPublishers[secondIndex].next(value2),
+						() -> testPublishers.get(startIndex).next(value1),
+						() -> testPublishers.get(secondIndex).next(value2),
 						scheduler);
 
 				while (index[0] > 0) {
@@ -186,7 +187,7 @@ public class OnDiscardShouldNotLeakTest {
 					Runnable nextAction = action;
 					action = () -> RaceTestUtils.race(
 							nextAction,
-							() -> testPublishers[nextIndex].next(nextValue),
+							() -> testPublishers.get(nextIndex).next(nextValue),
 							scheduler);
 				}
 				RaceTestUtils.race(() ->
@@ -213,15 +214,16 @@ public class OnDiscardShouldNotLeakTest {
 		for (int i = 0; i < 10000; i++) {
 			tracker.reset();
 			int[] index = new int[]{subscriptionsNumber};
-			TestPublisher<Tracked>[] testPublishers = new TestPublisher[subscriptionsNumber];
+			List<TestPublisher<Tracked>> testPublishers = new ArrayList<>(subscriptionsNumber);
 
 			for (int i1 = 0; i1 < subscriptionsNumber; i1++) {
-				testPublishers[i1] = TestPublisher.createNoncompliant(
+				testPublishers.add(TestPublisher.createNoncompliant(
 						TestPublisher.Violation.DEFER_CANCELLATION,
-						TestPublisher.Violation.REQUEST_OVERFLOW);
+						TestPublisher.Violation.REQUEST_OVERFLOW)
+				);
 			}
 
-			Publisher<Tracked> source = discardScenario.producePublisherFromSources(testPublishers[0], Arrays.copyOfRange(testPublishers, 1, testPublishers.length));
+			Publisher<Tracked> source = discardScenario.producePublisherFromSources(testPublishers.get(0), testPublishers.subList(1, testPublishers.size()));
 
 			if (conditional) {
 				if (source instanceof Flux) {
@@ -248,8 +250,8 @@ public class OnDiscardShouldNotLeakTest {
 			Tracked value23 = tracker.track(secondIndex+"3");
 			Tracked value24 = tracker.track(secondIndex+"4");
 			Runnable action = () -> RaceTestUtils.race(
-					() -> testPublishers[startIndex].next(value11, value12, value13, value14),
-					() -> testPublishers[secondIndex].next(value21, value22, value23, value24),
+					() -> testPublishers.get(startIndex).next(value11, value12, value13, value14),
+					() -> testPublishers.get(secondIndex).next(value21, value22, value23, value24),
 					scheduler);
 
 			while (index[0] > 0) {
@@ -261,7 +263,7 @@ public class OnDiscardShouldNotLeakTest {
 				Runnable nextAction = action;
 				action = () -> RaceTestUtils.race(
 						nextAction,
-						() -> testPublishers[nextIndex].next(nextValue1, nextValue2, nextValue3, nextValue4),
+						() -> testPublishers.get(nextIndex).next(nextValue1, nextValue2, nextValue3, nextValue4),
 						scheduler);
 			}
 			RaceTestUtils.race(() ->
@@ -286,7 +288,7 @@ public class OnDiscardShouldNotLeakTest {
 			TestPublisher<Tracked> testPublisher = TestPublisher.createNoncompliant(
 					TestPublisher.Violation.DEFER_CANCELLATION,
 					TestPublisher.Violation.REQUEST_OVERFLOW);
-			Publisher<Tracked> source = discardScenario.producePublisherFromSources(testPublisher);
+			Publisher<Tracked> source = discardScenario.producePublisherFromSources(testPublisher, null);
 
 			if (conditional) {
 				if (source instanceof Flux) {
@@ -336,7 +338,7 @@ public class OnDiscardShouldNotLeakTest {
 			TestPublisher<Tracked> testPublisher = TestPublisher.createNoncompliant(
 					TestPublisher.Violation.DEFER_CANCELLATION,
 					TestPublisher.Violation.REQUEST_OVERFLOW);
-			Publisher<Tracked> source = discardScenario.producePublisherFromSources(testPublisher);
+			Publisher<Tracked> source = discardScenario.producePublisherFromSources(testPublisher, null);
 
 			if (conditional) {
 				if (source instanceof Flux) {
@@ -383,8 +385,7 @@ public class OnDiscardShouldNotLeakTest {
 			TestPublisher<Tracked> testPublisher = TestPublisher.createNoncompliant(
 					TestPublisher.Violation.DEFER_CANCELLATION,
 					TestPublisher.Violation.REQUEST_OVERFLOW);
-			@SuppressWarnings("unchecked")
-			Publisher<Tracked> source = discardScenario.producePublisherFromSources(testPublisher);
+			Publisher<Tracked> source = discardScenario.producePublisherFromSources(testPublisher, null);
 
 			if (conditional) {
 				if (source instanceof Flux) {
@@ -436,7 +437,7 @@ public class OnDiscardShouldNotLeakTest {
 					TestPublisher.Violation.DEFER_CANCELLATION,
 					TestPublisher.Violation.REQUEST_OVERFLOW);
 			@SuppressWarnings("unchecked")
-			Publisher<Tracked> source = discardScenario.producePublisherFromSources(testPublisher);
+			Publisher<Tracked> source = discardScenario.producePublisherFromSources(testPublisher, null);
 
 			if (conditional) {
 				if (source instanceof Flux) {
@@ -493,8 +494,7 @@ public class OnDiscardShouldNotLeakTest {
 			TestPublisher<Tracked> testPublisher = TestPublisher.createNoncompliant(
 					TestPublisher.Violation.DEFER_CANCELLATION,
 					TestPublisher.Violation.REQUEST_OVERFLOW);
-			@SuppressWarnings("unchecked")
-			Publisher<Tracked> source = discardScenario.producePublisherFromSources(testPublisher);
+			Publisher<Tracked> source = discardScenario.producePublisherFromSources(testPublisher, null);
 
 			if (conditional) {
 				if (source instanceof Flux) {
@@ -544,13 +544,12 @@ public class OnDiscardShouldNotLeakTest {
 		}
 
 		static DiscardScenario allFluxSourceArray(String desc, int subs,
-				Function<Flux<Tracked>[], Publisher<Tracked>> producer) {
+				Function<List<Flux<Tracked>>, Publisher<Tracked>> producer) {
 			return new DiscardScenario(desc, subs, (main, others) -> {
-				@SuppressWarnings("unchecked")
-				Flux<Tracked>[] inners = new Flux[subs];
-				inners[0] = main.flux();
+				List<Flux<Tracked>> inners = new ArrayList<>(subs);
+				inners.add(main.flux());
 				for (int i = 1; i < subs; i++) {
-					inners[i] = others[i - 1].flux();
+					inners.add( others.get(i - 1).flux());
 				}
 				return producer.apply(inners);
 			});
@@ -559,22 +558,16 @@ public class OnDiscardShouldNotLeakTest {
 		final String scenarioDescription;
 		final int    subscriptionsNumber;
 
-		private final BiFunction<TestPublisher<Tracked>, TestPublisher<Tracked>[], Publisher<Tracked>>
+		private final BiFunction<TestPublisher<Tracked>, List<TestPublisher<Tracked>>, Publisher<Tracked>>
 				publisherProducer;
 
-		DiscardScenario(String description, int subscriptionsNumber, Function<TestPublisher<Tracked>, Publisher<Tracked>> simplePublisherProducer) {
-			this.scenarioDescription = description;
-			this.subscriptionsNumber = subscriptionsNumber;
-			this.publisherProducer = (main, others) -> simplePublisherProducer.apply(main);
-		}
-
-		DiscardScenario(String description, int subscriptionsNumber, BiFunction<TestPublisher<Tracked>, TestPublisher<Tracked>[], Publisher<Tracked>> publisherProducer) {
+		DiscardScenario(String description, int subscriptionsNumber, BiFunction<TestPublisher<Tracked>, List<TestPublisher<Tracked>>, Publisher<Tracked>> publisherProducer) {
 			this.scenarioDescription = description;
 			this.subscriptionsNumber = subscriptionsNumber;
 			this.publisherProducer = publisherProducer;
 		}
 
-		Publisher<Tracked> producePublisherFromSources(TestPublisher<Tracked> mainSource, TestPublisher<Tracked>... otherSources) {
+		Publisher<Tracked> producePublisherFromSources(TestPublisher<Tracked> mainSource, List<TestPublisher<Tracked>> otherSources) {
 			return publisherProducer.apply(mainSource, otherSources);
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
@@ -30,6 +30,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.test.util.RaceTestUtils;
 import reactor.util.context.Context;
+import reactor.util.retry.Retry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.with;
@@ -103,7 +104,7 @@ public class SerializedSubscriberTest {
 			.doFinally(sig -> latch.countDown())
 		    .publishOn(Schedulers.single())
 			.doFinally(sig -> latch.countDown())
-		    .retryWhen(p -> p.take(3))
+		    .retryWhen(Retry.from(p -> p.take(3)))
 			.doFinally(sig -> latch.countDown())
 		    .cancelOn(Schedulers.parallel())
 		    .doOnDiscard(Integer.class, i -> discarded.incrementAndGet())

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
@@ -40,6 +40,7 @@ import reactor.core.publisher.FluxProcessor;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
 import reactor.core.publisher.Processors;
+import reactor.core.publisher.Sinks;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
@@ -479,8 +480,8 @@ public class FluxSpecTests {
 	public void streamValuesCanBeExploded() {
 //		Stream"s values can be exploded
 //			given: "a source composable with a mapMany function"
-		FluxIdentityProcessor<Integer> source = Processors.multicast();
-		Flux<Integer> mapped = source
+		Sinks.StandaloneFluxSink<Integer> sink = Sinks.multicast();
+		Flux<Integer> mapped = sink.asFlux()
 				.log()
 				.publishOn(Schedulers.parallel())
 				.log()
@@ -491,7 +492,7 @@ public class FluxSpecTests {
 		MonoProcessor<Integer> value = mapped.next()
 		                                     .toProcessor();
 		value.subscribe();
-		source.sink().next(1);
+		sink.next(1);
 
 //		then: "the value is mapped"
 		int result = value.block(Duration.ofSeconds(5));


### PR DESCRIPTION
With this merged, the only left warnings should be related to internal implementation access such as `Unsafe`, etc