### PR TITLE
fix #2344 migrate reactor-core tests to junit5

### DIFF
--- a/buildSrc/src/main/java/io/reactor/gradle/JavaConventions.java
+++ b/buildSrc/src/main/java/io/reactor/gradle/JavaConventions.java
@@ -59,6 +59,8 @@ public class JavaConventions implements Plugin<Project> {
 					       "-Xlint:processing",
 					       "-Xlint:static",
 					       "-Xlint:try",
+						   "-Xmaxerrs", "1000",
+						   "-Xmaxwarns", "1",
 					       "-Xlint:deprecation",
 					       "-Xlint:unchecked",
 					       "-Xlint:-serial",      // intentionally disabled

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -73,7 +73,11 @@ dependencies {
 	//Optional JDK 9 Converter
 	jsr166backport "io.projectreactor:jsr166:$jsr166BackportVersion"
 
-	testImplementation "junit:junit:$jUnitVersion"
+	testImplementation platform("org.junit:junit-bom:${jUnitPlatformVersion}")
+	testImplementation "junit:junit:${jUnitVersion}"
+	testImplementation "org.junit.jupiter:junit-jupiter-api"
+	testImplementation "org.junit.jupiter:junit-jupiter-params"
+	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 
 	testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
 	// Testing
@@ -85,7 +89,6 @@ dependencies {
 	testImplementation "org.testng:testng:$testNgVersion"
 	testImplementation "org.mockito:mockito-core:$mockitoVersion"
 	testImplementation "org.openjdk.jol:jol-core:$javaObjectLayoutVersion"
-	testImplementation "pl.pragmatists:JUnitParams:$jUnitParamsVersion"
 	testImplementation "org.awaitility:awaitility:$awaitilityVersion"
 
 	// withMicrometerTest is a test-set that validates what happens when micrometer *IS*
@@ -203,6 +206,10 @@ task testNG(type: Test, group: 'verification') {
 	doFirst {
 		println "Additional tests from `testNG` ($includes)"
 	}
+}
+
+tasks.withType(Test).all {
+	useJUnitPlatform()
 }
 
 //inherit basic test task + common configuration in root

--- a/reactor-core/src/test/java/reactor/HooksTraceTest.java
+++ b/reactor-core/src/test/java/reactor/HooksTraceTest.java
@@ -19,9 +19,9 @@ package reactor;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 
 import reactor.core.Scannable;
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.*;
  */
 public class HooksTraceTest {
 
-	@After
+	@AfterEach
 	public void resetHooks() {
 		Hooks.resetOnEachOperator();
 		Hooks.resetOnLastOperator();

--- a/reactor-core/src/test/java/reactor/core/CoreTest.java
+++ b/reactor-core/src/test/java/reactor/core/CoreTest.java
@@ -18,7 +18,7 @@ package reactor.core;
 import java.util.Collections;
 
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.util.annotation.Nullable;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;

--- a/reactor-core/src/test/java/reactor/core/DisposableTest.java
+++ b/reactor-core/src/test/java/reactor/core/DisposableTest.java
@@ -18,7 +18,7 @@ package reactor.core;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.FakeDisposable;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-core/src/test/java/reactor/core/DisposablesTest.java
+++ b/reactor-core/src/test/java/reactor/core/DisposablesTest.java
@@ -19,7 +19,7 @@ package reactor.core;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.FakeDisposable;
 import reactor.test.util.RaceTestUtils;

--- a/reactor-core/src/test/java/reactor/core/ExceptionsTest.java
+++ b/reactor-core/src/test/java/reactor/core/ExceptionsTest.java
@@ -21,10 +21,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import java.util.function.Predicate;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import reactor.core.publisher.Mono;
 import reactor.test.util.RaceTestUtils;
@@ -289,7 +288,7 @@ public class ExceptionsTest {
 	static final AtomicReferenceFieldUpdater<ExceptionsTest, Throwable> ADD_THROWABLE =
 			AtomicReferenceFieldUpdater.newUpdater(ExceptionsTest.class, Throwable.class, "addThrowable");
 
-	@Before
+	@BeforeEach
 	public void resetAddThrowable() {
 		addThrowable = null;
 	}

--- a/reactor-core/src/test/java/reactor/core/ListCompositeDisposableTest.java
+++ b/reactor-core/src/test/java/reactor/core/ListCompositeDisposableTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Disposables.ListCompositeDisposable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.FakeDisposable;

--- a/reactor-core/src/test/java/reactor/core/ScannableTest.java
+++ b/reactor-core/src/test/java/reactor/core/ScannableTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;

--- a/reactor-core/src/test/java/reactor/core/SwapDisposableTest.java
+++ b/reactor-core/src/test/java/reactor/core/SwapDisposableTest.java
@@ -20,10 +20,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -32,12 +31,11 @@ import static org.mockito.Mockito.*;
 /**
  * @author David Karnok
  */
-@RunWith(MockitoJUnitRunner.class)
 public class SwapDisposableTest {
 
 	private Disposables.SwapDisposable sequentialDisposable;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		sequentialDisposable = new Disposables.SwapDisposable();
 	}
@@ -125,7 +123,8 @@ public class SwapDisposableTest {
 		verify(underlying).dispose();
 	}
 
-	@Test(timeout = 1000)
+	@Test
+	@Timeout(1)
 	public void settingUnderlyingWhenUnsubscribedCausesImmediateUnsubscriptionConcurrently()
 			throws InterruptedException {
 		final Disposable firstSet = mock(Disposable.class);

--- a/reactor-core/src/test/java/reactor/core/publisher/BaseSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BaseSubscriberTest.java
@@ -22,11 +22,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
@@ -134,35 +136,37 @@ public class BaseSubscriberTest {
 		assertThat(error.get(), is(instanceOf(IllegalStateException.class)));
 	}
 
-	@Test(expected = OutOfMemoryError.class)
+	@Test
 	public void onSubscribeFatalThrown() {
 		Flux<String> flux = Flux.just("foo");
 		AtomicReference<Throwable> error = new AtomicReference<>();
 		AtomicReference<SignalType> checkFinally = new AtomicReference<>();
 
-		flux.subscribe(new BaseSubscriber<String>() {
-			@Override
-			protected void hookOnSubscribe(Subscription subscription) {
-				throw new OutOfMemoryError("boom");
-			}
+		assertThatExceptionOfType(OutOfMemoryError.class).isThrownBy(() -> {
+			flux.subscribe(new BaseSubscriber<String>() {
+				@Override
+				protected void hookOnSubscribe(Subscription subscription) {
+					throw new OutOfMemoryError("boom");
+				}
 
-			@Override
-			protected void hookOnNext(String value) {
-				//NO-OP
-			}
+				@Override
+				protected void hookOnNext(String value) {
+					//NO-OP
+				}
 
-			@Override
-			protected void hookOnError(Throwable throwable) {
-				error.set(throwable);
-			}
+				@Override
+				protected void hookOnError(Throwable throwable) {
+					error.set(throwable);
+				}
 
-			@Override
-			protected void hookFinally(SignalType type) {
-				checkFinally.set(type);
-			}
+				@Override
+				protected void hookFinally(SignalType type) {
+					checkFinally.set(type);
+				}
+			});
 		});
-		assertThat(checkFinally.get(), is(SignalType.ON_ERROR));
-		assertThat(error.get(), is(nullValue()));
+		Assertions.assertThat(checkFinally.get()).isNull();
+		Assertions.assertThat(error.get()).isNull();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/BlockingIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BlockingIterableTest.java
@@ -28,19 +28,21 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Subscription;
 import reactor.core.Scannable;
 import reactor.core.Scannable.Attr;
 import reactor.test.StepVerifier;
 import reactor.util.concurrent.Queues;
 
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class BlockingIterableTest {
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void normal() {
 		List<Integer> values = new ArrayList<>();
 
@@ -52,7 +54,8 @@ public class BlockingIterableTest {
 		Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), values);
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void normal2() {
 		Queue<Integer> q = new ArrayBlockingQueue<>(1);
 		List<Integer> values = new ArrayList<>();
@@ -65,7 +68,8 @@ public class BlockingIterableTest {
 		Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), values);
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void empty() {
 		List<Integer> values = new ArrayList<>();
 
@@ -76,18 +80,22 @@ public class BlockingIterableTest {
 		Assert.assertEquals(Collections.emptyList(), values);
 	}
 
-	@Test(timeout = 5000, expected = RuntimeException.class)
+	@Test
+	@Timeout(5)
 	public void error() {
 		List<Integer> values = new ArrayList<>();
 
-		for (Integer i : Flux.<Integer>error(new RuntimeException("forced failure")).toIterable()) {
-			values.add(i);
-		}
+		assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> {
+			for (Integer i : Flux.<Integer>error(new RuntimeException("forced failure")).toIterable()) {
+				values.add(i);
+			}
+		});
 
 		Assert.assertEquals(Collections.emptyList(), values);
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void toStream() {
 		List<Integer> values = new ArrayList<>();
 
@@ -98,7 +106,8 @@ public class BlockingIterableTest {
 		Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), values);
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void streamEmpty() {
 		List<Integer> values = new ArrayList<>();
 
@@ -108,7 +117,8 @@ public class BlockingIterableTest {
 		Assert.assertEquals(Collections.emptyList(), values);
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void streamLimit() {
 		List<Integer> values = new ArrayList<>();
 
@@ -120,7 +130,8 @@ public class BlockingIterableTest {
 		Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), values);
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void streamParallel() {
 		int n = 1_000_000;
 
@@ -223,7 +234,8 @@ public class BlockingIterableTest {
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).describedAs("after CANCELLED").isTrue();
 	}
 
-	@Test(timeout = 1000)
+	@Test
+	@Timeout(1)
 	public void gh841_streamCreate() {
 		Flux<String> source = Flux.<String>create(sink -> {
 			sink.next("a");
@@ -238,7 +250,8 @@ public class BlockingIterableTest {
 				.withMessage("boom");
 	}
 
-	@Test(timeout = 1000)
+	@Test
+	@Timeout(1)
 	public void gh841_streamCreateDeferredError() {
 		Flux<Integer> source = Flux.<Integer>create(sink -> {
 			sink.next(1);
@@ -255,7 +268,8 @@ public class BlockingIterableTest {
 				.withMessage("/ by zero");
 	}
 
-	@Test(timeout = 1000)
+	@Test
+	@Timeout(1)
 	public void gh841_streamFromIterable() {
 		Flux<String> source = Flux.fromIterable(Arrays.asList("a","b"))
 		                          .sort((a, b) -> { throw new IllegalStateException("boom"); });
@@ -266,7 +280,8 @@ public class BlockingIterableTest {
 				.withMessage("boom");
 	}
 
-	@Test(timeout = 1000)
+	@Test
+	@Timeout(1)
 	public void gh841_iteratorFromCreate() {
 		Iterator<String> it = Flux.<String>create(sink -> {
 			sink.next("a");
@@ -281,7 +296,8 @@ public class BlockingIterableTest {
 				.withMessage("boom");
 	}
 
-	@Test(timeout = 1000)
+	@Test
+	@Timeout(1)
 	public void gh841_workaroundFlux() {
 		Flux<String> source = Flux.<String>create(sink -> {
 			sink.next("a");
@@ -298,7 +314,8 @@ public class BlockingIterableTest {
 		            .verify();
 	}
 
-	@Test(timeout = 1000)
+	@Test
+	@Timeout(1)
 	public void gh841_workaroundStream() {
 		Flux<String> source = Flux.<String>create(sink -> {
 			sink.next("a");

--- a/reactor-core/src/test/java/reactor/core/publisher/BlockingOptionalMonoSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BlockingOptionalMonoSubscriberTest.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.Scannable;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/BlockingSingleSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BlockingSingleSubscriberTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.Scannable;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/BlockingTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BlockingTests.java
@@ -26,29 +26,32 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import reactor.core.Exceptions;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 public class BlockingTests {
 
 	static Scheduler scheduler;
 	static Scheduler nonBlockingScheduler;
 
-	@BeforeClass
+	@BeforeAll
 	public static void before() {
 		scheduler = Schedulers.fromExecutorService(Executors.newSingleThreadExecutor());
 		nonBlockingScheduler = Schedulers.newSingle("nonBlockingScheduler");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void after() {
 		scheduler.dispose();
 		nonBlockingScheduler.dispose();
@@ -98,32 +101,40 @@ public class BlockingTests {
 		               .blockLast(Duration.ofMillis(1))).isNull();
 	}
 
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void blockingFirstError() {
-		Flux.error(new RuntimeException("test"))
-		    .publishOn(scheduler)
-		    .blockFirst();
+		assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> {
+			Flux.error(new RuntimeException("test"))
+					.publishOn(scheduler)
+					.blockFirst();
+		});
 	}
 
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void blockingFirstError2() {
-		Flux.error(new RuntimeException("test"))
-		    .publishOn(scheduler)
-		    .blockFirst(Duration.ofSeconds(1));
+		assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> {
+			Flux.error(new RuntimeException("test"))
+					.publishOn(scheduler)
+					.blockFirst(Duration.ofSeconds(1));
+		});
 	}
 
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void blockingLastError() {
-		Flux.defer(() -> Mono.error(new RuntimeException("test")))
-		    .subscribeOn(scheduler)
-		    .blockLast();
+		assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> {
+			Flux.defer(() -> Mono.error(new RuntimeException("test")))
+					.subscribeOn(scheduler)
+					.blockLast();
+		});
 	}
 
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void blockingLastError2() {
-		Flux.defer(() -> Mono.error(new RuntimeException("test")))
-		    .subscribeOn(scheduler)
-		    .blockLast(Duration.ofSeconds(1));
+		assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> {
+			Flux.defer(() -> Mono.error(new RuntimeException("test")))
+					.subscribeOn(scheduler)
+					.blockLast(Duration.ofSeconds(1));
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/ConnectableFluxOnAssemblyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ConnectableFluxOnAssemblyTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.core.publisher.FluxOnAssembly.AssemblySnapshot;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/ContextTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ContextTests.java
@@ -18,7 +18,7 @@ package reactor.core.publisher;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import reactor.test.StepVerifierOptions;
 import reactor.util.context.Context;

--- a/reactor-core/src/test/java/reactor/core/publisher/DelegateProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/DelegateProcessorTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/DirectProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/DirectProcessorTest.java
@@ -16,40 +16,49 @@
 package reactor.core.publisher;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 
 public class DirectProcessorTest {
 
-    @Test(expected = NullPointerException.class)
-    public void onNextNull() {
-	    DirectProcessor.create().onNext(null);
-    }
+	@Test
+	public void onNextNull() {
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			DirectProcessor.create().onNext(null);
+		});
+	}
 
-    @Test(expected = NullPointerException.class)
-    public void onErrorNull() {
-	    DirectProcessor.create().onError(null);
-    }
+	@Test
+	public void onErrorNull() {
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			DirectProcessor.create().onError(null);
+		});
+	}
 
-    @Test(expected = NullPointerException.class)
-    public void onSubscribeNull() {
-        DirectProcessor.create().onSubscribe(null);
-    }
+	@Test
+	public void onSubscribeNull() {
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			DirectProcessor.create().onSubscribe(null);
+		});
+	}
 
-    @Test(expected = NullPointerException.class)
-    public void subscribeNull() {
-	    DirectProcessor.create().subscribe((Subscriber<Object>)null);
-    }
+	@Test
+	public void subscribeNull() {
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			DirectProcessor.create().subscribe((Subscriber<Object>) null);
+		});
+	}
 
-    @Test
-    public void normal() {
-        DirectProcessor<Integer> tp = DirectProcessor.create();
+	@Test
+	public void normal() {
+		DirectProcessor<Integer> tp = DirectProcessor.create();
 
 	    StepVerifier.create(tp)
 	                .then(() -> {

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -28,8 +28,8 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.stream.Stream;
 
 import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -45,9 +45,14 @@ import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
 import static reactor.core.Scannable.Attr;
-import static reactor.core.Scannable.Attr.*;
+import static reactor.core.Scannable.Attr.BUFFERED;
+import static reactor.core.Scannable.Attr.CANCELLED;
+import static reactor.core.Scannable.Attr.CAPACITY;
+import static reactor.core.Scannable.Attr.PREFETCH;
+import static reactor.core.Scannable.Attr.TERMINATED;
 
 /**
  * @author Stephane Maldini
@@ -219,24 +224,32 @@ public class EmitterProcessorTest {
 
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void onNextNull() {
-		EmitterProcessor.create().onNext(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			EmitterProcessor.create().onNext(null);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void onErrorNull() {
-		EmitterProcessor.create().onError(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			EmitterProcessor.create().onError(null);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void onSubscribeNull() {
-		EmitterProcessor.create().onSubscribe(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			EmitterProcessor.create().onSubscribe(null);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void subscribeNull() {
-		EmitterProcessor.create().subscribe((Subscriber<Object>)null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			EmitterProcessor.create().subscribe((Subscriber<Object>) null);
+		});
 	}
 
 	@Test
@@ -376,19 +389,25 @@ public class EmitterProcessorTest {
 	}
 
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void failNullBufferSize() {
-		EmitterProcessor.create(0);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			EmitterProcessor.create(0);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void failNullNext() {
-		EmitterProcessor.create().onNext(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			EmitterProcessor.create().onNext(null);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void failNullError() {
-		EmitterProcessor.create().onError(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			EmitterProcessor.create().onError(null);
+		});
 	}
 
 	@Test
@@ -427,9 +446,11 @@ public class EmitterProcessorTest {
 		assertThat(ep.sink().isCancelled()).isTrue();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void failNegativeBufferSize() {
-		EmitterProcessor.create(-1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			EmitterProcessor.create(-1);
+		});
 	}
 
 	static final List<String> DATA     = new ArrayList<>();
@@ -442,7 +463,7 @@ public class EmitterProcessorTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void test() {
 		Scheduler asyncGroup = Schedulers.single();
 		FluxProcessor<String, String> emitter = EmitterProcessor.create();
@@ -481,7 +502,7 @@ public class EmitterProcessorTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void testPerformance() {
 		FluxProcessor<String, String> emitter = EmitterProcessor.create();
 
@@ -670,7 +691,7 @@ public class EmitterProcessorTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void testRacing() throws Exception {
 		int N_THREADS = 3;
 		int N_ITEMS = 8;

--- a/reactor-core/src/test/java/reactor/core/publisher/EventLoopProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EventLoopProcessorTest.java
@@ -22,8 +22,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.api.Condition;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -41,7 +41,7 @@ public class EventLoopProcessorTest {
 
 	EventLoopProcessor<String> test;
 
-	@Before
+	@BeforeEach
 	public void initProcessor() {
 		test = initProcessor(Executors.newSingleThreadExecutor());
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxArrayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxArrayTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
@@ -25,12 +25,15 @@ import reactor.test.MockUtils;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxArrayTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void arrayNull() {
-		Flux.fromArray((Integer[]) null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.fromArray((Integer[]) null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxAutoConnectFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxAutoConnectFuseableTest.java
@@ -16,11 +16,8 @@
 
 package reactor.core.publisher;
 
-import java.util.function.Consumer;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import reactor.core.Disposable;
 import reactor.core.Scannable;
 import reactor.test.MockUtils;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxAutoConnectTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxAutoConnectTest.java
@@ -18,7 +18,7 @@ package reactor.core.publisher;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import reactor.core.Disposable;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
@@ -33,7 +33,7 @@ import java.util.function.Supplier;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -32,6 +32,7 @@ import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxBufferTest extends FluxOperatorTest<String, List<String>> {
 
@@ -96,24 +97,32 @@ public class FluxBufferTest extends FluxOperatorTest<String, List<String>> {
 		);
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxBuffer<>(null, 1, ArrayList::new);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxBuffer<>(null, 1, ArrayList::new);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void supplierNull() {
-		Flux.never().buffer(1, 1, null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never().buffer(1, 1, null);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void sizeZero() {
-		Flux.never().buffer(0, 1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never().buffer(0, 1);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void skipZero() {
-		Flux.never().buffer(1, 0);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never().buffer(1, 0);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
@@ -24,8 +24,8 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxBufferTimeoutTest {
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		VirtualTimeScheduler.reset();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
@@ -33,7 +33,8 @@ import java.util.logging.Level;
 
 import org.assertj.core.api.Condition;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -678,7 +679,8 @@ public class FluxBufferWhenTest {
 		            .verifyComplete();
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void cancelWinsOverDrain() {
 		Queue<List<Integer>> queue = Queues.<List<Integer>>small().get();
 		queue.offer(Arrays.asList(1, 2, 3));

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCacheTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCacheTest.java
@@ -19,7 +19,7 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import reactor.test.scheduler.VirtualTimeScheduler;
 import reactor.util.function.Tuple2;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCallableOnAssemblyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCallableOnAssemblyTest.java
@@ -32,7 +32,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.core.publisher.FluxOnAssembly.AssemblySnapshot;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCallableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCallableTest.java
@@ -17,7 +17,7 @@ package reactor.core.publisher;
 
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.subscriber.AssertSubscriber;
 
 public class FluxCallableTest {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCancelOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCancelOnTest.java
@@ -19,7 +19,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -30,7 +31,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxCancelOnTest {
 
-	@Test(timeout = 3000L)
+	@Test
+	@Timeout(3)
 	public void cancelOnDedicatedScheduler() throws Exception {
 
 		CountDownLatch latch = new CountDownLatch(1);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCastTest.java
@@ -16,21 +16,27 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxCastTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		Flux.just(1)
-		    .cast(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.just(1)
+					.cast(null);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull2() {
-		Flux.just(1)
-		    .ofType(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.just(1)
+					.ofType(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCombineLatestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCombineLatestTest.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatArrayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatArrayTest.java
@@ -19,7 +19,7 @@ package reactor.core.publisher;
 import java.util.Arrays;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -28,12 +28,15 @@ import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxConcatArrayTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void arrayNull() {
-		Flux.concat((Publisher<Object>[]) null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.concat((Publisher<Object>[]) null);
+		});
 	}
 
 	final Publisher<Integer> source = Flux.range(1, 3);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatIterableTest.java
@@ -18,15 +18,19 @@ package reactor.core.publisher;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import reactor.test.subscriber.AssertSubscriber;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 public class FluxConcatIterableTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void arrayNull() {
-		Flux.concat((Iterable<? extends Publisher<?>>)null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.concat((Iterable<? extends Publisher<?>>) null);
+		});
 	}
 
 	final Publisher<Integer> source = Flux.range(1, 3);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatWithTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatWithTest.java
@@ -15,8 +15,7 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCreateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCreateTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDefaultIfEmptyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDefaultIfEmptyTest.java
@@ -16,24 +16,29 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxDefaultIfEmptyTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxDefaultIfEmpty<>(null, 1);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxDefaultIfEmpty<>(null, 1);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void valueNull() {
-		Flux.never().defaultIfEmpty(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never().defaultIfEmpty(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDeferComposeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDeferComposeTest.java
@@ -17,7 +17,7 @@ package reactor.core.publisher;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.subscriber.AssertSubscriber;
 
 public class FluxDeferComposeTest {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDeferTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDeferTest.java
@@ -19,14 +19,18 @@ package reactor.core.publisher;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxDeferTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void supplierNull() {
-		Flux.<Integer>defer(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.<Integer>defer(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDelaySequenceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDelaySequenceTest.java
@@ -21,8 +21,8 @@ import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -103,7 +103,7 @@ public class FluxDelaySequenceTest {
 		            .verifyComplete();
 	}
 
-	@Ignore("delayElements test for local comparison run")
+	@Disabled("delayElements test for local comparison run")
 	@Test
 	public void delayElements() {
 		Flux<Tuple2<Long, Long>> test = Flux.interval(Duration.ofMillis(50))

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDelaySubscriptionTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDelaySubscriptionTest.java
@@ -18,7 +18,7 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -27,17 +27,22 @@ import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxDelaySubscriptionTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxDelaySubscription<>(null, Flux.never());
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxDelaySubscription<>(null, Flux.never());
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void otherNull() {
-		Flux.never().delaySubscription((Publisher<?>)null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never().delaySubscription((Publisher<?>) null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDelayUntilTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDelayUntilTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.Disposable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDematerializeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDematerializeTest.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDetachTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDetachTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.awaitility.Awaitility;
 import org.awaitility.Duration;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctTest.java
@@ -25,12 +25,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiPredicate;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -38,7 +36,6 @@ import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.core.publisher.FluxDistinct.DistinctConditionalSubscriber;
 import reactor.core.publisher.FluxDistinct.DistinctSubscriber;
-import reactor.test.MemoryUtils;
 import reactor.test.MemoryUtils.RetainedDetector;
 import reactor.test.MockUtils;
 import reactor.test.StepVerifier;
@@ -48,9 +45,12 @@ import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class FluxDistinctTest extends FluxOperatorTest<String, String> {
 
@@ -89,34 +89,48 @@ public class FluxDistinctTest extends FluxOperatorTest<String, String> {
 		);
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxDistinct<>(null, k -> k, HashSet::new, HashSet::add, HashSet::clear);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxDistinct<>(null, k -> k, HashSet::new, HashSet::add, HashSet::clear);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void keyExtractorNull() {
-		Flux.never().distinct(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never().distinct(null);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void collectionSupplierNull() {
-		new FluxDistinct<>(Flux.never(), k -> k, null, (c, k) -> true, c -> {});
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxDistinct<>(Flux.never(), k -> k, null, (c, k) -> true, c -> {
+			});
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void collectionSupplierNullFuseable() {
-		new FluxDistinctFuseable<>(Flux.never(), k -> k, null, (c,k) -> true, c -> {});
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxDistinctFuseable<>(Flux.never(), k -> k, null, (c, k) -> true, c -> {
+			});
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void distinctPredicateNull() {
-		new FluxDistinct<>(Flux.never(), k -> k, HashSet::new, null, HashSet::clear);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxDistinct<>(Flux.never(), k -> k, HashSet::new, null, HashSet::clear);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void cleanupNull() {
-		new FluxDistinct<>(Flux.never(), k -> k, HashSet::new, HashSet::add, null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxDistinct<>(Flux.never(), k -> k, HashSet::new, HashSet::add, null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
@@ -20,11 +20,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -40,9 +39,9 @@ import reactor.test.MockUtils;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.test.util.RaceTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
 
 public class FluxDistinctUntilChangedTest extends FluxOperatorTest<String, String> {
@@ -66,19 +65,25 @@ public class FluxDistinctUntilChangedTest extends FluxOperatorTest<String, Strin
 		);
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxDistinctUntilChanged<>(null, v -> v, (k1, k2) -> true);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxDistinctUntilChanged<>(null, v -> v, (k1, k2) -> true);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void keyExtractorNull() {
-		Flux.never().distinctUntilChanged(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never().distinctUntilChanged(null);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void predicateNull() {
-		Flux.never().distinctUntilChanged(v -> v, null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never().distinctUntilChanged(v -> v, null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDoFinallyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDoFinallyTest.java
@@ -23,14 +23,15 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.Consumer;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
@@ -41,7 +42,7 @@ public class FluxDoFinallyTest implements Consumer<SignalType> {
 	volatile SignalType signalType;
 	volatile int calls;
 
-	@Before
+	@BeforeEach
 	public void before() {
 		signalType = null;
 		calls = 0;
@@ -320,9 +321,11 @@ public class FluxDoFinallyTest implements Consumer<SignalType> {
 		assertEquals(SignalType.ON_COMPLETE, signalType);
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullCallback() {
-		Flux.just(1).doFinally(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.just(1).doFinally(null);
+		});
 	}
 
 	@Test
@@ -475,7 +478,7 @@ public class FluxDoFinallyTest implements Consumer<SignalType> {
 	public void gh951_withoutDoOnError() {
 		List<String> events = new ArrayList<>();
 
-		Assertions.assertThatExceptionOfType(UnsupportedOperationException.class)
+		assertThatExceptionOfType(UnsupportedOperationException.class)
 		          .isThrownBy(Mono.just(true)
 		                          .map(this::throwError)
 		                          .doFinally(any -> events.add("doFinally " + any.toString()))

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDoFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDoFirstTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 
 import reactor.core.Fuseable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDoOnEachTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDoOnEachTest.java
@@ -25,11 +25,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
@@ -46,19 +45,21 @@ import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.fail;
 
-@RunWith(JUnitParamsRunner.class)
 public class FluxDoOnEachTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullSource() {
-		new FluxDoOnEach<>(null, null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxDoOnEach<>(null, null);
+		});
 	}
 
 	private static final String sourceErrorMessage = "boomSource";
 
-	private Object[] sourcesError() {
+	private static Object[] sourcesError() {
 		return new Object[] {
 				new Object[] { Flux.<Integer>error(new IllegalStateException(sourceErrorMessage))
 						.hide() },
@@ -70,7 +71,7 @@ public class FluxDoOnEachTest {
 		};
 	}
 
-	private Object[] sources12Complete() {
+	private static Object[] sources12Complete() {
 		return new Object[] {
 				new Object[] { Flux.just(1,2).hide() },
 				new Object[] { Flux.just(1,2).hide().filter(i -> true) },
@@ -79,7 +80,7 @@ public class FluxDoOnEachTest {
 		};
 	}
 
-	private Object[] sourcesEmpty() {
+	private static Object[] sourcesEmpty() {
 		return new Object[] {
 				new Object[] { Flux.<Integer>empty().hide() },
 				new Object[] { Flux.<Integer>empty().hide().filter(i -> true) },
@@ -88,7 +89,7 @@ public class FluxDoOnEachTest {
 		};
 	}
 
-	private Object[] sourcesNever() {
+	private static Object[] sourcesNever() {
 		return new Object[] {
 				new Object[] { Flux.<Integer>never().hide() },
 				new Object[] { Flux.<Integer>never().hide().filter(i -> true) },
@@ -97,8 +98,8 @@ public class FluxDoOnEachTest {
 		};
 	}
 
-	@Test
-	@Parameters(method = "sources12Complete")
+	@ParameterizedTest
+	@MethodSource("sources12Complete")
 	public void normal(Flux<Integer> source) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -295,8 +296,8 @@ public class FluxDoOnEachTest {
 		assertThat(onComplete).isFalse();
 	}
 
-	@Test
-	@Parameters(method = "sourcesError")
+	@ParameterizedTest
+	@MethodSource("sourcesError")
 	public void error(Flux<Integer> source) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -328,8 +329,8 @@ public class FluxDoOnEachTest {
 		assertThat(state.intValue()).isZero();
 	}
 
-	@Test
-	@Parameters(method = "sourcesEmpty")
+	@ParameterizedTest
+	@MethodSource("sourcesEmpty")
 	public void empty(Flux<Integer> source) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -360,8 +361,8 @@ public class FluxDoOnEachTest {
 		assertThat(state.intValue()).isEqualTo(0);
 	}
 
-	@Test
-	@Parameters(method = "sourcesNever")
+	@ParameterizedTest
+	@MethodSource("sourcesNever")
 	public void never(Flux<Integer> source) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -392,8 +393,8 @@ public class FluxDoOnEachTest {
 		assertThat(state.intValue()).isEqualTo(0);
 	}
 
-	@Test
-	@Parameters(method = "sources12Complete")
+	@ParameterizedTest
+	@MethodSource("sources12Complete")
 	public void nextCallbackError(Flux<Integer> source) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		LongAdder state = new LongAdder();
@@ -415,8 +416,8 @@ public class FluxDoOnEachTest {
 		Assert.assertEquals(1, state.intValue());
 	}
 
-	@Test
-	@Parameters(method = "sources12Complete")
+	@ParameterizedTest
+	@MethodSource("sources12Complete")
 	public void nextCallbackBubbleError(Flux<Integer> source) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		LongAdder state = new LongAdder();
@@ -442,8 +443,8 @@ public class FluxDoOnEachTest {
 		}
 	}
 
-	@Test
-	@Parameters(method = "sources12Complete")
+	@ParameterizedTest
+	@MethodSource("sources12Complete")
 	public void completeCallbackError(Flux<Integer> source) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		AtomicBoolean completeHandled = new AtomicBoolean();
@@ -471,8 +472,8 @@ public class FluxDoOnEachTest {
 		                        .isTrue();
 	}
 
-	@Test
-	@Parameters(method = "sourcesError")
+	@ParameterizedTest
+	@MethodSource("sourcesError")
 	public void errorCallbackError(Flux<Integer> source) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		LongAdder state = new LongAdder();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxElapsedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxElapsedTest.java
@@ -17,8 +17,7 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxEmptyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxEmptyTest.java
@@ -15,7 +15,7 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
 public class FluxEmptyTest {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxErrorSuppliedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxErrorSuppliedTest.java
@@ -34,7 +34,7 @@ package reactor.core.publisher;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxErrorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxErrorTest.java
@@ -15,7 +15,7 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxExpandTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxExpandTest.java
@@ -25,7 +25,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -294,7 +295,8 @@ public class FluxExpandTest {
 		);
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void depthFirst() {
 		Node root = createTest();
 
@@ -332,7 +334,8 @@ public class FluxExpandTest {
 		            .verify(Duration.ofSeconds(5));
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void breadthFirst() {
 		Node root = createTest();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFilterFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFilterFuseableTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFilterTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFilterTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -38,6 +38,7 @@ import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxFilterTest extends FluxOperatorTest<String, String> {
 
@@ -72,15 +73,19 @@ public class FluxFilterTest extends FluxOperatorTest<String, String> {
 		);
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxFilter<Integer>(null, e -> true);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxFilter<Integer>(null, e -> true);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void predicateNull() {
-		Flux.never()
-		    .filter(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never()
+					.filter(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFirstEmittingTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFirstEmittingTest.java
@@ -17,7 +17,7 @@ package reactor.core.publisher;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -25,17 +25,22 @@ import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxFirstEmittingTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void arrayNull() {
-		Flux.first((Publisher<Integer>[]) null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.first((Publisher<Integer>[]) null);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void iterableNull() {
-		new FluxFirstEmitting<>((Iterable<Publisher<Integer>>) null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxFirstEmitting<>((Iterable<Publisher<Integer>>) null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFirstEmittingWithTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFirstEmittingWithTest.java
@@ -18,7 +18,7 @@ package reactor.core.publisher;
 import java.util.Arrays;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import reactor.test.subscriber.AssertSubscriber;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -18,34 +18,24 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import java.util.stream.IntStream;
-import java.util.stream.LongStream;
-import java.util.stream.Stream;
 
 import org.awaitility.Awaitility;
 import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.core.publisher.FluxPeekFuseableTest.AssertQueueSubscription;
-import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
@@ -54,6 +44,7 @@ import reactor.test.util.RaceTestUtils;
 import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxFlatMapTest {
 
@@ -499,16 +490,20 @@ public class FluxFlatMapTest {
 		               .getPrefetch()).isEqualTo(Queues.XS_BUFFER_SIZE);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void failMaxConcurrency() {
-		Flux.just(1, 2, 3)
-		    .flatMap(Flux::just, -1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.just(1, 2, 3)
+					.flatMap(Flux::just, -1);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void failPrefetch() {
-		Flux.just(1, 2, 3)
-		    .flatMap(Flux::just, 128, -1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.just(1, 2, 3)
+					.flatMap(Flux::just, 128, -1);
+		});
 	}
 
 	@Test
@@ -1468,7 +1463,7 @@ public class FluxFlatMapTest {
     }
 
 	@Test
-	@Ignore
+	@Disabled
 	public void progressiveRequest() {
 		TestPublisher<Integer> tp = TestPublisher.create();
 		StepVerifier.create(tp.flux()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
@@ -25,9 +25,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
-
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
@@ -39,6 +38,7 @@ import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
@@ -138,10 +138,12 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
 		);
 	}
 
-	@Test(expected=IllegalArgumentException.class)
-	public void failPrefetch(){
-		Flux.never()
-	        .flatMapIterable(t -> null, -1);
+	@Test
+	public void failPrefetch() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never()
+					.flatMapIterable(t -> null, -1);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxGenerateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxGenerateTest.java
@@ -22,9 +22,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.CoreSubscriber;
-import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
@@ -35,21 +34,27 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxGenerateTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void stateSupplierNull() {
-		Flux.generate(null, (s, o) -> s, s -> {
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.generate(null, (s, o) -> s, s -> {
+			});
 		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void generatorNull() {
-		Flux.generate(() -> 1, null, s -> {
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.generate(() -> 1, null, s -> {
+			});
 		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void stateConsumerNull() {
-		Flux.generate(() -> 1, (s, o) -> s, null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.generate(() -> 1, (s, o) -> s, null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
@@ -23,8 +23,9 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
@@ -626,7 +627,7 @@ public class FluxGroupByTest extends
 	}
 
 	@Test
-	@Ignore("temporarily disabled, see gh-1028")
+	@Disabled("temporarily disabled, see gh-1028")
 	public void twoGroupsFullAsyncFullHide() {
 		ForkJoinPool forkJoinPool = new ForkJoinPool();
 
@@ -689,7 +690,7 @@ public class FluxGroupByTest extends
 	}
 
 	@Test
-	@Ignore("temporarily disabled, see gh-1028")
+	@Disabled("temporarily disabled, see gh-1028")
 	public void twoGroupsFullAsync() {
 		ForkJoinPool forkJoinPool = new ForkJoinPool();
 		AssertSubscriber<Integer> ts1 = AssertSubscriber.create();
@@ -883,7 +884,8 @@ public class FluxGroupByTest extends
 		assertThat(test.scan(Scannable.Attr.ERROR)).isSameAs(test.error);
 	}
 
-	@Test(timeout = 10000)
+	@Test
+	@Timeout(10)
 	public void fusedGroupByParallel() {
 		int parallelism = 2;
 		Scheduler process = Schedulers.newParallel("process", parallelism, true);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxGroupJoinTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxGroupJoinTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxHandleTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxHandleTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxHideTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxHideTest.java
@@ -15,7 +15,7 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxIndexTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxIndexTest.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Fuseable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxIndexedFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxIndexedFuseableTest.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import reactor.core.Fuseable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxIntervalTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxIntervalTest.java
@@ -20,10 +20,10 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
@@ -37,12 +37,12 @@ public class FluxIntervalTest {
 
 	Scheduler exec;
 
-	@Before
+	@BeforeEach
 	public void before() {
 		exec = Schedulers.newSingle("interval-test");
 	}
 
-	@After
+	@AfterEach
 	public void after() {
 		exec.dispose();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxIterableTest.java
@@ -22,9 +22,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
@@ -35,6 +34,7 @@ import reactor.util.context.Context;
 import reactor.util.function.Tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxIterableTest {
 
@@ -46,9 +46,11 @@ public class FluxIterableTest {
 	                .verifyComplete();
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullIterable() {
-		Flux.never().zipWithIterable(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never().zipWithIterable(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxJoinTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxJoinTest.java
@@ -19,11 +19,10 @@ package reactor.core.publisher;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxJustTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxJustTest.java
@@ -19,20 +19,23 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxJustTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void nullValue() {
-        Flux.just((Integer)null);
-    }
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.just((Integer) null);
+		});
+	}
 
     @Test
     @SuppressWarnings("unchecked")

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxLimitRequestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxLimitRequestTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMapSignalTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMapSignalTest.java
@@ -18,7 +18,7 @@ package reactor.core.publisher;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -27,12 +27,15 @@ import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxMapSignalTest extends FluxOperatorTest<String, String> {
 
-	@Test(expected = IllegalArgumentException.class)
-	public void allNull(){
-		Flux.never().flatMap(null, null, null);
+	@Test
+	public void allNull() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never().flatMap(null, null, null);
+		});
 	}
 
 	@Override

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMapTest.java
@@ -22,18 +22,19 @@ import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
-import reactor.test.StepVerifier;
 import reactor.test.MockUtils;
+import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxMapTest extends FluxOperatorTest<String, String> {
 
@@ -63,14 +64,18 @@ public class FluxMapTest extends FluxOperatorTest<String, String> {
 
 	Flux<Integer> just = Flux.just(1);
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullSource() {
-		new FluxMap<Integer, Integer>(null, v -> v);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxMap<Integer, Integer>(null, v -> v);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullMapper() {
-		just.map(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			just.map(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMaterializeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMaterializeTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
@@ -18,14 +18,13 @@ package reactor.core.publisher;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
@@ -30,8 +30,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -43,6 +43,7 @@ import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -55,7 +56,7 @@ public class FluxMergeSequentialTest {
 
 	final Function<Integer, Flux<Integer>> toRange = t -> Flux.range(t, 2);
 
-	@Before
+	@BeforeEach
 	public void before() {
 		ts = new AssertSubscriber<>();
 		tsBp = new AssertSubscriber<>(0L);
@@ -417,14 +418,18 @@ public class FluxMergeSequentialTest {
 		ts.assertError(RuntimeException.class);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidCapacityHint() {
-		Flux.just(1).flatMapSequential(toJust, 0, Queues.SMALL_BUFFER_SIZE);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.just(1).flatMapSequential(toJust, 0, Queues.SMALL_BUFFER_SIZE);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidMaxConcurrent() {
-		Flux.just(1).flatMapSequential(toJust, Queues.SMALL_BUFFER_SIZE, 0);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.just(1).flatMapSequential(toJust, Queues.SMALL_BUFFER_SIZE, 0);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeTest.java
@@ -19,7 +19,7 @@ package reactor.core.publisher;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeWithTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeWithTest.java
@@ -15,7 +15,7 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import reactor.test.subscriber.AssertSubscriber;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxNameFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxNameFuseableTest.java
@@ -20,7 +20,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxNameTest.java
@@ -20,7 +20,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxNeverTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxNeverTest.java
@@ -16,7 +16,7 @@
 package reactor.core.publisher;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.subscriber.AssertSubscriber;
 
 public class FluxNeverTest {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
@@ -22,8 +22,8 @@ import java.util.Iterator;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 
 public class FluxOnAssemblyTest {
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		Hooks.resetOnOperatorDebug();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
@@ -21,9 +21,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
@@ -55,7 +55,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 		return throwable;
 	}
 
-	@Before
+	@BeforeEach
 	public void before() {
 		this.droppedValue = null;
 		this.hookCapturedError = null;
@@ -63,7 +63,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 		Hooks.onOperatorError(this);
 	}
 
-	@After
+	@AfterEach
 	public void after() {
 		Hooks.resetOnOperatorError();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
@@ -37,14 +37,18 @@ import reactor.test.publisher.TestPublisher;
 import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FluxOnBackpressureBufferTest
 		extends FluxOperatorTest<String, String> {
 
-	@Test(expected = IllegalArgumentException.class)
-	public void failNegativeHistory(){
-		Flux.never().onBackpressureBuffer(-1);
+	@Test
+	public void failNegativeHistory() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never().onBackpressureBuffer(-1);
+		});
 	}
 
 	@Override

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferTimeoutTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureDropTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureDropTest.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -29,23 +29,30 @@ import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxOnBackpressureDropTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void source1Null() {
-		new FluxOnBackpressureDrop<>(null);
-	}
-
-	@Test(expected = NullPointerException.class)
-	public void source2Null() {
-		new FluxOnBackpressureDrop<>(null, v -> {
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxOnBackpressureDrop<>(null);
 		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
+	public void source2Null() {
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxOnBackpressureDrop<>(null, v -> {
+			});
+		});
+	}
+
+	@Test
 	public void onDropNull() {
-		Flux.never().onBackpressureDrop(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never().onBackpressureDrop(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureLatestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureLatestTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -24,12 +24,15 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxOnBackpressureLatestTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxOnBackpressureLatest<>(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxOnBackpressureLatest<>(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnErrorResumeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnErrorResumeTest.java
@@ -17,7 +17,7 @@
 package reactor.core.publisher;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Exceptions;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
@@ -31,7 +31,7 @@ import java.util.function.LongConsumer;
 import javax.annotation.Nullable;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -50,15 +50,22 @@ import reactor.util.context.Context;
 
 import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 import static reactor.core.scheduler.Schedulers.parallel;
 
 public class FluxPeekFuseableTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullSource() {
-		new FluxPeekFuseable<>(null, null, null, null, null, null, null, null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxPeekFuseable<>(null, null, null, null, null, null, null, null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
@@ -38,8 +38,14 @@ import reactor.util.concurrent.Queues;
 
 import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static reactor.core.scheduler.Schedulers.parallel;
 
 public class FluxPeekTest extends FluxOperatorTest<String, String> {
@@ -258,9 +264,11 @@ public class FluxPeekTest extends FluxOperatorTest<String, String> {
 		return combinedScenarios;
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullSource() {
-		new FluxPeek<>(null, null, null, null, null, null, null, null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxPeek<>(null, null, null, null, null, null, null, null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxProcessorTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
@@ -31,24 +31,31 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxProcessorTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	@SuppressWarnings("unchecked")
-	public void failNullSubscriber(){
-		FluxProcessor.wrap(UnicastProcessor.create(), UnicastProcessor.create())
-	                 .subscribe((Subscriber)null);
+	public void failNullSubscriber() {
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			FluxProcessor.wrap(UnicastProcessor.create(), UnicastProcessor.create())
+					.subscribe((Subscriber) null);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
-	public void failNullUpstream(){
-		FluxProcessor.wrap(null, UnicastProcessor.create());
+	@Test
+	public void failNullUpstream() {
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			FluxProcessor.wrap(null, UnicastProcessor.create());
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
-	public void failNullDownstream(){
-		FluxProcessor.wrap(UnicastProcessor.create(), null);
+	@Test
+	public void failNullDownstream() {
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			FluxProcessor.wrap(UnicastProcessor.create(), null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
@@ -23,16 +23,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
-import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
-import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
@@ -40,6 +38,7 @@ import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Fail.fail;
 import static reactor.core.publisher.Flux.range;
 import static reactor.core.publisher.Flux.zip;
@@ -116,10 +115,12 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
 		);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void failPrefetch(){
-		Flux.never()
-	        .publish(f -> f, -1);
+	@Test
+	public void failPrefetch() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never()
+					.publish(f -> f, -1);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
@@ -38,11 +38,12 @@ import java.util.concurrent.atomic.LongAdder;
 
 import org.assertj.core.api.Assertions;
 import org.hamcrest.CoreMatchers;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
@@ -62,6 +63,7 @@ import reactor.util.concurrent.Queues;
 import reactor.util.function.Tuple2;
 
 import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThan;
@@ -172,20 +174,22 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 
 	public static ExecutorService exec;
 
-	@BeforeClass
+	@BeforeAll
 	public static void before() {
 		exec = Executors.newSingleThreadExecutor();
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void after() {
 		exec.shutdownNow();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void failPrefetch() {
-		Flux.range(1, 10)
-		    .publishOn(Schedulers.immediate(), -1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.range(1, 10)
+					.publishOn(Schedulers.immediate(), -1);
+		});
 	}
 
 	@Test
@@ -940,7 +944,8 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		          .containsExactly(10L, 2L, 2L, 2L, 2L, 2L, 2L, 2L);
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void rejectedExecutionExceptionOnDataSignalExecutor()
 			throws InterruptedException {
 
@@ -993,7 +998,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	}
 
 	@Test
-	@Ignore //Fix or deprecate fromExecutor, this test might randomly hang on CI
+	@Disabled //Fix or deprecate fromExecutor, this test might randomly hang on CI
 	public void rejectedExecutionExceptionOnErrorSignalExecutor()
 			throws InterruptedException {
 
@@ -1049,8 +1054,9 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		}
 	}
 
-	@Test(timeout = 5000)
-	@Ignore
+	@Test
+	@Timeout(5)
+	@Disabled
 	public void rejectedExecutionExceptionOnDataSignalExecutorService()
 			throws InterruptedException {
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
@@ -24,9 +24,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Subscription;
-
 import reactor.core.Disposable;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
@@ -38,6 +38,7 @@ import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxPublishTest extends FluxOperatorTest<String, String> {
 
@@ -55,10 +56,12 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 		);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void failPrefetch(){
-		Flux.never()
-		    .publish( -1);
+	@Test
+	public void failPrefetch() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never()
+					.publish(-1);
+		});
 	}
 
 	@Test
@@ -642,7 +645,8 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 	}
 
 	//see https://github.com/reactor/reactor-core/issues/1528
-	@Test(timeout = 4000)
+	@Test
+	@Timeout(4)
 	public void syncFusionFromInfiniteStream() {
 		final ConnectableFlux<Integer> publish =
 				Flux.fromStream(Stream.iterate(0, i -> i + 1))
@@ -657,7 +661,8 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 	}
 
 	//see https://github.com/reactor/reactor-core/issues/1528
-	@Test(timeout = 4000)
+	@Test
+	@Timeout(4)
 	public void syncFusionFromInfiniteStreamAndTake() {
 		final Flux<Integer> publish =
 				Flux.fromStream(Stream.iterate(0, i -> i + 1))

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRangeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRangeTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
@@ -25,6 +25,7 @@ import reactor.test.MockUtils;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxRangeTest {
 
@@ -79,14 +80,18 @@ public class FluxRangeTest {
 		  .assertComplete();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void countIsNegative() {
-		Flux.range(1, -1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.range(1, -1);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void rangeOverflow() {
-		Flux.range(2, Integer.MAX_VALUE);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.range(2, Integer.MAX_VALUE);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Disposable;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatPredicateTest.java
@@ -18,19 +18,22 @@ package reactor.core.publisher;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 public class FluxRepeatPredicateTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void predicateNull() {
-		Flux.never()
-		    .repeat(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never()
+					.repeat(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatTest.java
@@ -19,16 +19,20 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 public class FluxRepeatTest {
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void timesInvalid() {
-		Flux.never()
-		    .repeat(-1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never()
+					.repeat(-1);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatWhenTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -34,13 +34,16 @@ import reactor.util.context.Context;
 import reactor.util.function.Tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxRepeatWhenTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void whenFactoryNull() {
-		Flux.never()
-		    .repeatWhen(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never()
+					.repeatWhen(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxReplayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxReplayTest.java
@@ -21,9 +21,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
@@ -63,27 +63,31 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 		);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void failPrefetch(){
-		Flux.never()
-		    .replay( -1);
+	@Test
+	public void failPrefetch() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never()
+					.replay(-1);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void failTime(){
-		Flux.never()
-		    .replay( Duration.ofDays(-1));
+	@Test
+	public void failTime() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never()
+					.replay(Duration.ofDays(-1));
+		});
 	}
 
 	VirtualTimeScheduler vts;
 
-	@Before
+	@BeforeEach
 	public void vtsStart() {
 		//delayElements (notably) now uses parallel() so VTS must be enabled everywhere
 		vts = VirtualTimeScheduler.getOrSet();
 	}
 
-	@After
+	@AfterEach
 	public void vtsStop() {
 		vts = null;
 		VirtualTimeScheduler.reset();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRetryPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRetryPredicateTest.java
@@ -19,24 +19,30 @@ package reactor.core.publisher;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxRetryPredicateTest {
 
 	final Flux<Integer> source = Flux.concat(Flux.range(1, 5),
 			Flux.error(new RuntimeException("forced failure 0")));
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxRetryPredicate<>(null, e -> true);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxRetryPredicate<>(null, e -> true);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void predicateNull() {
-		Flux.never()
-		    .retry(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never()
+					.retry(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRetryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRetryTest.java
@@ -19,21 +19,26 @@ package reactor.core.publisher;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 public class FluxRetryTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxRetry<>(null, 1);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxRetry<>(null, 1);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void timesInvalid() {
-		Flux.never()
-		    .retry(-1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never().retry(-1);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
@@ -21,7 +21,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -30,7 +29,7 @@ import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.LongAssert;
 import org.assertj.core.data.Percentage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -45,6 +44,7 @@ import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxRetryWhenTest {
 
@@ -54,15 +54,18 @@ public class FluxRetryWhenTest {
 	Flux<Integer> rangeError = Flux.concat(Flux.range(1, 2),
 			Flux.error(new RuntimeException("forced failure 0")));
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxRetryWhen<>(null, v -> v);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxRetryWhen<>(null, v -> v);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void whenFactoryNull() {
-		Flux.never()
-		    .retryWhen(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never().retryWhen(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSampleFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSampleFirstTest.java
@@ -20,7 +20,7 @@ import java.time.Duration;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTest.java
@@ -19,7 +19,7 @@ package reactor.core.publisher;
 import java.time.Duration;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -28,17 +28,22 @@ import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxSampleTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxSample<>(null, Flux.never());
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxSample<>(null, Flux.never());
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void otherNull() {
-		Flux.never().sample((Publisher<Object>)null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never().sample((Publisher<Object>) null);
+		});
 	}
 
 	void sample(boolean complete, boolean which) {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTimeoutTest.java
@@ -20,7 +20,7 @@ import java.time.Duration;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxScanSeedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxScanSeedTest.java
@@ -16,23 +16,21 @@
 
 package reactor.core.publisher;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
-
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.test.util.RaceTestUtils;
-import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxScanSeedTest extends FluxOperatorTest<String, String> {
 
@@ -78,21 +76,27 @@ public class FluxScanSeedTest extends FluxOperatorTest<String, String> {
 		);
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxScanSeed<>(null, () -> 1, (a, b) -> a);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxScanSeed<>(null, () -> 1, (a, b) -> a);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void initialValueNull() {
-		Flux.never()
-		    .scan(null, (a, b) -> a);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never()
+					.scan(null, (a, b) -> a);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void accumulatorNull() {
-		Flux.never()
-		    .scan(1, null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never()
+					.scan(1, null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxScanTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxScanTest.java
@@ -16,13 +16,12 @@
 
 package reactor.core.publisher;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 
 import reactor.core.CoreSubscriber;
@@ -30,9 +29,10 @@ import reactor.core.Scannable;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.test.util.RaceTestUtils;
-import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FluxScanTest extends FluxOperatorTest<String, String> {
 
@@ -60,14 +60,18 @@ public class FluxScanTest extends FluxOperatorTest<String, String> {
 		);
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxScan<>(null, (a, b) -> a);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxScan<>(null, (a, b) -> a);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void accumulatorNull() {
-		Flux.never().scan(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never().scan(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSkipLastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSkipLastTest.java
@@ -20,12 +20,15 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FluxSkipLastTest extends FluxOperatorTest<String, String> {
 	@Override
@@ -50,15 +53,19 @@ public class FluxSkipLastTest extends FluxOperatorTest<String, String> {
 	}
 
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxSkipLast<>(null, 1);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxSkipLast<>(null, 1);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void negativeNumber() {
-		Flux.never()
-		    .skipLast(-1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never()
+					.skipLast(-1);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSkipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSkipTest.java
@@ -20,13 +20,16 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FluxSkipTest extends FluxOperatorTest<String, String> {
 
@@ -49,14 +52,18 @@ public class FluxSkipTest extends FluxOperatorTest<String, String> {
 		return Arrays.asList(scenario(f -> f.skip(1)));
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxSkip<>(null, 1);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxSkip<>(null, 1);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void skipInvalid() {
-		Flux.never().skip(-1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never().skip(-1);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSkipUntilOtherTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSkipUntilOtherTest.java
@@ -21,13 +21,16 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FluxSkipUntilOtherTest extends FluxOperatorTest<String, String> {
 
@@ -69,15 +72,19 @@ public class FluxSkipUntilOtherTest extends FluxOperatorTest<String, String> {
 		);
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullSource() {
-		new FluxSkipUntilOther<>(null, Flux.never());
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxSkipUntilOther<>(null, Flux.never());
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullOther() {
-		Flux.never()
-		    .skipUntilOther(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never()
+					.skipUntilOther(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSkipUntilTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSkipUntilTest.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSkipWhileTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSkipWhileTest.java
@@ -20,13 +20,16 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FluxSkipWhileTest extends FluxOperatorTest<String, String> {
 
@@ -53,15 +56,19 @@ public class FluxSkipWhileTest extends FluxOperatorTest<String, String> {
 	}
 
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxSkipWhile<>(null, v -> true);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxSkipWhile<>(null, v -> true);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void predicateNull() {
-		Flux.never()
-		    .skipWhile(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never()
+					.skipWhile(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSourceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSourceTest.java
@@ -15,9 +15,7 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
-import org.reactivestreams.Subscription;
-import reactor.core.CoreSubscriber;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxStartWithTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxStartWithTest.java
@@ -15,7 +15,7 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import reactor.test.subscriber.AssertSubscriber;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxStreamTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxStreamTest.java
@@ -23,26 +23,31 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxStreamTest {
 
 	final List<Integer> source = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
 	@SuppressWarnings("ConstantConditions")
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullStream() {
-		Flux.fromStream((Stream<?>) null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.fromStream((Stream<?>) null);
+		});
 	}
 
 	@SuppressWarnings("ConstantConditions")
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullSupplier() {
-		Flux.fromStream((Supplier<Stream<?>>) null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.fromStream((Supplier<Stream<?>>) null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnCallableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnCallableTest.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import java.time.Duration;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnValueTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSubscribeOnValueTest.java
@@ -19,7 +19,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchIfEmptyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchIfEmptyTest.java
@@ -15,20 +15,26 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxSwitchIfEmptyTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxSwitchIfEmpty<>(null, Flux.never());
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxSwitchIfEmpty<>(null, Flux.never());
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void otherNull() {
-		Flux.never()
-		    .switchIfEmpty(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never()
+					.switchIfEmpty(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Disposables;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnNextTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnNextTest.java
@@ -16,10 +16,8 @@
 
 package reactor.core.publisher;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
-import reactor.test.subscriber.AssertSubscriber;
 
 public class FluxSwitchOnNextTest {
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeLastOneTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeLastOneTest.java
@@ -15,10 +15,12 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FluxTakeLastOneTest {
 
@@ -40,11 +42,13 @@ public class FluxTakeLastOneTest {
 	                .verifyErrorMessage("test");
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void illegal() {
-		StepVerifier.create(Flux.empty()
-		                        .takeLast(-1))
-	                .verifyComplete();
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			StepVerifier.create(Flux.empty()
+					.takeLast(-1))
+					.verifyComplete();
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeLastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeLastTest.java
@@ -17,22 +17,29 @@
 package reactor.core.publisher;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class FluxTakeLastTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxTakeLast<>(null, 1);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxTakeLast<>(null, 1);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void negativeNumber() {
-		Flux.never().takeLast(-1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never().takeLast(-1);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
@@ -35,24 +35,32 @@ import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FluxTakeTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxTake<>(null, 1);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxTake<>(null, 1);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void numberIsInvalid() {
-		Flux.never()
-		    .take(-1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never()
+					.take(-1);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void numberIsInvalidFused() {
-		Flux.just(1)
-		    .take(-1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.just(1)
+					.take(-1);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeUntilOtherTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeUntilOtherTest.java
@@ -19,24 +19,31 @@ package reactor.core.publisher;
 import java.time.Duration;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class FluxTakeUntilOtherTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullSource() {
-		new FluxTakeUntilOther<>(null, Flux.never());
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxTakeUntilOther<>(null, Flux.never());
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullOther() {
-		Flux.never()
-		    .takeUntilOther(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never()
+					.takeUntilOther(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeUntilPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeUntilPredicateTest.java
@@ -16,23 +16,30 @@
 package reactor.core.publisher;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class FluxTakeUntilPredicateTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxTakeUntil<>(null, v -> true);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxTakeUntil<>(null, v -> true);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void predicateNull() {
-		Flux.never()
-		    .takeUntil(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never()
+					.takeUntil(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeWhileTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeWhileTest.java
@@ -17,24 +17,31 @@
 package reactor.core.publisher;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class FluxTakeWhileTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxTakeWhile<>(null, v -> true);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxTakeWhile<>(null, v -> true);
+		});
+
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void predicateNull() {
-		Flux.never()
-		    .takeWhile(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never().takeWhile(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxThenManyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxThenManyTest.java
@@ -16,7 +16,7 @@
 package reactor.core.publisher;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.subscriber.AssertSubscriber;
 
 /**

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTimestampTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTimestampTest.java
@@ -17,7 +17,7 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import reactor.util.function.Tuple2;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxUsingTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxUsingTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -36,6 +36,8 @@ import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FluxUsingTest extends FluxOperatorTest<String, String> {
 
@@ -89,21 +91,27 @@ public class FluxUsingTest extends FluxOperatorTest<String, String> {
 		);
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void resourceSupplierNull() {
-		Flux.using(null, r -> Flux.empty(), r -> {
-		}, false);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.using(null, r -> Flux.empty(), r -> {
+			}, false);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceFactoryNull() {
-		Flux.using(() -> 1, null, r -> {
-		}, false);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.using(() -> 1, null, r -> {
+			}, false);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void resourceCleanupNull() {
-		Flux.using(() -> 1, r -> Flux.empty(), null, false);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.using(() -> 1, r -> Flux.empty(), null, false);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxUsingWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxUsingWhenTest.java
@@ -24,10 +24,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.logging.Level;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
@@ -50,7 +49,6 @@ import reactor.util.function.Tuple2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
-@RunWith(JUnitParamsRunner.class)
 public class FluxUsingWhenTest {
 
 	@Test
@@ -358,8 +356,8 @@ public class FluxUsingWhenTest {
 		testResource.rollbackProbe.assertWasSubscribed();
 	}
 
-	@Test
-	@Parameters(method = "sources01")
+	@ParameterizedTest
+	@MethodSource("sources01")
 	public void cancelWithHandler(Flux<String> source) {
 		TestResource testResource = new TestResource();
 
@@ -378,8 +376,8 @@ public class FluxUsingWhenTest {
 		testResource.rollbackProbe.assertWasSubscribed();
 	}
 
-	@Test
-	@Parameters(method = "sources01")
+	@ParameterizedTest
+	@MethodSource("sources01")
 	public void cancelWithHandlerFailure(Flux<String> source) {
 		TestResource testResource = new TestResource();
 		final TestLogger tl = new TestLogger();
@@ -411,8 +409,8 @@ public class FluxUsingWhenTest {
 				.contains("java.lang.IllegalStateException: rollback error");
 	}
 
-	@Test
-	@Parameters(method = "sources01")
+	@ParameterizedTest
+	@MethodSource("sources01")
 	public void cancelWithHandlerGenerationFailureLogs(Flux<String> source) throws InterruptedException {
 		TestLogger tl = new TestLogger();
 		Loggers.useCustomLoggers(name -> tl);
@@ -441,8 +439,8 @@ public class FluxUsingWhenTest {
 				.contains("java.lang.NullPointerException");
 	}
 
-	@Test
-	@Parameters(method = "sources01")
+	@ParameterizedTest
+	@MethodSource("sources01")
 	public void cancelWithoutHandlerAppliesCommit(Flux<String> source) {
 		TestResource testResource = new TestResource();
 
@@ -461,8 +459,8 @@ public class FluxUsingWhenTest {
 		testResource.rollbackProbe.assertWasNotSubscribed();
 	}
 
-	@Test
-	@Parameters(method = "sources01")
+	@ParameterizedTest
+	@MethodSource("sources01")
 	public void cancelDefaultHandlerFailure(Flux<String> source) {
 		TestResource testResource = new TestResource();
 		final TestLogger tl = new TestLogger();
@@ -493,8 +491,8 @@ public class FluxUsingWhenTest {
 				.contains("java.lang.IllegalStateException: commit error");
 	}
 
-	@Test
-	@Parameters(method = "sourcesFullTransaction")
+	@ParameterizedTest
+	@MethodSource("sourcesFullTransaction")
 	public void apiCommit(Flux<String> fullTransaction) {
 		final AtomicReference<TestResource> ref = new AtomicReference<>();
 
@@ -519,8 +517,8 @@ public class FluxUsingWhenTest {
 				.matches(tr -> !tr.rollbackProbe.wasSubscribed(), "no rollback");
 	}
 
-	@Test
-	@Parameters(method = "sourcesFullTransaction")
+	@ParameterizedTest
+	@MethodSource("sourcesFullTransaction")
 	public void apiCommitFailure(Flux<String> fullTransaction) {
 		final AtomicReference<TestResource> ref = new AtomicReference<>();
 
@@ -546,8 +544,8 @@ public class FluxUsingWhenTest {
 				.matches(tr -> !tr.rollbackProbe.wasSubscribed(), "no rollback");
 	}
 
-	@Test
-	@Parameters(method = "sourcesFullTransaction")
+	@ParameterizedTest
+	@MethodSource("sourcesFullTransaction")
 	public void commitGeneratingNull(Flux<String> fullTransaction) {
 		final AtomicReference<TestResource> ref = new AtomicReference<>();
 
@@ -574,8 +572,8 @@ public class FluxUsingWhenTest {
 				.matches(tr -> !tr.rollbackProbe.wasSubscribed(), "no rollback");
 	}
 
-	@Test
-	@Parameters(method = "sourcesTransactionError")
+	@ParameterizedTest
+	@MethodSource("sourcesTransactionError")
 	public void apiRollback(Flux<String> transactionWithError) {
 		final AtomicReference<TestResource> ref = new AtomicReference<>();
 		Flux<String> flux = Flux.usingWhen(Mono.fromCallable(TestResource::new),
@@ -600,8 +598,8 @@ public class FluxUsingWhenTest {
 				.matches(tr -> tr.rollbackProbe.wasSubscribed(), "rollback method used");
 	}
 
-	@Test
-	@Parameters(method = "sourcesTransactionError")
+	@ParameterizedTest
+	@MethodSource("sourcesTransactionError")
 	public void apiRollbackFailure(Flux<String> transactionWithError) {
 		final AtomicReference<TestResource> ref = new AtomicReference<>();
 		Flux<String> flux = Flux.usingWhen(Mono.fromCallable(TestResource::new),
@@ -626,8 +624,8 @@ public class FluxUsingWhenTest {
 				.matches(tr -> tr.rollbackProbe.wasSubscribed(), "rollback method used");
 	}
 
-	@Test
-	@Parameters(method = "sourcesTransactionError")
+	@ParameterizedTest
+	@MethodSource("sourcesTransactionError")
 	public void apiRollbackGeneratingNull(Flux<String> transactionWithError) {
 		final AtomicReference<TestResource> ref = new AtomicReference<>();
 		Flux<String> flux = Flux.usingWhen(Mono.fromCallable(TestResource::new),
@@ -716,8 +714,8 @@ public class FluxUsingWhenTest {
 		assertThat(test).isNotInstanceOf(Fuseable.QueueSubscription.class);
 	}
 
-	@Test
-	@Parameters(method = "sourcesContext")
+	@ParameterizedTest
+	@MethodSource("sourcesContext")
 	public void contextPropagationOnCommit(Mono<String> source) {
 		AtomicReference<String> probeContextValue = new AtomicReference<>();
 		AtomicReference<String> resourceContextValue = new AtomicReference<>();
@@ -756,8 +754,8 @@ public class FluxUsingWhenTest {
 		assertThat(resourceContextValue).hasValue("contextual");
 	}
 
-	@Test
-	@Parameters(method = "sourcesContextError")
+	@ParameterizedTest
+	@MethodSource("sourcesContextError")
 	public void contextPropagationOnRollback(Mono<String> source) {
 		AtomicReference<String> probeContextValue = new AtomicReference<>();
 		AtomicReference<String> resourceContextValue = new AtomicReference<>();
@@ -795,8 +793,8 @@ public class FluxUsingWhenTest {
 		assertThat(resourceContextValue).hasValue("contextual");
 	}
 
-	@Test
-	@Parameters(method = "sources01")
+	@ParameterizedTest
+	@MethodSource("sources01")
 	public void contextPropagationOnCancel(Flux<String> source) {
 		TestResource testResource = new TestResource();
 		AtomicReference<Throwable> errorRef = new AtomicReference<>();
@@ -825,8 +823,8 @@ public class FluxUsingWhenTest {
 		assertThat(errorRef).hasValue(null);
 	}
 
-	@Test
-	@Parameters(method = "sources01")
+	@ParameterizedTest
+	@MethodSource("sources01")
 	public void contextPropagationOnCancelWithNoHandler(Flux<String> source) {
 		TestResource testResource = new TestResource();
 		AtomicReference<Throwable> errorRef = new AtomicReference<>();
@@ -1244,21 +1242,21 @@ public class FluxUsingWhenTest {
 
 	//unit test parameter providers
 
-	private Object[] sources01() {
+	private static Object[] sources01() {
 		return new Object[] {
 				new Object[] { Flux.interval(Duration.ofMillis(100)).map(String::valueOf) },
 				new Object[] { Flux.range(0, 2).map(String::valueOf) }
 		};
 	}
 
-	private Object[] sourcesFullTransaction() {
+	private static Object[] sourcesFullTransaction() {
 		return new Object[] {
 				new Object[] { Flux.just("Transaction started", "work in transaction", "more work in transaction").hide() },
 				new Object[] { Flux.just("Transaction started", "work in transaction", "more work in transaction") }
 		};
 	}
 
-	private Object[] sourcesTransactionError() {
+	private static Object[] sourcesTransactionError() {
 		return new Object[] {
 				new Object[] { Flux.just("Transaction started", "work in transaction")
 						.concatWith(Mono.error(new IllegalStateException("boom"))) },
@@ -1267,14 +1265,14 @@ public class FluxUsingWhenTest {
 		};
 	}
 
-	private Object[] sourcesContext() {
+	private static Object[] sourcesContext() {
 		return new Object[] {
 				new Object[] { Mono.subscriberContext().map(it -> it.get(String.class)).hide() },
 				new Object[] { Mono.subscriberContext().map(it -> it.get(String.class)) }
 		};
 	}
 
-	private Object[] sourcesContextError() {
+	private static Object[] sourcesContextError() {
 		return new Object[] {
 				new Object[] { Mono
 						.subscriberContext()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
@@ -29,7 +29,7 @@ import java.util.logging.Level;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Supplier;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
@@ -34,6 +34,8 @@ import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
@@ -77,47 +79,63 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 	final Supplier<Queue<Integer>>                   pqs = ConcurrentLinkedQueue::new;
 	final Supplier<Queue<UnicastProcessor<Integer>>> oqs = ConcurrentLinkedQueue::new;
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void source1Null() {
-		new FluxWindow<>(null, 1, pqs);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxWindow<>(null, 1, pqs);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void source2Null() {
-		new FluxWindow<>(null, 1, 2, pqs, oqs);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxWindow<>(null, 1, 2, pqs, oqs);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void processorQueue1Null() {
-		new FluxWindow<>(Flux.never(), 1, null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxWindow<>(Flux.never(), 1, null);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void processorQueue2Null() {
-		new FluxWindow<>(Flux.never(), 1, 1, null, oqs);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxWindow<>(Flux.never(), 1, 1, null, oqs);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void overflowQueueNull() {
-		new FluxWindow<>(Flux.never(), 1, 1, pqs, null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxWindow<>(Flux.never(), 1, 1, pqs, null);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void size1Invalid() {
-		Flux.never()
-		    .window(0);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never()
+					.window(0);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void size2Invalid() {
-		Flux.never()
-		    .window(0, 2);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never()
+					.window(0, 2);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void skipInvalid() {
-		Flux.never()
-		    .window(1, 0);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.never()
+					.window(1, 0);
+		});
 	}
 
 	static <T> AssertSubscriber<T> toList(Publisher<T> windows) {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTimeoutTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
@@ -16,12 +16,8 @@
 
 package reactor.core.publisher;
 
-import java.lang.ref.PhantomReference;
-import java.lang.ref.ReferenceQueue;
-import java.lang.ref.WeakReference;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -31,7 +27,7 @@ import java.util.concurrent.atomic.LongAdder;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWithLatestFromTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWithLatestFromTest.java
@@ -17,7 +17,7 @@ package reactor.core.publisher;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -25,24 +25,33 @@ import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.context.Context;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class FluxWithLatestFromTest {
 
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxWithLatestFrom<>(null, Flux.never(), (a, b) -> a);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxWithLatestFrom<>(null, Flux.never(), (a, b) -> a);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void otherNull() {
-		Flux.never()
-		    .withLatestFrom(null, (a, b) -> a);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never()
+					.withLatestFrom(null, (a, b) -> a);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void combinerNull() {
-		Flux.never()
-		    .withLatestFrom(Flux.never(), null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never()
+					.withLatestFrom(Flux.never(), null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxZipIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxZipIterableTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -31,6 +31,9 @@ import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.function.Tuples;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FluxZipIterableTest extends FluxOperatorTest<String, String> {
 
@@ -101,21 +104,27 @@ public class FluxZipIterableTest extends FluxOperatorTest<String, String> {
 		);
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new FluxZipIterable<>(null, Collections.emptyList(), (a, b) -> a);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new FluxZipIterable<>(null, Collections.emptyList(), (a, b) -> a);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void iterableNull() {
-		Flux.never()
-		    .zipWithIterable(null, (a, b) -> a);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never()
+					.zipWithIterable(null, (a, b) -> a);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void zipperNull() {
-		Flux.never()
-		    .zipWithIterable(Collections.emptyList(), null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never()
+					.zipWithIterable(Collections.emptyList(), null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
@@ -40,6 +40,8 @@ import reactor.util.function.Tuple7;
 import reactor.util.function.Tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FluxZipTest extends FluxOperatorTest<String, String> {
 
@@ -608,14 +610,18 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 		assertThat(f.getPrefetch()).isEqualTo(123);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void failPrefetch() {
-		Flux.zip(obj -> 0, -1, Flux.just(1), Flux.just(2));
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.zip(obj -> 0, -1, Flux.just(1), Flux.just(2));
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void failPrefetchIterable() {
-		Flux.zip(Arrays.asList(Flux.just(1), Flux.just(2)), -1, obj -> 0);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Flux.zip(Arrays.asList(Flux.just(1), Flux.just(2)), -1, obj -> 0);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
@@ -30,15 +30,14 @@ import java.util.function.Function;
 import java.util.logging.Level;
 
 import org.assertj.core.api.Assertions;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
-import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -55,7 +54,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  */
 public class HooksTest {
 
-	@After
+	@AfterEach
 	public void resetAllHooks() {
 		Hooks.resetOnOperatorError();
 		Hooks.resetOnNextDropped();

--- a/reactor-core/src/test/java/reactor/core/publisher/InnerProducerTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/InnerProducerTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.Scannable;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/LambdaSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/LambdaSubscriberTest.java
@@ -19,7 +19,7 @@ package reactor.core.publisher;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.Scannable;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/LiftFunctionTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/LiftFunctionTest.java
@@ -22,8 +22,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.awaitility.Awaitility;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.Fuseable;
 
@@ -143,7 +143,7 @@ public class LiftFunctionTest {
 				.untilAsserted(() -> assertThat(cancelSupportInvoked).isTrue());
 	}
 
-	@Ignore("GroupedFlux is always fuseable for now")
+	@Disabled("GroupedFlux is always fuseable for now")
 	@Test
 	public void liftGroupedFlux() {
 		Flux<GroupedFlux<String, Integer>> sourceGroups = Flux

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoAllTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoAllTest.java
@@ -17,24 +17,29 @@
 package reactor.core.publisher;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoAllTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new MonoAll<>(null, v -> true);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoAll<>(null, v -> true);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void predicateNull() {
-		new MonoAll<>(null, null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoAll<>(null, null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoAnyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoAnyTest.java
@@ -17,7 +17,7 @@
 package reactor.core.publisher;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -26,22 +26,29 @@ import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoAnyTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new MonoAny<>(null, v -> true);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoAny<>(null, v -> true);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void predicateNull() {
-		new MonoAny<>(null, null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoAny<>(null, null);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void elementNull() {
-		Flux.never().hasElement(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never().hasElement(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import reactor.core.Disposable;
 import reactor.core.scheduler.Schedulers;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCallableOnAssemblyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCallableOnAssemblyTest.java
@@ -32,7 +32,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.core.publisher.FluxOnAssembly.AssemblySnapshot;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCallableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCallableTest.java
@@ -22,169 +22,170 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.assertj.core.data.Offset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
-
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.function.Tuple2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoCallableTest {
 
-    @Test(expected = NullPointerException.class)
-    public void nullCallable() {
-        Mono.<Integer>fromCallable(null);
-    }
+	@Test
+	public void nullCallable() {
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Mono.<Integer>fromCallable(null);
+		});
+	}
 
-    @Test
-    public void callableReturnsNull() {
-        AssertSubscriber<Integer> ts = AssertSubscriber.create();
+	@Test
+	public void callableReturnsNull() {
+		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-        Mono.<Integer>fromCallable(() -> null).subscribe(ts);
+		Mono.<Integer>fromCallable(() -> null).subscribe(ts);
 
-        ts.assertNoValues()
-          .assertNoError()
-          .assertComplete();
-    }
+		ts.assertNoValues()
+				.assertNoError()
+				.assertComplete();
+	}
 
-    @Test
-    public void callableReturnsNullShortcircuitsBackpressure() {
-        AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
+	@Test
+	public void callableReturnsNullShortcircuitsBackpressure() {
+		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
-        Mono.<Integer>fromCallable(() -> null).subscribe(ts);
+		Mono.<Integer>fromCallable(() -> null).subscribe(ts);
 
-        ts.assertNoValues()
-          .assertNoError()
-          .assertComplete();
-    }
+		ts.assertNoValues()
+				.assertNoError()
+				.assertComplete();
+	}
 
-    @Test
-    public void normal() {
-        AssertSubscriber<Integer> ts = AssertSubscriber.create();
+	@Test
+	public void normal() {
+		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-        Mono.fromCallable(() -> 1).subscribe(ts);
+		Mono.fromCallable(() -> 1).subscribe(ts);
 
-        ts.assertValues(1)
-          .assertComplete()
-          .assertNoError();
-    }
+		ts.assertValues(1)
+				.assertComplete()
+				.assertNoError();
+	}
 
-    @Test
-    public void normalBackpressured() {
-        AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
+	@Test
+	public void normalBackpressured() {
+		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
-        Mono.fromCallable(() -> 1).subscribe(ts);
+		Mono.fromCallable(() -> 1).subscribe(ts);
 
-        ts.assertNoValues()
-          .assertNotComplete()
-          .assertNoError();
+		ts.assertNoValues()
+				.assertNotComplete()
+				.assertNoError();
 
-        ts.request(1);
+		ts.request(1);
 
-        ts.assertValues(1)
-          .assertComplete()
-          .assertNoError();
-    }
+		ts.assertValues(1)
+				.assertComplete()
+				.assertNoError();
+	}
 
-    @Test
-    public void callableThrows() {
-        AssertSubscriber<Object> ts = AssertSubscriber.create();
+	@Test
+	public void callableThrows() {
+		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-        Mono.fromCallable(() -> {
-            throw new IOException("forced failure");
-        }).subscribe(ts);
+		Mono.fromCallable(() -> {
+			throw new IOException("forced failure");
+		}).subscribe(ts);
 
-        ts.assertNoValues()
-          .assertNotComplete()
-          .assertError(IOException.class)
-          .assertErrorMessage("forced failure");
-    }
+		ts.assertNoValues()
+				.assertNotComplete()
+				.assertError(IOException.class)
+				.assertErrorMessage("forced failure");
+	}
 
-    @Test
-    public void onMonoSuccessCallableOnBlock() {
-        assertThat(Mono.fromCallable(() -> "test")
-                       .block()).isEqualToIgnoringCase("test");
-    }
+	@Test
+	public void onMonoSuccessCallableOnBlock() {
+		assertThat(Mono.fromCallable(() -> "test")
+				.block()).isEqualToIgnoringCase("test");
+	}
 
-    @Test
-    public void onMonoEmptyCallableOnBlock() {
-        assertThat(Mono.fromCallable(() -> null)
-                       .block()).isNull();
-    }
+	@Test
+	public void onMonoEmptyCallableOnBlock() {
+		assertThat(Mono.fromCallable(() -> null)
+				.block()).isNull();
+	}
 
-    @Test(expected = RuntimeException.class)
-    public void onMonoErrorCallableOnBlock() {
-        Mono.fromCallable(() -> {
-            throw new Exception("test");
-        })
-            .block();
-    }
+	@Test
+	public void onMonoErrorCallableOnBlock() {
+		assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> {
+			Mono.fromCallable(() -> {
+				throw new Exception("test");
+			}).block();
+		});
+	}
 
-    @Test
-    public void delegateCall() throws Exception {
-        MonoCallable<Integer> monoCallable = new MonoCallable<>(() -> 1);
+	@Test
+	public void delegateCall() throws Exception {
+		MonoCallable<Integer> monoCallable = new MonoCallable<>(() -> 1);
 
-        assertThat(monoCallable.call()).isEqualTo(1);
-    }
+		assertThat(monoCallable.call()).isEqualTo(1);
+	}
 
-    @Test
-    public void delegateCallError() {
-        MonoCallable<Integer> monoCallable = new MonoCallable<>(() -> {
-            throw new IllegalStateException("boom");
-        });
+	@Test
+	public void delegateCallError() {
+		MonoCallable<Integer> monoCallable = new MonoCallable<>(() -> {
+			throw new IllegalStateException("boom");
+		});
 
-        assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(monoCallable::call)
-                .withMessage("boom");
-    }
+		assertThatExceptionOfType(IllegalStateException.class)
+				.isThrownBy(monoCallable::call)
+				.withMessage("boom");
+	}
 
-    @Test
-    public void delegateCallNull() throws Exception {
-        MonoCallable<Integer> monoCallable = new MonoCallable<>(() -> null);
+	@Test
+	public void delegateCallNull() throws Exception {
+		MonoCallable<Integer> monoCallable = new MonoCallable<>(() -> null);
 
-        assertThat(monoCallable.call()).isNull();
-    }
+		assertThat(monoCallable.call()).isNull();
+	}
 
-    //see https://github.com/reactor/reactor-core/issues/1503
-    @Test
-    public void callableCancelledBeforeRun() {
-        AtomicBoolean actual = new AtomicBoolean(true);
-        Mono<?> mono = Mono.fromCallable(() -> actual.getAndSet(false))
-                           .doOnSubscribe(Subscription::cancel);
+	//see https://github.com/reactor/reactor-core/issues/1503
+	@Test
+	public void callableCancelledBeforeRun() {
+		AtomicBoolean actual = new AtomicBoolean(true);
+		Mono<?> mono = Mono.fromCallable(() -> actual.getAndSet(false))
+				.doOnSubscribe(Subscription::cancel);
 
-        StepVerifier.create(mono)
-                    .expectSubscription()
-                    .expectNoEvent(Duration.ofSeconds(1))
-                    .thenCancel()
-                    .verify();
+		StepVerifier.create(mono)
+				.expectSubscription()
+				.expectNoEvent(Duration.ofSeconds(1))
+				.thenCancel()
+				.verify();
 
-        assertThat(actual).as("cancelled before run").isTrue();
-    }
+		assertThat(actual).as("cancelled before run").isTrue();
+	}
 
-    //see https://github.com/reactor/reactor-core/issues/1503
-    //see https://github.com/reactor/reactor-core/issues/1504
-    @Test
-    public void callableSubscribeToCompleteMeasurement() {
-        AtomicLong subscribeTs = new AtomicLong();
-        Mono<String> mono = Mono.fromCallable(() -> {
-            try {
-                Thread.sleep(500);
-            }
-            catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-            return "foo";
-        })
-                                .doOnSubscribe(sub -> subscribeTs.set(-1 * System.nanoTime()))
-                                .doFinally(fin -> subscribeTs.addAndGet(System.nanoTime()));
+	//see https://github.com/reactor/reactor-core/issues/1503
+	//see https://github.com/reactor/reactor-core/issues/1504
+	@Test
+	public void callableSubscribeToCompleteMeasurement() {
+		AtomicLong subscribeTs = new AtomicLong();
+		Mono<String> mono = Mono.fromCallable(() -> {
+			try {
+				Thread.sleep(500);
+			}
+			catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+			return "foo";
+		})
+				.doOnSubscribe(sub -> subscribeTs.set(-1 * System.nanoTime()))
+				.doFinally(fin -> subscribeTs.addAndGet(System.nanoTime()));
 
-        StepVerifier.create(mono)
-                    .expectNext("foo")
-                    .verifyComplete();
+		StepVerifier.create(mono)
+				.expectNext("foo")
+				.verifyComplete();
 
-        assertThat(TimeUnit.NANOSECONDS.toMillis(subscribeTs.get())).isCloseTo(500L, Offset.offset(50L));
-    }
+		assertThat(TimeUnit.NANOSECONDS.toMillis(subscribeTs.get())).isCloseTo(500L, Offset.offset(50L));
+	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCancelOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCancelOnTest.java
@@ -19,7 +19,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.subscriber.AssertSubscriber;
@@ -28,7 +29,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoCancelOnTest {
 
-	@Test(timeout = 3000L)
+	@Test
+	@Timeout(3)
 	public void cancelOnDedicatedScheduler() throws Exception {
 
 		CountDownLatch latch = new CountDownLatch(1);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCastTest.java
@@ -16,21 +16,25 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoCastTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		Mono.just(1)
-		    .cast(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Mono.just(1).cast(null);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull2() {
-		Mono.just(1)
-		    .ofType(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Mono.just(1).ofType(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCollectMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCollectMapTest.java
@@ -18,7 +18,7 @@ package reactor.core.publisher;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCollectTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCollectTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
@@ -38,26 +38,34 @@ import reactor.util.Loggers;
 import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoCollectTest {
 
 	static final Logger LOGGER = Loggers.getLogger(MonoCollectListTest.class);
 
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullSource() {
-		new MonoCollect<>(null, () -> 1, (a, b) -> {
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoCollect<>(null, () -> 1, (a, b) -> {
+			});
 		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullSupplier() {
-		Flux.never().collect(null, (a, b) -> {});
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never().collect(null, (a, b) -> {
+			});
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullAction() {
-		Flux.never().collect(() -> 1, null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never().collect(() -> 1, null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCompletionStageTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCompletionStageTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 
 import reactor.test.StepVerifier;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCountTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCountTest.java
@@ -16,19 +16,22 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoCountTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new MonoCount<>(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoCount<>(null);
+		});
 	}
 
 	public void normal() {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCreateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCreateTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDefaultIfEmptyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDefaultIfEmptyTest.java
@@ -16,20 +16,26 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 public class MonoDefaultIfEmptyTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new MonoDefaultIfEmpty<>(null, 1);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoDefaultIfEmpty<>(null, 1);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void valueNull() {
-		Mono.never().defaultIfEmpty(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Mono.never().defaultIfEmpty(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDeferComposeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDeferComposeTest.java
@@ -17,8 +17,7 @@ package reactor.core.publisher;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 import reactor.test.subscriber.AssertSubscriber;
 
 public class MonoDeferComposeTest {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDeferTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDeferTest.java
@@ -18,7 +18,7 @@ package reactor.core.publisher;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MonoDeferTest {
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDelayElementTest.java
@@ -24,10 +24,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
-import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -102,7 +102,8 @@ public class MonoDelayElementTest {
 		assertThat(cancelled.get()).isTrue();
 	}
 
-	@Test(timeout = 5000L)
+	@Test
+	@Timeout(5)
 	public void emptyIsImmediate() {
 		Mono<String> source = Mono.<String>empty().log().hide();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDelaySubscriptionTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDelaySubscriptionTest.java
@@ -18,21 +18,27 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 public class MonoDelaySubscriptionTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new MonoDelaySubscription<>(null, Mono.never());
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoDelaySubscription<>(null, Mono.never());
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void otherNull() {
-		Mono.never().delaySubscription((Publisher<?>)null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Mono.never().delaySubscription((Publisher<?>) null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDelayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDelayTest.java
@@ -19,7 +19,7 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDelayUntilTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDelayUntilTest.java
@@ -19,14 +19,12 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
-import reactor.core.Disposable;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDematerializeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDematerializeTest.java
@@ -15,8 +15,8 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import reactor.test.subscriber.AssertSubscriber;
 
 public class MonoDematerializeTest {
@@ -114,7 +114,7 @@ public class MonoDematerializeTest {
 	}
 
 	@Test
-	@Ignore("use virtual time?")
+	@Disabled("use virtual time?")
 	public void neverEnding() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDetachTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDetachTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.awaitility.Awaitility;
 import org.awaitility.Duration;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import reactor.test.subscriber.AssertSubscriber;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDoFinallyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDoFinallyTest.java
@@ -22,11 +22,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.Exceptions;
 import reactor.test.StepVerifier;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
@@ -44,7 +45,7 @@ public class MonoDoFinallyTest implements Consumer<SignalType> {
 	volatile SignalType signalType;
 	volatile int calls;
 
-	@Before
+	@BeforeEach
 	public void before() {
 		signalType = null;
 		calls = 0;
@@ -146,9 +147,11 @@ public class MonoDoFinallyTest implements Consumer<SignalType> {
 	}
 
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullCallback() {
-		Mono.just(1).doFinally(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Mono.just(1).doFinally(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDoFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDoFirstTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 
 import reactor.core.Fuseable;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDoOnEachTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDoOnEachTest.java
@@ -25,8 +25,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import reactor.core.CoreSubscriber;
@@ -339,7 +339,7 @@ public class MonoDoOnEachTest {
 
 	//see https://github.com/reactor/reactor-core/issues/1547
 	@Test
-	@Ignore("Mono doesn't trigger tryOnNext")
+	@Disabled("Mono doesn't trigger tryOnNext")
 	public void triggersCompleteSignalInMonoOnNextConditional() {
 		CopyOnWriteArrayList<String> eventOrder = new CopyOnWriteArrayList<>();
 
@@ -366,7 +366,7 @@ public class MonoDoOnEachTest {
 
 	//see https://github.com/reactor/reactor-core/issues/1547
 	@Test
-	@Ignore("Mono doesn't trigger tryOnNext")
+	@Disabled("Mono doesn't trigger tryOnNext")
 	public void triggersCompleteSignalInMonoOnNextConditionalFused() {
 		CopyOnWriteArrayList<String> eventOrder = new CopyOnWriteArrayList<>();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoElapsedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoElapsedTest.java
@@ -17,7 +17,7 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoElementAtTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoElementAtTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -24,32 +24,43 @@ import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoElementAtTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void source1Null() {
-		new MonoElementAt<>(null, 1);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoElementAt<>(null, 1);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void source2Null() {
-		new MonoElementAt<>(null, 1, 1);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoElementAt<>(null, 1, 1);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void defaultSupplierNull() {
-		Flux.never().elementAt(1, null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never().elementAt(1, null);
+		});
 	}
 
-	@Test(expected = IndexOutOfBoundsException.class)
+	@Test
 	public void indexNegative1() {
-		Flux.never().elementAt(-1);
+		assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> {
+			Flux.never().elementAt(-1);
+		});
 	}
 
-	@Test(expected = IndexOutOfBoundsException.class)
+	@Test
 	public void indexNegative2() {
-		Flux.never().elementAt(-1, 1);
+		assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> {
+			Flux.never().elementAt(-1, 1);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoEmptyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoEmptyTest.java
@@ -15,7 +15,7 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
 public class MonoEmptyTest {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoErrorSuppliedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoErrorSuppliedTest.java
@@ -19,7 +19,7 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoErrorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoErrorTest.java
@@ -15,8 +15,10 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoErrorTest {
 
@@ -26,9 +28,11 @@ public class MonoErrorTest {
 		            .verifyErrorMessage("test");
 	}
 
-	@Test(expected = Exception.class)
+	@Test
 	public void onMonoRejectedThrowOnBlock() {
-		Mono.error(new Exception("test"))
-		    .block();
+		assertThatExceptionOfType(Exception.class).isThrownBy(() -> {
+			Mono.error(new Exception("test"))
+					.block();
+		});
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoExpandTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoExpandTest.java
@@ -25,7 +25,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -273,7 +274,8 @@ public class MonoExpandTest {
 		);
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void depthFirst() {
 		FluxExpandTest.Node root = createTest();
 
@@ -311,7 +313,8 @@ public class MonoExpandTest {
 		            .verify(Duration.ofSeconds(5));
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void breadthFirst() {
 		FluxExpandTest.Node root = createTest();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFilterTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFilterTest.java
@@ -16,25 +16,29 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.testng.Assert;
 import reactor.core.Exceptions;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoFilterTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new MonoFilter<Integer>(null, e -> true);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoFilter<Integer>(null, e -> true);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void predicateNull() {
-		Mono.never()
-		    .filter(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Mono.never().filter(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFirstTest.java
@@ -20,7 +20,8 @@ import java.time.Duration;
 import java.util.Arrays;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
@@ -28,7 +29,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoFirstTest {
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void allEmpty() {
 		Assert.assertNull(Mono.first(Mono.empty(),
 				Mono.delay(Duration.ofMillis(250))
@@ -36,7 +38,8 @@ public class MonoFirstTest {
 		                      .block());
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void someEmpty() {
 		Assert.assertNull(Mono.first(Mono.empty(), Mono.delay(Duration.ofMillis(250)))
 		                      .block());
@@ -65,7 +68,8 @@ public class MonoFirstTest {
 		 .assertComplete();
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void allEmptyIterable() {
 		Assert.assertNull(Mono.first(Arrays.asList(Mono.empty(),
 				Mono.delay(Duration.ofMillis(250))
@@ -73,7 +77,8 @@ public class MonoFirstTest {
 		                      .block());
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void someEmptyIterable() {
 		Assert.assertNull(Mono.first(Arrays.asList(Mono.empty(),
 				Mono.delay(Duration.ofMillis(250))))

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFlatMapManyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFlatMapManyTest.java
@@ -15,7 +15,7 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFlatMapTest.java
@@ -15,7 +15,7 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoHandleTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoHandleTest.java
@@ -15,7 +15,7 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static java.util.Collections.singleton;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoHasElementsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoHasElementsTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -28,12 +28,15 @@ import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoHasElementsTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new MonoHasElements<>(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoHasElements<>(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoHideTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoHideTest.java
@@ -15,7 +15,7 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Fuseable;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreEmptyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreEmptyTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoJustTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoJustTest.java
@@ -18,20 +18,23 @@ package reactor.core.publisher;
 import java.util.Optional;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoJustTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void nullValue() {
-        new MonoJust<Integer>(null);
-    }
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoJust<Integer>(null);
+		});
+	}
 
     @Test
     public void valueSame() {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMapTest.java
@@ -18,9 +18,11 @@ package reactor.core.publisher;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.publisher.MonoOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoMapTest extends MonoOperatorTest<String, String> {
 
@@ -40,14 +42,18 @@ public class MonoMapTest extends MonoOperatorTest<String, String> {
 
 	final Mono<Integer> just = Mono.just(1);
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullSource() {
-		new MonoMap<Integer, Integer>(null, v -> v);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoMap<Integer, Integer>(null, v -> v);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullMapper() {
-		just.map(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			just.map(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMaterializeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMaterializeTest.java
@@ -15,7 +15,7 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNameFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNameFuseableTest.java
@@ -20,7 +20,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNameTest.java
@@ -20,7 +20,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNeverTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNeverTest.java
@@ -15,7 +15,7 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.subscriber.AssertSubscriber;
 
 public class MonoNeverTest {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNextTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNextTest.java
@@ -15,7 +15,7 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoOnAssemblyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoOnAssemblyTest.java
@@ -32,7 +32,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.core.publisher.FluxOnAssembly.AssemblySnapshot;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoOnErrorResumeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoOnErrorResumeTest.java
@@ -17,7 +17,7 @@
 package reactor.core.publisher;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPeekAfterTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPeekAfterTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.scheduler.Schedulers;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTerminalTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTerminalTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTest.java
@@ -18,7 +18,7 @@ package reactor.core.publisher;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.Exceptions;
 import reactor.test.StepVerifier;
@@ -148,11 +148,13 @@ public class MonoPeekTest {
 		assertThat(ref.get()).isNull();
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void onMonoSuccessNullDoOnSuccess() {
 		Mono<String> mp = Mono.just("test");
-		mp.doOnSuccess(null)
-		  .subscribe();
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			mp.doOnSuccess(null)
+					.subscribe();
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoProcessorTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Scannable;
@@ -35,6 +35,7 @@ import reactor.util.function.Tuple2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MonoProcessorTest {
 
@@ -80,22 +81,21 @@ public class MonoProcessorTest {
 
 		future.completeExceptionally(new IllegalStateException());
 
-		assertThatExceptionOfType(IllegalStateException.class)
-				.isThrownBy(data::block);
+		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(data::block);
 
 		future = null;
 		source = null;
 		System.gc();
 
 		int cycles;
-		for (cycles = 10; cycles > 0 ; cycles--) {
+		for (cycles = 10; cycles > 0; cycles--) {
 			if (refFuture.get() == null) break;
 			Thread.sleep(100);
 		}
 
 		assertThat(refFuture.get()).isNull();
 		assertThat(cycles).isNotZero()
-		                  .isPositive();
+				.isPositive();
 	}
 
 	@Test
@@ -125,10 +125,12 @@ public class MonoProcessorTest {
 		                  .isPositive();
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void MonoProcessorResultNotAvailable() {
-		MonoProcessor<String> mp = MonoProcessor.create();
-		mp.block(Duration.ofMillis(1));
+		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> {
+			MonoProcessor<String> mp = MonoProcessor.create();
+			mp.block(Duration.ofMillis(1));
+		});
 	}
 
 	@Test
@@ -222,11 +224,13 @@ public class MonoProcessorTest {
 		assertThat(mp.isError()).isTrue();
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void MonoProcessorRejectedSubscribeCallbackNull() {
 		MonoProcessor<String> mp = MonoProcessor.create();
 
-		mp.subscribe((Subscriber<String>)null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			mp.subscribe((Subscriber<String>) null);
+		});
 	}
 
 	@Test
@@ -344,20 +348,24 @@ public class MonoProcessorTest {
 		            .verifyErrorMessage("test");
 	}
 
-	@Test(expected = Exception.class)
+	@Test
 	public void MonoProcessorDoubleError() {
 		MonoProcessor<String> mp = MonoProcessor.create();
 
 		mp.onError(new Exception("test"));
-		mp.onError(new Exception("test"));
+		assertThatExceptionOfType(Exception.class).isThrownBy(() -> {
+			mp.onError(new Exception("test"));
+		});
 	}
 
-	@Test(expected = Exception.class)
+	@Test
 	public void MonoProcessorDoubleSignal() {
 		MonoProcessor<String> mp = MonoProcessor.create();
 
 		mp.onNext("test");
-		mp.onError(new Exception("test"));
+		assertThatExceptionOfType(Exception.class).isThrownBy(() -> {
+			mp.onError(new Exception("test"));
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPublishMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPublishMulticastTest.java
@@ -21,19 +21,15 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.extractProperty;
 import static org.assertj.core.api.Fail.fail;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
 
 public class MonoPublishMulticastTest {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPublishOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPublishOnTest.java
@@ -26,8 +26,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
@@ -268,7 +268,7 @@ public class MonoPublishOnTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	//FIXME the behavior is not failing fast anymore, find original issue and re-evaluate
 	public void rejectedExecutionSubscribeExecutorScheduler() {
 		CountDownLatch latch = new CountDownLatch(1);
@@ -308,7 +308,7 @@ public class MonoPublishOnTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	//FIXME the behavior is not failing fast anymore, find original issue and re-evaluate
 	public void rejectedExecutionSubscribeExecutorServiceScheduler() {
 		CountDownLatch latch = new CountDownLatch(1);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoReduceSeedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoReduceSeedTest.java
@@ -21,9 +21,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
-
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.publisher.ReduceOperatorTest;
@@ -32,6 +31,7 @@ import reactor.test.util.RaceTestUtils;
 import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoReduceSeedTest extends ReduceOperatorTest<String, String> {
 
@@ -56,21 +56,27 @@ public class MonoReduceSeedTest extends ReduceOperatorTest<String, String> {
 		);
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new MonoReduceSeed<>(null, () -> 1, (a, b) -> (Integer) b);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoReduceSeed<>(null, () -> 1, (a, b) -> (Integer) b);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void supplierNull() {
-		Flux.never()
-		    .reduceWith(null, (a, b) -> b);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never()
+					.reduceWith(null, (a, b) -> b);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void accumulatorNull() {
-		Flux.never()
-		    .reduceWith(() -> 1, null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never()
+					.reduceWith(() -> 1, null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoReduceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoReduceTest.java
@@ -22,8 +22,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRepeatPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRepeatPredicateTest.java
@@ -16,18 +16,21 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 public class MonoRepeatPredicateTest {
 
 	//these tests essentially cover the API and its escape hatches
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void predicateNull() {
-		Mono.never()
-		    .repeat(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Mono.never()
+					.repeat(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRepeatTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRepeatTest.java
@@ -20,16 +20,20 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 public class MonoRepeatTest {
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void timesInvalid() {
-		Mono.never()
-		    .repeat(-1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Mono.never()
+					.repeat(-1);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRepeatWhenEmptyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRepeatWhenEmptyTest.java
@@ -17,11 +17,11 @@
 package reactor.core.publisher;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -93,7 +93,8 @@ public class MonoRepeatWhenEmptyTest {
         Assert.assertEquals(Arrays.asList(0L, 1L), iterations);
     }
 
-    @Test(timeout = 1000L)
+    @Test
+    @Timeout(1)
     public void gh2196_discardHandlerHang() {
         StepVerifier.create(Mono.empty()
                 .repeatWhenEmpty(f -> f.next())

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRetryPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRetryPredicateTest.java
@@ -18,7 +18,7 @@ package reactor.core.publisher;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
 public class MonoRetryPredicateTest {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRetryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRetryTest.java
@@ -18,21 +18,26 @@ package reactor.core.publisher;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Exceptions;
 import reactor.test.subscriber.AssertSubscriber;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 public class MonoRetryTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new MonoRetry<>(null, 1);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoRetry<>(null, 1);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void timesInvalid() {
-		Mono.never()
-		    .retry(-1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Mono.never().retry(-1);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRetryWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRetryWhenTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.assertj.core.data.Percentage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoRunnableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoRunnableTest.java
@@ -24,21 +24,22 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.assertj.core.data.Offset;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
-
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.function.Tuple2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoRunnableTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullValue() {
-		new MonoRunnable(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoRunnable<>(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSequenceEqualTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSequenceEqualTest.java
@@ -16,7 +16,6 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
-import java.util.Comparator;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -24,7 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -144,7 +143,7 @@ public class MonoSequenceEqualTest {
 		            .verify(Duration.ofSeconds(5));
 	}
 
-		@Test
+	@Test
 	public void syncFusedCrash() {
 		Flux<Integer> source = Flux.range(1, 10).map(i -> { throw new IllegalArgumentException("boom"); });
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSingleMonoTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSingleMonoTest.java
@@ -2,7 +2,7 @@ package reactor.core.publisher;
 
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSingleTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSingleTest.java
@@ -18,25 +18,29 @@ package reactor.core.publisher;
 
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
-import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoSingleTest {
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void source1Null() {
-		new MonoSingle<>(null, 1, false);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoSingle<>(null, 1, false);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void defaultSupplierNull() {
-		Flux.never().single(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.never().single(null);
+		});
 	}
 
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSourceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSourceTest.java
@@ -18,7 +18,7 @@ package reactor.core.publisher;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoStreamCollectorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoStreamCollectorTest.java
@@ -32,7 +32,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSubscribeOnCallableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSubscribeOnCallableTest.java
@@ -18,7 +18,7 @@ package reactor.core.publisher;
 import java.io.IOException;
 import java.time.Duration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSubscribeOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSubscribeOnTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 
 import reactor.core.CoreSubscriber;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSubscribeOnValueTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSubscribeOnValueTest.java
@@ -15,7 +15,7 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSubscriberTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.publisher.Operators.MonoSubscriber;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSupplierTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSupplierTest.java
@@ -17,12 +17,13 @@ package reactor.core.publisher;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoSupplierTest {
 
@@ -89,11 +90,12 @@ public class MonoSupplierTest {
 		               .block()).isEqualToIgnoringCase("test");
 	}
 
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void onMonoErrorSupplierOnBlock() {
-		Mono.fromSupplier(() -> {
-			throw new RuntimeException("test");
-		})
-		    .block();
+		assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> {
+			Mono.fromSupplier(() -> {
+				throw new RuntimeException("test");
+			}).block();
+		});
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSwitchIfEmptyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSwitchIfEmptyTest.java
@@ -15,20 +15,26 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoSwitchIfEmptyTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceNull() {
-		new MonoSwitchIfEmpty<>(null, Mono.never());
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoSwitchIfEmpty<>(null, Mono.never());
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void otherNull() {
-		Mono.never()
-		    .switchIfEmpty(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Mono.never()
+					.switchIfEmpty(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTakeLastOneTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTakeLastOneTest.java
@@ -16,14 +16,12 @@
 package reactor.core.publisher;
 
 import java.util.NoSuchElementException;
-import java.util.function.Predicate;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
-import reactor.util.function.Tuple3;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTakeUntilOtherTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTakeUntilOtherTest.java
@@ -19,7 +19,7 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.scheduler.VirtualTimeScheduler;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoThenIgnoreTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoThenIgnoreTest.java
@@ -17,7 +17,7 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoThenManyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoThenManyTest.java
@@ -17,7 +17,7 @@
 package reactor.core.publisher;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.subscriber.AssertSubscriber;
 
 /**

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
@@ -18,7 +18,7 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.concurrent.TimeoutException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTimestampTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTimestampTest.java
@@ -17,7 +17,7 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import reactor.util.function.Tuple2;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoToCompletableFutureTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoToCompletableFutureTest.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoUsingTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoUsingTest.java
@@ -21,29 +21,36 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.assertj.core.api.Condition;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MonoUsingTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void resourceSupplierNull() {
-		Mono.using(null, r -> Mono.empty(), r -> {
-		}, false);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Mono.using(null, r -> Mono.empty(), r -> {
+			}, false);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceFactoryNull() {
-		Mono.using(() -> 1, null, r -> {
-		}, false);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Mono.using(() -> 1, null, r -> {
+			}, false);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void resourceCleanupNull() {
-		Mono.using(() -> 1, r -> Mono.empty(), null, false);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Mono.using(() -> 1, r -> Mono.empty(), null, false);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoUsingWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoUsingWhenTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoWhenTest.java
@@ -19,7 +19,7 @@ package reactor.core.publisher;
 import java.util.Arrays;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoZipTest.java
@@ -21,7 +21,8 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
@@ -34,7 +35,6 @@ import reactor.util.function.Tuple4;
 import reactor.util.function.Tuple5;
 import reactor.util.function.Tuple6;
 import reactor.util.function.Tuple7;
-import reactor.util.function.Tuple8;
 import reactor.util.function.Tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -92,7 +92,8 @@ public class MonoZipTest {
 		               .block()).isEqualTo(3);
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void castCheck() {
 		Mono<String[]> mono = Mono.zip(a -> Arrays.copyOf(a, a.length, String[].class),
 				Mono.just("hello"),

--- a/reactor-core/src/test/java/reactor/core/publisher/OnNextFailureStrategyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnNextFailureStrategyTest.java
@@ -20,8 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.assertj.core.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import reactor.core.Exceptions;
 import reactor.test.StepVerifier;

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorDisposablesTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorDisposablesTest.java
@@ -18,7 +18,7 @@ package reactor.core.publisher;
 
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.scheduler.Schedulers;

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelArraySourceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelArraySourceTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelCollectTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelCollectTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelConcatMapTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.util.concurrent.Queues;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFilterTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFilterTest.java
@@ -16,9 +16,8 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
-import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFlatMapTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.util.concurrent.Queues;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxHideTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxHideTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxNameTest.java
@@ -17,11 +17,10 @@
 package reactor.core.publisher;
 
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxOnAssemblyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxOnAssemblyTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.core.publisher.FluxOnAssembly.AssemblySnapshot;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.LongAdder;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -50,7 +50,9 @@ import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ParallelFluxTest {
 
@@ -325,11 +327,13 @@ public class ParallelFluxTest {
 				.hasMessage("boom");
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void testDoOnEachSignalNullConsumer() {
-		Flux.just(1)
-		    .parallel()
-		    .doOnEach(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.just(1)
+					.parallel()
+					.doOnEach(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelGroupTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelGroupTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelLiftTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelLiftTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelLogTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelLogTest.java
@@ -16,9 +16,8 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
-import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelMapTest.java
@@ -16,9 +16,8 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
-import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelMergeOrderedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelMergeOrderedTest.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelMergeReduceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelMergeReduceTest.java
@@ -18,7 +18,7 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelMergeSequentialTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelMergeSequentialTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelMergeSortTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelMergeSortTest.java
@@ -18,7 +18,7 @@ package reactor.core.publisher;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelPeekTest.java
@@ -16,9 +16,8 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
-import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.util.concurrent.Queues;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelReduceSeedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelReduceSeedTest.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelRunOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelRunOnTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelSourceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelSourceTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/QueueDrainSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/QueueDrainSubscriberTest.java
@@ -18,7 +18,7 @@ package reactor.core.publisher;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openjdk.jol.info.ClassLayout;
 import org.openjdk.jol.info.FieldLayout;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/ReplayProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ReplayProcessorTest.java
@@ -17,10 +17,10 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
@@ -31,6 +31,7 @@ import reactor.test.scheduler.VirtualTimeScheduler;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ReplayProcessorTest {
 
@@ -600,14 +601,18 @@ public class ReplayProcessorTest {
 		}
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void failNegativeBufferSizeBounded() {
-		ReplayProcessor.create(-1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			ReplayProcessor.create(-1);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void failNegativeBufferBoundedAndTimed() {
-		ReplayProcessor.createSizeAndTimeout(-1, Duration.ofSeconds(1));
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			ReplayProcessor.createSizeAndTimeout(-1, Duration.ofSeconds(1));
+		});
 	}
 
 	@Test
@@ -633,12 +638,12 @@ public class ReplayProcessorTest {
 		assertThat(test.scan(Scannable.Attr.CAPACITY)).isEqualTo(Integer.MAX_VALUE);
 	}
 
-	@Before
+	@BeforeEach
 	public void virtualTime(){
     	VirtualTimeScheduler.getOrSet();
 	}
 
-	@After
+	@AfterEach
 	public void teardownVirtualTime(){
 		VirtualTimeScheduler.reset();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
@@ -21,8 +21,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.awaitility.Awaitility;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/SignalLoggerTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SignalLoggerTests.java
@@ -21,11 +21,10 @@ import java.util.Objects;
 import java.util.logging.Level;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Subscription;
 
-import reactor.core.CoreTest;
 import reactor.core.Fuseable;
 import reactor.core.Fuseable.SynchronousSubscription;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/publisher/SignalTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SignalTest.java
@@ -15,7 +15,7 @@
  */
 package reactor.core.publisher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.test.StepVerifier;
 import reactor.util.context.Context;

--- a/reactor-core/src/test/java/reactor/core/publisher/StrictSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/StrictSubscriberTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;

--- a/reactor-core/src/test/java/reactor/core/publisher/TopicProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/TopicProcessorTest.java
@@ -24,7 +24,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -40,6 +41,7 @@ import reactor.util.concurrent.Queues;
 import reactor.util.concurrent.WaitStrategy;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.*;
 
 /**
@@ -274,23 +276,30 @@ public class TopicProcessorTest {
 
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void failNullBufferSize() {
-		TopicProcessor.builder().name("test").bufferSize(0);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			TopicProcessor.builder().name("test").bufferSize(0);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void failNonPowerOfTwo() {
-		TopicProcessor.builder().name("test").bufferSize(3);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			TopicProcessor.builder().name("test").bufferSize(3);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void failNegativeBufferSize() {
-		TopicProcessor.builder().name("test").bufferSize(-1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			TopicProcessor.builder().name("test").bufferSize(-1);
+		});
 	}
 
 	//see https://github.com/reactor/reactor-core/issues/445
-	@Test(timeout = 5_000)
+	@Test
+	@Timeout(5)
 	public void testBufferSize1Shared() throws Exception {
 		TopicProcessor<String> broadcast = TopicProcessor.<String>builder()
 				.name("share-name")
@@ -319,7 +328,8 @@ public class TopicProcessorTest {
 	}
 
 	//see https://github.com/reactor/reactor-core/issues/445
-	@Test(timeout = 5_000)
+	@Test
+	@Timeout(5)
 	public void testBufferSize1Created() throws Exception {
 		TopicProcessor<String> broadcast = TopicProcessor.<String>builder().name("share-name").bufferSize(1).autoCancel(true).build();
 
@@ -432,13 +442,11 @@ public class TopicProcessorTest {
 	public void customRequestTaskThreadRejectsNull() {
 		ExecutorService customTaskExecutor = null;
 
-		Assertions.assertThatExceptionOfType(NullPointerException.class)
-		          .isThrownBy(() -> new TopicProcessor<>(
-				          Thread::new,
-				          Executors.newCachedThreadPool(),
-				          customTaskExecutor,
-				          8, WaitStrategy.liteBlocking(), true, true, Object::new)
-		          );
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> new TopicProcessor<>(
+				Thread::new,
+				Executors.newCachedThreadPool(),
+				customTaskExecutor,
+				8, WaitStrategy.liteBlocking(), true, true, Object::new));
 	}
 
 

--- a/reactor-core/src/test/java/reactor/core/publisher/TracesTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/TracesTest.java
@@ -32,8 +32,7 @@
 
 package reactor.core.publisher;
 
-import org.junit.Test;
-import reactor.core.publisher.Traces;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
@@ -25,13 +25,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Consumer;
 
-import org.assertj.core.api.Assumptions;
-import org.junit.Test;
-import org.reactivestreams.Publisher;
-import reactor.core.CoreSubscriber;
+import org.junit.jupiter.api.Test;
 import reactor.core.Disposable;
-import reactor.core.Fuseable;
-import reactor.core.Scannable;
 import reactor.test.MemoryUtils;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;

--- a/reactor-core/src/test/java/reactor/core/publisher/WorkQueueProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/WorkQueueProcessorTest.java
@@ -35,8 +35,9 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -54,6 +55,7 @@ import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
 import reactor.util.concurrent.WaitStrategy;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import static reactor.util.concurrent.WaitStrategy.liteBlocking;
@@ -209,7 +211,8 @@ public class WorkQueueProcessorTest {
 		TimeUnit.SECONDS.sleep(1);
 	}
 
-	@Test(timeout = 15000L)
+	@Test
+	@Timeout(15)
 	public void cancelDoesNotHang() throws Exception {
 		WorkQueueProcessor<String> wq = WorkQueueProcessor.create();
 
@@ -223,7 +226,8 @@ public class WorkQueueProcessorTest {
 		}
 	}
 
-	@Test(timeout = 15000L)
+	@Test
+	@Timeout(15)
 	public void completeDoesNotHang() throws Exception {
 		WorkQueueProcessor<String> wq = WorkQueueProcessor.create();
 
@@ -237,7 +241,8 @@ public class WorkQueueProcessorTest {
 		}
 	}
 
-	@Test(timeout = 15000L)
+	@Test
+	@Timeout(15)
 	public void disposeSubscribeNoThreadLeak() throws Exception {
 		WorkQueueProcessor<String> wq = WorkQueueProcessor.<String>builder().autoCancel(false).build();
 
@@ -455,7 +460,8 @@ public class WorkQueueProcessorTest {
 	}
 
 	/* see https://github.com/reactor/reactor-core/issues/199 */
-	@Test(timeout = 4000)
+	@Test
+	@Timeout(4)
 	public void singleThreadWorkQueueSucceedsWithOneSubscriber() {
 		ExecutorService executorService = Executors.newSingleThreadExecutor();
 		WorkQueueProcessor<String> bc = WorkQueueProcessor.<String>builder().executor(executorService).bufferSize(2).build();
@@ -596,19 +602,25 @@ public class WorkQueueProcessorTest {
 
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void failNonPowerOfTwo() {
-		WorkQueueProcessor.builder().name("test").bufferSize(3);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			WorkQueueProcessor.builder().name("test").bufferSize(3);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void failNullBufferSize() {
-		WorkQueueProcessor.builder().name("test").bufferSize(0);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			WorkQueueProcessor.builder().name("test").bufferSize(0);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void failNegativeBufferSize() {
-		WorkQueueProcessor.builder().name("test").bufferSize(-1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			WorkQueueProcessor.builder().name("test").bufferSize(-1);
+		});
 	}
 
 
@@ -854,7 +866,7 @@ public class WorkQueueProcessorTest {
 	}
 
 	// This test runs ok on it's own but hangs in when running whole class!
-	@Ignore
+	@Disabled
 	@Test
 	public void retryErrorPropagatedFromWorkQueueSubscriberHotPoisonSignalFlatMapPrefetch1()
 			throws Exception {
@@ -894,7 +906,8 @@ public class WorkQueueProcessorTest {
 
 
 	//see https://github.com/reactor/reactor-core/issues/445
-	@Test(timeout = 5_000)
+	@Test
+	@Timeout(5)
 	public void testBufferSize1Shared() throws Exception {
 		WorkQueueProcessor<String> broadcast = WorkQueueProcessor.<String>builder()
 				.share(true)
@@ -923,7 +936,8 @@ public class WorkQueueProcessorTest {
 	}
 
 	//see https://github.com/reactor/reactor-core/issues/445
-	@Test(timeout = 5_000)
+	@Test
+	@Timeout(5)
 	public void testBufferSize1Created() throws Exception {
 		WorkQueueProcessor<String> broadcast = WorkQueueProcessor.<String>builder()
 				.share(true).name("share-name")
@@ -1040,13 +1054,13 @@ public class WorkQueueProcessorTest {
 	public void customRequestTaskThreadRejectsNull() {
 		ExecutorService customTaskExecutor = null;
 
-		Assertions.assertThatExceptionOfType(NullPointerException.class)
-		          .isThrownBy(() -> new WorkQueueProcessor<>(
-				          Thread::new,
-				          Executors.newCachedThreadPool(),
-				          customTaskExecutor,
-				          8, WaitStrategy.liteBlocking(), true, true)
-		          );
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new WorkQueueProcessor<>(
+					Thread::new,
+					Executors.newCachedThreadPool(),
+					customTaskExecutor,
+					8, WaitStrategy.liteBlocking(), true, true);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/loop/FluxGroupByLoop.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/loop/FluxGroupByLoop.java
@@ -15,7 +15,7 @@
  */
 package reactor.core.publisher.loop;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.FluxGroupByTest;
 
 /**

--- a/reactor-core/src/test/java/reactor/core/publisher/loop/FluxPublishOnLoop.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/loop/FluxPublishOnLoop.java
@@ -17,9 +17,9 @@ package reactor.core.publisher.loop;
 
 import java.util.concurrent.Executors;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxPublishOnTest;
 import reactor.core.scheduler.Scheduler;
@@ -33,12 +33,12 @@ public class FluxPublishOnLoop {
 
 	final FluxPublishOnTest publishOnTest = new FluxPublishOnTest();
 
-	@BeforeClass
+	@BeforeAll
 	public static void before() {
 		FluxPublishOnTest.exec = Executors.newSingleThreadExecutor();
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void after() {
 		FluxPublishOnTest.exec.shutdownNow();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/AbstractReactorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/AbstractReactorTest.java
@@ -20,8 +20,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
@@ -35,13 +35,13 @@ public abstract class AbstractReactorTest {
 
 	protected final Map<Thread, AtomicLong> counters = new ConcurrentHashMap<>();
 
-	@BeforeClass
+	@BeforeAll
 	public static void loadEnv() {
 		ioGroup = Schedulers.newElastic("work");
 		asyncGroup = Schedulers.newParallel("parallel", 4);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void closeEnv() {
 		ioGroup.dispose();
 		asyncGroup.dispose();

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/BurstyWorkQueueProcessorTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/BurstyWorkQueueProcessorTests.java
@@ -20,14 +20,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAccumulator;
-import java.util.logging.Level;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
-import reactor.core.publisher.SignalType;
 import reactor.core.publisher.WorkQueueProcessor;
 
 import static org.testng.Assert.assertEquals;
@@ -51,7 +49,7 @@ public class BurstyWorkQueueProcessorTests {
 	private ExecutorService            producerExecutor;
 	private AtomicLong                 droppedCount;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		maxRingBufferPending =  new LongAccumulator(Long::max, Long.MIN_VALUE);
 		droppedCount = new AtomicLong(0);
@@ -59,7 +57,7 @@ public class BurstyWorkQueueProcessorTests {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void test() throws Exception {
 		processor = WorkQueueProcessor.builder().name("test-processor").bufferSize(RINGBUFFER_SIZE).build();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/CombinationTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/CombinationTests.java
@@ -22,9 +22,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.EmitterProcessor;
@@ -50,13 +50,13 @@ public class CombinationTests {
 	private FluxProcessor<SensorData, SensorData> sensorEven;
 	private FluxProcessor<SensorData, SensorData> sensorOdd;
 
-	@Before
+	@BeforeEach
 	public void before() {
 		sensorEven();
 		sensorOdd();
 	}
 
-	@After
+	@AfterEach
 	public void then() {
 		if (sensorEven != null) {
 			sensorEven.onComplete();
@@ -297,7 +297,7 @@ public class CombinationTests {
 	ReplayProcessor<Long>  emitter1;
 	ReplayProcessor<Long>  emitter2;
 
-	@Before
+	@BeforeEach
 	public void anotherBefore() {
 		ts = AssertSubscriber.create();
 		emitter1 = ReplayProcessor.create();

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/ConsistentProcessorTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/ConsistentProcessorTests.java
@@ -25,10 +25,10 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Processor;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -49,7 +49,7 @@ public class ConsistentProcessorTests {
 	private Processor<String, String> workProcessor;
 
 	@Test
-	@Ignore
+	@Disabled
 	public void testMultipleConsumersMultipleTimes() throws Exception {
 		Sender sender = new Sender();
 
@@ -109,12 +109,12 @@ public class ConsistentProcessorTests {
 		assertTrue(dups.isEmpty());
 	}
 
-	@Before
+	@BeforeEach
 	public void loadEnv() {
 		setupPipeline();
 	}
 
-	@After
+	@AfterEach
 	public void clean() throws Exception {
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FizzBuzzTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FizzBuzzTests.java
@@ -22,7 +22,7 @@ import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.TopicProcessor;

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxSpecTests.java
@@ -32,7 +32,8 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxProcessor;
@@ -129,8 +130,7 @@ public class FluxSpecTests {
 		final Mono<Void> errorTap = stream.then();
 
 //		then: "it is available"
-		assertThatExceptionOfType(Exception.class)
-				.isThrownBy(errorTap::block);
+		assertThatExceptionOfType(Exception.class).isThrownBy(errorTap::block);
 	}
 
 	@Test
@@ -698,15 +698,14 @@ public class FluxSpecTests {
 
 //		when: "element at index 2 is requested"
 		Integer tap = s.elementAt(2)
-		               .block();
+				.block();
 
 //		then: "3 is emitted"
 		assertThat(tap).isEqualTo(3);
 
 //		when: "element with negative index is requested"
 //		then: "error is thrown"
-		assertThatExceptionOfType(IndexOutOfBoundsException.class)
-			.isThrownBy(() -> s.elementAt(-1));
+		assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> s.elementAt(-1));
 
 //		when: "element with index > number of values is requested"
 //		then: "error is thrown"
@@ -1089,7 +1088,8 @@ public class FluxSpecTests {
 		            .verifyComplete();
 	}
 
-	@Test(timeout = 10000L)
+	@Test
+	@Timeout(10)
 	public void collectFromMultipleThread1() throws Exception {
 		EmitterProcessor<Integer> head = EmitterProcessor.create();
 		AtomicInteger sum = new AtomicInteger();

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -50,10 +50,11 @@ import java.util.stream.IntStream;
 
 import org.assertj.core.api.Assertions;
 import org.hamcrest.Matcher;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
@@ -81,6 +82,7 @@ import reactor.util.Loggers;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -94,7 +96,7 @@ public class FluxTests extends AbstractReactorTest {
 	static final String2Integer STRING_2_INTEGER = new String2Integer();
 
 	//simplifies fluxFromXXXCallsAssemblyHook tests below
-	@After
+	@AfterEach
 	public void resetHooks() {
 		Hooks.resetOnEachOperator();
 		Hooks.resetOnLastOperator();
@@ -280,9 +282,11 @@ public class FluxTests extends AbstractReactorTest {
 				is("foo"));
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void testDoOnEachSignalNullConsumer() {
-		Flux.just(1).doOnEach(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Flux.just(1).doOnEach(null);
+		});
 	}
 
 	@Test
@@ -1025,7 +1029,7 @@ public class FluxTests extends AbstractReactorTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void testDiamond() throws InterruptedException, IOException {
 		Flux<Point> points = Flux.<Double, Random>generate(Random::new, (r, sub) -> {
 			sub.next(r.nextDouble());
@@ -1334,7 +1338,7 @@ public class FluxTests extends AbstractReactorTest {
 	 * @throws TimeoutException     - on failure. <p> by @masterav10 : https://github.com/reactor/reactor/issues/469
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void endLessTimer() throws InterruptedException, TimeoutException {
 		int tasks = 50;
 		long delayMS = 50; // XXX: Fails when less than 100
@@ -1430,7 +1434,8 @@ public class FluxTests extends AbstractReactorTest {
 		}
 	}
 
-	@Test(timeout = TIMEOUT)
+	@Test
+	@Timeout(10)
 	public void multiplexUsingProcessors() throws Exception {
 
 		final Flux<Integer> forkStream = Flux.just(1, 2, 3)
@@ -1485,7 +1490,8 @@ public class FluxTests extends AbstractReactorTest {
 	 * </pre>
      * @throws Exception for convenience
 	 */
-	@Test(timeout = TIMEOUT)
+	@Test
+	@Timeout(10)
 	public void multiplexUsingDispatchersAndSplit() throws Exception {
 
 		final EmitterProcessor<Integer> forkEmitterProcessor = EmitterProcessor.create();
@@ -1586,7 +1592,7 @@ public class FluxTests extends AbstractReactorTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void splitBugEventuallyHappens() throws Exception {
 		int successCount = 0;
 		try {
@@ -1787,8 +1793,6 @@ public class FluxTests extends AbstractReactorTest {
 		source.next();
 		Assertions.assertThat(wrappedCount).hasValue(1);
 	}
-
-	private static final long TIMEOUT = 10_000;
 
 	// Setting it to 1 doesn't help.
 	private static final int BACKLOG = 1024;

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxWindowConsistencyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxWindowConsistencyTest.java
@@ -24,8 +24,8 @@ import java.util.function.Predicate;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;
@@ -56,7 +56,7 @@ public class FluxWindowConsistencyTest {
 
 	private AtomicInteger mainTerminated = new AtomicInteger();
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		source = sourceProcessor.doOnNext(i -> sourceCount.incrementAndGet());
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/MonoTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/MonoTests.java
@@ -27,8 +27,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 
 import reactor.core.publisher.Flux;
@@ -43,16 +43,18 @@ import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Stephane Maldini
  */
 public class MonoTests {
 
-	@After
+	@AfterEach
 	public void resetHooks() {
 		Hooks.resetOnEachOperator();
 		Hooks.resetOnLastOperator();
@@ -134,9 +136,11 @@ public class MonoTests {
 				is("foo"));
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void testDoOnEachSignalNullConsumer() {
-		Mono.just(1).doOnEach(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			Mono.just(1).doOnEach(null);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/PopularTagTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/PopularTagTests.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Disposable;
 import reactor.util.Loggers;
 import reactor.core.publisher.Flux;

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/ScatterGatherTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/ScatterGatherTests.java
@@ -21,12 +21,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
-import reactor.test.subscriber.AssertSubscriber;
 
 public class ScatterGatherTests {
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
@@ -19,11 +19,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import org.junit.jupiter.api.Timeout;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.Exceptions;
@@ -51,7 +52,7 @@ public abstract class AbstractSchedulerTest {
 		toCleanUp.add(resource);
 		return resource;
 	}
-	@After
+	@AfterEach
 	public void cleanupCompositeDisposable() {
 		toCleanUp.dispose();
 	}
@@ -74,12 +75,13 @@ public abstract class AbstractSchedulerTest {
 
 	protected boolean shouldCheckWorkerTimeScheduling() { return true; }
 
-	@Before
+	@BeforeEach
 	public void checkNotCached() {
 		assertThat(scheduler()).isNotInstanceOf(Schedulers.CachedScheduler.class);
 	}
 
-	@Test(timeout = 10000)
+	@Test
+	@Timeout(10)
 	final public void directScheduleAndDispose() throws Exception {
 		Scheduler s = scheduler();
 
@@ -153,7 +155,8 @@ public abstract class AbstractSchedulerTest {
 		}
 	}
 
-	@Test(timeout = 10000)
+	@Test
+	@Timeout(10)
 	final public void workerScheduleAndDispose() throws Exception {
 		Scheduler s = scheduler();
 		try {
@@ -244,7 +247,8 @@ public abstract class AbstractSchedulerTest {
 		}
 	}
 
-	@Test(timeout = 10000)
+	@Test
+	@Timeout(10)
 	final public void directScheduleAndDisposeDelay() throws Exception {
 		Scheduler s = scheduler();
 
@@ -253,7 +257,8 @@ public abstract class AbstractSchedulerTest {
 
 			if (!shouldCheckDirectTimeScheduling()) {
 				assertThatExceptionOfType(RejectedExecutionException.class)
-						.isThrownBy(() -> s.schedule(() -> { }, 10, TimeUnit.MILLISECONDS))
+						.isThrownBy(() -> s.schedule(() -> {
+						}, 10, TimeUnit.MILLISECONDS))
 						.as("Scheduler marked as not supporting time scheduling")
 						.isSameAs(Exceptions.failWithRejectedNotTimeCapable());
 				return;
@@ -282,15 +287,15 @@ public abstract class AbstractSchedulerTest {
 			s.dispose();
 			assertThat(s.isDisposed()).isTrue();
 
-			assertThatExceptionOfType(RejectedExecutionException.class)
-					.isThrownBy(() -> s.schedule(() -> { }));
+			assertThatExceptionOfType(RejectedExecutionException.class).isThrownBy(() -> s.schedule(() -> { }));
 		}
 		finally {
 			s.dispose();
 		}
 	}
 
-	@Test(timeout = 10000)
+	@Test
+	@Timeout(10)
 	final public void workerScheduleAndDisposeDelay() throws Exception {
 		Scheduler s = scheduler();
 		Scheduler.Worker w = s.createWorker();
@@ -339,7 +344,8 @@ public abstract class AbstractSchedulerTest {
 		}
 	}
 
-	@Test(timeout = 10000)
+	@Test
+	@Timeout(10)
 	final public void directScheduleAndDisposePeriod() throws Exception {
 		Scheduler s = scheduler();
 
@@ -380,15 +386,15 @@ public abstract class AbstractSchedulerTest {
 			s.dispose();
 			assertThat(s.isDisposed()).isTrue();
 
-			assertThatExceptionOfType(RejectedExecutionException.class)
-					.isThrownBy(() -> s.schedule(() -> { }));
+			assertThatExceptionOfType(RejectedExecutionException.class).isThrownBy(() -> s.schedule(() -> {	}));
 		}
 		finally {
 			s.dispose();
 		}
 	}
 
-	@Test(timeout = 10000)
+	@Test
+	@Timeout(10)
 	final public void workerScheduleAndDisposePeriod() throws Exception {
 		Scheduler s = scheduler();
 		Scheduler.Worker w = s.createWorker();

--- a/reactor-core/src/test/java/reactor/core/scheduler/DelegateServiceSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/DelegateServiceSchedulerTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import reactor.core.Exceptions;
 import reactor.core.Scannable;

--- a/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
@@ -19,7 +19,8 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import reactor.core.Disposable;
 import reactor.core.Scannable;
 import reactor.core.publisher.Flux;
@@ -27,6 +28,8 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Stephane Maldini
@@ -39,14 +42,18 @@ public class ElasticSchedulerTest extends AbstractSchedulerTest {
 		return Schedulers.newElastic("ElasticSchedulerTest");
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void unsupportedStart() {
-		Schedulers.elastic().start();
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> {
+			Schedulers.elastic().start();
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void negativeTime() throws Exception {
-		Schedulers.newElastic("test", -1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Schedulers.newElastic("test", -1);
+		});
 	}
 
 	@Override
@@ -54,7 +61,8 @@ public class ElasticSchedulerTest extends AbstractSchedulerTest {
 		return true;
 	}
 
-	@Test(timeout = 10000)
+	@Test
+	@Timeout(10)
 	public void eviction() throws Exception {
 		Scheduler s = Schedulers.newElastic("test-recycle", 2);
 		((ElasticScheduler)s).evictor.shutdownNow();

--- a/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTrampolineTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTrampolineTest.java
@@ -17,7 +17,7 @@ package reactor.core.scheduler;
 
 import java.util.concurrent.Executor;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-core/src/test/java/reactor/core/scheduler/ImmediateSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ImmediateSchedulerTest.java
@@ -18,7 +18,7 @@ package reactor.core.scheduler;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler.Worker;

--- a/reactor-core/src/test/java/reactor/core/scheduler/InstantPeriodicWorkerTaskTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/InstantPeriodicWorkerTaskTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.test.util.RaceTestUtils;

--- a/reactor-core/src/test/java/reactor/core/scheduler/ParallelSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ParallelSchedulerTest.java
@@ -22,13 +22,15 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Stephane Maldini
@@ -40,9 +42,11 @@ public class ParallelSchedulerTest extends AbstractSchedulerTest {
 		return Schedulers.newParallel("ParallelSchedulerTest");
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void negativeParallelism() throws Exception {
-		Schedulers.newParallel("test", -1);
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			Schedulers.newParallel("test", -1);
+		});
 	}
 
 	@Override

--- a/reactor-core/src/test/java/reactor/core/scheduler/RejectedExecutionTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/RejectedExecutionTest.java
@@ -23,11 +23,10 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.Disposable;
@@ -45,8 +44,7 @@ import static org.junit.Assert.assertTrue;
 
 public class RejectedExecutionTest {
 
-	@Rule
-	public TestName testName = new TestName();
+	private TestInfo testInfo;
 
 	private BoundedScheduler scheduler;
 
@@ -58,7 +56,11 @@ public class RejectedExecutionTest {
 	private ConcurrentLinkedQueue<Long> onOperatorErrorData = new ConcurrentLinkedQueue<>();
 	private ConcurrentLinkedQueue<Throwable> onSchedulerHandleError = new ConcurrentLinkedQueue<>();
 
-	@Before
+	public RejectedExecutionTest(TestInfo testInfo) {
+		this.testInfo = testInfo;
+	}
+
+	@BeforeEach
 	public void setUp() {
 		scheduler = new BoundedScheduler(Schedulers.newSingle("bounded-single"));
 		Hooks.onNextDropped(o -> onNextDropped.add(o));
@@ -75,7 +77,7 @@ public class RejectedExecutionTest {
 		Schedulers.onHandleError((thread, t) -> onSchedulerHandleError.add(t));
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		scheduler.dispose();
 		Hooks.resetOnNextDropped();
@@ -297,7 +299,7 @@ public class RejectedExecutionTest {
 						"Data dropped from onOperatorError should always be >= 1");
 
 		if (!onOperatorErrorData.isEmpty()) {
-			System.out.println(testName.getMethodName() + " legitimately has data dropped from onOperatorError: " + onOperatorErrorData);
+			System.out.println(testInfo.getDisplayName() + " legitimately has data dropped from onOperatorError: " + onOperatorErrorData);
 		}
 	}
 
@@ -331,7 +333,7 @@ public class RejectedExecutionTest {
 						"Data dropped from onOperatorError should always be >= elementCount");
 
 		if (!onOperatorErrorData.isEmpty()) {
-			System.out.println(testName.getMethodName() + " legitimately has data dropped from onOperatorError: " + onOperatorErrorData);
+			System.out.println(testInfo.getDisplayName() + " legitimately has data dropped from onOperatorError: " + onOperatorErrorData);
 		}
 
 	}

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -39,11 +39,11 @@ import java.util.function.Supplier;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
-import org.awaitility.Awaitility;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import org.junit.jupiter.api.Timeout;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.Exceptions;
@@ -92,7 +92,7 @@ public class SchedulersTest {
 	final static Condition<Scheduler> CACHED_SCHEDULER = new Condition<>(
 			s -> s instanceof Schedulers.CachedScheduler, "a cached scheduler");
 
-	@After
+	@AfterEach
 	public void resetSchedulers() {
 		Schedulers.resetFactory();
 		Schedulers.DECORATORS.clear();
@@ -521,8 +521,8 @@ public class SchedulersTest {
 		Assert.assertEquals(cachedTimerNew, Schedulers.newSingle("unused"));
 		Assert.assertNotSame(cachedTimerNew, cachedTimerOld);
 		//assert that the old factory"s cached scheduler was shut down
-		Assertions.assertThatExceptionOfType(RejectedExecutionException.class)
-		          .isThrownBy(() -> cachedTimerOld.schedule(() -> {}));
+		assertThatExceptionOfType(RejectedExecutionException.class).isThrownBy(() -> cachedTimerOld.schedule(() -> {
+		}));
 		//independently created schedulers are still the programmer"s responsibility
 		Assert.assertNotNull(standaloneTimer.schedule(() -> {}));
 		//new factory = new alive cached scheduler
@@ -800,7 +800,8 @@ public class SchedulersTest {
 	}
 
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void parallelSchedulerThreadCheck() throws Exception{
 		Scheduler s = Schedulers.newParallel("work", 2);
 		try {
@@ -824,7 +825,8 @@ public class SchedulersTest {
 		}
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void singleSchedulerThreadCheck() throws Exception{
 		Scheduler s = Schedulers.newSingle("work");
 		try {
@@ -849,7 +851,8 @@ public class SchedulersTest {
 	}
 
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void elasticSchedulerThreadCheck() throws Exception{
 		Scheduler s = Schedulers.newElastic("work");
 		try {
@@ -873,7 +876,8 @@ public class SchedulersTest {
 		}
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void executorThreadCheck() throws Exception{
 		ExecutorService es = Executors.newSingleThreadExecutor();
 		Scheduler s = Schedulers.fromExecutor(es::execute);
@@ -900,7 +904,8 @@ public class SchedulersTest {
 		}
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void executorThreadCheck2() throws Exception{
 		ExecutorService es = Executors.newSingleThreadExecutor();
 		Scheduler s = Schedulers.fromExecutor(es::execute, true);
@@ -927,7 +932,8 @@ public class SchedulersTest {
 		}
 	}
 
-	@Test(timeout = 5000)
+	@Test
+	@Timeout(5)
 	public void sharedSingleCheck() throws Exception{
 		Scheduler p = Schedulers.newParallel("shared");
 		Scheduler s = Schedulers.single(p);

--- a/reactor-core/src/test/java/reactor/core/scheduler/SingleSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SingleSchedulerTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.*;
 
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.core.publisher.*;
 import reactor.core.scheduler.Scheduler.Worker;

--- a/reactor-core/src/test/java/reactor/core/scheduler/SingleWorkerSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SingleWorkerSchedulerTest.java
@@ -15,7 +15,7 @@
  */
 package reactor.core.scheduler;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-core/src/test/java/reactor/core/scheduler/TimedSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/TimedSchedulerTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Disposable;
 import reactor.core.scheduler.Scheduler.Worker;
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/WorkerTaskTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/WorkerTaskTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.test.util.RaceTestUtils;

--- a/reactor-core/src/test/java/reactor/guide/GuideDebuggingExtraTests.java
+++ b/reactor-core/src/test/java/reactor/guide/GuideDebuggingExtraTests.java
@@ -19,7 +19,7 @@ package reactor.guide;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 

--- a/reactor-core/src/test/java/reactor/guide/GuideTests.java
+++ b/reactor-core/src/test/java/reactor/guide/GuideTests.java
@@ -36,11 +36,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.Disposable;
@@ -70,7 +69,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class GuideTests {
 
-	@Test @SuppressWarnings("unchecked")
+	@Test
+	@SuppressWarnings("unchecked")
 	public void introFutureHell() {
 		CompletableFuture<List<String>> ids = ifhIds(); // <1>
 
@@ -944,23 +944,20 @@ public class GuideTests {
 		           .single();
 	}
 
-	@Rule
-	public TestName testName = new TestName();
-
-	@Before
-	public void populateDebug() {
-		if (testName.getMethodName().equals("debuggingCommonStacktrace")) {
+	@BeforeEach
+	public void populateDebug(TestInfo testInfo) {
+		if (testInfo.getDisplayName().equals("debuggingCommonStacktrace()")) {
 			toDebug = scatterAndGather(urls());
 		}
-		else if (testName.getMethodName().startsWith("debuggingActivated")) {
+		else if (testInfo.getDisplayName().startsWith("debuggingActivated")) { // TODO better handled by JUnit5 tags
 			Hooks.onOperatorDebug();
 			toDebug = scatterAndGather(urls());
 		}
 	}
 
-	@After
-	public void removeHooks() {
-		if (testName.getMethodName().startsWith("debuggingActivated")) {
+	@AfterEach
+	public void removeHooks(TestInfo testInfo) {
+		if (testInfo.getDisplayName().startsWith("debuggingActivated")) {
 			Hooks.resetOnOperatorDebug();
 		}
 	}

--- a/reactor-core/src/test/java/reactor/test/publisher/BaseOperatorTest.java
+++ b/reactor-core/src/test/java/reactor/test/publisher/BaseOperatorTest.java
@@ -23,9 +23,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -40,7 +40,6 @@ import reactor.core.publisher.ReplayProcessor;
 import reactor.core.publisher.UnicastProcessor;
 import reactor.test.StepVerifier;
 import reactor.util.annotation.Nullable;
-import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static reactor.core.Fuseable.*;
@@ -54,13 +53,13 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 
 	boolean defaultEmpty = false;
 
-	@After
+	@AfterEach
 	public void afterScenariosRun(){
 		resetHooks();
 		defaultEmpty = false;
 	}
 
-	@Before
+	@BeforeEach
 	public final void initDefaultScenario() {
 		defaultScenario = defaultScenarioOptions(new OperatorScenario<>(null, null));
 	}

--- a/reactor-core/src/test/java/reactor/util/ConsoleLoggerTest.java
+++ b/reactor-core/src/test/java/reactor/util/ConsoleLoggerTest.java
@@ -19,9 +19,9 @@ package reactor.util;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,12 +34,12 @@ public class ConsoleLoggerTest {
 
 	private Logger logger;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		logger = new Loggers.ConsoleLogger("test", new PrintStream(outContent), new PrintStream(errContent), true);
 	}
 
-	@After
+	@AfterEach
 	public void cleanUp() {
 		outContent.reset();
 		errContent.reset();

--- a/reactor-core/src/test/java/reactor/util/JdkLoggerTest.java
+++ b/reactor-core/src/test/java/reactor/util/JdkLoggerTest.java
@@ -21,7 +21,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-core/src/test/java/reactor/util/LoggersTest.java
+++ b/reactor-core/src/test/java/reactor/util/LoggersTest.java
@@ -16,7 +16,7 @@
 
 package reactor.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/reactor-core/src/test/java/reactor/util/MetricsNoMicrometerTest.java
+++ b/reactor-core/src/test/java/reactor/util/MetricsNoMicrometerTest.java
@@ -18,9 +18,7 @@ package reactor.util;
 
 import java.util.concurrent.Executors;
 
-import org.assertj.core.api.Assumptions;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;

--- a/reactor-core/src/test/java/reactor/util/concurrent/MpscLinkedQueueTest.java
+++ b/reactor-core/src/test/java/reactor/util/concurrent/MpscLinkedQueueTest.java
@@ -2,9 +2,10 @@ package reactor.util.concurrent;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MpscLinkedQueueTest {
 
@@ -13,16 +14,20 @@ public class MpscLinkedQueueTest {
 		assertThat(Queues.unboundedMultiproducer().get()).isInstanceOf(MpscLinkedQueue.class);
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void shouldRejectNullableValues() {
 		MpscLinkedQueue<Object> q = new MpscLinkedQueue<>();
-		q.offer(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			q.offer(null);
+		});
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void shouldRejectNullableValuesForTest() {
 		MpscLinkedQueue<Object> q = new MpscLinkedQueue<>();
-		q.test(null, null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			q.test(null, null);
+		});
 	}
 
 	@Test
@@ -35,19 +40,23 @@ public class MpscLinkedQueueTest {
 		assertThat(q.poll()).isNull();
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void shouldNotAllowIteratingWithIterator() {
 		MpscLinkedQueue<Object> q = new MpscLinkedQueue<>();
 
-		q.iterator();
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> {
+			q.iterator();
+		});
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void shouldNotAllowElementsRemoving() {
 		MpscLinkedQueue<Object> q = new MpscLinkedQueue<>();
 
 		q.offer(1);
-		q.remove(1);
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> {
+			q.remove(1);
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/concurrent/QueuesOneQueueTest.java
+++ b/reactor-core/src/test/java/reactor/util/concurrent/QueuesOneQueueTest.java
@@ -16,7 +16,7 @@
 
 package reactor.util.concurrent;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Queue;
 

--- a/reactor-core/src/test/java/reactor/util/concurrent/QueuesTest.java
+++ b/reactor-core/src/test/java/reactor/util/concurrent/QueuesTest.java
@@ -24,7 +24,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;

--- a/reactor-core/src/test/java/reactor/util/concurrent/SpscArrayQueueTest.java
+++ b/reactor-core/src/test/java/reactor/util/concurrent/SpscArrayQueueTest.java
@@ -1,9 +1,10 @@
 package reactor.util.concurrent;
 
 import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class SpscArrayQueueTest {
 
@@ -12,55 +13,69 @@ public class SpscArrayQueueTest {
 		assertThat(Queues.xs().get()).isInstanceOf(SpscArrayQueue.class);
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void shouldRejectNullableValues() {
 		SpscArrayQueue<Object> q = new SpscArrayQueue<>(32);
-		q.offer(null);
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			q.offer(null);
+		});
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void shouldNotAllowIteratingWithIterator() {
 		SpscArrayQueue<Object> q = new SpscArrayQueue<>(32);
 
-		q.iterator();
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> {
+			q.iterator();
+		});
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void shouldNotAllowElementsRemoving() {
 		SpscArrayQueue<Object> q = new SpscArrayQueue<>(32);
 
 		q.offer(1);
-		q.remove(1);
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> {
+			q.remove(1);
+		});
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void shouldNotAllowAllElementsRemoving() {
 		SpscArrayQueue<Object> q = new SpscArrayQueue<>(32);
 
 		q.offer(1);
 		q.offer(2);
-		q.removeAll(Arrays.asList(1,2));
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> {
+			q.removeAll(Arrays.asList(1, 2));
+		});
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void shouldNotAllowAllElementsRetaining() {
 		SpscArrayQueue<Object> q = new SpscArrayQueue<>(32);
 
 		q.offer(1);
 		q.offer(2);
-		q.retainAll(Arrays.asList(1,2));
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> {
+			q.retainAll(Arrays.asList(1, 2));
+		});
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void shouldNotAllowAdd() {
 		SpscArrayQueue<Object> q = new SpscArrayQueue<>(32);
-		q.add(1);
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> {
+			q.add(1);
+		});
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void shouldNotAllowAddAll() {
 		SpscArrayQueue<Object> q = new SpscArrayQueue<>(32);
-		q.addAll(Arrays.asList(1,2,3));
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> {
+			q.addAll(Arrays.asList(1, 2, 3));
+		});
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/context/Context0Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context0Test.java
@@ -19,7 +19,7 @@ package reactor.util.context;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/reactor-core/src/test/java/reactor/util/context/Context1Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context1Test.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/reactor-core/src/test/java/reactor/util/context/Context2Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context2Test.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/reactor-core/src/test/java/reactor/util/context/Context3Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context3Test.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/reactor-core/src/test/java/reactor/util/context/Context4Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context4Test.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;

--- a/reactor-core/src/test/java/reactor/util/context/Context5Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context5Test.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/reactor-core/src/test/java/reactor/util/context/ContextNTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextNTest.java
@@ -22,8 +22,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
 import static reactor.util.context.ContextTest.*;
@@ -32,7 +32,7 @@ public class ContextNTest {
 
 	Context c;
 
-	@Before
+	@BeforeEach
 	public void initContext() {
 		c = new ContextN(1, "A", 2, "B", 3, "C",
 			4, "D", 5, "E", 6, "F");

--- a/reactor-core/src/test/java/reactor/util/context/ContextTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextTest.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.assertj.core.api.Condition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
 

--- a/reactor-core/src/test/java/reactor/util/function/Tuple2Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple2Test.java
@@ -16,7 +16,7 @@
 
 package reactor.util.function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/reactor-core/src/test/java/reactor/util/function/Tuple3Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple3Test.java
@@ -16,7 +16,7 @@
 
 package reactor.util.function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/reactor-core/src/test/java/reactor/util/function/Tuple4Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple4Test.java
@@ -16,7 +16,7 @@
 
 package reactor.util.function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/reactor-core/src/test/java/reactor/util/function/Tuple5Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple5Test.java
@@ -16,7 +16,7 @@
 
 package reactor.util.function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/reactor-core/src/test/java/reactor/util/function/Tuple6Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple6Test.java
@@ -16,7 +16,7 @@
 
 package reactor.util.function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
 

--- a/reactor-core/src/test/java/reactor/util/function/Tuple7Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple7Test.java
@@ -16,7 +16,7 @@
 
 package reactor.util.function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/reactor-core/src/test/java/reactor/util/function/Tuple8Test.java
+++ b/reactor-core/src/test/java/reactor/util/function/Tuple8Test.java
@@ -16,7 +16,7 @@
 
 package reactor.util.function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/reactor-core/src/test/java/reactor/util/function/TupleTests.java
+++ b/reactor-core/src/test/java/reactor/util/function/TupleTests.java
@@ -18,7 +18,7 @@ package reactor.util.function;
 
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import java.lang.Object;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-core/src/test/kotlin/reactor/core/publisher/FluxExtensionsTests.kt
+++ b/reactor-core/src/test/kotlin/reactor/core/publisher/FluxExtensionsTests.kt
@@ -17,8 +17,8 @@
 package reactor.core.publisher
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.reactivestreams.Publisher
 import reactor.test.StepVerifier
 import reactor.test.test
@@ -138,7 +138,7 @@ class FluxExtensionsTests {
         fluxOnError.doOnError(IllegalStateException::class) {
             invoked = true
         }.subscribe()
-        Assert.assertTrue(invoked)
+        Assertions.assertTrue(invoked)
     }
 
     @Test

--- a/reactor-core/src/test/kotlin/reactor/core/publisher/MonoExtensionsTests.kt
+++ b/reactor-core/src/test/kotlin/reactor/core/publisher/MonoExtensionsTests.kt
@@ -17,8 +17,8 @@
 package reactor.core.publisher
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.reactivestreams.Publisher
 import reactor.test.StepVerifier
 import reactor.test.publisher.TestPublisher
@@ -170,7 +170,7 @@ class MonoExtensionsTests {
         monoOnError.doOnError(IllegalStateException::class) {
             invoked = true
         }.subscribe()
-        Assert.assertTrue(invoked)
+        Assertions.assertTrue(invoked)
     }
 
     @Test

--- a/reactor-core/src/test/kotlin/reactor/core/publisher/MonoFunctionsTests.kt
+++ b/reactor-core/src/test/kotlin/reactor/core/publisher/MonoFunctionsTests.kt
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import reactor.test.StepVerifier
 import reactor.test.publisher.TestPublisher
 

--- a/reactor-core/src/test/kotlin/reactor/util/function/TupleExtensionsTests.kt
+++ b/reactor-core/src/test/kotlin/reactor/util/function/TupleExtensionsTests.kt
@@ -16,8 +16,8 @@
 
 package reactor.util.function
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 object O1; object O2; object O3; object O4
 object O5; object O6; object O7; object O8

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxMetricsFuseableTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxMetricsFuseableTest.java
@@ -31,9 +31,9 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.Fuseable;
 import reactor.test.StepVerifier;
@@ -46,12 +46,12 @@ public class FluxMetricsFuseableTest {
 
 	private MeterRegistry registry;
 
-	@Before
+	@BeforeEach
 	public void setupRegistry() {
 		registry = new SimpleMeterRegistry();
 	}
 
-	@After
+	@AfterEach
 	public void removeRegistry() {
 		registry.close();
 	}

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxMetricsTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxMetricsTest.java
@@ -29,9 +29,9 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -45,12 +45,12 @@ public class FluxMetricsTest {
 
 	private MeterRegistry registry;
 
-	@Before
+	@BeforeEach
 	public void setupRegistry() {
 		registry = new SimpleMeterRegistry();
 	}
 
-	@After
+	@AfterEach
 	public void removeRegistry() {
 		registry.close();
 	}

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoMetricsFuseableTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoMetricsFuseableTest.java
@@ -18,7 +18,6 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -32,16 +31,15 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.Disposable;
 import reactor.core.Fuseable;
 import reactor.core.publisher.MonoMetrics.MicrometerMonoMetricsFuseableSubscriber;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
-import reactor.util.annotation.Nullable;
 
 import static org.assertj.core.api.Assertions.*;
 import static reactor.core.publisher.FluxMetrics.*;
@@ -50,12 +48,12 @@ public class MonoMetricsFuseableTest {
 
 	private MeterRegistry registry;
 
-	@Before
+	@BeforeEach
 	public void setupRegistry() {
 		registry = new SimpleMeterRegistry();
 	}
 
-	@After
+	@AfterEach
 	public void removeRegistry() {
 		registry.close();
 	}

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoMetricsTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoMetricsTest.java
@@ -29,9 +29,9 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
@@ -47,12 +47,12 @@ public class MonoMetricsTest {
 
 	private MeterRegistry registry;
 
-	@Before
+	@BeforeEach
 	public void setupRegistry() {
 		registry = new SimpleMeterRegistry();
 	}
 
-	@After
+	@AfterEach
 	public void removeRegistry() {
 		registry.close();
 	}

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/scheduler/SchedulersMetricsTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/scheduler/SchedulersMetricsTest.java
@@ -5,9 +5,9 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import reactor.core.Disposable;
 import reactor.core.Disposables;
@@ -19,13 +19,13 @@ public class SchedulersMetricsTest {
 	final SimpleMeterRegistry simpleMeterRegistry = new SimpleMeterRegistry();
 	final Disposable.Composite toCleanUp = Disposables.composite();
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		Metrics.addRegistry(simpleMeterRegistry);
 		Schedulers.enableMetrics();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		Schedulers.disableMetrics();
 		Metrics.globalRegistry.forEachMeter(Metrics.globalRegistry::remove);

--- a/reactor-core/src/withMicrometerTest/java/reactor/util/MetricsTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/util/MetricsTest.java
@@ -32,7 +32,7 @@
 
 package reactor.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
Opening a draft PR for now.

It's actually not that bad to review once you look at all commits together, manual cleanups included.

Of particular interest are
```
reactor-core/src/test/java/reactor/guide/GuideTests.java
reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
reactor-core/src/test/java/reactor/core/publisher/FluxUsingWhenTest.java
reactor-core/src/test/java/reactor/core/publisher/FluxDoOnEachTest.java
```

I also looked at the Assert -> AssertJ migration but it's not that trivial, and introduces 56 compile errors. I think it will be better handled as a change after this one.
Opening this as a draft for now, if you want to take a look @simonbasle, while I assess the 3.2.x -> 3.3.x difficulty