### PR TITLE
fix #2260 Avoid onSubscribe race in FluxTimeout

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTimeout.java
@@ -81,6 +81,9 @@ final class FluxTimeout<T, U, V> extends InternalFluxOperator<T, T> {
 		TimeoutMainSubscriber<T, V> main =
 				new TimeoutMainSubscriber<>(serial, itemTimeout, other, timeoutDescription);
 
+		// First upstream, then downstream, to avoid overriding the fallback subscription.
+		source.subscribe(main);
+
 		serial.onSubscribe(main);
 
 		TimeoutTimeoutSubscriber ts = new TimeoutTimeoutSubscriber(main, 0L);
@@ -89,7 +92,7 @@ final class FluxTimeout<T, U, V> extends InternalFluxOperator<T, T> {
 
 		firstTimeout.subscribe(ts);
 
-		return main;
+		return null;
 	}
 
 	@Nullable

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTimeout.java
@@ -76,7 +76,7 @@ final class FluxTimeout<T, U, V> extends InternalFluxOperator<T, T> {
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
-		return new TimeoutMainSubscriber<>(actual, itemTimeout, other, timeoutDescription, firstTimeout);
+		return new TimeoutMainSubscriber<>(actual, firstTimeout, itemTimeout, other, timeoutDescription);
 	}
 
 	@Nullable
@@ -98,11 +98,12 @@ final class FluxTimeout<T, U, V> extends InternalFluxOperator<T, T> {
 	static final class TimeoutMainSubscriber<T, V>
 			extends Operators.MultiSubscriptionSubscriber<T, T> {
 
+		final Publisher<?> firstTimeout;
+
 		final Function<? super T, ? extends Publisher<V>> itemTimeout;
 
 		final Publisher<? extends T> other;
 		final String timeoutDescription; //only useful/non-null when no `other`
-		final Publisher<?> firstTimeout;
 
 		Subscription s;
 
@@ -119,10 +120,13 @@ final class FluxTimeout<T, U, V> extends InternalFluxOperator<T, T> {
 		static final AtomicLongFieldUpdater<TimeoutMainSubscriber> INDEX =
 				AtomicLongFieldUpdater.newUpdater(TimeoutMainSubscriber.class, "index");
 
-		TimeoutMainSubscriber(CoreSubscriber<? super T> actual,
+		TimeoutMainSubscriber(
+				CoreSubscriber<? super T> actual,
+				Publisher<?> firstTimeout,
 				Function<? super T, ? extends Publisher<V>> itemTimeout,
 				@Nullable Publisher<? extends T> other,
-				@Nullable String timeoutDescription, Publisher<?> firstTimeout) {
+				@Nullable String timeoutDescription
+		) {
 			super(Operators.serialize(actual));
 			this.itemTimeout = itemTimeout;
 			this.other = other;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTimeout.java
@@ -65,22 +65,12 @@ final class MonoTimeout<T, U, V> extends InternalMonoOperator<T, T> {
 	@Override
 	@SuppressWarnings("unchecked")
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
-
-		CoreSubscriber<T> serial = Operators.serialize(actual);
-
-		FluxTimeout.TimeoutMainSubscriber<T, V> main =
-				new FluxTimeout.TimeoutMainSubscriber<>(serial, NEVER, other,
-						addNameToTimeoutDescription(source, timeoutDescription));
-
-		serial.onSubscribe(main);
-
-		FluxTimeout.TimeoutTimeoutSubscriber ts =
-				new FluxTimeout.TimeoutTimeoutSubscriber(main, 0L);
-
-		main.setTimeout(ts);
-
-		firstTimeout.subscribe(ts);
-
-		return main;
+		return new FluxTimeout.TimeoutMainSubscriber<T, T>(
+				Operators.serialize(actual),
+				NEVER,
+				other,
+				addNameToTimeoutDescription(source, timeoutDescription),
+				firstTimeout
+		);
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTimeout.java
@@ -67,10 +67,10 @@ final class MonoTimeout<T, U, V> extends InternalMonoOperator<T, T> {
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
 		return new FluxTimeout.TimeoutMainSubscriber<T, T>(
 				Operators.serialize(actual),
+				firstTimeout,
 				NEVER,
 				other,
-				addNameToTimeoutDescription(source, timeoutDescription),
-				firstTimeout
+				addNameToTimeoutDescription(source, timeoutDescription)
 		);
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
@@ -24,6 +24,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
+import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,16 +45,23 @@ public class FluxTimeoutTest {
 	}
 
 	@Test
-	public void immediateTimeout() {
+	public void noTimeoutOnInstantSource() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		Flux.range(1, 10)
 		    .timeout(Flux.empty(), v -> Flux.never())
 		    .subscribe(ts);
 
-		ts.assertNoValues()
-		  .assertNotComplete()
-		  .assertError(TimeoutException.class);
+		ts.assertValueCount(10).assertComplete();
+	}
+
+	@Test
+	public void immediateTimeout() {
+		TestPublisher<Object> source = TestPublisher.create();
+		source.flux()
+		      .timeout(Flux.empty(), v -> Flux.never())
+		      .as(StepVerifier::create)
+		      .verifyError(TimeoutException.class);
 	}
 
 	@Test
@@ -198,18 +206,22 @@ public class FluxTimeoutTest {
 	}
 
 	@Test
+	public void dropsErrorOnCompletedSource() {
+		Flux.range(0, 10)
+		             .timeout(Flux.error(new RuntimeException("forced failure")), v -> Flux.never())
+		             .as(StepVerifier::create)
+		             .expectNextCount(10)
+		             .verifyComplete();
+	}
+
+	@Test
 	public void firstTimeoutError() {
-		AssertSubscriber<Integer> ts = AssertSubscriber.create();
-
-		Flux.range(1, 10)
-		    .timeout(Flux.error(new RuntimeException("forced " + "failure")),
-				    v -> Flux.never())
-		    .subscribe(ts);
-
-		ts.assertNoValues()
-		  .assertNotComplete()
-		  .assertError(RuntimeException.class)
-		  .assertErrorMessage("forced failure");
+		TestPublisher<Object> source = TestPublisher.create();
+		source.flux()
+		      .timeout(Flux.error(new RuntimeException("forced failure")), v -> Flux.never())
+		      .as(StepVerifier::create)
+		      .then(source::complete)
+		      .verifyErrorMessage("forced failure");
 	}
 
 	@Test
@@ -405,9 +417,12 @@ public class FluxTimeoutTest {
 		for (int i = 0; i < 10_000; i++) {
 			Flux.just("Hello")
 			    .concatMap(v -> Mono.delay(Duration.ofSeconds(10)))
-			    .timeout(Duration.ofMillis(0), Mono.just(123L))
+			    .timeout(Duration.ofMillis(i % 100 == 0 ? 1 : 0), Mono.just(123L))
 			    .collectList()
-			    .block(Duration.ofSeconds(1));
+			    .as(StepVerifier::create)
+			    .expectNextMatches(it -> it.get(0).equals(123L))
+			    .expectComplete()
+				.verify(Duration.ofSeconds(1));
 		}
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
@@ -399,4 +399,15 @@ public class FluxTimeoutTest {
 
 		assertThat(generatorUsed.get()).as("generator used").isTrue();
 	}
+
+	@Test
+	public void onSubscribeRace() {
+		for (int i = 0; i < 10_000; i++) {
+			Flux.just("Hello")
+			    .concatMap(v -> Mono.delay(Duration.ofSeconds(10)))
+			    .timeout(Duration.ofMillis(0), Mono.just(123L))
+			    .collectList()
+			    .block(Duration.ofSeconds(1));
+		}
+	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
@@ -208,10 +208,10 @@ public class FluxTimeoutTest {
 	@Test
 	public void dropsErrorOnCompletedSource() {
 		Flux.range(0, 10)
-		             .timeout(Flux.error(new RuntimeException("forced failure")), v -> Flux.never())
-		             .as(StepVerifier::create)
-		             .expectNextCount(10)
-		             .verifyComplete();
+		    .timeout(Flux.error(new RuntimeException("forced failure")), v -> Flux.never())
+		    .as(StepVerifier::create)
+		    .expectNextCount(10)
+		    .verifyComplete();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
@@ -43,8 +43,8 @@ public class MonoTimeoutTest {
 		Mono.just(1)
 		    .timeout(Mono.empty())
 		    .as(StepVerifier::create)
-			.expectNext(1)
-			.verifyComplete();
+		    .expectNext(1)
+		    .verifyComplete();
 	}
 
 	@Test
@@ -53,7 +53,7 @@ public class MonoTimeoutTest {
 		    .delaySubscription(Duration.ofMillis(1))
 		    .timeout(Mono.empty())
 		    .as(StepVerifier::create)
-			.expectError(TimeoutException.class);
+		    .expectError(TimeoutException.class);
 	}
 
 	@Test
@@ -61,8 +61,8 @@ public class MonoTimeoutTest {
 		Mono.just(1)
 		    .timeout(Mono.error(new RuntimeException("forced " + "failure")))
 		    .as(StepVerifier::create)
-			.expectNext(1)
-			.verifyComplete();
+		    .expectNext(1)
+		    .verifyComplete();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.junit.Test;
 import reactor.test.StepVerifier;
+import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 
 public class MonoTimeoutTest {
@@ -38,30 +39,40 @@ public class MonoTimeoutTest {
 	}
 
 	@Test
-	public void immediateTimeout() {
-		AssertSubscriber<Integer> ts = AssertSubscriber.create();
-
+	public void noTimeoutOnInstantSource() {
 		Mono.just(1)
 		    .timeout(Mono.empty())
-		    .subscribe(ts);
+		    .as(StepVerifier::create)
+			.expectNext(1)
+			.verifyComplete();
+	}
 
-		ts.assertNoValues()
-		  .assertNotComplete()
-		  .assertError(TimeoutException.class);
+	@Test
+	public void immediateTimeout() {
+		Mono.just(1)
+		    .delaySubscription(Duration.ofMillis(1))
+		    .timeout(Mono.empty())
+		    .as(StepVerifier::create)
+			.expectError(TimeoutException.class);
+	}
+
+	@Test
+	public void dropsErrorOnCompletedSource() {
+		Mono.just(1)
+		    .timeout(Mono.error(new RuntimeException("forced " + "failure")))
+		    .as(StepVerifier::create)
+			.expectNext(1)
+			.verifyComplete();
 	}
 
 	@Test
 	public void firstTimeoutError() {
-		AssertSubscriber<Integer> ts = AssertSubscriber.create();
-
-		Mono.just(1)
-		    .timeout(Mono.error(new RuntimeException("forced " + "failure")))
-		    .subscribe(ts);
-
-		ts.assertNoValues()
-		  .assertNotComplete()
-		  .assertError(RuntimeException.class)
-		  .assertErrorMessage("forced failure");
+		TestPublisher<Object> source = TestPublisher.create();
+		source.flux()
+		      .timeout(Mono.error(new RuntimeException("forced " + "failure")))
+		      .as(StepVerifier::create)
+		      .then(source::complete)
+		      .verifyErrorMessage("forced failure");
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #2260 