### PR TITLE
1928 update name behavior

### DIFF
--- a/docs/asciidoc/metrics.adoc
+++ b/docs/asciidoc/metrics.adoc
@@ -63,7 +63,7 @@ To enable the metrics for this source `Flux` (returned from `listenToEvents()`),
 [source,java]
 ----
 listenToEvents()
-    .name("events") <1> (optionnal)
+    .name("events") <1> (optional)
     .metrics() <2>
     .doOnNext(event -> log.info("Received {}", event))
     .delayUntil(this::processEvent)
@@ -99,15 +99,9 @@ Want to be alerted when the listener throws an error? `reactor.flow.duration` wi
 
 Please note that when giving a name to a sequence, this sequence could not be aggregated with others anymore. As a compromise if you want to identify your sequence but still make it possible to aggregate with other views, you can use a <<Custom tags>> for the name by calling `(tag("flow", "events"))` for example.
 
-=== Common tags
+=== Common tag
 
-Every metric will have the following tag in common:
-[width="100%",options="header"]
-|=======
-| tag name | description | example
-
-| type | Publisher's type | "Mono"
-|=======
+Every metric will have a `type` tag in common, which value will be either `Flux` or `Mono` depending on the publisher's nature.
 
 === Custom tags
 
@@ -116,16 +110,18 @@ Users are allowed to add custom tags to their reactive chains:
 [source,java]
 ----
 listenToEvents()
-    .name("events")
-    .tag("source", "kafka") <1>
-    .metrics() <2>
+    .name("events") <1>
+    .tag("source", "kafka") <2>
+    .metrics() <3>
     .doOnNext(event -> log.info("Received {}", event))
     .delayUntil(this::processEvent)
     .retry()
     .subscribe();
 ----
-<1> Set a custom tag "source" to value "kafka".
-<2> All reported metrics will have `source=kafka` tag assigned in addition to the common tags described above.
+<1> Every metric at this stage will be identified as "events".
+<2> Set a custom tag "source" to value "kafka".
+<3> All reported metrics will have `source=kafka` tag assigned in addition to the common tag described above.
 ====
 
-Be careful when using `Flux#name` and `Flux#tag` operators together: some monitoring systems like Prometheus require to have the exact same set of tags for each metric with the same name.
+Please note that depending on the monitoring system you're using, using a name can be considered mandatory when using tags, since it would otherwise result in a different set of tags between two default-named sequences.
+Some systems like Prometheus might also require to have the exact same set of tags for each metric with the same name.

--- a/docs/asciidoc/metrics.adoc
+++ b/docs/asciidoc/metrics.adoc
@@ -97,13 +97,11 @@ Interested in "events per second" metric? Measure the rate of `reactor.onNext.de
 
 Want to be alerted when the listener throws an error? `reactor.flow.duration` with `status=error` tag is your friend.
 
-Please note that when giving a name to a sequence, this sequence could not be aggregated with others anymore. As a compromise if you want to identify your sequence but still make it possible to aggregate with other views, you can use a <<Custom tags>> for the name by calling `(tag("flow", "events"))` for example.
+Please note that when giving a name to a sequence, this sequence could not be aggregated with others anymore. As a compromise if you want to identify your sequence but still make it possible to aggregate with other views, you can use a <<Tags>> for the name by calling `(tag("flow", "events"))` for example.
 
-=== Common tag
+=== Tags
 
 Every metric will have a `type` tag in common, which value will be either `Flux` or `Mono` depending on the publisher's nature.
-
-=== Custom tags
 
 Users are allowed to add custom tags to their reactive chains:
 ====

--- a/docs/asciidoc/metrics.adoc
+++ b/docs/asciidoc/metrics.adoc
@@ -57,12 +57,13 @@ listenToEvents()
 ----
 ====
 
-To enable the metrics for this source `Flux` (returned from `listenToEvents()`), we need to give it a name and turn on the metrics collecting:
+To enable the metrics for this source `Flux` (returned from `listenToEvents()`), we need to turn on the metrics collecting:
+
 ====
 [source,java]
 ----
 listenToEvents()
-    .name("events") <1>
+    .name("events") <1> (optionnal)
     .metrics() <2>
     .doOnNext(event -> log.info("Received {}", event))
     .delayUntil(this::processEvent)
@@ -70,7 +71,7 @@ listenToEvents()
     .subscribe();
 ----
 <1> Every metric at this stage will be identified as "events".
-<2> `Flux#metrics` operator enables the reporting of metrics and uses the last known name up in the pipeline.
+<2> `Flux#metrics` operator enables the reporting of metrics, using the name provided in when calling `Flux#name` operator. In case `Flux#name` operator has not been used, the default name will be `reactor`.
 ====
 
 Just adding these two operators will expose a whole bunch of useful metrics!
@@ -79,15 +80,15 @@ Just adding these two operators will expose a whole bunch of useful metrics!
 |=======
 | metric name | type | description
 
-| reactor.subscribed | Counter | Counts how many Reactor sequences have been subscribed to
+| [name].subscribed | Counter | Counts how many Reactor sequences have been subscribed to
 
-| reactor.malformed.source | Counter | Counts the number of events received from a malformed source (ie an onNext after an onComplete)
+| [name].malformed.source | Counter | Counts the number of events received from a malformed source (ie an onNext after an onComplete)
 
-| reactor.requested | DistributionSummary | Counts the amount requested to a named Flux by all subscribers, until at least one requests an unbounded amount
+| [name].requested | DistributionSummary | Counts the amount requested to a named Flux by all subscribers, until at least one requests an unbounded amount
 
-| reactor.onNext.delay | Timer | Measures delays between onNext signals (or between onSubscribe and first onNext)
+| [name].onNext.delay | Timer | Measures delays between onNext signals (or between onSubscribe and first onNext)
 
-| reactor.flow.duration | Timer | Times the duration elapsed between a subscription and the termination or cancellation of the sequence. A status tag is added to specify what event caused the timer to end (`onComplete`, `onError`, `cancel`).
+| [name].flow.duration | Timer | Times the duration elapsed between a subscription and the termination or cancellation of the sequence. A status tag is added to specify what event caused the timer to end (`onComplete`, `onError`, `cancel`).
 |=======
 
 Want to know how many times your event processing has restarted due to some error? Read `reactor.subscribed`, because `retry()` operator will re-subscribe to the source publisher on error.
@@ -96,16 +97,16 @@ Interested in "events per second" metric? Measure the rate of `reactor.onNext.de
 
 Want to be alerted when the listener throws an error? `reactor.flow.duration` with `status=error` tag is your friend.
 
+Please note that when giving a name to a sequence, this sequence could not be aggregated with others anymore. As a compromise if you want to identify your sequence but still make it possible to aggregate with other views, you can use a <<Custom tags>> for the name by calling `(tag("flow", "events"))` for example.
+
 === Common tags
 
-Every metric will have the following tags in common:
+Every metric will have the following tag in common:
 [width="100%",options="header"]
 |=======
 | tag name | description | example
 
 | type | Publisher's type | "Mono"
-
-| flow | current flow's name, set by `.name()` operator | "events"
 |=======
 
 === Custom tags
@@ -115,8 +116,8 @@ Users are allowed to add custom tags to their reactive chains:
 [source,java]
 ----
 listenToEvents()
-    .tag("source", "kafka") <1>
     .name("events")
+    .tag("source", "kafka") <1>
     .metrics() <2>
     .doOnNext(event -> log.info("Received {}", event))
     .delayUntil(this::processEvent)
@@ -125,5 +126,6 @@ listenToEvents()
 ----
 <1> Set a custom tag "source" to value "kafka".
 <2> All reported metrics will have `source=kafka` tag assigned in addition to the common tags described above.
-
 ====
+
+Be careful when using `Flux#name` and `Flux#tag` operators together: some monitoring systems like Prometheus require to have the exact same set of tags for each metric with the same name.

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -6001,12 +6001,16 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * {@link #name(String) name} (and optionally {@link #tag(String, String) tag}) the
 	 * sequence.
 	 * <p>
+	 * In case no name has been provided, the default name "reactor" will be applied.
+	 * <p>
 	 * The {@link MeterRegistry} used by reactor can be configured via
 	 * {@link Metrics.MicrometerConfiguration#useRegistry(MeterRegistry)} prior to using this operator, the default being
 	 * {@link io.micrometer.core.instrument.Metrics#globalRegistry}.
-	 * </p>
 	 *
 	 * @return an instrumented {@link Flux}
+	 *
+	 * @see {@link #name(String)}
+	 * @see {@link #tag(String, String)}
 	 */
 	public final Flux<T> metrics() {
 		if (!Metrics.isInstrumentationAvailable()) {
@@ -6022,9 +6026,16 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	/**
 	 * Give a name to this sequence, which can be retrieved using {@link Scannable#name()}
 	 * as long as this is the first reachable {@link Scannable#parents()}.
+	 * <p>
+	 * If {@link #metrics()} operator is called later in the chain, this name will be used for
+	 * {@link io.micrometer.core.instrument.Meter}.
 	 *
 	 * @param name a name for the sequence
+	 *
 	 * @return the same sequence, but bearing a name
+	 *
+	 * @see {@link #metrics()}
+	 * @see {@link #tag(String, String)}
 	 */
 	public final Flux<T> name(String name) {
 		return FluxName.createOrAppend(this, name);
@@ -8289,10 +8300,17 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * all tags throughout the publisher chain by using {@link Scannable#tags()} (as
 	 * traversed
 	 * by {@link Scannable#parents()}).
+	 * <p>
+	 * Note that some monitoring systems like Prometheus require to have the exact same set of
+	 * tags for each {@link io.micrometer.core.instrument.Meter} bearing the same name.
 	 *
 	 * @param key a tag key
 	 * @param value a tag value
+	 *
 	 * @return the same sequence, but bearing tags
+	 *
+	 * @see {@link #name(String)}
+	 * @see {@link #metrics()}
 	 */
 	public final Flux<T> tag(String key, String value) {
 		return FluxName.createOrAppend(this, key, value);

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -6001,7 +6001,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * {@link #name(String) name} (and optionally {@link #tag(String, String) tag}) the
 	 * sequence.
 	 * <p>
-	 * In case no name has been provided, the default name "reactor" will be applied.
+	 * The name serves as a prefix in the reported metrics names. In case no name has been provided, the default name "reactor" will be applied.
 	 * <p>
 	 * The {@link MeterRegistry} used by reactor can be configured via
 	 * {@link Metrics.MicrometerConfiguration#useRegistry(MeterRegistry)} prior to using this operator, the default being
@@ -6027,8 +6027,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * Give a name to this sequence, which can be retrieved using {@link Scannable#name()}
 	 * as long as this is the first reachable {@link Scannable#parents()}.
 	 * <p>
-	 * If {@link #metrics()} operator is called later in the chain, this name will be used for
-	 * {@link io.micrometer.core.instrument.Meter}.
+	 * If {@link #metrics()} operator is called later in the chain, this name will be used as a prefix for meters' name.
 	 *
 	 * @param name a name for the sequence
 	 *
@@ -8302,7 +8301,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * by {@link Scannable#parents()}).
 	 * <p>
 	 * Note that some monitoring systems like Prometheus require to have the exact same set of
-	 * tags for each {@link io.micrometer.core.instrument.Meter} bearing the same name.
+	 * tags for each meter bearing the same name.
 	 *
 	 * @param key a tag key
 	 * @param value a tag value

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetricsFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetricsFuseable.java
@@ -49,7 +49,7 @@ final class FluxMetricsFuseable<T> extends InternalFluxOperator<T, T> implements
 		super(flux);
 
 		this.name = resolveName(flux);
-		this.tags = resolveTags(flux, FluxMetrics.DEFAULT_TAGS_FLUX, this.name);
+		this.tags = resolveTags(flux, FluxMetrics.DEFAULT_TAGS_FLUX);
 		this.registryCandidate = Metrics.MicrometerConfiguration.getRegistry();
 	}
 
@@ -107,7 +107,7 @@ final class FluxMetricsFuseable<T> extends InternalFluxOperator<T, T> implements
 			}
 
 			if (done) {
-				recordMalformed(commonTags, registry);
+				recordMalformed(sequenceName, commonTags, registry);
 				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
@@ -130,7 +130,7 @@ final class FluxMetricsFuseable<T> extends InternalFluxOperator<T, T> implements
 				T v = qs.poll();
 
 				if (v == null && mode == SYNC) {
-					recordOnComplete(commonTags, registry, subscribeToTerminateSample);
+					recordOnComplete(sequenceName, commonTags, registry, subscribeToTerminateSample);
 				}
 				if (v != null) {
 					//this is an onNext event
@@ -142,7 +142,7 @@ final class FluxMetricsFuseable<T> extends InternalFluxOperator<T, T> implements
 				return v;
 			}
 			catch (Throwable e) {
-				recordOnError(commonTags, registry, subscribeToTerminateSample, e);
+				recordOnError(sequenceName, commonTags, registry, subscribeToTerminateSample, e);
 				throw e;
 			}
 		}
@@ -150,7 +150,7 @@ final class FluxMetricsFuseable<T> extends InternalFluxOperator<T, T> implements
 		@Override
 		public void onSubscribe(Subscription s) {
 			if (Operators.validate(this.s, s)) {
-				recordOnSubscribe(commonTags, registry);
+				recordOnSubscribe(sequenceName, commonTags, registry);
 				this.subscribeToTerminateSample = Timer.start(clock);
 				this.lastNextEventNanos = clock.monotonicTime();
 				this.qs = Operators.as(s);

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -3020,12 +3020,17 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * {@link #name(String) name} (and optionally {@link #tag(String, String) tag}) the
 	 * sequence.
 	 * <p>
+	 * The name serves as a prefix in the reported metrics names. In case no name has been provided, the default name "reactor" will be applied.
+	 * <p>
 	 * The {@link MeterRegistry} used by reactor can be configured via
 	 * {@link Metrics.MicrometerConfiguration#useRegistry(MeterRegistry)} prior to using this operator, the default being
 	 * {@link io.micrometer.core.instrument.Metrics#globalRegistry}.
 	 * </p>
 	 *
-	 * @return an instrumented {@link Mono}
+	 * @return an instrumented {@link Flux}
+	 *
+	 * @see {@link #name(String)}
+	 * @see {@link #tag(String, String)}
 	 */
 	public final Mono<T> metrics() {
 		if (!Metrics.isInstrumentationAvailable()) {
@@ -3041,9 +3046,15 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	/**
 	 * Give a name to this sequence, which can be retrieved using {@link Scannable#name()}
 	 * as long as this is the first reachable {@link Scannable#parents()}.
+	 * <p>
+	 * If {@link #metrics()} operator is called later in the chain, this name will be used as a prefix for meters' name.
 	 *
 	 * @param name a name for the sequence
+	 *
 	 * @return the same sequence, but bearing a name
+	 *
+	 * @see {@link #metrics()}
+	 * @see {@link #tag(String, String)}
 	 */
 	public final Mono<T> name(String name) {
 		return MonoName.createOrAppend(this, name);
@@ -3991,10 +4002,17 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * all tags throughout the publisher chain by using {@link Scannable#tags()} (as
 	 * traversed
 	 * by {@link Scannable#parents()}).
+	 * <p>
+	 * Note that some monitoring systems like Prometheus require to have the exact same set of
+	 * tags for each meter bearing the same name.
 	 *
 	 * @param key a tag key
 	 * @param value a tag value
+	 *
 	 * @return the same sequence, but bearing tags
+	 *
+	 * @see {@link #name(String)}
+	 * @see {@link #metrics()}
 	 */
 	public final Mono<T> tag(String key, String value) {
 		return MonoName.createOrAppend(this, key, value);


### PR DESCRIPTION
-  remove the flow tag altogether
-  using the name operator will replace the reactor prefix in meter names with whatever name was given to the sequence
-  using tags but not name will be documented as potentially dangerous, as it creates a sparse set of tags for sequences in the application that don't have a unique name
-  aggregated view is still somewhat possible in this mode by refraining from giving a name to the sequence, but consistently using a tag("flow", "theName") across all usages of .metrics() (which might be challenging if a framework or library also uses metrics() without a name())