### PR TITLE
fix #2470 Make refguide BOM snippets use version from gradle.properties

### DIFF
--- a/docs/asciidoc/gettingStarted.adoc
+++ b/docs/asciidoc/gettingStarted.adoc
@@ -86,7 +86,7 @@ and specify dependencies by their artifact versions.
 WARNING: As of this version (reactor-core {project-version}), the latest stable BOM in the associated
 release train line is `{reactorReleaseTrain}`, which is what is used in snippets below.
 There might be newer versions since then (including snapshots, milestones and new release train lines),
-see https://github.com/reactor/reactor/releases/.
+see https://projectreactor.io/docs for the latest artifacts and BOMs.
 
 === Maven Installation
 

--- a/docs/asciidoc/gettingStarted.adoc
+++ b/docs/asciidoc/gettingStarted.adoc
@@ -1,4 +1,4 @@
-:reactorReleaseTrain: {PLEASE-LOOKUP-LATEST}
+:reactorReleaseTrain: Dysprosium-SR13
 [[getting-started]]
 = Getting Started
 

--- a/docs/asciidoc/gettingStarted.adoc
+++ b/docs/asciidoc/gettingStarted.adoc
@@ -1,4 +1,3 @@
-:reactorReleaseTrain: Dysprosium-SR13
 [[getting-started]]
 = Getting Started
 

--- a/docs/asciidoc/gettingStarted.adoc
+++ b/docs/asciidoc/gettingStarted.adoc
@@ -1,3 +1,4 @@
+:reactorReleaseTrain: {PLEASE-LOOKUP-LATEST}
 [[getting-started]]
 = Getting Started
 
@@ -83,20 +84,25 @@ However, if you want to force the use of a specific artifact's version, you can 
 it when adding your dependency, as you usually would. You can also forgo the BOM entirely
 and specify dependencies by their artifact versions.
 
+WARNING: As of this version (reactor-core {project-version}), the latest stable BOM in the associated
+release train line is `{reactorReleaseTrain}`, which is what is used in snippets below.
+There might be newer versions since then (including snapshots, milestones and new release train lines),
+see https://github.com/reactor/reactor/releases/.
+
 === Maven Installation
 
 Maven natively supports the BOM concept. First, you need to import the BOM by
 adding the following snippet to your `pom.xml`:
 
 ====
-[source,xml]
+[source,xml,subs=attributes+]
 ----
 <dependencyManagement> <1>
     <dependencies>
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-bom</artifactId>
-            <version>Bismuth-RELEASE</version>
+            <version>{reactorReleaseTrain}</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -155,11 +161,11 @@ Check for updates.
 Then use it to import the BOM, as follows:
 
 ====
-[source,groovy]
+[source,groovy,subs=attributes+]
 ----
 dependencyManagement {
      imports {
-          mavenBom "io.projectreactor:reactor-bom:Bismuth-RELEASE"
+          mavenBom "io.projectreactor:reactor-bom:{reactorReleaseTrain}"
      }
 }
 ----
@@ -181,10 +187,10 @@ the BOM.
 Since Gradle 5.0, you can use the native Gradle support for BOMs:
 
 ====
-[source,groovy]
+[source,groovy,subs=attributes+]
 ----
 dependencies {
-     implementation platform('io.projectreactor:reactor-bom:Bismuth-RELEASE')
+     implementation platform('io.projectreactor:reactor-bom:{reactorReleaseTrain}')
      implementation 'io.projectreactor:reactor-core' <1>
 }
 ----

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ version=3.3.12.BUILD-SNAPSHOT
 reactiveStreamsVersion=1.0.3
 compatibleVersion=3.3.0.RELEASE
 perfBaselineVersion=3.3.6.RELEASE
+bomVersion=Dysprosium-SR13

--- a/gradle/asciidoc.gradle
+++ b/gradle/asciidoc.gradle
@@ -44,6 +44,7 @@ configure(rootProject) {
 			doctype: 'book'
 		]
 		attributes 'allow-uri-read': '',
+			reactorReleaseTrain: "$bomVersion",
 			imagesdir: "images/",
 			stylesdir: "stylesheets/",
 			stylesheet: 'reactor.css',

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -55,13 +55,6 @@ task copyReadme(type: Copy, group: "releaser helpers", description: "copies the 
 	into rootProject.buildDir
 }
 
-task copyGettingStarted(type: Copy, group: "releaser helpers", description: "copies the gettingStarted.adoc in preparation for search and replace") {
-	from(rootProject.rootDir) {
-		include "docs/asciidoc/gettingStarted.adoc"
-	}
-	into rootProject.buildDir
-}
-
 task bumpVersionsInReadme(type: Copy, group: "releaser helpers", description: "replaces versions in README") {
 	def oldVersion = rootProject.findProperty("oldVersion")
 	def currentVersion = rootProject.findProperty("currentVersion")

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -63,7 +63,6 @@ task copyGettingStarted(type: Copy, group: "releaser helpers", description: "cop
 }
 
 task bumpVersionsInReadme(type: Copy, group: "releaser helpers", description: "replaces versions in README") {
-	def bomVersion = rootProject.findProperty("bomVersion")
 	def oldVersion = rootProject.findProperty("oldVersion")
 	def currentVersion = rootProject.findProperty("currentVersion")
 	def nextVersion = rootProject.findProperty("nextVersion")
@@ -71,24 +70,17 @@ task bumpVersionsInReadme(type: Copy, group: "releaser helpers", description: "r
 
 	onlyIf { oldVersion != null && currentVersion != null && nextVersion != null }
 	dependsOn copyReadme
-	dependsOn copyGettingStarted
 
 	doLast {
 		println "Will replace $oldVersion with $currentVersion and $oldSnapshot with $nextVersion"
-		if (bomVersion == null) println "No `bomVersion` set, will not change bom version in gettingStarted.adoc"
-		else println "Will change bomVersion in gettingStarted.adoc to $bomVersion"
 	}
 	from(rootProject.buildDir) {
 		include 'README.md'
-		include "docs/asciidoc/gettingStarted.adoc"
 	}
 	into rootProject.rootDir
-	filter { line -> (bomVersion == null) ?
-		line.replace(oldVersion, currentVersion)
-			.replace(oldSnapshot, nextVersion) :
-		line.replace(oldVersion, currentVersion)
-			.replace(oldSnapshot, nextVersion)
-			.replaceAll("\\:reactorReleaseTrain\\: .*", ":reactorReleaseTrain: " + bomVersion)
+	filter { line -> line
+		.replace(oldVersion, currentVersion)
+		.replace(oldSnapshot, nextVersion)
 	}
 }
 

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -55,7 +55,15 @@ task copyReadme(type: Copy, group: "releaser helpers", description: "copies the 
 	into rootProject.buildDir
 }
 
+task copyGettingStarted(type: Copy, group: "releaser helpers", description: "copies the gettingStarted.adoc in preparation for search and replace") {
+	from(rootProject.rootDir) {
+		include "docs/asciidoc/gettingStarted.adoc"
+	}
+	into rootProject.buildDir
+}
+
 task bumpVersionsInReadme(type: Copy, group: "releaser helpers", description: "replaces versions in README") {
+	def bomVersion = rootProject.findProperty("bomVersion")
 	def oldVersion = rootProject.findProperty("oldVersion")
 	def currentVersion = rootProject.findProperty("currentVersion")
 	def nextVersion = rootProject.findProperty("nextVersion")
@@ -63,17 +71,24 @@ task bumpVersionsInReadme(type: Copy, group: "releaser helpers", description: "r
 
 	onlyIf { oldVersion != null && currentVersion != null && nextVersion != null }
 	dependsOn copyReadme
+	dependsOn copyGettingStarted
 
 	doLast {
 		println "Will replace $oldVersion with $currentVersion and $oldSnapshot with $nextVersion"
+		if (bomVersion == null) println "No `bomVersion` set, will not change bom version in gettingStarted.adoc"
+		else println "Will change bomVersion in gettingStarted.adoc to $bomVersion"
 	}
 	from(rootProject.buildDir) {
 		include 'README.md'
+		include "docs/asciidoc/gettingStarted.adoc"
 	}
 	into rootProject.rootDir
-	filter { line -> line
-		.replace(oldVersion, currentVersion)
-		.replace(oldSnapshot, nextVersion)
+	filter { line -> (bomVersion == null) ?
+		line.replace(oldVersion, currentVersion)
+			.replace(oldSnapshot, nextVersion) :
+		line.replace(oldVersion, currentVersion)
+			.replace(oldSnapshot, nextVersion)
+			.replaceAll("\\:reactorReleaseTrain\\: .*", ":reactorReleaseTrain: " + bomVersion)
 	}
 }
 


### PR DESCRIPTION
Additional tasks once approved:
 - [ ] merge with squash, editing the original commit message to reflect new properties-based approach (and `Reviewed-in: #2474`)
 - [ ] ⚠️ merge the commit from 3.3.x into `master` with an edit:
   - [ ] `git merge --no-commit 3.3.x`
   - [ ] change the `bomVersion` attribute in `gradle.properties` to `2020.0.0`
   - [ ] `git commit`
   - [ ] push to master