### PR TITLE
fix #1995 Let exception handler deal with errors in Mono.subscribe

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/LambdaMonoSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/LambdaMonoSubscriber.java
@@ -171,8 +171,7 @@ final class LambdaMonoSubscriber<T> implements InnerConsumer<T>, Disposable {
 				consumer.accept(x);
 			}
 			catch (Throwable t) {
-				Operators.onErrorDropped(t, this.initialContext);
-				return;
+				doError(t);
 			}
 		}
 		if (completeConsumer != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/LambdaMonoSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/LambdaMonoSubscriber.java
@@ -171,6 +171,8 @@ final class LambdaMonoSubscriber<T> implements InnerConsumer<T>, Disposable {
 				consumer.accept(x);
 			}
 			catch (Throwable t) {
+				Exceptions.throwIfFatal(t);
+				s.cancel();
 				doError(t);
 			}
 		}

--- a/reactor-core/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
@@ -30,9 +30,9 @@ import reactor.test.LoggerUtils;
 import reactor.test.util.TestLogger;
 import reactor.util.context.Context;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 public class LambdaMonoSubscriberTest {
 
@@ -45,7 +45,7 @@ public class LambdaMonoSubscriberTest {
 		    .doOnNext(contextRef::set)
 		    .subscribe(null, null, null, Context.of("subscriber", "context"));
 
-		Assertions.assertThat(contextRef.get())
+		assertThat(contextRef.get())
 		          .isNotNull()
 		          .matches(c -> c.hasKey("subscriber"));
 	}
@@ -61,7 +61,7 @@ public class LambdaMonoSubscriberTest {
 		//now trigger drop
 		sub.onError(expectDropped);
 
-		Assertions.assertThat(droppedRef).hasValue(expectDropped);
+		assertThat(droppedRef).hasValue(expectDropped);
 	}
 
 	@Test
@@ -175,49 +175,7 @@ public class LambdaMonoSubscriberTest {
 	}
 
 	@Test
-	public void onNextConsumerBubblesUpErrorCallbackNotImplemented() {
-		LambdaMonoSubscriber<String> tested = new LambdaMonoSubscriber<>(
-				value -> { throw new IllegalArgumentException(); },
-				null,
-				() -> {},
-				null);
-
-		TestSubscription testSubscription = new TestSubscription();
-		tested.onSubscribe(testSubscription);
-
-		//the error is expected to be thrown as there is no error handler
-		assertThatIllegalArgumentException().isThrownBy(() -> tested.onNext("foo"));
-		assertThat(testSubscription.isCancelled).as("subscription isCancelled").isTrue();
-	}
-
-	@Test
-	public void onNextConsumerFatalDoesntTriggerCancellation() {
-		AtomicReference<Throwable> errorHolder = new AtomicReference<>(null);
-
-		LambdaMonoSubscriber<String> tested = new LambdaMonoSubscriber<>(
-				value -> { throw new OutOfMemoryError(); },
-				errorHolder::set,
-				() -> {},
-				null);
-
-		TestSubscription testSubscription = new TestSubscription();
-		tested.onSubscribe(testSubscription);
-
-		//the error is expected to be thrown as it is fatal
-		try {
-			tested.onNext("foo");
-			fail("Expected OutOfMemoryError to be thrown");
-		}
-		catch (OutOfMemoryError e) {
-			//expected
-		}
-
-		assertThat(errorHolder.get()).as("onError").isNull();
-		assertThat(testSubscription.isCancelled).as("subscription isCancelled").isFalse();
-	}
-
-	@Test
-	public void onNextConsumerExceptionBubblesUpDoesntTriggerCancellation() {
+	public void onNextConsumerExceptionNonFatalTriggersCancellation() {
 		TestLogger testLogger = new TestLogger();
 		LoggerUtils.addAppender(testLogger, Operators.class);
 		try {
@@ -237,7 +195,7 @@ public class LambdaMonoSubscriberTest {
 			          .contains("IllegalArgumentException");
 
 			assertThat(testSubscription.isCancelled).as("subscription isCancelled")
-			                                        .isFalse();
+			                                        .isTrue();
 		}
 		finally {
 			LoggerUtils.resetAppender(Operators.class);
@@ -257,11 +215,9 @@ public class LambdaMonoSubscriberTest {
 			TestSubscription testSubscription = new TestSubscription();
 			tested.onSubscribe(testSubscription);
 
-			//the error is expected to be thrown as it is fatal
-			tested.onNext("foo");
-			Assertions.assertThat(testLogger.getErrContent())
-			          .contains("Operator called default onErrorDropped")
-			          .contains("OutOfMemoryError");
+			//the error is expected to be thrown as it is fatal, so it doesn't go through onErrorDropped
+			assertThatExceptionOfType(OutOfMemoryError.class).isThrownBy(() -> tested.onNext("foo"));
+			Assertions.assertThat(testLogger.getErrContent()).isEmpty();
 
 			assertThat(testSubscription.isCancelled).as("subscription isCancelled")
 			                                        .isFalse();
@@ -327,7 +283,7 @@ public class LambdaMonoSubscriberTest {
 			Mono.error(boom)
 			    .subscribe(v -> {
 			    });
-			Assertions.assertThat(testLogger.getErrContent())
+			assertThat(testLogger.getErrContent())
 			          .contains("Operator called default onErrorDropped")
 			          .contains(
 					          "reactor.core.Exceptions$ErrorCallbackNotImplemented: java.lang.IllegalArgumentException: boom");
@@ -344,7 +300,7 @@ public class LambdaMonoSubscriberTest {
 		    .doOnCancel(cancelCount::incrementAndGet)
 		    .subscribe(v -> {})
 		    .dispose();
-		Assertions.assertThat(cancelCount.get()).isEqualTo(1);
+		assertThat(cancelCount.get()).isEqualTo(1);
 	}
 
 	@Test
@@ -353,17 +309,17 @@ public class LambdaMonoSubscriberTest {
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 
-		Assertions.assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
-		Assertions.assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
-		Assertions.assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
+		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 
-		Assertions.assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
-		Assertions.assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
 
 		test.dispose();
 
-		Assertions.assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
-		Assertions.assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
 	}
 
 	private static class TestSubscription implements Subscription {

--- a/reactor-core/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
@@ -31,6 +31,7 @@ import reactor.test.util.TestLogger;
 import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.junit.Assert.*;
 
 public class LambdaMonoSubscriberTest {
@@ -173,11 +174,8 @@ public class LambdaMonoSubscriberTest {
 		assertThat(testSubscription.isCancelled).as("subscription isCancelled").isTrue();
 	}
 
-
 	@Test
 	public void onNextConsumerBubblesUpErrorCallbackNotImplemented() {
-		AtomicReference<Throwable> errorHolder = new AtomicReference<>(null);
-
 		LambdaMonoSubscriber<String> tested = new LambdaMonoSubscriber<>(
 				value -> { throw new IllegalArgumentException(); },
 				null,
@@ -188,15 +186,7 @@ public class LambdaMonoSubscriberTest {
 		tested.onSubscribe(testSubscription);
 
 		//the error is expected to be thrown as there is no error handler
-		try {
-			tested.onNext("foo");
-			fail("Expected IllegalArgumentException to be thrown");
-		}
-		catch (UnsupportedOperationException e) {
-			//expected
-		}
-
-		assertThat(errorHolder.get()).as("onError").isNull();
+		assertThatIllegalArgumentException().isThrownBy(() -> tested.onNext("foo"));
 		assertThat(testSubscription.isCancelled).as("subscription isCancelled").isTrue();
 	}
 


### PR DESCRIPTION
When an error handler is provided to `Mono.subscribe()`, let it handle the error instead of dropping threw `Operators.onErrorDropped`