### PR TITLE
Handle `ASYNC` fusion in `EmitterProcessor#onNext` vs `emitNext`

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -227,11 +227,6 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Si
 			return Emission.FAIL_TERMINATED;
 		}
 
-		if (sourceMode == Fuseable.ASYNC) {
-			drain();
-			return Emission.OK;
-		}
-
 		Objects.requireNonNull(t, "onNext");
 
 		Queue<T> q = queue;
@@ -317,6 +312,11 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Si
 	@Override
 	@SuppressWarnings("unchecked")
 	public void onNext(T t) {
+		if (sourceMode == Fuseable.ASYNC) {
+			drain();
+			return;
+		}
+
 		emitNext(t);
 	}
 


### PR DESCRIPTION
This change follow up #2218 and removes the `ASYNC` check that allows
`null` value (while the arg is `NonNull`) from user-called `emitNext`.