### PR TITLE
fix #2424 Pure Mono implementation of materialize() avoids cancel

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMaterialize.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMaterialize.java
@@ -15,7 +15,11 @@
  */
 package reactor.core.publisher;
 
+import org.reactivestreams.Subscription;
+
 import reactor.core.CoreSubscriber;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * @author Stephane Maldini
@@ -28,12 +32,125 @@ final class MonoMaterialize<T> extends InternalMonoOperator<T, Signal<T>> {
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super Signal<T>> actual) {
-		return new FluxMaterialize.MaterializeSubscriber<>(new MonoNext.NextSubscriber<Signal<T>>(actual));
+		return new MaterializeSubscriber<>(actual);
 	}
 
 	@Override
 	public Object scanUnsafe(Attr key) {
 		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
 		return super.scanUnsafe(key);
+	}
+
+	static final class MaterializeSubscriber<T> implements InnerOperator<T, Signal<T>> {
+
+		final CoreSubscriber<? super Signal<T>> actual;
+
+		/**
+		 * Allows to distinguish onNext+onComplete vs onComplete (ignore the complete in the first case)
+		 * while still being able to null out {@link #signalToReplayUponFirstRequest} below.
+		 */
+		boolean      alreadyReceivedSignalFromSource;
+		Subscription s;
+
+		/**
+		 * Captures the fact that we were requested. The amount or the number of request
+		 * calls doesn't matter since the source is a Mono.
+		 */
+		volatile boolean   requested;
+		/**
+		 * This captures an early termination (onComplete or onError), with the goal to
+		 * avoid capturing onNext, so as to simplify cleanup and avoid discard concerns.
+		 */
+		@Nullable
+		volatile Signal<T> signalToReplayUponFirstRequest;
+
+		MaterializeSubscriber(CoreSubscriber<? super Signal<T>> actual) {
+			this.actual = actual;
+		}
+
+		@Override
+		public CoreSubscriber<? super Signal<T>> actual() {
+			return this.actual;
+		}
+
+		@Nullable
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) return s;
+			if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+
+			return InnerOperator.super.scanUnsafe(key);
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.validate(this.s, s)) {
+				this.s = s;
+				actual.onSubscribe(this);
+			}
+		}
+
+		@Override
+		public void onNext(T t) {
+			if (alreadyReceivedSignalFromSource || !requested) {
+				//protocol error: there was an onNext, onComplete or onError before (which are all breaking RS or Mono contract)
+				Operators.onNextDropped(t, currentContext());
+				return;
+			}
+			alreadyReceivedSignalFromSource = true;
+			Signal<T> signal = Signal.next(t, currentContext());
+			actual.onNext(signal);
+			actual.onComplete();
+		}
+
+		@Override
+		public void onError(Throwable throwable) {
+			if (alreadyReceivedSignalFromSource) {
+				//protocol error: there was an onNext, onComplete or onError before (which are all breaking RS or Mono contract)
+				Operators.onErrorDropped(throwable, currentContext());
+				return;
+			}
+			alreadyReceivedSignalFromSource = true;
+			signalToReplayUponFirstRequest = Signal.error(throwable, currentContext());
+			drain();
+		}
+
+		@Override
+		public void onComplete() {
+			if (alreadyReceivedSignalFromSource) {
+				//either protocol error, or there was an `onNext` (in which case we already did the job)
+				return;
+			}
+			alreadyReceivedSignalFromSource = true;
+			signalToReplayUponFirstRequest = Signal.complete(currentContext());
+			drain();
+		}
+
+		boolean drain() {
+			final Signal<T> signal = signalToReplayUponFirstRequest;
+			if (signal != null && requested) {
+				actual.onNext(signal);
+				actual.onComplete();
+				signalToReplayUponFirstRequest = null;
+				return true;
+			}
+			return false;
+		}
+
+		@Override
+		public void request(long l) {
+			if (Operators.validate(l)) {
+				this.requested = true;
+				if (drain()) {
+					return; //there was an early completion
+				}
+				s.request(l);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			s.cancel();
+		}
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDematerializeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDematerializeTest.java
@@ -180,7 +180,7 @@ public class MonoDematerializeTest {
 		            .expectNext("foo")
 		            .verifyComplete();
 
-		testPublisher.assertWasCancelled();
+		testPublisher.assertWasNotCancelled(); //new behavior as of 3.4.0 for MonoMaterialize
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMaterializeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMaterializeTest.java
@@ -13,70 +13,139 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.junit.jupiter.api.Test;
+
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MonoMaterializeTest {
+class MonoMaterializeTest {
 
-    @Test
-    public void completeOnlyBackpressured() {
-        AssertSubscriber<Signal<Integer>> ts = AssertSubscriber.create(0L);
-        
-        Mono.<Integer>empty().materialize()
-        .subscribe(ts);
-        
-        ts.assertNoValues()
-        .assertNoError()
-        .assertNotComplete();
-        
-        ts.request(1);
-        
-        ts.assertValues(Signal.complete())
-        .assertNoError()
-        .assertComplete();
-    }
+	@Test
+	void nextOnlyBackpressured() {
+		AssertSubscriber<Signal<Integer>> ts = AssertSubscriber.create(0L);
 
-    @Test
-    public void errorOnlyBackpressured() {
-        AssertSubscriber<Signal<Integer>> ts = AssertSubscriber.create(0L);
+		Mono.just(1)
+		    .materialize()
+		    .subscribe(ts);
 
-        RuntimeException ex = new RuntimeException();
-        
-        Mono.<Integer>error(ex).materialize()
-        .subscribe(ts);
-        
-        ts.assertNoValues()
-        .assertNoError()
-        .assertNotComplete();
-        
-        ts.request(1);
-        
-        ts.assertValues(Signal.error(ex))
-        .assertNoError()
-        .assertComplete();
-    }
+		ts.assertNoValues()
+		  .assertNoError()
+		  .assertNotComplete();
 
+		ts.request(1);
 
+		ts.assertValues(Signal.next(1))
+		  .assertNoError()
+		  .assertComplete();
+	}
 
-    @Test
-    public void materialize() {
-        StepVerifier.create(Mono.just("Three")
-                                .materialize())
-                    .expectNextMatches(s -> s.isOnNext() && s.get()
-                                                             .equals("Three"))
-                    .verifyComplete();
-    }
+	@Test
+	void completeOnlyBackpressured() {
+		AssertSubscriber<Signal<Integer>> ts = AssertSubscriber.create(0L);
 
-    @Test
-    public void scanOperator(){
-        MonoMaterialize<String> test = new MonoMaterialize<>(Mono.just("foo"));
+		Mono.<Integer>empty()
+				.materialize()
+				.subscribe(ts);
 
-        assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
-    }
+		ts.assertNoValues()
+		  .assertNoError()
+		  .assertNotComplete();
+
+		ts.request(1);
+
+		ts.assertValues(Signal.complete())
+		  .assertNoError()
+		  .assertComplete();
+	}
+
+	@Test
+	void errorOnlyBackpressured() {
+		AssertSubscriber<Signal<Integer>> ts = AssertSubscriber.create(0L);
+
+		RuntimeException ex = new RuntimeException();
+
+		Mono.<Integer>error(ex)
+				.materialize()
+				.subscribe(ts);
+
+		ts.assertNoValues()
+		  .assertNoError()
+		  .assertNotComplete();
+
+		ts.request(1);
+
+		ts.assertValues(Signal.error(ex))
+		  .assertNoError()
+		  .assertComplete();
+	}
+
+	@Test
+	void materialize() {
+		StepVerifier.create(Mono.just("Three")
+		                        .materialize())
+		            .expectNextMatches(s -> s.isOnNext() && s.get().equals("Three"))
+		            .verifyComplete();
+	}
+
+	@Test
+	void valuedSourceMonoNotCancelled() {
+		AtomicBoolean cancelled = new AtomicBoolean();
+		final Mono<Integer> source = Mono.just(1)
+		                                 .hide()
+		                                 .doOnCancel(() -> cancelled.set(true));
+
+		source.materialize()
+		      .as(StepVerifier::create)
+		      .expectNext(Signal.next(1))
+		      .verifyComplete();
+
+		assertThat(cancelled).isFalse();
+	}
+
+	@Test
+	void emptySourceMonoNotCancelled() {
+		AtomicBoolean cancelled = new AtomicBoolean();
+		final Mono<?> source = Mono.empty()
+		                           .hide()
+		                           .doOnCancel(() -> cancelled.set(true));
+
+		source.materialize()
+		      .as(StepVerifier::create)
+		      .expectNext(Signal.complete())
+		      .expectComplete()
+		      .verify(Duration.ofSeconds(5));
+
+		assertThat(cancelled).isFalse();
+	}
+
+	@Test
+	void errorSourceMonoNotCancelled() {
+		AtomicBoolean cancelled = new AtomicBoolean();
+		final Mono<?> source = Mono.error(new IllegalStateException("boom"))
+		                           .hide()
+		                           .doOnCancel(() -> cancelled.set(true));
+
+		source.materialize()
+		      .as(StepVerifier::create)
+		      .assertNext(signal -> assertThat(signal.getThrowable()).isInstanceOf(IllegalStateException.class).hasMessage("boom"))
+		      .verifyComplete();
+
+		assertThat(cancelled).isFalse();
+	}
+
+	@Test
+	void scanOperator() {
+		MonoMaterialize<String> test = new MonoMaterialize<>(Mono.just("foo"));
+
+		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
+	}
 }


### PR DESCRIPTION
This commit avoids unnecessary cancellation of the Mono source when
materializing, by relying on a dedicated implementation rather than
one based on FluxMaterialize.MaterializeSubscriber and MonoNext.