### PR TITLE
[doc typo] Fix List ref name in hybrid push/pull code

### DIFF
--- a/docs/asciidoc/producing.adoc
+++ b/docs/asciidoc/producing.adoc
@@ -240,7 +240,7 @@ Flux<String> bridge = Flux.create(sink -> {
     });
     sink.onRequest(n -> {
         List<String> messages = myMessageProcessor.getHistory(n); // <1>
-        for(String s : message) {
+        for(String s : messages) {
            sink.next(s); // <2>
         }
     });


### PR DESCRIPTION
Change from `message` to `messages`