### PR TITLE
[doc] Improve firstWithValue doc on error/empty consequences (see #2459)

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -992,9 +992,13 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * Sources with values always "win" over empty sources (ones that only emit onComplete)
 	 * or failing sources (ones that only emit onError).
 	 * When no source can provide a value, this operator fails with a {@link NoSuchElementException}
-	 * (provided there are at least two sources). This exception itself suppressed a single
-	 * {@link Exceptions#multiple(Throwable...) composite} that reflects errors from failing sources
-	 * and a per-source {@link NoSuchElementException} for empty sources (see {@link Exceptions#unwrapMultiple(Throwable)}).
+	 * (provided there are at least two sources). This exception has a {@link Exceptions#multiple(Throwable...) composite}
+	 * as its {@link Throwable#getCause() cause} that can be used to inspect what went wrong with each source
+	 * (so the composite has as many elements as there are sources).
+	 * Exceptions from failing sources are directly reflected in the composite at the index of the failing source
+	 * For empty sources, a {@link NoSuchElementException} is added at their respective index.
+	 * One can use {@link Exceptions#unwrapMultiple(Throwable) Exceptions.unwrapMultiple(topLevel.getCause())}
+	 * to easily inspect these errors as a {@link List}.
 	 * <p>
 	 * Note that like in {@link #firstWithSignal(Iterable)}, an infinite source can be problematic
 	 * if no other source emits onNext.
@@ -1018,9 +1022,13 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * Sources with values always "win" over an empty source (ones that only emit onComplete)
 	 * or failing sources (ones that only emit onError).
 	 * When no source can provide a value, this operator fails with a {@link NoSuchElementException}
-	 * (provided there are at least two sources). This exception itself suppressed a single
-	 * {@link Exceptions#multiple(Throwable...) composite} that reflects errors from failing sources
-	 * and a per-source {@link NoSuchElementException} for empty sources (see {@link Exceptions#unwrapMultiple(Throwable)}).
+	 * (provided there are at least two sources). This exception has a {@link Exceptions#multiple(Throwable...) composite}
+	 * as its {@link Throwable#getCause() cause} that can be used to inspect what went wrong with each source
+	 * (so the composite has as many elements as there are sources).
+	 * Exceptions from failing sources are directly reflected in the composite at the index of the failing source
+	 * For empty sources, a {@link NoSuchElementException} is added at their respective index.
+	 * One can use {@link Exceptions#unwrapMultiple(Throwable) Exceptions.unwrapMultiple(topLevel.getCause())}
+	 * to easily inspect these errors as a {@link List}.
 	 * <p>
 	 * Note that like in {@link #firstWithSignal(Publisher[])}, an infinite source can be problematic
 	 * if no other source emits onNext.

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -991,11 +991,13 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <p>
 	 * Sources with values always "win" over empty sources (ones that only emit onComplete)
 	 * or failing sources (ones that only emit onError).
+	 * <p>
 	 * When no source can provide a value, this operator fails with a {@link NoSuchElementException}
 	 * (provided there are at least two sources). This exception has a {@link Exceptions#multiple(Throwable...) composite}
 	 * as its {@link Throwable#getCause() cause} that can be used to inspect what went wrong with each source
 	 * (so the composite has as many elements as there are sources).
-	 * Exceptions from failing sources are directly reflected in the composite at the index of the failing source
+	 * <p>
+	 * Exceptions from failing sources are directly reflected in the composite at the index of the failing source.
 	 * For empty sources, a {@link NoSuchElementException} is added at their respective index.
 	 * One can use {@link Exceptions#unwrapMultiple(Throwable) Exceptions.unwrapMultiple(topLevel.getCause())}
 	 * to easily inspect these errors as a {@link List}.
@@ -1021,11 +1023,13 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <p>
 	 * Sources with values always "win" over an empty source (ones that only emit onComplete)
 	 * or failing sources (ones that only emit onError).
+	 * <p>
 	 * When no source can provide a value, this operator fails with a {@link NoSuchElementException}
 	 * (provided there are at least two sources). This exception has a {@link Exceptions#multiple(Throwable...) composite}
 	 * as its {@link Throwable#getCause() cause} that can be used to inspect what went wrong with each source
 	 * (so the composite has as many elements as there are sources).
-	 * Exceptions from failing sources are directly reflected in the composite at the index of the failing source
+	 * <p>
+	 * Exceptions from failing sources are directly reflected in the composite at the index of the failing source.
 	 * For empty sources, a {@link NoSuchElementException} is added at their respective index.
 	 * One can use {@link Exceptions#unwrapMultiple(Throwable) Exceptions.unwrapMultiple(topLevel.getCause())}
 	 * to easily inspect these errors as a {@link List}.

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -991,12 +991,16 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <p>
 	 * Sources with values always "win" over empty sources (ones that only emit onComplete)
 	 * or failing sources (ones that only emit onError).
+	 * When no source can provide a value, this operator fails with a {@link NoSuchElementException}
+	 * (provided there are at least two sources). This exception itself suppressed a single
+	 * {@link Exceptions#multiple(Throwable...) composite} that reflects errors from failing sources
+	 * and a per-source {@link NoSuchElementException} for empty sources (see {@link Exceptions#unwrapMultiple(Throwable)}).
+	 * <p>
 	 * Note that like in {@link #firstWithSignal(Iterable)}, an infinite source can be problematic
 	 * if no other source emits onNext.
-	 *
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/firstWithValueForFlux.svg" alt="">
-
+	 *
 	 * @param sources An {@link Iterable} of the competing source publishers
 	 * @param <I> The type of values in both source and output sequences
 	 *
@@ -1010,21 +1014,21 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * Pick the first {@link Publisher} to emit any value and replay all values
 	 * from that {@link Publisher}, effectively behaving like the source that first
 	 * emits an {@link Subscriber#onNext(Object) onNext}.
-	 *
 	 * <p>
 	 * Sources with values always "win" over an empty source (ones that only emit onComplete)
 	 * or failing sources (ones that only emit onError).
+	 * When no source can provide a value, this operator fails with a {@link NoSuchElementException}
+	 * (provided there are at least two sources). This exception itself suppressed a single
+	 * {@link Exceptions#multiple(Throwable...) composite} that reflects errors from failing sources
+	 * and a per-source {@link NoSuchElementException} for empty sources (see {@link Exceptions#unwrapMultiple(Throwable)}).
+	 * <p>
 	 * Note that like in {@link #firstWithSignal(Publisher[])}, an infinite source can be problematic
 	 * if no other source emits onNext.
-	 *
-	 * <p>
 	 * In case the {@code first} source is already an array-based {@link #firstWithValue(Publisher, Publisher[])}
 	 * instance, nesting is avoided: a single new array-based instance is created with all the
 	 * sources from {@code first} plus all the {@code others} sources at the same level.
-	 *
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/firstWithValueForFlux.svg" alt="">
-
 	 *
 	 * @param first The first competing source publisher
 	 * @param others The other competing source publishers

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
@@ -400,9 +401,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * Valued sources always "win" over an empty source (one that only emits onComplete)
 	 * or a failing source (one that only emits onError).
 	 * When no source can provide a value, this operator fails with a {@link NoSuchElementException}
-	 * (provided there are at least two sources). This exception itself suppressed a single
-	 * {@link Exceptions#multiple(Throwable...) composite} that reflects errors from failing sources
-	 * and a per-source {@link NoSuchElementException} for empty sources (see {@link Exceptions#unwrapMultiple(Throwable)}).
+	 * (provided there are at least two sources). This exception has a {@link Exceptions#multiple(Throwable...) composite}
+	 * as its {@link Throwable#getCause() cause} that can be used to inspect what went wrong with each source
+	 * (so the composite has as many elements as there are sources).
+	 * Exceptions from failing sources are directly reflected in the composite at the index of the failing source
+	 * For empty sources, a {@link NoSuchElementException} is added at their respective index.
+	 * One can use {@link Exceptions#unwrapMultiple(Throwable) Exceptions.unwrapMultiple(topLevel.getCause())}
+	 * to easily inspect these errors as a {@link List}.
 	 * <p>
 	 * Note that like in {@link #firstWithSignal(Iterable)}, an infinite source can be problematic
 	 * if no other source emits onNext.
@@ -426,9 +431,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * Valued sources always "win" over an empty source (one that only emits onComplete)
 	 * or a failing source (one that only emits onError).
 	 * When no source can provide a value, this operator fails with a {@link NoSuchElementException}
-	 * (provided there are at least two sources). This exception itself suppressed a single
-	 * {@link Exceptions#multiple(Throwable...) composite} that reflects errors from failing sources
-	 * and a per-source {@link NoSuchElementException} for empty sources (see {@link Exceptions#unwrapMultiple(Throwable)}).
+	 * (provided there are at least two sources). This exception has a {@link Exceptions#multiple(Throwable...) composite}
+	 * as its {@link Throwable#getCause() cause} that can be used to inspect what went wrong with each source
+	 * (so the composite has as many elements as there are sources).
+	 * Exceptions from failing sources are directly reflected in the composite at the index of the failing source
+	 * For empty sources, a {@link NoSuchElementException} is added at their respective index.
+	 * One can use {@link Exceptions#unwrapMultiple(Throwable) Exceptions.unwrapMultiple(topLevel.getCause())}
+	 * to easily inspect these errors as a {@link List}.
 	 * <p>
 	 * Note that like in {@link #firstWithSignal(Mono[])}, an infinite source can be problematic
 	 * if no other source emits onNext.

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -399,12 +399,16 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * <p>
 	 * Valued sources always "win" over an empty source (one that only emits onComplete)
 	 * or a failing source (one that only emits onError).
+	 * When no source can provide a value, this operator fails with a {@link NoSuchElementException}
+	 * (provided there are at least two sources). This exception itself suppressed a single
+	 * {@link Exceptions#multiple(Throwable...) composite} that reflects errors from failing sources
+	 * and a per-source {@link NoSuchElementException} for empty sources (see {@link Exceptions#unwrapMultiple(Throwable)}).
+	 * <p>
 	 * Note that like in {@link #firstWithSignal(Iterable)}, an infinite source can be problematic
 	 * if no other source emits onNext.
-	 *
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/firstWithValueForMono.svg" alt="">
-	 * <p>
+	 *
 	 * @param monos An {@link Iterable} of the competing source monos
 	 * @param <T> The type of the element in the sources and the resulting mono
 	 *
@@ -418,19 +422,21 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * Pick the first {@link Mono} source to emit any value and replay that signal,
 	 * effectively behaving like the source that first emits an
 	 * {@link Subscriber#onNext(Object) onNext}.
-	 *
 	 * <p>
 	 * Valued sources always "win" over an empty source (one that only emits onComplete)
 	 * or a failing source (one that only emits onError).
+	 * When no source can provide a value, this operator fails with a {@link NoSuchElementException}
+	 * (provided there are at least two sources). This exception itself suppressed a single
+	 * {@link Exceptions#multiple(Throwable...) composite} that reflects errors from failing sources
+	 * and a per-source {@link NoSuchElementException} for empty sources (see {@link Exceptions#unwrapMultiple(Throwable)}).
+	 * <p>
 	 * Note that like in {@link #firstWithSignal(Mono[])}, an infinite source can be problematic
 	 * if no other source emits onNext.
-	 * <p>
 	 * In case the {@code first} source is already an array-based {@link #firstWithValue(Mono, Mono[])}
 	 * instance, nesting is avoided: a single new array-based instance is created with all the
 	 * sources from {@code first} plus all the {@code others} sources at the same level.
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/firstWithValueForMono.svg" alt="">
-	 * <p>
 	 *
 	 * @param first the first competing source {@link Mono}
 	 * @param others the other competing sources {@link Mono}

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -400,11 +400,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * <p>
 	 * Valued sources always "win" over an empty source (one that only emits onComplete)
 	 * or a failing source (one that only emits onError).
+	 * <p>
 	 * When no source can provide a value, this operator fails with a {@link NoSuchElementException}
 	 * (provided there are at least two sources). This exception has a {@link Exceptions#multiple(Throwable...) composite}
 	 * as its {@link Throwable#getCause() cause} that can be used to inspect what went wrong with each source
 	 * (so the composite has as many elements as there are sources).
-	 * Exceptions from failing sources are directly reflected in the composite at the index of the failing source
+	 * <p>
+	 * Exceptions from failing sources are directly reflected in the composite at the index of the failing source.
 	 * For empty sources, a {@link NoSuchElementException} is added at their respective index.
 	 * One can use {@link Exceptions#unwrapMultiple(Throwable) Exceptions.unwrapMultiple(topLevel.getCause())}
 	 * to easily inspect these errors as a {@link List}.
@@ -430,11 +432,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * <p>
 	 * Valued sources always "win" over an empty source (one that only emits onComplete)
 	 * or a failing source (one that only emits onError).
+	 * <p>
 	 * When no source can provide a value, this operator fails with a {@link NoSuchElementException}
 	 * (provided there are at least two sources). This exception has a {@link Exceptions#multiple(Throwable...) composite}
 	 * as its {@link Throwable#getCause() cause} that can be used to inspect what went wrong with each source
 	 * (so the composite has as many elements as there are sources).
-	 * Exceptions from failing sources are directly reflected in the composite at the index of the failing source
+	 * <p>
+	 * Exceptions from failing sources are directly reflected in the composite at the index of the failing source.
 	 * For empty sources, a {@link NoSuchElementException} is added at their respective index.
 	 * One can use {@link Exceptions#unwrapMultiple(Throwable) Exceptions.unwrapMultiple(topLevel.getCause())}
 	 * to easily inspect these errors as a {@link List}.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFirstWithValueTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFirstWithValueTest.java
@@ -17,6 +17,7 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 
 import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
@@ -59,19 +61,77 @@ class FluxFirstWithValueTest {
 	}
 
 	@Test
-	void onlyErrorOrCompleteEmptyEmitsError() {
-		StepVerifier.withVirtualTime(() -> Flux.firstWithValue(
-				Flux.error(new RuntimeException("Boom!")),
-				Flux.empty()
-		))
-				.expectErrorSatisfies(e -> {
-					assertThat(e).isInstanceOf(NoSuchElementException.class);
-					assertThat(e).hasMessage("All sources completed with error or without values");
-					Throwable throwable = e.getCause();
-					assertThat(throwable.getSuppressed()[0]).hasMessage("Boom!");
-					assertThat(throwable.getSuppressed()[1]).hasMessage("source at index 1 completed empty");
-				})
-				.verify();
+	void singleErrorIsPropagatedAsIs() {
+		StepVerifier.create(Flux.firstWithValue(Flux.error(new IllegalStateException("boom"))))
+		            .expectErrorSatisfies(e -> assertThat(e)
+				            .isInstanceOf(IllegalStateException.class)
+				            .hasMessage("boom")
+				            .hasNoCause()
+				            .hasNoSuppressedExceptions())
+		            .verify();
+	}
+
+	@Test
+	void singleEmptyLeadsToComplete() {
+		StepVerifier.create(Flux.firstWithValue(Flux.empty()))
+		            .expectComplete()
+		            .verify();
+	}
+
+	@Test
+	void errorAndEmptySourcesTriggerNoSuchElementWithOneSuppressedCompositeOfTwo() {
+		StepVerifier.create(Flux.firstWithValue(
+				Flux.error(new IllegalStateException("boom")),
+				Flux.empty()))
+		            .expectErrorSatisfies(e -> {
+			            assertThat(e)
+					            .isInstanceOf(NoSuchElementException.class)
+					            .hasMessage("All sources completed with error or without values")
+					            .hasCauseInstanceOf(RuntimeException.class);
+			            List<Throwable> composite = Exceptions.unwrapMultiple(e.getCause());
+			            assertThat(composite)
+					            .hasSize(2)
+					            .extracting(Throwable::toString)
+					            .containsExactly("java.lang.IllegalStateException: boom",
+							            "java.util.NoSuchElementException: source at index 1 completed empty");
+		            })
+		            .verify();
+	}
+
+	@Test
+	void twoErrorsTriggerNoSuchElementWithOneSuppressedCompositeOfBothErrors() {
+		StepVerifier.create(Flux.firstWithValue(Flux.error(new IllegalStateException("boom1")), Flux.error(new IllegalArgumentException("boom2"))))
+		            .expectErrorSatisfies(e -> {
+			            assertThat(e)
+					            .isInstanceOf(NoSuchElementException.class)
+					            .hasMessage("All sources completed with error or without values")
+					            .hasCauseInstanceOf(RuntimeException.class);
+			            List<Throwable> composite = Exceptions.unwrapMultiple(e.getCause());
+			            assertThat(composite)
+					            .hasSize(2)
+					            .extracting(Throwable::toString)
+					            .containsExactly("java.lang.IllegalStateException: boom1",
+							            "java.lang.IllegalArgumentException: boom2");
+		            })
+		            .verify();
+	}
+
+	@Test
+	void twoEmptyTriggersNoSuchElementWithOneSuppressedCompositeOfTwoNoSuchElement() {
+		StepVerifier.create(Flux.firstWithValue(Flux.empty(), Flux.empty()))
+		            .expectErrorSatisfies(e -> {
+			            assertThat(e)
+					            .isInstanceOf(NoSuchElementException.class)
+					            .hasMessage("All sources completed with error or without values")
+					            .hasCauseInstanceOf(RuntimeException.class);
+			            List<Throwable> composite = Exceptions.unwrapMultiple(e.getCause());
+			            assertThat(composite)
+					            .hasSize(2)
+					            .extracting(Throwable::toString)
+					            .containsExactly("java.util.NoSuchElementException: source at index 0 completed empty",
+							            "java.util.NoSuchElementException: source at index 1 completed empty");
+		            })
+		            .verify();
 	}
 
 	@Test


### PR DESCRIPTION
This commit improves the javadoc and adds some tests around the possible
combinations of error+empty sources that lead to NoSuchElementException
at top-level, with a suppressed composite (that itself can contain inner
NoSuchElementExceptions materializing empty sources).

Also added a few tests and improved one existing test around such cases.