### PR TITLE
[doc] Polish typos and SampleSubscriber snippet in ref guide

### DIFF
--- a/docs/asciidoc/advancedFeatures.adoc
+++ b/docs/asciidoc/advancedFeatures.adoc
@@ -1045,7 +1045,7 @@ Mono<Tuple2<Integer, String>> doPut(String url, Mono<String> data) {
 }
 ----
 <1> Materialize the `ContextView` through `Mono.deferContextual` and...
-<2> within the defer, extract a value for a the correlation ID key, as an `Optional`.
+<2> within the defer, extract a value for the correlation ID key, as an `Optional`.
 <3> If the key was present in the context, use the correlation ID as a header.
 ====
 

--- a/docs/asciidoc/subscribe-details.adoc
+++ b/docs/asciidoc/subscribe-details.adoc
@@ -159,7 +159,7 @@ such a `Subscriber`, we provide an extendable class called `BaseSubscriber`.
 WARNING: Instances of `BaseSubscriber` (or subclasses of it) are *single-use*,
 meaning that a `BaseSubscriber` cancels its subscription to the first `Publisher` if it
 is subscribed to a second `Publisher`.
-That is because using an instance twice would violate the Reactive Streams rule that a
+That is because using an instance twice would violate the Reactive Streams rule that
 the `onNext` method of a `Subscriber` must not be called in parallel.
 As a result, anonymous implementations are fine only if they are declared directly within
 the call to `Publisher#subscribe(Subscriber)`.
@@ -172,10 +172,6 @@ example shows how it would be attached to a `Flux`:
 ----
 SampleSubscriber<Integer> ss = new SampleSubscriber<Integer>();
 Flux<Integer> ints = Flux.range(1, 4);
-ints.subscribe(i -> System.out.println(i),
-    error -> System.err.println("Error " + error),
-    () -> {System.out.println("Done");},
-    s -> s.request(10));
 ints.subscribe(ss);
 ----
 ====
@@ -241,5 +237,5 @@ in as a `SignalType` parameter)
 
 NOTE: You almost certainly want to implement the `hookOnError`, `hookOnCancel`, and
 `hookOnComplete` methods. You may also want to implement the `hookFinally` method.
-`SampleSubscribe` is the absolute minimum implementation of a `Subscriber` _that performs
+`SampleSubscriber` is the absolute minimum implementation of a `Subscriber` _that performs
 bounded requests_.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
@@ -31,7 +31,7 @@ import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
 /**
- * Wraps a the downstream Subscriber into a single emission object and calls the given
+ * Wraps the downstream Subscriber into a single emission object and calls the given
  * callback to produce a signal (a)synchronously.
  *
  * @param <T> the value type


### PR DESCRIPTION
This PR fixes some typos and polishes trivial stuff.