### PR TITLE
Handle `null` publisher in `MonoDelayUntil`

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
@@ -208,6 +208,7 @@ final class MonoDelayUntil<T> extends Mono<T> implements Scannable,
 
 			try {
 				p = generator.apply(value);
+				Objects.requireNonNull(p, "mapper returned null value");
 			}
 			catch (Throwable t) {
 				onError(t);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDelayUntilTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDelayUntilTest.java
@@ -253,4 +253,11 @@ public class MonoDelayUntilTest {
 		test.error = new IllegalStateException("boom");
 		assertThat(test.scan(Scannable.Attr.ERROR)).hasMessage("boom");
 	}
+
+	@Test
+	public void testNullPublisherFromMapper() {
+		StepVerifier.create(Mono.just("foo").delayUntil(a -> null))
+		            .expectErrorMessage("mapper returned null value")
+					.verify();
+	}
 }


### PR DESCRIPTION
The null check was missing and the NPE error message was missing the important detail