### PR TITLE
[polish] FluxUsingWhenTest awaitility + order of capturing subscription

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/FluxUsingWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxUsingWhenTest.java
@@ -1006,8 +1006,8 @@ public class FluxUsingWhenTest {
 
 			@Override
 			public void onSubscribe(Subscription s) {
-				s.request(1);
 				subscription = s;
+				s.request(1);
 			}
 
 			@Override
@@ -1039,8 +1039,8 @@ public class FluxUsingWhenTest {
 
 			@Override
 			public void onSubscribe(Subscription s) {
-				s.request(1);
 				subscription = s;
+				s.request(1);
 			}
 
 			@Override
@@ -1090,8 +1090,8 @@ public class FluxUsingWhenTest {
 
 			@Override
 			public void onSubscribe(Subscription s) {
-				s.request(1);
 				subscription = s;
+				s.request(1);
 			}
 
 			@Override
@@ -1106,8 +1106,8 @@ public class FluxUsingWhenTest {
 			public void onComplete() {}
 		});
 
-		Thread.sleep(300);
-		assertThat(cleanupCount.sum()).isEqualTo(1000);
+		Awaitility.waitAtMost(500, TimeUnit.MILLISECONDS)
+		          .untilAsserted(() -> assertThat(cleanupCount.sum()).isEqualTo(1000));
 		assertThat(cancelled).as("source cancelled").isTrue();
 	}
 
@@ -1143,8 +1143,8 @@ public class FluxUsingWhenTest {
 
 			@Override
 			public void onSubscribe(Subscription s) {
-				s.request(1);
 				subscription = s;
+				s.request(1);
 			}
 
 			@Override
@@ -1159,9 +1159,9 @@ public class FluxUsingWhenTest {
 			public void onComplete() {}
 		});
 
-		Thread.sleep(300);
-			          assertThat(cleanupCount.sum()).isEqualTo(1000);
-			          assertThat(cancelled).as("source cancelled").isTrue();
+		Awaitility.waitAtMost(500, TimeUnit.MILLISECONDS)
+		          .untilAsserted(() -> assertThat(cleanupCount.sum()).isEqualTo(1000));
+		assertThat(cancelled).as("source cancelled").isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
These tests would sometimes fail due to hiccups when running tests, so increasing the max duration for the assertion + asserting using Awaitility.

On top of that tests that capture and cancel the subscription would sometimes encounter a NPE when attempting said cancellation. This should be fixed by capturing the `Subscription` _before_ requesting it.