### PR TITLE
fix #2343 migrate reactor-tests' tests to JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ ext {
 	logbackVersion = '1.1.2'
 
 	// Testing
+	jUnitPlatformVersion = '5.6.0'
 	jUnitVersion = '4.13'
 	assertJVersion = '3.11.1'
 	mockitoVersion = '2.23.0'

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -43,8 +43,9 @@ dependencies {
 	compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}"
 	testImplementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}"
 
-	testImplementation "junit:junit:$jUnitVersion"
-
+	testImplementation platform("org.junit:junit-bom:${jUnitPlatformVersion}")
+	testImplementation "org.junit.jupiter:junit-jupiter-api"
+	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 	testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
 
 	testImplementation "org.assertj:assertj-core:$assertJVersion"
@@ -136,6 +137,10 @@ jar {
 			'Automatic-Module-Name': 'reactor.test'
 	}
 	bnd(bndOptions)
+}
+
+tasks.withType(Test).all {
+	useJUnitPlatform()
 }
 
 check.dependsOn japicmp

--- a/reactor-test/src/test/java/reactor/test/DefaultContextExpectationsTest.java
+++ b/reactor-test/src/test/java/reactor/test/DefaultContextExpectationsTest.java
@@ -24,7 +24,7 @@ import java.util.function.Function;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ThrowableAssertAlternative;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.publisher.Flux;

--- a/reactor-test/src/test/java/reactor/test/DefaultStepVerifierBuilderTests.java
+++ b/reactor-test/src/test/java/reactor/test/DefaultStepVerifierBuilderTests.java
@@ -21,7 +21,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import reactor.core.publisher.Flux;
 import reactor.test.DefaultStepVerifierBuilder.DefaultVerifySubscriber;
 import reactor.test.DefaultStepVerifierBuilder.DescriptionEvent;
@@ -58,7 +59,8 @@ public class DefaultStepVerifierBuilderTests {
 				.withMessageStartingWith("expectation failed (an unexpected Subscription has been received");
 	}
 
-	@Test(timeout = 4000)
+	@Test
+	@Timeout(4)
 	public void manuallyManagedVirtualTime() {
 		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 		try {

--- a/reactor-test/src/test/java/reactor/test/ErrorFormatterTest.java
+++ b/reactor-test/src/test/java/reactor/test/ErrorFormatterTest.java
@@ -18,7 +18,7 @@ package reactor.test;
 
 import java.time.Duration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/reactor-test/src/test/java/reactor/test/StepVerifierAssertionsTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierAssertionsTests.java
@@ -19,7 +19,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;

--- a/reactor-test/src/test/java/reactor/test/StepVerifierDefaultTimeoutTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierDefaultTimeoutTests.java
@@ -18,21 +18,21 @@ package reactor.test;
 
 import java.time.Duration;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class StepVerifierDefaultTimeoutTests {
 
-	@BeforeClass
+	@BeforeAll
 	public static void init() {
 		StepVerifier.setDefaultTimeout(Duration.ofMillis(100));
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void clean() {
 		StepVerifier.resetDefaultTimeout();
 	}

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -31,9 +31,9 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.LockSupport;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import reactor.core.Fuseable;
 import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.MonoProcessor;
@@ -48,6 +48,7 @@ import reactor.util.context.Context;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static reactor.test.publisher.TestPublisher.Violation.REQUEST_OVERFLOW;
 
 /**
@@ -1072,7 +1073,8 @@ public class StepVerifierTests {
 	            .withMessage("scenarioSupplier");
 	}
 
-	@Test(timeout = 3000)
+	@Test
+	@Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
 	public void verifyVirtualTimeOnNextIntervalManual() {
 		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 
@@ -1114,7 +1116,8 @@ public class StepVerifierTests {
 		            .verify();
 	}
 
-	@Test(timeout = 1000)
+	@Test
+	@Timeout(value = 1000, unit = TimeUnit.MILLISECONDS)
 	public void verifyCreatedForAllSchedulerUsesVirtualTime() {
 		//a timeout will occur if virtual time isn't used
 		StepVerifier.withVirtualTime(() -> Flux.interval(Duration.ofSeconds(3))
@@ -1140,7 +1143,8 @@ public class StepVerifierTests {
 		assertThat(verifyDuration.toMillis()).isGreaterThanOrEqualTo(1000L);
 	}
 
-	@Test(timeout = 500)
+	@Test
+	@Timeout(value = 500, unit = TimeUnit.MILLISECONDS)
 	public void noSignalVirtualTime() {
 		StepVerifier.withVirtualTime(Mono::never, 1)
 		            .expectSubscription()
@@ -1727,7 +1731,8 @@ public class StepVerifierTests {
 		assertThat(totalRequest.longValue()).isEqualTo(12L);
 	}
 
-	@Test(timeout = 1000L)
+	@Test
+	@Timeout(value = 1000L, unit = TimeUnit.MILLISECONDS)
 	public void expectCancelDoNotHang() {
 		StepVerifier.create(Flux.just("foo", "bar"), 1)
 		            .expectNext("foo")
@@ -1735,7 +1740,8 @@ public class StepVerifierTests {
 		            .verify();
 	}
 
-	@Test(timeout = 1000L)
+	@Test
+	@Timeout(value = 1000L, unit = TimeUnit.MILLISECONDS)
 	public void consumeNextWithLowRequestShortcircuits() {
 		StepVerifier.Step<String> validSoFar = StepVerifier.create(Flux.just("foo", "bar"), 1)
 				                         .expectNext("foo");
@@ -1746,7 +1752,8 @@ public class StepVerifierTests {
 	            .withMessageEndingWith("request remaining since last step: 0, expected: 1");
 	}
 
-	@Test(timeout = 1000L)
+	@Test
+	@Timeout(value = 1000L, unit = TimeUnit.MILLISECONDS)
 	public void assertNextLowRequestShortcircuits() {
 		StepVerifier.Step<String> validSoFar = StepVerifier.create(Flux.just("foo", "bar"), 1)
 		                                                   .expectNext("foo");
@@ -1757,7 +1764,8 @@ public class StepVerifierTests {
 				.withMessageEndingWith("request remaining since last step: 0, expected: 1");
 	}
 
-	@Test(timeout = 1000L)
+	@Test
+	@Timeout(value = 1000L, unit = TimeUnit.MILLISECONDS)
 	public void expectNextLowRequestShortcircuits() {
 		StepVerifier.Step<String> validSoFar = StepVerifier.create(Flux.just("foo", "bar"), 1)
 		                                                   .expectNext("foo");
@@ -1768,7 +1776,8 @@ public class StepVerifierTests {
 				.withMessageEndingWith("request remaining since last step: 0, expected: 1");
 	}
 
-	@Test(timeout = 1000L)
+	@Test
+	@Timeout(value = 1000L, unit = TimeUnit.MILLISECONDS)
 	public void expectNextCountLowRequestShortcircuits() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
 				.isThrownBy(() -> StepVerifier.create(Flux.just("foo", "bar"), 1)
@@ -1778,7 +1787,8 @@ public class StepVerifierTests {
 				.withMessageEndingWith("request remaining since last step: 1, expected: 2");
 	}
 
-	@Test(timeout = 1000L)
+	@Test
+	@Timeout(value = 1000L, unit = TimeUnit.MILLISECONDS)
 	public void expectNextMatchesLowRequestShortcircuits() {
 		StepVerifier.Step<String> validSoFar = StepVerifier.create(Flux.just("foo", "bar"), 1)
 		                                                   .expectNext("foo");
@@ -1789,7 +1799,8 @@ public class StepVerifierTests {
 				.withMessageEndingWith("request remaining since last step: 0, expected: 1");
 	}
 
-	@Test(timeout = 1000L)
+	@Test
+	@Timeout(value = 1000L, unit = TimeUnit.MILLISECONDS)
 	public void expectNextSequenceLowRequestShortcircuits() {
 		StepVerifier.Step<String> validSoFar = StepVerifier.create(Flux.just("foo", "bar"), 1);
 		List<String> expected = Arrays.asList("foo", "bar");
@@ -1800,7 +1811,8 @@ public class StepVerifierTests {
 				.withMessageEndingWith("request remaining since last step: 1, expected: 2");
 	}
 
-	@Test(timeout = 1000L)
+	@Test
+	@Timeout(value = 1000L, unit = TimeUnit.MILLISECONDS)
 	public void thenConsumeWhileLowRequestShortcircuits() {
 		StepVerifier.Step<Integer> validSoFar = StepVerifier.create(Flux.just(1, 2), 1)
 		                                                    .expectNext(1);
@@ -1811,7 +1823,8 @@ public class StepVerifierTests {
 	            .withMessageEndingWith("request remaining since last step: 0, expected: at least 1 (best effort estimation)");
 	}
 
-	@Test(timeout = 1000L)
+	@Test
+	@Timeout(value = 1000L, unit = TimeUnit.MILLISECONDS)
 	public void lowRequestCheckCanBeDisabled() {
 		StepVerifier.create(Flux.just(1, 2),
 				StepVerifierOptions.create().initialRequest(1).checkUnderRequesting(false))
@@ -1870,7 +1883,7 @@ public class StepVerifierTests {
 		                                       .take(100000)
 		                                       .collectList())
 		            .thenAwait(Duration.ofHours(1000))
-		            .consumeNextWith(list -> Assert.assertTrue(list.size() == 100000))
+		            .consumeNextWith(list -> assertTrue(list.size() == 100000))
 		            .verifyComplete();
 	}
 
@@ -2008,7 +2021,7 @@ public class StepVerifierTests {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	//FIXME this case of doubly-nested schedules is still not fully fixed
 	public void gh783_withInnerFlatmap() {
 		int size = 61;

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTimeoutTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTimeoutTests.java
@@ -17,7 +17,7 @@ package reactor.test;
 
 import java.time.Duration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/reactor-test/src/test/java/reactor/test/publisher/ColdTestPublisherTests.java
+++ b/reactor-test/src/test/java/reactor/test/publisher/ColdTestPublisherTests.java
@@ -18,7 +18,7 @@ package reactor.test.publisher;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;

--- a/reactor-test/src/test/java/reactor/test/publisher/DefaultTestPublisherTests.java
+++ b/reactor-test/src/test/java/reactor/test/publisher/DefaultTestPublisherTests.java
@@ -17,7 +17,7 @@ package reactor.test.publisher;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;

--- a/reactor-test/src/test/java/reactor/test/publisher/PublisherProbeTest.java
+++ b/reactor-test/src/test/java/reactor/test/publisher/PublisherProbeTest.java
@@ -18,7 +18,7 @@ package reactor.test.publisher;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;

--- a/reactor-test/src/test/java/reactor/test/scheduler/VirtualTimeSchedulerTests.java
+++ b/reactor-test/src/test/java/reactor/test/scheduler/VirtualTimeSchedulerTests.java
@@ -23,9 +23,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -49,21 +48,21 @@ public class VirtualTimeSchedulerTests {
 
 	@Test
 	public void allEnabled() {
-		Assert.assertFalse(Schedulers.newParallel("") instanceof VirtualTimeScheduler);
-		Assert.assertFalse(Schedulers.newElastic("") instanceof VirtualTimeScheduler);
-		Assert.assertFalse(Schedulers.newSingle("") instanceof VirtualTimeScheduler);
+		assertThat(Schedulers.newParallel("")).isNotInstanceOf(VirtualTimeScheduler.class);
+		assertThat(Schedulers.newElastic("")).isNotInstanceOf(VirtualTimeScheduler.class);
+		assertThat(Schedulers.newSingle("")).isNotInstanceOf(VirtualTimeScheduler.class);
 
 		VirtualTimeScheduler.getOrSet();
 
-		Assert.assertTrue(Schedulers.newParallel("") instanceof VirtualTimeScheduler);
-		Assert.assertTrue(Schedulers.newElastic("") instanceof VirtualTimeScheduler);
-		Assert.assertTrue(Schedulers.newSingle("") instanceof VirtualTimeScheduler);
+		assertThat(Schedulers.newParallel("") instanceof VirtualTimeScheduler).isTrue();
+		assertThat(Schedulers.newElastic("") instanceof VirtualTimeScheduler).isTrue();
+		assertThat(Schedulers.newSingle("") instanceof VirtualTimeScheduler).isTrue();
 
 		VirtualTimeScheduler t = VirtualTimeScheduler.get();
 
-		Assert.assertSame(Schedulers.newParallel(""), t);
-		Assert.assertSame(Schedulers.newElastic(""), t);
-		Assert.assertSame(Schedulers.newSingle(""), t);
+		assertThat(Schedulers.newParallel("")).isSameAs(t);
+		assertThat(Schedulers.newElastic("")).isSameAs(t);
+		assertThat(Schedulers.newSingle("")).isSameAs(t);
 	}
 
 	@Test
@@ -72,14 +71,14 @@ public class VirtualTimeSchedulerTests {
 
 		VirtualTimeScheduler.getOrSet(vts);
 
-		Assert.assertSame(vts, uncache(Schedulers.single()));
-		Assert.assertFalse(vts.shutdown);
+		assertThat(vts).isSameAs(uncache(Schedulers.single()));
+		assertThat(vts.shutdown).isFalse();
 
 
 		VirtualTimeScheduler.getOrSet(vts);
 
-		Assert.assertSame(vts, uncache(Schedulers.single()));
-		Assert.assertFalse(vts.shutdown);
+		assertThat(vts).isSameAs(uncache(Schedulers.single()));
+		assertThat(vts.shutdown).isFalse();
 	}
 
 	@Test
@@ -90,10 +89,10 @@ public class VirtualTimeSchedulerTests {
 		VirtualTimeScheduler firstEnableResult = VirtualTimeScheduler.getOrSet(vts1);
 		VirtualTimeScheduler secondEnableResult = VirtualTimeScheduler.getOrSet(vts2);
 
-		Assert.assertSame(vts1, firstEnableResult);
-		Assert.assertSame(vts1, secondEnableResult);
-		Assert.assertSame(vts1, uncache(Schedulers.single()));
-		Assert.assertFalse(vts1.shutdown);
+		assertThat(vts1).isSameAs(firstEnableResult);
+		assertThat(vts1).isSameAs(secondEnableResult);
+		assertThat(vts1).isSameAs(uncache(Schedulers.single()));
+		assertThat(vts1.shutdown).isFalse();
 	}
 
 	@Test
@@ -323,7 +322,7 @@ public class VirtualTimeSchedulerTests {
 		return potentialCached;
 	}
 
-	@After
+	@AfterEach
 	public void cleanup() {
 		VirtualTimeScheduler.reset();
 	}

--- a/reactor-test/src/test/kotlin/reactor/test/StepVerifierExtensionsTests.kt
+++ b/reactor-test/src/test/kotlin/reactor/test/StepVerifierExtensionsTests.kt
@@ -16,7 +16,7 @@
 
 package reactor.test
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import reactor.core.publisher.toMono
 
 class StepVerifierExtensionsTests {


### PR DESCRIPTION
Getting 
```
Gradle Test Run :reactor-test:test Results: SUCCESS (358 tests, 357 successes, 0 failures, 1 skipped)
```

both before and after this refactoring.

Forward porting to 3.3.x and 3.4.x will require additional work for tests that only exist there.