### PR TITLE
fix 2239 remove build warnings

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -13,7 +13,7 @@ configurations {
 dependencies {
   // Use the baseline to avoid using new APIs in the benchmarks
   compileOnly "io.projectreactor:reactor-core:${perfBaselineVersion}"
-  compileOnly "com.google.code.findbugs:jsr305:${jsr305Version}"
+  compileOnly "com.google.code.findbugs:jsr305:${findbugsVersion}"
 
   implementation "org.openjdk.jmh:jmh-core:1.21"
   implementation "io.projectreactor.addons:reactor-extra:3.3.3.RELEASE", {

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,11 @@ ext {
 	 * Versions not necessarily bumped by a script (testing, etc...) below:
 	 */
 	// Misc not often upgraded
+
+	// Used as a way to get jsr305 annotations.
+	// 3.0.1 is the last version that has the 'annotations' jar needed on the compile classpath
 	findbugsVersion = '3.0.1'
+	
 	jsr166BackportVersion = '1.0.0.RELEASE'
 
 	// Blockhound

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext {
 	 * Versions not necessarily bumped by a script (testing, etc...) below:
 	 */
 	// Misc not often upgraded
-	jsr305Version = '3.0.2'
+	findbugsVersion = '3.0.1'
 	jsr166BackportVersion = '1.0.0.RELEASE'
 
 	// Blockhound

--- a/buildSrc/src/main/java/io/reactor/gradle/JavaConventions.java
+++ b/buildSrc/src/main/java/io/reactor/gradle/JavaConventions.java
@@ -64,7 +64,9 @@ public class JavaConventions implements Plugin<Project> {
 					       "-Xlint:-serial",      // intentionally disabled
 					       "-Xlint:-options",     // intentionally disabled
 					       "-Xlint:-fallthrough", // intentionally disabled
-					       "-Xlint:-rawtypes"     // TODO enable and fix warnings
+					       "-Xlint:-rawtypes",     // TODO enable and fix warnings
+						   "-Xmaxwarns",
+						   "1000"
 			       ));
 		       });
 

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -78,7 +78,7 @@ dependencies {
 	testCompile "org.reactivestreams:reactive-streams-tck:${reactiveStreamsVersion}"
 
 	// JSR-305 annotations
-	optional "com.google.code.findbugs:jsr305:$jsr305Version"
+	optional "com.google.code.findbugs:jsr305:${findbugsVersion}"
 
 	//Optional Logging Operator
 	optional "org.slf4j:slf4j-api:$slf4jVersion"

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
@@ -183,6 +183,7 @@ final class FluxConcatMapNoPrefetch<T, R> extends InternalFluxOperator<T, R> {
 				Objects.requireNonNull(p, "The mapper returned a null Publisher");
 
 				if (p instanceof Callable) {
+					@SuppressWarnings("unchecked")
 					Callable<R> callable = (Callable<R>) p;
 
 					R result = callable.call();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
@@ -979,7 +979,7 @@ public class FluxBufferPredicateTest {
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
 		FluxBufferPredicate<Integer, ArrayList<Integer>> test =
-				new FluxBufferPredicate<>(parent, v -> (Integer) v != 0, ArrayList::new, FluxBufferPredicate.Mode.UNTIL);
+				new FluxBufferPredicate<>(parent, v -> v != 0, ArrayList::new, FluxBufferPredicate.Mode.UNTIL);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTest.java
@@ -442,7 +442,7 @@ public class FluxBufferTest extends FluxOperatorTest<String, List<String>> {
 
 	@Test
 	public void scanOperator(){
-	    FluxBuffer<Integer, List<Integer>> test = new FluxBuffer(Flux.just(1, 2, 3), 2, 1, ArrayList::new);
+	    FluxBuffer<Integer, List<Integer>> test = new FluxBuffer<>(Flux.just(1, 2, 3), 2, 1, ArrayList::new);
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
@@ -360,7 +360,7 @@ public class FluxBufferWhenTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> source = Flux.just(1);
-		FluxBufferWhen test = new FluxBufferWhen(source,
+		FluxBufferWhen<Integer, ?, ?, List<Integer>> test = new FluxBufferWhen<>(source,
 				Flux.interval(Duration.ZERO, Duration.ofMillis(200)),
 				open -> Mono.delay(Duration.ofMillis(100)),
 				ArrayList::new,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatArrayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatArrayTest.java
@@ -270,8 +270,9 @@ public class FluxConcatArrayTest {
 	@Test
 	public void scanSubscriber() {
 		CoreSubscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+		@SuppressWarnings("unchecked")
 		Publisher<String>[] publishers = (Publisher<String>[]) new Publisher[0];
-		FluxConcatArray.ConcatArraySubscriber<String> test = new FluxConcatArray.ConcatArraySubscriber(actual, publishers);
+		FluxConcatArray.ConcatArraySubscriber<String> test = new FluxConcatArray.ConcatArraySubscriber<>(actual, publishers);
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatIterableTest.java
@@ -101,7 +101,7 @@ public class FluxConcatIterableTest {
 
 	@Test
 	public void scanOperator(){
-	    FluxConcatIterable<Integer> test = new FluxConcatIterable(Arrays.asList(source, source, source));
+	    FluxConcatIterable<Integer> test = new FluxConcatIterable<>(Arrays.asList(source, source, source));
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}
@@ -110,7 +110,7 @@ public class FluxConcatIterableTest {
 	public void scanSubscriber(){
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		List<Publisher<Integer>> publishers = Arrays.asList(source, source, source);
-		FluxConcatIterable.ConcatIterableSubscriber<Integer> test = new FluxConcatIterable.ConcatIterableSubscriber(actual, publishers.iterator());
+		FluxConcatIterable.ConcatIterableSubscriber<Integer> test = new FluxConcatIterable.ConcatIterableSubscriber<>(actual, publishers.iterator());
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapNoPrefetchTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapNoPrefetchTest.java
@@ -79,7 +79,7 @@ public class FluxConcatMapNoPrefetchTest extends AbstractFluxConcatMapTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1, 2);
-		FluxConcatMapNoPrefetch<Integer, String> test = new FluxConcatMapNoPrefetch(parent, Flux.IDENTITY_FUNCTION , FluxConcatMap.ErrorMode.END);
+		FluxConcatMapNoPrefetch<Integer, String> test = new FluxConcatMapNoPrefetch<>(parent, i -> Flux.just(i.toString()) , FluxConcatMap.ErrorMode.END);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isZero();
@@ -89,8 +89,8 @@ public class FluxConcatMapNoPrefetchTest extends AbstractFluxConcatMapTest {
 	@Test
 	public void scanConcatMapNoPrefetchDelayError() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
-		FluxConcatMapNoPrefetch.FluxConcatMapNoPrefetchSubscriber test =
-				new FluxConcatMapNoPrefetch.FluxConcatMapNoPrefetchSubscriber(actual, Flux.IDENTITY_FUNCTION, FluxConcatMap.ErrorMode.END);
+		FluxConcatMapNoPrefetch.FluxConcatMapNoPrefetchSubscriber<Integer, Integer> test =
+				new FluxConcatMapNoPrefetch.FluxConcatMapNoPrefetchSubscriber<>(actual, Flux::just, FluxConcatMap.ErrorMode.END);
 
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
@@ -207,7 +207,7 @@ public class  FluxConcatMapTest extends AbstractFluxConcatMapTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1, 2);
-		FluxConcatMap<Integer, String> test = new FluxConcatMap(parent, Flux.IDENTITY_FUNCTION , Queues.one(), Integer.MAX_VALUE, FluxConcatMap.ErrorMode.END);
+		FluxConcatMap<Integer, Integer> test = new FluxConcatMap<>(parent, Flux::just, Queues.one(), Integer.MAX_VALUE, FluxConcatMap.ErrorMode.END);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
@@ -295,7 +295,7 @@ public class  FluxConcatMapTest extends AbstractFluxConcatMapTest {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		FluxConcatMap.ConcatMapImmediate<String, Integer> parent = new FluxConcatMap.ConcatMapImmediate<>(
 				actual, s -> Mono.just(s.length()), Queues.one(), 123);
-		FluxConcatMap.ConcatMapInner test = new FluxConcatMap.ConcatMapInner(parent);
+		FluxConcatMap.ConcatMapInner<Integer> test = new FluxConcatMap.ConcatMapInner<>(parent);
 
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxContextStartTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxContextStartTest.java
@@ -13,7 +13,7 @@ public class FluxContextStartTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxContextStart test = new FluxContextStart(parent, c -> c);
+		FluxContextStart<Integer> test = new FluxContextStart<>(parent, c -> c);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
@@ -22,7 +22,7 @@ public class FluxContextStartTest {
 	@Test
 	public void scanSubscriber(){
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
-		FluxContextStart.ContextStartSubscriber test = new FluxContextStart.ContextStartSubscriber(actual, Context.empty());
+		FluxContextStart.ContextStartSubscriber<Integer> test = new FluxContextStart.ContextStartSubscriber<>(actual, Context.empty());
 
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCreateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCreateTest.java
@@ -1164,7 +1164,7 @@ class FluxCreateTest {
 
 	@Test
 	public void scanOperator(){
-		FluxCreate test = new FluxCreate(v -> Arrays.asList(1, 2, 3), OverflowStrategy.BUFFER, FluxCreate.CreateMode.PUSH_ONLY);
+		FluxCreate<?> test = new FluxCreate<>(v -> {}, OverflowStrategy.BUFFER, FluxCreate.CreateMode.PUSH_ONLY);
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.ASYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDeferTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDeferTest.java
@@ -100,7 +100,7 @@ public class FluxDeferTest {
 
 	@Test
 	public void scanOperator(){
-	    FluxDefer<Integer> test = new FluxDefer(() -> Flux.just(1));
+	    FluxDefer<Integer> test = new FluxDefer<>(() -> Flux.just(1));
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDeferWithContextTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDeferWithContextTest.java
@@ -9,7 +9,7 @@ public class FluxDeferWithContextTest {
 
 	@Test
 	public void scanOperator(){
-		FluxDeferWithContext test = new FluxDeferWithContext(context -> Flux.just(1));
+		FluxDeferWithContext<Integer> test = new FluxDeferWithContext<>(context -> Flux.just(1));
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDematerializeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDematerializeTest.java
@@ -284,8 +284,8 @@ public class FluxDematerializeTest extends FluxOperatorTest<Signal<String>, Stri
 
 	@Test
 	public void scanOperator(){
-		Flux<Integer> parent = Flux.just(1);
-		FluxDematerialize<Integer> test = new FluxDematerialize(parent);
+		Flux<Signal<Integer>> parent = Flux.just(Signal.next(1));
+		FluxDematerialize<Integer> test = new FluxDematerialize<>(parent);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDetachTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDetachTest.java
@@ -184,7 +184,7 @@ public class FluxDetachTest {
 	
 	@Test
 	public void scanOperator(){
-	    FluxDetach<String> test = new FluxDetach(Flux.just(1));
+	    FluxDetach<Integer> test = new FluxDetach<>(Flux.just(1));
 	    
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDoFinallyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDoFinallyTest.java
@@ -391,7 +391,7 @@ public class FluxDoFinallyTest implements Consumer<SignalType> {
 	@Test
 	public void scanFuseableOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxDoFinallyFuseable test = new FluxDoFinallyFuseable(parent, s -> {});
+		FluxDoFinallyFuseable<Integer> test = new FluxDoFinallyFuseable<>(parent, s -> {});
 
 		Assertions.assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		Assertions.assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxErrorSuppliedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxErrorSuppliedTest.java
@@ -98,7 +98,7 @@ public class FluxErrorSuppliedTest {
 
 	@Test
 	public void scanOperator(){
-	    FluxErrorSupplied test = new FluxErrorSupplied(() -> new IllegalStateException());
+	    FluxErrorSupplied<?> test = new FluxErrorSupplied<>(() -> new IllegalStateException());
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFilterFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFilterFuseableTest.java
@@ -36,7 +36,7 @@ public class FluxFilterFuseableTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxFilterFuseable<Integer> test = new FluxFilterFuseable(parent, e -> true);
+		FluxFilterFuseable<Integer> test = new FluxFilterFuseable<>(parent, e -> true);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFilterTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFilterTest.java
@@ -258,7 +258,7 @@ public class FluxFilterTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxFilter test = new FluxFilter(parent, e -> true);
+		FluxFilter<Integer> test = new FluxFilter<>(parent, e -> true);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
@@ -402,7 +402,7 @@ public class FluxFilterWhenTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxFilterWhen test = new FluxFilterWhen(parent, v -> true, 123);
+		FluxFilterWhen<Integer> test = new FluxFilterWhen<>(parent, v -> Flux.just(true), 123);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFirstEmittingTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFirstEmittingTest.java
@@ -143,7 +143,8 @@ public class FluxFirstEmittingTest {
 
 	@Test
 	public void scanOperator(){
-	    FluxFirstEmitting test = new FluxFirstEmitting(Flux.range(1, 10), Flux.range(11, 10));
+		@SuppressWarnings("unchecked")
+	    FluxFirstEmitting<Integer> test = new FluxFirstEmitting<>(Flux.range(1, 10), Flux.range(11, 10));
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -702,9 +702,9 @@ public class FluxFlatMapTest {
 		try {
 			StepVerifier.create(Flux.from(s -> {
 				s.onSubscribe(Operators.emptySubscription());
-				Exceptions.terminate(FluxFlatMap.FlatMapMain.ERROR, (FluxFlatMap.FlatMapMain) s);
-				((FluxFlatMap.FlatMapMain) s).done = true;
-				((FluxFlatMap.FlatMapMain) s).drain(null);
+				Exceptions.terminate(FluxFlatMap.FlatMapMain.ERROR, (FluxFlatMap.FlatMapMain<?, ?>) s);
+				((FluxFlatMap.FlatMapMain<?, ?>) s).done = true;
+				((FluxFlatMap.FlatMapMain<?, ?>) s).drain(null);
 				s.onError(new Exception("test"));
 			})
 			                        .flatMap(Flux::just))

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -1365,7 +1365,7 @@ public class FluxFlatMapTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxFlatMap test = new FluxFlatMap(parent, i -> Flux.just(i), false, 3, Queues::empty, 123, Queues::empty);
+		FluxFlatMap<Integer, Integer> test = new FluxFlatMap<>(parent, i -> Flux.just(i), false, 3, Queues.empty(), 123, Queues.empty());
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(123);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxHandleTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxHandleTest.java
@@ -388,7 +388,7 @@ public class FluxHandleTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxHandle test = new FluxHandle(parent, (t, s) -> { });
+		FluxHandle<Integer, ?> test = new FluxHandle<>(parent, (t, s) -> { });
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
@@ -397,7 +397,7 @@ public class FluxHandleTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void scanFuseableOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxHandleFuseable test = new FluxHandleFuseable(parent, (t, s) -> { });
+		FluxHandleFuseable<Integer, ?> test = new FluxHandleFuseable<>(parent, (t, s) -> { });
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxHideTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxHideTest.java
@@ -120,7 +120,7 @@ public class FluxHideTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxHide test = new FluxHide(parent);
+		FluxHide<Integer> test = new FluxHide<>(parent);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxIndexTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxIndexTest.java
@@ -261,7 +261,7 @@ public class FluxIndexTest extends FluxOperatorTest<Integer, Tuple2<Long, Intege
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxIndex test = new FluxIndex<>(parent, Tuples::of);
+		FluxIndex<Integer, Tuple2<Long, Integer>> test = new FluxIndex<>(parent, Tuples::of);
 
 	    assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
@@ -269,9 +269,9 @@ public class FluxIndexTest extends FluxOperatorTest<Integer, Tuple2<Long, Intege
 
 	@Test
 	public void scanSubscriber(){
-		CoreSubscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+		CoreSubscriber<Object> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		FluxIndex.IndexSubscriber<Object, Tuple2<Long, Object>> test =
-				new FluxIndex.IndexSubscriber(actual, Tuples::of);
+				new FluxIndex.IndexSubscriber<>(actual, Tuples::of);
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 
@@ -286,9 +286,10 @@ public class FluxIndexTest extends FluxOperatorTest<Integer, Tuple2<Long, Intege
 
 	@Test
 	public void scanConditionnalSubscriber(){
-		Fuseable.ConditionalSubscriber<String> actual = Mockito.mock(MockUtils.TestScannableConditionalSubscriber.class);
-		FluxIndex.IndexConditionalSubscriber<Object, Tuple2<Long, Object>> test =
-				new FluxIndex.IndexConditionalSubscriber(actual, Tuples::of);
+		@SuppressWarnings("unchecked")
+		Fuseable.ConditionalSubscriber<Tuple2<Long, String>> actual = Mockito.mock(MockUtils.TestScannableConditionalSubscriber.class);
+		FluxIndex.IndexConditionalSubscriber<String, Tuple2<Long, String>> test =
+				new FluxIndex.IndexConditionalSubscriber<>(actual, Tuples::of);
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxIndexedFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxIndexedFuseableTest.java
@@ -295,7 +295,7 @@ public class FluxIndexedFuseableTest extends FluxOperatorTest<Integer, Tuple2<Lo
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxIndexFuseable test = new FluxIndexFuseable<>(parent, Tuples::of);
+		FluxIndexFuseable<Integer, Tuple2<Long, Integer>> test = new FluxIndexFuseable<>(parent, Tuples::of);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
@@ -303,9 +303,9 @@ public class FluxIndexedFuseableTest extends FluxOperatorTest<Integer, Tuple2<Lo
 
 	@Test
 	public void scanSubscriber(){
-		CoreSubscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
-		FluxIndexFuseable.IndexFuseableSubscriber<Object, Tuple2<Long, Object>> test =
-				new FluxIndexFuseable.IndexFuseableSubscriber(actual, Tuples::of);
+		CoreSubscriber<Tuple2<Long, String>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+		FluxIndexFuseable.IndexFuseableSubscriber<Tuple2<Long, String>, String> test =
+				new FluxIndexFuseable.IndexFuseableSubscriber<>(actual, Tuples::of);
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 
@@ -320,9 +320,10 @@ public class FluxIndexedFuseableTest extends FluxOperatorTest<Integer, Tuple2<Lo
 
 	@Test
 	public void scanConditionnalSubscriber(){
-		Fuseable.ConditionalSubscriber<String> actual = Mockito.mock(MockUtils.TestScannableConditionalSubscriber.class);
-		FluxIndexFuseable.IndexFuseableConditionalSubscriber<Object, Tuple2<Long, Object>> test =
-				new FluxIndexFuseable.IndexFuseableConditionalSubscriber(actual, Tuples::of);
+		@SuppressWarnings("unchecked")
+		Fuseable.ConditionalSubscriber<Tuple2<Long, String>> actual = Mockito.mock(MockUtils.TestScannableConditionalSubscriber.class);
+		FluxIndexFuseable.IndexFuseableConditionalSubscriber<Tuple2<Long, String>, String> test =
+				new FluxIndexFuseable.IndexFuseableConditionalSubscriber<>(actual, Tuples::of);
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxJoinTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxJoinTest.java
@@ -257,7 +257,7 @@ public class FluxJoinTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxJoin test = new FluxJoin(parent, Flux.just(2), just(Flux.just(3)), just(Flux.just(4)), add);
+		FluxJoin<Integer, Integer, Integer, Integer, Integer> test = new FluxJoin<>(parent, Flux.just(2), just(Flux.just(3)), just(Flux.just(4)), add);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(-1);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMapSignalTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMapSignalTest.java
@@ -134,7 +134,7 @@ public class FluxMapSignalTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxMapSignal test = new FluxMapSignal(parent, v -> v, v -> v, () -> Flux.just(10));
+		FluxMapSignal<Integer, Integer> test = new FluxMapSignal<>(parent, v -> v, e -> 1, () -> 10);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMapTest.java
@@ -301,7 +301,7 @@ public class FluxMapTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxMap<String, String> test = new FluxMap(parent, v -> v.toString());
+		FluxMap<Integer, String> test = new FluxMap<>(parent, v -> v.toString());
 
 	    assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
@@ -342,7 +342,7 @@ public class FluxMapTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void scanFuseableOperator(){
-		FluxMapFuseable<String, String> test = new FluxMapFuseable(Flux.just(1), v -> v.toString());
+		FluxMapFuseable<Integer, String> test = new FluxMapFuseable<>(Flux.just(1), v -> v.toString());
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMaterializeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMaterializeTest.java
@@ -165,7 +165,7 @@ public class FluxMaterializeTest
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxMaterialize test = new FluxMaterialize(parent);
+		FluxMaterialize<Integer> test = new FluxMaterialize<>(parent);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
@@ -800,7 +800,7 @@ public class FluxMergeSequentialTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.range(1, 5);
-		FluxMergeSequential test = new FluxMergeSequential(parent, t -> Flux.just(t), 3, 123, ErrorMode.END);
+		FluxMergeSequential<Integer, Integer> test = new FluxMergeSequential<>(parent, t -> Flux.just(t), 3, 123, ErrorMode.END);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
@@ -810,7 +810,7 @@ public class FluxMergeSequentialTest {
     public void scanMain() {
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
         FluxMergeSequential.MergeSequentialMain<Integer, Integer> test =
-        		new FluxMergeSequential.MergeSequentialMain<Integer, Integer>(actual, i -> Mono.just(i),
+        		new FluxMergeSequential.MergeSequentialMain<>(actual, i -> Mono.just(i),
         				5, 123, ErrorMode.BOUNDARY, Queues.unbounded());
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMetricsFuseableTest.java
@@ -477,7 +477,7 @@ public class FluxMetricsFuseableTest {
 	@Test
 	public void scanOperator(){
 	    Flux<Integer> parent = Flux.just(1);
-		FluxMetricsFuseable test = new FluxMetricsFuseable(parent);
+		FluxMetricsFuseable<Integer> test = new FluxMetricsFuseable<>(parent);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
@@ -492,7 +492,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxOnBackpressureBufferStrategy test = new FluxOnBackpressureBufferStrategy(parent, 3, t -> {}, ERROR);
+		FluxOnBackpressureBufferStrategy<Integer> test = new FluxOnBackpressureBufferStrategy<>(parent, 3, t -> {}, ERROR);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureDropTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureDropTest.java
@@ -147,7 +147,7 @@ public class FluxOnBackpressureDropTest {
 
 	@Test
 	public void scanOperator(){
-	    FluxOnBackpressureDrop test = new FluxOnBackpressureDrop(Flux.just(1));
+	    FluxOnBackpressureDrop<Integer> test = new FluxOnBackpressureDrop<>(Flux.just(1));
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnErrorResumeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnErrorResumeTest.java
@@ -376,7 +376,7 @@ public class FluxOnErrorResumeTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = just(1);
-		FluxOnErrorResume test = new FluxOnErrorResume(parent, (e) -> just(10));
+		FluxOnErrorResume<Integer> test = new FluxOnErrorResume<>(parent, (e) -> just(10));
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
@@ -384,8 +384,9 @@ public class FluxOnErrorResumeTest {
 
 	@Test
 	public void scanSubscriber(){
-		Fuseable.ConditionalSubscriber<String> actual = Mockito.mock(MockUtils.TestScannableConditionalSubscriber.class);
-		FluxOnErrorResume.ResumeSubscriber test = new FluxOnErrorResume.ResumeSubscriber(actual, (e) -> just(10));
+		@SuppressWarnings("unchecked")
+		Fuseable.ConditionalSubscriber<Integer> actual = Mockito.mock(MockUtils.TestScannableConditionalSubscriber.class);
+		FluxOnErrorResume.ResumeSubscriber<Integer> test = new FluxOnErrorResume.ResumeSubscriber<>(actual, (e) -> just(10));
 
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
@@ -285,7 +285,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
     @Test
     public void scanOperator(){
     	Flux<Integer> parent = Flux.just(1);
-		FluxPublishMulticast test = new FluxPublishMulticast(parent, v -> v, 123, Queues::one);
+		FluxPublishMulticast<Integer, Integer> test = new FluxPublishMulticast<>(parent, v -> v, 123, Queues.one());
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
     	assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
@@ -1263,7 +1263,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	public void scanOperator(){
 		Flux<Integer> source = Flux.just(1);
 		Scheduler scheduler = Schedulers.immediate();
-		FluxPublishOn test = new FluxPublishOn(source, scheduler, false, 3, 4, Queues::one);
+		FluxPublishOn<Integer> test = new FluxPublishOn<>(source, scheduler, false, 3, 4, Queues.one());
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);
 		assertThat(test.scan(PREFETCH)).isEqualTo(3);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
@@ -376,9 +376,9 @@ public class FluxRefCountGraceTest {
 	@Test
 	public void scanInner(){
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, sub -> sub.request(100));
-		FluxRefCountGrace<Integer> parent = new FluxRefCountGrace(Flux.just(10).publish(), 17, Duration.ofSeconds(1), Schedulers.single());
+		FluxRefCountGrace<Integer> parent = new FluxRefCountGrace<>(Flux.just(10).publish(), 17, Duration.ofSeconds(1), Schedulers.single());
 
-		FluxRefCountGrace.RefCountInner test = new FluxRefCountGrace.RefCountInner(actual, parent, new FluxRefCountGrace.RefConnection(parent));
+		FluxRefCountGrace.RefCountInner<Integer> test = new FluxRefCountGrace.RefCountInner<>(actual, parent, new FluxRefCountGrace.RefConnection(parent));
 
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatPredicateTest.java
@@ -169,7 +169,7 @@ public class FluxRepeatPredicateTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxRepeatPredicate test = new FluxRepeatPredicate(parent, () -> true);
+		FluxRepeatPredicate<Integer> test = new FluxRepeatPredicate<>(parent, () -> true);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
@@ -180,7 +180,7 @@ public class FluxRepeatPredicateTest {
 		Flux<Integer> source = Flux.just(1);
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		FluxRepeatPredicate.RepeatPredicateSubscriber<Integer> test =
-				new FluxRepeatPredicate.RepeatPredicateSubscriber(source, actual,  () -> true);
+				new FluxRepeatPredicate.RepeatPredicateSubscriber<>(source, actual,  () -> true);
 
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatTest.java
@@ -195,7 +195,7 @@ public class FluxRepeatTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxRepeat test = new FluxRepeat(parent, 4);
+		FluxRepeat<Integer> test = new FluxRepeat<>(parent, 4);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatWhenTest.java
@@ -373,7 +373,7 @@ public class FluxRepeatWhenTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxRepeatWhen<Integer> test = new FluxRepeatWhen(parent, v -> (Integer) v != 10);
+		FluxRepeatWhen<Integer> test = new FluxRepeatWhen<>(parent, c -> c.take(3));
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRetryPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRetryPredicateTest.java
@@ -238,7 +238,7 @@ public class FluxRetryPredicateTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxRetryPredicate test = new FluxRetryPredicate(parent, p -> true);
+		FluxRetryPredicate<Integer> test = new FluxRetryPredicate<>(parent, p -> true);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
@@ -249,7 +249,7 @@ public class FluxRetryPredicateTest {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
 		Flux<Integer> source = Flux.just(1);
 		FluxRetryPredicate.RetryPredicateSubscriber<Integer> test =
-				new FluxRetryPredicate.RetryPredicateSubscriber(source, actual, p -> true);
+				new FluxRetryPredicate.RetryPredicateSubscriber<>(source, actual, p -> true);
 
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRetryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRetryTest.java
@@ -168,7 +168,7 @@ public class FluxRetryTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxRetry<Integer> test = new FluxRetry(parent, 3L);
+		FluxRetry<Integer> test = new FluxRetry<>(parent, 3L);
 
 	    assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 	    assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(-1);
@@ -178,8 +178,8 @@ public class FluxRetryTest {
 	@Test
 	public void scanSubscriber(){
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
-		FluxRetry<Integer> source = new FluxRetry(Flux.just(1), 3L);
-		FluxRetry.RetrySubscriber<Integer> test = new FluxRetry.RetrySubscriber(source, ts, 1L);
+		FluxRetry<Integer> source = new FluxRetry<>(Flux.just(1), 3L);
+		FluxRetry.RetrySubscriber<Integer> test = new FluxRetry.RetrySubscriber<>(source, ts, 1L);
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
@@ -370,7 +370,7 @@ public class FluxRetryWhenTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxRetryWhen test = new FluxRetryWhen(parent, Retry.from(other -> Flux.just(2)));
+		FluxRetryWhen<Integer> test = new FluxRetryWhen<>(parent, Retry.from(other -> Flux.just(2)));
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(-1);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSampleFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSampleFirstTest.java
@@ -179,7 +179,7 @@ public class FluxSampleFirstTest {
 
 	@Test
 	public void scanOperator(){
-	    FluxSampleFirst<Integer, Integer> test = new FluxSampleFirst(Flux.just(1), i -> i);
+	    FluxSampleFirst<Integer, Integer> test = new FluxSampleFirst<>(Flux.just(1), i -> Flux.just(i));
 
 		Assertions.assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTimeoutTest.java
@@ -205,7 +205,7 @@ public class FluxSampleTimeoutTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxSampleTimeout test = new FluxSampleTimeout(parent, v -> Flux.just(2), Queues::empty);
+		FluxSampleTimeout<Integer, Integer> test = new FluxSampleTimeout<>(parent, v -> Flux.just(2), Queues.empty());
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxScanSeedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxScanSeedTest.java
@@ -232,7 +232,7 @@ FluxScanSeedTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxScanSeed test = new FluxScanSeed(parent, () -> Flux.empty(), (v1, v2) -> Flux.just(1));
+		FluxScanSeed<Integer, Integer> test = new FluxScanSeed<>(parent, () -> 0, (v1, v2) -> 1);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
@@ -241,8 +241,8 @@ FluxScanSeedTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void scanCoordinator(){
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
-		FluxScanSeed.ScanSeedCoordinator test =
-				new FluxScanSeed.ScanSeedCoordinator(actual, Flux.just(1), (v1, v2) -> Flux.just(1), () -> Flux.empty());
+		FluxScanSeed.ScanSeedCoordinator<Integer, Integer> test =
+				new FluxScanSeed.ScanSeedCoordinator<>(actual, Flux.just(1), (v1, v2) -> v1, () -> 0);
 
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxScanTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxScanTest.java
@@ -200,7 +200,7 @@ public class FluxScanTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxScan test = new FluxScan(parent, (v1, v2) -> Flux.just(v1));
+		FluxScan<Integer> test = new FluxScan<>(parent, (v1, v2) -> v1);
 
 		Assertions.assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		Assertions.assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSkipLastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSkipLastTest.java
@@ -178,7 +178,7 @@ public class FluxSkipLastTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxSkipLast test = new FluxSkipLast(parent, 3);
+		FluxSkipLast<Integer> test = new FluxSkipLast<>(parent, 3);
 
 		Assertions.assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		Assertions.assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSkipUntilOtherTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSkipUntilOtherTest.java
@@ -256,7 +256,7 @@ public class FluxSkipUntilOtherTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxSkipUntilOther test = new FluxSkipUntilOther(parent, Flux.just(2));
+		FluxSkipUntilOther<Integer, Integer> test = new FluxSkipUntilOther<>(parent, Flux.just(2));
 
 		Assertions.assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		Assertions.assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSkipWhileTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSkipWhileTest.java
@@ -201,7 +201,7 @@ public class FluxSkipWhileTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxSkipWhile test = new FluxSkipWhile(parent, p -> true);
+		FluxSkipWhile<Integer> test = new FluxSkipWhile<>(parent, p -> true);
 
 		Assertions.assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		Assertions.assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSourceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSourceTest.java
@@ -114,7 +114,7 @@ public class FluxSourceTest {
 	@Test
 	public void scanOperatorWithSyncSource() {
 		Flux<Integer> parent = Flux.range(1,  10).map(i -> i);
-		FluxSource<Integer> test = new FluxSource(parent);
+		FluxSource<Integer> test = new FluxSource<>(parent);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(-1);
@@ -123,8 +123,8 @@ public class FluxSourceTest {
 
 	@Test
 	public void scanOperatorWithAsyncSource(){
-		FluxDelaySequence<String> source = new FluxDelaySequence(Flux.just(1), Duration.ofMillis(50), Schedulers.immediate());
-		FluxSource<String> test = new FluxSource(source);
+		FluxDelaySequence<Integer> source = new FluxDelaySequence<>(Flux.just(1), Duration.ofMillis(50), Schedulers.immediate());
+		FluxSource<Integer> test = new FluxSource<>(source);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(-1);
@@ -153,8 +153,8 @@ public class FluxSourceTest {
 
 	@Test
 	public void scanFuseableOperatorWithAsyncSource(){
-		FluxDelaySequence<String> source = new FluxDelaySequence(Flux.just(1), Duration.ofMillis(50), Schedulers.immediate());
-		FluxSourceFuseable<String> test = new FluxSourceFuseable(source);
+		FluxDelaySequence<Integer> source = new FluxDelaySequence<>(Flux.just(1), Duration.ofMillis(50), Schedulers.immediate());
+		FluxSourceFuseable<Integer> test = new FluxSourceFuseable<>(source);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(-1);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxStreamTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxStreamTest.java
@@ -452,7 +452,7 @@ public class FluxStreamTest {
 
 	@Test
 	public void scanOperator(){
-		FluxStream test = new FluxStream(() -> source.stream());
+		FluxStream<Integer> test = new FluxStream<>(() -> source.stream());
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchIfEmptyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchIfEmptyTest.java
@@ -109,7 +109,7 @@ public class FluxSwitchIfEmptyTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxSwitchIfEmpty test = new FluxSwitchIfEmpty(parent, Flux.just(2));
+		FluxSwitchIfEmpty<Integer> test = new FluxSwitchIfEmpty<>(parent, Flux.just(2));
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
@@ -1861,7 +1861,7 @@ public class FluxSwitchOnFirstTest {
     @Test
     public void scanOperator(){
     	Flux<Integer> parent = Flux.just(1);
-        FluxSwitchOnFirst test = new FluxSwitchOnFirst(parent, (s, f) -> Flux.empty(), false);
+        FluxSwitchOnFirst<Integer, Integer> test = new FluxSwitchOnFirst<>(parent, (s, f) -> Flux.empty(), false);
 
         Assertions.assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
         Assertions.assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
@@ -1870,8 +1870,8 @@ public class FluxSwitchOnFirstTest {
     @Test
     public void scanMain(){
         CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
-        FluxSwitchOnFirst.SwitchOnFirstMain test =
-                new FluxSwitchOnFirst.SwitchOnFirstMain(actual, (s, f) -> Flux.empty(), false);
+        FluxSwitchOnFirst.SwitchOnFirstMain<Integer, Integer> test =
+                new FluxSwitchOnFirst.SwitchOnFirstMain<>(actual, (s, f) -> Flux.empty(), false);
 
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
@@ -1885,9 +1885,10 @@ public class FluxSwitchOnFirstTest {
 
     @Test
     public void scanMainConditional(){
+        @SuppressWarnings("unchecked")
         Fuseable.ConditionalSubscriber<String> actual = Mockito.mock(MockUtils.TestScannableConditionalSubscriber.class);
-        FluxSwitchOnFirst.SwitchOnFirstConditionalMain test =
-                new FluxSwitchOnFirst.SwitchOnFirstConditionalMain(actual, (s, f) -> Flux.empty(), false);
+        FluxSwitchOnFirst.SwitchOnFirstConditionalMain<String, String> test =
+                new FluxSwitchOnFirst.SwitchOnFirstConditionalMain<>(actual, (s, f) -> Flux.empty(), false);
 
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
@@ -1901,10 +1902,11 @@ public class FluxSwitchOnFirstTest {
 
     @Test
     public void scanSubscriber(){
+        @SuppressWarnings("unchecked")
         Fuseable.ConditionalSubscriber<String> delegate = Mockito.mock(MockUtils.TestScannableConditionalSubscriber.class);
-        FluxSwitchOnFirst.SwitchOnFirstConditionalMain parent =
-                new FluxSwitchOnFirst.SwitchOnFirstConditionalMain(delegate, (s, f) -> Flux.empty(), false);
-        FluxSwitchOnFirst.SwitchOnFirstControlSubscriber test = new FluxSwitchOnFirst.SwitchOnFirstControlSubscriber(parent, delegate, false);
+        FluxSwitchOnFirst.SwitchOnFirstConditionalMain<String, String> parent =
+                new FluxSwitchOnFirst.SwitchOnFirstConditionalMain<>(delegate, (s, f) -> Flux.empty(), false);
+        FluxSwitchOnFirst.SwitchOnFirstControlSubscriber<String> test = new FluxSwitchOnFirst.SwitchOnFirstControlSubscriber<>(parent, delegate, false);
 
         Subscription sub = Operators.emptySubscription();
         test.onSubscribe(sub);
@@ -1916,10 +1918,11 @@ public class FluxSwitchOnFirstTest {
 
     @Test
     public void scanConditionnalSubscriber(){
+        @SuppressWarnings("unchecked")
         Fuseable.ConditionalSubscriber<String> delegate = Mockito.mock(MockUtils.TestScannableConditionalSubscriber.class);
-        FluxSwitchOnFirst.SwitchOnFirstConditionalMain main =
-                new FluxSwitchOnFirst.SwitchOnFirstConditionalMain(delegate, (s, f) -> Flux.empty(), false);
-        FluxSwitchOnFirst.SwitchOnFirstConditionalControlSubscriber test = new FluxSwitchOnFirst.SwitchOnFirstConditionalControlSubscriber(main, delegate, false);
+        FluxSwitchOnFirst.SwitchOnFirstConditionalMain<String, String> main =
+                new FluxSwitchOnFirst.SwitchOnFirstConditionalMain<>(delegate, (s, f) -> Flux.empty(), false);
+        FluxSwitchOnFirst.SwitchOnFirstConditionalControlSubscriber<String> test = new FluxSwitchOnFirst.SwitchOnFirstConditionalControlSubscriber<>(main, delegate, false);
 
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeLastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeLastTest.java
@@ -169,7 +169,7 @@ public class FluxTakeLastTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1, 2, 3, 4, 5);
-		FluxTakeLast<Integer> test = new FluxTakeLast(parent, 3);
+		FluxTakeLast<Integer> test = new FluxTakeLast<>(parent, 3);
 
 	    Assertions.assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 	    Assertions.assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeUntilPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeUntilPredicateTest.java
@@ -162,7 +162,7 @@ public class FluxTakeUntilPredicateTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxTakeUntil test = new FluxTakeUntil(parent, v -> true);
+		FluxTakeUntil<Integer> test = new FluxTakeUntil<>(parent, v -> true);
 
 		Assertions.assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		Assertions.assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeWhileTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeWhileTest.java
@@ -174,7 +174,7 @@ public class FluxTakeWhileTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxTakeWhile test = new FluxTakeWhile(parent, v -> true);
+		FluxTakeWhile<Integer> test = new FluxTakeWhile<>(parent, v -> true);
 
 		Assertions.assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		Assertions.assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
@@ -436,7 +436,7 @@ public class FluxTimeoutTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxTimeout test = new FluxTimeout(parent, Flux.just(2), v -> Flux.empty(), "desc");
+		FluxTimeout<Integer, Integer, ?> test = new FluxTimeout<>(parent, Flux.just(2), v -> Flux.empty(), "desc");
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
@@ -444,8 +444,8 @@ public class FluxTimeoutTest {
 
 	@Test
 	public void scanMainSubscriber(){
-		CoreSubscriber<List<String>> actual = new LambdaSubscriber<>(null, e -> {}, null, s -> s.request(1));
-		TimeoutMainSubscriber test = new TimeoutMainSubscriber(actual, Flux.empty(), v -> Flux.just(2), Flux.empty(), "desc");
+		CoreSubscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, s -> s.request(1));
+		FluxTimeout.TimeoutMainSubscriber<String, Integer> test = new FluxTimeout.TimeoutMainSubscriber<>(actual, Flux.empty(), v -> Flux.just(2), Flux.empty(), "desc");
 
 		Subscription subscription = Operators.emptySubscription();
 		test.onSubscribe(subscription);
@@ -463,9 +463,9 @@ public class FluxTimeoutTest {
 
 	@Test
 	public void scanOtherSubscriber(){
-		CoreSubscriber<List<String>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
-		TimeoutMainSubscriber main = new TimeoutMainSubscriber(actual, Flux.empty(), v -> Flux.just(2), Flux.empty(), "desc");
-		TimeoutOtherSubscriber test = new TimeoutOtherSubscriber(actual, main);
+		CoreSubscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+		FluxTimeout.TimeoutMainSubscriber<String, Integer> main = new FluxTimeout.TimeoutMainSubscriber<>(actual, Flux.empty(), v -> Flux.just(2), Flux.empty(), "desc");
+		FluxTimeout.TimeoutOtherSubscriber<String> test = new FluxTimeout.TimeoutOtherSubscriber<>(actual, main);
 
 		Subscription subscription = Operators.emptySubscription();
 		test.onSubscribe(subscription);
@@ -476,9 +476,9 @@ public class FluxTimeoutTest {
 
 	@Test
 	public void scanTimeoutSubscriber(){
-		CoreSubscriber<List<String>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
-		TimeoutMainSubscriber main = new TimeoutMainSubscriber(actual, Flux.empty(), v -> Flux.just(2), Flux.empty(), "desc");
-		TimeoutTimeoutSubscriber test = new TimeoutTimeoutSubscriber(main, 2);
+		CoreSubscriber<String> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+		FluxTimeout.TimeoutMainSubscriber<String, Integer> main = new FluxTimeout.TimeoutMainSubscriber<>(actual, Flux.empty(), v -> Flux.just(2), Flux.empty(), "desc");
+		FluxTimeout.TimeoutTimeoutSubscriber test = new FluxTimeout.TimeoutTimeoutSubscriber(main, 2);
 
 		Subscription subscription = Operators.emptySubscription();
 		test.onSubscribe(subscription);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
@@ -251,7 +251,7 @@ public class FluxWindowBoundaryTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxWindowBoundary test = new FluxWindowBoundary(parent, Flux.just(2), Queues::empty);
+		FluxWindowBoundary<Integer, Integer> test = new FluxWindowBoundary<>(parent, Flux.just(2), Queues.empty());
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
@@ -1059,7 +1059,7 @@ public class FluxWindowPredicateTest extends
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxWindowPredicate test = new FluxWindowPredicate(parent, Queues::empty, Queues::empty, 35, v -> true, Mode.UNTIL);
+		FluxWindowPredicate<Integer> test = new FluxWindowPredicate<>(parent, Queues.empty(), Queues.empty(), 35, v -> true, Mode.UNTIL);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTest.java
@@ -582,7 +582,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxWindow test = new FluxWindow(parent, 3, Queues::empty);
+		FluxWindow<Integer> test = new FluxWindow<>(parent, 3, Queues.empty());
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
@@ -578,7 +578,7 @@ public class FluxWindowWhenTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxWindowWhen test = new FluxWindowWhen(parent, Flux.just(2), v -> Flux.empty(), Queues::empty);
+		FluxWindowWhen<Integer, Integer, Object> test = new FluxWindowWhen<>(parent, Flux.just(2), v -> Flux.empty(), Queues.empty());
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/LiftFunctionTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/LiftFunctionTest.java
@@ -16,8 +16,6 @@
 
 package reactor.core.publisher;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -27,27 +25,26 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
-
 import reactor.core.CorePublisher;
 import reactor.core.Fuseable;
-import reactor.core.Scannable;
 import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static reactor.core.Scannable.*;
+import static reactor.core.Scannable.Attr;
+import static reactor.core.Scannable.from;
 
 public class LiftFunctionTest {
 
 	Publisher<Integer> liftOperator;
 
-	Publisher createPublisherAndApply(CorePublisher source) {
-		Operators.LiftFunction<Integer, Integer> liftFunction =
+	<T> Publisher<T> createPublisherAndApply(CorePublisher<T> source) {
+		Operators.LiftFunction<T, T> liftFunction =
 				Operators.LiftFunction.liftScannable(null, (s, actual) -> actual);
 		return liftFunction.apply(source);
 	}
 
-	void lift(Class publisher, Class fluxPublisher) {
+	void lift(Class<?> publisher, Class<?> fluxPublisher) {
 		assertThat(liftOperator)
 				.isInstanceOf(publisher)
 				.isExactlyInstanceOf(fluxPublisher);
@@ -57,7 +54,7 @@ public class LiftFunctionTest {
 				.doesNotThrowAnyException();
 	}
 
-	void liftFuseable(Class publisher, Class fluxPublisher) {
+	void liftFuseable(Class<?> publisher, Class<?> fluxPublisher) {
 		assertThat(liftOperator)
 				.isInstanceOf(publisher)
 				.isInstanceOf(Fuseable.class)
@@ -68,7 +65,7 @@ public class LiftFunctionTest {
 				.doesNotThrowAnyException();
 	}
 
-	void scanOperator(CorePublisher source, int prefetch, Attr.RunStyle runStyle) {
+	void scanOperator(CorePublisher<?> source, int prefetch, Attr.RunStyle runStyle) {
 		assertThat(from(liftOperator).scan(Attr.PARENT)).isSameAs(source);
 		assertThat(from(liftOperator).scan(Attr.PREFETCH)).isEqualTo(prefetch);
 		assertThat(from(liftOperator).scan(Attr.RUN_STYLE)).isSameAs(runStyle);
@@ -255,9 +252,9 @@ public class LiftFunctionTest {
 	@Nested
 	class ParallelLiftFuseableTest {
 
-		ParallelFlux<List<Integer>> source = Flux.just(1)
+		ParallelFlux<Integer> source = Flux.just(1)
 				.parallel(2)
-				.collect(ArrayList::new, List::add);
+				.reduce(() -> 1, (a, b) -> a);
 
 		@BeforeEach
 		void createFluxAndApply() {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoAllTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoAllTest.java
@@ -110,7 +110,7 @@ public class MonoAllTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoAll<Integer> test = new MonoAll(Flux.just(1, 2, 3), v -> true);
+	    MonoAll<Integer> test = new MonoAll<>(Flux.just(1, 2, 3), v -> true);
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoAnyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoAnyTest.java
@@ -174,7 +174,7 @@ public class MonoAnyTest {
 	@Test
 	public void scanOperator() {
 		Flux<Integer> parent = Flux.just(1);
-		MonoAny test = new MonoAny(parent, v -> true);
+		MonoAny<Integer> test = new MonoAny<>(parent, v -> true);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
@@ -866,7 +866,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 	@Test
 	public void scanOperator(){
 	    Mono<Integer> source = Mono.just(1);
-		MonoCacheTime test = new MonoCacheTime(source);
+		MonoCacheTime<Integer> test = new MonoCacheTime<>(source);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
@@ -875,8 +875,8 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 
 	@Test
 	public void scanCoordinatorSubscriber(){
-		MonoCacheTime main = new MonoCacheTime(Mono.just(1));
-		MonoCacheTime.CoordinatorSubscriber test = new MonoCacheTime.CoordinatorSubscriber(main);
+		MonoCacheTime<Integer> main = new MonoCacheTime<>(Mono.just(1));
+		MonoCacheTime.CoordinatorSubscriber<Integer> test = new MonoCacheTime.CoordinatorSubscriber<>(main);
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}
@@ -884,7 +884,7 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 	@Test
 	public void scanSubscriber() {
 		CoreSubscriber<Boolean> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
-		MonoCacheTime.CacheMonoSubscriber test = new MonoCacheTime.CacheMonoSubscriber(actual);
+		MonoCacheTime.CacheMonoSubscriber<Boolean> test = new MonoCacheTime.CacheMonoSubscriber<>(actual);
 
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
@@ -152,7 +152,7 @@ public class MonoCollectListTest {
 	@Test
 	public void scanOperator(){
 	    Flux<Integer> source = Flux.just(1);
-		MonoCollectList test = new MonoCollectList(source);
+		MonoCollectList<Integer> test = new MonoCollectList<>(source);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCollectTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCollectTest.java
@@ -134,7 +134,7 @@ public class MonoCollectTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> source = Flux.just(1, 2, 3);
-		MonoCollect test = new MonoCollect(source, () -> 1, (a, b) -> {});
+		MonoCollect<Integer, List<Integer>> test = new MonoCollect<>(source, ArrayList::new, (a, b) -> {});
 
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCompletionStageTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCompletionStageTest.java
@@ -151,7 +151,7 @@ MonoCompletionStageTest {
 	@Test
 	public void scanOperator(){
 		CompletionStage<String> completionStage = CompletableFuture.supplyAsync(() -> "helloFuture");
-		MonoCompletionStage<String> test = new MonoCompletionStage(completionStage);
+		MonoCompletionStage<String> test = new MonoCompletionStage<>(completionStage);
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.ASYNC);
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isNull();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCountTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCountTest.java
@@ -59,7 +59,7 @@ public class MonoCountTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoCount test = new MonoCount(Flux.just(1, 2, 3));
+	    MonoCount<Integer> test = new MonoCount<>(Flux.just(1, 2, 3));
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCreateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCreateTest.java
@@ -318,7 +318,7 @@ public class MonoCreateTest {
 
 	@Test
 	public void scanOperator() {
-		MonoCreate<String> test = new MonoCreate(null);
+		MonoCreate<String> test = new MonoCreate<>(null);
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.ASYNC);
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isNull();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDeferTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDeferTest.java
@@ -58,7 +58,7 @@ public class MonoDeferTest {
 	public void scanOperator() {
 		AtomicInteger i = new AtomicInteger();
 
-		MonoDefer<Integer> test = new MonoDefer(() -> Mono.just(i.incrementAndGet()));
+		MonoDefer<Integer> test = new MonoDefer<>(() -> Mono.just(i.incrementAndGet()));
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isNull();
@@ -68,7 +68,7 @@ public class MonoDeferTest {
 	public void scanOperatorWithContext() {
 		AtomicInteger i = new AtomicInteger();
 
-		MonoDeferWithContext<Integer> test = new MonoDeferWithContext(c -> Mono.just(i.incrementAndGet()));
+		MonoDeferWithContext<Integer> test = new MonoDeferWithContext<>(c -> Mono.just(i.incrementAndGet()));
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isNull();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDelaySubscriptionTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDelaySubscriptionTest.java
@@ -175,7 +175,7 @@ public class MonoDelaySubscriptionTest {
 
 	@Test
 	public void scanOperator(){
-		MonoDelaySubscription<Integer, Integer> test = new MonoDelaySubscription(Mono.just(1), Mono.just(2));
+		MonoDelaySubscription<Integer, Integer> test = new MonoDelaySubscription<>(Mono.just(1), Mono.just(2));
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDelayUntilTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDelayUntilTest.java
@@ -205,7 +205,7 @@ public class MonoDelayUntilTest {
 	@Test
 	public void scanOperator(){
 	    Mono<Integer> source = Mono.just(1);
-		MonoDelayUntil test = new MonoDelayUntil(source, i -> Mono.just(1));
+		MonoDelayUntil<Integer> test = new MonoDelayUntil<>(source, i -> Mono.just(1));
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDematerializeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDematerializeTest.java
@@ -216,7 +216,7 @@ public class MonoDematerializeTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoDematerialize test = new MonoDematerialize(Mono.just(Signal.next(1)));
+	    MonoDematerialize<Integer> test = new MonoDematerialize<>(Mono.just(Signal.next(1)));
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoElementAtTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoElementAtTest.java
@@ -218,7 +218,7 @@ public class MonoElementAtTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoElementAt<String> test = new MonoElementAt(Flux.just(1, 2, 3), 1);
+	    MonoElementAt<Integer> test = new MonoElementAt<>(Flux.just(1, 2, 3), 1);
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoErrorSuppliedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoErrorSuppliedTest.java
@@ -128,7 +128,7 @@ public class MonoErrorSuppliedTest {
 
 	@Test
 	public void scanOperator(){
-		MonoErrorSupplied test = new MonoErrorSupplied(() -> new NullPointerException());
+		MonoErrorSupplied<?> test = new MonoErrorSupplied<>(() -> new NullPointerException());
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
@@ -318,7 +318,7 @@ public class MonoFilterWhenTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoFilterWhen<Integer> test = new MonoFilterWhen(Mono.just(1), null);
+	    MonoFilterWhen<Integer> test = new MonoFilterWhen<>(Mono.just(1), null);
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFirstTest.java
@@ -134,6 +134,7 @@ public class MonoFirstTest {
 
 	@Test
 	public void scanOperator(){
+		@SuppressWarnings("unchecked")
 		MonoFirst<Integer> test = new MonoFirst<>(Mono.just(1), Mono.just(2));
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFlatMapManyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFlatMapManyTest.java
@@ -63,7 +63,7 @@ public class MonoFlatMapManyTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoFlatMapMany<String, Integer> test = new MonoFlatMapMany(Mono.just("foo"), s -> Mono.just(1));
+	    MonoFlatMapMany<String, Integer> test = new MonoFlatMapMany<>(Mono.just("foo"), s -> Mono.just(1));
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFlatMapTest.java
@@ -53,7 +53,7 @@ public class MonoFlatMapTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoFlatMap<String, Integer> test = new MonoFlatMap(Mono.just("foo"), s -> Mono.just(1));
+	    MonoFlatMap<String, Integer> test = new MonoFlatMap<>(Mono.just("foo"), s -> Mono.just(1));
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFlattenIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFlattenIterableTest.java
@@ -13,8 +13,8 @@ public class MonoFlattenIterableTest {
 
 	@Test
 	public void scanOperator() {
-		MonoFlattenIterable<Integer, ArrayList<Integer>> test =
-                new MonoFlattenIterable(Mono.just(1), i -> Arrays.asList(i), Integer.MAX_VALUE, Queues.one());
+		MonoFlattenIterable<Integer, Integer> test =
+                new MonoFlattenIterable<>(Mono.just(1), i -> Arrays.asList(i), Integer.MAX_VALUE, Queues.one());
 
         assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFromPublisherTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFromPublisherTest.java
@@ -9,7 +9,7 @@ public class MonoFromPublisherTest {
 
 	@Test
 	public void scanOperator(){
-		MonoFromPublisher test = new MonoFromPublisher(Flux.just("foo", "bar"));
+		MonoFromPublisher<String> test = new MonoFromPublisher<>(Flux.just("foo", "bar"));
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoHandleTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoHandleTest.java
@@ -56,14 +56,14 @@ public class MonoHandleTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoHandle<Integer, Integer> test = new MonoHandle(Mono.just(1), (v, s) -> {});
+	    MonoHandle<Integer, Integer> test = new MonoHandle<>(Mono.just(1), (v, s) -> {});
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}
 
 	@Test
 	public void scanFuseableOperator(){
-		MonoHandleFuseable<Integer, Integer> test = new MonoHandleFuseable(Mono.just(1), (v, s) -> {});
+		MonoHandleFuseable<Integer, Integer> test = new MonoHandleFuseable<>(Mono.just(1), (v, s) -> {});
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoHideTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoHideTest.java
@@ -35,7 +35,7 @@ public class MonoHideTest {
 	@Test
 	public void scanOperator(){
 		Mono<Integer> parent = Mono.just(1);
-		MonoHide<Integer> test = new MonoHide(parent);
+		MonoHide<Integer> test = new MonoHide<>(parent);
 
 	    assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 	    assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreElementTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreElementTest.java
@@ -9,7 +9,7 @@ public class MonoIgnoreElementTest {
 
     @Test
     public void scanOperator(){
-        MonoIgnoreElement<Integer> test = new MonoIgnoreElement(Mono.just(1));
+        MonoIgnoreElement<Integer> test = new MonoIgnoreElement<>(Mono.just(1));
 
         assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
     }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreElementsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreElementsTest.java
@@ -12,7 +12,7 @@ public class MonoIgnoreElementsTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> source = Flux.just(1);
-		MonoIgnoreElements<Integer> test = new MonoIgnoreElements(source);
+		MonoIgnoreElements<Integer> test = new MonoIgnoreElements<>(source);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
@@ -22,7 +22,7 @@ public class MonoIgnoreElementsTest {
 	@Test
 	public void scanSubscriber() {
 		CoreSubscriber<Boolean> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
-		MonoIgnoreElements.IgnoreElementsSubscriber test = new MonoIgnoreElements.IgnoreElementsSubscriber(actual);
+		MonoIgnoreElements.IgnoreElementsSubscriber<Boolean> test = new MonoIgnoreElements.IgnoreElementsSubscriber<>(actual);
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoIgnorePublisherTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoIgnorePublisherTest.java
@@ -17,7 +17,7 @@ public class MonoIgnorePublisherTest {
 
     @Test
     public void scanOperator(){
-        MonoIgnoreElement<String> test = new MonoIgnoreElement(Mono.just("foo"));
+        MonoIgnoreElement<String> test = new MonoIgnoreElement<>(Mono.just("foo"));
 
         assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
     }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreThenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreThenTest.java
@@ -14,7 +14,7 @@ public class MonoIgnoreThenTest {
 
     @Test
     public void scanOperator() {
-        MonoIgnoreThen<String> test = new MonoIgnoreThen(new Publisher[]{Mono.just("foo")}, Mono.just("bar"));
+        MonoIgnoreThen<String> test = new MonoIgnoreThen<>(new Publisher[]{Mono.just("foo")}, Mono.just("bar"));
 
         assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
     }
@@ -22,7 +22,7 @@ public class MonoIgnoreThenTest {
     @Test
     public void scanThenIgnoreMain() {
         AssertSubscriber<String> actual = new AssertSubscriber<>();
-        MonoIgnoreThen.ThenIgnoreMain<String> test = new MonoIgnoreThen.ThenIgnoreMain(actual, new Publisher[]{Mono.just("foo")}, Mono.just("bar"));
+        MonoIgnoreThen.ThenIgnoreMain<String> test = new MonoIgnoreThen.ThenIgnoreMain<>(actual, new Publisher[]{Mono.just("foo")}, Mono.just("bar"));
 
         assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
     }
@@ -31,7 +31,7 @@ public class MonoIgnoreThenTest {
     public void scanThenIgnoreInner() {
         AssertSubscriber<String> actual = new AssertSubscriber<>();
         MonoIgnoreThen.ThenIgnoreMain<String> main =
-                new MonoIgnoreThen.ThenIgnoreMain(actual, new Publisher[]{Mono.just("foo")}, Mono.just("bar"));
+                new MonoIgnoreThen.ThenIgnoreMain<>(actual, new Publisher[]{Mono.just("foo")}, Mono.just("bar"));
         MonoIgnoreThen.ThenIgnoreInner test = new MonoIgnoreThen.ThenIgnoreInner(main);
 
         Subscription innerSubscription = Operators.emptySubscription();
@@ -51,8 +51,8 @@ public class MonoIgnoreThenTest {
     public void scanThenAcceptInner() {
         AssertSubscriber<String> actual = new AssertSubscriber<>();
         MonoIgnoreThen.ThenIgnoreMain<String> main =
-                new MonoIgnoreThen.ThenIgnoreMain(actual, new Publisher[]{Mono.just("foo")}, Mono.just("bar"));
-        MonoIgnoreThen.ThenAcceptInner<String> test = new MonoIgnoreThen.ThenAcceptInner(main);
+                new MonoIgnoreThen.ThenIgnoreMain<>(actual, new Publisher[]{Mono.just("foo")}, Mono.just("bar"));
+        MonoIgnoreThen.ThenAcceptInner<String> test = new MonoIgnoreThen.ThenAcceptInner<>(main);
 
         Subscription innerSubscription = Operators.emptySubscription();
         test.onSubscribe(innerSubscription);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoLogTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoLogTest.java
@@ -12,7 +12,7 @@ public class MonoLogTest {
     @Test
     public void scanOperator(){
         Mono<Integer> source = Mono.just(1);
-        MonoLog<Integer> test = new MonoLog(source,
+        MonoLog<Integer> test = new MonoLog<>(source,
                 new SignalLogger<>(source, "category", Level.INFO, false, SignalType.ON_COMPLETE));
 
         assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
@@ -21,7 +21,7 @@ public class MonoLogTest {
     @Test
     public void scanFuseableOperator(){
         Mono<Integer> source = Mono.just(1);
-        MonoLogFuseable<Integer> test = new MonoLogFuseable(source,
+        MonoLogFuseable<Integer> test = new MonoLogFuseable<>(source,
                 new SignalLogger<>(source, "category", Level.INFO, false, SignalType.ON_COMPLETE));
 
         assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMetricsFuseableTest.java
@@ -72,7 +72,7 @@ public class MonoMetricsFuseableTest {
 	@Test
 	public void scanSubscriber(){
 		CoreSubscriber<Integer> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
-		MetricsFuseableSubscriber<Integer> test = new MetricsFuseableSubscriber(actual, registry, Clock.SYSTEM, Tags.empty());
+		MetricsFuseableSubscriber<Integer> test = new MetricsFuseableSubscriber<>(actual, registry, Clock.SYSTEM, Tags.empty());
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNextTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNextTest.java
@@ -65,7 +65,7 @@ public class MonoNextTest {
 	@Test
 	public void scanOperator(){
 		Flux<String> source = Flux.just("foo", "bar");
-		MonoNext test = new MonoNext(source);
+		MonoNext<String> test = new MonoNext<>(source);
 
 	    assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);
 	    assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoOnErrorResumeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoOnErrorResumeTest.java
@@ -285,7 +285,7 @@ public class MonoOnErrorResumeTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoOnErrorResume<String> test = new MonoOnErrorResume(Mono.just("foo"), e -> Mono.just("bar"));
+	    MonoOnErrorResume<String> test = new MonoOnErrorResume<>(Mono.just("foo"), e -> Mono.just("bar"));
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTerminalTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTerminalTest.java
@@ -27,7 +27,7 @@ public class MonoPeekTerminalTest {
 
 	@Test
 	public void scanOperator(){
-		MonoPeekTerminal test = new MonoPeekTerminal(Mono.just("foo"), null, null, null);
+		MonoPeekTerminal<String> test = new MonoPeekTerminal<>(Mono.just("foo"), null, null, null);
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTest.java
@@ -183,14 +183,14 @@ public class MonoPeekTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoPeek test = new MonoPeek(Mono.just(1), null, null, null, null);
+	    MonoPeek<Integer> test = new MonoPeek<>(Mono.just(1), null, null, null, null);
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}
 
 	@Test
 	public void scanFuseableOperator(){
-		MonoPeekFuseable test = new MonoPeekFuseable(Mono.just(1), null, null, null, null);
+		MonoPeekFuseable<Integer> test = new MonoPeekFuseable<>(Mono.just(1), null, null, null, null);
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
@@ -704,7 +704,7 @@ public class MonoProcessorTest {
 		MonoProcessor<String> processor = MonoProcessor.create();
 		AssertSubscriber<String> subscriber = new AssertSubscriber<>();
 
-		MonoProcessor.NextInner test = new MonoProcessor.NextInner(subscriber, processor);
+		MonoProcessor.NextInner<String> test = new MonoProcessor.NextInner<>(subscriber, processor);
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoReduceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoReduceTest.java
@@ -306,7 +306,7 @@ public class MonoReduceTest extends ReduceOperatorTest<String, String>{
 
 	@Test
 	public void scanOperator(){
-	    MonoReduce<Integer> test = new MonoReduce(Flux.just(1, 2, 3), (a, b) -> (Integer) a + (Integer) b);
+	    MonoReduce<Integer> test = new MonoReduce<>(Flux.just(1, 2, 3), (a, b) -> a + b);
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRepeatPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRepeatPredicateTest.java
@@ -70,7 +70,7 @@ public class MonoRepeatPredicateTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoRepeatPredicate<Integer> test = new MonoRepeatPredicate(Mono.just(1), () -> true);
+	    MonoRepeatPredicate<Integer> test = new MonoRepeatPredicate<>(Mono.just(1), () -> true);
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRepeatTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRepeatTest.java
@@ -136,7 +136,7 @@ public class MonoRepeatTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoRepeat<Integer> test = new MonoRepeat(Mono.just(1), 5L);
+	    MonoRepeat<Integer> test = new MonoRepeat<>(Mono.just(1), 5L);
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRepeatWhenEmptyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRepeatWhenEmptyTest.java
@@ -107,7 +107,7 @@ public class MonoRepeatWhenEmptyTest {
 
     @Test
     public void scanOperator(){
-        MonoRepeatWhen<Integer> test = new MonoRepeatWhen(Mono.just(1), o -> Mono.empty());
+        MonoRepeatWhen<Integer> test = new MonoRepeatWhen<>(Mono.just(1), o -> Mono.empty());
 
         assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
     }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRetryPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRetryPredicateTest.java
@@ -68,7 +68,7 @@ public class MonoRetryPredicateTest {
 
 	@Test
 	public void scanOperator(){
-		MonoRetryPredicate<String> test = new MonoRetryPredicate(Mono.just("foo"), e -> true);
+		MonoRetryPredicate<String> test = new MonoRetryPredicate<>(Mono.just("foo"), e -> true);
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRetryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRetryTest.java
@@ -123,7 +123,7 @@ public class MonoRetryTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoRetry test = new MonoRetry(Mono.just(1), 3L);
+	    MonoRetry<Integer> test = new MonoRetry<>(Mono.just(1), 3L);
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRetryWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRetryWhenTest.java
@@ -336,7 +336,7 @@ public class MonoRetryWhenTest {
 	@Test
 	public void scanOperator(){
 		Mono<String> parent = Mono.just("foo");
-		MonoRetryWhen<String> test = new MonoRetryWhen(parent, Retry.backoff(5, Duration.ofMinutes(30)));
+		MonoRetryWhen<String> test = new MonoRetryWhen<>(parent, Retry.backoff(5, Duration.ofMinutes(30)));
 
 	    assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRunnableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRunnableTest.java
@@ -169,7 +169,7 @@ public class MonoRunnableTest {
 
 	@Test
 	public void scanOperator(){
-		MonoRunnable<String> test = new MonoRunnable(() -> {});
+		MonoRunnable<String> test = new MonoRunnable<>(() -> {});
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSingleMonoTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSingleMonoTest.java
@@ -42,7 +42,7 @@ public class MonoSingleMonoTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoSingleMono<String> test = new MonoSingleMono(Mono.just("foo"));
+	    MonoSingleMono<String> test = new MonoSingleMono<>(Mono.just("foo"));
 	    
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSingleTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSingleTest.java
@@ -246,7 +246,7 @@ public class MonoSingleTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoSingle<String> test = new MonoSingle(Flux.just("foo"));
+	    MonoSingle<String> test = new MonoSingle<>(Flux.just("foo"));
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSourceFluxTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSourceFluxTest.java
@@ -10,7 +10,7 @@ public class MonoSourceFluxTest {
 	@Test
 	public void scanOperator(){
 		Flux<String> source = Flux.just("foo", "bar");
-		MonoSourceFlux<String> test = new MonoSourceFlux(source);
+		MonoSourceFlux<String> test = new MonoSourceFlux<>(source);
 
 	    assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
@@ -20,7 +20,7 @@ public class MonoSourceFluxTest {
 	@Test
 	public void scanFuseableOperator(){
 		Flux<String> source = Flux.just("foo", "bar");
-		MonoSourceFluxFuseable<String> test = new MonoSourceFluxFuseable(source);
+		MonoSourceFluxFuseable<String> test = new MonoSourceFluxFuseable<>(source);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSourceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSourceTest.java
@@ -264,7 +264,7 @@ public class MonoSourceTest {
 	@Test
 	public void scanSubscriber() {
 		Flux<String> source = Flux.just("foo").map(i -> i);
-		MonoSource<String> test = new MonoSource(source);
+		MonoSource<String> test = new MonoSource<>(source);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isNull();
@@ -274,7 +274,7 @@ public class MonoSourceTest {
 	@Test
 	public void scanFuseableSubscriber(){
 		Mono<String> source = Mono.just("foo");
-		MonoSourceFuseable<String> test = new MonoSourceFuseable(source);
+		MonoSourceFuseable<String> test = new MonoSourceFuseable<>(source);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
@@ -283,7 +283,7 @@ public class MonoSourceTest {
 	@Test
 	public void scanSubscriberHide() {
 		Flux<String> source = Flux.just("foo").hide();
-		MonoSource<String> test = new MonoSource(source);
+		MonoSource<String> test = new MonoSource<>(source);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isNull();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoStreamCollectorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoStreamCollectorTest.java
@@ -115,7 +115,7 @@ public class MonoStreamCollectorTest {
 	@Test
 	public void scanOperator(){
 	    Flux<Integer> source = Flux.just(1);
-		MonoStreamCollector test = new MonoStreamCollector(source, Collectors.toSet());
+		MonoStreamCollector<Integer, ?, Set<Integer>> test = new MonoStreamCollector<>(source, Collectors.toSet());
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSubscriberContextTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSubscriberContextTest.java
@@ -10,7 +10,7 @@ public class MonoSubscriberContextTest {
 
     @Test
     public void scanOperator(){
-        MonoSubscriberContext<String> test = new MonoSubscriberContext(Mono.just(1), c -> c);
+        MonoSubscriberContext<Integer> test = new MonoSubscriberContext<>(Mono.just(1), c -> c);
 
         assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
     }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSupplierTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSupplierTest.java
@@ -100,7 +100,7 @@ public class MonoSupplierTest {
 
 	@Test
 	public void scanOperator(){
-		MonoSupplier<String> test = new MonoSupplier(() -> "test");
+		MonoSupplier<String> test = new MonoSupplier<>(() -> "test");
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSwitchIfEmptyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSwitchIfEmptyTest.java
@@ -100,7 +100,7 @@ public class MonoSwitchIfEmptyTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoSwitchIfEmpty<String> test = new MonoSwitchIfEmpty(Mono.just(1), Mono.empty());
+	    MonoSwitchIfEmpty<Integer> test = new MonoSwitchIfEmpty<>(Mono.just(1), Mono.empty());
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTakeLastOneTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTakeLastOneTest.java
@@ -155,7 +155,7 @@ public class MonoTakeLastOneTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoTakeLastOne<Integer> test = new MonoTakeLastOne(Flux.just(1, 2, 3));
+	    MonoTakeLastOne<Integer> test = new MonoTakeLastOne<>(Flux.just(1, 2, 3));
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTakeUntilOtherTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTakeUntilOtherTest.java
@@ -196,7 +196,7 @@ public class MonoTakeUntilOtherTest {
 	@Test
 	public void scanOperator(){
 		TestPublisher<String> other = TestPublisher.create();
-	    MonoTakeUntilOther<Integer, String> test = new MonoTakeUntilOther(Mono.just(1), other);
+	    MonoTakeUntilOther<Integer, String> test = new MonoTakeUntilOther<>(Mono.just(1), other);
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
@@ -173,7 +173,7 @@ public class MonoTimeoutTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoTimeout test = new MonoTimeout(Mono.just(1), Mono.just("foo"), "timeout");
+	    MonoTimeout<Integer, String, String> test = new MonoTimeout<>(Mono.just(1), Mono.just("foo"), "timeout");
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoUsingTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoUsingTest.java
@@ -397,7 +397,7 @@ public class MonoUsingTest {
 
 	@Test
 	public void scanOperator(){
-		MonoUsing<Integer, Integer> test = new MonoUsing(() -> 1, r -> Mono.just(1), c -> {}, false);
+		MonoUsing<Integer, Integer> test = new MonoUsing<>(() -> 1, r -> Mono.just(1), c -> {}, false);
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isNull();
@@ -407,7 +407,7 @@ public class MonoUsingTest {
 	@Test
 	public void scanSubscriber() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
-		MonoUsing.MonoUsingSubscriber test = new MonoUsing.MonoUsingSubscriber(actual, rc -> {}, "foo", false, false);
+		MonoUsing.MonoUsingSubscriber<Integer, ?> test = new MonoUsing.MonoUsingSubscriber<>(actual, rc -> {}, "foo", false, false);
 
 		final Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelArraySourceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelArraySourceTest.java
@@ -38,6 +38,7 @@ public class ParallelArraySourceTest {
 
 	@Test
 	public void scanOperator(){
+		@SuppressWarnings("unchecked")
 		Publisher<Integer>[] sources = new Publisher[2];
 		sources[0] = Flux.range(1, 4);
 		sources[1] = just(10);

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelDoOnEachTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelDoOnEachTest.java
@@ -11,7 +11,7 @@ public class ParallelDoOnEachTest {
 	@Test
 	public void scanOperator(){
 		ParallelFlux<Integer> parent = Flux.just(1).parallel(2);
-		ParallelDoOnEach test = new ParallelDoOnEach(parent, (k, v) -> {}, (k, v) -> {}, v -> {});
+		ParallelDoOnEach<Integer> test = new ParallelDoOnEach<>(parent, (k, v) -> {}, (k, v) -> {}, v -> {});
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(Queues.SMALL_BUFFER_SIZE);

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -37,7 +37,7 @@ ext {
 
 dependencies {
 	compile project(":reactor-core")
-	compileOnly "com.google.code.findbugs:jsr305:${jsr305Version}"
+	compileOnly "com.google.code.findbugs:jsr305:${findbugsVersion}"
 
 	optional "org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}"
 

--- a/reactor-test/src/test/java/reactor/test/publisher/ColdTestPublisherTests.java
+++ b/reactor-test/src/test/java/reactor/test/publisher/ColdTestPublisherTests.java
@@ -307,7 +307,7 @@ public class ColdTestPublisherTests {
 		TestPublisher<String> publisher = TestPublisher.createCold();
 
 		assertThatExceptionOfType(NullPointerException.class)
-				.isThrownBy(() -> publisher.next(null, null)) //this causes a compiler warning, on purpose
+				.isThrownBy(() -> publisher.next(null, (String[]) null)) //end users forgetting to cast would see compiler warning as well
 				.withMessage("rest array is null, please cast to T if null T required");
 	}
 
@@ -316,7 +316,7 @@ public class ColdTestPublisherTests {
 		TestPublisher<String> publisher = TestPublisher.createCold();
 
 		assertThatExceptionOfType(NullPointerException.class)
-				.isThrownBy(() -> publisher.emit(null)) //this causes a compiler warning, on purpose
+				.isThrownBy(() -> publisher.emit((String[])null)) //end users forgetting to cast would see compiler warning as well
 				.withMessage("values array is null, please cast to T if null T required");
 	}
 

--- a/reactor-test/src/test/java/reactor/test/publisher/DefaultTestPublisherTests.java
+++ b/reactor-test/src/test/java/reactor/test/publisher/DefaultTestPublisherTests.java
@@ -378,7 +378,7 @@ public class DefaultTestPublisherTests {
 		TestPublisher<String> publisher = TestPublisher.create();
 
 		assertThatExceptionOfType(NullPointerException.class)
-				.isThrownBy(() -> publisher.next(null, null)) //this causes a compiler warning, on purpose
+				.isThrownBy(() -> publisher.next(null, (String[]) null)) //end users forgetting to cast would see compiler warning as well
 				.withMessage("rest array is null, please cast to T if null T required");
 	}
 
@@ -387,7 +387,7 @@ public class DefaultTestPublisherTests {
 		TestPublisher<String> publisher = TestPublisher.create();
 
 		assertThatExceptionOfType(NullPointerException.class)
-				.isThrownBy(() -> publisher.emit(null)) //this causes a compiler warning, on purpose
+				.isThrownBy(() -> publisher.emit((String[]) null)) //end users forgetting to cast would see compiler warning as well
 				.withMessage("values array is null, please cast to T if null T required");
 	}
 

--- a/reactor-test/src/test/java/reactor/test/scheduler/VirtualTimeSchedulerTests.java
+++ b/reactor-test/src/test/java/reactor/test/scheduler/VirtualTimeSchedulerTests.java
@@ -23,14 +23,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
-
-import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -55,21 +51,27 @@ public class VirtualTimeSchedulerTests {
 	@Test
 	public void allEnabled() {
 		assertThat(Schedulers.newParallel("")).isNotInstanceOf(VirtualTimeScheduler.class);
-		assertThat(Schedulers.newElastic("")).isNotInstanceOf(VirtualTimeScheduler.class);
+		@SuppressWarnings("deprecation")
+		Scheduler elastic1 = Schedulers.newElastic("");
+		assertThat(elastic1).isNotInstanceOf(VirtualTimeScheduler.class);
 		assertThat(Schedulers.newBoundedElastic(4, Integer.MAX_VALUE, "")).isNotInstanceOf(VirtualTimeScheduler.class);
 		assertThat(Schedulers.newSingle("")).isNotInstanceOf(VirtualTimeScheduler.class);
 
 		VirtualTimeScheduler.getOrSet();
 
 		assertThat(Schedulers.newParallel("")).isInstanceOf(VirtualTimeScheduler.class);
-		assertThat(Schedulers.newElastic("")).isInstanceOf(VirtualTimeScheduler.class);
+		@SuppressWarnings("deprecation")
+		Scheduler elastic2 = Schedulers.newElastic("");
+		assertThat(elastic2).isInstanceOf(VirtualTimeScheduler.class);
 		assertThat(Schedulers.newBoundedElastic(4, Integer.MAX_VALUE, "")).isInstanceOf(VirtualTimeScheduler.class);
 		assertThat(Schedulers.newSingle("")).isInstanceOf(VirtualTimeScheduler.class);
 
 		VirtualTimeScheduler t = VirtualTimeScheduler.get();
 
 		Assert.assertSame(Schedulers.newParallel(""), t);
-		Assert.assertSame(Schedulers.newElastic(""), t);
+		@SuppressWarnings("deprecation")
+		Scheduler elastic3 = Schedulers.newElastic("");
+		Assert.assertSame(elastic3, t);
 		Assert.assertSame(Schedulers.newBoundedElastic(5, Integer.MAX_VALUE, ""), t); //same even though different parameter
 		Assert.assertSame(Schedulers.newSingle(""), t);
 	}

--- a/reactor-tools/build.gradle
+++ b/reactor-tools/build.gradle
@@ -36,6 +36,9 @@ configurations {
 dependencies {
     compile project(':reactor-core')
 
+    compileOnly "com.google.code.findbugs:jsr305:${findbugsVersion}"
+    compileOnly "com.google.code.findbugs:annotations:${findbugsVersion}"
+
     shaded 'net.bytebuddy:byte-buddy-agent:1.10.9'
     shaded 'net.bytebuddy:byte-buddy:1.10.9'
     for (dependency in project.configurations.shaded.dependencies) {


### PR DESCRIPTION
This commit removes 150+ warnings. Most of them are fixed by using
the diamond operator where it hadn't been used previously.
Some fixes involves actually "fixing" compile type problems (that weren't
problematic in practice in tests due to erasure).
Also fixes warnings due to the absence of findbugs on the compile
classpath in some projects.