### PR TITLE
fix #2429 Bump jcstress-gradle-plugin to natively fix jar classifier

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 	}
 
 	dependencies {
-		classpath 'com.github.erizo.gradle:jcstress-gradle-plugin:0.8.4'
+		classpath 'com.github.erizo.gradle:jcstress-gradle-plugin:0.8.5'
 	}
 }
 
@@ -355,7 +355,6 @@ check.dependsOn japicmp
 jcstress {
 	mode = 'quick'
 }
-tasks.jcstressJar.classifier("jcstress") // make sure jcstress jar doesn't override our own
 tasks.check.dependsOn(tasks.jcstress)
 
 if (JavaVersion.current().java9Compatible) {


### PR DESCRIPTION
This fixes #2400 natively in the plugin rather than by us.