### PR TITLE
fix #2246 Remove usage of globalRegistry in metrics tests

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsFuseableTest.java
@@ -99,7 +99,6 @@ public class FluxMetricsFuseableTest {
 		MockClock clock = new MockClock();
 		removeRegistry();
 		registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
-		Metrics.globalRegistry.add(registry);
 
 		AssertSubscriber<Integer> testSubscriber = AssertSubscriber.create();
 		FluxMetricsFuseable.MetricsFuseableSubscriber<Integer> fuseableSubscriber =
@@ -132,7 +131,6 @@ public class FluxMetricsFuseableTest {
 		MockClock clock = new MockClock();
 		removeRegistry();
 		registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
-		Metrics.globalRegistry.add(registry);
 
 		AssertSubscriber<Integer> testSubscriber = AssertSubscriber.create();
 		FluxMetricsFuseable.MetricsFuseableSubscriber<Integer> fuseableSubscriber =
@@ -168,7 +166,6 @@ public class FluxMetricsFuseableTest {
 		MockClock clock = new MockClock();
 		removeRegistry();
 		registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
-		Metrics.globalRegistry.add(registry);
 
 		AssertSubscriber<Integer> testSubscriber = AssertSubscriber.create();
 		FluxMetricsFuseable.MetricsFuseableSubscriber<Integer> fuseableSubscriber =

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsFuseableTest.java
@@ -100,7 +100,6 @@ public class MonoMetricsFuseableTest {
 		MockClock clock = new MockClock();
 		removeRegistry();
 		registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
-		Metrics.globalRegistry.add(registry);
 
 		AssertSubscriber<Integer> testSubscriber = AssertSubscriber.create();
 		MetricsFuseableSubscriber<Integer> fuseableSubscriber =
@@ -132,7 +131,6 @@ public class MonoMetricsFuseableTest {
 		MockClock clock = new MockClock();
 		removeRegistry();
 		registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
-		Metrics.globalRegistry.add(registry);
 
 		AssertSubscriber<Integer> testSubscriber = AssertSubscriber.create();
 		MetricsFuseableSubscriber<Integer> fuseableSubscriber =
@@ -168,7 +166,6 @@ public class MonoMetricsFuseableTest {
 		MockClock clock = new MockClock();
 		removeRegistry();
 		registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
-		Metrics.globalRegistry.add(registry);
 
 		AssertSubscriber<Integer> testSubscriber = AssertSubscriber.create();
 		MetricsFuseableSubscriber<Integer> fuseableSubscriber =


### PR DESCRIPTION
Direct usage of global registry pollutes the per-test registry of subsequent runs, as seen in #2246.

❓ should this target 3.3.x ❓ 