### PR TITLE
fix #2428 redirect jcstress stdout to file

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -355,6 +355,7 @@ check.dependsOn japicmp
 jcstress {
 	mode = 'quick'
 }
+tasks.jcstress.setStandardOutput(new FileOutputStream(new File(buildDir, "reports/jcstress-stdout.txt")))
 tasks.check.dependsOn(tasks.jcstress)
 
 if (JavaVersion.current().java9Compatible) {


### PR DESCRIPTION
This does not "reduce" logging per se, but cuts down noise considerably.

The stdout is redirected to a file. The task still thinks it's a terminal, so some control characters do appear, which is sad.

A test failure still does trigger output on the console (stderr I assume), so test errors definitely get noticed.

This may be a good compromise until jcstress gets a more configurable logging solution (which I doubt it will)