### PR TITLE
fix #2317 Add examples to deprecation notes of processors

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
@@ -80,7 +80,7 @@ import reactor.util.annotation.Nullable;
  *
  * @param <T> the input and output value type
  * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks}:
- * <pre>Sinks.empty();</pre> for example.
+ * <pre>Sinks.many().multicast().onBackpressureError();</pre> for example.
  */
 @Deprecated
 public final class DirectProcessor<T> extends FluxProcessor<T, T> implements Sinks.Many<T> {

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
@@ -79,8 +79,8 @@ import reactor.util.annotation.Nullable;
  * </p>
  *
  * @param <T> the input and output value type
- * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks}:
- * <pre><code>Sinks.many().multicast().onBackpressureError();</code></pre>.
+ * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks} with
+ * {@link Sinks.MulticastSpec#onBackpressureError() Sinks.many().multicast().onBackpressureError()}.
  */
 @Deprecated
 public final class DirectProcessor<T> extends FluxProcessor<T, T> implements Sinks.Many<T> {

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
@@ -59,7 +59,7 @@ import reactor.util.annotation.Nullable;
  * </p>
  *
  * </br>
- * </br>
+ * </br>`
  *
  * <p>
  *      <b>Note: </b> If there are no Subscribers, upstream items are dropped and only
@@ -80,7 +80,7 @@ import reactor.util.annotation.Nullable;
  *
  * @param <T> the input and output value type
  * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks}:
- * <pre>Sinks.many().multicast().onBackpressureError();</pre> for example.
+ * <pre><code>Sinks.many().multicast().onBackpressureError();</code></pre>.
  */
 @Deprecated
 public final class DirectProcessor<T> extends FluxProcessor<T, T> implements Sinks.Many<T> {

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
@@ -59,7 +59,7 @@ import reactor.util.annotation.Nullable;
  * </p>
  *
  * </br>
- * </br>`
+ * </br>
  *
  * <p>
  *      <b>Note: </b> If there are no Subscribers, upstream items are dropped and only

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
@@ -79,7 +79,8 @@ import reactor.util.annotation.Nullable;
  * </p>
  *
  * @param <T> the input and output value type
- * @deprecated Prefer clear cut usage of {@link Sinks}, to be removed in 3.5
+ * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks}:
+ * <pre>Sinks.empty();</pre> for example.
  */
 @Deprecated
 public final class DirectProcessor<T> extends FluxProcessor<T, T> implements Sinks.Many<T> {

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -56,7 +56,10 @@ import static reactor.core.publisher.FluxPublish.PublishSubscriber.TERMINATED;
  * variations of <pre><code>Sinks.many().multicast().onBackpressureBuffer()</code></pre>.
  *
  * This processor is blocking on {@link EmitterProcessor#emitNext(T)}. This behaviour can be implemented
- * with the {@link Sinks} API by calling {@link Sinks#many()#tryEmitNext(T)} and one of the xWhile method.
+ * with the {@link Sinks} API by calling {@link Sinks#many()#tryEmitNext(T)} and retrying, e.g.:
+ *  <pre><code>
+ *      while (sink.tryEmitNext(v).hasFailed()) LockSupport.parkNanos(10);
+ *  </code></pre>
  */
 @Deprecated
 public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Sinks.Many<T> {

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -53,13 +53,13 @@ import static reactor.core.publisher.FluxPublish.PublishSubscriber.TERMINATED;
  *
  * @author Stephane Maldini
  * @deprecated To be removed in 3.5. Prefer clear cut usage of {@link Sinks} through
- * variations of <pre><code>Sinks.many().multicast().onBackpressureBuffer()</code></pre>.
- *
+ * variations of {@link Sinks.MulticastSpec#onBackpressureBuffer() Sinks.many().multicast().onBackpressureBuffer()}.
  * This processor is blocking on {@link EmitterProcessor#emitNext(T)}. This behaviour can be implemented
  * with the {@link Sinks} API by calling {@link Sinks#many()#tryEmitNext(T)} and retrying, e.g.:
- *  <pre><code>
- *      while (sink.tryEmitNext(v).hasFailed()) LockSupport.parkNanos(10);
- *  </code></pre>
+ * <pre>{@code while (sink.tryEmitNext(v).hasFailed()) {
+ *     LockSupport.parkNanos(10);
+ * }
+ * }</pre>
  */
 @Deprecated
 public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Sinks.Many<T> {

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.reactivestreams.Subscriber;
@@ -51,8 +52,11 @@ import static reactor.core.publisher.FluxPublish.PublishSubscriber.TERMINATED;
  * @param <T> the input and output value type
  *
  * @author Stephane Maldini
- * @deprecated To be removed in 3.5. Prefer clear cut usage of {@link Sinks}:
- * <pre>Sinks.many().multicast().onBackpressureBuffer();</pre> for example.
+ * @deprecated To be removed in 3.5. Prefer clear cut usage of {@link Sinks} through
+ * variations of <pre><code>Sinks.many().multicast().onBackpressureBuffer()</code></pre>.
+ *
+ * This processor is blocking on {@link EmitterProcessor#emitNext(T)}. This behaviour can be implemented
+ * with the {@link Sinks} API by calling {@link Sinks#many()#tryEmitNext(T)} and one of the xWhile method.
  */
 @Deprecated
 public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Sinks.Many<T> {

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -51,7 +51,8 @@ import static reactor.core.publisher.FluxPublish.PublishSubscriber.TERMINATED;
  * @param <T> the input and output value type
  *
  * @author Stephane Maldini
- * @deprecated Prefer clear cut usage of {@link Sinks}, to be removed in 3.5
+ * @deprecated To be removed in 3.5. Prefer clear cut usage of {@link Sinks}:
+ * <pre>Sinks.many().multicast().onBackpressureBuffer();</pre> for example.
  */
 @Deprecated
 public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements Sinks.Many<T> {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -226,12 +226,8 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 	 * </ul>
 	 *
 	 * @return a serializing {@link FluxSink}
-	 * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks}:
-	 * <pre>
-	 *     final Sinks.Many<String> sink = Sinks.many().replay().latest();
-	 *     sink.emitNext("value");
-	 * </pre>
-	 * for example.
+	 * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks}
+	 * though the {@link Sinks#many()} spec.
 	 */
 	@Deprecated
 	public final FluxSink<IN> sink() {
@@ -257,12 +253,8 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 	 * for the
 	 * available strategies
 	 * @return a serializing {@link FluxSink}
-	 * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks}:
-	 * <pre>
-	 *     final Sinks.Many<String> sink = Sinks.many().replay().latest();
-	 *     sink.emitNext("value");
-	 * </pre>
-	 * for example.
+	 * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks}
+	 * through the {@link Sinks#many()} spec.
 	 */
 	@Deprecated
 	public final FluxSink<IN> sink(FluxSink.OverflowStrategy strategy) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -226,7 +226,12 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 	 * </ul>
 	 *
 	 * @return a serializing {@link FluxSink}
-	 * @deprecated Prefer clear cut usage of {@link Sinks}, to be removed in 3.5
+	 * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks}:
+	 * <pre>
+	 *     final Sinks.Many<String> sink = Sinks.many().replay().latest();
+	 *     sink.emitNext("value");
+	 * </pre>
+	 * for example.
 	 */
 	@Deprecated
 	public final FluxSink<IN> sink() {
@@ -252,7 +257,12 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 	 * for the
 	 * available strategies
 	 * @return a serializing {@link FluxSink}
-	 * @deprecated Prefer clear cut usage of {@link Sinks}, to be removed in 3.5
+	 * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks}:
+	 * <pre>
+	 *     final Sinks.Many<String> sink = Sinks.many().replay().latest();
+	 *     sink.emitNext("value");
+	 * </pre>
+	 * for example.
 	 */
 	@Deprecated
 	public final FluxSink<IN> sink(FluxSink.OverflowStrategy strategy) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -227,7 +227,7 @@ public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
 	 *
 	 * @return a serializing {@link FluxSink}
 	 * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks}
-	 * though the {@link Sinks#many()} spec.
+	 * through the {@link Sinks#many()} spec.
 	 */
 	@Deprecated
 	public final FluxSink<IN> sink() {

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -48,7 +48,8 @@ import static reactor.core.publisher.FluxReplay.ReplaySubscriber.TERMINATED;
  * <p>
  *
  * @param <T> the value type
- * @deprecated Prefer clear cut usage of {@link Sinks}, to be removed in 3.5
+ * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks}:
+ * <pre>Sinks.many().replay().all()</pre> or <pre>Sinks.many().replay().latest()</pre> for example.
  */
 @Deprecated
 public final class ReplayProcessor<T> extends FluxProcessor<T, T>

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -48,8 +48,8 @@ import static reactor.core.publisher.FluxReplay.ReplaySubscriber.TERMINATED;
  * <p>
  *
  * @param <T> the value type
- * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks}:
- * <pre><code>Sinks.many().replay()</code></pre>.
+ * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks} through
+ * variations under {@link reactor.core.publisher.Sinks.MulticastReplaySpec Sinks.many().replay()}.
  */
 @Deprecated
 public final class ReplayProcessor<T> extends FluxProcessor<T, T>

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -49,7 +49,7 @@ import static reactor.core.publisher.FluxReplay.ReplaySubscriber.TERMINATED;
  *
  * @param <T> the value type
  * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks}:
- * <pre>Sinks.many().replay().all()</pre> or <pre>Sinks.many().replay().latest()</pre> for example.
+ * <pre><code>Sinks.many().replay()</code></pre>.
  */
 @Deprecated
 public final class ReplayProcessor<T> extends FluxProcessor<T, T>

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -84,8 +84,8 @@ import reactor.util.context.Context;
  * </p>
  *
  * @param <T> the input and output type
- * @deprecated to be removed in 3.5, prefer clear cut usage of {@link Sinks}:
- * <pre><code>Sinks.many().unicast()</code></pre>.
+ * @deprecated to be removed in 3.5, prefer clear cut usage of {@link Sinks} through
+ * variations under {@link reactor.core.publisher.Sinks.UnicastSpec Sinks.many().unicast()}.
  */
 @Deprecated
 public final class UnicastProcessor<T> extends FluxProcessor<T, T>

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -85,7 +85,7 @@ import reactor.util.context.Context;
  *
  * @param <T> the input and output type
  * @deprecated to be removed in 3.5, prefer clear cut usage of {@link Sinks}:
- * <pre>Sinks.many().unicast().onBackpressureBuffer()</pre> for example.
+ * <pre><code>Sinks.many().unicast()</code></pre>.
  */
 @Deprecated
 public final class UnicastProcessor<T> extends FluxProcessor<T, T>

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -84,7 +84,8 @@ import reactor.util.context.Context;
  * </p>
  *
  * @param <T> the input and output type
- * @deprecated Prefer clear cut usage of {@link Sinks}, to be removed in 3.5
+ * @deprecated to be removed in 3.5, prefer clear cut usage of {@link Sinks}:
+ * <pre>Sinks.many().unicast().onBackpressureBuffer()</pre> for example.
  */
 @Deprecated
 public final class UnicastProcessor<T> extends FluxProcessor<T, T>


### PR DESCRIPTION
Add an example in the Javadoc of each deprecated processor to give a hint to users on how to write the equivalent Sink