### PR TITLE
fix #1053 MonoProcessor rework

### DIFF
--- a/docs/asciidoc/processors.adoc
+++ b/docs/asciidoc/processors.adoc
@@ -19,8 +19,8 @@ Since `3.4.0`, an effort has been started to hide concrete processor implementat
 advertise the standalone sink pattern first and foremost:
 
  - concrete processor implementations are deprecated and slated for removal in 3.5.0
- - processors can still be constructed through the `FluxProcessor.fromSink` and `MonoProcessor.fromSink` factories
  - sinks which are not produced by an operator are constructed through factory methods in the `Sinks` class.
+ - processors can still be obtained through the `FluxProcessor.fromSink` and `MonoProcessor.fromSink` factories
 
 [[sinks]]
 = Safely Produce from Multiple Threads by Using `Sinks.One` and `Sinks.Many`

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -13,7 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import japicmp.model.JApiCompatibility
 import me.champeau.gradle.japicmp.JapicmpTask
+import me.champeau.gradle.japicmp.report.Violation
+import me.champeau.gradle.japicmp.report.stdrules.AbstractRecordingSeenMembers
+import me.champeau.gradle.japicmp.report.stdrules.RecordSeenMembersSetup
 
 buildscript {
 	repositories {
@@ -128,6 +133,59 @@ task downloadBaseline(type: Download) {
 	dest "${buildDir}/baselineLibs/reactor-core-${compatibleVersion}.jar"
 }
 
+class IncompatibleChangeWithExclusions extends AbstractRecordingSeenMembers implements Serializable {
+
+	private final Map<String, String> acceptedViolations
+
+	IncompatibleChangeWithExclusions(Map<String, String> params) {
+		acceptedViolations = params
+	}
+
+	@Override
+	public Violation maybeAddViolation(final JApiCompatibility memberRaw) {
+		def member = Violation.describe(memberRaw)
+		def memberViolationsStringList = memberRaw.compatibilityChanges.collect {it.toString() }
+		def memberViolations = memberViolationsStringList.join(",")
+
+		def memberAcceptedViolations = acceptedViolations[member]
+		if (memberAcceptedViolations == memberViolations) {
+			println "Excluded violation $memberAcceptedViolations for $member"
+			return null;
+		}
+		if (memberAcceptedViolations) {
+			println "Recognized exclusions for $member, but has more changes: $memberViolations"
+		}
+		if (!memberRaw.isBinaryCompatible()) {
+			//let's see if there are generic binary exceptions:
+			def acceptedBinaryViolations = acceptedViolations
+				.getOrDefault("BINARY_COMPATIBLE", "")
+				.tokenize(",")
+				.toSet()
+			if (acceptedBinaryViolations.containsAll(memberViolationsStringList)
+				|| acceptedBinaryViolations.contains("*")) {
+				return null;
+			}
+			return Violation.notBinaryCompatible(memberRaw);
+		}
+		else if (!memberRaw.isSourceCompatible()) {
+			//let's see if there are generic source exceptions:
+			def acceptedSourceViolations = acceptedViolations
+				.getOrDefault("SOURCE_COMPATIBLE", "")
+				.tokenize(",")
+				.toSet()
+
+			if (acceptedSourceViolations.containsAll(memberViolationsStringList)
+				|| acceptedSourceViolations.contains("*")) {
+				return null;
+			}
+			return Violation.error(memberRaw, "Is not source compatible", )
+		}
+		else {
+			return null;
+		}
+	}
+}
+
 task japicmp(type: JapicmpTask) {
 	if (project.gradle.startParameter.isOffline()) {
 		println "Offline: skipping downloading of baseline and JAPICMP"
@@ -144,9 +202,9 @@ task japicmp(type: JapicmpTask) {
 
 	oldClasspath = files("${buildDir}/baselineLibs/reactor-core-${compatibleVersion}.jar")
 	newClasspath = files(jar.archiveFile)
-	onlyBinaryIncompatibleModified = true
-	failOnModification = true
-	failOnSourceIncompatibility = true
+	onlyBinaryIncompatibleModified = false
+	failOnModification = false
+	failOnSourceIncompatibility = false
 	txtOutputFile = file("${project.buildDir}/reports/japi.txt")
 	ignoreMissingClasses = true
 	includeSynthetic = true
@@ -188,10 +246,33 @@ task japicmp(type: JapicmpTask) {
 
 			'reactor.core.publisher.ParallelFlux#composeGroup(java.util.function.Function)',
 	]
+
+	Map<String, String> specificChangeExclusions = [
+		// class Excludes
+		"Class reactor.core.publisher.MonoProcessor" : "CLASS_NOW_ABSTRACT", //MonoProcessor was final so should be fine to be now abstract
+
+		// method Excludes
+
+		// these methods are now abstract, should be source compatible
+		"Method reactor.core.publisher.MonoProcessor.onSubscribe(org.reactivestreams.Subscription)" : "METHOD_REMOVED",
+		"Method reactor.core.publisher.MonoProcessor.onNext(java.lang.Object)" : "METHOD_REMOVED",
+		"Method reactor.core.publisher.MonoProcessor.onError(java.lang.Throwable)" : "METHOD_REMOVED",
+		"Method reactor.core.publisher.MonoProcessor.onComplete()" : "METHOD_REMOVED",
+
+		// generic excludes
+		"SOURCE_COMPATIBLE" : "METHOD_ADDED_TO_INTERFACE" //needed for the rule to ignore new default methods
+	]
+
+	richReport {
+		addDefaultRules = false
+		addSetupRule(RecordSeenMembersSetup)
+		addRule(IncompatibleChangeWithExclusions, specificChangeExclusions)
+	}
 }
 
 gradle.taskGraph.afterTask { task, state ->
-	if (task instanceof JapicmpTask && state.failure) {
+	if (task instanceof JapicmpTask && state.failure && ((JapicmpTask) task).richReport == null) {
+		//FIXME print the rich report somehow on console ?
 		print file("${project.buildDir}/reports/japi.txt").getText()
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -6745,9 +6745,13 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <img class="marble" src="doc-files/marbles/publishNext.svg" alt="">
 	 *
 	 * @return a new {@link Mono}
+	 * @deprecated use {@link #shareNext()} instead, or use `publish().next()` if you need
+	 * to `{@link ConnectableFlux#connect() connect()}. To be removed in 3.5.0
 	 */
+	@Deprecated
 	public final Mono<T> publishNext() {
-		return Mono.onAssembly(new MonoProcessor<>(this));
+		//Should add a ConnectableMono to align with #publish()
+		return shareNext();
 	}
 
 	/**
@@ -7457,6 +7461,20 @@ public abstract class Flux<T> implements CorePublisher<T> {
 		return onAssembly(new FluxRefCount<>(
 				new FluxPublish<>(this, Queues.SMALL_BUFFER_SIZE, Queues.small()), 1)
 		);
+	}
+
+	/**
+	 * Prepare a {@link Mono} which shares this {@link Flux} sequence and dispatches the
+	 * first observed item to subscribers.
+	 * This will effectively turn any type of sequence into a hot sequence when the first
+	 * {@link Subscriber} subscribes.
+	 * <p>
+	 * <img class="marble" src="doc-files/marbles/shareNext.svg" alt="">
+	 *
+	 * @return a new {@link Mono}
+	 */
+	public final Mono<T> shareNext() {
+		return Mono.onAssembly(new NextProcessor<>(this));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -45,6 +45,16 @@ import static reactor.core.publisher.Sinks.Many;
 public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 		implements Processor<IN, OUT>, CoreSubscriber<IN>, Scannable, Disposable {
 
+	/**
+	 * Convert a {@link Sinks.Many} to a {@link FluxProcessor} : subscribing to the processor
+	 * will be akin to subscribing to the {@link Many#asFlux()}, and having the processor
+	 * subscribed to an upstream {@link org.reactivestreams.Publisher} will pass signals from
+	 * said {@link org.reactivestreams.Publisher} as calls to the sink's {@link Sinks.Many#emitNext(Object) emit methods}.
+	 *
+	 * @param sink the {@link Sinks.Many} to convert
+	 * @param <IN> the type of values that can be emitted by the sink
+	 * @return a {@link FluxProcessor} with the same semantics as the {@link Sinks.Many}
+	 */
 	public static <IN> FluxProcessor<IN, IN> fromSink(Many<IN> sink) {
 		if (sink instanceof FluxProcessor) {
 			@SuppressWarnings("unchecked")
@@ -53,7 +63,7 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 				return processor;
 			}
 		}
-		return new DelegateSinkFluxProcessor<>(sink.asFlux(), sink);
+		return new DelegateSinkFluxProcessor<>(sink);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoErrorSupplied.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoErrorSupplied.java
@@ -45,7 +45,7 @@ import reactor.core.Fuseable;
  * @param <T> the value type
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
-final class MonoErrorSupplied<T> extends Mono<T> implements Fuseable.ScalarCallable, SourceProducer<T> {
+final class MonoErrorSupplied<T> extends Mono<T> implements Fuseable.ScalarCallable<T>, SourceProducer<T> {
 
 	final Supplier<? extends Throwable> errorSupplier;
 
@@ -72,7 +72,7 @@ final class MonoErrorSupplied<T> extends Mono<T> implements Fuseable.ScalarCalla
 	}
 
 	@Override
-	public Object call() throws Exception {
+	public T call() throws Exception {
 		Throwable error = Objects.requireNonNull(errorSupplier.get(), "the errorSupplier returned null");
 		if(error instanceof Exception){
 			throw ((Exception) error);

--- a/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
@@ -1,0 +1,415 @@
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.stream.Stream;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
+
+import reactor.core.CorePublisher;
+import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
+import reactor.core.Scannable;
+import reactor.core.publisher.Sinks.Emission;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+
+class NextProcessor<O> extends MonoProcessor<O> implements Sinks.One<O> {
+
+	volatile NextInner<O>[] subscribers;
+
+	@SuppressWarnings("rawtypes")
+	static final AtomicReferenceFieldUpdater<NextProcessor, NextInner[]> SUBSCRIBERS = AtomicReferenceFieldUpdater.newUpdater(NextProcessor.class, NextInner[].class, "subscribers");
+
+	@SuppressWarnings("rawtypes")
+	static final NextInner[] EMPTY = new NextInner[0];
+
+	@SuppressWarnings("rawtypes")
+	static final NextInner[] TERMINATED = new NextInner[0];
+
+	@SuppressWarnings("rawtypes")
+	static final NextInner[] EMPTY_WITH_SOURCE = new NextInner[0];
+
+	volatile     Subscription                                             subscription;
+	static final AtomicReferenceFieldUpdater<NextProcessor, Subscription> UPSTREAM = AtomicReferenceFieldUpdater.newUpdater(NextProcessor.class, Subscription.class, "subscription");
+
+	CorePublisher<? extends O> source;
+
+	Throwable error;
+	O         value;
+
+	NextProcessor(@Nullable CorePublisher<? extends O> source) {
+		this.source = source;
+		SUBSCRIBERS.lazySet(this, source != null ? EMPTY_WITH_SOURCE : EMPTY);
+	}
+
+	@Override
+	public Mono<O> asMono() {
+		return this;
+	}
+
+	@Override
+	public O peek() {
+		if (!isTerminated()) {
+			return null;
+		}
+
+		if (value != null) {
+			return value;
+		}
+
+		if (error != null) {
+			RuntimeException re = Exceptions.propagate(error);
+			re = Exceptions.addSuppressed(re, new Exception("Mono#peek terminated with an error"));
+			throw re;
+		}
+
+		return null;
+	}
+
+	@Override
+	@Nullable
+	public O block(@Nullable Duration timeout) {
+		try {
+			if (isTerminated()) {
+				return peek();
+			}
+
+			connect();
+
+			long delay;
+			if (null == timeout) {
+				delay = 0L;
+			}
+			else {
+				delay = System.nanoTime() + timeout.toNanos();
+			}
+			for (; ; ) {
+				if (isTerminated()) {
+					if (error != null) {
+						RuntimeException re = Exceptions.propagate(error);
+						re = Exceptions.addSuppressed(re, new Exception("Mono#block terminated with an error"));
+						throw re;
+					}
+					return value;
+				}
+				if (timeout != null && delay < System.nanoTime()) {
+					cancel();
+					throw new IllegalStateException("Timeout on Mono blocking read");
+				}
+
+				Thread.sleep(1);
+			}
+
+		}
+		catch (InterruptedException ie) {
+			Thread.currentThread()
+				  .interrupt();
+
+			throw new IllegalStateException("Thread Interruption on Mono blocking read");
+		}
+	}
+
+	@Override
+	public Emission emitEmpty() {
+		return emitValue(null);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Emission emitError(Throwable cause) {
+		Objects.requireNonNull(cause, "onError cannot be null");
+
+		if (UPSTREAM.getAndSet(this, Operators.cancelledSubscription()) == Operators.cancelledSubscription()) {
+			Operators.onErrorDroppedMulticast(cause);
+			return Emission.FAIL_TERMINATED;
+		}
+
+		error = cause;
+		value = null;
+		source = null;
+
+		//no need to double check since UPSTREAM.getAndSet gates the completion already
+		for (NextInner<O> as : SUBSCRIBERS.getAndSet(this, TERMINATED)) {
+			as.onError(cause);
+		}
+		return Emission.OK;
+	}
+
+	@Override
+	public Emission emitValue(@Nullable O value) {
+		Subscription s;
+		if ((s = UPSTREAM.getAndSet(this, Operators.cancelledSubscription())) == Operators.cancelledSubscription()) {
+			if (value != null) {
+				Operators.onNextDroppedMulticast(value);
+			}
+			return Emission.FAIL_TERMINATED;
+		}
+
+		this.value = value;
+		Publisher<? extends O> parent = source;
+		source = null;
+
+		@SuppressWarnings("unchecked") NextInner<O>[] array = SUBSCRIBERS.getAndSet(this, TERMINATED);
+
+		if (value == null) {
+			for (NextInner<O> as : array) {
+				as.onComplete();
+			}
+		}
+		else {
+			if (s != null && !(parent instanceof Mono)) {
+				s.cancel();
+			}
+
+			for (NextInner<O> as : array) {
+				as.complete(value);
+			}
+		}
+		return Emission.OK;
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PARENT)
+			return subscription;
+		return super.scanUnsafe(key);
+	}
+
+	@Override
+	public Context currentContext() {
+		return Operators.multiSubscribersContext(subscribers);
+	}
+
+	@Override
+	public long downstreamCount() {
+		return subscribers.length;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public void dispose() {
+		Subscription s = UPSTREAM.getAndSet(this, Operators.cancelledSubscription());
+		if (s == Operators.cancelledSubscription()) {
+			return;
+		}
+
+		source = null;
+		if (s != null) {
+			s.cancel();
+		}
+
+
+		NextInner<O>[] a;
+		if ((a = SUBSCRIBERS.getAndSet(this, TERMINATED)) != TERMINATED) {
+			Exception e = new CancellationException("Disposed");
+			error = e;
+			value = null;
+
+			for (NextInner<O> as : a) {
+				as.onError(e);
+			}
+		}
+	}
+
+	@Override
+	@SuppressWarnings("deprecation")
+	public void cancel() {
+		if (isTerminated()) {
+			return;
+		}
+
+		Subscription s = UPSTREAM.getAndSet(this, Operators.cancelledSubscription());
+		if (s == Operators.cancelledSubscription()) {
+			return;
+		}
+
+		source = null;
+		if (s != null) {
+			s.cancel();
+		}
+	}
+
+	@Override
+	public final void onComplete() {
+		emitValue(null);
+	}
+
+	@Override
+	public final void onError(Throwable cause) {
+		emitError(cause);
+	}
+
+	@Override
+	public final void onNext(@Nullable O value) {
+		emitValue(value);
+	}
+
+	@Override
+	public final void onSubscribe(Subscription subscription) {
+		if (Operators.setOnce(UPSTREAM, this, subscription)) {
+			subscription.request(Long.MAX_VALUE);
+		}
+	}
+
+	@Override
+	@SuppressWarnings("deprecation")
+	public boolean isCancelled() {
+		return subscription == Operators.cancelledSubscription() && !isTerminated();
+	}
+
+	@Override
+	public boolean isTerminated() {
+		return subscribers == TERMINATED;
+	}
+
+	@Override
+	public Throwable getError() {
+		return error;
+	}
+
+	boolean add(NextInner<O> ps) {
+		for (; ; ) {
+			NextInner<O>[] a = subscribers;
+
+			if (a == TERMINATED) {
+				return false;
+			}
+
+			int n = a.length;
+			@SuppressWarnings("unchecked") NextInner<O>[] b = new NextInner[n + 1];
+			System.arraycopy(a, 0, b, 0, n);
+			b[n] = ps;
+
+			if (SUBSCRIBERS.compareAndSet(this, a, b)) {
+				Publisher<? extends O> parent = source;
+				if (parent != null && a == EMPTY_WITH_SOURCE) {
+					parent.subscribe(this);
+				}
+				return true;
+			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	void remove(NextInner<O> ps) {
+		for (; ; ) {
+			NextInner<O>[] a = subscribers;
+			int n = a.length;
+			if (n == 0) {
+				return;
+			}
+
+			int j = -1;
+			for (int i = 0; i < n; i++) {
+				if (a[i] == ps) {
+					j = i;
+					break;
+				}
+			}
+
+			if (j < 0) {
+				return;
+			}
+
+			NextInner<O>[] b;
+
+			if (n == 1) {
+				b = EMPTY;
+			}
+			else {
+				b = new NextInner[n - 1];
+				System.arraycopy(a, 0, b, 0, j);
+				System.arraycopy(a, j + 1, b, j, n - j - 1);
+			}
+			if (SUBSCRIBERS.compareAndSet(this, a, b)) {
+				return;
+			}
+		}
+	}
+
+	@Override
+	public void subscribe(final CoreSubscriber<? super O> actual) {
+		NextInner<O> as = new NextInner<>(actual, this);
+		actual.onSubscribe(as);
+		if (add(as)) {
+			if (as.isCancelled()) {
+				remove(as);
+			}
+		}
+		else {
+			Throwable ex = error;
+			if (ex != null) {
+				actual.onError(ex);
+			}
+			else {
+				O v = value;
+				if (v != null) {
+					as.complete(v);
+				}
+				else {
+					as.onComplete();
+				}
+			}
+		}
+	}
+
+	@Override
+	public Stream<? extends Scannable> inners() {
+		return Stream.of(subscribers);
+	}
+
+	void connect() {
+		Publisher<? extends O> parent = source;
+		if (parent != null && SUBSCRIBERS.compareAndSet(this, EMPTY_WITH_SOURCE, EMPTY)) {
+			parent.subscribe(this);
+		}
+	}
+
+	final static class NextInner<T> extends Operators.MonoSubscriber<T, T> {
+		final NextProcessor<T> parent;
+
+		NextInner(CoreSubscriber<? super T> actual, NextProcessor<T> parent) {
+			super(actual);
+			this.parent = parent;
+		}
+
+		@Override
+		public void cancel() {
+			if (STATE.getAndSet(this, CANCELLED) != CANCELLED) {
+				parent.remove(this);
+			}
+		}
+
+		@Override
+		public void onComplete() {
+			if (!isCancelled()) {
+				actual.onComplete();
+			}
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			if (isCancelled()) {
+				Operators.onOperatorError(t, currentContext());
+			}
+			else {
+				actual.onError(t);
+			}
+		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) {
+				return parent;
+			}
+			if (key == Attr.RUN_STYLE) {
+				return Attr.RunStyle.SYNC;
+			}
+			return super.scanUnsafe(key);
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -41,16 +41,17 @@ public final class Sinks {
 	}
 
 	/**
-	 * A {@link Sinks.One} with the following characteristics:
+	 * A {@link Sinks.Empty} which exclusively produces one terminal signal: error or complete.
+	 * It has the following characteristics:
 	 * <ul>
 	 *     <li>Multicast</li>
 	 *     <li>Backpressure : this sink does not need any demand since it can only signal error or completion</li>
 	 *     <li>Replaying: Replay the terminal signal (error or complete).</li>
 	 * </ul>
-	 * Use {@link One#asMono()} to expose the {@link Mono} view of the sink to downstream consumers.
+	 * Use {@link Sinks.Empty#asMono()} to expose the {@link Mono} view of the sink to downstream consumers.
 	 */
 	public static <T> Sinks.Empty<T> empty() {
-		return MonoProcessor.create();
+		return new VoidProcessor<T>();
 	}
 
 	/**
@@ -62,7 +63,7 @@ public final class Sinks {
 	 * Use {@link One#asMono()} to expose the {@link Mono} view of the sink to downstream consumers.
 	 */
 	public static <T> Sinks.One<T> one() {
-		return MonoProcessor.create();
+		return new NextProcessor<>(null);
 	}
 
 	/**
@@ -139,7 +140,7 @@ public final class Sinks {
 	}
 
 	/**
-	 * Provide {@link Sinks.Many} specs for sinks which can emit multiple elements
+	 * Provides {@link Sinks.Many} specs for sinks which can emit multiple elements
 	 */
 	public interface ManySpec {
 		/**
@@ -167,7 +168,7 @@ public final class Sinks {
 		/**
 		 * Return a builder for more advanced use cases such as building operators.
 		 * Unsafe {@link Sinks.Many} are not serialized and expect usage to be externally synchronized to respect
-		 * the Reactive Streams specification. The builder also allows to create {@link FluxProcessor} and {@link MonoProcessor}.
+		 * the Reactive Streams specification.
 		 *
 		 * @return {@link ManySpec}
 		 */
@@ -175,7 +176,7 @@ public final class Sinks {
 	}
 
 	/**
-	 * Provide unicast: 1 sink, 1 {@link Subscriber}
+	 * Provides unicast: 1 sink, 1 {@link Subscriber}
 	 */
 	public interface UnicastSpec {
 
@@ -225,7 +226,7 @@ public final class Sinks {
 	}
 
 	/**
-	 * Provide multicast : 1 sink, N {@link Subscriber}
+	 * Provides multicast : 1 sink, N {@link Subscriber}
 	 */
 	public interface MulticastSpec {
 
@@ -300,7 +301,7 @@ public final class Sinks {
 
 
 	/**
-	 * Provide multicast with history/replay capacity : 1 sink, N {@link Subscriber}
+	 * Provides multicast with history/replay capacity : 1 sink, N {@link Subscriber}
 	 */
 	public interface MulticastReplaySpec {
 		/**

--- a/reactor-core/src/main/java/reactor/core/publisher/VoidProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/VoidProcessor.java
@@ -1,0 +1,353 @@
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.stream.Stream;
+
+import org.reactivestreams.Subscription;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
+import reactor.core.Scannable;
+import reactor.core.publisher.Sinks.Emission;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+
+final class VoidProcessor<T> extends MonoProcessor<T> implements Sinks.One<T> {
+
+	volatile VoidInner<T>[] subscribers;
+
+	@SuppressWarnings("rawtypes")
+	static final AtomicReferenceFieldUpdater<VoidProcessor, VoidInner[]> SUBSCRIBERS =
+			AtomicReferenceFieldUpdater.newUpdater(VoidProcessor.class, VoidInner[].class, "subscribers");
+
+	@SuppressWarnings("rawtypes")
+	static final VoidInner[] EMPTY = new VoidInner[0];
+
+	@SuppressWarnings("rawtypes")
+	static final VoidInner[] TERMINATED = new VoidInner[0];
+
+	Throwable error;
+
+	VoidProcessor() {
+		SUBSCRIBERS.lazySet(this, EMPTY);
+	}
+
+	@Override
+	public Mono<T> asMono() {
+		return this;
+	}
+
+	@Override
+	public T peek() {
+		if (!isTerminated()) {
+			return null;
+		}
+
+		if (error != null) {
+			RuntimeException re = Exceptions.propagate(error);
+			re = Exceptions.addSuppressed(re, new Exception("VoidProcessor#peek cannot return a value since this mono has terminated with an error"));
+			throw re;
+		}
+
+		return null;
+	}
+
+	@Override
+	@Nullable
+	public T block(@Nullable Duration timeout) {
+		try {
+			if (isTerminated()) {
+				return peek();
+			}
+
+			long delay;
+			if (null == timeout) {
+				delay = 0L;
+			}
+			else {
+				delay = System.nanoTime() + timeout.toNanos();
+			}
+			for (; ; ) {
+				if (isTerminated()) {
+					if (error != null) {
+						RuntimeException re = Exceptions.propagate(error);
+						re = Exceptions.addSuppressed(re, new Exception("Mono#block terminated with an error"));
+						throw re;
+					}
+					return null;
+				}
+				if (timeout != null && delay < System.nanoTime()) {
+					throw new IllegalStateException("Timeout on Mono blocking read, the operator is still waiting to observe a signal");
+				}
+
+				Thread.sleep(1);
+			}
+
+		}
+		catch (InterruptedException ie) {
+			Thread.currentThread()
+				  .interrupt();
+
+			throw new IllegalStateException("Thread Interruption on Mono blocking read");
+		}
+	}
+
+	@Override
+	public Emission emitEmpty() {
+		VoidInner<?>[] array = SUBSCRIBERS.getAndSet(this, TERMINATED);
+
+		if (array == TERMINATED) {
+			return Emission.FAIL_TERMINATED;
+		}
+
+		for (VoidInner<?> as : array) {
+			as.onComplete();
+		}
+		return Emission.OK;
+	}
+
+	@Override
+	public Emission emitError(Throwable cause) {
+		Objects.requireNonNull(cause, "onError cannot be null");
+
+		if (isTerminated()) {
+			Operators.onErrorDroppedMulticast(cause);
+			return Emission.FAIL_TERMINATED;
+		}
+
+		//guarded by a read memory barrier (isTerminated) and a subsequent write with getAndSet
+		error = cause;
+
+		for (VoidInner<?> as : SUBSCRIBERS.getAndSet(this, TERMINATED)) {
+			as.onError(cause);
+		}
+		return Emission.OK;
+	}
+
+	@Override
+	@Deprecated
+	public Emission emitValue(@Nullable T value) {
+		if (value != null) {
+			throw new UnsupportedOperationException("emitValue on VoidProcessor, which should be exposed as a Sinks.Empty");
+		}
+		return emitEmpty();
+	}
+
+	@Override
+	public Context currentContext() {
+		return Operators.multiSubscribersContext(subscribers);
+	}
+
+	@Override
+	public long downstreamCount() {
+		return subscribers.length;
+	}
+
+	@Override
+	public void dispose() {
+		if (isTerminated()) {
+			return;
+		}
+
+		Exception e = new CancellationException("Disposed");
+		error = e;
+
+		for (VoidInner<?> as : SUBSCRIBERS.getAndSet(this, TERMINATED)) {
+			as.onError(e);
+		}
+	}
+
+	@Override
+	public final void onComplete() {
+		emitEmpty();
+	}
+
+	@Override
+	public final void onError(Throwable cause) {
+		emitError(cause);
+	}
+
+	@Override
+	public final void onNext(@Nullable T value) {
+		if (value != null) {
+			emitError(new UnsupportedOperationException("emitValue on VoidProcessor, which should be exposed as a Sinks.Empty"));
+		}
+		else {
+			emitEmpty();
+		}
+	}
+
+	@Override
+	public final void onSubscribe(Subscription subscription) {
+		subscription.request(Long.MAX_VALUE);
+	}
+
+	@Override
+	public boolean isTerminated() {
+		return SUBSCRIBERS.get(this) == TERMINATED;
+	}
+
+	@Override
+	public Throwable getError() {
+		return error;
+	}
+
+	boolean add(VoidInner<T> ps) {
+		for (; ; ) {
+			VoidInner<T>[] a = subscribers;
+
+			if (a == TERMINATED) {
+				return false;
+			}
+
+			int n = a.length;
+			@SuppressWarnings("unchecked")
+			VoidInner<T>[] b = new VoidInner[n + 1];
+			System.arraycopy(a, 0, b, 0, n);
+			b[n] = ps;
+
+			if (SUBSCRIBERS.compareAndSet(this, a, b)) {
+				return true;
+			}
+		}
+	}
+
+
+	void remove(VoidInner<T> ps) {
+		for (; ; ) {
+			VoidInner<T>[] a = subscribers;
+			int n = a.length;
+			if (n == 0) {
+				return;
+			}
+
+			int j = -1;
+			for (int i = 0; i < n; i++) {
+				if (a[i] == ps) {
+					j = i;
+					break;
+				}
+			}
+
+			if (j < 0) {
+				return;
+			}
+
+			VoidInner<?>[] b;
+
+			if (n == 1) {
+				b = EMPTY;
+			}
+			else {
+				b = new VoidInner[n - 1];
+				System.arraycopy(a, 0, b, 0, j);
+				System.arraycopy(a, j + 1, b, j, n - j - 1);
+			}
+			if (SUBSCRIBERS.compareAndSet(this, a, b)) {
+				return;
+			}
+		}
+	}
+
+	@Override
+	public void subscribe(final CoreSubscriber<? super T> actual) {
+		VoidInner<T> as = new VoidInner<T>(actual, this);
+		actual.onSubscribe(as);
+		if (add(as)) {
+			if (as.get()) {
+				remove(as);
+			}
+		}
+		else {
+			if (as.get()) {
+				return;
+			}
+			Throwable ex = error;
+			if (ex != null) {
+				actual.onError(ex);
+			}
+			else {
+				actual.onComplete();
+			}
+		}
+	}
+
+	@Override
+	public Stream<? extends Scannable> inners() {
+		return Stream.of(subscribers);
+	}
+
+	final static class VoidInner<T> extends AtomicBoolean implements InnerOperator<Void, T> {
+		final VoidProcessor<T>          parent;
+		final CoreSubscriber<? super T> actual;
+
+		VoidInner(CoreSubscriber<? super T> actual, VoidProcessor<T> parent) {
+			this.actual = actual;
+			this.parent = parent;
+		}
+
+		@Override
+		public void cancel() {
+			if (getAndSet(true)) {
+				return;
+			}
+
+			parent.remove(this);
+		}
+
+		@Override
+		public void request(long l) {
+			Operators.validate(l);
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			Objects.requireNonNull(s);
+		}
+
+		@Override
+		public void onNext(Void aVoid) {
+
+		}
+
+		@Override
+		public void onComplete() {
+			if (get()) {
+				return;
+			}
+			actual.onComplete();
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			if (get()) {
+				Operators.onOperatorError(t, currentContext());
+				return;
+			}
+			actual.onError(t);
+		}
+
+		@Override
+		public CoreSubscriber<? super T> actual() {
+			return actual;
+		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) {
+				return parent;
+			}
+			if (key == Attr.CANCELLED) {
+				return get();
+			}
+			if (key == Attr.RUN_STYLE) {
+				return Attr.RunStyle.SYNC;
+			}
+			return InnerOperator.super.scanUnsafe(key);
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/shareForMono.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/shareForMono.svg
@@ -1,0 +1,118 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 60 518 499" width="518" height="499" id="svg166">
+ <defs id="defs31">
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g4">
+    <path d="M12 0L0-4v9z" id="path2" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-miterlimit="10" viewBox="-10 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g9">
+    <path d="M-8 0l8 3v-6z" id="path7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="20" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face12" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma-Bold"/>
+   </font-face-src>
+  </font-face>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#b4b4b4" stroke-linejoin="miter">
+   <g id="g16">
+    <path d="M8 0L0-3v6z" id="path14" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_4" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g21">
+    <path d="M8 0L0-3v6z" id="path19" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="16" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face24" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma"/>
+   </font-face-src>
+  </font-face>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_5" stroke-miterlimit="10" viewBox="-10 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g28">
+    <path d="M-8 0l8 3v-6z" id="path26" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-3" stroke-miterlimit="10" viewBox="-6 -3 7 6" markerWidth="7" markerHeight="6" color="#45b8de" stroke-linejoin="miter">
+   <g id="g9-6">
+    <path d="M-5 0l5 2v-4z" id="path7-7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_9" stroke-miterlimit="10" viewBox="-10 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g50">
+    <path d="M-8 0l8 3v-6z" id="path48" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_6" stroke-miterlimit="10" viewBox="-10 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g35">
+    <path d="M-8 0l8 3v-6z" id="path33" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-5" stroke-miterlimit="10" viewBox="-10 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g9-3">
+    <path d="M-8 0l8 3v-6z" id="path7-5" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker1428" stroke-miterlimit="10" viewBox="-10 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g1426">
+    <path d="M-8 0l8 3v-6z" id="path1424" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker1434" stroke-miterlimit="10" viewBox="-10 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g1432">
+    <path d="M-8 0l8 3v-6z" id="path1430" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+ </defs>
+ <path id="line39" d="M29 427h261" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
+ <path id="path42" d="M269 403h1l2 2v44l-2 2h-1l-2-2v-44z" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line45" d="M270 383l-2-76" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_2)"/>
+ <path d="M46 216h472l1 1v86l-1 1H46l-1-1v-86z" id="path50" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <text id="text54" x="-16" y="248" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="24" font-weight="700" x="251" y="266" id="tspan52" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c">share</tspan>
+ </text>
+ <circle id="ellipse65" cy="427" cx="227" r="23" fill="#7ebd50" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse67" cy="427" cx="227" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line70" d="M227 383l-1-76" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_2)"/>
+ <path id="line73" d="M299 529h210" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
+ <circle id="ellipse76" cy="529" cx="448" r="23" fill="#7ebd50" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse78" cy="529" cx="448" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path81" d="M490 505l2 2v45l-2 2c-2 0-2-1-2-2v-45c0-1 0-2 2-2z" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line122" d="M32 89h383" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
+ <circle id="ellipse128" cy="89" cx="176" r="23" fill="#7ebd50" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse130" cy="89" cx="176" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line136" d="M176 195v-81" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000004,6.00000011" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_5)"/>
+ <text id="text94" transform="rotate(-90)" x="-202" y="197" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan92" y="212" x="-202" font-weight="400" font-size="16" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">cancel()</tspan>
+ </text>
+ <path id="line187" d="M89 324v97" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6.00000001" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_6)"/>
+ <text id="text192" transform="rotate(-90)" x="-411" y="64" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan190" y="79" x="-411" font-weight="400" font-size="16" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">subscribe()</tspan>
+ </text>
+ <path id="line243" d="M127 324v97" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6.00000001" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_9)"/>
+ <text id="text252" transform="rotate(-90)" x="-411" y="101" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan246" y="116" x="-410" font-weight="400" font-size="16" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request()</tspan>
+ </text>
+ <path id="line1176" d="M333 323v206" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999995,5.99999984" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_6)"/>
+ <text y="308" x="-520" transform="rotate(-90)" id="text1180" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="16" font-weight="400" x="-520" y="323" id="tspan1178" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">subscribe()</tspan>
+ </text>
+ <path id="line1182" d="M371 323v206" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999995,5.99999984" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_9)"/>
+ <text y="346" x="-520" transform="rotate(-90)" id="text1186" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="16" font-weight="400" x="-519" y="361" id="tspan1184" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request()</tspan>
+ </text>
+ <path id="line1188" d="M89 111v100" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000002,6.00000007" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_6)"/>
+ <text y="63" x="-201" transform="rotate(-90)" id="text1192" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="16" font-weight="400" x="-201" y="78" id="tspan1190" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">subscribe()</tspan>
+ </text>
+ <path id="line1194" d="M127 111v100" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000002,6.00000007" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_9)"/>
+ <text y="101" x="-201" transform="rotate(-90)" id="text1198" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="16" font-weight="400" x="-200" y="116" id="tspan1196" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request()</tspan>
+ </text>
+ <path id="line1200" d="M227 111v100" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000002,6.00000007" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_9)"/>
+ <path d="M440.51 483.72l-58.6-178.7" id="line1396" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999998,5.99999993" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_2-5)"/>
+ <path d="M478.74 485.58l-96.83-180.56" id="path1411" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999995,5.99999987" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_2-5)"/>
+ <circle cx="276" cy="89" id="ellipse56713" r="23" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+</svg>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/shareNext.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/shareNext.svg
@@ -1,0 +1,118 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="23 60 518 499" width="518" height="499" id="svg166">
+ <defs id="defs31">
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g4">
+    <path d="M12 0L0-4v9z" id="path2" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-miterlimit="10" viewBox="-10 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g9">
+    <path d="M-8 0l8 3v-6z" id="path7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="20" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face12" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma-Bold"/>
+   </font-face-src>
+  </font-face>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#b4b4b4" stroke-linejoin="miter">
+   <g id="g16">
+    <path d="M8 0L0-3v6z" id="path14" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_4" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g21">
+    <path d="M8 0L0-3v6z" id="path19" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="16" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face24" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma"/>
+   </font-face-src>
+  </font-face>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_5" stroke-miterlimit="10" viewBox="-10 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g28">
+    <path d="M-8 0l8 3v-6z" id="path26" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-3" stroke-miterlimit="10" viewBox="-6 -3 7 6" markerWidth="7" markerHeight="6" color="#45b8de" stroke-linejoin="miter">
+   <g id="g9-6">
+    <path d="M-5 0l5 2v-4z" id="path7-7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_9" stroke-miterlimit="10" viewBox="-10 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g50">
+    <path d="M-8 0l8 3v-6z" id="path48" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_6" stroke-miterlimit="10" viewBox="-10 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g35">
+    <path d="M-8 0l8 3v-6z" id="path33" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-5" stroke-miterlimit="10" viewBox="-10 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g9-3">
+    <path d="M-8 0l8 3v-6z" id="path7-5" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker1428" stroke-miterlimit="10" viewBox="-10 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g1426">
+    <path d="M-8 0l8 3v-6z" id="path1424" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="marker1434" stroke-miterlimit="10" viewBox="-10 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g1432">
+    <path d="M-8 0l8 3v-6z" id="path1430" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+ </defs>
+ <path id="line39" d="M29 427h261" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
+ <path id="path42" d="M269 403h1l2 2v44l-2 2h-1l-2-2v-44z" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line45" d="M270 383l-2-76" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_2)"/>
+ <path d="M46 216h472l1 1v86l-1 1H46l-1-1v-86z" id="path50" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <text id="text54" x="-16" y="248" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="24" font-weight="700" x="211" y="266" id="tspan52" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c">shareNext</tspan>
+ </text>
+ <circle id="ellipse65" cy="427" cx="227" r="23" fill="#7ebd50" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse67" cy="427" cx="227" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line70" d="M227 383l-1-76" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_2)"/>
+ <path id="line73" d="M299 529h210" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
+ <circle id="ellipse76" cy="529" cx="448" r="23" fill="#7ebd50" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse78" cy="529" cx="448" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path81" d="M490 505l2 2v45l-2 2c-2 0-2-1-2-2v-45c0-1 0-2 2-2z" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line122" d="M32 89h383" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
+ <circle id="ellipse128" cy="89" cx="176" r="23" fill="#7ebd50" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle id="ellipse130" cy="89" cx="176" r="23" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line136" d="M176 195v-81" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000004,6.00000011" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_5)"/>
+ <text id="text94" transform="rotate(-90)" x="-202" y="197" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan92" y="212" x="-202" font-weight="400" font-size="16" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">cancel()</tspan>
+ </text>
+ <path id="line187" d="M89 324v97" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6.00000001" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_6)"/>
+ <text id="text192" transform="rotate(-90)" x="-411" y="64" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan190" y="79" x="-411" font-weight="400" font-size="16" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">subscribe()</tspan>
+ </text>
+ <path id="line243" d="M127 324v97" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6.00000001" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_9)"/>
+ <text id="text252" transform="rotate(-90)" x="-411" y="101" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan246" y="116" x="-410" font-weight="400" font-size="16" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request()</tspan>
+ </text>
+ <path id="line1176" d="M333 323v206" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999995,5.99999984" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_6)"/>
+ <text y="308" x="-520" transform="rotate(-90)" id="text1180" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="16" font-weight="400" x="-520" y="323" id="tspan1178" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">subscribe()</tspan>
+ </text>
+ <path id="line1182" d="M371 323v206" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999995,5.99999984" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_9)"/>
+ <text y="346" x="-520" transform="rotate(-90)" id="text1186" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="16" font-weight="400" x="-519" y="361" id="tspan1184" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request()</tspan>
+ </text>
+ <path id="line1188" d="M89 111v100" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000002,6.00000007" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_6)"/>
+ <text y="63" x="-201" transform="rotate(-90)" id="text1192" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="16" font-weight="400" x="-201" y="78" id="tspan1190" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">subscribe()</tspan>
+ </text>
+ <path id="line1194" d="M127 111v100" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000002,6.00000007" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_9)"/>
+ <text y="101" x="-201" transform="rotate(-90)" id="text1198" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="16" font-weight="400" x="-200" y="116" id="tspan1196" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request()</tspan>
+ </text>
+ <path id="line1200" d="M227 111v100" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000002,6.00000007" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_9)"/>
+ <path d="M440.51 483.72l-58.6-178.7" id="line1396" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999998,5.99999993" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_2-5)"/>
+ <path d="M478.74 485.58l-96.83-180.56" id="path1411" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.99999995,5.99999987" stroke-opacity="1" marker-start="url(#FilledArrow_Marker_2-5)"/>
+ <circle cx="276" cy="89" id="ellipse56713" r="23" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+</svg>

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSourceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSourceTest.java
@@ -29,7 +29,7 @@ public class FluxSourceTest {
 
 	@Test
 	public void wrapToFlux(){
-		MonoProcessor<String> mp = MonoProcessor.create();
+		NextProcessor<String> mp = new NextProcessor<>(null);
 
 		mp.onNext("test");
 		StepVerifier.create(Flux.from(mp))

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Assert;
 import org.junit.Test;
+
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoAnyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoAnyTest.java
@@ -162,11 +162,10 @@ public class MonoAnyTest {
 	public void cancel() {
 		TestPublisher<String> cancelTester = TestPublisher.create();
 
-		MonoProcessor<Boolean> processor = cancelTester.flux()
-		                                               .any(s -> s.length() > 100)
-		                                               .toProcessor();
-		processor.subscribe();
-		processor.cancel();
+		StepVerifier.create(cancelTester.flux()
+										.any(s -> s.length() > 100))
+					.thenCancel()
+					.verify();
 
 		cancelTester.assertCancelled();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoElementAtTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoElementAtTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
+import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 
@@ -207,11 +208,10 @@ public class MonoElementAtTest {
 	public void cancel() {
 		TestPublisher<String> cancelTester = TestPublisher.create();
 
-		MonoProcessor<String> processor = cancelTester.flux()
-		                                              .elementAt(1000)
-		                                              .toProcessor();
-		processor.subscribe();
-		processor.cancel();
+		StepVerifier.create(cancelTester.flux()
+										.elementAt(1000))
+					.thenCancel()
+					.verify();
 
 		cancelTester.assertCancelled();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFilterTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFilterTest.java
@@ -126,7 +126,7 @@ public class MonoFilterTest {
 	public void asyncFusion() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-		MonoProcessor<Integer> up = MonoProcessor.create();
+		NextProcessor<Integer> up = new NextProcessor<>(null);
 
 		up.filter(v -> (v & 1) == 0)
 		  .subscribe(ts);
@@ -142,7 +142,7 @@ public class MonoFilterTest {
 	public void asyncFusionBackpressured() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create(1);
 
-		MonoProcessor<Integer> up = MonoProcessor.create();
+		NextProcessor<Integer> up = new NextProcessor<>(null);
 
 		Mono.just(1)
 		    .hide()
@@ -169,7 +169,7 @@ public class MonoFilterTest {
 
 	@Test
 	public void filterMono() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
 		StepVerifier.create(Mono.just(2).filter(s -> s % 2 == 0).subscribeWith(mp))
 		            .then(() -> assertThat(mp.isError()).isFalse())
 		            .then(() -> assertThat(mp.isSuccess()).isTrue())
@@ -182,7 +182,7 @@ public class MonoFilterTest {
 
 	@Test
 	public void filterMonoNot() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
 		StepVerifier.create(Mono.just(1).filter(s -> s % 2 == 0).subscribeWith(mp))
 		            .then(() -> assertThat(mp.isError()).isFalse())
 		            .then(() -> assertThat(mp.isSuccess()).isTrue())

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFirstTest.java
@@ -107,7 +107,7 @@ public class MonoFirstTest {
 
 	@Test
 	public void firstMonoJust() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
 		StepVerifier.create(Mono.first(Mono.just(1), Mono.just(2))
 		                        .subscribeWith(mp))
 		            .then(() -> assertThat(mp.isError()).isFalse())

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFlatMapTest.java
@@ -42,11 +42,10 @@ public class MonoFlatMapTest {
 	public void cancel() {
 		TestPublisher<String> cancelTester = TestPublisher.create();
 
-		MonoProcessor<Integer> processor = cancelTester.mono()
-													   .flatMap(s -> Mono.just(s.length()))
-													   .toProcessor();
-		processor.subscribe();
-		processor.cancel();
+		StepVerifier.create(cancelTester.mono()
+										.flatMap(s -> Mono.just(s.length())))
+					.thenCancel()
+					.verify();
 
 		cancelTester.assertCancelled();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNextTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNextTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
+import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 
@@ -53,11 +54,10 @@ public class MonoNextTest {
 	public void cancel() {
 		TestPublisher<String> cancelTester = TestPublisher.create();
 
-		MonoProcessor<String> processor = cancelTester.flux()
-		                                              .next()
-		                                              .toProcessor();
-		processor.subscribe();
-		processor.cancel();
+		StepVerifier.create(cancelTester.flux()
+										.next())
+					.thenCancel()
+					.verify();
 
 		cancelTester.assertCancelled();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoOnErrorResumeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoOnErrorResumeTest.java
@@ -197,7 +197,7 @@ public class MonoOnErrorResumeTest {
 
 	@Test
 	public void mapError() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
 		StepVerifier.create(Mono.<Integer>error(new TestException())
 				.onErrorMap(TestException.class, e -> new Exception("test"))
 				.subscribeWith(mp))
@@ -209,7 +209,7 @@ public class MonoOnErrorResumeTest {
 
 	@Test
 	public void otherwiseErrorFilter() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
 		StepVerifier.create(Mono.<Integer>error(new TestException())
 				.onErrorResume(TestException.class, e -> Mono.just(1))
 				.subscribeWith(mp))
@@ -222,7 +222,7 @@ public class MonoOnErrorResumeTest {
 
 	@Test
 	public void otherwiseErrorUnfilter() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
 		StepVerifier.create(Mono.<Integer>error(new TestException())
 				.onErrorResume(RuntimeException.class, e -> Mono.just(1))
 				.subscribeWith(mp))
@@ -234,7 +234,7 @@ public class MonoOnErrorResumeTest {
 
 	@Test
 	public void otherwiseReturnErrorFilter() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
 		StepVerifier.create(Mono.<Integer>error(new TestException())
 				.onErrorReturn(TestException.class, 1)
 				.subscribeWith(mp))
@@ -248,7 +248,7 @@ public class MonoOnErrorResumeTest {
 
 	@Test
 	public void otherwiseReturnErrorFilter2() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
 		StepVerifier.create(Mono.<Integer>error(new TestException())
 				.onErrorReturn(TestException.class::isInstance, 1)
 				.subscribeWith(mp))
@@ -261,7 +261,7 @@ public class MonoOnErrorResumeTest {
 
 	@Test
 	public void otherwiseReturnErrorUnfilter() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
 		StepVerifier.create(Mono.<Integer>error(new TestException())
 				.onErrorReturn(RuntimeException.class, 1)
 				.subscribeWith(mp))
@@ -273,7 +273,7 @@ public class MonoOnErrorResumeTest {
 
 	@Test
 	public void otherwiseReturnErrorUnfilter2() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
 		StepVerifier.create(Mono.<Integer>error(new TestException())
 				.onErrorReturn(RuntimeException.class::isInstance, 1)
 				.subscribeWith(mp))

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTest.java
@@ -147,10 +147,8 @@ public class MonoPeekTest {
 		Mono<String> mp = Mono.error(new TestException());
 		AtomicReference<Throwable> ref = new AtomicReference<>();
 
-		MonoProcessor<String> processor = mp.doOnError(RuntimeException.class, ref::set)
-		                                    .toProcessor();
-		processor.subscribe();
-		assertThat(processor.getError()).isInstanceOf(TestException.class);
+		StepVerifier.create(mp.doOnError(RuntimeException.class, ref::set))
+					.verifyError(TestException.class);
 
 		assertThat(ref.get()).isNull();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPublishMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPublishMulticastTest.java
@@ -73,7 +73,7 @@ public class MonoPublishMulticastTest {
 	public void cancelComposes() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		MonoProcessor<Integer> sp = MonoProcessor.create();
+		NextProcessor<Integer> sp = new NextProcessor<>(null);
 
 		sp.publish(o -> Mono.<Integer>never())
 		  .subscribe(ts);
@@ -89,7 +89,7 @@ public class MonoPublishMulticastTest {
 	public void cancelComposes2() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		MonoProcessor<Integer> sp = MonoProcessor.create();
+		NextProcessor<Integer> sp = new NextProcessor<>(null);
 
 		sp.publish(o -> Mono.<Integer>empty())
 		  .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoThenIgnoreTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoThenIgnoreTest.java
@@ -76,11 +76,10 @@ public class MonoThenIgnoreTest {
 	public void cancel() {
 		TestPublisher<String> cancelTester = TestPublisher.create();
 
-		MonoProcessor<Void> processor = cancelTester.flux()
-		                                            .then()
-		                                            .toProcessor();
-		processor.subscribe();
-		processor.cancel();
+		StepVerifier.create(cancelTester.flux()
+										.then())
+					.thenCancel()
+					.verify();
 
 		cancelTester.assertCancelled();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
@@ -82,7 +82,7 @@ public class MonoTimeoutTest {
 	public void timeoutRequested() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		MonoProcessor<Integer> source = MonoProcessor.create();
+		NextProcessor<Integer> source = new NextProcessor<>(null);
 
 		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().onBackpressureError();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoUsingTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoUsingTest.java
@@ -213,7 +213,7 @@ public class MonoUsingTest {
 
 		AtomicInteger cleanup = new AtomicInteger();
 
-		MonoProcessor<Integer> tp = MonoProcessor.create();
+		NextProcessor<Integer> tp = new NextProcessor<>(null);
 
 		Mono.using(() -> 1, r -> tp, cleanup::set, true)
 		    .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoZipTest.java
@@ -202,7 +202,7 @@ public class MonoZipTest {
 
 	@Test
 	public void whenMonoJust() {
-		MonoProcessor<Tuple2<Integer, Integer>> mp = MonoProcessor.create();
+		NextProcessor<Tuple2<Integer, Integer>> mp = new NextProcessor<>(null);
 		StepVerifier.create(Mono.zip(Mono.just(1), Mono.just(2))
 		                        .subscribeWith(mp))
 		            .then(() -> assertThat(mp.isError()).isFalse())
@@ -214,7 +214,7 @@ public class MonoZipTest {
 
 	@Test
 	public void whenMonoJust3() {
-		MonoProcessor<Tuple3<Integer, Integer, Integer>> mp = MonoProcessor.create();
+		NextProcessor<Tuple3<Integer, Integer, Integer>> mp = new NextProcessor<>(null);
 		StepVerifier.create(Mono.zip(Mono.just(1), Mono.just(2), Mono.just(3))
 		                        .subscribeWith(mp))
 		            .then(() -> assertThat(mp.isError()).isFalse())
@@ -226,8 +226,8 @@ public class MonoZipTest {
 
 	@Test
 	public void whenMonoJust4() {
-		MonoProcessor<Tuple4<Integer, Integer, Integer, Integer>> mp =
-				MonoProcessor.create();
+		NextProcessor<Tuple4<Integer, Integer, Integer, Integer>> mp =
+				new NextProcessor<>(null);
 		StepVerifier.create(Mono.zip(Mono.just(1),
 				Mono.just(2),
 				Mono.just(3),
@@ -242,8 +242,8 @@ public class MonoZipTest {
 
 	@Test
 	public void whenMonoJust5() {
-		MonoProcessor<Tuple5<Integer, Integer, Integer, Integer, Integer>> mp =
-				MonoProcessor.create();
+		NextProcessor<Tuple5<Integer, Integer, Integer, Integer, Integer>> mp =
+				new NextProcessor<>(null);
 		StepVerifier.create(Mono.zip(Mono.just(1),
 				Mono.just(2),
 				Mono.just(3),
@@ -259,8 +259,8 @@ public class MonoZipTest {
 
 	@Test
 	public void whenMonoJust6() {
-		MonoProcessor<Tuple6<Integer, Integer, Integer, Integer, Integer, Integer>> mp =
-				MonoProcessor.create();
+		NextProcessor<Tuple6<Integer, Integer, Integer, Integer, Integer, Integer>> mp =
+				new NextProcessor<>(null);
 		StepVerifier.create(Mono.zip(Mono.just(1),
 				Mono.just(2),
 				Mono.just(3),
@@ -304,7 +304,7 @@ public class MonoZipTest {
 
 	@Test
 	public void whenMonoError() {
-		MonoProcessor<Tuple2<Integer, Integer>> mp = MonoProcessor.create();
+		NextProcessor<Tuple2<Integer, Integer>> mp = new NextProcessor<>(null);
 		StepVerifier.create(Mono.zip(Mono.<Integer>error(new Exception("test1")),
 				Mono.<Integer>error(new Exception("test2")))
 		                        .subscribeWith(mp))
@@ -316,7 +316,7 @@ public class MonoZipTest {
 
 	@Test
 	public void whenMonoCallable() {
-		MonoProcessor<Tuple2<Integer, Integer>> mp = MonoProcessor.create();
+		NextProcessor<Tuple2<Integer, Integer>> mp = new NextProcessor<>(null);
 		StepVerifier.create(Mono.zip(Mono.fromCallable(() -> 1),
 				Mono.fromCallable(() -> 2))
 		                        .subscribeWith(mp))
@@ -329,7 +329,7 @@ public class MonoZipTest {
 
 	@Test
 	public void whenDelayJustMono() {
-		MonoProcessor<Tuple2<Integer, Integer>> mp = MonoProcessor.create();
+		NextProcessor<Tuple2<Integer, Integer>> mp = new NextProcessor<>(null);
 		StepVerifier.create(Mono.zipDelayError(Mono.just(1), Mono.just(2))
 		                        .subscribeWith(mp))
 		            .then(() -> assertThat(mp.isError()).isFalse())
@@ -341,7 +341,7 @@ public class MonoZipTest {
 
 	@Test
 	public void whenDelayJustMono3() {
-		MonoProcessor<Tuple3<Integer, Integer, Integer>> mp = MonoProcessor.create();
+		NextProcessor<Tuple3<Integer, Integer, Integer>> mp = new NextProcessor<>(null);
 		StepVerifier.create(Mono.zipDelayError(Mono.just(1), Mono.just(2), Mono.just(3))
 		                        .subscribeWith(mp))
 		            .then(() -> assertThat(mp.isError()).isFalse())
@@ -353,8 +353,8 @@ public class MonoZipTest {
 
 	@Test
 	public void whenDelayMonoJust4() {
-		MonoProcessor<Tuple4<Integer, Integer, Integer, Integer>> mp =
-				MonoProcessor.create();
+		NextProcessor<Tuple4<Integer, Integer, Integer, Integer>> mp =
+				new NextProcessor<>(null);
 		StepVerifier.create(Mono.zipDelayError(Mono.just(1),
 				Mono.just(2),
 				Mono.just(3),
@@ -369,8 +369,8 @@ public class MonoZipTest {
 
 	@Test
 	public void whenDelayMonoJust5() {
-		MonoProcessor<Tuple5<Integer, Integer, Integer, Integer, Integer>> mp =
-				MonoProcessor.create();
+		NextProcessor<Tuple5<Integer, Integer, Integer, Integer, Integer>> mp =
+				new NextProcessor<>(null);
 		StepVerifier.create(Mono.zipDelayError(Mono.just(1),
 				Mono.just(2),
 				Mono.just(3),
@@ -386,8 +386,8 @@ public class MonoZipTest {
 
 	@Test
 	public void whenDelayMonoJust6() {
-		MonoProcessor<Tuple6<Integer, Integer, Integer, Integer, Integer, Integer>> mp =
-				MonoProcessor.create();
+		NextProcessor<Tuple6<Integer, Integer, Integer, Integer, Integer, Integer>> mp =
+				new NextProcessor<>(null);
 		StepVerifier.create(Mono.zipDelayError(Mono.just(1),
 				Mono.just(2),
 				Mono.just(3),
@@ -404,8 +404,8 @@ public class MonoZipTest {
 
 	@Test
 	public void whenDelayMonoJust7() {
-		MonoProcessor<Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer>> mp =
-				MonoProcessor.create();
+		NextProcessor<Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer>> mp =
+				new NextProcessor<>(null);
 		StepVerifier.create(Mono.zipDelayError(Mono.just(1),
 				Mono.just(2),
 				Mono.just(3),

--- a/reactor-core/src/test/java/reactor/core/publisher/NextProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/NextProcessorTest.java
@@ -39,7 +39,7 @@ import reactor.util.function.Tuple2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class MonoProcessorTest {
+public class NextProcessorTest {
 
 	@Test
 	public void noRetentionOnTermination() throws InterruptedException {
@@ -50,7 +50,7 @@ public class MonoProcessorTest {
 		WeakReference<CompletableFuture<Date>> refFuture = new WeakReference<>(future);
 
 		Mono<Date> source = Mono.fromFuture(future);
-		Mono<String> data = source.map(Date::toString).as(MonoProcessor::new);
+		Mono<String> data = source.map(Date::toString).as(NextProcessor::new);
 
 		future.complete(date);
 		assertThat(data.block()).isEqualTo(date.toString());
@@ -79,7 +79,7 @@ public class MonoProcessorTest {
 		WeakReference<CompletableFuture<Date>> refFuture = new WeakReference<>(future);
 
 		Mono<Date> source = Mono.fromFuture(future);
-		Mono<String> data = source.map(Date::toString).as(MonoProcessor::new);
+		Mono<String> data = source.map(Date::toString).as(NextProcessor::new);
 
 		future.completeExceptionally(new IllegalStateException());
 
@@ -108,7 +108,7 @@ public class MonoProcessorTest {
 		WeakReference<CompletableFuture<Date>> refFuture = new WeakReference<>(future);
 
 		Mono<Date> source = Mono.fromFuture(future);
-		Mono<String> data = source.map(Date::toString).as(MonoProcessor::new);
+		Mono<String> data = source.map(Date::toString).as(NextProcessor::new);
 
 		future = null;
 		source = null;
@@ -129,15 +129,15 @@ public class MonoProcessorTest {
 	}
 
 	@Test(expected = IllegalStateException.class)
-	public void MonoProcessorResultNotAvailable() {
-		MonoProcessor<String> mp = MonoProcessor.create();
+	public void NextProcessorResultNotAvailable() {
+		NextProcessor<String> mp = new NextProcessor<>(null);
 		mp.block(Duration.ofMillis(1));
 	}
 
 	@SuppressWarnings("deprecation")
 	@Test
 	public void MonoProcessorRejectedDoOnSuccessOrError() {
-		MonoProcessor<String> mp = MonoProcessor.create();
+		NextProcessor<String> mp = new NextProcessor<>(null);
 		AtomicReference<Throwable> ref = new AtomicReference<>();
 
 		mp.doOnSuccessOrError((s, f) -> ref.set(f)).subscribe();
@@ -150,7 +150,7 @@ public class MonoProcessorTest {
 
 	@Test
 	public void MonoProcessorRejectedDoOnTerminate() {
-		MonoProcessor<String> mp = MonoProcessor.create();
+		NextProcessor<String> mp = new NextProcessor<>(null);
 		AtomicInteger invoked = new AtomicInteger();
 
 		mp.doOnTerminate(invoked::incrementAndGet).subscribe();
@@ -163,7 +163,7 @@ public class MonoProcessorTest {
 
 	@Test
 	public void MonoProcessorRejectedSubscribeCallback() {
-		MonoProcessor<String> mp = MonoProcessor.create();
+		NextProcessor<String> mp = new NextProcessor<>(null);
 		AtomicReference<Throwable> ref = new AtomicReference<>();
 
 		mp.subscribe(v -> {}, ref::set);
@@ -177,7 +177,7 @@ public class MonoProcessorTest {
 	@SuppressWarnings("deprecation")
 	@Test
 	public void MonoProcessorSuccessDoOnSuccessOrError() {
-		MonoProcessor<String> mp = MonoProcessor.create();
+		NextProcessor<String> mp = new NextProcessor<>(null);
 		AtomicReference<String> ref = new AtomicReference<>();
 
 		mp.doOnSuccessOrError((s, f) -> ref.set(s)).subscribe();
@@ -190,7 +190,7 @@ public class MonoProcessorTest {
 
 	@Test
 	public void MonoProcessorSuccessDoOnTerminate() {
-		MonoProcessor<String> mp = MonoProcessor.create();
+		NextProcessor<String> mp = new NextProcessor<>(null);
 		AtomicInteger invoked = new AtomicInteger();
 
 		mp.doOnTerminate(invoked::incrementAndGet).subscribe();
@@ -203,7 +203,7 @@ public class MonoProcessorTest {
 
 	@Test
 	public void MonoProcessorSuccessSubscribeCallback() {
-		MonoProcessor<String> mp = MonoProcessor.create();
+		NextProcessor<String> mp = new NextProcessor<>(null);
 		AtomicReference<String> ref = new AtomicReference<>();
 
 		mp.subscribe(ref::set);
@@ -216,7 +216,7 @@ public class MonoProcessorTest {
 
 	@Test
 	public void MonoProcessorRejectedDoOnError() {
-		MonoProcessor<String> mp = MonoProcessor.create();
+		NextProcessor<String> mp = new NextProcessor<>(null);
 		AtomicReference<Throwable> ref = new AtomicReference<>();
 
 		mp.doOnError(ref::set).subscribe();
@@ -229,14 +229,14 @@ public class MonoProcessorTest {
 
 	@Test(expected = NullPointerException.class)
 	public void MonoProcessorRejectedSubscribeCallbackNull() {
-		MonoProcessor<String> mp = MonoProcessor.create();
+		NextProcessor<String> mp = new NextProcessor<>(null);
 
 		mp.subscribe((Subscriber<String>)null);
 	}
 
 	@Test
 	public void MonoProcessorSuccessDoOnSuccess() {
-		MonoProcessor<String> mp = MonoProcessor.create();
+		NextProcessor<String> mp = new NextProcessor<>(null);
 		AtomicReference<String> ref = new AtomicReference<>();
 
 		mp.doOnSuccess(ref::set).subscribe();
@@ -249,8 +249,8 @@ public class MonoProcessorTest {
 
 	@Test
 	public void MonoProcessorSuccessChainTogether() {
-		MonoProcessor<String> mp = MonoProcessor.create();
-		MonoProcessor<String> mp2 = MonoProcessor.create();
+		NextProcessor<String> mp = new NextProcessor<>(null);
+		NextProcessor<String> mp2 = new NextProcessor<>(null);
 		mp.subscribe(mp2);
 
 		mp.onNext("test");
@@ -262,8 +262,8 @@ public class MonoProcessorTest {
 
 	@Test
 	public void MonoProcessorRejectedChainTogether() {
-		MonoProcessor<String> mp = MonoProcessor.create();
-		MonoProcessor<String> mp2 = MonoProcessor.create();
+		NextProcessor<String> mp = new NextProcessor<>(null);
+		NextProcessor<String> mp2 = new NextProcessor<>(null);
 		mp.subscribe(mp2);
 
 		mp.onError(new Exception("test"));
@@ -275,7 +275,7 @@ public class MonoProcessorTest {
 
 	@Test
 	public void MonoProcessorDoubleFulfill() {
-		MonoProcessor<String> mp = MonoProcessor.create();
+		NextProcessor<String> mp = new NextProcessor<>(null);
 
 		StepVerifier.create(mp)
 		            .then(() -> {
@@ -290,7 +290,7 @@ public class MonoProcessorTest {
 
 	@Test
 	public void MonoProcessorNullFulfill() {
-		MonoProcessor<String> mp = MonoProcessor.create();
+		NextProcessor<String> mp = new NextProcessor<>(null);
 
 		mp.onNext(null);
 
@@ -301,12 +301,13 @@ public class MonoProcessorTest {
 
 	@Test
 	public void MonoProcessorMapFulfill() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
 
 		mp.onNext(1);
 
-		MonoProcessor<Integer> mp2 = mp.map(s -> s * 2)
-		                               .toProcessor();
+		NextProcessor<Integer> mp2 = mp.map(s -> s * 2)
+									   .cache()
+		                               .subscribeWith(new NextProcessor<>(null));
 		mp2.subscribe();
 
 		assertThat(mp2.isTerminated()).isTrue();
@@ -316,12 +317,12 @@ public class MonoProcessorTest {
 
 	@Test
 	public void MonoProcessorThenFulfill() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
 
 		mp.onNext(1);
 
-		MonoProcessor<Integer> mp2 = mp.flatMap(s -> Mono.just(s * 2))
-		                               .toProcessor();
+		NextProcessor<Integer> mp2 = mp.flatMap(s -> Mono.just(s * 2))
+		                               .subscribeWith(new NextProcessor<>(null));
 		mp2.subscribe();
 
 		assertThat(mp2.isTerminated()).isTrue();
@@ -331,11 +332,11 @@ public class MonoProcessorTest {
 
 	@Test
 	public void MonoProcessorMapError() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
 
 		mp.onNext(1);
 
-		MonoProcessor<Integer> mp2 = MonoProcessor.create();
+		NextProcessor<Integer> mp2 = new NextProcessor<>(null);
 
 		StepVerifier.create(mp.<Integer>map(s -> {
 			throw new RuntimeException("test");
@@ -354,7 +355,7 @@ public class MonoProcessorTest {
 		TestLogger testLogger = new TestLogger();
 		LoggerUtils.addAppender(testLogger, Operators.class);
 		try {
-			MonoProcessor<String> mp = MonoProcessor.create();
+			NextProcessor<String> mp = new NextProcessor<>(null);
 
 			mp.onError(new Exception("test"));
 			mp.onError(new Exception("test2"));
@@ -372,7 +373,7 @@ public class MonoProcessorTest {
 		TestLogger testLogger = new TestLogger();
 		LoggerUtils.addAppender(testLogger, Operators.class);
 		try {
-			MonoProcessor<String> mp = MonoProcessor.create();
+			NextProcessor<String> mp = new NextProcessor<>(null);
 
 			mp.onNext("test");
 			mp.onError(new Exception("test2"));
@@ -388,20 +389,19 @@ public class MonoProcessorTest {
 
 	@Test
 	public void zipMonoProcessor() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
-		MonoProcessor<Integer> mp2 = MonoProcessor.create();
-		MonoProcessor<Tuple2<Integer, Integer>> mp3 = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
+		NextProcessor<Integer> mp2 = new NextProcessor<>(null);
+		NextProcessor<Tuple2<Integer, Integer>> mp3 = new NextProcessor<>(null);
 
 		StepVerifier.create(Mono.zip(mp, mp2)
 		                        .subscribeWith(mp3))
-		            .then(() -> assertThat(mp3.isPending()).isTrue())
+		            .then(() -> assertThat(mp3.isTerminated()).isFalse())
 		            .then(() -> mp.onNext(1))
-		            .then(() -> assertThat(mp3.isPending()).isTrue())
+		            .then(() -> assertThat(mp3.isTerminated()).isFalse())
 		            .then(() -> mp2.onNext(2))
 		            .then(() -> {
 			            assertThat(mp3.isTerminated()).isTrue();
 			            assertThat(mp3.isSuccess()).isTrue();
-			            assertThat(mp3.isPending()).isFalse();
 			            assertThat(mp3.peek()
 			                          .getT1()).isEqualTo(1);
 			            assertThat(mp3.peek()
@@ -413,17 +413,16 @@ public class MonoProcessorTest {
 
 	@Test
 	public void zipMonoProcessor2() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
-		MonoProcessor<Integer> mp3 = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
+		NextProcessor<Integer> mp3 = new NextProcessor<>(null);
 
 		StepVerifier.create(Mono.zip(d -> (Integer)d[0], mp)
 		                        .subscribeWith(mp3))
-		            .then(() -> assertThat(mp3.isPending()).isTrue())
+		            .then(() -> assertThat(mp3.isTerminated()).isFalse())
 		            .then(() -> mp.onNext(1))
 		            .then(() -> {
 			            assertThat(mp3.isTerminated()).isTrue();
 			            assertThat(mp3.isSuccess()).isTrue();
-			            assertThat(mp3.isPending()).isFalse();
 			            assertThat(mp3.peek()).isEqualTo(1);
 		            })
 		            .expectNext(1)
@@ -432,18 +431,17 @@ public class MonoProcessorTest {
 
 	@Test
 	public void zipMonoProcessorRejected() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
-		MonoProcessor<Integer> mp2 = MonoProcessor.create();
-		MonoProcessor<Tuple2<Integer, Integer>> mp3 = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
+		NextProcessor<Integer> mp2 = new NextProcessor<>(null);
+		NextProcessor<Tuple2<Integer, Integer>> mp3 = new NextProcessor<>(null);
 
 		StepVerifier.create(Mono.zip(mp, mp2)
 		                        .subscribeWith(mp3))
-		            .then(() -> assertThat(mp3.isPending()).isTrue())
+		            .then(() -> assertThat(mp3.isTerminated()).isFalse())
 		            .then(() -> mp.onError(new Exception("test")))
 		            .then(() -> {
 			            assertThat(mp3.isTerminated()).isTrue();
 			            assertThat(mp3.isSuccess()).isFalse();
-			            assertThat(mp3.isPending()).isFalse();
 			            assertThat(mp3.getError()).hasMessage("test");
 		            })
 		            .verifyErrorMessage("test");
@@ -452,8 +450,8 @@ public class MonoProcessorTest {
 
 	@Test
 	public void filterMonoProcessor() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
-		MonoProcessor<Integer> mp2 = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
+		NextProcessor<Integer> mp2 = new NextProcessor<>(null);
 		StepVerifier.create(mp.filter(s -> s % 2 == 0).subscribeWith(mp2))
 		            .then(() -> mp.onNext(2))
 		            .then(() -> assertThat(mp2.isError()).isFalse())
@@ -467,8 +465,8 @@ public class MonoProcessorTest {
 
 	@Test
 	public void filterMonoProcessorNot() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
-		MonoProcessor<Integer> mp2 = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
+		NextProcessor<Integer> mp2 = new NextProcessor<>(null);
 		StepVerifier.create(mp.filter(s -> s % 2 == 0).subscribeWith(mp2))
 		            .then(() -> mp.onNext(1))
 		            .then(() -> assertThat(mp2.isError()).isFalse())
@@ -480,8 +478,8 @@ public class MonoProcessorTest {
 
 	@Test
 	public void filterMonoProcessorError() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
-		MonoProcessor<Integer> mp2 = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
+		NextProcessor<Integer> mp2 = new NextProcessor<>(null);
 		StepVerifier.create(mp.filter(s -> {throw new RuntimeException("test"); })
 					.subscribeWith
 						(mp2))
@@ -495,8 +493,8 @@ public class MonoProcessorTest {
 
 	@Test
 	public void doOnSuccessMonoProcessorError() {
-		MonoProcessor<Integer> mp = MonoProcessor.create();
-		MonoProcessor<Integer> mp2 = MonoProcessor.create();
+		NextProcessor<Integer> mp = new NextProcessor<>(null);
+		NextProcessor<Integer> mp2 = new NextProcessor<>(null);
 		AtomicReference<Throwable> ref = new AtomicReference<>();
 
 		StepVerifier.create(mp.doOnSuccess(s -> {throw new RuntimeException("test"); })
@@ -517,7 +515,7 @@ public class MonoProcessorTest {
 		AtomicLong cancelCounter = new AtomicLong();
 		Flux.range(1, 10)
 		    .doOnCancel(cancelCounter::incrementAndGet)
-		    .publishNext()
+		    .shareNext()
 		    .subscribe();
 
 		assertThat(cancelCounter.get()).isEqualTo(1);
@@ -526,17 +524,16 @@ public class MonoProcessorTest {
 	@Test
 	public void monoNotCancelledByMonoProcessor() {
 		AtomicLong cancelCounter = new AtomicLong();
-		MonoProcessor<String> monoProcessor = Mono.just("foo")
-		                                          .doOnCancel(cancelCounter::incrementAndGet)
-		                                          .toProcessor();
-		monoProcessor.subscribe();
+		Mono.just("foo")
+			.doOnCancel(cancelCounter::incrementAndGet)
+			.subscribe();
 
 		assertThat(cancelCounter.get()).isEqualTo(0);
 	}
 
 	@Test
 	public void scanProcessor() {
-		MonoProcessor<String> test = MonoProcessor.create();
+		NextProcessor<String> test = new NextProcessor<>(null);
 		Subscription subscription = Operators.emptySubscription();
 		test.onSubscribe(subscription);
 
@@ -552,7 +549,7 @@ public class MonoProcessorTest {
 
 	@Test
 	public void scanProcessorCancelled() {
-		MonoProcessor<String> test = MonoProcessor.create();
+		NextProcessor<String> test = new NextProcessor<>(null);
 		Subscription subscription = Operators.emptySubscription();
 		test.onSubscribe(subscription);
 
@@ -567,7 +564,7 @@ public class MonoProcessorTest {
 
 	@Test
 	public void scanProcessorSubscription() {
-		MonoProcessor<String> test = MonoProcessor.create();
+		NextProcessor<String> test = new NextProcessor<>(null);
 		Subscription subscription = Operators.emptySubscription();
 		test.onSubscribe(subscription);
 
@@ -577,7 +574,7 @@ public class MonoProcessorTest {
 
 	@Test
 	public void scanProcessorError() {
-		MonoProcessor<String> test = MonoProcessor.create();
+		NextProcessor<String> test = new NextProcessor<>(null);
 		Subscription subscription = Operators.emptySubscription();
 		test.onSubscribe(subscription);
 
@@ -588,28 +585,30 @@ public class MonoProcessorTest {
 	}
 
 	@Test
-	public void monoToProcessorReusesInstance() {
-		MonoProcessor<String> monoProcessor = Mono.just("foo")
-		                                          .toProcessor();
+	@SuppressWarnings("deprecated")
+	public void sharedMonoReusesInstance() {
+		Mono<String> sharedMono = Mono.just("foo")
+									  .hide()
+									  .share();
 
-		assertThat(monoProcessor)
-				.isSameAs(monoProcessor.toProcessor())
-				.isSameAs(monoProcessor.subscribe());
+		assertThat(sharedMono)
+				.isSameAs(sharedMono.share())
+				.isSameAs(sharedMono.subscribe());
 	}
 
 	@Test
-	public void monoToProcessorConnects() {
+	public void sharedMonoParentIsNotNull() {
 		TestPublisher<String> tp = TestPublisher.create();
-		MonoProcessor<String> connectedProcessor = tp.mono().toProcessor();
+		Mono<String> connectedProcessor = tp.mono().share();
+		connectedProcessor.subscribe();
 
-		assertThat(connectedProcessor.subscription).isNotNull();
+		assertThat(Scannable.from(connectedProcessor).scan(Scannable.Attr.PARENT)).isNotNull();
 	}
 
 	@Test
-	public void monoToProcessorChain() {
-		StepVerifier.withVirtualTime(() -> Mono.just("foo")
-		                                       .toProcessor()
-		                                       .delayElement(Duration.ofMillis(500)))
+	public void sharedMonoParentChain() {
+		Mono<String> m = Mono.just("foo").share();
+		StepVerifier.withVirtualTime(() -> m.delayElement(Duration.ofMillis(500)))
 		            .expectSubscription()
 		            .expectNoEvent(Duration.ofMillis(500))
 		            .expectNext("foo")
@@ -617,34 +616,18 @@ public class MonoProcessorTest {
 	}
 
 	@Test
-	public void monoToProcessorChainColdToHot() {
+	public void sharedMonoChainColdToHot() {
 		AtomicInteger subscriptionCount = new AtomicInteger();
 		Mono<String> coldToHot = Mono.just("foo")
 		                             .doOnSubscribe(sub -> subscriptionCount.incrementAndGet())
-		                             .toProcessor() //this actually subscribes
+		                             .share() //this actually subscribes
 		                             .filter(s -> s.length() < 4);
 
-		assertThat(subscriptionCount.get()).isEqualTo(1);
-
 		coldToHot.block();
 		coldToHot.block();
 		coldToHot.block();
 
 		assertThat(subscriptionCount.get()).isEqualTo(1);
-	}
-
-	@Test
-	public void monoProcessorBlockIsUnbounded() {
-		long start = System.nanoTime();
-
-		String result = Mono.just("foo")
-		                    .delayElement(Duration.ofMillis(500))
-		                    .toProcessor()
-		                    .block();
-
-		assertThat(result).isEqualTo("foo");
-		assertThat(Duration.ofNanos(System.nanoTime() - start))
-				.isGreaterThanOrEqualTo(Duration.ofMillis(500));
 	}
 
 	@Test
@@ -654,7 +637,7 @@ public class MonoProcessorTest {
 		assertThatExceptionOfType(IllegalStateException.class)
 				.isThrownBy(() -> Mono.just("foo")
 				                      .delayElement(Duration.ofMillis(500))
-				                      .toProcessor()
+				                      .share()
 				                      .block(Duration.ofSeconds(-1)))
 				.withMessage("Timeout on Mono blocking read");
 
@@ -669,7 +652,7 @@ public class MonoProcessorTest {
 		assertThatExceptionOfType(IllegalStateException.class)
 				.isThrownBy(() -> Mono.just("foo")
 				                      .delayElement(Duration.ofMillis(500))
-				                      .toProcessor()
+				                      .share()
 				                      .block(Duration.ZERO))
 		        .withMessage("Timeout on Mono blocking read");
 
@@ -678,8 +661,9 @@ public class MonoProcessorTest {
 	}
 
 	@Test
+	//FIXME that should not be the case even if it works
 	public void disposeBeforeValueSendsCancellationException() {
-		MonoProcessor<String> processor = MonoProcessor.create();
+		Mono<String> processor = Mono.<String>never().share();
 		AtomicReference<Throwable> e1 = new AtomicReference<>();
 		AtomicReference<Throwable> e2 = new AtomicReference<>();
 		AtomicReference<Throwable> e3 = new AtomicReference<>();
@@ -689,7 +673,7 @@ public class MonoProcessorTest {
 		processor.subscribe(v -> Assertions.fail("expected second subscriber to error"), e2::set);
 		processor.subscribe(v -> Assertions.fail("expected third subscriber to error"), e3::set);
 
-		processor.dispose();
+		processor.subscribe().dispose();
 
 		assertThat(e1.get()).isInstanceOf(CancellationException.class);
 		assertThat(e2.get()).isInstanceOf(CancellationException.class);
@@ -701,10 +685,10 @@ public class MonoProcessorTest {
 
 	@Test
 	public void scanSubscriber(){
-		MonoProcessor<String> processor = MonoProcessor.create();
+		NextProcessor<String> processor = new NextProcessor<>(null);
 		AssertSubscriber<String> subscriber = new AssertSubscriber<>();
 
-		MonoProcessor.NextInner<String> test = new MonoProcessor.NextInner<>(subscriber, processor);
+		NextProcessor.NextInner<String> test = new NextProcessor.NextInner<>(subscriber, processor);
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/VoidProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/VoidProcessorTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VoidProcessorTest {
+
+
+	@Test(expected = IllegalStateException.class)
+	public void NextProcessorResultNotAvailable() {
+		VoidProcessor<Void> mp = new VoidProcessor<>();
+		mp.block(Duration.ofMillis(1));
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
+	public void VoidProcessorRejectedDoOnSuccessOrError() {
+		VoidProcessor<Void> mp = new VoidProcessor<>();
+		AtomicReference<Throwable> ref = new AtomicReference<>();
+
+		mp.doOnSuccessOrError((s, f) -> ref.set(f)).subscribe();
+		mp.onError(new Exception("test"));
+
+		assertThat(ref.get()).hasMessage("test");
+		assertThat(mp.isSuccess()).isFalse();
+		assertThat(mp.isError()).isTrue();
+	}
+
+	@Test
+	public void VoidProcessorRejectedDoOnTerminate() {
+		VoidProcessor<Void> mp = new VoidProcessor<>();
+		AtomicInteger invoked = new AtomicInteger();
+
+		mp.doOnTerminate(invoked::incrementAndGet).subscribe();
+		mp.onError(new Exception("test"));
+
+		assertThat(invoked.get()).isEqualTo(1);
+		assertThat(mp.isSuccess()).isFalse();
+		assertThat(mp.isError()).isTrue();
+	}
+
+	@Test
+	public void VoidProcessorRejectedSubscribeCallback() {
+		VoidProcessor<Void> mp = new VoidProcessor<>();
+		AtomicReference<Throwable> ref = new AtomicReference<>();
+
+		mp.subscribe(v -> {}, ref::set);
+		mp.onError(new Exception("test"));
+
+		assertThat(ref.get()).hasMessage("test");
+		assertThat(mp.isSuccess()).isFalse();
+		assertThat(mp.isError()).isTrue();
+	}
+
+
+	@Test
+	public void VoidProcessorRejectedDoOnError() {
+		VoidProcessor<Void> mp = new VoidProcessor<>();
+		AtomicReference<Throwable> ref = new AtomicReference<>();
+
+		mp.doOnError(ref::set).subscribe();
+		mp.onError(new Exception("test"));
+
+		assertThat(ref.get()).hasMessage("test");
+		assertThat(mp.isSuccess()).isFalse();
+		assertThat(mp.isError()).isTrue();
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void VoidProcessorRejectedSubscribeCallbackNull() {
+		VoidProcessor<Void> mp = new VoidProcessor<>();
+
+		mp.subscribe((Subscriber<Void>)null);
+	}
+
+
+	@Test
+	public void VoidProcessorSuccessChainTogether() {
+		VoidProcessor<Void> mp = new VoidProcessor<>();
+		VoidProcessor<Void> mp2 = new VoidProcessor<>();
+		mp.subscribe(mp2);
+
+		mp.onComplete();
+
+		assertThat(mp.isSuccess()).isTrue();
+		assertThat(mp.isError()).isFalse();
+	}
+
+	@Test
+	public void VoidProcessorRejectedChainTogether() {
+		VoidProcessor<Void> mp = new VoidProcessor<>();
+		VoidProcessor<Void> mp2 = new VoidProcessor<>();
+		mp.subscribe(mp2);
+
+		mp.onError(new Exception("test"));
+
+		assertThat(mp2.getError()).hasMessage("test");
+		assertThat(mp.isSuccess()).isFalse();
+		assertThat(mp.isError()).isTrue();
+	}
+
+	@Test
+	public void VoidProcessorCancel() {
+		VoidProcessor<Void> mp = new VoidProcessor<>();
+		StepVerifier.create(mp)
+					.thenCancel()
+					.verify();
+
+		assertThat(mp.downstreamCount()).isEqualTo(0);
+	}
+
+	@Test
+	public void VoidProcessorNullFulfill() {
+		VoidProcessor<Void> mp = new VoidProcessor<>();
+
+		mp.onNext(null);
+
+		assertThat(mp.isTerminated()).isTrue();
+		assertThat(mp.isSuccess()).isTrue();
+		assertThat(mp.peek()).isNull();
+	}
+
+	@Test
+	public void VoidProcessorDoubleError() {
+		VoidProcessor<Void> mp = new VoidProcessor<>();
+
+		mp.onError(new Exception("test"));
+		assertThat(mp.emitError(new Exception("test")).hasFailed()).isTrue();
+	}
+
+	@Test
+	public void VoidProcessorDoubleSignal() {
+		VoidProcessor<Void> mp = new VoidProcessor<>();
+
+		mp.onComplete();
+		assertThat(mp.emitError(new Exception("test")).hasFailed()).isTrue();
+	}
+
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/MonoTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/MonoTests.java
@@ -34,8 +34,8 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
-import reactor.core.publisher.MonoProcessor;
 import reactor.core.publisher.Signal;
+import reactor.core.publisher.Sinks;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
@@ -214,10 +214,10 @@ public class MonoTests {
 
 	@Test
 	public void testMono() throws Exception {
-		MonoProcessor<String> promise = MonoProcessor.create();
-		promise.onNext("test");
+		Sinks.One<String> promise = Sinks.one();
+		promise.emitValue("test");
 		final CountDownLatch successCountDownLatch = new CountDownLatch(1);
-		promise.subscribe(v -> successCountDownLatch.countDown());
+		promise.asMono().subscribe(v -> successCountDownLatch.countDown());
 		assertThat("Failed", successCountDownLatch.await(10, TimeUnit.SECONDS));
 	}
 

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -15,23 +15,6 @@
  */
 package reactor.test;
 
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
-import reactor.core.CoreSubscriber;
-import reactor.core.Fuseable;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.core.publisher.MonoProcessor;
-import reactor.core.publisher.Operators;
-import reactor.core.publisher.Sinks;
-import reactor.core.scheduler.Scheduler;
-import reactor.core.scheduler.Schedulers;
-import reactor.test.publisher.TestPublisher;
-import reactor.test.scheduler.VirtualTimeScheduler;
-import reactor.util.context.Context;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,6 +31,23 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.LockSupport;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Operators;
+import reactor.core.publisher.Sinks;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.publisher.TestPublisher;
+import reactor.test.scheduler.VirtualTimeScheduler;
+import reactor.util.context.Context;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.*;
@@ -2317,10 +2317,10 @@ public class StepVerifierTests {
 
 	@Test
 	public void verifyDrainOnRequestInCaseOfFusion() {
-		MonoProcessor<Integer> processor = MonoProcessor.create();
-		StepVerifier.create(processor, 0)
+		Sinks.One<Integer> processor = Sinks.one();
+		StepVerifier.create(processor.asMono(), 0)
 				.expectFusion(Fuseable.ANY)
-				.then(() -> processor.onNext(1))
+				.then(() -> processor.emitValue(1))
 				.thenRequest(1)
 				.expectNext(1)
 				.verifyComplete();


### PR DESCRIPTION
This PR introduces NextProcessor and VoidProcessor. A possible LatestProcessor could be added too.
It also introduces Flux.shareNext and Mono.share in addition to publishNext for consistency. A follow up would be to add a ConnectableMono.

Now if we add a latest processor, how to represent it in the new `Sinks` ? right now the sinks is expressed around cardinality, should `Sinks.singleOrEmpty()` becomes `Sinks.singleOrEmpty().first()` and `last()` to differentiate the first and last signals ? Should this be better under `Sinks.many().latest()` ?