### PR TITLE
Exploring a way to connect sinks to sources as advanced (unsafe) use case

### DIFF
--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManySerializedStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManySerializedStressTest.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
+import java.util.function.BiConsumer;
 
 import org.openjdk.jcstress.annotations.Actor;
 import org.openjdk.jcstress.annotations.Arbiter;
@@ -137,6 +138,17 @@ public class SinkManySerializedStressTest {
 
 		@Override
 		public int currentSubscriberCount() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Nullable
+		@Override
+		public BiConsumer<Long, Long> setRequestHandler(@Nullable BiConsumer<Long, Long> requestRangeConsumer) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void requestSnapshot() {
 			throw new UnsupportedOperationException();
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectInnerContainer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectInnerContainer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+//also used by DirectProcessor, which shouldn't implement Sinks.Many
+interface DirectInnerContainer<T> {
+
+	/**
+	 * Add a new {@link SinkManyBestEffort.DirectInner} to this publisher.
+	 *
+	 * @param s the new {@link SinkManyBestEffort.DirectInner} to add
+	 *
+	 * @return {@code true} if the inner could be added, {@code false} if the publisher cannot accept new subscribers
+	 */
+	boolean add(SinkManyBestEffort.DirectInner<T> s);
+
+	/**
+	 * Remove an {@link SinkManyBestEffort.DirectInner} from this publisher. Does nothing if the inner is not currently managed
+	 * by the publisher.
+	 *
+	 * @param s the  {@link SinkManyBestEffort.DirectInner} to remove
+	 */
+	void remove(SinkManyBestEffort.DirectInner<T> s);
+
+	void requestSnapshot(); //compatible with Sinks.Many
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
@@ -233,6 +233,11 @@ public final class DirectProcessor<T> extends FluxProcessor<T, T>
 	}
 
 	@Override
+	public void requestSnapshot() {
+		//NO-OP
+	}
+
+	@Override
 	protected boolean isIdentityProcessor() {
 		return true;
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -310,31 +310,49 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements In
 		if (consumer == null) {
 			return;
 		}
+
 		FluxPublish.PubSubInner<T>[] subs = this.subscribers;
-		long highestServiceable = 0L;
-		long highestWithoutDropping = -1L;
-		long maxDiff = this.prefetch;
+		if (subs.length == 0) {
+			return;
+		}
+
+		long highestRequest = 0L;
+		long lowestRequest = -1L;
+		int bufferCapacity = this.prefetch;
 		for (FluxPublish.PubSubInner<T> sub : subs) {
 			long r = sub.requested;
 			if (sub.isCancelled()) {
 				continue;
 			}
-			if (highestWithoutDropping == -1L) {
-				highestWithoutDropping = r;
+			if (lowestRequest == -1L || r < lowestRequest) {
+				lowestRequest = r;
 			}
-			else if (r < highestWithoutDropping) {
-				highestWithoutDropping = r;
+			if (r > highestRequest) {
+				highestRequest = r;
 			}
-			if (highestServiceable < r) {
-				highestServiceable = r;
-			}
-		}
-		if (highestServiceable > highestWithoutDropping + maxDiff) {
-			highestServiceable = highestWithoutDropping + maxDiff;
 		}
 
-		if (highestServiceable != 0) {
-			consumer.accept(highestWithoutDropping, highestServiceable);
+		if (lowestRequest == -1L) {
+			return; //no subscribers that are not cancelled
+		}
+		if (lowestRequest == Long.MAX_VALUE) {
+			consumer.accept(Long.MAX_VALUE, Long.MAX_VALUE);
+			return;
+		}
+		if (highestRequest == 0L && bufferCapacity > 0) {
+			consumer.accept(0L, Operators.unboundedOrPrefetch(bufferCapacity));
+			return;
+		}
+
+		//careful not to overflow
+		long lowestWithCapacity = (bufferCapacity == Integer.MAX_VALUE) ? Long.MAX_VALUE : lowestRequest + bufferCapacity;
+		if (lowestWithCapacity < 0) {
+			lowestWithCapacity = Long.MAX_VALUE;
+		}
+		long serviceableRequest = Math.min(highestRequest, lowestWithCapacity);
+
+		if (serviceableRequest > 0) {
+			consumer.accept(lowestRequest, serviceableRequest);
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -334,7 +334,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements In
 		}
 
 		if (highestServiceable != 0) {
-			consumer.accept(highestServiceable, highestWithoutDropping);
+			consumer.accept(highestWithoutDropping, highestServiceable);
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -583,6 +583,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 			if (Operators.validate(n)) {
 				Operators.addCapCancellable(REQUESTED, this, n);
 				drainParent();
+				notifyRequest(requested); //the request could have been partially served from parent's buffer
 			}
 		}
 
@@ -618,6 +619,9 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 
 		abstract void drainParent();
 		abstract void removeAndDrainParent();
+		void notifyRequest(long totalRequestAfterDrain) {
+			//default NO-OP
+		}
 	}
 
 	static final class PublishInner<T> extends PubSubInner<T> {

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -528,7 +528,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 		FluxReplay.ReplaySubscription<T>[] subs = this.subscribers;
 		long highestServiceable = 0L;
 		long highestWithoutDropping = -1L;
-		long maxDiff = this.buffer.capacity();
+		long maxDiff = this.buffer.capacity(); //TODO check the logic here
 		for (FluxReplay.ReplaySubscription<T> sub : subs) {
 			long r = sub.requested();
 			if (sub.isCancelled()) {
@@ -549,7 +549,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 		}
 
 		if (highestServiceable != 0) {
-			consumer.accept(highestServiceable, highestWithoutDropping);
+			consumer.accept(highestWithoutDropping, highestServiceable);
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
@@ -221,7 +221,7 @@ final class SinkManyBestEffort<T> extends Flux<T>
 		}
 
 		if (highestServiceable != 0) {
-			requestRangeConsumer.accept(highestServiceable, highestWithoutDropping);
+			consumer.accept(highestWithoutDropping, highestServiceable);
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
@@ -421,27 +421,4 @@ final class SinkManyBestEffort<T> extends Flux<T>
 			actual.onComplete();
 		}
 	}
-
-}
-
-//also used by DirectProcessor, which shouldn't implement Sinks.Many
-interface DirectInnerContainer<T> {
-
-	/**
-	 * Add a new {@link SinkManyBestEffort.DirectInner} to this publisher.
-	 *
-	 * @param s the new {@link SinkManyBestEffort.DirectInner} to add
-	 * @return {@code true} if the inner could be added, {@code false} if the publisher cannot accept new subscribers
-	 */
-	boolean add(SinkManyBestEffort.DirectInner<T> s);
-
-	/**
-	 * Remove an {@link SinkManyBestEffort.DirectInner} from this publisher. Does nothing if the inner is not currently managed
-	 * by the publisher.
-	 *
-	 * @param s the  {@link SinkManyBestEffort.DirectInner} to remove
-	 */
-	void remove(SinkManyBestEffort.DirectInner<T> s);
-
-	void requestSnapshot(); //compatible with Sinks.Many
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
@@ -220,7 +220,10 @@ final class SinkManyBestEffort<T> extends Flux<T>
 			}
 		}
 
-		if (highestServiceable != 0) {
+		if (allOrNothing && highestWithoutDropping != 0) {
+			consumer.accept(highestWithoutDropping, highestWithoutDropping);
+		}
+		else if (!allOrNothing && highestServiceable != 0) {
 			consumer.accept(highestWithoutDropping, highestServiceable);
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
@@ -201,7 +201,12 @@ final class SinkManyBestEffort<T> extends Flux<T>
 		if (consumer == null) {
 			return;
 		}
+
 		DirectInner<T>[] subs = this.subscribers;
+		if (subs.length == 0) {
+			return;
+		}
+
 		long highestServiceable = 0L;
 		long highestWithoutDropping = -1L;
 		for (DirectInner<T> sub : subs) {
@@ -220,10 +225,10 @@ final class SinkManyBestEffort<T> extends Flux<T>
 			}
 		}
 
-		if (allOrNothing && highestWithoutDropping != 0) {
+		if (allOrNothing && highestWithoutDropping > 0) {
 			consumer.accept(highestWithoutDropping, highestWithoutDropping);
 		}
-		else if (!allOrNothing && highestServiceable != 0) {
+		else if (!allOrNothing && highestServiceable > 0) {
 			consumer.accept(highestWithoutDropping, highestServiceable);
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManySerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManySerialized.java
@@ -18,6 +18,7 @@ import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
 import java.util.Objects;
+import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
 final class SinkManySerialized<T> extends SinksSpecs.AbstractSerializedSink
@@ -100,6 +101,17 @@ final class SinkManySerialized<T> extends SinksSpecs.AbstractSerializedSink
 				LOCKED_AT.compareAndSet(this, currentThread, null);
 			}
 		}
+	}
+
+	@Override
+	@Nullable
+	public BiConsumer<Long, Long> setRequestHandler(BiConsumer<Long, Long> requestRangeConsumer) {
+		return sink.setRequestHandler(requestRangeConsumer);
+	}
+
+	@Override
+	public void requestSnapshot() {
+		sink.requestSnapshot();
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -287,7 +287,7 @@ public final class Sinks {
 		ManySpec many();
 	}
 
-	interface RootUnsafeSpec extends RootSpec {
+	public interface RootUnsafeSpec extends RootSpec {
 
 		/**
 		 * Connect a {@link Sinks.Many} to an arbitrary {@link Publisher} of compatible type.

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -320,7 +320,7 @@ public final class Sinks {
 		<T> Disposable connectMany(Publisher<T> source, Sinks.Many<T> manySink);
 
 		/**
-		 * Connect a {@link Sinks.Empty} to an arbitrary {@link Void} {@link Publisher}.
+		 * Connect a {@link Sinks.Empty} to a {@link Void} {@link Mono}.
 		 * This is considered an unsafe operation because connecting implies adhering to some rules
 		 * and ceremony:
 		 * <ol>
@@ -341,13 +341,13 @@ public final class Sinks {
 		 * However, it is generally ok (and even preferable maybe) to connect an {@link Sinks#unsafe() unsafe sink}, as the parent
 		 * subscriber will ensure intrinsic serialization by respecting the Reactive Streams specification.
 		 *
-		 * @param source the source {@link Publisher} to connect to
+		 * @param source the source {@link Mono} to connect to
 		 * @param emptySink the {@link Sinks.Empty} to feed
 		 * @param <T> the (ignored) type of the sink's {@link Empty#asMono() asMono() view}
 		 * @return a {@link Disposable} allowing to disconnect the sink from the source, cancelling the subscription to the source
 		 * @see org.reactivestreams.Processor
 		 */
-		<T> Disposable connectEmpty(Publisher<Void> source, Sinks.Empty<T> emptySink);
+		<T> Disposable connectEmpty(Mono<Void> source, Sinks.Empty<T> emptySink);
 
 		/**
 		 * Connect a {@link Sinks.One} to a {@link Mono} of compatible type.

--- a/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
@@ -72,7 +72,7 @@ final class SinksSpecs {
 		}
 
 		@Override
-		public <T> Disposable connectEmpty(Publisher<Void> emptySource, Empty<T> emptySink) {
+		public <T> Disposable connectEmpty(Mono<Void> emptySource, Empty<T> emptySink) {
 			EmptySubscriberAdapter<T> subscriber = new EmptySubscriberAdapter<>(emptySink);
 			emptySource.subscribe(subscriber);
 			return subscriber;

--- a/reactor-core/src/main/java/reactor/core/publisher/SinksSubscribers.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinksSubscribers.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import org.reactivestreams.Subscription;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+import reactor.util.context.Context;
+
+/**
+ * @author Simon Baslé
+ */
+final class SinksSubscribers {
+
+	private SinksSubscribers() {}
+
+	static abstract class AbstractSubscriberAdapter<T, SINK> implements CoreSubscriber<T>, Disposable {
+
+		final SINK sink;
+		final Context context;
+		final Sinks.EmitFailureHandler emitFailureHandler;
+
+		volatile Subscription                                                     s;
+		@SuppressWarnings("rawtypes")
+		static   AtomicReferenceFieldUpdater<AbstractSubscriberAdapter, Subscription> S
+				= AtomicReferenceFieldUpdater.newUpdater(AbstractSubscriberAdapter.class, Subscription.class, "s");
+
+		AbstractSubscriberAdapter(SINK sink) {
+			this.sink = sink;
+			this.context = sink instanceof ContextHolder ? ((ContextHolder) sink).currentContext() : Context.empty();
+			this.emitFailureHandler = Sinks.EmitFailureHandler.FAIL_FAST;
+		}
+
+		@Override
+		public Context currentContext() {
+			return context;
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.setOnce(S, this, s)) {
+				s.request(Long.MAX_VALUE);
+			}
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return s == Operators.cancelledSubscription();
+		}
+
+		@Override
+		public void dispose() {
+			Operators.terminate(S, this);
+		}
+	}
+
+	static final class ManySubscriberAdapter<T> extends AbstractSubscriberAdapter<T, Sinks.Many<T>> {
+
+		ManySubscriberAdapter(Sinks.Many<T> many) {
+			super(many);
+		}
+
+		@Override
+		public void onNext(T t) {
+			sink.emitNext(t, emitFailureHandler);
+		}
+
+		@Override
+		public void onError(Throwable throwable) {
+			Subscription s = S.getAndSet(this, Operators.cancelledSubscription());
+			if (s == Operators.cancelledSubscription()) {
+				Operators.onErrorDropped(throwable, this.context);
+				return;
+			}
+			sink.emitError(throwable, emitFailureHandler);
+		}
+
+		@Override
+		public void onComplete() {
+			Subscription s = S.getAndSet(this, Operators.cancelledSubscription());
+			if (s == Operators.cancelledSubscription()) {
+				return;
+			}
+			sink.emitComplete(emitFailureHandler);
+		}
+	}
+
+	static final class EmptySubscriberAdapter<T> extends AbstractSubscriberAdapter<Void, Sinks.Empty<T>> {
+
+		EmptySubscriberAdapter(Sinks.Empty<T> sink) {
+			super(sink);
+		}
+
+		@Override
+		public void onNext(Void t) {
+			//should never be called, but no-op by nature anyway
+		}
+
+		@Override
+		public void onError(Throwable throwable) {
+			Subscription s = S.getAndSet(this, Operators.cancelledSubscription());
+			if (s == Operators.cancelledSubscription()) {
+				Operators.onErrorDropped(throwable, this.context);
+				return;
+			}
+			sink.emitError(throwable, emitFailureHandler);
+		}
+
+		@Override
+		public void onComplete() {
+			Subscription s = S.getAndSet(this, Operators.cancelledSubscription());
+			if (s == Operators.cancelledSubscription()) {
+				return;
+			}
+			sink.emitEmpty(emitFailureHandler);
+		}
+	}
+
+	/**
+	 * This class assumes that it will be subscribed to a Mono or Mono-compatible source
+	 * (only onNext+onComplete, onComplete or onError allowed).
+	 * @param <T>
+	 */
+	static final class OneSubscriberAdapter<T> extends AbstractSubscriberAdapter<T, Sinks.One<T>> {
+
+		OneSubscriberAdapter(Sinks.One<T> sink) {
+			super(sink);
+		}
+
+		@Override
+		public void onNext(T t) {
+			Subscription s = S.getAndSet(this, Operators.cancelledSubscription());
+			if (s == Operators.cancelledSubscription()) {
+				Operators.onDiscard(t, this.context);
+				//TODO differentiate between onNext+onNext and onComplete+onNext, so that first case cancels upstream?
+				return;
+			}
+			sink.emitValue(t, emitFailureHandler);
+		}
+
+		@Override
+		public void onError(Throwable throwable) {
+			Subscription s = S.getAndSet(this, Operators.cancelledSubscription());
+			if (s == Operators.cancelledSubscription()) {
+				Operators.onErrorDropped(throwable, this.context);
+				return;
+			}
+			sink.emitError(throwable, emitFailureHandler);
+		}
+
+		@Override
+		public void onComplete() {
+			Subscription s = S.getAndSet(this, Operators.cancelledSubscription());
+			if (s == Operators.cancelledSubscription()) {
+				return; //either complete empty or already completed as part of onNext
+			}
+			sink.emitEmpty(emitFailureHandler);
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastManySinkNoBackpressure.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastManySinkNoBackpressure.java
@@ -194,9 +194,10 @@ final class UnicastManySinkNoBackpressure<T> extends Flux<T> implements Internal
 	@Override
 	public synchronized void requestSnapshot() {
 		BiConsumer<Long, Long> consumer = requestRangeConsumer;
-		if (consumer == null) {
+		if (consumer == null || this.state == State.INITIAL) {
 			return;
 		}
+
 		long r = this.requested;
 		if (r > 0L && this.state != State.CANCELLED) {
 			consumer.accept(r, r);

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -347,7 +347,7 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 	@Override
 	public synchronized void requestSnapshot() {
 		BiConsumer<Long, Long> consumer = requestRangeConsumer;
-		if (consumer == null) {
+		if (consumer == null || once == 0) {
 			return;
 		}
 		long r = this.requested;

--- a/reactor-core/src/test/java/reactor/core/publisher/InternalManySinkTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/InternalManySinkTest.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -26,6 +27,7 @@ import reactor.core.Exceptions;
 import reactor.core.publisher.Sinks.EmitResult;
 import reactor.core.publisher.Sinks.EmissionException;
 import reactor.core.publisher.Sinks.EmitFailureHandler;
+import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -199,6 +201,17 @@ class InternalManySinkTest {
 
 		@Override
 		public int currentSubscriberCount() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Nullable
+		@Override
+		public BiConsumer<Long, Long> setRequestHandler(BiConsumer<Long, Long> requestRangeConsumer) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void requestSnapshot() {
 			throw new UnsupportedOperationException();
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkManySerializedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkManySerializedTest.java
@@ -19,6 +19,7 @@ package reactor.core.publisher;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -141,6 +142,17 @@ public class SinkManySerializedTest {
 		@Override
 		public int currentSubscriberCount() {
 			return delegate.currentSubscriberCount();
+		}
+
+		@Nullable
+		@Override
+		public BiConsumer<Long, Long> setRequestHandler(BiConsumer<Long, Long> requestRangeConsumer) {
+			return delegate.setRequestHandler(requestRangeConsumer);
+		}
+
+		@Override
+		public void requestSnapshot() {
+			delegate.requestSnapshot();
 		}
 
 		@Override

--- a/reactor-core/src/test/java/reactor/core/publisher/SinksSubscribersTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinksSubscribersTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import reactor.core.Disposable;
+import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SinksSubscribersTest {
+
+	//arguments for the adapterRequestPatternUsesHighestServiceable test below
+	private static Stream<Arguments> multicastRequestPatterns() {
+		return Stream.of(
+				Arguments.of(Sinks.unsafe().many().multicast().directBestEffort(), 100, 250L, 100, 3, 250L),
+				Arguments.of(Sinks.unsafe().many().multicast().directAllOrNothing(), 3, 3L, 100, 100, 3L + 110L),
+				Arguments.of(Sinks.unsafe().many().multicast().onBackpressureBuffer(50), 3, 50L + 3L, 100, 100, 50L + 3L + 110L),
+
+				Arguments.of(Sinks.unsafe().many().unicast().onBackpressureBuffer(), 100, 250L, 100, 0, 250L),
+				Arguments.of(Sinks.unsafe().many().unicast().onBackpressureError(), 100, 250L, 100, 0, 250L),
+
+				Arguments.of(Sinks.unsafe().many().replay().all(), 100, 250L, 100, 100, 250L),
+				Arguments.of(Sinks.unsafe().many().replay().limit(50), 53, 50L + 3L, 100, 100, 50L + 3L + 110L),
+				Arguments.of(Sinks.unsafe().many().replay().latest(), 4, 1L + 3L, 100, 100, 1L + 3L + 110L)
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("multicastRequestPatterns")
+	void adapterRequestPatternUsesHighestServiceable(Sinks.Many<Integer> sink, int whileSlowExpectedCount, long whileSlowSourceExpectedRequest,
+			int onceCaughtUpFastExpectedCount, int onceCaughtUpSlowExpectedCount, long onceCaughtUpExpectedRequest) {
+		AtomicLong sourceRequested = new AtomicLong();
+		boolean unicast = sink.getClass().getSimpleName().contains("Unicast");
+		Flux<Integer> source = Flux.range(1, 100)
+		                           .doOnRequest(sourceRequested::addAndGet)
+		                           .hide();
+
+		AssertSubscriber<Integer> downstream1 = AssertSubscriber.create(250);
+		AssertSubscriber<Integer> downstream2 = AssertSubscriber.create(3);
+
+		sink.asFlux().subscribe(downstream1);
+		sink.asFlux().subscribe(downstream2);
+
+		//TODO test parallel subscribe / requesting, implement cancel-and-recompute requestSnapshot strategy
+		Disposable d = Sinks.unsafe().connectMany(source, sink);
+
+		assertThat(downstream1.values()).as("fast count while slow").hasSize(whileSlowExpectedCount);
+
+		if (!unicast) {
+			assertThat(downstream2.values()).as("slow count while slow").containsExactly(1, 2, 3);
+		}
+
+		assertThat(sourceRequested).as("source request while slow").hasValue(whileSlowSourceExpectedRequest);
+
+		downstream2.request(110);
+
+		assertThat(downstream1.values()).as("fast count once caught up").hasSize(onceCaughtUpFastExpectedCount);
+		assertThat(downstream2.values()).as("slow count once caught up").hasSize(onceCaughtUpSlowExpectedCount);
+		downstream1.assertComplete();
+		if (!unicast) {
+			downstream2.assertComplete();
+		}
+
+		assertThat(sourceRequested).as("source request once caught up").hasValue(onceCaughtUpExpectedRequest);
+	}
+
+}

--- a/reactor-core/src/test/java/reactor/test/subscriber/AssertSubscriber.java
+++ b/reactor-core/src/test/java/reactor/test/subscriber/AssertSubscriber.java
@@ -1133,7 +1133,6 @@ public class AssertSubscriber<T>
 		return values;
 	}
 
-
 	public final AssertSubscriber<T> assertNoEvents() {
 		return assertNoValues().assertNoError().assertNotComplete();
 	}


### PR DESCRIPTION
leaving this as draft for now as it needs further discussion probably (as well as polishing), but it could be an intermediate solution to the boilerplate issue you've reported @rstoyanchev.

that is only for the cases where one subscribes to a source through `subscribe(...)`, as an alternative to explicitly doing the subscription and using lambdas.

usage pattern:

```
//given `Mono<T> source`
Sinks.One<T> sink = Sinks.unsafe().one();
Disposable connected = Sinks.unsafe().connectOne(source, sink);

//from there on you MUST stop using the `sink` emit APIs directly but can use `asMono`
Mono<T> downstream = sink.asMono();
downstream.subscribe(/*...*/);
downstream.subscribe(/*---*/);

//disconnect the sink to reuse it manually
connected.dispose();
sink.emitNext("foo", FAIL_FAST);
```