### PR TITLE
Have DirectProcessor detect all inners overflowed (#2368)

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -340,7 +340,11 @@ public final class Sinks {
 		 * <ul>
 		 *     <li>Multicast</li>
 		 *     <li>Without {@link Subscriber}: elements pushed via {@link Many#tryEmitNext(Object)} are ignored</li>
-		 *     <li>Backpressure : this sink is not able to honor downstream demand and will emit {@link Subscriber#onError(Throwable)} if there is a mismatch.</li>
+		 *     <li>Backpressure : this sink is not able to honor individual downstream demand and will terminate the
+		 *     {@link Subscriber} for which there is a mismatch with {@link Subscriber#onError(Throwable)}.
+		 *     {@link Many#tryEmitNext(Object)} only returns {@link Emission#FAIL_OVERFLOW} if all current subscribers
+		 *     were terminated like that. In any case, {@link Many#emitNext(Object)} doesn't terminate the sink in case
+		 *     of overflow.</li>
 		 *     <li>Replaying: No replay. Only forwards to a {@link Subscriber} the elements that have been
 		 *     pushed to the sink AFTER this subscriber was subscribed.</li>
 		 * </ul>

--- a/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
@@ -276,10 +276,10 @@ public abstract class AbstractFluxConcatMapTest extends FluxOperatorTest<String,
 	public void singleSubscriberOnlyBoundary() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = Sinks.many().multicast().onBackpressureError();
+		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().onBackpressureError();
 
-		Sinks.Many<Integer> source1 = Sinks.many().multicast().onBackpressureError();
-		Sinks.Many<Integer> source2 = Sinks.many().multicast().onBackpressureError();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().onBackpressureError();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().onBackpressureError();
 
 		source.asFlux().concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux(), implicitPrefetchValue())
 		      .subscribe(ts);


### PR DESCRIPTION
This commit let DirectProcessor detect wether ALL inners overflowed,
in which case it can notify tryEmitNext with FAIL_OVERFLOW.