### PR TITLE
[build] Bump Kotlin to 1.3.72

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 buildscript {
 	//we define kotlin version for benefit of both core and test (see kotlin-gradle-plugin below)
-	ext.kotlinVersion = '1.3.71'
+	ext.kotlinVersion = '1.3.72'
 	repositories {
 		maven { url "https://repo.spring.io/plugins-release" }
 	}


### PR DESCRIPTION
This hopefully will avoid OutOfMemoryError: Java heap space that we got
from within IntelliJ lately. (see PR for more details)

Reviewed-in: #2247