### PR TITLE
Add multicast sink with best effort/drop on backpressure

### DIFF
--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxConcatMapNoPrefetchStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxConcatMapNoPrefetchStressTest.java
@@ -28,7 +28,7 @@ import static org.openjdk.jcstress.annotations.Expect.*;
 
 public abstract class FluxConcatMapNoPrefetchStressTest {
 
-	final StressSubscriber stressSubscriber = new StressSubscriber();
+	final StressSubscriber<Object> stressSubscriber = new StressSubscriber<>();
 
 	final FluxConcatMapNoPrefetchSubscriber<Object, Object> concatMapImmediate = new FluxConcatMapNoPrefetchSubscriber<>(
 			stressSubscriber,

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManyBestEffortStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManyBestEffortStressTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2020-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.core.publisher;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.I_Result;
+import org.openjdk.jcstress.infra.results.LI_Result;
+import org.reactivestreams.Subscription;
+
+import static org.openjdk.jcstress.annotations.Expect.*;
+
+public class SinkManyBestEffortStressTest {
+
+	@JCStressTest
+	@Outcome(id = {"6"}, expect = ACCEPTABLE, desc = "Six parallel subscribes")
+	@State
+	public static class ParallelSubscribersStressTest {
+
+		final SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createBestEffort();
+
+		@Actor
+		public void one() {
+			sink.subscribe(new StressSubscriber<>());
+		}
+
+		@Actor
+		public void two() {
+			sink.subscribe(new StressSubscriber<>());
+		}
+
+		@Actor
+		public void three() {
+			sink.subscribe(new StressSubscriber<>());
+		}
+
+		@Actor
+		public void four() {
+			sink.subscribe(new StressSubscriber<>());
+		}
+
+		@Actor
+		public void five() {
+			sink.subscribe(new StressSubscriber<>());
+		}
+
+		@Actor
+		public void six() {
+			sink.subscribe(new StressSubscriber<>());
+		}
+
+		@Arbiter
+		public void arbiter(I_Result r) {
+			r.r1 = sink.currentSubscriberCount();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"1"}, expect = ACCEPTABLE, desc = "One subscriber counted")
+	@State
+	public static class ImmediatelyCancelledSubscriberAndNewSubscriberStressTest {
+
+		final SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createBestEffort();
+
+		@Actor
+		public void one() {
+			sink.subscribe(new StressSubscriber<>(0));
+		}
+
+		@Actor
+		public void two() {
+			sink.subscribe(new BaseSubscriber<Integer>() {
+				@Override
+				protected void hookOnSubscribe(Subscription subscription) {
+					subscription.cancel();
+				}
+			});
+		}
+
+		@Arbiter
+		public void arbiter(I_Result r) {
+			r.r1 = sink.currentSubscriberCount();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"0"}, expect = ACCEPTABLE, desc = "No subscriber counted")
+	@State
+	public static class CancelledVsSubscribeOneSubscriberStressTest {
+
+		final SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createBestEffort();
+		final StressSubscriber<Integer> sub = new StressSubscriber<>(0);
+
+		@Actor
+		public void cancellingSub() {
+			sub.cancel();
+		}
+
+		@Actor
+		public void subscribingSub() {
+			sink.subscribe(sub);
+		}
+
+		@Arbiter
+		public void arbiter(I_Result r) {
+			r.r1 = sink.currentSubscriberCount();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"1"}, expect = ACCEPTABLE, desc = "One subscriber counted")
+	@State
+	public static class CancelledVsSubscribeTwoSubscribersStressTest {
+
+		final SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createBestEffort();
+		final StressSubscriber<Integer> sub2 = new StressSubscriber<>(0);
+
+		@Actor
+		public void subscribingSub1() {
+			sink.subscribe(new StressSubscriber<>(0));
+		}
+
+		@Actor
+		public void subscribingSub2() {
+			sink.subscribe(sub2);
+		}
+
+		@Actor
+		public void cancellingSub2() {
+			sub2.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(I_Result r) {
+			r.r1 = sink.currentSubscriberCount();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"FAIL_ZERO_SUBSCRIBER, 0"}, expect = ACCEPTABLE, desc = "Zero Subscriber because cancelled")
+	@Outcome(id = {"FAIL_OVERFLOW, 0"}, expect = ACCEPTABLE, desc = "Overflow because not cancelled nor requested")
+	@Outcome(id = {"OK, 1"}, expect = ACCEPTABLE, desc = "OK because requested before cancelled")
+	@State
+	public static class InnerTryEmitNextCancelVersusRequestStressTest {
+
+		final SinkManyBestEffort<Integer>             sink       = SinkManyBestEffort.createBestEffort();
+		final StressSubscriber<Integer>               subscriber = new StressSubscriber<>(0);
+		final SinkManyBestEffort.DirectInner<Integer> inner;
+
+		{
+			sink.subscribe(subscriber);
+			inner = sink.subscribers[0];
+		}
+
+		@Actor
+		public void tryEmitNext(LI_Result r) {
+			r.r1 = sink.tryEmitNext(1);
+		}
+
+		@Actor
+		public void cancel() {
+			inner.set(true);
+		}
+
+		@Actor
+		public void request() {
+			inner.request(1);
+		}
+
+		@Arbiter
+		public void arbiter(LI_Result r) {
+			r.r2 = subscriber.onNextCalls.get();
+		}
+	}
+
+}

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/StressSubscriber.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/StressSubscriber.java
@@ -19,13 +19,18 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class StressSubscriber extends BaseSubscriber<Object> {
+import org.reactivestreams.Subscription;
+
+public class StressSubscriber<T> extends BaseSubscriber<T> {
 
 	enum Operation {
 		ON_NEXT,
 		ON_ERROR,
 		ON_COMPLETE,
+		ON_SUBSCRIBE
 	}
+
+	final long initRequest;
 
 	public AtomicReference<Operation> guard = new AtomicReference<>(null);
 
@@ -35,14 +40,49 @@ public class StressSubscriber extends BaseSubscriber<Object> {
 
 	public AtomicBoolean concurrentOnComplete = new AtomicBoolean(false);
 
+	public AtomicBoolean concurrentOnSubscribe = new AtomicBoolean(false);
+
 	public final AtomicInteger onNextCalls = new AtomicInteger();
 
 	public final AtomicInteger onErrorCalls = new AtomicInteger();
 
 	public final AtomicInteger onCompleteCalls = new AtomicInteger();
 
+	public final AtomicInteger onSubscribeCalls = new AtomicInteger();
+
+	/**
+	 * Build a {@link StressSubscriber} that makes an unbounded request upon subscription.
+	 */
+	public StressSubscriber() {
+		this(Long.MAX_VALUE);
+	}
+
+	/**
+	 * Build a {@link StressSubscriber} that requests the provided amount in
+	 * {@link #onSubscribe(Subscription)}. Use {@code 0} to avoid any initial request
+	 * upon subscription.
+	 *
+	 * @param initRequest the requested amount upon subscription, or zero to disable initial request
+	 */
+	public StressSubscriber(long initRequest) {
+		this.initRequest = initRequest;
+	}
+
 	@Override
-	protected void hookOnNext(Object value) {
+	protected void hookOnSubscribe(Subscription subscription) {
+		if (!guard.compareAndSet(null, Operation.ON_SUBSCRIBE)) {
+			concurrentOnSubscribe.set(true);
+		} else {
+			if (initRequest > 0) {
+				subscription.request(initRequest);
+			}
+			guard.compareAndSet(Operation.ON_SUBSCRIBE, null);
+		}
+		onSubscribeCalls.incrementAndGet();
+	}
+
+	@Override
+	protected void hookOnNext(T value) {
 		if (!guard.compareAndSet(null, Operation.ON_NEXT)) {
 			concurrentOnNext.set(true);
 		} else {

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
@@ -1,0 +1,438 @@
+/*
+ * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.stream.Stream;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
+import reactor.core.Scannable;
+import reactor.core.publisher.Sinks.Emission;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+
+/**
+ * @author Simon Baslé
+ */
+final class SinkManyBestEffort<T> extends Flux<T>
+		implements Sinks.Many<T>, ContextHolder, Scannable,
+		           DirectInnerContainer<T> {
+
+	static final DirectInner[] EMPTY      = new DirectInner[0];
+	static final DirectInner[] TERMINATED = new DirectInner[0];
+
+	static final <T> SinkManyBestEffort<T> createBestEffort() {
+		return new SinkManyBestEffort<>(false);
+	}
+
+	static final <T> SinkManyBestEffort<T> createAllOrNothing() {
+		return new SinkManyBestEffort<>(true);
+	}
+
+	final boolean allOrNothing;
+
+	/**
+	 * Stores the error that terminated this sink, for immediate replay to late subscribers
+	 */
+	Throwable error;
+
+	volatile     DirectInner<T>[]                                              subscribers;
+	@SuppressWarnings("rawtypes")
+	static final AtomicReferenceFieldUpdater<SinkManyBestEffort, DirectInner[]>SUBSCRIBERS =
+			AtomicReferenceFieldUpdater.newUpdater(SinkManyBestEffort.class, DirectInner[].class, "subscribers");
+
+	SinkManyBestEffort(boolean allOrNothing) {
+		this.allOrNothing = allOrNothing;
+		SUBSCRIBERS.lazySet(this, EMPTY);
+	}
+
+	public Context currentContext() {
+		return Operators.multiSubscribersContext(subscribers);
+	}
+
+	@Override
+	public Stream<? extends Scannable> inners() {
+		return Stream.of(subscribers);
+	}
+
+	@Nullable
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.TERMINATED) return subscribers == TERMINATED;
+		if (key == Attr.ERROR) return error;
+
+		return null;
+	}
+
+	@Override
+	public Emission tryEmitNext(T t) {
+		Objects.requireNonNull(t, "tryEmitNext(null) is forbidden");
+
+		DirectInner<T>[] subs = subscribers;
+
+		if (subs == EMPTY) {
+			return Emission.FAIL_ZERO_SUBSCRIBER;
+		}
+		if (subs == TERMINATED) {
+			return Emission.FAIL_TERMINATED;
+		}
+
+		int expectedEmitted = subs.length;
+		int cancelledCount = 0;
+		if (allOrNothing) {
+			long commonRequest = Long.MAX_VALUE;
+			for (DirectInner<T> sub : subs) {
+				long subRequest = sub.requested;
+				if (sub.isCancelled()) {
+					cancelledCount++;
+					continue;
+				}
+				if (subRequest < commonRequest) {
+					commonRequest = subRequest;
+				}
+			}
+			if (commonRequest == 0) {
+				return Emission.FAIL_OVERFLOW;
+			}
+			if (cancelledCount == expectedEmitted) {
+				return Emission.FAIL_ZERO_SUBSCRIBER;
+			}
+		}
+
+		int emittedCount = 0;
+		cancelledCount = 0;
+		for (DirectInner<T> sub : subs) {
+			if (sub.isCancelled()) {
+				cancelledCount++;
+				continue;
+			}
+			if (sub.tryEmitNext(t)) {
+				emittedCount++;
+			}
+			else if (sub.isCancelled()) {
+				cancelledCount++;
+			}
+		}
+		if (cancelledCount == expectedEmitted) {
+			return Emission.FAIL_ZERO_SUBSCRIBER;
+		}
+		else if (cancelledCount + emittedCount == expectedEmitted) {
+			return Emission.OK;
+		}
+		else {
+			return Emission.FAIL_OVERFLOW;
+		}
+	}
+
+	@Override
+	public Emission tryEmitComplete() {
+		@SuppressWarnings("unchecked")
+		DirectInner<T>[] subs = SUBSCRIBERS.getAndSet(this, TERMINATED);
+
+		if (subs == TERMINATED) {
+			return Emission.FAIL_TERMINATED;
+		}
+
+		for (DirectInner<?> s : subs) {
+			s.emitComplete();
+		}
+		return Emission.OK;
+	}
+
+	@Override
+	public Emission tryEmitError(Throwable error) {
+		Objects.requireNonNull(error, "tryEmitError(null) is forbidden");
+		@SuppressWarnings("unchecked")
+		DirectInner<T>[] subs = SUBSCRIBERS.getAndSet(this, TERMINATED);
+
+		if (subs == TERMINATED) {
+			return Emission.FAIL_TERMINATED;
+		}
+
+		this.error = error;
+
+		for (DirectInner<?> s : subs) {
+			s.emitError(error);
+		}
+		return Emission.OK;
+	}
+
+	@Override
+	public void emitComplete() {
+		//no particular error condition handling for onComplete
+		@SuppressWarnings("unused")
+		Emission emission = tryEmitComplete();
+	}
+
+	@Override
+	public void emitError(Throwable error) {
+		Emission result = tryEmitError(error);
+		if (result == Emission.FAIL_TERMINATED) {
+			Operators.onErrorDroppedMulticast(error, subscribers);
+		}
+	}
+
+	@Override
+	public void emitNext(T value) {
+		switch (tryEmitNext(value)) {
+			case FAIL_ZERO_SUBSCRIBER:
+				//we want to "discard" without rendering the sink terminated.
+				// effectively NO-OP cause there's no subscriber, so no context :(
+				break;
+			case FAIL_OVERFLOW:
+				Operators.onDiscard(value, currentContext());
+				//the emitError will onErrorDropped if already terminated
+				emitError(Exceptions.failWithOverflow("Backpressure overflow during Sinks.Many#emitNext"));
+				break;
+			case FAIL_CANCELLED:
+				Operators.onDiscard(value, currentContext());
+				break;
+			case FAIL_TERMINATED:
+				Operators.onNextDroppedMulticast(value, subscribers);
+				break;
+			case OK:
+				break;
+			default:
+				throw new IllegalStateException("Unexpected return code");
+		}
+	}
+
+	@Override
+	public int currentSubscriberCount() {
+		return subscribers.length;
+	}
+
+	@Override
+	public Flux<T> asFlux() {
+		return this;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super T> actual) {
+		Objects.requireNonNull(actual, "subscribe(null) is forbidden");
+
+		DirectInner<T> p = new DirectInner<>(actual, this);
+		actual.onSubscribe(p);
+
+		if (p.isCancelled()) {
+			return;
+		}
+
+		if (add(p)) {
+			if (p.isCancelled()) {
+				remove(p);
+			}
+		}
+		else {
+			Throwable e = error;
+			if (e != null) {
+				actual.onError(e);
+			}
+			else {
+				actual.onComplete();
+			}
+		}
+	}
+
+	@Override
+	public boolean add(DirectInner<T> s) {
+		DirectInner<T>[] a = subscribers;
+		if (a == TERMINATED) {
+			return false;
+		}
+
+		synchronized (this) {
+			a = subscribers;
+			if (a == TERMINATED) {
+				return false;
+			}
+			int len = a.length;
+
+			@SuppressWarnings("unchecked")
+			DirectInner<T>[] b = new DirectInner[len + 1];
+			System.arraycopy(a, 0, b, 0, len);
+			b[len] = s;
+
+			subscribers = b;
+
+			return true;
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void remove(DirectInner<T> s) {
+		DirectInner<T>[] a = subscribers;
+		if (a == TERMINATED || a == EMPTY) {
+			return;
+		}
+
+		synchronized (this) {
+			a = subscribers;
+			if (a == TERMINATED || a == EMPTY) {
+				return;
+			}
+			int len = a.length;
+
+			int j = -1;
+
+			for (int i = 0; i < len; i++) {
+				if (a[i] == s) {
+					j = i;
+					break;
+				}
+			}
+			if (j < 0) {
+				return;
+			}
+			if (len == 1) {
+				subscribers = EMPTY;
+				return;
+			}
+
+			DirectInner<T>[] b = new DirectInner[len - 1];
+			System.arraycopy(a, 0, b, 0, j);
+			System.arraycopy(a, j + 1, b, j, len - j - 1);
+
+			subscribers = b;
+		}
+	}
+
+	static class DirectInner<T> extends AtomicBoolean implements InnerProducer<T> {
+
+		final CoreSubscriber<? super T> actual;
+		final DirectInnerContainer<T>   parent;
+
+		volatile     long                                requested;
+		@SuppressWarnings("rawtypes")
+		static final AtomicLongFieldUpdater<DirectInner> REQUESTED = AtomicLongFieldUpdater.newUpdater(
+				DirectInner.class, "requested");
+
+		DirectInner(CoreSubscriber<? super T> actual, DirectInnerContainer<T> parent) {
+			this.actual = actual;
+			this.parent = parent;
+		}
+
+		@Override
+		public void request(long n) {
+			if (Operators.validate(n)) {
+				Operators.addCap(REQUESTED, this, n);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			if (compareAndSet(false, true)) {
+				parent.remove(this);
+			}
+		}
+
+		boolean isCancelled() {
+			return get();
+		}
+
+		@Override
+		@Nullable
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) return parent;
+			if (key == Attr.CANCELLED) return isCancelled();
+
+			return InnerProducer.super.scanUnsafe(key);
+		}
+
+		@Override
+		public CoreSubscriber<? super T> actual() {
+			return actual;
+		}
+
+		/**
+		 * Try to emit if the downstream is not cancelled and has some demand.
+		 * @param value the value to emit
+		 * @return true if enough demand and not cancelled, false otherwise
+		 */
+		boolean tryEmitNext(T value) {
+			if (requested != 0L) {
+				if (isCancelled()) {
+					return false;
+				}
+				actual.onNext(value);
+				if (requested != Long.MAX_VALUE) {
+					REQUESTED.decrementAndGet(this);
+				}
+				return true;
+			}
+			return false;
+		}
+
+		/**
+		 * Emit a value to the downstream, unless it doesn't have sufficient demand.
+		 * In that case, the downstream is terminated with an {@link Exceptions#failWithOverflow()}.
+		 *
+		 * @param value the value to emit
+		 */
+		void directEmitNext(T value) {
+			if (requested != 0L) {
+				actual.onNext(value);
+				if (requested != Long.MAX_VALUE) {
+					REQUESTED.decrementAndGet(this);
+				}
+				return;
+			}
+			parent.remove(this);
+			actual.onError(Exceptions.failWithOverflow("Can't deliver value due to lack of requests"));
+		}
+
+		void emitError(Throwable e) {
+			if (isCancelled()) {
+				return;
+			}
+			actual.onError(e);
+		}
+
+		void emitComplete() {
+			if (isCancelled()) {
+				return;
+			}
+			actual.onComplete();
+		}
+	}
+
+}
+
+//also used by DirectProcessor
+interface DirectInnerContainer<T> {
+
+	/**
+	 * Add a new {@link SinkManyBestEffort.DirectInner} to this publisher.
+	 *
+	 * @param s the new {@link SinkManyBestEffort.DirectInner} to add
+	 * @return {@code true} if the inner could be added, {@code false} if the publisher cannot accept new subscribers
+	 */
+	boolean add(SinkManyBestEffort.DirectInner<T> s);
+
+	/**
+	 * Remove an {@link SinkManyBestEffort.DirectInner} from this publisher. Does nothing if the inner is not currently managed
+	 * by the publisher.
+	 *
+	 * @param s the  {@link SinkManyBestEffort.DirectInner} to remove
+	 */
+	void remove(SinkManyBestEffort.DirectInner<T> s);
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -356,6 +356,48 @@ public final class Sinks {
 		 * @param autoCancel should the sink fully shutdowns (not publishing anymore) when the last subscriber cancels
 		 */
 		<T> Sinks.Many<T> onBackpressureBuffer(int bufferSize, boolean autoCancel);
+
+		/**
+		 A {@link Sinks.Many} with the following characteristics:
+		 * <ul>
+		 *     <li>Multicast</li>
+		 *     <li>Without {@link Subscriber}: fail fast on {@link Many#tryEmitNext(Object) tryEmitNext}.</li>
+		 *     <li>Backpressure : notify the caller with {@link Emission#FAIL_OVERFLOW} if any of the subscribers
+		 *     cannot process an element, failing fast and backing off from emitting the element at all (all or nothing).
+		 * 	   From the perspective of subscribers, data is dropped and never seen but they are not terminated.
+		 *     </li>
+		 *     <li>Replaying: No replay of elements. Only forwards to a {@link Subscriber} the elements that
+		 *     have been pushed to the sink AFTER this subscriber was subscribed, provided all of the subscribers
+		 *     have demand.</li>
+		 * </ul>
+		 * <p>
+		 * <img class="marble" src="doc-files/marbles/sinkDirectAllOrNothing.svg" alt="">
+		 *
+		 * @param <T> the type of elements to emit
+		 * @return a multicast {@link Sinks.Many} that "drops" in case any subscriber is too slow
+		 */
+		<T> Sinks.Many<T> directAllOrNothing();
+
+		/**
+		 A {@link Sinks.Many} with the following characteristics:
+		 * <ul>
+		 *     <li>Multicast</li>
+		 *     <li>Without {@link Subscriber}: fail fast on {@link Many#tryEmitNext(Object) tryEmitNext}.</li>
+		 *     <li>Backpressure : notify the caller with {@link Emission#FAIL_OVERFLOW} if <strong>none</strong>
+		 *     of the subscribers can process an element. Otherwise, it ignores slow subscribers and emits the
+		 *     element to fast ones as a best effort. From the perspective of slow subscribers, data is dropped
+		 *     and never seen, but they are not terminated.
+		 *     </li>
+		 *     <li>Replaying: No replay of elements. Only forwards to a {@link Subscriber} the elements that
+		 *     have been pushed to the sink AFTER this subscriber was subscribed.</li>
+		 * </ul>
+		 * <p>
+		 * <img class="marble" src="doc-files/marbles/sinkDirectBestEffort.svg" alt="">
+		 *
+		 * @param <T> the type of elements to emit
+		 * @return a multicast {@link Sinks.Many} that "drops" in case of no demand from any subscriber
+		 */
+		<T> Sinks.Many<T> directBestEffort();
 	}
 
 

--- a/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
@@ -315,6 +315,16 @@ final class MulticastSpecImpl extends SinkSpecImpl implements Sinks.MulticastSpe
 	public <T> Many<T> onBackpressureBuffer(int bufferSize, boolean autoCancel) {
 		return toSerializedSink(EmitterProcessor.create(bufferSize, autoCancel));
 	}
+
+	@Override
+	public <T> Many<T> directAllOrNothing() {
+		return toSerializedSink(SinkManyBestEffort.createAllOrNothing());
+	}
+
+	@Override
+	public <T> Many<T> directBestEffort() {
+		return toSerializedSink(SinkManyBestEffort.createBestEffort());
+	}
 }
 
 @SuppressWarnings("deprecation")

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sinkDirectAllOrNothing.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sinkDirectAllOrNothing.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 87 579.85 396" width="579.85" height="396" id="svg131">
+ <g fill-opacity="1" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" id="g3392" transform="translate(160.29 -71.48)">
+  <circle r="23.02" cx="313.71" cy="187.48" id="ellipse1155" fill="#e739ce" stroke="#000" stroke-width=".53"/>
+  <circle r="23" id="ellipse42-3" cy="187.48" cx="313.71" fill="none" stroke="#34302c" stroke-width="2"/>
+ </g>
+ <defs id="defs24">
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g4">
+    <path d="M12 0L0-4v9z" id="path2" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g9">
+    <path d="M8 0L0-3v6z" id="path7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g16">
+    <path d="M12 0L0-4v9z" id="path14" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_4" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g21">
+    <path d="M8 0L0-3v6z" id="path19" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" refY="0" refX="0" id="Arrow2Lend-6" overflow="visible">
+   <path id="path5247-9" d="M-11-4L1 0l-12 4c2-2 2-6 0-8z" fill="#000" fill-opacity="1" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linejoin="round" stroke-opacity="1"/>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g16-6">
+    <path d="M8 0L0-3v6z" id="path14-7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3-6" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g16-6-8">
+    <path d="M8 0L0-3v6z" id="path14-7-9" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face12" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma-Bold"/>
+   </font-face-src>
+  </font-face>
+ </defs>
+ <circle r="23" id="ellipse35" cy="116.43" cx="134" fill="#6cb33e" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="23" id="ellipse37" cy="116.43" cx="134" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="23" id="ellipse40" cy="116.43" cx="193" fill="#e6ba31" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="23" id="ellipse42" cy="116.43" cx="193" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="23" id="ellipse45" cy="116.43" cx="373" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M27 202.43h555l1 .96v62.3l-1 .95H27l-1-.96v-62.3z" id="path67" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line82" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3)" d="M46.94 369.43H568"/>
+ <text id="text71" x="125.27" y="204.43" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="24" font-weight="700" x="279.27" y="226.43" id="tspan69" font-family="'Tahoma','Nimbus Sans L'" fill="#34302c">sink</tspan>
+ </text>
+ <path d="M346.85 453.43H568" marker-end="url(#FilledArrow_Marker_3)" stroke-opacity="1" stroke-dasharray="none" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#34302c" fill-opacity="1" fill="none" id="path250"/>
+ <path id="line1307" d="M45.62 367.59v-77.95" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000002,6.00000009" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-6)"/>
+ <text id="text1313" transform="rotate(-90)" x="-362.02" y="27.62" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan1311" y="40.62" x="-362.02" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">subscribe</tspan>
+ </text>
+ <path marker-end="url(#FilledArrow_Marker_3-3-6)" stroke-opacity="1" stroke-dasharray="2.00000002,6.00000009" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#45b8de" fill-opacity="1" fill="none" d="M426.47 451.67V287.9" id="path514"/>
+ <text stroke-opacity="1" stroke-dasharray="none" stroke="none" fill-opacity="1" fill="#45b8de" y="408.47" x="-449.69" transform="rotate(-90)" id="text518">
+  <tspan fill="#45b8de" font-family="Tahoma,'Nimbus Sans L'" font-size="14" font-weight="400" x="-449.69" y="421.47" id="tspan516">request(1)</tspan>
+ </text>
+ <text stroke-opacity="1" stroke-dasharray="none" stroke="none" fill-opacity="1" fill="#34302c" y="236.43" x="96.7" id="text524">
+  <tspan fill="#34302c" font-family="'Tahoma','Nimbus Sans L'" id="tspan522" y="258.43" x="250.7" font-weight="700" font-size="24">.asFlux()</tspan>
+ </text>
+ <path stroke-opacity="1" stroke-linejoin="miter" stroke-linecap="butt" stroke-width="1" stroke="#000" fill="none" id="path526" d="M36.16 235.72l535.1-1.2"/>
+ <path id="line53" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)" d="M134 141.31v75.06"/>
+ <path id="line56" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)" d="M193 141.97v74.7"/>
+ <path id="line59" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)" d="M373 140.19v76.49"/>
+ <path id="path87" d="M532.66 94.09l2 2v45l-2 2-2-2v-45z" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <path stroke-opacity="1" stroke-dasharray="none" stroke="none" fill-opacity="1" fill="#34302c" d="M532.66 344.09l2 2v45l-2 2-2-2v-45z" id="path543"/>
+ <path id="path545" d="M532.66 428.09l2 2v45l-2 2-2-2v-45z" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M533 140.19v76.49" marker-end="url(#FilledArrow_Marker_2)" stroke-opacity="1" stroke-dasharray="2,6" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#34302c" fill-opacity="1" fill="none" id="path547"/>
+ <path d="M533 270.24v54.66" marker-end="url(#FilledArrow_Marker_4)" stroke-opacity="1" stroke-dasharray="2,6" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#34302c" fill-opacity="1" fill="none" id="path549"/>
+ <path id="path551" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_4)" d="M533 369.82v39.33"/>
+ <path marker-end="url(#FilledArrow_Marker_3-3-6)" stroke-opacity="1" stroke-dasharray="2.00000002,6.00000009" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#45b8de" fill-opacity="1" fill="none" d="M89.62 367.11v-77.47" id="path146"/>
+ <text stroke-opacity="1" stroke-dasharray="none" stroke="none" fill-opacity="1" fill="#45b8de" y="69.62" x="-362.02" transform="rotate(-90)" id="text150">
+  <tspan fill="#45b8de" font-family="Tahoma,'Nimbus Sans L'" font-size="14" font-weight="400" x="-362.02" y="82.62" id="tspan148">request(1)</tspan>
+ </text>
+ <circle stroke-opacity="1" stroke-dasharray="none" stroke="none" fill-opacity="1" fill="#6cb33e" cx="134" cy="370.43" id="circle156" r="23"/>
+ <circle stroke-opacity="1" stroke-dasharray="none" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#34302c" fill-opacity="1" fill="none" cx="134" cy="370.43" id="circle158" r="23"/>
+ <path d="M134 269.07v57.85" marker-end="url(#FilledArrow_Marker_2)" stroke-opacity="1" stroke-dasharray="2,6" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#34302c" fill-opacity="1" fill="none" id="path160"/>
+ <path id="path162" d="M309.62 367.11v-77.47" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000002,6.00000009" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-6)"/>
+ <text id="text166" transform="rotate(-90)" x="-362.02" y="289.62" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan164" y="302.62" x="-362.02" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request(5)</tspan>
+ </text>
+ <circle stroke-opacity="1" stroke-dasharray="none" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#34302c" fill-opacity="1" fill="none" cx="373" cy="116.43" id="circle3343" r="23"/>
+ <path d="M474 140.19v76.49" marker-end="url(#FilledArrow_Marker_2)" stroke-opacity="1" stroke-dasharray="2,6" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#34302c" fill-opacity="1" fill="none" id="path3394"/>
+ <path d="M474 269.07v57.85" marker-end="url(#FilledArrow_Marker_2)" stroke-opacity="1" stroke-dasharray="2,6" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#34302c" fill-opacity="1" fill="none" id="path3400"/>
+ <g stroke-opacity="1" stroke-dasharray="none" stroke-linejoin="round" stroke-linecap="round" fill-opacity="1" transform="translate(160.29 182.52)" id="g3408">
+  <circle stroke-width=".53" stroke="#000" fill="#e739ce" id="circle3404" cy="187.48" cx="313.71" r="23.02"/>
+  <circle stroke-width="2" stroke="#34302c" fill="none" cx="313.71" cy="187.48" id="circle3406" r="23"/>
+ </g>
+ <path id="path3686" d="M346.47 451.66V287.37" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000002,6.00000009" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-6)"/>
+ <text id="text3690" transform="rotate(-90)" x="-449.69" y="328.47" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan3688" y="341.47" x="-449.69" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">subscribe</tspan>
+ </text>
+ <g fill-opacity="1" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" id="g3696" transform="translate(160.29 266.52)">
+  <circle r="23.02" cx="313.71" cy="187.48" id="circle3692" fill="#e739ce" stroke="#000" stroke-width=".53"/>
+  <circle r="23" id="circle3694" cy="187.48" cx="313.71" fill="none" stroke="#34302c" stroke-width="2"/>
+ </g>
+ <path id="path3698" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)" d="M474 396.86v14.28"/>
+</svg>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sinkDirectBestEffort.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/sinkDirectBestEffort.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="20 87 579.85 396" width="579.85" height="396" id="svg131">
+ <g id="g3392" transform="translate(160.29 -71.48)" fill-opacity="1" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1">
+  <circle r="23.02" cx="313.71" cy="187.48" id="ellipse1155" fill="#e739ce" stroke="#000" stroke-width=".53"/>
+  <circle r="23" id="ellipse42-3" cy="187.48" cx="313.71" fill="none" stroke="#34302c" stroke-width="2"/>
+ </g>
+ <defs id="defs24">
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g4">
+    <path d="M12 0L0-4v9z" id="path2" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g9">
+    <path d="M8 0L0-3v6z" id="path7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g16">
+    <path d="M12 0L0-4v9z" id="path14" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_4" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g21">
+    <path d="M8 0L0-3v6z" id="path19" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" refY="0" refX="0" id="Arrow2Lend-6" overflow="visible">
+   <path id="path5247-9" d="M-11-4L1 0l-12 4c2-2 2-6 0-8z" fill="#000" fill-opacity="1" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linejoin="round" stroke-opacity="1"/>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g16-6">
+    <path d="M8 0L0-3v6z" id="path14-7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3-6" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g16-6-8">
+    <path d="M8 0L0-3v6z" id="path14-7-9" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face12" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma-Bold"/>
+   </font-face-src>
+  </font-face>
+ </defs>
+ <circle r="23" id="ellipse35" cy="116.43" cx="134" fill="#6cb33e" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="23" id="ellipse37" cy="116.43" cx="134" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="23" id="ellipse40" cy="116.43" cx="193" fill="#e6ba31" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="23" id="ellipse42" cy="116.43" cx="193" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="23" id="ellipse45" cy="116.43" cx="373" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M27 202.43h555l1 .96v62.3l-1 .96H27l-1-.96v-62.3z" id="path67" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line82" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3)" d="M46.95 369.43H568"/>
+ <text id="text71" x="125.28" y="204.43" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="24" font-weight="700" x="279.28" y="226.43" id="tspan69" font-family="'Tahoma','Nimbus Sans L'" fill="#34302c">sink</tspan>
+ </text>
+ <path d="M339.72 453.43H568" marker-end="url(#FilledArrow_Marker_3)" stroke-opacity="1" stroke-dasharray="none" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#34302c" fill-opacity="1" fill="none" id="path250"/>
+ <path id="line1307" d="M45.62 367.6v-77.97" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000002,6.00000009" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-6)"/>
+ <text id="text1313" transform="rotate(-90)" x="-362.02" y="27.62" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan1311" y="40.62" x="-362.02" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">subscribe</tspan>
+ </text>
+ <path marker-end="url(#FilledArrow_Marker_3-3-6)" stroke-opacity="1" stroke-dasharray="2.00000002,6.00000009" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#45b8de" fill-opacity="1" fill="none" d="M426.48 451.67V287.9" id="path514"/>
+ <text stroke-opacity="1" stroke-dasharray="none" stroke="none" fill-opacity="1" fill="#45b8de" y="408.48" x="-449.69" transform="rotate(-90)" id="text518">
+  <tspan fill="#45b8de" font-family="Tahoma,'Nimbus Sans L'" font-size="14" font-weight="400" x="-449.69" y="421.48" id="tspan516">request(1)</tspan>
+ </text>
+ <text stroke-opacity="1" stroke-dasharray="none" stroke="none" fill-opacity="1" fill="#34302c" y="236.43" x="96.7" id="text524">
+  <tspan fill="#34302c" font-family="'Tahoma','Nimbus Sans L'" id="tspan522" y="258.43" x="250.7" font-weight="700" font-size="24">.asFlux()</tspan>
+ </text>
+ <path id="path526" d="M36.16 235.72l535.1-1.19" fill="none" stroke="#000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1"/>
+ <path id="line53" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)" d="M134 141.31v75.07"/>
+ <path id="line56" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)" d="M193 141.98v74.7"/>
+ <path id="line59" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)" d="M373 140.2v76.48"/>
+ <path id="path87" d="M532.67 94.1l2 2v45l-2 2-2-2v-45z" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <path stroke-opacity="1" stroke-dasharray="none" stroke="none" fill-opacity="1" fill="#34302c" d="M532.67 344.1l2 2v45l-2 2-2-2v-45z" id="path543"/>
+ <path id="path545" d="M532.67 428.1l2 2v45l-2 2-2-2v-45z" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <path d="M533 140.2v76.48" marker-end="url(#FilledArrow_Marker_2)" stroke-opacity="1" stroke-dasharray="2,6" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#34302c" fill-opacity="1" fill="none" id="path547"/>
+ <path d="M533 270.2v52.61" marker-end="url(#FilledArrow_Marker_4)" stroke-opacity="1" stroke-dasharray="2,6" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#34302c" fill-opacity="1" fill="none" id="path549"/>
+ <path id="path551" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_4)" d="M533 369.83v39.83"/>
+ <path marker-end="url(#FilledArrow_Marker_3-3-6)" stroke-opacity="1" stroke-dasharray="2.00000002,6.00000009" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#45b8de" fill-opacity="1" fill="none" d="M89.62 367.12v-77.5" id="path146"/>
+ <text stroke-opacity="1" stroke-dasharray="none" stroke="none" fill-opacity="1" fill="#45b8de" y="69.62" x="-362.02" transform="rotate(-90)" id="text150">
+  <tspan fill="#45b8de" font-family="Tahoma,'Nimbus Sans L'" font-size="14" font-weight="400" x="-362.02" y="82.62" id="tspan148">request(1)</tspan>
+ </text>
+ <circle stroke-opacity="1" stroke-dasharray="none" stroke="none" fill-opacity="1" fill="#6cb33e" cx="134" cy="370.43" id="circle156" r="23"/>
+ <circle stroke-opacity="1" stroke-dasharray="none" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#34302c" fill-opacity="1" fill="none" cx="134" cy="370.43" id="circle158" r="23"/>
+ <path d="M134 269.07v57.86" marker-end="url(#FilledArrow_Marker_2)" stroke-opacity="1" stroke-dasharray="2,6" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#34302c" fill-opacity="1" fill="none" id="path160"/>
+ <path id="path162" d="M309.62 367.12v-77.5" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000002,6.00000009" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-6)"/>
+ <text id="text166" transform="rotate(-90)" x="-362.02" y="289.62" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan164" y="302.62" x="-362.02" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">request(5)</tspan>
+ </text>
+ <circle stroke-opacity="1" stroke-dasharray="none" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#34302c" fill-opacity="1" fill="none" cx="373" cy="116.43" id="circle3343" r="23"/>
+ <path d="M474 140.2v76.48" marker-end="url(#FilledArrow_Marker_2)" stroke-opacity="1" stroke-dasharray="2,6" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#34302c" fill-opacity="1" fill="none" id="path3394"/>
+ <path d="M474 269.07v57.86" marker-end="url(#FilledArrow_Marker_2)" stroke-opacity="1" stroke-dasharray="2,6" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke="#34302c" fill-opacity="1" fill="none" id="path3400"/>
+ <g transform="translate(160.29 182.52)" id="g3408" stroke-opacity="1" stroke-dasharray="none" stroke-linejoin="round" stroke-linecap="round" fill-opacity="1">
+  <circle stroke-width=".53" stroke="#000" fill="#e739ce" id="circle3404" cy="187.48" cx="313.71" r="23.02"/>
+  <circle stroke-width="2" stroke="#34302c" fill="none" cx="313.71" cy="187.48" id="circle3406" r="23"/>
+ </g>
+ <path id="path3686" d="M340.48 451.67v-164.3" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000002,6.00000009" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-3-6)"/>
+ <text id="text3690" transform="rotate(-90)" x="-449.69" y="322.48" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan3688" y="335.48" x="-449.69" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">subscribe</tspan>
+ </text>
+ <g id="g3696" transform="translate(160.29 266.52)" fill-opacity="1" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1">
+  <circle r="23.02" cx="313.71" cy="187.48" id="circle3692" fill="#e739ce" stroke="#000" stroke-width=".53"/>
+  <circle r="23" id="circle3694" cy="187.48" cx="313.71" fill="none" stroke="#34302c" stroke-width="2"/>
+ </g>
+ <path id="path3698" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)" d="M474 396.86v14.28"/>
+ <circle stroke-opacity="1" stroke-dasharray="none" stroke="none" fill-opacity="1" fill="#45b8de" cx="373" cy="368.43" id="circle3866" r="23"/>
+ <circle r="23" id="circle3870" cy="368.43" cx="373" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="path3872" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_2)" d="M374 269.07v57.86"/>
+</svg>

--- a/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
@@ -277,10 +277,10 @@ public abstract class AbstractFluxConcatMapTest extends FluxOperatorTest<String,
 	public void singleSubscriberOnlyBoundary() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = DirectProcessor.create();
+		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
 
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		source.asFlux().concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux(), implicitPrefetchValue())
 		      .subscribe(ts);
@@ -316,10 +316,10 @@ public abstract class AbstractFluxConcatMapTest extends FluxOperatorTest<String,
 	public void mainErrorsImmediate() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = DirectProcessor.create();
+		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
 
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		source.asFlux().concatMap(v -> v == 1 ? source1.asFlux() : source2.asFlux(), implicitPrefetchValue())
 		      .subscribe(ts);
@@ -350,10 +350,10 @@ public abstract class AbstractFluxConcatMapTest extends FluxOperatorTest<String,
 	public void mainErrorsBoundary() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = DirectProcessor.create();
+		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
 
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		source.asFlux().concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux(), implicitPrefetchValue())
 		      .subscribe(ts);
@@ -391,10 +391,10 @@ public abstract class AbstractFluxConcatMapTest extends FluxOperatorTest<String,
 	public void innerErrorsImmediate() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = DirectProcessor.create();
+		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
 
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		source.asFlux().concatMap(v -> v == 1 ? source1.asFlux() : source2.asFlux(), implicitPrefetchValue())
 		      .subscribe(ts);
@@ -847,10 +847,10 @@ public abstract class AbstractFluxConcatMapTest extends FluxOperatorTest<String,
 	public void innerErrorsBoundary() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = DirectProcessor.create();
+		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
 
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		//gh-1101: default changed from BOUNDARY to END
 		source.asFlux().concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux(), false, implicitPrefetchValue())
@@ -882,10 +882,10 @@ public abstract class AbstractFluxConcatMapTest extends FluxOperatorTest<String,
 	public void innerErrorsEnd() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = DirectProcessor.create();
+		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
 
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		source.asFlux().concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux(), true, implicitPrefetchValue())
 		      .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/DirectProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/DirectProcessorTest.java
@@ -20,13 +20,11 @@ import java.time.Duration;
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
-import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 @SuppressWarnings("deprecation")
 public class DirectProcessorTest {
@@ -57,7 +55,7 @@ public class DirectProcessorTest {
 
 	    StepVerifier.create(tp)
 	                .then(() -> {
-		                assertThat(tp.currentSubscriberCount()).as("has subscriber").isPositive();
+		                assertThat(tp.hasDownstreams()).as("has downstreams").isTrue();
 		                assertThat(tp.hasCompleted()).as("hasCompleted").isFalse();
 		                assertThat(tp.getError()).as("getError").isNull();
 		                assertThat(tp.hasError()).as("hasError").isFalse();
@@ -75,7 +73,7 @@ public class DirectProcessorTest {
 	                .expectComplete()
 	                .verify();
 
-	    assertThat(tp.currentSubscriberCount()).as("has subscriber").isZero();
+	    assertThat(tp.hasDownstreams()).as("has downstreams").isFalse();
 	    assertThat(tp.hasCompleted()).as("hasCompleted").isTrue();
 	    assertThat(tp.getError()).as("getError").isNull();
 	    assertThat(tp.hasError()).as("hasError").isFalse();
@@ -87,7 +85,7 @@ public class DirectProcessorTest {
 
 	    StepVerifier.create(tp, 0L)
 	                .then(() -> {
-		                assertThat(tp.currentSubscriberCount()).as("has subscriber").isPositive();
+		                assertThat(tp.hasDownstreams()).as("has downstreams").isTrue();
 		                assertThat(tp.hasCompleted()).as("hasCompleted").isFalse();
 		                assertThat(tp.getError()).as("getError").isNull();
 		                assertThat(tp.hasError()).as("hasError").isFalse();
@@ -102,7 +100,7 @@ public class DirectProcessorTest {
 	                .expectComplete()
 	                .verify();
 
-	    assertThat(tp.currentSubscriberCount()).as("has subscriber").isZero();
+	    assertThat(tp.hasDownstreams()).as("has downstreams").isFalse();
 	    assertThat(tp.hasCompleted()).as("hasCompleted").isTrue();
 	    assertThat(tp.getError()).as("getError").isNull();
 	    assertThat(tp.hasError()).as("hasError").isFalse();
@@ -131,7 +129,7 @@ public class DirectProcessorTest {
 
         tp.subscribe(ts);
 
-	    assertThat(tp.currentSubscriberCount()).as("has subscriber").isPositive();
+	    assertThat(tp.hasDownstreams()).as("has downstreams").isTrue();
 	    assertThat(tp.hasCompleted()).as("hasCompleted").isFalse();
 	    assertThat(tp.getError()).as("getError").isNull();
 	    assertThat(tp.hasError()).as("hasError").isFalse();
@@ -150,7 +148,7 @@ public class DirectProcessorTest {
         tp.onNext(3);
         tp.onError(new RuntimeException("forced failure"));
 
-	    assertThat(tp.currentSubscriberCount()).as("has subscriber").isZero();
+	    assertThat(tp.hasDownstreams()).as("has downstreams").isFalse();
 	    assertThat(tp.hasCompleted()).as("hasCompleted").isFalse();
 	    assertThat(tp.hasError()).as("hasError").isTrue();
 	    assertThat(tp.getError()).as("getError")
@@ -173,7 +171,7 @@ public class DirectProcessorTest {
 
         tp.subscribe(ts);
 
-	    assertThat(tp.currentSubscriberCount()).as("has subscriber").isZero();
+	    assertThat(tp.hasDownstreams()).as("has downstreams").isFalse();
 	    assertThat(tp.hasCompleted()).as("hasCompleted").isFalse();
 	    assertThat(tp.hasError()).as("hasError").isTrue();
 	    assertThat(tp.getError()).as("getError")
@@ -196,7 +194,7 @@ public class DirectProcessorTest {
 
         tp.subscribe(ts);
 
-	    assertThat(tp.currentSubscriberCount()).as("has subscriber").isZero();
+	    assertThat(tp.hasDownstreams()).as("has downstreams").isFalse();
 	    assertThat(tp.hasCompleted()).as("hasCompleted").isTrue();
 	    assertThat(tp.getError()).as("getError").isNull();
 	    assertThat(tp.hasError()).as("hasError").isFalse();
@@ -215,7 +213,7 @@ public class DirectProcessorTest {
 
         tp.subscribe(ts);
 
-	    assertThat(tp.currentSubscriberCount()).as("has subscriber").isZero();
+	    assertThat(tp.hasDownstreams()).as("has downstreams").isFalse();
 
         tp.onNext(1);
 
@@ -233,7 +231,7 @@ public class DirectProcessorTest {
 
         tp.subscribe(ts);
 
-	    assertThat(tp.currentSubscriberCount()).as("has subscriber").isPositive();
+	    assertThat(tp.hasDownstreams()).as("has downstreams").isTrue();
 
         tp.onNext(1);
 
@@ -243,30 +241,13 @@ public class DirectProcessorTest {
 
         ts.cancel();
 
-	    assertThat(tp.currentSubscriberCount()).as("has subscriber").isZero();
+	    assertThat(tp.hasDownstreams()).as("has downstreams").isFalse();
 
         tp.onNext(2);
 
         ts.assertValues(1)
           .assertNotComplete()
           .assertNoError();
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void scanInner() {
-	    InnerConsumer<? super String> actual = mock(InnerConsumer.class);
-        DirectProcessor<String> parent = new DirectProcessor<>();
-
-        DirectProcessor.DirectInner<String> test =
-                new DirectProcessor.DirectInner<>(actual, parent);
-
-        assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
-        assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
-        assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
-
-        test.cancel();
-        assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
     }
 
     @Test
@@ -284,43 +265,15 @@ public class DirectProcessorTest {
     }
 
 	@Test
-	public void tryEmitNextWithNoSubscriberFails() {
+	public void onNextWithNoSubscriberJustDiscardsWithoutTerminatingTheSink() {
 		DirectProcessor<Integer> directProcessor = DirectProcessor.create();
-
-		assertThat(directProcessor.tryEmitNext(1)).isEqualTo(Sinks.Emission.FAIL_ZERO_SUBSCRIBER);
-		assertThat(directProcessor.tryEmitComplete()).isEqualTo(Sinks.Emission.OK);
-
-		StepVerifier.create(directProcessor)
-		            .verifyComplete();
-	}
-
-	@Test
-	public void tryEmitNextWithNoSubscriberFailsIfAllSubscribersCancelled() {
-		//in case of autoCancel, removing all subscribers results in TERMINATED rather than EMPTY
-		DirectProcessor<Integer> directProcessor = DirectProcessor.create();
-		AssertSubscriber<Integer> testSubscriber = AssertSubscriber.create();
-
-		directProcessor.subscribe(testSubscriber);
-
-		assertThat(directProcessor.tryEmitNext(1)).as("emit 1, with subscriber").isEqualTo(Sinks.Emission.OK);
-		assertThat(directProcessor.tryEmitNext(2)).as("emit 2, with subscriber").isEqualTo(Sinks.Emission.OK);
-		assertThat(directProcessor.tryEmitNext(3)).as("emit 3, with subscriber").isEqualTo(Sinks.Emission.OK);
-
-		testSubscriber.cancel();
-
-		assertThat(directProcessor.tryEmitNext(4)).as("emit 4, without subscriber").isEqualTo(Sinks.Emission.FAIL_ZERO_SUBSCRIBER);
-	}
-
-	@Test
-	public void emitNextWithNoSubscriberJustDiscardsWithoutTerminatingTheSink() {
-		DirectProcessor<Integer> directProcessor = DirectProcessor.create();
-		directProcessor.emitNext(1);
+		directProcessor.onNext(1);
 
 		StepVerifier.create(directProcessor)
 		            .expectSubscription()
 		            .expectNoEvent(Duration.ofSeconds(1))
-		            .then(() -> directProcessor.emitNext(2))
-		            .then(directProcessor::emitComplete)
+		            .then(() -> directProcessor.onNext(2))
+		            .then(directProcessor::onComplete)
 		            .expectNext(2)
 		            .expectComplete()
 		            .verify(Duration.ofSeconds(5));

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
@@ -76,8 +76,8 @@ public class FluxBufferBoundaryTest
 	public void normal() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .buffer(sp2.asFlux())
@@ -128,8 +128,8 @@ public class FluxBufferBoundaryTest
 	public void mainError() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .buffer(sp2.asFlux())
@@ -175,8 +175,8 @@ public class FluxBufferBoundaryTest
 	public void otherError() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .buffer(sp2.asFlux())
@@ -222,8 +222,8 @@ public class FluxBufferBoundaryTest
 	public void bufferSupplierThrows() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .buffer(sp2.asFlux(), (Supplier<List<Integer>>) () -> {
@@ -244,8 +244,8 @@ public class FluxBufferBoundaryTest
 	public void bufferSupplierThrowsLater() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		int count[] = {1};
 
@@ -276,8 +276,8 @@ public class FluxBufferBoundaryTest
 	public void bufferSupplierReturnsNUll() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .buffer(sp2.asFlux(), (Supplier<List<Integer>>) () -> null)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
@@ -62,7 +62,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalUntil() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL);
 
@@ -126,7 +126,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void mainErrorUntil() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL);
 
@@ -146,7 +146,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void predicateErrorUntil() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(),
 				i -> {
@@ -170,7 +170,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalUntilOther() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE);
 
@@ -201,7 +201,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void mainErrorUntilOther() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther =
 				new FluxBufferPredicate<>(sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(),
 						FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE);
@@ -222,7 +222,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void predicateErrorUntilOther() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther =
 				new FluxBufferPredicate<>(sp1.asFlux(),
 				i -> {
@@ -375,7 +375,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalWhile() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 != 0, Flux.listSupplier(),
 				FluxBufferPredicate.Mode.WHILE);
@@ -407,7 +407,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalWhileDoesntInitiallyMatch() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
 
@@ -438,7 +438,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalWhileDoesntMatch() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i > 4, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
 
@@ -464,7 +464,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void mainErrorWhile() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
 
@@ -484,7 +484,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void predicateErrorWhile() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
 				sp1.asFlux(),
 				i -> {
@@ -509,7 +509,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void bufferSupplierThrows() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0,
 				() -> { throw new RuntimeException("supplier failure"); },
@@ -524,7 +524,7 @@ public class FluxBufferPredicateTest {
 
 	@Test
 	public void bufferSupplierThrowsLater() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		int count[] = {1};
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0,
@@ -549,7 +549,7 @@ public class FluxBufferPredicateTest {
 
 	@Test
 	public void bufferSupplierReturnsNull() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0,
 				() -> null,
@@ -568,7 +568,7 @@ public class FluxBufferPredicateTest {
 	@SuppressWarnings("unchecked")
 	public void multipleTriggersOfEmptyBufferKeepInitialBuffer() {
 		//this is best demonstrated with bufferWhile:
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		LongAdder bufferCount = new LongAdder();
 		Supplier<List<Integer>> bufferSupplier = () -> {
 			bufferCount.increment();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
@@ -166,10 +166,10 @@ public class FluxBufferWhenTest {
 	public void normal() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
-		Sinks.Many<Integer> sp3 = DirectProcessor.create();
-		Sinks.Many<Integer> sp4 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp3 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp4 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .bufferWhen(sp2.asFlux(), v -> v == 1 ? sp3.asFlux() : sp4.asFlux())
@@ -226,9 +226,9 @@ public class FluxBufferWhenTest {
 	public void startCompletes() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = DirectProcessor.create();
-		Sinks.Many<Integer> open = DirectProcessor.create();
-		Sinks.Many<Integer> close = DirectProcessor.create();
+		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> open = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> close = Sinks.many().unsafe().multicast().directBestEffort();
 
 		source.asFlux()
 			  .bufferWhen(open.asFlux(), v -> close.asFlux())

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCombineLatestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCombineLatestTest.java
@@ -159,8 +159,8 @@ public class FluxCombineLatestTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void fused() {
-		Sinks.Many<Integer> dp1 = DirectProcessor.create();
-		Sinks.Many<Integer> dp2 = DirectProcessor.create();
+		Sinks.Many<Integer> dp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> dp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		ts.requestedFusionMode(Fuseable.ANY);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
@@ -110,10 +110,10 @@ public class  FluxConcatMapTest extends AbstractFluxConcatMapTest {
 	public void singleSubscriberOnly() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = DirectProcessor.create();
+		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
 
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		source.asFlux()
 			  .concatMap(v -> v == 1 ? source1.asFlux() : source2.asFlux())
@@ -150,10 +150,10 @@ public class  FluxConcatMapTest extends AbstractFluxConcatMapTest {
 	public void singleSubscriberOnlyBoundary() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = DirectProcessor.create();
+		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
 
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		source.asFlux()
 			  .concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux())

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
@@ -228,7 +228,7 @@ public class FluxDistinctUntilChangedTest extends FluxOperatorTest<String, Strin
 
 	@Test
 	public void allDistinctConditional() {
-		Sinks.Many<Integer> dp = DirectProcessor.create();
+		Sinks.Many<Integer> dp = Sinks.many().unsafe().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = dp.asFlux()
 										 .distinctUntilChanged()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxGroupJoinTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxGroupJoinTest.java
@@ -46,8 +46,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void behaveAsJoin() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Flux<Integer> m =
 				source1.asFlux().groupJoin(source2.asFlux(), just(Flux.never()), just(Flux.never()), add2)
@@ -138,8 +138,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void leftThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Flux<Flux<Integer>> m =
 				source1.asFlux().groupJoin(source2.asFlux(), just(Flux.never()), just(Flux.never()), add2);
@@ -157,8 +157,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void rightThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Flux<Flux<Integer>> m =
 				source1.asFlux().groupJoin(source2.asFlux(), just(Flux.never()), just(Flux.never()), add2);
@@ -176,8 +176,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void leftDurationThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Flux<Integer> duration1 = Flux.error(new RuntimeException("Forced failure"));
 
@@ -195,8 +195,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void rightDurationThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Flux<Integer> duration1 = Flux.error(new RuntimeException("Forced failure"));
 
@@ -214,8 +214,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void leftDurationSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Function<Integer, Flux<Integer>> fail = t1 -> {
 			throw new RuntimeException("Forced failure");
@@ -235,8 +235,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void rightDurationSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Function<Integer, Flux<Integer>> fail = t1 -> {
 			throw new RuntimeException("Forced failure");
@@ -256,8 +256,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void resultSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		BiFunction<Integer, Flux<Integer>, Integer> fail = (t1, t2) -> {
 			throw new RuntimeException("Forced failure");

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxJoinTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxJoinTest.java
@@ -39,8 +39,8 @@ public class FluxJoinTest {
 	public void normal1() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Flux<Integer> m =
 				source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(Flux.never()), add);
@@ -66,10 +66,10 @@ public class FluxJoinTest {
 	@Test
 	public void normal1WithDuration() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
-		Sinks.Many<Integer> duration1 = DirectProcessor.create();
+		Sinks.Many<Integer> duration1 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Flux<Integer> m = source1.asFlux().join(source2.asFlux(), just(duration1.asFlux()), just(Flux.never()), add);
 		m.subscribe(ts);
@@ -95,8 +95,8 @@ public class FluxJoinTest {
 	@Test
 	public void normal2() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Flux<Integer> m =
 				source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(Flux.never()), add);
@@ -121,8 +121,8 @@ public class FluxJoinTest {
 	@Test
 	public void leftThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Flux<Integer> m =
 				source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(Flux.never()), add);
@@ -140,8 +140,8 @@ public class FluxJoinTest {
 	@Test
 	public void rightThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Flux<Integer> m =
 				source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(Flux.never()), add);
@@ -159,8 +159,8 @@ public class FluxJoinTest {
 	@Test
 	public void leftDurationThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Flux<Integer> duration1 = Flux.error(new RuntimeException("Forced failure"));
 
@@ -177,8 +177,8 @@ public class FluxJoinTest {
 	@Test
 	public void rightDurationThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Flux<Integer> duration1 = Flux.error(new RuntimeException("Forced failure"));
 
@@ -195,8 +195,8 @@ public class FluxJoinTest {
 	@Test
 	public void leftDurationSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Function<Integer, Flux<Integer>> fail = t1 -> {
 			throw new RuntimeException("Forced failure");
@@ -215,8 +215,8 @@ public class FluxJoinTest {
 	@Test
 	public void rightDurationSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Function<Integer, Flux<Integer>> fail = t1 -> {
 			throw new RuntimeException("Forced failure");
@@ -235,8 +235,8 @@ public class FluxJoinTest {
 	@Test
 	public void resultSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = DirectProcessor.create();
-		Sinks.Many<Integer> source2 = DirectProcessor.create();
+		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		BiFunction<Integer, Integer, Integer> fail = (t1, t2) -> {
 			throw new RuntimeException("Forced failure");

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
@@ -143,8 +143,8 @@ public class FluxMergeSequentialTest {
 
 	@Test
 	public void mainErrorsDelayEnd() {
-		Sinks.Many<Integer> main = DirectProcessor.create();
-		final Sinks.Many<Integer> inner = DirectProcessor.create();
+		Sinks.Many<Integer> main = Sinks.many().unsafe().multicast().directBestEffort();
+		final Sinks.Many<Integer> inner = Sinks.many().unsafe().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = main.asFlux()
 										   .flatMapSequentialDelayError(t -> inner.asFlux(), 32, 32)
@@ -170,8 +170,8 @@ public class FluxMergeSequentialTest {
 
 	@Test
 	public void mainErrorsImmediate() {
-		Sinks.Many<Integer> main = DirectProcessor.create();
-		final Sinks.Many<Integer> inner = DirectProcessor.create();
+		Sinks.Many<Integer> main = Sinks.many().unsafe().multicast().directBestEffort();
+		final Sinks.Many<Integer> inner = Sinks.many().unsafe().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = main.asFlux().flatMapSequential(t -> inner.asFlux())
 		                                   .subscribeWith(AssertSubscriber.create());
@@ -463,7 +463,7 @@ public class FluxMergeSequentialTest {
 
 	@Test
 	public void testReentrantWork() {
-		final Sinks.Many<Integer> subject = DirectProcessor.create();
+		final Sinks.Many<Integer> subject = Sinks.many().unsafe().multicast().directBestEffort();
 
 		final AtomicBoolean once = new AtomicBoolean();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
@@ -103,7 +103,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void drop() {
-		Sinks.Many<String> processor = DirectProcessor.create();
+		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, this, DROP_LATEST);
@@ -131,7 +131,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void dropOldest() {
-		Sinks.Many<String> processor = DirectProcessor.create();
+		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, this, DROP_OLDEST);
@@ -159,7 +159,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void error() {
-		Sinks.Many<String> processor = DirectProcessor.create();
+		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, this, ERROR);
@@ -264,7 +264,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void dropCallbackError() {
-		Sinks.Many<String> processor = DirectProcessor.create();
+		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, v -> { throw new IllegalArgumentException("boom"); },
@@ -294,7 +294,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void dropOldestCallbackError() {
-		Sinks.Many<String> processor = DirectProcessor.create();
+		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, v -> { throw new IllegalArgumentException("boom"); },
@@ -324,7 +324,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void errorCallbackError() {
-		Sinks.Many<String> processor = DirectProcessor.create();
+		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, v -> { throw new IllegalArgumentException("boom"); },
@@ -354,7 +354,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void noCallbackWithErrorStrategyOverflowsAfterDrain() {
-		Sinks.Many<String> processor = DirectProcessor.create();
+		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, null, ERROR);
@@ -384,7 +384,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void noCallbackWithDropStrategyNoError() {
-		Sinks.Many<String> processor = DirectProcessor.create();
+		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, null, DROP_LATEST);
@@ -412,7 +412,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void noCallbackWithDropOldestStrategyNoError() {
-		Sinks.Many<String> processor = DirectProcessor.create();
+		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, null, DROP_OLDEST);
@@ -440,7 +440,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void fluxOnBackpressureBufferStrategyNoCallback() {
-		Sinks.Many<String> processor = DirectProcessor.create();
+		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
 
 		StepVerifier.create(processor.asFlux().onBackpressureBuffer(2, DROP_OLDEST), 0)
 		            .thenRequest(1)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureDropTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureDropTest.java
@@ -90,7 +90,7 @@ public class FluxOnBackpressureDropTest {
 
 	@Test
 	public void someDrops() {
-		Sinks.Many<Integer> tp = DirectProcessor.create();
+		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureLatestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureLatestTest.java
@@ -68,7 +68,7 @@ public class FluxOnBackpressureLatestTest {
 
 	@Test
 	public void backpressured() {
-		Sinks.Many<Integer> tp = DirectProcessor.create();
+		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
@@ -107,7 +107,7 @@ public class FluxOnBackpressureLatestTest {
 
 	@Test
 	public void error() {
-		Sinks.Many<Integer> tp = DirectProcessor.create();
+		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
@@ -123,7 +123,7 @@ public class FluxOnBackpressureLatestTest {
 
 	@Test
 	public void backpressureWithDrop() {
-		Sinks.Many<Integer> tp = DirectProcessor.create();
+		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = new AssertSubscriber<Integer>(0) {
 			@Override

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
@@ -449,14 +449,15 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		Assert.assertEquals(1, count.get());
 	}
 
+	@Test
 	public void diamond() {
 		@SuppressWarnings("deprecation")
-		DirectProcessor<Integer> sp = DirectProcessor.create();
+		FluxProcessor<Integer, Integer> processor = EmitterProcessor.create();
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Flux<Integer> fork1 = sp.map(d -> d)
+		Flux<Integer> fork1 = processor.map(d -> d)
 		                        .publishOn(Schedulers.fromExecutorService(exec));
-		Flux<Integer> fork2 = sp.map(d -> d)
+		Flux<Integer> fork2 = processor.map(d -> d)
 		                        .publishOn(Schedulers.fromExecutorService(exec));
 
 		ts.request(256);
@@ -467,7 +468,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		Flux.range(0, 128)
 		    .hide()
 		    .publishOn(Schedulers.fromExecutorService(ForkJoinPool.commonPool()))
-		    .subscribe(sp);
+		    .subscribe(processor);
 
 		ts.await(Duration.ofSeconds(5))
 		  .assertTerminated()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
@@ -493,7 +493,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void retry() {
-		Sinks.Many<Integer> dp = DirectProcessor.create();
+		Sinks.Many<Integer> dp = Sinks.many().unsafe().multicast().directBestEffort();
 		StepVerifier.create(
 				dp.asFlux()
 				  .publish()
@@ -520,7 +520,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void retryWithPublishOn() {
-		Sinks.Many<Integer> dp = DirectProcessor.create();
+		Sinks.Many<Integer> dp = Sinks.many().unsafe().multicast().directBestEffort();
 		StepVerifier.create(
 				dp.asFlux()
 				  .publishOn(Schedulers.parallel()).publish()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
@@ -399,7 +399,7 @@ public class FluxRefCountTest {
 
 	@Test
 	public void delayElementShouldNotCancelTwice() throws Exception {
-		Sinks.Many<Long> p = DirectProcessor.create();
+		Sinks.Many<Long> p = Sinks.many().unsafe().multicast().directBestEffort();
 		AtomicInteger cancellations = new AtomicInteger();
 
 		Flux<Long> publishedFlux = p.asFlux()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatWhenTest.java
@@ -415,7 +415,7 @@ public class FluxRepeatWhenTest {
 	@Test
 	public void inners() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
-		Sinks.Many<Long> signaller = DirectProcessor.create();
+		Sinks.Many<Long> signaller = Sinks.many().unsafe().multicast().directBestEffort();
 		Flux<Integer> when = Flux.empty();
 		FluxRepeatWhen.RepeatWhenMainSubscriber<Integer> main = new FluxRepeatWhen.RepeatWhenMainSubscriber<>(actual, signaller, when);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
@@ -574,7 +574,7 @@ public class FluxRetryWhenTest {
 	@Test
 	public void inners() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
-		Sinks.Many<Retry.RetrySignal> signaller = DirectProcessor.create();
+		Sinks.Many<Retry.RetrySignal> signaller = Sinks.many().unsafe().multicast().directBestEffort();
 		Flux<Integer> when = Flux.empty();
 		FluxRetryWhen.RetryWhenMainSubscriber<Integer> main = new FluxRetryWhen
 				.RetryWhenMainSubscriber<>(actual, signaller, when, Context.empty());

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSampleFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSampleFirstTest.java
@@ -34,9 +34,9 @@ public class FluxSampleFirstTest {
 	public void normal() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
-		Sinks.Many<Integer> sp3 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp3 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleFirst(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
@@ -81,9 +81,9 @@ public class FluxSampleFirstTest {
 	public void mainError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
-		Sinks.Many<Integer> sp3 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp3 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleFirst(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
@@ -106,9 +106,9 @@ public class FluxSampleFirstTest {
 	public void throttlerError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
-		Sinks.Many<Integer> sp3 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp3 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleFirst(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
@@ -131,7 +131,7 @@ public class FluxSampleFirstTest {
 	public void throttlerThrows() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleFirst(v -> {
@@ -153,7 +153,7 @@ public class FluxSampleFirstTest {
 	public void throttlerReturnsNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleFirst(v -> null)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTest.java
@@ -42,9 +42,9 @@ public class FluxSampleTest {
 	}
 
 	void sample(boolean complete, boolean which) {
-		Sinks.Many<Integer> main = DirectProcessor.create();
+		Sinks.Many<Integer> main = Sinks.many().unsafe().multicast().directBestEffort();
 
-		Sinks.Many<String> other = DirectProcessor.create();
+		Sinks.Many<String> other = Sinks.many().unsafe().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -128,9 +128,9 @@ public class FluxSampleTest {
 
 	@Test
 	public void subscriberCancels() {
-		Sinks.Many<Integer> main = DirectProcessor.create();
+		Sinks.Many<Integer> main = Sinks.many().unsafe().multicast().directBestEffort();
 
-		Sinks.Many<String> other = DirectProcessor.create();
+		Sinks.Many<String> other = Sinks.many().unsafe().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -150,9 +150,9 @@ public class FluxSampleTest {
 	}
 
 	public void completeImmediately(boolean which) {
-		Sinks.Many<Integer> main = DirectProcessor.create();
+		Sinks.Many<Integer> main = Sinks.many().unsafe().multicast().directBestEffort();
 
-		Sinks.Many<String> other = DirectProcessor.create();
+		Sinks.Many<String> other = Sinks.many().unsafe().multicast().directBestEffort();
 
 		if (which) {
 			main.emitComplete();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTimeoutTest.java
@@ -36,9 +36,9 @@ public class FluxSampleTimeoutTest {
 	public void normal() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
-		Sinks.Many<Integer> sp3 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp3 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleTimeout(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
@@ -77,8 +77,8 @@ public class FluxSampleTimeoutTest {
 	public void mainError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleTimeout(v -> sp2.asFlux())
@@ -100,8 +100,8 @@ public class FluxSampleTimeoutTest {
 	public void throttlerError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleTimeout(v -> sp2.asFlux())
@@ -123,7 +123,7 @@ public class FluxSampleTimeoutTest {
 	public void throttlerReturnsNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleTimeout(v -> null)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
@@ -34,8 +34,8 @@ public class FluxSwitchMapTest {
 	public void noswitch() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .switchMap(v -> sp2.asFlux())
@@ -65,8 +65,8 @@ public class FluxSwitchMapTest {
 	public void noswitchBackpressured() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .switchMap(v -> sp2.asFlux())
@@ -108,9 +108,9 @@ public class FluxSwitchMapTest {
 	public void doswitch() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
-		Sinks.Many<Integer> sp3 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp3 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .switchMap(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
@@ -159,8 +159,8 @@ public class FluxSwitchMapTest {
 	public void mainCompletesBefore() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux().switchMap(v -> sp2.asFlux())
 		   .subscribe(ts);
@@ -188,8 +188,8 @@ public class FluxSwitchMapTest {
 	public void mainError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux().switchMap(v -> sp2.asFlux())
 		   .subscribe(ts);
@@ -213,8 +213,8 @@ public class FluxSwitchMapTest {
 	public void innerError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux().switchMap(v -> sp2.asFlux())
 		   .subscribe(ts);
@@ -240,7 +240,7 @@ public class FluxSwitchMapTest {
 	public void mapperThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .switchMap(v -> {
@@ -260,7 +260,7 @@ public class FluxSwitchMapTest {
 	public void mapperReturnsNull() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .switchMap(v -> null)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.reactivestreams.Subscription;
 
@@ -110,9 +109,9 @@ public class FluxTimeoutTest {
 
 	@Test
 	public void oldTimeoutHasNoEffect() {
-		Sinks.Many<Integer> source = DirectProcessor.create();
+		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
 
-		Sinks.Many<Integer> tp = DirectProcessor.create();
+		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -135,9 +134,9 @@ public class FluxTimeoutTest {
 
 	@Test
 	public void oldTimeoutCompleteHasNoEffect() {
-		Sinks.Many<Integer> source = DirectProcessor.create();
+		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
 
-		Sinks.Many<Integer> tp = DirectProcessor.create();
+		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -160,9 +159,9 @@ public class FluxTimeoutTest {
 
 	@Test
 	public void oldTimeoutErrorHasNoEffect() {
-		Sinks.Many<Integer> source = DirectProcessor.create();
+		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
 
-		Sinks.Many<Integer> tp = DirectProcessor.create();
+		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -250,9 +249,9 @@ public class FluxTimeoutTest {
 	public void timeoutRequested() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = DirectProcessor.create();
+		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
 
-		Sinks.Many<Integer> tp = DirectProcessor.create();
+		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
 
 		source.asFlux()
 			  .timeout(tp.asFlux(), v -> tp.asFlux())

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxUsingTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxUsingTest.java
@@ -263,7 +263,7 @@ public class FluxUsingTest extends FluxOperatorTest<String, String> {
 
 		AtomicInteger cleanup = new AtomicInteger();
 
-		Sinks.Many<Integer> tp = DirectProcessor.create();
+		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Flux.using(() -> 1, r -> tp.asFlux(), cleanup::set, true)
 		    .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
@@ -53,8 +53,8 @@ public class FluxWindowBoundaryTest {
 	public void normal() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .window(sp2.asFlux())
@@ -89,8 +89,8 @@ public class FluxWindowBoundaryTest {
 	public void normalOtherCompletes() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .window(sp2.asFlux())
@@ -125,8 +125,8 @@ public class FluxWindowBoundaryTest {
 	public void mainError() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .window(sp2.asFlux())
@@ -167,8 +167,8 @@ public class FluxWindowBoundaryTest {
 	public void otherError() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .window(sp2.asFlux())

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
@@ -431,7 +431,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalUntil() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(sp1.asFlux(),
 				Queues.small(),
 				Queues.unbounded(),
@@ -498,7 +498,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void mainErrorUntilIsPropagatedToBothWindowAndMain() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.UNTIL);
@@ -524,7 +524,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void predicateErrorUntil() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> {
@@ -552,7 +552,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalUntilCutBefore() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowUntilCutBefore = new FluxWindowPredicate<>(sp1.asFlux(),
 				Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.UNTIL_CUT_BEFORE);
@@ -583,7 +583,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void mainErrorUntilCutBeforeIsPropagatedToBothWindowAndMain() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowUntilCutBefore =
 				new FluxWindowPredicate<>(sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 						i -> i % 3 == 0, Mode.UNTIL_CUT_BEFORE);
@@ -610,7 +610,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void predicateErrorUntilCutBefore() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowUntilCutBefore =
 				new FluxWindowPredicate<>(sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> {
@@ -644,7 +644,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalWhile() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 != 0, Mode.WHILE);
@@ -675,7 +675,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalWhileDoesntInitiallyMatch() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.WHILE);
@@ -713,7 +713,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalWhileDoesntMatch() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i > 4, Mode.WHILE);
@@ -748,7 +748,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void mainErrorWhileIsPropagatedToBothWindowAndMain() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.WHILE);
@@ -795,7 +795,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void predicateErrorWhile() {
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTest.java
@@ -427,7 +427,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 	public void exactError() {
 		AssertSubscriber<Publisher<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp = DirectProcessor.create();
+		Sinks.Many<Integer> sp = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp.asFlux()
 		  .window(2, 2)
@@ -456,7 +456,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 	public void skipError() {
 		AssertSubscriber<Publisher<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp = DirectProcessor.create();
+		Sinks.Many<Integer> sp = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp.asFlux()
 		  .window(2, 3)
@@ -485,7 +485,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 	public void skipInGapError() {
 		AssertSubscriber<Publisher<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp = DirectProcessor.create();
+		Sinks.Many<Integer> sp = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp.asFlux()
 		  .window(1, 3)
@@ -511,7 +511,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 	public void overlapError() {
 		AssertSubscriber<Publisher<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp = DirectProcessor.create();
+		Sinks.Many<Integer> sp = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp.asFlux()
 		  .window(2, 1)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
@@ -149,10 +149,10 @@ public class FluxWindowWhenTest {
 	public void normal() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = DirectProcessor.create();
-		Sinks.Many<Integer> sp2 = DirectProcessor.create();
-		Sinks.Many<Integer> sp3 = DirectProcessor.create();
-		Sinks.Many<Integer> sp4 = DirectProcessor.create();
+		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp3 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp4 = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp1.asFlux().windowWhen(sp2.asFlux(), v -> v == 1 ? sp3.asFlux() : sp4.asFlux())
 		   .subscribe(ts);
@@ -192,10 +192,10 @@ public class FluxWindowWhenTest {
 	public void normalStarterEnds() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = DirectProcessor.create();
-		Sinks.Many<Integer> openSelector = DirectProcessor.create();
-		Sinks.Many<Integer> closeSelectorFor1 = DirectProcessor.create();
-		Sinks.Many<Integer> closeSelectorForOthers = DirectProcessor.create();
+		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> openSelector = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> closeSelectorFor1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> closeSelectorForOthers = Sinks.many().unsafe().multicast().directBestEffort();
 
 		source.asFlux().windowWhen(openSelector.asFlux(), v -> v == 1 ? closeSelectorFor1.asFlux() : closeSelectorForOthers.asFlux())
 		      .subscribe(ts);
@@ -236,10 +236,10 @@ public class FluxWindowWhenTest {
 	public void oneWindowOnly() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = DirectProcessor.create();
-		Sinks.Many<Integer> openSelector = DirectProcessor.create();
-		Sinks.Many<Integer> closeSelectorFor1 = DirectProcessor.create();
-		Sinks.Many<Integer> closeSelectorOthers = DirectProcessor.create();
+		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> openSelector = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> closeSelectorFor1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> closeSelectorOthers = Sinks.many().unsafe().multicast().directBestEffort();
 
 		source.asFlux().windowWhen(openSelector.asFlux(), v -> v == 1 ? closeSelectorFor1.asFlux() : closeSelectorOthers.asFlux())
 		      .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -791,7 +791,7 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void failDoubleTerminalPublisher() {
-		Sinks.Many<Integer> d1 = DirectProcessor.create();
+		Sinks.Many<Integer> d1 = Sinks.many().unsafe().multicast().directBestEffort();
 		Hooks.onErrorDropped(e -> {
 		});
 		StepVerifier.create(Flux.zip(obj -> 0, Flux.just(1), d1.asFlux(), s -> {
@@ -1083,7 +1083,7 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void prematureCompleteSourceEmptyDouble() {
-		Sinks.Many<Integer> d = DirectProcessor.create();
+		Sinks.Many<Integer> d = Sinks.many().unsafe().multicast().directBestEffort();
 		StepVerifier.create(Flux.zip(obj -> 0, d.asFlux(), s -> {
 			Scannable directInner = Scannable.from(d).inners().findFirst().get();
 			CoreSubscriber<?> directInnerDownstream = (CoreSubscriber<?>) directInner.scan(Scannable.Attr.ACTUAL);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
@@ -85,7 +85,7 @@ public class MonoTimeoutTest {
 
 		NextProcessor<Integer> source = new NextProcessor<>(null);
 
-		Sinks.Many<Integer> tp = DirectProcessor.create();
+		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
 
 		source.timeout(tp.asFlux())
 		      .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/SerializedManySinkTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SerializedManySinkTest.java
@@ -92,10 +92,10 @@ public class SerializedManySinkTest {
 
 	@Test
 	public void sameThreadRecursion() throws Exception {
-		DirectProcessor<Object> processor = DirectProcessor.create();
-		SerializedManySink<Object> manySink = new SerializedManySink<>(processor, Context::empty);
+		Sinks.Many<Object> sink = Sinks.many().unsafe().multicast().directBestEffort();
+		SerializedManySink<Object> manySink = new SerializedManySink<>(sink, Context::empty);
 
-		CompletableFuture<Object> muchFuture = processor.doOnNext(o -> {
+		CompletableFuture<Object> muchFuture = sink.asFlux().doOnNext(o -> {
 			if ("first".equals(o)) {
 				assertThat(manySink.lockedAt).as("lockedAt").isEqualTo(Thread.currentThread());
 				assertThat(manySink.tryEmitNext("second")).as("second").isEqualTo(Emission.OK);
@@ -108,7 +108,7 @@ public class SerializedManySinkTest {
 
 	static class EmptyMany<T> implements Sinks.Many<T> {
 
-		final Sinks.Many<T> delegate = DirectProcessor.create();
+		final Sinks.Many<T> delegate = Sinks.many().unsafe().multicast().directBestEffort();
 
 		@Override
 		public Emission tryEmitNext(T o) {

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkManyBestEffortTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkManyBestEffortTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Disposable;
+import reactor.core.Scannable;
+import reactor.core.publisher.SinkManyBestEffort.DirectInner;
+import reactor.core.publisher.Sinks.Emission;
+import reactor.test.StepVerifier;
+import reactor.test.subscriber.AssertSubscriber;
+import reactor.util.context.Context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class SinkManyBestEffortTest {
+
+	@Test
+	void currentContextReflectSubscriberContext() {
+		SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createBestEffort();
+
+		assertThat(sink.currentContext()).isSameAs(Context.empty());
+
+		AssertSubscriber<Integer> subscriber1 = new AssertSubscriber<>(Context.of("key", "value1"));
+		AssertSubscriber<Integer> subscriber2 = new AssertSubscriber<>(Context.of("key", "value2"));
+		sink.subscribe(subscriber1);
+		sink.subscribe(subscriber2);
+
+		assertThat(sink.currentContext()).isEqualTo(subscriber1.currentContext());
+	}
+
+	@Test
+	void tryEmitNextNoSubscribers() {
+		SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createBestEffort();
+
+		assertThat(sink.tryEmitNext(1)).as("tryEmitNext").isEqualTo(Emission.FAIL_ZERO_SUBSCRIBER);
+	}
+
+	@Test
+	void tryEmitNextOnTerminated() {
+		SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createBestEffort();
+		sink.tryEmitComplete().orThrow();
+
+		assertThat(sink.tryEmitNext(1)).as("tryEmitNext").isEqualTo(Emission.FAIL_TERMINATED);
+	}
+
+	@Test
+	void tryEmitCompleteNoSubscribersRetains() {
+		SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createBestEffort();
+
+		assertThat(sink.tryEmitComplete()).as("tryEmitComplete").isEqualTo(Emission.OK);
+
+		StepVerifier.create(sink.asFlux())
+		            .verifyComplete();
+	}
+
+	@Test
+	void tryEmitCompleteOnTerminated() {
+		SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createBestEffort();
+		sink.tryEmitComplete().orThrow();
+
+		assertThat(sink.tryEmitComplete()).as("tryEmitComplete").isEqualTo(Emission.FAIL_TERMINATED);
+	}
+
+	@Test
+	void tryEmitErrorNoSubscribersRetains() {
+		SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createBestEffort();
+
+		assertThat(sink.tryEmitError(new IllegalStateException("boom"))).as("tryEmitError").isEqualTo(Emission.OK);
+
+		StepVerifier.create(sink.asFlux())
+		            .verifyErrorMessage("boom");
+	}
+
+	@Test
+	void tryEmitErrorOnTerminated() {
+		SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createBestEffort();
+		sink.tryEmitError(new IllegalStateException("boom")).orThrow();
+
+		assertThat(sink.tryEmitError(new IllegalStateException("boom ignored"))).as("tryEmitError").isEqualTo(Emission.FAIL_TERMINATED);
+
+		StepVerifier.create(sink.asFlux())
+		            .verifyErrorMessage("boom");
+	}
+
+	@Test
+	void tryEmitErrorOnSubscribers() {
+		SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createBestEffort();
+
+		AssertSubscriber<Integer> sub1 = AssertSubscriber.create();
+		AssertSubscriber<Integer> sub2 = AssertSubscriber.create(0);
+		sink.subscribe(sub1);
+		sink.subscribe(sub2);
+
+		assertThat(sink.tryEmitError(new IllegalStateException("boom"))).as("tryEmitError").isEqualTo(Emission.OK);
+
+		sub1.assertErrorMessage("boom");
+		sub2.assertErrorMessage("boom");
+	}
+
+	@Test
+	void addSubscriberThatCancelsOnSubscription() {
+		SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createBestEffort();
+
+		sink.subscribe(new BaseSubscriber<Integer>() {
+			@Override
+			protected void hookOnSubscribe(Subscription subscription) {
+				subscription.cancel();
+			}
+		});
+
+		assertThat(sink.currentSubscriberCount()).as("immediately removes").isZero();
+	}
+
+	@Test
+	void innersReflectsSubscribers() {
+		SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createBestEffort();
+
+		assertThat(sink.inners()).as("before subscribers").isEmpty();
+
+		Disposable sub1 = sink.subscribe();
+		Disposable sub2 = sink.subscribe();
+
+		assertThat(sink.inners()).hasSize(2);
+		assertThat(sink.inners().map(inner -> inner.scanUnsafe(Scannable.Attr.ACTUAL)))
+				.containsExactly(sub1, sub2);
+	}
+
+	@Test
+	void scanSink() {
+		SinkManyBestEffort<Integer> sinkNormal = SinkManyBestEffort.createBestEffort();
+
+		assertThat(sinkNormal.scan(Scannable.Attr.TERMINATED)).as("normal not terminated").isFalse();
+		sinkNormal.tryEmitComplete().orThrow();
+		assertThat(sinkNormal.scan(Scannable.Attr.TERMINATED)).as("normal terminated").isTrue();
+
+		SinkManyBestEffort<Integer> sinkError = SinkManyBestEffort.createBestEffort();
+		Throwable expectedError = new IllegalStateException("boom");
+		sinkError.tryEmitError(expectedError).orThrow();
+
+		assertThat(sinkError.scan(Scannable.Attr.TERMINATED)).as("error terminated").isTrue();
+		assertThat(sinkError.scan(Scannable.Attr.ERROR)).as("error captured").isSameAs(expectedError);
+	}
+
+	@Test
+	void scanInner() {
+		InnerConsumer<? super String> actual = mock(InnerConsumer.class);
+		DirectInnerContainer<String> parent = mock(DirectInnerContainer.class);
+
+		DirectInner<String> test = new SinkManyBestEffort.DirectInner<>(actual, parent);
+
+		assertThat(test.scanUnsafe(Scannable.Attr.PARENT)).isSameAs(parent); //the mock isn't scannable
+		assertThat(test.scanUnsafe(Scannable.Attr.ACTUAL)).isSameAs(actual); //the mock isn't scannable
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+
+		test.cancel();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
+	}
+
+	@Nested
+	class IndividualSpecific {
+
+		@Test
+		void downstreamStillUsableAfterBackpressure() {
+			SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createBestEffort();
+
+			AssertSubscriber<Integer> sub1 = AssertSubscriber.create();
+			AssertSubscriber<Integer> sub2 = AssertSubscriber.create(0);
+
+			sink.subscribe(sub1);
+			sink.subscribe(sub2);
+
+			assertThat(sink.tryEmitNext(1)).as("tryEmitNext(1)").isEqualTo(Emission.FAIL_OVERFLOW);
+
+			sub1.assertValues(1).assertNotTerminated();
+			sub2.assertNoValues().assertNotTerminated();
+
+			sub2.request(1);
+
+			assertThat(sink.tryEmitNext(2)).as("tryEmitNext(2)").isEqualTo(Emission.OK);
+			sub1.assertValues(1, 2);
+			sub2.assertValues(2);
+
+			sink.tryEmitComplete().orThrow();
+			sub1.assertValues(1, 2).assertComplete();
+			sub2.assertValues(2).assertComplete();
+		}
+
+		@Test
+		void allCancelledWhenTryingEmitInner() {
+			SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createBestEffort();
+
+			AssertSubscriber<Integer> sub1 = AssertSubscriber.create();
+			AssertSubscriber<Integer> sub2 = AssertSubscriber.create(0);
+
+			sink.subscribe(sub1);
+			sink.subscribe(sub2);
+
+			sink.subscribers[0].set(true); //mark as cancelled
+			sink.subscribers[1].set(true);
+
+			assertThat(sink.tryEmitNext(1)).as("tryEmitNext(1)").isEqualTo(Emission.FAIL_ZERO_SUBSCRIBER);
+
+			sub1.assertNoValues().assertNotTerminated();
+			sub2.assertNoValues().assertNotTerminated();
+		}
+	}
+
+	@Nested
+	class AllOrNothingSpecific {
+
+		@Test
+		void downstreamStillUsableAfterBackpressure() {
+			SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createAllOrNothing();
+
+			AssertSubscriber<Integer> sub1 = AssertSubscriber.create();
+			AssertSubscriber<Integer> sub2 = AssertSubscriber.create(0);
+
+			sink.subscribe(sub1);
+			sink.subscribe(sub2);
+
+			assertThat(sink.tryEmitNext(1)).as("tryEmitNext(1)").isEqualTo(Emission.FAIL_OVERFLOW);
+
+			sub1.assertNoValues().assertNotTerminated();
+			sub2.assertNoValues().assertNotTerminated();
+
+			sub2.request(1);
+
+			assertThat(sink.tryEmitNext(2)).as("tryEmitNext(2)").isEqualTo(Emission.OK);
+			sub1.assertValues(2);
+			sub2.assertValues(2);
+
+			sink.tryEmitComplete().orThrow();
+			sub1.assertValues(2).assertComplete();
+			sub2.assertValues(2).assertComplete();
+		}
+
+		@Test
+		void oneCancelledDuringRequestAccountingLoopIsIgnored() {
+			SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createAllOrNothing();
+
+			AssertSubscriber<Integer> sub1 = AssertSubscriber.create();
+			AssertSubscriber<Integer> sub2 = AssertSubscriber.create(0);
+
+			sink.subscribe(sub1);
+			sink.subscribe(sub2);
+
+			SinkManyBestEffort.DirectInner<Integer> inner2 = sink.subscribers[1];
+			inner2.set(true);
+
+			assertThat(sink.tryEmitNext(1)).as("tryEmitNext(1)").isEqualTo(Emission.OK);
+
+			sub1.assertValues(1).assertNotTerminated();
+			sub2.assertNoValues().assertNotTerminated();
+
+			//now properly remove / cancel the subscriber
+			sink.remove(inner2);
+
+			assertThat(sink.tryEmitNext(2)).as("tryEmitNext(2)").isEqualTo(Emission.OK);
+			assertThat(sink.tryEmitComplete()).as("tryEmitComplete").isEqualTo(Emission.OK);
+			sub1.assertValues(1, 2).assertComplete();
+			sub2.assertNoValues().assertNotTerminated();
+		}
+
+		@Test
+		void allCancelledDuringRequestAccountingLoopIsIgnored() {
+			SinkManyBestEffort<Integer> sink = SinkManyBestEffort.createAllOrNothing();
+
+			AssertSubscriber<Integer> sub1 = AssertSubscriber.create();
+			AssertSubscriber<Integer> sub2 = AssertSubscriber.create(0);
+
+			sink.subscribe(sub1);
+			sink.subscribe(sub2);
+
+			sink.subscribers[0].set(true);
+			sink.subscribers[1].set(true);
+
+			assertThat(sink.tryEmitNext(1)).as("tryEmitNext(1)").isEqualTo(Emission.FAIL_ZERO_SUBSCRIBER);
+
+			sub1.assertNoValues().assertNotTerminated();
+			sub2.assertNoValues().assertNotTerminated();
+		}
+	}
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/StrictSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/StrictSubscriberTest.java
@@ -73,7 +73,7 @@ public class StrictSubscriberTest {
 		AtomicBoolean state2 = new AtomicBoolean();
 		AtomicReference<Throwable> e = new AtomicReference<>();
 
-		Sinks.Many<Integer> sp = DirectProcessor.create();
+		Sinks.Many<Integer> sp = Sinks.many().unsafe().multicast().directBestEffort();
 
 		sp.asFlux().doOnCancel(() -> state2.set(state1.get()))
 		  .subscribe(new Subscriber<Integer>() {

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxWindowConsistencyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxWindowConsistencyTest.java
@@ -25,7 +25,6 @@ import java.util.function.Predicate;
 import org.junit.Before;
 import org.junit.Test;
 
-import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.GroupedFlux;
 import reactor.core.publisher.Sinks;
@@ -35,7 +34,7 @@ import static org.junit.Assert.assertEquals;
 
 public class FluxWindowConsistencyTest {
 
-	Sinks.Many<Integer> sourceProcessor = DirectProcessor.create();
+	Sinks.Many<Integer> sourceProcessor = Sinks.many().unsafe().multicast().directBestEffort();
 
 	Flux<Integer> source;
 
@@ -208,7 +207,7 @@ public class FluxWindowConsistencyTest {
 
 	@Test
 	public void windowBoundaryComplete() throws Exception {
-		Sinks.Many<Integer> boundary = DirectProcessor.create();
+		Sinks.Many<Integer> boundary = Sinks.many().unsafe().multicast().directBestEffort();
 		Flux<Flux<Integer>> windows = source.window(boundary.asFlux());
 		subscribe(windows);
 		generate(0, 3);
@@ -219,9 +218,9 @@ public class FluxWindowConsistencyTest {
 
 	@Test
 	public void windowStartEndComplete() throws Exception {
-		Sinks.Many<Integer> start = DirectProcessor.create();
-		Sinks.Many<Integer> end1 = DirectProcessor.create();
-		Sinks.Many<Integer> end2 = DirectProcessor.create();
+		Sinks.Many<Integer> start = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> end1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> end2 = Sinks.many().unsafe().multicast().directBestEffort();
 		Flux<Flux<Integer>> windows = source.windowWhen(start.asFlux(), v -> v == 1 ? end1.asFlux() : end2.asFlux());
 		subscribe(windows);
 		start.emitNext(1);
@@ -306,7 +305,7 @@ public class FluxWindowConsistencyTest {
 
 	@Test
 	public void windowBoundaryMainCancel() throws Exception {
-		Sinks.Many<Integer> boundary = DirectProcessor.create();
+		Sinks.Many<Integer> boundary = Sinks.many().unsafe().multicast().directBestEffort();
 		Flux<Flux<Integer>> windows = source.window(boundary.asFlux());
 
 		subscribe(windows);
@@ -322,9 +321,9 @@ public class FluxWindowConsistencyTest {
 
 	@Test
 	public void windowStartEndMainCancel() throws Exception {
-		Sinks.Many<Integer> start = DirectProcessor.create();
-		Sinks.Many<Integer> end1 = DirectProcessor.create();
-		Sinks.Many<Integer> end2 = DirectProcessor.create();
+		Sinks.Many<Integer> start = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> end1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> end2 = Sinks.many().unsafe().multicast().directBestEffort();
 		Flux<Flux<Integer>> windows = source.windowWhen(start.asFlux(), v -> v == 1 ? end1.asFlux() : end2.asFlux());
 		subscribe(windows);
 		start.emitNext(1);
@@ -414,7 +413,7 @@ public class FluxWindowConsistencyTest {
 
 	@Test
 	public void windowBoundaryMainCancelNoNewWindow() throws Exception {
-		Sinks.Many<Integer> boundary = DirectProcessor.create();
+		Sinks.Many<Integer> boundary = Sinks.many().unsafe().multicast().directBestEffort();
 		Flux<Flux<Integer>> windows = source.window(boundary.asFlux());
 
 		subscribe(windows);
@@ -427,9 +426,9 @@ public class FluxWindowConsistencyTest {
 
 	@Test
 	public void windowStartEndMainCancelNoNewWindow() throws Exception {
-		Sinks.Many<Integer> start = DirectProcessor.create();
-		Sinks.Many<Integer> end1 = DirectProcessor.create();
-		Sinks.Many<Integer> end2 = DirectProcessor.create();
+		Sinks.Many<Integer> start = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> end1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> end2 = Sinks.many().unsafe().multicast().directBestEffort();
 		Flux<Flux<Integer>> windows = source.windowWhen(start.asFlux(), v -> v == 1 ? end1.asFlux() : end2.asFlux());
 		subscribe(windows);
 		start.emitNext(1);
@@ -507,7 +506,7 @@ public class FluxWindowConsistencyTest {
 
 	@Test
 	public void windowBoundaryInnerCancel() throws Exception {
-		Sinks.Many<Integer> boundaryProcessor = DirectProcessor.create();
+		Sinks.Many<Integer> boundaryProcessor = Sinks.many().unsafe().multicast().directBestEffort();
 		Flux<Flux<Integer>> windows = source.window(boundaryProcessor.asFlux());
 		subscribe(windows);
 		generateWithCancel(0, 6, 1);
@@ -516,9 +515,9 @@ public class FluxWindowConsistencyTest {
 
 	@Test
 	public void windowStartEndInnerCancel() throws Exception {
-		Sinks.Many<Integer> start = DirectProcessor.create();
-		Sinks.Many<Integer> end1 = DirectProcessor.create();
-		Sinks.Many<Integer> end2 = DirectProcessor.create();
+		Sinks.Many<Integer> start = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> end1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> end2 = Sinks.many().unsafe().multicast().directBestEffort();
 		Flux<Flux<Integer>> windows = source.windowWhen(start.asFlux(), v -> v == 1 ? end1.asFlux() : end2.asFlux());
 		subscribe(windows);
 		start.emitNext(1);

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -46,7 +46,6 @@ import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
-import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
@@ -663,7 +662,7 @@ public class SchedulersTest {
 
 	public void assertRejectingScheduler(Scheduler scheduler) {
 		try {
-			Sinks.Many<String> p = DirectProcessor.create();
+			Sinks.Many<String> p = Sinks.many().unsafe().multicast().directBestEffort();
 
 			AtomicReference<String> r = new AtomicReference<>();
 			CountDownLatch l = new CountDownLatch(1);

--- a/reactor-core/src/test/java/reactor/guide/GuideTests.java
+++ b/reactor-core/src/test/java/reactor/guide/GuideTests.java
@@ -48,7 +48,6 @@ import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.publisher.BaseSubscriber;
 import reactor.core.publisher.ConnectableFlux;
-import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
@@ -202,7 +201,7 @@ public class GuideTests {
 
 	@Test
 	public void advancedHot() {
-		Sinks.Many<String> hotSource = DirectProcessor.create();
+		Sinks.Many<String> hotSource = Sinks.many().unsafe().multicast().directBestEffort();
 
 		Flux<String> hotFlux = hotSource.asFlux().map(String::toUpperCase);
 


### PR DESCRIPTION
This commit adds a new `Sinks.Many` with multicast semantics close to
DirectProcessor but not quite like it: it doesn't buffer but tries to
push elements to fast subscribers when encountering a mix of fast and
slow subscribers. In that case, Emission.OK is returned as soon as at
least one subscriber had enough demand to be pushed the value to. If
none of the subscribers have demand, then Emission.FAIL_OVERFLOW is
returned instead.

It can also be configured to fail fast: the whole array of Subscribers
is checked for demand and if at least one has not enough demand, the
element is not pushed at all. In that case, the Emission.FAIL_OVERFLOW
result is returned.