### PR TITLE
fix #2389 Potential integer overflow on BoundedElasticScheduler ctor

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
@@ -148,7 +148,7 @@ final class BoundedElasticScheduler implements Scheduler, Scannable {
 	 * @param ttlSeconds the time-to-live (TTL) of idle threads, in seconds
 	 */
 	BoundedElasticScheduler(int maxThreads, int maxTaskQueuedPerThread, ThreadFactory factory, int ttlSeconds) {
-		this(maxThreads, maxTaskQueuedPerThread, factory, ttlSeconds * 1000,
+		this(maxThreads, maxTaskQueuedPerThread, factory, ttlSeconds * 1000L,
 				Clock.tickSeconds(BoundedServices.ZONE_UTC));
 	}
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/BoundedElasticSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/BoundedElasticSchedulerTest.java
@@ -337,6 +337,12 @@ public class BoundedElasticSchedulerTest extends AbstractSchedulerTest {
 	}
 
 	@Test
+	public void maximumTtl() {
+		BoundedElasticScheduler s = new BoundedElasticScheduler(1, Integer.MAX_VALUE,null, Integer.MAX_VALUE);
+		assertThat(s.ttlMillis).isEqualTo(Integer.MAX_VALUE * 1000L);
+	}
+
+	@Test
 	public void negativeThreadCap() {
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> new BoundedElasticScheduler(-1, Integer.MAX_VALUE, null, 1))


### PR DESCRIPTION
This PR fix [#2389 ](https://github.com/reactor/reactor-core/issues/2389)