### PR TITLE
Rework Sinks specs to put unsafe() at root level

### DIFF
--- a/docs/asciidoc/processors.adoc
+++ b/docs/asciidoc/processors.adoc
@@ -151,9 +151,9 @@ It can be created in multiple configurations:
 Additional overloads for fine tuning of the above can also be found under `Sinks.many().replay()`, as well
 as a variant that allows caching of a single element (`latest()` and `latestOrDefault(T)`).
 
-== Sinks.many().unsafe()
+== Sinks.unsafe().many()
 
-Advanced users and operators builders might want to consider using `Sinks.many().unsafe()`
+Advanced users and operators builders might want to consider using `Sinks.unsafe().many()`
 which will provide the same `Sinks.Many` factories _without_ the extra producer thread safety.
 As a result there will be less overhead per sink, since thread-safe sinks have to detect multi-threaded access.
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGroupJoin.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGroupJoin.java
@@ -313,7 +313,7 @@ final class FluxGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R>
 					if (mode == LEFT_VALUE) {
 						@SuppressWarnings("unchecked") TLeft left = (TLeft) val;
 
-						Sinks.Many<TRight> up = Sinks.many().unsafe().unicast().onBackpressureBuffer(processorQueueSupplier.get());
+						Sinks.Many<TRight> up = Sinks.unsafe().many().unicast().onBackpressureBuffer(processorQueueSupplier.get());
 						int idx = leftIndex++;
 						lefts.put(idx, up);
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindow.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindow.java
@@ -165,7 +165,7 @@ final class FluxWindow<T> extends InternalFluxOperator<T, Flux<T>> {
 			if (cancelled == 0 && i == 0) {
 				WINDOW_COUNT.getAndIncrement(this);
 
-				w = Sinks.many().unsafe().unicast().onBackpressureBuffer(processorQueueSupplier.get(), this);
+				w = Sinks.unsafe().many().unicast().onBackpressureBuffer(processorQueueSupplier.get(), this);
 				window = w;
 
 				actual.onNext(w.asFlux());
@@ -335,7 +335,7 @@ final class FluxWindow<T> extends InternalFluxOperator<T, Flux<T>> {
 			if (i == 0) {
 				WINDOW_COUNT.getAndIncrement(this);
 
-				w = Sinks.many().unsafe().unicast().onBackpressureBuffer(processorQueueSupplier.get(), this);
+				w = Sinks.unsafe().many().unicast().onBackpressureBuffer(processorQueueSupplier.get(), this);
 				window = w;
 
 				actual.onNext(w.asFlux());
@@ -541,7 +541,7 @@ final class FluxWindow<T> extends InternalFluxOperator<T, Flux<T>> {
 				if (cancelled == 0) {
 					WINDOW_COUNT.getAndIncrement(this);
 
-					Sinks.Many<T> w = Sinks.many().unsafe().unicast().onBackpressureBuffer(processorQueueSupplier.get(), this);
+					Sinks.Many<T> w = Sinks.unsafe().many().unicast().onBackpressureBuffer(processorQueueSupplier.get(), this);
 
 					offer(w);
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
@@ -139,7 +139,7 @@ final class FluxWindowBoundary<T, U> extends InternalFluxOperator<T, Flux<T>> {
 				Queue<T> processorQueue) {
 			this.actual = actual;
 			this.processorQueueSupplier = processorQueueSupplier;
-			this.window = Sinks.many().unsafe().unicast().onBackpressureBuffer(processorQueue, this);
+			this.window = Sinks.unsafe().many().unicast().onBackpressureBuffer(processorQueue, this);
 			WINDOW_COUNT.lazySet(this, 2);
 			this.boundary = new WindowBoundaryOther<>(this);
 			this.queue = Queues.unboundedMultiproducer().get();
@@ -329,7 +329,7 @@ final class FluxWindowBoundary<T, U> extends InternalFluxOperator<T, Flux<T>> {
 
 								WINDOW_COUNT.getAndIncrement(this);
 
-								w = Sinks.many().unsafe().unicast().onBackpressureBuffer(pq, this);
+								w = Sinks.unsafe().many().unicast().onBackpressureBuffer(pq, this);
 								window = w;
 
 								a.onNext(w.asFlux());

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
@@ -165,7 +165,7 @@ final class FluxWindowTimeout<T> extends InternalFluxOperator<T, Flux<T>> {
 					return;
 				}
 
-				Sinks.Many<T> w = Sinks.many().unsafe().unicast().onBackpressureBuffer();
+				Sinks.Many<T> w = Sinks.unsafe().many().unicast().onBackpressureBuffer();
 				window = w;
 
 				long r = requested;
@@ -219,7 +219,7 @@ final class FluxWindowTimeout<T> extends InternalFluxOperator<T, Flux<T>> {
 					long r = requested;
 
 					if (r != 0L) {
-						w = Sinks.many().unsafe().unicast().onBackpressureBuffer();
+						w = Sinks.unsafe().many().unicast().onBackpressureBuffer();
 						window = w;
 						actual.onNext(w.asFlux());
 						if (r != Long.MAX_VALUE) {
@@ -346,7 +346,7 @@ final class FluxWindowTimeout<T> extends InternalFluxOperator<T, Flux<T>> {
 					if (isHolder) {
 						w.emitComplete(Sinks.EmitFailureHandler.FAIL_FAST);
 						count = 0;
-						w = Sinks.many().unsafe().unicast().onBackpressureBuffer();
+						w = Sinks.unsafe().many().unicast().onBackpressureBuffer();
 						window = w;
 
 						long r = requested;
@@ -380,7 +380,7 @@ final class FluxWindowTimeout<T> extends InternalFluxOperator<T, Flux<T>> {
 						long r = requested;
 
 						if (r != 0L) {
-							w = Sinks.many().unsafe().unicast().onBackpressureBuffer();
+							w = Sinks.unsafe().many().unicast().onBackpressureBuffer();
 							window = w;
 							actual.onNext(w.asFlux());
 							if (r != Long.MAX_VALUE) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
@@ -275,7 +275,7 @@ final class FluxWindowWhen<T, U, V> extends InternalFluxOperator<T, Flux<T>> {
 						}
 
 
-						w = Sinks.many().unsafe().unicast().onBackpressureBuffer(processorQueueSupplier.get());
+						w = Sinks.unsafe().many().unicast().onBackpressureBuffer(processorQueueSupplier.get());
 
 						long r = requested();
 						if (r != 0L) {

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkEmptySerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkEmptySerialized.java
@@ -21,7 +21,8 @@ import reactor.util.context.Context;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-class SinkEmptySerialized<T> extends SerializedSink implements InternalEmptySink<T>, ContextHolder {
+class SinkEmptySerialized<T> extends SinksSpecs.AbstractSerializedSink
+		implements InternalEmptySink<T>, ContextHolder {
 
 	final Empty<T> sink;
 	final ContextHolder contextHolder;

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManySerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManySerialized.java
@@ -20,7 +20,8 @@ import reactor.util.context.Context;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-final class SinkManySerialized<T> extends SerializedSink implements InternalManySink<T>, Scannable {
+final class SinkManySerialized<T> extends SinksSpecs.AbstractSerializedSink
+		implements InternalManySink<T>, Scannable {
 
 	final Sinks.Many<T> sink;
 	final ContextHolder contextHolder;

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -55,9 +55,10 @@ public final class Sinks {
 	 * Use {@link Sinks.Empty#asMono()} to expose the {@link Mono} view of the sink to downstream consumers.
 	 *
 	 * @return a new {@link Sinks.Empty}
+	 * @see RootSpec#empty()
 	 */
 	public static <T> Sinks.Empty<T> empty() {
-		return new SinkEmptyMulticast<T>();
+		return SinksSpecs.DEFAULT_ROOT_SPEC.empty();
 	}
 
 	/**
@@ -69,9 +70,10 @@ public final class Sinks {
 	 * Use {@link One#asMono()} to expose the {@link Mono} view of the sink to downstream consumers.
 	 *
 	 * @return a new {@link Sinks.One}
+	 * @see RootSpec#one()
 	 */
 	public static <T> Sinks.One<T> one() {
-		return new NextProcessor<>(null);
+		return SinksSpecs.DEFAULT_ROOT_SPEC.one();
 	}
 
 	/**
@@ -80,9 +82,21 @@ public final class Sinks {
 	 * Use {@link Many#asFlux()} to expose the {@link Flux} view of the sink to the downstream consumers.
 	 *
 	 * @return {@link ManySpec}
+	 * @see RootSpec#many()
 	 */
 	public static ManySpec many() {
-		return SinksSpecs.MANY_SPEC;
+		return SinksSpecs.DEFAULT_ROOT_SPEC.many();
+	}
+
+	/**
+	 * Return a {@link RootSpec root spec} for more advanced use cases such as building operators.
+	 * Unsafe {@link Sinks.Many}, {@link Sinks.One} and {@link Sinks.Empty} are not serialized nor thread safe,
+	 * which implies they MUST be externally synchronized so as to respect the Reactive Streams specification.
+	 *
+	 * @return {@link RootSpec}
+	 */
+	public static RootSpec unsafe() {
+		return SinksSpecs.UNSAFE_ROOT_SPEC;
 	}
 
 	/**
@@ -230,6 +244,44 @@ public final class Sinks {
 	}
 
 	/**
+	 * Provides a choice of {@link Sinks.One}/{@link Sinks.Empty} factories and
+	 * {@link Sinks.ManySpec further specs} for {@link Sinks.Many}.
+	 */
+	public interface RootSpec {
+
+		/**
+		 * A {@link Sinks.Empty} which exclusively produces one terminal signal: error or complete.
+		 * It has the following characteristics:
+		 * <ul>
+		 *     <li>Multicast</li>
+		 *     <li>Backpressure : this sink does not need any demand since it can only signal error or completion</li>
+		 *     <li>Replaying: Replay the terminal signal (error or complete).</li>
+		 * </ul>
+		 * Use {@link Sinks.Empty#asMono()} to expose the {@link Mono} view of the sink to downstream consumers.
+		 */
+		<T> Sinks.Empty<T> empty();
+
+		/**
+		 * A {@link Sinks.One} that works like a conceptual promise: it can be completed
+		 * with or without a value at any time, but only once. This completion is replayed to late subscribers.
+		 * Calling {@link One#emitValue(Object)} (or {@link One#tryEmitValue(Object)}) is enough and will
+		 * implicitly produce a {@link Subscriber#onComplete()} signal as well.
+		 * <p>
+		 * Use {@link One#asMono()} to expose the {@link Mono} view of the sink to downstream consumers.
+		 */
+		<T> Sinks.One<T> one();
+
+		/**
+		 * Help building {@link Sinks.Many} sinks that will broadcast multiple signals to one or more {@link Subscriber}.
+		 * <p>
+		 * Use {@link Many#asFlux()} to expose the {@link Flux} view of the sink to the downstream consumers.
+		 *
+		 * @return {@link ManySpec}
+		 */
+		ManySpec many();
+	}
+
+	/**
 	 * Provides {@link Sinks.Many} specs for sinks which can emit multiple elements
 	 */
 	public interface ManySpec {
@@ -254,15 +306,6 @@ public final class Sinks {
 		 * @return {@link MulticastReplaySpec}
 		 */
 		MulticastReplaySpec replay();
-
-		/**
-		 * Return a builder for more advanced use cases such as building operators.
-		 * Unsafe {@link Sinks.Many} are not serialized and expect usage to be externally synchronized to respect
-		 * the Reactive Streams specification.
-		 *
-		 * @return {@link ManySpec}
-		 */
-		ManySpec unsafe();
 	}
 
 	/**
@@ -442,7 +485,6 @@ public final class Sinks {
 		 */
 		<T> Sinks.Many<T> directBestEffort();
 	}
-
 
 	/**
 	 * Provides multicast with history/replay capacity : 1 sink, N {@link Subscriber}
@@ -851,6 +893,5 @@ public final class Sinks {
 		 * @see Subscriber#onComplete()
 		 */
 		void emitValue(@Nullable T value, EmitFailureHandler failureHandler);
-
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
@@ -6,7 +6,9 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import reactor.core.Disposable;
+import reactor.core.publisher.Sinks.Empty;
 import reactor.core.publisher.Sinks.Many;
+import reactor.core.publisher.Sinks.One;
 import reactor.core.scheduler.Scheduler;
 
 final class SinksSpecs {
@@ -58,18 +60,16 @@ class RootSpecImpl implements Sinks.RootSpec,
 		this.unicastSpec = new UnicastSpecImpl(serialized);
 	}
 
-	<T> Sinks.Empty<T> wrapEmpty(Sinks.Empty<T> original) {
+	<T, EMPTY extends Empty<T> & ContextHolder> Empty<T> wrapEmpty(EMPTY original) {
 		if (serialized) {
-			//FIXME return wrapped
-			return original;
+			return new SinkEmptySerialized<>(original, original);
 		}
 		return original;
 	}
 
-	<T> Sinks.One<T> wrapOne(Sinks.One<T> original) {
+	<T, ONE extends One<T> & ContextHolder> One<T> wrapOne(ONE original) {
 		if (serialized) {
-			//FIXME return wrapped
-			return original;
+			return new SinkOneSerialized<>(original, original);
 		}
 		return original;
 	}
@@ -87,12 +87,12 @@ class RootSpecImpl implements Sinks.RootSpec,
 	}
 
 	@Override
-	public <T> Sinks.Empty<T> empty() {
+	public <T> Empty<T> empty() {
 		return wrapEmpty(new SinkEmptyMulticast<>());
 	}
 
 	@Override
-	public <T> Sinks.One<T> one() {
+	public <T> One<T> one() {
 		return wrapOne(new NextProcessor<>(null));
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
@@ -15,239 +15,240 @@ final class SinksSpecs {
 
 	static final Sinks.RootSpec UNSAFE_ROOT_SPEC  = new RootSpecImpl(false);
 	static final Sinks.RootSpec DEFAULT_ROOT_SPEC = new RootSpecImpl(true);
-}
 
-abstract class SerializedSink {
+	abstract static class AbstractSerializedSink {
 
-	volatile int wip;
-	static final AtomicIntegerFieldUpdater<SerializedSink> WIP =
-			AtomicIntegerFieldUpdater.newUpdater(SerializedSink.class, "wip");
+		volatile int                                                   wip;
+		static final AtomicIntegerFieldUpdater<AbstractSerializedSink> WIP =
+				AtomicIntegerFieldUpdater.newUpdater(AbstractSerializedSink.class, "wip");
 
-	volatile Thread lockedAt;
-	static final AtomicReferenceFieldUpdater<SerializedSink, Thread> LOCKED_AT =
-			AtomicReferenceFieldUpdater.newUpdater(SerializedSink.class, Thread.class, "lockedAt");
+		volatile Thread                                                          lockedAt;
+		static final AtomicReferenceFieldUpdater<AbstractSerializedSink, Thread> LOCKED_AT =
+				AtomicReferenceFieldUpdater.newUpdater(AbstractSerializedSink.class, Thread.class, "lockedAt");
 
-	boolean tryAcquire(Thread currentThread) {
-		if (WIP.get(this) == 0 && WIP.compareAndSet(this, 0, 1)) {
-			// lazySet in thread A here is ok because:
-			// 1. initial state is `null`
-			// 2. `LOCKED_AT.get(this) != currentThread` from a different thread B could see outdated null or an outdated old thread
-			// 3. but that old thread cannot be B: since we're in thread B, it must have executed the compareAndSet which would have loaded the update from A
-			// 4. Seeing `null` or `C` is equivalent from seeing `A` from the perspective of the condition (`!= currentThread` is still true in all three cases)
-			LOCKED_AT.lazySet(this, currentThread);
-		}
-		else {
-			if (LOCKED_AT.get(this) != currentThread) {
-				return false;
+		boolean tryAcquire(Thread currentThread) {
+			if (WIP.get(this) == 0 && WIP.compareAndSet(this, 0, 1)) {
+				// lazySet in thread A here is ok because:
+				// 1. initial state is `null`
+				// 2. `LOCKED_AT.get(this) != currentThread` from a different thread B could see outdated null or an outdated old thread
+				// 3. but that old thread cannot be B: since we're in thread B, it must have executed the compareAndSet which would have loaded the update from A
+				// 4. Seeing `null` or `C` is equivalent from seeing `A` from the perspective of the condition (`!= currentThread` is still true in all three cases)
+				LOCKED_AT.lazySet(this, currentThread);
 			}
-			WIP.incrementAndGet(this);
+			else {
+				if (LOCKED_AT.get(this) != currentThread) {
+					return false;
+				}
+				WIP.incrementAndGet(this);
+			}
+			return true;
 		}
-		return true;
+	}
+
+	static final class RootSpecImpl implements Sinks.RootSpec,
+	                                     Sinks.ManySpec,
+	                                     Sinks.MulticastSpec,
+	                                     Sinks.MulticastReplaySpec {
+
+		final boolean serialized;
+		final Sinks.UnicastSpec unicastSpec; //needed because UnicastSpec method names overlap with MulticastSpec
+
+		RootSpecImpl(boolean serialized) {
+			this.serialized = serialized;
+			//there will only be as many instances of UnicastSpecImpl as there are RootSpecImpl instances (2)
+			this.unicastSpec = new UnicastSpecImpl(serialized);
+		}
+
+		<T, EMPTY extends Empty<T> & ContextHolder> Empty<T> wrapEmpty(EMPTY original) {
+			if (serialized) {
+				return new SinkEmptySerialized<>(original, original);
+			}
+			return original;
+		}
+
+		<T, ONE extends One<T> & ContextHolder> One<T> wrapOne(ONE original) {
+			if (serialized) {
+				return new SinkOneSerialized<>(original, original);
+			}
+			return original;
+		}
+
+		<T, MANY extends Many<T> & ContextHolder> Many<T> wrapMany(MANY original) {
+			if (serialized) {
+				return new SinkManySerialized<>(original, original);
+			}
+			return original;
+		}
+
+		@Override
+		public Sinks.ManySpec many() {
+			return this;
+		}
+
+		@Override
+		public <T> Empty<T> empty() {
+			return wrapEmpty(new SinkEmptyMulticast<>());
+		}
+
+		@Override
+		public <T> One<T> one() {
+			return wrapOne(new NextProcessor<>(null));
+		}
+
+		@Override
+		public Sinks.UnicastSpec unicast() {
+			return this.unicastSpec;
+		}
+
+		@Override
+		public Sinks.MulticastSpec multicast() {
+			return this;
+		}
+
+		@Override
+		public Sinks.MulticastReplaySpec replay() {
+			return this;
+		}
+
+		@Override
+		public <T> Many<T> onBackpressureBuffer() {
+			@SuppressWarnings("deprecation")
+			final EmitterProcessor<T> original = EmitterProcessor.create();
+			return wrapMany(original);
+		}
+
+		@Override
+		public <T> Many<T> onBackpressureBuffer(int bufferSize) {
+			@SuppressWarnings("deprecation")
+			final EmitterProcessor<T> original = EmitterProcessor.create(bufferSize);
+			return wrapMany(original);
+		}
+
+		@Override
+		public <T> Many<T> onBackpressureBuffer(int bufferSize, boolean autoCancel) {
+			@SuppressWarnings("deprecation")
+			final EmitterProcessor<T> original = EmitterProcessor.create(bufferSize, autoCancel);
+			return wrapMany(original);
+		}
+
+		@Override
+		public <T> Many<T> directAllOrNothing() {
+			final SinkManyBestEffort<T> original = SinkManyBestEffort.createAllOrNothing();
+			return wrapMany(original);
+		}
+
+		@Override
+		public <T> Many<T> directBestEffort() {
+			final SinkManyBestEffort<T> original = SinkManyBestEffort.createBestEffort();
+			return wrapMany(original);
+		}
+
+
+		@Override
+		public <T> Many<T> all() {
+			@SuppressWarnings("deprecation")
+			final ReplayProcessor<T> original = ReplayProcessor.create();
+			return wrapMany(original);
+		}
+
+		@Override
+		public <T> Many<T> all(int batchSize) {
+			@SuppressWarnings("deprecation")
+			final ReplayProcessor<T> original = ReplayProcessor.create(batchSize, true);
+			return wrapMany(original);
+		}
+
+		@Override
+		public <T> Many<T> latest() {
+			@SuppressWarnings("deprecation")
+			final ReplayProcessor<T> original = ReplayProcessor.cacheLast();
+			return wrapMany(original);
+		}
+
+		@Override
+		public <T> Many<T> latestOrDefault(T value) {
+			@SuppressWarnings("deprecation")
+			final ReplayProcessor<T> original = ReplayProcessor.cacheLastOrDefault(value);
+			return wrapMany(original);
+		}
+
+		@Override
+		public <T> Many<T> limit(int historySize) {
+			@SuppressWarnings("deprecation")
+			final ReplayProcessor<T> original = ReplayProcessor.create(historySize);
+			return wrapMany(original);
+		}
+
+		@Override
+		public <T> Many<T> limit(Duration maxAge) {
+			@SuppressWarnings("deprecation")
+			final ReplayProcessor<T> original = ReplayProcessor.createTimeout(maxAge);
+			return wrapMany(original);
+		}
+
+		@Override
+		public <T> Many<T> limit(Duration maxAge, Scheduler scheduler) {
+			@SuppressWarnings("deprecation")
+			final ReplayProcessor<T> original = ReplayProcessor.createTimeout(maxAge, scheduler);
+			return wrapMany(original);
+		}
+
+		@Override
+		public <T> Many<T> limit(int historySize, Duration maxAge) {
+			@SuppressWarnings("deprecation")
+			final ReplayProcessor<T> original = ReplayProcessor.createSizeAndTimeout(historySize, maxAge);
+			return wrapMany(original);
+		}
+
+		@Override
+		public <T> Many<T> limit(int historySize, Duration maxAge, Scheduler scheduler) {
+			@SuppressWarnings("deprecation")
+			final ReplayProcessor<T> original = ReplayProcessor.createSizeAndTimeout(historySize, maxAge, scheduler);
+			return wrapMany(original);
+		}
+	}
+
+	static final class UnicastSpecImpl implements Sinks.UnicastSpec {
+
+		final boolean serialized;
+
+		UnicastSpecImpl(boolean serialized) {
+			this.serialized = serialized;
+		}
+
+		<T, MANY extends Many<T> & ContextHolder> Many<T> wrapMany(MANY original) {
+			if (serialized) {
+				return new SinkManySerialized<>(original, original);
+			}
+			return original;
+		}
+
+		@Override
+		public <T> Many<T> onBackpressureBuffer() {
+			@SuppressWarnings("deprecation")
+			final UnicastProcessor<T> original = UnicastProcessor.create();
+			return wrapMany(original);
+		}
+
+		@Override
+		public <T> Many<T> onBackpressureBuffer(Queue<T> queue) {
+			@SuppressWarnings("deprecation")
+			final UnicastProcessor<T> original = UnicastProcessor.create(queue);
+			return wrapMany(original);
+		}
+
+		@Override
+		public <T> Many<T> onBackpressureBuffer(Queue<T> queue, Disposable endCallback) {
+			@SuppressWarnings("deprecation")
+			final UnicastProcessor<T> original = UnicastProcessor.create(queue, endCallback);
+			return wrapMany(original);
+		}
+
+		@Override
+		public <T> Many<T> onBackpressureError() {
+			final UnicastManySinkNoBackpressure<T> original = UnicastManySinkNoBackpressure.create();
+			return wrapMany(original);
+		}
 	}
 }
 
-class RootSpecImpl implements Sinks.RootSpec,
-                              Sinks.ManySpec,
-                              Sinks.MulticastSpec,
-                              Sinks.MulticastReplaySpec {
-
-	final boolean serialized;
-	final Sinks.UnicastSpec unicastSpec; //needed because UnicastSpec method names overlap with MulticastSpec
-
-	RootSpecImpl(boolean serialized) {
-		this.serialized = serialized;
-		//there will only be as many instances of UnicastSpecImpl as there are RootSpecImpl instances (2)
-		this.unicastSpec = new UnicastSpecImpl(serialized);
-	}
-
-	<T, EMPTY extends Empty<T> & ContextHolder> Empty<T> wrapEmpty(EMPTY original) {
-		if (serialized) {
-			return new SinkEmptySerialized<>(original, original);
-		}
-		return original;
-	}
-
-	<T, ONE extends One<T> & ContextHolder> One<T> wrapOne(ONE original) {
-		if (serialized) {
-			return new SinkOneSerialized<>(original, original);
-		}
-		return original;
-	}
-
-	<T, MANY extends Many<T> & ContextHolder> Many<T> wrapMany(MANY original) {
-		if (serialized) {
-			return new SinkManySerialized<>(original, original);
-		}
-		return original;
-	}
-
-	@Override
-	public Sinks.ManySpec many() {
-		return this;
-	}
-
-	@Override
-	public <T> Empty<T> empty() {
-		return wrapEmpty(new SinkEmptyMulticast<>());
-	}
-
-	@Override
-	public <T> One<T> one() {
-		return wrapOne(new NextProcessor<>(null));
-	}
-
-	@Override
-	public Sinks.UnicastSpec unicast() {
-		return this.unicastSpec;
-	}
-
-	@Override
-	public Sinks.MulticastSpec multicast() {
-		return this;
-	}
-
-	@Override
-	public Sinks.MulticastReplaySpec replay() {
-		return this;
-	}
-
-	@Override
-	public <T> Many<T> onBackpressureBuffer() {
-		@SuppressWarnings("deprecation")
-		final EmitterProcessor<T> original = EmitterProcessor.create();
-		return wrapMany(original);
-	}
-
-	@Override
-	public <T> Many<T> onBackpressureBuffer(int bufferSize) {
-		@SuppressWarnings("deprecation")
-		final EmitterProcessor<T> original = EmitterProcessor.create(bufferSize);
-		return wrapMany(original);
-	}
-
-	@Override
-	public <T> Many<T> onBackpressureBuffer(int bufferSize, boolean autoCancel) {
-		@SuppressWarnings("deprecation")
-		final EmitterProcessor<T> original = EmitterProcessor.create(bufferSize, autoCancel);
-		return wrapMany(original);
-	}
-
-	@Override
-	public <T> Many<T> directAllOrNothing() {
-		final SinkManyBestEffort<T> original = SinkManyBestEffort.createAllOrNothing();
-		return wrapMany(original);
-	}
-
-	@Override
-	public <T> Many<T> directBestEffort() {
-		final SinkManyBestEffort<T> original = SinkManyBestEffort.createBestEffort();
-		return wrapMany(original);
-	}
-
-
-	@Override
-	public <T> Many<T> all() {
-		@SuppressWarnings("deprecation")
-		final ReplayProcessor<T> original = ReplayProcessor.create();
-		return wrapMany(original);
-	}
-
-	@Override
-	public <T> Many<T> all(int batchSize) {
-		@SuppressWarnings("deprecation")
-		final ReplayProcessor<T> original = ReplayProcessor.create(batchSize, true);
-		return wrapMany(original);
-	}
-
-	@Override
-	public <T> Many<T> latest() {
-		@SuppressWarnings("deprecation")
-		final ReplayProcessor<T> original = ReplayProcessor.cacheLast();
-		return wrapMany(original);
-	}
-
-	@Override
-	public <T> Many<T> latestOrDefault(T value) {
-		@SuppressWarnings("deprecation")
-		final ReplayProcessor<T> original = ReplayProcessor.cacheLastOrDefault(value);
-		return wrapMany(original);
-	}
-
-	@Override
-	public <T> Many<T> limit(int historySize) {
-		@SuppressWarnings("deprecation")
-		final ReplayProcessor<T> original = ReplayProcessor.create(historySize);
-		return wrapMany(original);
-	}
-
-	@Override
-	public <T> Many<T> limit(Duration maxAge) {
-		@SuppressWarnings("deprecation")
-		final ReplayProcessor<T> original = ReplayProcessor.createTimeout(maxAge);
-		return wrapMany(original);
-	}
-
-	@Override
-	public <T> Many<T> limit(Duration maxAge, Scheduler scheduler) {
-		@SuppressWarnings("deprecation")
-		final ReplayProcessor<T> original = ReplayProcessor.createTimeout(maxAge, scheduler);
-		return wrapMany(original);
-	}
-
-	@Override
-	public <T> Many<T> limit(int historySize, Duration maxAge) {
-		@SuppressWarnings("deprecation")
-		final ReplayProcessor<T> original = ReplayProcessor.createSizeAndTimeout(historySize, maxAge);
-		return wrapMany(original);
-	}
-
-	@Override
-	public <T> Many<T> limit(int historySize, Duration maxAge, Scheduler scheduler) {
-		@SuppressWarnings("deprecation")
-		final ReplayProcessor<T> original = ReplayProcessor.createSizeAndTimeout(historySize, maxAge, scheduler);
-		return wrapMany(original);
-	}
-}
-
-class UnicastSpecImpl implements Sinks.UnicastSpec {
-
-	final boolean serialized;
-
-	UnicastSpecImpl(boolean serialized) {
-		this.serialized = serialized;
-	}
-
-	<T, MANY extends Many<T> & ContextHolder> Many<T> wrapMany(MANY original) {
-		if (serialized) {
-			return new SinkManySerialized<>(original, original);
-		}
-		return original;
-	}
-
-	@Override
-	public <T> Many<T> onBackpressureBuffer() {
-		@SuppressWarnings("deprecation")
-		final UnicastProcessor<T> original = UnicastProcessor.create();
-		return wrapMany(original);
-	}
-
-	@Override
-	public <T> Many<T> onBackpressureBuffer(Queue<T> queue) {
-		@SuppressWarnings("deprecation")
-		final UnicastProcessor<T> original = UnicastProcessor.create(queue);
-		return wrapMany(original);
-	}
-
-	@Override
-	public <T> Many<T> onBackpressureBuffer(Queue<T> queue, Disposable endCallback) {
-		@SuppressWarnings("deprecation")
-		final UnicastProcessor<T> original = UnicastProcessor.create(queue, endCallback);
-		return wrapMany(original);
-	}
-
-	@Override
-	public <T> Many<T> onBackpressureError() {
-		final UnicastManySinkNoBackpressure<T> original = UnicastManySinkNoBackpressure.create();
-		return wrapMany(original);
-	}
-}

--- a/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
@@ -278,10 +278,10 @@ public abstract class AbstractFluxConcatMapTest extends FluxOperatorTest<String,
 	public void singleSubscriberOnlyBoundary() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source = Sinks.unsafe().many().multicast().directBestEffort();
 
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		source.asFlux().concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux(), implicitPrefetchValue())
 		      .subscribe(ts);
@@ -317,10 +317,10 @@ public abstract class AbstractFluxConcatMapTest extends FluxOperatorTest<String,
 	public void mainErrorsImmediate() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source = Sinks.unsafe().many().multicast().directBestEffort();
 
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		source.asFlux().concatMap(v -> v == 1 ? source1.asFlux() : source2.asFlux(), implicitPrefetchValue())
 		      .subscribe(ts);
@@ -351,10 +351,10 @@ public abstract class AbstractFluxConcatMapTest extends FluxOperatorTest<String,
 	public void mainErrorsBoundary() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source = Sinks.unsafe().many().multicast().directBestEffort();
 
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		source.asFlux().concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux(), implicitPrefetchValue())
 		      .subscribe(ts);
@@ -392,10 +392,10 @@ public abstract class AbstractFluxConcatMapTest extends FluxOperatorTest<String,
 	public void innerErrorsImmediate() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source = Sinks.unsafe().many().multicast().directBestEffort();
 
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		source.asFlux().concatMap(v -> v == 1 ? source1.asFlux() : source2.asFlux(), implicitPrefetchValue())
 		      .subscribe(ts);
@@ -848,10 +848,10 @@ public abstract class AbstractFluxConcatMapTest extends FluxOperatorTest<String,
 	public void innerErrorsBoundary() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source = Sinks.unsafe().many().multicast().directBestEffort();
 
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		//gh-1101: default changed from BOUNDARY to END
 		source.asFlux().concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux(), false, implicitPrefetchValue())
@@ -883,10 +883,10 @@ public abstract class AbstractFluxConcatMapTest extends FluxOperatorTest<String,
 	public void innerErrorsEnd() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source = Sinks.unsafe().many().multicast().directBestEffort();
 
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		source.asFlux().concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux(), true, implicitPrefetchValue())
 		      .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferBoundaryTest.java
@@ -77,8 +77,8 @@ public class FluxBufferBoundaryTest
 	public void normal() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .buffer(sp2.asFlux())
@@ -129,8 +129,8 @@ public class FluxBufferBoundaryTest
 	public void mainError() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .buffer(sp2.asFlux())
@@ -176,8 +176,8 @@ public class FluxBufferBoundaryTest
 	public void otherError() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .buffer(sp2.asFlux())
@@ -223,8 +223,8 @@ public class FluxBufferBoundaryTest
 	public void bufferSupplierThrows() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .buffer(sp2.asFlux(), (Supplier<List<Integer>>) () -> {
@@ -245,8 +245,8 @@ public class FluxBufferBoundaryTest
 	public void bufferSupplierThrowsLater() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		int count[] = {1};
 
@@ -277,8 +277,8 @@ public class FluxBufferBoundaryTest
 	public void bufferSupplierReturnsNUll() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .buffer(sp2.asFlux(), (Supplier<List<Integer>>) () -> null)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
@@ -63,7 +63,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalUntil() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL);
 
@@ -127,7 +127,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void mainErrorUntil() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL);
 
@@ -147,7 +147,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void predicateErrorUntil() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(),
 				i -> {
@@ -171,7 +171,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalUntilOther() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE);
 
@@ -202,7 +202,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void mainErrorUntilOther() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther =
 				new FluxBufferPredicate<>(sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(),
 						FluxBufferPredicate.Mode.UNTIL_CUT_BEFORE);
@@ -223,7 +223,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void predicateErrorUntilOther() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntilOther =
 				new FluxBufferPredicate<>(sp1.asFlux(),
 				i -> {
@@ -376,7 +376,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalWhile() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 != 0, Flux.listSupplier(),
 				FluxBufferPredicate.Mode.WHILE);
@@ -408,7 +408,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalWhileDoesntInitiallyMatch() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
 
@@ -439,7 +439,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalWhileDoesntMatch() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i > 4, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
 
@@ -465,7 +465,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void mainErrorWhile() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0, Flux.listSupplier(), FluxBufferPredicate.Mode.WHILE);
 
@@ -485,7 +485,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void predicateErrorWhile() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferWhile = new FluxBufferPredicate<>(
 				sp1.asFlux(),
 				i -> {
@@ -510,7 +510,7 @@ public class FluxBufferPredicateTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void bufferSupplierThrows() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0,
 				() -> { throw new RuntimeException("supplier failure"); },
@@ -525,7 +525,7 @@ public class FluxBufferPredicateTest {
 
 	@Test
 	public void bufferSupplierThrowsLater() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		int count[] = {1};
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0,
@@ -550,7 +550,7 @@ public class FluxBufferPredicateTest {
 
 	@Test
 	public void bufferSupplierReturnsNull() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxBufferPredicate<Integer, List<Integer>> bufferUntil = new FluxBufferPredicate<>(
 				sp1.asFlux(), i -> i % 3 == 0,
 				() -> null,
@@ -569,7 +569,7 @@ public class FluxBufferPredicateTest {
 	@SuppressWarnings("unchecked")
 	public void multipleTriggersOfEmptyBufferKeepInitialBuffer() {
 		//this is best demonstrated with bufferWhile:
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		LongAdder bufferCount = new LongAdder();
 		Supplier<List<Integer>> bufferSupplier = () -> {
 			bufferCount.increment();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
@@ -167,10 +167,10 @@ public class FluxBufferWhenTest {
 	public void normal() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp3 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp4 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp3 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp4 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .bufferWhen(sp2.asFlux(), v -> v == 1 ? sp3.asFlux() : sp4.asFlux())
@@ -227,9 +227,9 @@ public class FluxBufferWhenTest {
 	public void startCompletes() {
 		AssertSubscriber<List<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> open = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> close = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> open = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> close = Sinks.unsafe().many().multicast().directBestEffort();
 
 		source.asFlux()
 			  .bufferWhen(open.asFlux(), v -> close.asFlux())

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCombineLatestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCombineLatestTest.java
@@ -160,8 +160,8 @@ public class FluxCombineLatestTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void fused() {
-		Sinks.Many<Integer> dp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> dp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> dp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> dp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		ts.requestedFusionMode(Fuseable.ANY);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapTest.java
@@ -111,10 +111,10 @@ public class  FluxConcatMapTest extends AbstractFluxConcatMapTest {
 	public void singleSubscriberOnly() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source = Sinks.unsafe().many().multicast().directBestEffort();
 
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		source.asFlux()
 			  .concatMap(v -> v == 1 ? source1.asFlux() : source2.asFlux())
@@ -151,10 +151,10 @@ public class  FluxConcatMapTest extends AbstractFluxConcatMapTest {
 	public void singleSubscriberOnlyBoundary() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source = Sinks.unsafe().many().multicast().directBestEffort();
 
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		source.asFlux()
 			  .concatMapDelayError(v -> v == 1 ? source1.asFlux() : source2.asFlux())

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDistinctUntilChangedTest.java
@@ -229,7 +229,7 @@ public class FluxDistinctUntilChangedTest extends FluxOperatorTest<String, Strin
 
 	@Test
 	public void allDistinctConditional() {
-		Sinks.Many<Integer> dp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> dp = Sinks.unsafe().many().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = dp.asFlux()
 										 .distinctUntilChanged()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFilterTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFilterTest.java
@@ -189,7 +189,7 @@ public class FluxFilterTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
 		Sinks.Many<Integer> up =
-				Sinks.many().unsafe().unicast().onBackpressureBuffer(new ConcurrentLinkedQueue<>());
+				Sinks.unsafe().many().unicast().onBackpressureBuffer(new ConcurrentLinkedQueue<>());
 
 		up.asFlux()
 		  .filter(v -> (v & 1) == 0)
@@ -210,7 +210,7 @@ public class FluxFilterTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Object> ts = AssertSubscriber.create(1);
 
 		Sinks.Many<Integer> up =
-				Sinks.many().unsafe().unicast().onBackpressureBuffer(new ConcurrentLinkedQueue<>());
+				Sinks.unsafe().many().unicast().onBackpressureBuffer(new ConcurrentLinkedQueue<>());
 
 		Flux.just(1)
 		    .hide()
@@ -236,7 +236,7 @@ public class FluxFilterTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Object> ts = AssertSubscriber.create(1);
 
 		Sinks.Many<Integer> up =
-				Sinks.many().unsafe().unicast().onBackpressureBuffer(new ConcurrentLinkedQueue<>());
+				Sinks.unsafe().many().unicast().onBackpressureBuffer(new ConcurrentLinkedQueue<>());
 
 		Flux.just(1)
 		    .hide()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxGroupJoinTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxGroupJoinTest.java
@@ -47,8 +47,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void behaveAsJoin() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Flux<Integer> m =
 				source1.asFlux().groupJoin(source2.asFlux(), just(Flux.never()), just(Flux.never()), add2)
@@ -139,8 +139,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void leftThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Flux<Flux<Integer>> m =
 				source1.asFlux().groupJoin(source2.asFlux(), just(Flux.never()), just(Flux.never()), add2);
@@ -158,8 +158,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void rightThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Flux<Flux<Integer>> m =
 				source1.asFlux().groupJoin(source2.asFlux(), just(Flux.never()), just(Flux.never()), add2);
@@ -177,8 +177,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void leftDurationThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Flux<Integer> duration1 = Flux.error(new RuntimeException("Forced failure"));
 
@@ -196,8 +196,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void rightDurationThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Flux<Integer> duration1 = Flux.error(new RuntimeException("Forced failure"));
 
@@ -215,8 +215,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void leftDurationSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Function<Integer, Flux<Integer>> fail = t1 -> {
 			throw new RuntimeException("Forced failure");
@@ -236,8 +236,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void rightDurationSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Function<Integer, Flux<Integer>> fail = t1 -> {
 			throw new RuntimeException("Forced failure");
@@ -257,8 +257,8 @@ public class FluxGroupJoinTest {
 	@Test
 	public void resultSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		BiFunction<Integer, Flux<Integer>, Integer> fail = (t1, t2) -> {
 			throw new RuntimeException("Forced failure");

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxJoinTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxJoinTest.java
@@ -40,8 +40,8 @@ public class FluxJoinTest {
 	public void normal1() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Flux<Integer> m =
 				source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(Flux.never()), add);
@@ -67,10 +67,10 @@ public class FluxJoinTest {
 	@Test
 	public void normal1WithDuration() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
-		Sinks.Many<Integer> duration1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> duration1 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Flux<Integer> m = source1.asFlux().join(source2.asFlux(), just(duration1.asFlux()), just(Flux.never()), add);
 		m.subscribe(ts);
@@ -96,8 +96,8 @@ public class FluxJoinTest {
 	@Test
 	public void normal2() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Flux<Integer> m =
 				source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(Flux.never()), add);
@@ -122,8 +122,8 @@ public class FluxJoinTest {
 	@Test
 	public void leftThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Flux<Integer> m =
 				source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(Flux.never()), add);
@@ -141,8 +141,8 @@ public class FluxJoinTest {
 	@Test
 	public void rightThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Flux<Integer> m =
 				source1.asFlux().join(source2.asFlux(), just(Flux.never()), just(Flux.never()), add);
@@ -160,8 +160,8 @@ public class FluxJoinTest {
 	@Test
 	public void leftDurationThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Flux<Integer> duration1 = Flux.error(new RuntimeException("Forced failure"));
 
@@ -178,8 +178,8 @@ public class FluxJoinTest {
 	@Test
 	public void rightDurationThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Flux<Integer> duration1 = Flux.error(new RuntimeException("Forced failure"));
 
@@ -196,8 +196,8 @@ public class FluxJoinTest {
 	@Test
 	public void leftDurationSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Function<Integer, Flux<Integer>> fail = t1 -> {
 			throw new RuntimeException("Forced failure");
@@ -216,8 +216,8 @@ public class FluxJoinTest {
 	@Test
 	public void rightDurationSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Function<Integer, Flux<Integer>> fail = t1 -> {
 			throw new RuntimeException("Forced failure");
@@ -236,8 +236,8 @@ public class FluxJoinTest {
 	@Test
 	public void resultSelectorThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		Sinks.Many<Integer> source1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> source2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> source2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		BiFunction<Integer, Integer, Integer> fail = (t1, t2) -> {
 			throw new RuntimeException("Forced failure");

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMapTest.java
@@ -149,7 +149,7 @@ public class FluxMapTest extends FluxOperatorTest<String, String> {
 	public void asyncFusion() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> up = Sinks.many().unsafe().unicast().onBackpressureBuffer(new ConcurrentLinkedQueue<>());
+		Sinks.Many<Integer> up = Sinks.unsafe().many().unicast().onBackpressureBuffer(new ConcurrentLinkedQueue<>());
 
 		up.asFlux()
 		  .map(v -> v + 1)
@@ -170,7 +170,7 @@ public class FluxMapTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Object> ts = AssertSubscriber.create(1);
 
 		Sinks.Many<Integer> up =
-				Sinks.many().unsafe().unicast().onBackpressureBuffer(new ConcurrentLinkedQueue<>());
+				Sinks.unsafe().many().unicast().onBackpressureBuffer(new ConcurrentLinkedQueue<>());
 
 		Flux.just(1)
 		    .hide()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
@@ -84,7 +84,7 @@ public class FluxMergeSequentialTest {
 	@SuppressWarnings("dreprecated")
 	public void normalFusedAsync() {
 		StepVerifier.create(Flux.range(1, 5)
-		                        .subscribeWith(FluxProcessor.fromSink(Sinks.many().unsafe().unicast().onBackpressureBuffer()))
+		                        .subscribeWith(FluxProcessor.fromSink(Sinks.unsafe().many().unicast().onBackpressureBuffer()))
 		                        .flatMapSequential(t -> Flux.range(t, 2)))
 		            .expectNext(1, 2, 2, 3, 3, 4, 4, 5, 5, 6)
 		            .verifyComplete();
@@ -144,8 +144,8 @@ public class FluxMergeSequentialTest {
 
 	@Test
 	public void mainErrorsDelayEnd() {
-		Sinks.Many<Integer> main = Sinks.many().unsafe().multicast().directBestEffort();
-		final Sinks.Many<Integer> inner = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> main = Sinks.unsafe().many().multicast().directBestEffort();
+		final Sinks.Many<Integer> inner = Sinks.unsafe().many().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = main.asFlux()
 										   .flatMapSequentialDelayError(t -> inner.asFlux(), 32, 32)
@@ -171,8 +171,8 @@ public class FluxMergeSequentialTest {
 
 	@Test
 	public void mainErrorsImmediate() {
-		Sinks.Many<Integer> main = Sinks.many().unsafe().multicast().directBestEffort();
-		final Sinks.Many<Integer> inner = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> main = Sinks.unsafe().many().multicast().directBestEffort();
+		final Sinks.Many<Integer> inner = Sinks.unsafe().many().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = main.asFlux().flatMapSequential(t -> inner.asFlux())
 		                                   .subscribeWith(AssertSubscriber.create());
@@ -464,7 +464,7 @@ public class FluxMergeSequentialTest {
 
 	@Test
 	public void testReentrantWork() {
-		final Sinks.Many<Integer> subject = Sinks.many().unsafe().multicast().directBestEffort();
+		final Sinks.Many<Integer> subject = Sinks.unsafe().many().multicast().directBestEffort();
 
 		final AtomicBoolean once = new AtomicBoolean();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
@@ -104,7 +104,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void drop() {
-		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<String> processor = Sinks.unsafe().many().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, this, DROP_LATEST);
@@ -132,7 +132,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void dropOldest() {
-		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<String> processor = Sinks.unsafe().many().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, this, DROP_OLDEST);
@@ -160,7 +160,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void error() {
-		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<String> processor = Sinks.unsafe().many().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, this, ERROR);
@@ -265,7 +265,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void dropCallbackError() {
-		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<String> processor = Sinks.unsafe().many().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, v -> { throw new IllegalArgumentException("boom"); },
@@ -295,7 +295,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void dropOldestCallbackError() {
-		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<String> processor = Sinks.unsafe().many().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, v -> { throw new IllegalArgumentException("boom"); },
@@ -325,7 +325,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void errorCallbackError() {
-		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<String> processor = Sinks.unsafe().many().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, v -> { throw new IllegalArgumentException("boom"); },
@@ -355,7 +355,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void noCallbackWithErrorStrategyOverflowsAfterDrain() {
-		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<String> processor = Sinks.unsafe().many().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, null, ERROR);
@@ -385,7 +385,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void noCallbackWithDropStrategyNoError() {
-		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<String> processor = Sinks.unsafe().many().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, null, DROP_LATEST);
@@ -413,7 +413,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void noCallbackWithDropOldestStrategyNoError() {
-		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<String> processor = Sinks.unsafe().many().multicast().directBestEffort();
 
 		FluxOnBackpressureBufferStrategy<String> flux = new FluxOnBackpressureBufferStrategy<>(
 				processor.asFlux(), 2, null, DROP_OLDEST);
@@ -441,7 +441,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@Test
 	public void fluxOnBackpressureBufferStrategyNoCallback() {
-		Sinks.Many<String> processor = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<String> processor = Sinks.unsafe().many().multicast().directBestEffort();
 
 		StepVerifier.create(processor.asFlux().onBackpressureBuffer(2, DROP_OLDEST), 0)
 		            .thenRequest(1)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureDropTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureDropTest.java
@@ -91,7 +91,7 @@ public class FluxOnBackpressureDropTest {
 
 	@Test
 	public void someDrops() {
-		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> tp = Sinks.unsafe().many().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureLatestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureLatestTest.java
@@ -69,7 +69,7 @@ public class FluxOnBackpressureLatestTest {
 
 	@Test
 	public void backpressured() {
-		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> tp = Sinks.unsafe().many().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
@@ -108,7 +108,7 @@ public class FluxOnBackpressureLatestTest {
 
 	@Test
 	public void error() {
-		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> tp = Sinks.unsafe().many().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
@@ -124,7 +124,7 @@ public class FluxOnBackpressureLatestTest {
 
 	@Test
 	public void backpressureWithDrop() {
-		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> tp = Sinks.unsafe().many().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = new AssertSubscriber<Integer>(0) {
 			@Override

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
@@ -489,7 +489,7 @@ public class FluxPeekFuseableTest {
 	public void asyncFusionAvailable() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.many().unsafe()
+		Sinks.unsafe().many()
 			 .unicast()
 			 .onBackpressureBuffer(Queues.<Integer>get(2).get())
 			 .asFlux()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
@@ -664,7 +664,7 @@ public class FluxPeekTest extends FluxOperatorTest<String, String> {
 	public void asyncFusionAvailable() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.many().unsafe()
+		Sinks.unsafe().many()
 			 .unicast()
 			 .onBackpressureBuffer(Queues.<Integer>get(2).get())
 			 .asFlux()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxProcessorTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SuppressWarnings("deprecation")
 public class FluxProcessorTest {
 
-	final FluxProcessor<?, ?> processor = FluxProcessor.fromSink(Sinks.many().unsafe().unicast().onBackpressureBuffer());
+	final FluxProcessor<?, ?> processor = FluxProcessor.fromSink(Sinks.unsafe().many().unicast().onBackpressureBuffer());
 
 	@Test(expected = NullPointerException.class)
 	@SuppressWarnings("unchecked")
@@ -63,7 +63,7 @@ public class FluxProcessorTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void normalBlackboxProcessor(){
-		FluxProcessor<Integer, Integer> upstream = FluxProcessor.fromSink(Sinks.many().unsafe().unicast().onBackpressureBuffer());
+		FluxProcessor<Integer, Integer> upstream = FluxProcessor.fromSink(Sinks.unsafe().many().unicast().onBackpressureBuffer());
 		FluxProcessor<Integer, Integer> processor =
 				FluxProcessor.wrap(upstream, upstream.map(i -> i + 1)
 				                                     .filter(i -> i % 2 == 0));
@@ -83,7 +83,7 @@ public class FluxProcessorTest {
 
 	@Test
 	public void disconnectedBlackboxProcessor(){
-		FluxProcessor<Integer, Integer> upstream = FluxProcessor.fromSink(Sinks.many().unsafe().unicast().onBackpressureBuffer());
+		FluxProcessor<Integer, Integer> upstream = FluxProcessor.fromSink(Sinks.unsafe().many().unicast().onBackpressureBuffer());
 		FluxProcessor<Integer, Integer> processor =
 				FluxProcessor.wrap(upstream, Flux.just(1));
 
@@ -94,7 +94,7 @@ public class FluxProcessorTest {
 
 	@Test
 	public void symmetricBlackboxProcessor(){
-		FluxProcessor<Integer, Integer> upstream = FluxProcessor.fromSink(Sinks.many().unsafe().unicast().onBackpressureBuffer());
+		FluxProcessor<Integer, Integer> upstream = FluxProcessor.fromSink(Sinks.unsafe().many().unicast().onBackpressureBuffer());
 		FluxProcessor<Integer, Integer> processor =
 				FluxProcessor.wrap(upstream, upstream);
 
@@ -106,7 +106,7 @@ public class FluxProcessorTest {
 
 	@Test
 	public void errorSymmetricBlackboxProcessor(){
-		FluxProcessor<Integer, Integer> upstream = FluxProcessor.fromSink(Sinks.many().unsafe().unicast().onBackpressureBuffer());
+		FluxProcessor<Integer, Integer> upstream = FluxProcessor.fromSink(Sinks.unsafe().many().unicast().onBackpressureBuffer());
 		FluxProcessor<Integer, Integer> processor =
 				FluxProcessor.wrap(upstream, upstream);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishMulticastTest.java
@@ -77,7 +77,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
 				scenario(f -> f.publish(p -> Flux.just("test", "test1", "test2")))
 						.fusionMode(Fuseable.SYNC),
 
-				scenario(f -> f.publish(p -> p.subscribeWith(FluxProcessor.fromSink(Sinks.many().unsafe().unicast().onBackpressureBuffer())), 256))
+				scenario(f -> f.publish(p -> p.subscribeWith(FluxProcessor.fromSink(Sinks.unsafe().many().unicast().onBackpressureBuffer())), 256))
 						.fusionMode(Fuseable.ASYNC),
 
 
@@ -96,7 +96,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
 		return Arrays.asList(scenario(f -> f.publish(p -> p)),
 
 				scenario(f -> f.publish(p ->
-						p.subscribeWith(FluxProcessor.fromSink(Sinks.many().unsafe().unicast().onBackpressureBuffer()))))
+						p.subscribeWith(FluxProcessor.fromSink(Sinks.unsafe().many().unicast().onBackpressureBuffer()))))
 						.fusionMode(Fuseable.ASYNC),
 
 				scenario(f -> f.publish(p -> p))
@@ -155,7 +155,7 @@ public class FluxPublishMulticastTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		Sinks.Many<Integer> up =
-				Sinks.many().unsafe().unicast().onBackpressureBuffer(Queues.<Integer>get(16).get());
+				Sinks.unsafe().many().unicast().onBackpressureBuffer(Queues.<Integer>get(16).get());
 
 		up.asFlux()
 		  .publish(o -> zip((Object[] a) -> (Integer) a[0] + (Integer) a[1], o, o.skip(1)))

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishOnTest.java
@@ -244,7 +244,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		Sinks.Many<Integer> up =
-				Sinks.many().unsafe().unicast().onBackpressureBuffer(new ConcurrentLinkedQueue<>());
+				Sinks.unsafe().many().unicast().onBackpressureBuffer(new ConcurrentLinkedQueue<>());
 
 		for (int i = 0; i < 1_000_000; i++) {
 			up.emitNext(i, FAIL_FAST);
@@ -265,7 +265,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void normalAsyncFusedBackpressured() throws Exception {
 		Sinks.Many<Integer> up =
-				Sinks.many().unsafe().unicast().onBackpressureBuffer(Queues.<Integer>unbounded(1024).get());
+				Sinks.unsafe().many().unicast().onBackpressureBuffer(Queues.<Integer>unbounded(1024).get());
 
 		for (int i = 0; i < 1_000_000; i++) {
 			up.emitNext(0, FAIL_FAST);
@@ -697,7 +697,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	public void mappedAsyncSourceWithNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		Sinks.Many<Integer> up =
-				Sinks.many().unsafe().unicast().onBackpressureBuffer(Queues.<Integer>get(2).get());
+				Sinks.unsafe().many().unicast().onBackpressureBuffer(Queues.<Integer>get(2).get());
 		up.emitNext(1, FAIL_FAST);
 		up.emitNext(2, FAIL_FAST);
 		up.emitComplete(FAIL_FAST);
@@ -717,7 +717,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	public void mappedAsyncSourceWithNullPostFilter() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		Sinks.Many<Integer> up =
-				Sinks.many().unsafe().unicast().onBackpressureBuffer(Queues.<Integer>get(2).get());
+				Sinks.unsafe().many().unicast().onBackpressureBuffer(Queues.<Integer>get(2).get());
 		up.emitNext(1, FAIL_FAST);
 		up.emitNext(2, FAIL_FAST);
 		up.emitComplete(FAIL_FAST);
@@ -799,7 +799,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void threadBoundaryPreventsInvalidFusionMap() {
 		Sinks.Many<Integer> up =
-				Sinks.many().unsafe().unicast().onBackpressureBuffer(Queues.<Integer>get(2).get());
+				Sinks.unsafe().many().unicast().onBackpressureBuffer(Queues.<Integer>get(2).get());
 
 		AssertSubscriber<String> ts = AssertSubscriber.create();
 
@@ -822,7 +822,7 @@ public class FluxPublishOnTest extends FluxOperatorTest<String, String> {
 	@Test
 	public void threadBoundaryPreventsInvalidFusionFilter() {
 		Sinks.Many<Integer> up =
-				Sinks.many().unsafe().unicast().onBackpressureBuffer(Queues.<Integer>get(2).get());
+				Sinks.unsafe().many().unicast().onBackpressureBuffer(Queues.<Integer>get(2).get());
 
 		String s = Thread.currentThread()
 		                 .getName();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
@@ -210,7 +210,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts1 = AssertSubscriber.create();
 		AssertSubscriber<Integer> ts2 = AssertSubscriber.create();
 
-		Sinks.Many<Integer> up = Sinks.many().unsafe().unicast().onBackpressureBuffer(Queues.<Integer>get(8).get());
+		Sinks.Many<Integer> up = Sinks.unsafe().many().unicast().onBackpressureBuffer(Queues.<Integer>get(8).get());
 		up.emitNext(1, FAIL_FAST);
 		up.emitNext(2, FAIL_FAST);
 		up.emitNext(3, FAIL_FAST);
@@ -249,7 +249,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts1 = AssertSubscriber.create(0);
 		AssertSubscriber<Integer> ts2 = AssertSubscriber.create(0);
 
-		Sinks.Many<Integer> up = Sinks.many().unsafe().unicast().onBackpressureBuffer(Queues.<Integer>get(8).get());
+		Sinks.Many<Integer> up = Sinks.unsafe().many().unicast().onBackpressureBuffer(Queues.<Integer>get(8).get());
 		up.emitNext(1, FAIL_FAST);
 		up.emitNext(2, FAIL_FAST);
 		up.emitNext(3, FAIL_FAST);
@@ -494,7 +494,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void retry() {
-		Sinks.Many<Integer> dp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> dp = Sinks.unsafe().many().multicast().directBestEffort();
 		StepVerifier.create(
 				dp.asFlux()
 				  .publish()
@@ -521,7 +521,7 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void retryWithPublishOn() {
-		Sinks.Many<Integer> dp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> dp = Sinks.unsafe().many().multicast().directBestEffort();
 		StepVerifier.create(
 				dp.asFlux()
 				  .publishOn(Schedulers.parallel()).publish()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
@@ -400,7 +400,7 @@ public class FluxRefCountTest {
 
 	@Test
 	public void delayElementShouldNotCancelTwice() throws Exception {
-		Sinks.Many<Long> p = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Long> p = Sinks.unsafe().many().multicast().directBestEffort();
 		AtomicInteger cancellations = new AtomicInteger();
 
 		Flux<Long> publishedFlux = p.asFlux()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRepeatWhenTest.java
@@ -415,7 +415,7 @@ public class FluxRepeatWhenTest {
 	@Test
 	public void inners() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
-		Sinks.Many<Long> signaller = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Long> signaller = Sinks.unsafe().many().multicast().directBestEffort();
 		Flux<Integer> when = Flux.empty();
 		FluxRepeatWhen.RepeatWhenMainSubscriber<Integer> main = new FluxRepeatWhen.RepeatWhenMainSubscriber<>(actual, signaller, when);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
@@ -574,7 +574,7 @@ public class FluxRetryWhenTest {
 	@Test
 	public void inners() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
-		Sinks.Many<Retry.RetrySignal> signaller = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Retry.RetrySignal> signaller = Sinks.unsafe().many().multicast().directBestEffort();
 		Flux<Integer> when = Flux.empty();
 		FluxRetryWhen.RetryWhenMainSubscriber<Integer> main = new FluxRetryWhen
 				.RetryWhenMainSubscriber<>(actual, signaller, when, Context.empty());

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSampleFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSampleFirstTest.java
@@ -35,9 +35,9 @@ public class FluxSampleFirstTest {
 	public void normal() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp3 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp3 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleFirst(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
@@ -82,9 +82,9 @@ public class FluxSampleFirstTest {
 	public void mainError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp3 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp3 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleFirst(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
@@ -107,9 +107,9 @@ public class FluxSampleFirstTest {
 	public void throttlerError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp3 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp3 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleFirst(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
@@ -132,7 +132,7 @@ public class FluxSampleFirstTest {
 	public void throttlerThrows() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleFirst(v -> {
@@ -154,7 +154,7 @@ public class FluxSampleFirstTest {
 	public void throttlerReturnsNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleFirst(v -> null)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTest.java
@@ -43,9 +43,9 @@ public class FluxSampleTest {
 	}
 
 	void sample(boolean complete, boolean which) {
-		Sinks.Many<Integer> main = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> main = Sinks.unsafe().many().multicast().directBestEffort();
 
-		Sinks.Many<String> other = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<String> other = Sinks.unsafe().many().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -129,9 +129,9 @@ public class FluxSampleTest {
 
 	@Test
 	public void subscriberCancels() {
-		Sinks.Many<Integer> main = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> main = Sinks.unsafe().many().multicast().directBestEffort();
 
-		Sinks.Many<String> other = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<String> other = Sinks.unsafe().many().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -151,9 +151,9 @@ public class FluxSampleTest {
 	}
 
 	public void completeImmediately(boolean which) {
-		Sinks.Many<Integer> main = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> main = Sinks.unsafe().many().multicast().directBestEffort();
 
-		Sinks.Many<String> other = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<String> other = Sinks.unsafe().many().multicast().directBestEffort();
 
 		if (which) {
 			main.emitComplete(FAIL_FAST);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSampleTimeoutTest.java
@@ -37,9 +37,9 @@ public class FluxSampleTimeoutTest {
 	public void normal() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp3 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp3 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleTimeout(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
@@ -78,8 +78,8 @@ public class FluxSampleTimeoutTest {
 	public void mainError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleTimeout(v -> sp2.asFlux())
@@ -101,8 +101,8 @@ public class FluxSampleTimeoutTest {
 	public void throttlerError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleTimeout(v -> sp2.asFlux())
@@ -124,7 +124,7 @@ public class FluxSampleTimeoutTest {
 	public void throttlerReturnsNull() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .sampleTimeout(v -> null)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
@@ -36,8 +36,8 @@ public class FluxSwitchMapTest {
 	public void noswitch() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .switchMap(v -> sp2.asFlux())
@@ -67,8 +67,8 @@ public class FluxSwitchMapTest {
 	public void noswitchBackpressured() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .switchMap(v -> sp2.asFlux())
@@ -110,9 +110,9 @@ public class FluxSwitchMapTest {
 	public void doswitch() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp3 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp3 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .switchMap(v -> v == 1 ? sp2.asFlux() : sp3.asFlux())
@@ -161,8 +161,8 @@ public class FluxSwitchMapTest {
 	public void mainCompletesBefore() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux().switchMap(v -> sp2.asFlux())
 		   .subscribe(ts);
@@ -190,8 +190,8 @@ public class FluxSwitchMapTest {
 	public void mainError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux().switchMap(v -> sp2.asFlux())
 		   .subscribe(ts);
@@ -215,8 +215,8 @@ public class FluxSwitchMapTest {
 	public void innerError() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux().switchMap(v -> sp2.asFlux())
 		   .subscribe(ts);
@@ -242,7 +242,7 @@ public class FluxSwitchMapTest {
 	public void mapperThrows() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .switchMap(v -> {
@@ -262,7 +262,7 @@ public class FluxSwitchMapTest {
 	public void mapperReturnsNull() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .switchMap(v -> null)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTimeoutTest.java
@@ -110,9 +110,9 @@ public class FluxTimeoutTest {
 
 	@Test
 	public void oldTimeoutHasNoEffect() {
-		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source = Sinks.unsafe().many().multicast().directBestEffort();
 
-		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> tp = Sinks.unsafe().many().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -135,9 +135,9 @@ public class FluxTimeoutTest {
 
 	@Test
 	public void oldTimeoutCompleteHasNoEffect() {
-		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source = Sinks.unsafe().many().multicast().directBestEffort();
 
-		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> tp = Sinks.unsafe().many().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -160,9 +160,9 @@ public class FluxTimeoutTest {
 
 	@Test
 	public void oldTimeoutErrorHasNoEffect() {
-		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source = Sinks.unsafe().many().multicast().directBestEffort();
 
-		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> tp = Sinks.unsafe().many().multicast().directBestEffort();
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
@@ -250,9 +250,9 @@ public class FluxTimeoutTest {
 	public void timeoutRequested() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source = Sinks.unsafe().many().multicast().directBestEffort();
 
-		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> tp = Sinks.unsafe().many().multicast().directBestEffort();
 
 		source.asFlux()
 			  .timeout(tp.asFlux(), v -> tp.asFlux())

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxUsingTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxUsingTest.java
@@ -264,7 +264,7 @@ public class FluxUsingTest extends FluxOperatorTest<String, String> {
 
 		AtomicInteger cleanup = new AtomicInteger();
 
-		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> tp = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Flux.using(() -> 1, r -> tp.asFlux(), cleanup::set, true)
 		    .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
@@ -54,8 +54,8 @@ public class FluxWindowBoundaryTest {
 	public void normal() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .window(sp2.asFlux())
@@ -90,8 +90,8 @@ public class FluxWindowBoundaryTest {
 	public void normalOtherCompletes() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .window(sp2.asFlux())
@@ -126,8 +126,8 @@ public class FluxWindowBoundaryTest {
 	public void mainError() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .window(sp2.asFlux())
@@ -168,8 +168,8 @@ public class FluxWindowBoundaryTest {
 	public void otherError() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux()
 		   .window(sp2.asFlux())

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
@@ -432,7 +432,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalUntil() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(sp1.asFlux(),
 				Queues.small(),
 				Queues.unbounded(),
@@ -499,7 +499,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void mainErrorUntilIsPropagatedToBothWindowAndMain() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.UNTIL);
@@ -525,7 +525,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void predicateErrorUntil() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowUntil = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> {
@@ -553,7 +553,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalUntilCutBefore() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowUntilCutBefore = new FluxWindowPredicate<>(sp1.asFlux(),
 				Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.UNTIL_CUT_BEFORE);
@@ -584,7 +584,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void mainErrorUntilCutBeforeIsPropagatedToBothWindowAndMain() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowUntilCutBefore =
 				new FluxWindowPredicate<>(sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 						i -> i % 3 == 0, Mode.UNTIL_CUT_BEFORE);
@@ -611,7 +611,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void predicateErrorUntilCutBefore() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowUntilCutBefore =
 				new FluxWindowPredicate<>(sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> {
@@ -645,7 +645,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalWhile() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 != 0, Mode.WHILE);
@@ -676,7 +676,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalWhileDoesntInitiallyMatch() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.WHILE);
@@ -714,7 +714,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void normalWhileDoesntMatch() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i > 4, Mode.WHILE);
@@ -749,7 +749,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void mainErrorWhileIsPropagatedToBothWindowAndMain() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> i % 3 == 0, Mode.WHILE);
@@ -796,7 +796,7 @@ public class FluxWindowPredicateTest extends
 
 	@Test
 	public void predicateErrorWhile() {
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
 		FluxWindowPredicate<Integer> windowWhile = new FluxWindowPredicate<>(
 				sp1.asFlux(), Queues.small(), Queues.unbounded(), Queues.SMALL_BUFFER_SIZE,
 				i -> {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTest.java
@@ -428,7 +428,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 	public void exactError() {
 		AssertSubscriber<Publisher<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp.asFlux()
 		  .window(2, 2)
@@ -457,7 +457,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 	public void skipError() {
 		AssertSubscriber<Publisher<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp.asFlux()
 		  .window(2, 3)
@@ -486,7 +486,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 	public void skipInGapError() {
 		AssertSubscriber<Publisher<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp.asFlux()
 		  .window(1, 3)
@@ -512,7 +512,7 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 	public void overlapError() {
 		AssertSubscriber<Publisher<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp.asFlux()
 		  .window(2, 1)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
@@ -150,10 +150,10 @@ public class FluxWindowWhenTest {
 	public void normal() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> sp1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp2 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp3 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> sp4 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp2 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp3 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> sp4 = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp1.asFlux().windowWhen(sp2.asFlux(), v -> v == 1 ? sp3.asFlux() : sp4.asFlux())
 		   .subscribe(ts);
@@ -193,10 +193,10 @@ public class FluxWindowWhenTest {
 	public void normalStarterEnds() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> openSelector = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> closeSelectorFor1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> closeSelectorForOthers = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> openSelector = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> closeSelectorFor1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> closeSelectorForOthers = Sinks.unsafe().many().multicast().directBestEffort();
 
 		source.asFlux().windowWhen(openSelector.asFlux(), v -> v == 1 ? closeSelectorFor1.asFlux() : closeSelectorForOthers.asFlux())
 		      .subscribe(ts);
@@ -237,10 +237,10 @@ public class FluxWindowWhenTest {
 	public void oneWindowOnly() {
 		AssertSubscriber<Flux<Integer>> ts = AssertSubscriber.create();
 
-		Sinks.Many<Integer> source = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> openSelector = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> closeSelectorFor1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> closeSelectorOthers = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> source = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> openSelector = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> closeSelectorFor1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> closeSelectorOthers = Sinks.unsafe().many().multicast().directBestEffort();
 
 		source.asFlux().windowWhen(openSelector.asFlux(), v -> v == 1 ? closeSelectorFor1.asFlux() : closeSelectorOthers.asFlux())
 		      .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -792,7 +792,7 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void failDoubleTerminalPublisher() {
-		Sinks.Many<Integer> d1 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> d1 = Sinks.unsafe().many().multicast().directBestEffort();
 		Hooks.onErrorDropped(e -> {
 		});
 		StepVerifier.create(Flux.zip(obj -> 0, Flux.just(1), d1.asFlux(), s -> {
@@ -1084,7 +1084,7 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 
 	@Test
 	public void prematureCompleteSourceEmptyDouble() {
-		Sinks.Many<Integer> d = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> d = Sinks.unsafe().many().multicast().directBestEffort();
 		StepVerifier.create(Flux.zip(obj -> 0, d.asFlux(), s -> {
 			Scannable directInner = Scannable.from(d).inners().findFirst().get();
 			CoreSubscriber<?> directInnerDownstream = (CoreSubscriber<?>) directInner.scan(Scannable.Attr.ACTUAL);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTimeoutTest.java
@@ -86,7 +86,7 @@ public class MonoTimeoutTest {
 
 		NextProcessor<Integer> source = new NextProcessor<>(null);
 
-		Sinks.Many<Integer> tp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> tp = Sinks.unsafe().many().multicast().directBestEffort();
 
 		source.timeout(tp.asFlux())
 		      .subscribe(ts);

--- a/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
@@ -73,9 +73,9 @@ public class OnDiscardShouldNotLeakTest {
 					.map(Function.identity())
 					.map(Function.identity())
 					.publishOn(Schedulers.immediate())),
-			DiscardScenario.fluxSource("unicastProcessor", 1, f -> f.subscribeWith(FluxProcessor.fromSink(Sinks.many().unsafe().unicast().onBackpressureBuffer()))),
+			DiscardScenario.fluxSource("unicastProcessor", 1, f -> f.subscribeWith(FluxProcessor.fromSink(Sinks.unsafe().many().unicast().onBackpressureBuffer()))),
 			DiscardScenario.fluxSource("unicastProcessorAndPublishOn", 1, f -> f
-					.subscribeWith(FluxProcessor.fromSink(Sinks.many().unsafe().unicast().onBackpressureBuffer()))
+					.subscribeWith(FluxProcessor.fromSink(Sinks.unsafe().many().unicast().onBackpressureBuffer()))
 					.publishOn(Schedulers.immediate())),
 	};
 

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkManySerializedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkManySerializedTest.java
@@ -92,7 +92,7 @@ public class SinkManySerializedTest {
 
 	@Test
 	public void sameThreadRecursion() throws Exception {
-		Sinks.Many<Object> sink = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Object> sink = Sinks.unsafe().many().multicast().directBestEffort();
 		SinkManySerialized<Object> manySink = new SinkManySerialized<>(sink, Context::empty);
 
 		CompletableFuture<Object> muchFuture = sink.asFlux().doOnNext(o -> {
@@ -108,7 +108,7 @@ public class SinkManySerializedTest {
 
 	static class EmptyMany<T> implements Sinks.Many<T> {
 
-		final Sinks.Many<T> delegate = Sinks.many().unsafe().multicast().directBestEffort();
+		final Sinks.Many<T> delegate = Sinks.unsafe().many().multicast().directBestEffort();
 
 		@Override
 		public Emission tryEmitNext(T o) {

--- a/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
@@ -50,6 +50,30 @@ import static reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST;
  */
 class SinksTest {
 
+	@Test
+	void oneIsSerialized() {
+		assertThat(Sinks.one())
+				.isInstanceOf(SerializedSink.class)
+				.isExactlyInstanceOf(SinkOneSerialized.class);
+	}
+
+	@Test
+	void emptyIsSerialized() {
+		assertThat(Sinks.empty())
+				.isInstanceOf(SerializedSink.class)
+				.isExactlyInstanceOf(SinkEmptySerialized.class);
+	}
+
+	@Test
+	void unsafeOneIsNotSerialized() {
+		assertThat(Sinks.unsafe().one()).isNotInstanceOf(SerializedSink.class);
+	}
+
+	@Test
+	void unsafeEmptyIsNotSerialized() {
+		assertThat(Sinks.unsafe().empty()).isNotInstanceOf(SerializedSink.class);
+	}
+
 	@Nested
 	class MulticastNoWarmup {
 

--- a/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
@@ -53,25 +53,25 @@ class SinksTest {
 	@Test
 	void oneIsSerialized() {
 		assertThat(Sinks.one())
-				.isInstanceOf(SerializedSink.class)
+				.isInstanceOf(SinksSpecs.AbstractSerializedSink.class)
 				.isExactlyInstanceOf(SinkOneSerialized.class);
 	}
 
 	@Test
 	void emptyIsSerialized() {
 		assertThat(Sinks.empty())
-				.isInstanceOf(SerializedSink.class)
+				.isInstanceOf(SinksSpecs.AbstractSerializedSink.class)
 				.isExactlyInstanceOf(SinkEmptySerialized.class);
 	}
 
 	@Test
 	void unsafeOneIsNotSerialized() {
-		assertThat(Sinks.unsafe().one()).isNotInstanceOf(SerializedSink.class);
+		assertThat(Sinks.unsafe().one()).isNotInstanceOf(SinksSpecs.AbstractSerializedSink.class);
 	}
 
 	@Test
 	void unsafeEmptyIsNotSerialized() {
-		assertThat(Sinks.unsafe().empty()).isNotInstanceOf(SerializedSink.class);
+		assertThat(Sinks.unsafe().empty()).isNotInstanceOf(SinksSpecs.AbstractSerializedSink.class);
 	}
 
 	@Nested

--- a/reactor-core/src/test/java/reactor/core/publisher/StrictSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/StrictSubscriberTest.java
@@ -73,7 +73,7 @@ public class StrictSubscriberTest {
 		AtomicBoolean state2 = new AtomicBoolean();
 		AtomicReference<Throwable> e = new AtomicReference<>();
 
-		Sinks.Many<Integer> sp = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sp = Sinks.unsafe().many().multicast().directBestEffort();
 
 		sp.asFlux().doOnCancel(() -> state2.set(state1.get()))
 		  .subscribe(new Subscriber<Integer>() {

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -1237,12 +1237,12 @@ public class FluxTests extends AbstractReactorTest {
 
 		Phaser phaser = new Phaser(2);
 
-		Flux<Object> s1 = Sinks.many().unsafe()
+		Flux<Object> s1 = Sinks.unsafe().many()
 							   .replay()
 							   .latestOrDefault(new Object())
 							   .asFlux()
 							   .publishOn(asyncGroup);
-		Flux<Object> s2 = Sinks.many().unsafe()
+		Flux<Object> s2 = Sinks.unsafe().many()
 							   .replay()
 							   .latestOrDefault(new Object())
 							   .asFlux()
@@ -1373,8 +1373,8 @@ public class FluxTests extends AbstractReactorTest {
 	@Test(timeout = TIMEOUT)
 	public void multiplexUsingDispatchersAndSplit() {
 		final Sinks.Many<Integer> forkEmitterProcessor = Sinks.many().multicast().onBackpressureBuffer();
-		final Sinks.Many<Integer> computationEmitterProcessor = Sinks.many()
-																	 .unsafe()
+		final Sinks.Many<Integer> computationEmitterProcessor = Sinks.unsafe()
+		                                                             .many()
 																	 .multicast()
 																	 .onBackpressureBuffer(256, false);
 
@@ -1395,8 +1395,8 @@ public class FluxTests extends AbstractReactorTest {
 											.doOnNext(ls -> println("Computed: ", ls))
 											.log("computation");
 
-		final Sinks.Many<Integer> persistenceEmitterProcessor = Sinks.many()
-																	 .unsafe()
+		final Sinks.Many<Integer> persistenceEmitterProcessor = Sinks.unsafe()
+																	 .many()
 																	 .multicast()
 																	 .onBackpressureBuffer(Queues.SMALL_BUFFER_SIZE, false);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxWindowConsistencyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxWindowConsistencyTest.java
@@ -35,7 +35,7 @@ import static reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST;
 
 public class FluxWindowConsistencyTest {
 
-	Sinks.Many<Integer> sourceProcessor = Sinks.many().unsafe().multicast().directBestEffort();
+	Sinks.Many<Integer> sourceProcessor = Sinks.unsafe().many().multicast().directBestEffort();
 
 	Flux<Integer> source;
 
@@ -208,7 +208,7 @@ public class FluxWindowConsistencyTest {
 
 	@Test
 	public void windowBoundaryComplete() throws Exception {
-		Sinks.Many<Integer> boundary = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> boundary = Sinks.unsafe().many().multicast().directBestEffort();
 		Flux<Flux<Integer>> windows = source.window(boundary.asFlux());
 		subscribe(windows);
 		generate(0, 3);
@@ -219,9 +219,9 @@ public class FluxWindowConsistencyTest {
 
 	@Test
 	public void windowStartEndComplete() throws Exception {
-		Sinks.Many<Integer> start = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> end1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> end2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> start = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> end1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> end2 = Sinks.unsafe().many().multicast().directBestEffort();
 		Flux<Flux<Integer>> windows = source.windowWhen(start.asFlux(), v -> v == 1 ? end1.asFlux() : end2.asFlux());
 		subscribe(windows);
 		start.emitNext(1, FAIL_FAST);
@@ -306,7 +306,7 @@ public class FluxWindowConsistencyTest {
 
 	@Test
 	public void windowBoundaryMainCancel() throws Exception {
-		Sinks.Many<Integer> boundary = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> boundary = Sinks.unsafe().many().multicast().directBestEffort();
 		Flux<Flux<Integer>> windows = source.window(boundary.asFlux());
 
 		subscribe(windows);
@@ -322,9 +322,9 @@ public class FluxWindowConsistencyTest {
 
 	@Test
 	public void windowStartEndMainCancel() throws Exception {
-		Sinks.Many<Integer> start = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> end1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> end2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> start = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> end1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> end2 = Sinks.unsafe().many().multicast().directBestEffort();
 		Flux<Flux<Integer>> windows = source.windowWhen(start.asFlux(), v -> v == 1 ? end1.asFlux() : end2.asFlux());
 		subscribe(windows);
 		start.emitNext(1, FAIL_FAST);
@@ -414,7 +414,7 @@ public class FluxWindowConsistencyTest {
 
 	@Test
 	public void windowBoundaryMainCancelNoNewWindow() throws Exception {
-		Sinks.Many<Integer> boundary = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> boundary = Sinks.unsafe().many().multicast().directBestEffort();
 		Flux<Flux<Integer>> windows = source.window(boundary.asFlux());
 
 		subscribe(windows);
@@ -427,9 +427,9 @@ public class FluxWindowConsistencyTest {
 
 	@Test
 	public void windowStartEndMainCancelNoNewWindow() throws Exception {
-		Sinks.Many<Integer> start = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> end1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> end2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> start = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> end1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> end2 = Sinks.unsafe().many().multicast().directBestEffort();
 		Flux<Flux<Integer>> windows = source.windowWhen(start.asFlux(), v -> v == 1 ? end1.asFlux() : end2.asFlux());
 		subscribe(windows);
 		start.emitNext(1, FAIL_FAST);
@@ -507,7 +507,7 @@ public class FluxWindowConsistencyTest {
 
 	@Test
 	public void windowBoundaryInnerCancel() throws Exception {
-		Sinks.Many<Integer> boundaryProcessor = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> boundaryProcessor = Sinks.unsafe().many().multicast().directBestEffort();
 		Flux<Flux<Integer>> windows = source.window(boundaryProcessor.asFlux());
 		subscribe(windows);
 		generateWithCancel(0, 6, 1);
@@ -516,9 +516,9 @@ public class FluxWindowConsistencyTest {
 
 	@Test
 	public void windowStartEndInnerCancel() throws Exception {
-		Sinks.Many<Integer> start = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> end1 = Sinks.many().unsafe().multicast().directBestEffort();
-		Sinks.Many<Integer> end2 = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> start = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> end1 = Sinks.unsafe().many().multicast().directBestEffort();
+		Sinks.Many<Integer> end2 = Sinks.unsafe().many().multicast().directBestEffort();
 		Flux<Flux<Integer>> windows = source.windowWhen(start.asFlux(), v -> v == 1 ? end1.asFlux() : end2.asFlux());
 		subscribe(windows);
 		start.emitNext(1, FAIL_FAST);

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -663,7 +663,7 @@ public class SchedulersTest {
 
 	public void assertRejectingScheduler(Scheduler scheduler) {
 		try {
-			Sinks.Many<String> p = Sinks.many().unsafe().multicast().directBestEffort();
+			Sinks.Many<String> p = Sinks.unsafe().many().multicast().directBestEffort();
 
 			AtomicReference<String> r = new AtomicReference<>();
 			CountDownLatch l = new CountDownLatch(1);

--- a/reactor-core/src/test/java/reactor/guide/GuideTests.java
+++ b/reactor-core/src/test/java/reactor/guide/GuideTests.java
@@ -202,7 +202,7 @@ public class GuideTests {
 
 	@Test
 	public void advancedHot() {
-		Sinks.Many<String> hotSource = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<String> hotSource = Sinks.unsafe().many().multicast().directBestEffort();
 
 		Flux<String> hotFlux = hotSource.asFlux().map(String::toUpperCase);
 

--- a/reactor-core/src/test/java/reactor/test/publisher/BaseOperatorTest.java
+++ b/reactor-core/src/test/java/reactor/test/publisher/BaseOperatorTest.java
@@ -392,7 +392,7 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 
 	final Flux<I> fluxFuseableAsync(OperatorScenario<I, PI, O, PO> scenario) {
 		int p = scenario.producerCount();
-		Sinks.Many<I> rp = Sinks.many().unsafe()
+		Sinks.Many<I> rp = Sinks.unsafe().many()
 		                        .replay()
 		                        .all();
 
@@ -580,7 +580,7 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 	}
 
 	final StepVerifier.Step<O> inputFusedAsyncOutputFusedAsync(OperatorScenario<I, PI, O, PO> scenario) {
-		FluxProcessor<I, I> up = FluxProcessor.fromSink(Sinks.many().unsafe().unicast().onBackpressureBuffer());
+		FluxProcessor<I, I> up = FluxProcessor.fromSink(Sinks.unsafe().many().unicast().onBackpressureBuffer());
 		return StepVerifier.create(scenario.body()
 		                                   .apply(withFluxSource(up)))
 		                   .expectFusion(Fuseable.ASYNC)
@@ -588,7 +588,7 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 	}
 
 	final StepVerifier.Step<O> inputFusedAsyncOutputFusedAsyncConditional(OperatorScenario<I, PI, O, PO> scenario) {
-		FluxProcessor<I, I> up = FluxProcessor.fromSink(Sinks.many().unsafe().unicast().onBackpressureBuffer());
+		FluxProcessor<I, I> up = FluxProcessor.fromSink(Sinks.unsafe().many().unicast().onBackpressureBuffer());
 		return StepVerifier.create(scenario.body()
 		                                   .andThen(this::conditional)
 		                                   .apply(withFluxSource(up)))
@@ -598,7 +598,7 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 
 	final void inputFusedAsyncOutputFusedAsyncCancel(OperatorScenario<I, PI, O, PO> scenario) {
 		if ((scenario.fusionMode() & Fuseable.ASYNC) != 0) {
-			FluxProcessor<I, I> up = FluxProcessor.fromSink(Sinks.many().unsafe().unicast().onBackpressureBuffer());
+			FluxProcessor<I, I> up = FluxProcessor.fromSink(Sinks.unsafe().many().unicast().onBackpressureBuffer());
 			testUnicastSource(scenario, up);
 			StepVerifier.create(scenario.body()
 			                            .apply(withFluxSource(up)), 0)
@@ -642,7 +642,7 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 			            .thenCancel()
 			            .verify();
 
-			Sinks.Many<I> up2 = Sinks.many().unsafe().unicast().onBackpressureBuffer();
+			Sinks.Many<I> up2 = Sinks.unsafe().many().unicast().onBackpressureBuffer();
 			StepVerifier.create(scenario.body()
 			                            .apply(withFluxSource(up2.asFlux())), 0)
 			            .consumeSubscriptionWith(s -> {
@@ -661,7 +661,7 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 	@SuppressWarnings({"unchecked", "deprecated"})
 	final void inputFusedAsyncOutputFusedAsyncConditionalCancel(OperatorScenario<I, PI, O, PO> scenario) {
 		if ((scenario.fusionMode() & Fuseable.ASYNC) != 0) {
-			FluxProcessor<I, I> up = FluxProcessor.fromSink(Sinks.many().unsafe().unicast().onBackpressureBuffer());
+			FluxProcessor<I, I> up = FluxProcessor.fromSink(Sinks.unsafe().many().unicast().onBackpressureBuffer());
 			testUnicastSource(scenario, up);
 			StepVerifier.create(scenario.body()
 			                            .andThen(f -> doOnSubscribe(f, s -> {
@@ -698,7 +698,7 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 			            .thenCancel()
 			            .verify();
 
-			Sinks.Many<I> up2 = Sinks.many().unsafe().unicast().onBackpressureBuffer();
+			Sinks.Many<I> up2 = Sinks.unsafe().many().unicast().onBackpressureBuffer();
 			StepVerifier.create(scenario.body()
 			                            .andThen(f -> doOnSubscribe(f, s -> {
 				                            if (s instanceof Fuseable.QueueSubscription) {
@@ -848,7 +848,7 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 
 	@SuppressWarnings("unchecked")
 	final StepVerifier.Step<O> inputFusedError(OperatorScenario<I, PI, O, PO> scenario) {
-		Sinks.Many<I> up = Sinks.many().unsafe().unicast().onBackpressureBuffer();
+		Sinks.Many<I> up = Sinks.unsafe().many().unicast().onBackpressureBuffer();
 
 		return StepVerifier.create(scenario.body()
 		                                   .apply(up.asFlux().as(f -> withFluxSource(new FluxFuseableExceptionOnPoll<>(
@@ -908,7 +908,7 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 	}
 
 	final StepVerifier.Step<O> inputFusedAsyncErrorOutputFusedAsync(OperatorScenario<I, PI, O, PO> scenario) {
-		Sinks.Many<I> up = Sinks.many().unsafe().unicast().onBackpressureBuffer();
+		Sinks.Many<I> up = Sinks.unsafe().many().unicast().onBackpressureBuffer();
 		up.emitNext(item(0), FAIL_FAST);
 		return StepVerifier.create(scenario.body()
 		                                   .apply(up.asFlux().as(f -> withFluxSource(new FluxFuseableExceptionOnPoll<>(
@@ -919,7 +919,7 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 
 	@SuppressWarnings("unchecked")
 	final StepVerifier.Step<O> inputFusedErrorOutputFusedConditional(OperatorScenario<I, PI, O, PO> scenario) {
-		Sinks.Many<I> up = Sinks.many().unsafe().unicast().onBackpressureBuffer();
+		Sinks.Many<I> up = Sinks.unsafe().many().unicast().onBackpressureBuffer();
 		return StepVerifier.create(scenario.body()
 		                                   .andThen(this::conditional)
 		                                   .apply(up.asFlux().as(f -> withFluxSource(new FluxFuseableExceptionOnPoll<>(

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -2086,7 +2086,7 @@ public class StepVerifierTests {
 	@Test
 	public void assertNextWithSubscribeOnSink() {
 		Scheduler scheduler = Schedulers.newBoundedElastic(1, 100, "test");
-		Sinks.Many<Integer> sink = Sinks.many().unsafe().multicast().directBestEffort();
+		Sinks.Many<Integer> sink = Sinks.unsafe().many().multicast().directBestEffort();
 		Mono<Integer> doAction = Mono.fromSupplier(() -> 22)
 		                             .doOnNext(v -> sink.tryEmitNext(v).orThrow())
 		                             .subscribeOn(scheduler);


### PR DESCRIPTION
This commit reworks the Sinks specs in preparation the fact that
one() and empty() should have a serialized versions

This implies that `Sinks.one()` is serialized and thus there
should be an unsafe version. But `unsafe()` lives at the ManySpec level.
So this commit introduces RootSpec and moves the `unsafe()` switch from
`ManySpec` to `Sinks` directly, retuning a `RootSpec` which allows
access to unsafe `one()` and `empty()`.

Internally, the implementation is simplified, collapsing most of the
specs into a single RootSpecImpl, to the exception of UnicastSpec
(since one cannot implement both UnicastSpec and MulticastSpec).