### PR TITLE
fix #2465 Add custom AssertJ Representation of QueueSubscription in core

### DIFF
--- a/reactor-core/src/test/java/reactor/ReactorTestExecutionListener.java
+++ b/reactor-core/src/test/java/reactor/ReactorTestExecutionListener.java
@@ -19,8 +19,11 @@ package reactor;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.TestPlan;
+
 import reactor.core.publisher.Hooks;
 import reactor.core.scheduler.Schedulers;
+import reactor.test.AssertionsUtils;
 
 public class ReactorTestExecutionListener implements TestExecutionListener {
 
@@ -46,5 +49,10 @@ public class ReactorTestExecutionListener implements TestExecutionListener {
 	@Override
 	public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
 		reset();
+	}
+
+	@Override
+	public void testPlanExecutionStarted(TestPlan testPlan) {
+		AssertionsUtils.installAssertJTestRepresentation();
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/QueueSubscriptionTest.java
+++ b/reactor-core/src/test/java/reactor/core/QueueSubscriptionTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import reactor.core.publisher.Operators;
+import reactor.test.AssertionsUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * @author Simon Baslé
+ */
+class QueueSubscriptionTest {
+
+	@Test
+	void assertJShouldProperlyFormatQueueSubscription() {
+		//on purpose, doesn't set any particular representation for QueueSubscriptions
+		Fuseable.QueueSubscription<?> queueSubscription = new Fuseable.QueueSubscription<Object>() {
+			@Override
+			public int requestFusion(int requestedMode) {
+				return 0;
+			}
+
+			@Override
+			public Object poll() {
+				return null;
+			}
+
+			@Override
+			public int size() {
+				return 0;
+			}
+
+			@Override
+			public boolean isEmpty() {
+				return false;
+			}
+
+			@Override
+			public void clear() {
+
+			}
+
+			@Override
+			public void request(long n) {
+
+			}
+
+			@Override
+			public void cancel() {
+
+			}
+
+			@Override
+			public String toString() {
+				return "ThisIsNotAQueue";
+			}
+		};
+
+		assertThatExceptionOfType(AssertionError.class)
+				.isThrownBy(() -> {
+					assertThat(queueSubscription).isNull();
+				})
+		.withMessage("\n" + "Expecting:\n" + " <ThisIsNotAQueue>\n" + "to be equal to:\n" + " <null>\n" + "but was not.");
+	}
+
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
@@ -493,7 +493,7 @@ public class FluxPeekFuseableTest {
 		    .subscribe(ts);
 
 		Subscription s = ts.upstream();
-		assertThat(s).withFailMessage("Non-fuseable upstream: %s", s.getClass()).isInstanceOf(QueueSubscription.class);
+		assertThat(s).as("check QueueSubscription").isInstanceOf(QueueSubscription.class);
 	}
 
 	@Test
@@ -506,7 +506,7 @@ public class FluxPeekFuseableTest {
 		                .subscribe(ts);
 
 		Subscription s = ts.upstream();
-		assertThat(s).withFailMessage("Non-fuseable upstream: %s", s.getClass()).isInstanceOf(QueueSubscription.class);
+		assertThat(s).as("check QueueSubscription").isInstanceOf(QueueSubscription.class);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
@@ -716,7 +716,7 @@ public class FluxPeekTest extends FluxOperatorTest<String, String> {
 		    .subscribe(ts);
 
 		Subscription s = ts.upstream();
-		assertThat(s).withFailMessage("Non-fuseable upstream: %s", s.getClass()).isInstanceOf(QueueSubscription.class);
+		assertThat(s).as("check QueueSubscription").isInstanceOf(QueueSubscription.class);
 	}
 
 	@Test
@@ -729,7 +729,7 @@ public class FluxPeekTest extends FluxOperatorTest<String, String> {
 		                .subscribe(ts);
 
 		Subscription s = ts.upstream();
-		assertThat(s).withFailMessage("Non-fuseable upstream: %s", s.getClass()).isInstanceOf(QueueSubscription.class);
+		assertThat(s).as("check QueueSubscription").isInstanceOf(QueueSubscription.class);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/test/AssertionsUtils.java
+++ b/reactor-core/src/test/java/reactor/test/AssertionsUtils.java
@@ -21,6 +21,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.presentation.StandardRepresentation;
 
+import reactor.core.Fuseable;
+
 /**
  * Utilities around assertions in core tests, eg. AssertJ configuration of representations.
  *
@@ -47,6 +49,14 @@ public class AssertionsUtils {
 				return atomicBoolean.toString();
 			}
 			return super.toStringOf(atomicBoolean);
+		}
+
+		@Override
+		protected String smartFormat(Iterable<?> iterable) {
+			if (iterable instanceof Fuseable.QueueSubscription) {
+				return String.valueOf(iterable);
+			}
+			return super.smartFormat(iterable);
 		}
 	};
 }

--- a/reactor-core/src/test/java/reactor/test/MemoryUtils.java
+++ b/reactor-core/src/test/java/reactor/test/MemoryUtils.java
@@ -97,8 +97,8 @@ public class MemoryUtils {
 
 
 		public OffHeapDetector() {
+			//note: AssertJ representation of Tracked is installed in ReactorTestExecutionListener
 			tracker = new ConcurrentLinkedQueue<>();
-			AssertionsUtils.installAssertJTestRepresentation();
 		}
 
 		/**


### PR DESCRIPTION
This commit adds the `QueueSubscription` case to the reactor custom
representation (in `AssertionsUtils`), in addition to recognizing
`MemoryUtils.Tracked`.

Additionally, it leverages `ReactorTestExecutionListener` to set up
AssertJ automatically with said StandardRepresentation in core tests.

This should mark the end of "Although QueueSubscription extends Queue
it is purely internal..." messages in assertions.