### PR TITLE
fix #2305 update on error metric behavior

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
@@ -337,9 +337,7 @@ final class FluxMetrics<T> extends InternalFluxOperator<T, T> {
 	static void recordOnError(String name, Tags commonTags, MeterRegistry registry, Timer.Sample flowDuration, Throwable e) {
 		Timer timer = Timer.builder(name + METER_FLOW_DURATION)
 		                   .tags(commonTags.and(TAG_ON_ERROR))
-		                   .tag(TAG_KEY_EXCEPTION,
-				                   e.getClass()
-				                    .getName())
+		                   .tag(TAG_KEY_EXCEPTION, e.toString())
 		                   .description(
 				                   "Times the duration elapsed between a subscription and the onError termination of the sequence, with the exception name as a tag.")
 		                   .register(registry);

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxMetricsTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxMetricsTest.java
@@ -136,13 +136,13 @@ public class FluxMetricsTest {
 		Timer unnamedMeter = registry
 				.find(REACTOR_DEFAULT_NAME + METER_FLOW_DURATION)
 				.tags(Tags.of(TAG_ON_ERROR))
-				.tag(TAG_KEY_EXCEPTION, ArithmeticException.class.getName())
+				.tag(TAG_KEY_EXCEPTION, ArithmeticException.class.getName() + ": boom")
 				.timer();
 
 		Timer namedMeter = registry
 				.find("foo" + METER_FLOW_DURATION)
 				.tags(Tags.of(TAG_ON_ERROR))
-				.tag(TAG_KEY_EXCEPTION, ArithmeticException.class.getName())
+				.tag(TAG_KEY_EXCEPTION, ArithmeticException.class.getName() + ": / by zero")
 				.timer();
 
 		assertThat(unnamedMeter).isNotNull();


### PR DESCRIPTION
When recording `onError` metric, use `toString` method instead of `getClass().getName()` only for the exception tag.