### PR TITLE
fix #2362 Prevent ConcurrentModificationEx on bufferPredicate discard

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
@@ -110,7 +110,7 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 		final Predicate<? super T> predicate;
 
 		@Nullable
-		volatile C buffer;
+		C buffer;
 
 		boolean done;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
@@ -54,6 +54,8 @@ import static org.junit.Assert.assertThat;
 
 public class FluxBufferPredicateTest {
 
+	private static final int ROUNDS = 10_000; //increase this number locally if you want better confidence that no race condition occurs
+
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalUntil() {
@@ -692,7 +694,7 @@ public class FluxBufferPredicateTest {
 
 	@Test
 	public void requestRaceWithOnNextLoops() {
-		for (int i = 0; i < 100_000; i++) {
+		for (int i = 0; i < ROUNDS; i++) {
 			requestRaceWithOnNext();
 			onNextRaceWithRequest();
 			onNextRaceWithRequestOfTwo();
@@ -934,7 +936,6 @@ public class FluxBufferPredicateTest {
 
 	@Test
 	public void discardRaceWithOnNext_bufferAdds() {
-		final int ROUNDS = 100_000;
 		Predicate<AtomicInteger> predicate = v -> v.get() == 100;
 		FluxBufferPredicate.Mode mode = FluxBufferPredicate.Mode.UNTIL;
 
@@ -966,7 +967,6 @@ public class FluxBufferPredicateTest {
 
 	@Test
 	public void discardRaceWithOnNext_bufferUntilWithMatch() {
-		final int ROUNDS = 100_000;
 		Predicate<AtomicInteger> predicate = v -> v.get() == -2;
 		FluxBufferPredicate.Mode mode = FluxBufferPredicate.Mode.UNTIL;
 
@@ -999,7 +999,6 @@ public class FluxBufferPredicateTest {
 
 	@Test
 	public void discardRaceWithOnNext_bufferUntilCutBeforeWithMatch() {
-		final int ROUNDS = 100_000;
 		Predicate<AtomicInteger> predicate = v -> v.get() == -2;
 		FluxBufferPredicate.Mode mode = FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE;
 
@@ -1031,7 +1030,6 @@ public class FluxBufferPredicateTest {
 
 	@Test
 	public void discardRaceWithOnNext_bufferWhileWithNoMatch() {
-		final int ROUNDS = 100_000;
 		Predicate<AtomicInteger> predicate = v -> v.get() != -2;
 		FluxBufferPredicate.Mode mode = FluxBufferPredicate.Mode.WHILE;
 


### PR DESCRIPTION
This commit adds some internal synchronization of the buffer in
FluxBufferPredicate in order to ensure that cancellation racing with
onNext doesn't trigger a ConcurrentModificationException (due to the
buffer being iterated by onDiscard while onNext adds an element to it).