### PR TITLE
fix #2328 Make ParallelFlux.subscribe(array) public to allow delegation

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -951,7 +951,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 * @param subscribers the subscribers array to run in parallel, the number of items
 	 * must be equal to the parallelism level of this ParallelFlux
 	 */
-	protected abstract void subscribe(CoreSubscriber<? super T>[] subscribers);
+	public abstract void subscribe(CoreSubscriber<? super T>[] subscribers);
 
 	/**
 	 * Subscribes to this {@link ParallelFlux} and triggers the execution chain for all

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelLift.java
@@ -74,7 +74,7 @@ final class ParallelLift<I, O> extends ParallelFlux<O> implements Scannable {
 	}
 
 	@Override
-	protected void subscribe(CoreSubscriber<? super O>[] s) {
+	public void subscribe(CoreSubscriber<? super O>[] s) {
 		@SuppressWarnings("unchecked") CoreSubscriber<? super I>[] subscribers =
 				new CoreSubscriber[parallelism()];
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelLiftFuseable.java
@@ -77,7 +77,7 @@ final class ParallelLiftFuseable<I, O> extends ParallelFlux<O>
 	}
 
 	@Override
-	protected void subscribe(CoreSubscriber<? super O>[] s) {
+	public void subscribe(CoreSubscriber<? super O>[] s) {
 		@SuppressWarnings("unchecked") CoreSubscriber<? super I>[] subscribers =
 				new CoreSubscriber[parallelism()];
 


### PR DESCRIPTION
This commit switches the `subscribe(CoreSubscriber[])` method from
protected to public, in order to allow overloading methods to delegate
to any existing `ParallelFlux`.
