### PR TITLE
Mutualize with DirectProcessor's inner through a common interface for parent

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/DirectProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/DirectProcessorTest.java
@@ -20,13 +20,11 @@ import java.time.Duration;
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
-import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 @SuppressWarnings("deprecation")
 public class DirectProcessorTest {
@@ -250,23 +248,6 @@ public class DirectProcessorTest {
         ts.assertValues(1)
           .assertNotComplete()
           .assertNoError();
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void scanInner() {
-	    InnerConsumer<? super String> actual = mock(InnerConsumer.class);
-        DirectProcessor<String> parent = new DirectProcessor<>();
-
-        DirectProcessor.DirectInner<String> test =
-                new DirectProcessor.DirectInner<>(actual, parent);
-
-        assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
-        assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
-        assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
-
-        test.cancel();
-        assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
     }
 
     @Test

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkManyBestEffortTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkManyBestEffortTest.java
@@ -171,8 +171,8 @@ class SinkManyBestEffortTest {
 
 		DirectInner<String> test = new SinkManyBestEffort.DirectInner<>(actual, parent);
 
-		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
-		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
+		assertThat(test.scanUnsafe(Scannable.Attr.PARENT)).isSameAs(parent); //the mock isn't scannable
+		assertThat(test.scanUnsafe(Scannable.Attr.ACTUAL)).isSameAs(actual); //the mock isn't scannable
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
 
 		test.cancel();


### PR DESCRIPTION
see https://github.com/reactor/reactor-core/pull/2392#discussion_r491953793