### PR TITLE
fix #2468 Review and polish deprecation suppressions

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -7599,7 +7599,6 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @return a new {@link Mono}
 	 */
 	public final Mono<T> shareNext() {
-		@SuppressWarnings("deprecation") //TODO NextProcessor will be turned into an internal class only in 3.5
 		final NextProcessor<T> nextProcessor = new NextProcessor<>(this);
 		return Mono.onAssembly(nextProcessor);
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/ImmutableSignal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ImmutableSignal.java
@@ -146,10 +146,16 @@ final class ImmutableSignal<T> implements Signal<T>, Serializable {
 		}
 	}
 
-	/**
-	 * @deprecated as Signal is now associated with {@link Context}, prefer using per-subscription instances.
-	 */
-	@Deprecated
-	static final Signal<Void> ON_COMPLETE =
+	private static final Signal<?> ON_COMPLETE =
 			new ImmutableSignal<>(Context.empty(), SignalType.ON_COMPLETE, null, null, null);
+
+	/**
+	 * @return a singleton signal to signify onComplete.
+	 * As Signal is now associated with {@link Context}, prefer using per-subscription instances.
+	 * This instance is used when context doesn't matter.
+	 */
+	@SuppressWarnings("unchecked")
+	static <U> Signal<U> onComplete() {
+		return (Signal<U>) ON_COMPLETE;
+	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -2205,7 +2205,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @param afterSuccessOrError the callback to call after {@link Subscriber#onNext}, {@link Subscriber#onComplete} without preceding {@link Subscriber#onNext} or {@link Subscriber#onError}
 	 *
 	 * @return a new {@link Mono}
-	 * @deprecated prefer using {@link #doAfterTerminate(Runnable)} or {@link #doFinally(Consumer)}. will be removed in 3.4.0
+	 * @deprecated prefer using {@link #doAfterTerminate(Runnable)} or {@link #doFinally(Consumer)}. will be removed in 3.5.0
 	 */
 	@Deprecated
 	public final Mono<T> doAfterSuccessOrError(BiConsumer<? super T, Throwable> afterSuccessOrError) {
@@ -2516,7 +2516,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @param onSuccessOrError the callback to call {@link Subscriber#onNext}, {@link Subscriber#onComplete} without preceding {@link Subscriber#onNext} or {@link Subscriber#onError}
 	 *
 	 * @return a new {@link Mono}
-	 * @deprecated prefer using {@link #doOnNext(Consumer)}, {@link #doOnError(Consumer)}, {@link #doOnTerminate(Runnable)} or {@link #doOnSuccess(Consumer)}. will be removed in 3.4.0
+	 * @deprecated prefer using {@link #doOnNext(Consumer)}, {@link #doOnError(Consumer)}, {@link #doOnTerminate(Runnable)} or {@link #doOnSuccess(Consumer)}. will be removed in 3.5.0
 	 */
 	@Deprecated
 	public final Mono<T> doOnSuccessOrError(BiConsumer<? super T, Throwable> onSuccessOrError) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -3769,7 +3769,6 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 *
 	 * @return a new {@link Mono}
 	 */
-	@SuppressWarnings("deprecation") //TODO NextProcessor will be turned into an internal class only in 3.5
 	public final Mono<T> share() {
 		if (this instanceof Fuseable.ScalarCallable) {
 			return this;
@@ -3828,7 +3827,6 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 *
 	 * @return a new {@link Disposable} that can be used to cancel the underlying {@link Subscription}
 	 */
-	@SuppressWarnings("deprecation") //TODO NextProcessor will be turned into an internal class only in 3.5
 	public final Disposable subscribe() {
 		if(this instanceof NextProcessor){
 			NextProcessor<T> s = (NextProcessor<T>)this;

--- a/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
@@ -18,6 +18,7 @@ import reactor.core.publisher.Sinks.EmitFailureHandler;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
+// NextProcessor extends a deprecated class but is itself not deprecated and is here to stay, hence the following line is ok.
 @SuppressWarnings("deprecation")
 class NextProcessor<O> extends MonoProcessor<O> implements InternalOneSink<O> {
 

--- a/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
@@ -241,6 +241,7 @@ class NextProcessor<O> extends MonoProcessor<O> implements InternalOneSink<O> {
 	}
 
 	@Override
+	// This method is inherited from a deprecated class and will be removed in 3.5.
 	@SuppressWarnings("deprecation")
 	public void cancel() {
 		if (isTerminated()) {
@@ -266,6 +267,7 @@ class NextProcessor<O> extends MonoProcessor<O> implements InternalOneSink<O> {
 	}
 
 	@Override
+	// This method is inherited from a deprecated class and will be removed in 3.5.
 	@SuppressWarnings("deprecation")
 	public boolean isCancelled() {
 		return subscription == Operators.cancelledSubscription() && !isTerminated();

--- a/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
@@ -18,7 +18,7 @@ import reactor.core.publisher.Sinks.EmitFailureHandler;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
-@Deprecated
+@SuppressWarnings("deprecation")
 class NextProcessor<O> extends MonoProcessor<O> implements InternalOneSink<O> {
 
 	volatile NextInner<O>[] subscribers;

--- a/reactor-core/src/main/java/reactor/core/publisher/Signal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Signal.java
@@ -46,9 +46,8 @@ public interface Signal<T> extends Supplier<T>, Consumer<Subscriber<? super T>> 
 	 *
 	 * @return an {@code OnCompleted} variety of {@code Signal}
 	 */
-	@SuppressWarnings({"deprecation", "unchecked"})
 	static <T> Signal<T> complete() {
-		return (Signal<T>) ImmutableSignal.ON_COMPLETE;
+		return ImmutableSignal.onComplete();
 	}
 
 	/**
@@ -60,10 +59,9 @@ public interface Signal<T> extends Supplier<T>, Consumer<Subscriber<? super T>> 
 	 *
 	 * @return an {@code OnCompleted} variety of {@code Signal}
 	 */
-	@SuppressWarnings({"deprecation", "unchecked"})
 	static <T> Signal<T> complete(Context context) {
 		if (context.isEmpty()) {
-			return (Signal<T>) ImmutableSignal.ON_COMPLETE;
+			return ImmutableSignal.onComplete();
 		}
 		return new ImmutableSignal<>(context, SignalType.ON_COMPLETE, null, null, null);
 	}
@@ -160,9 +158,8 @@ public interface Signal<T> extends Supplier<T>, Consumer<Subscriber<? super T>> 
 	 * @param o the object to check
 	 * @return true if object represents the completion signal
 	 */
-	@SuppressWarnings("deprecation")
 	static boolean isComplete(Object o) {
-		return o == ImmutableSignal.ON_COMPLETE ||
+		return o == ImmutableSignal.onComplete() ||
 				(o instanceof Signal && ((Signal) o).getType() == SignalType.ON_COMPLETE);
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
@@ -92,7 +92,6 @@ final class SinksSpecs {
 
 		@Override
 		public <T> One<T> one() {
-			@SuppressWarnings("deprecation") //TODO NextProcessor will be turned into an internal class only in 3.5
 			final NextProcessor<T> original = new NextProcessor<>(null);
 			return wrapOne(original);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
@@ -113,21 +113,21 @@ final class SinksSpecs {
 
 		@Override
 		public <T> Many<T> onBackpressureBuffer() {
-			@SuppressWarnings("deprecation")
+			@SuppressWarnings("deprecation") // EmitterProcessor will be removed in 3.5.
 			final EmitterProcessor<T> original = EmitterProcessor.create();
 			return wrapMany(original);
 		}
 
 		@Override
 		public <T> Many<T> onBackpressureBuffer(int bufferSize) {
-			@SuppressWarnings("deprecation")
+			@SuppressWarnings("deprecation") // EmitterProcessor will be removed in 3.5.
 			final EmitterProcessor<T> original = EmitterProcessor.create(bufferSize);
 			return wrapMany(original);
 		}
 
 		@Override
 		public <T> Many<T> onBackpressureBuffer(int bufferSize, boolean autoCancel) {
-			@SuppressWarnings("deprecation")
+			@SuppressWarnings("deprecation") // EmitterProcessor will be removed in 3.5.
 			final EmitterProcessor<T> original = EmitterProcessor.create(bufferSize, autoCancel);
 			return wrapMany(original);
 		}
@@ -147,63 +147,63 @@ final class SinksSpecs {
 
 		@Override
 		public <T> Many<T> all() {
-			@SuppressWarnings("deprecation")
+			@SuppressWarnings("deprecation") // ReplayProcessor will be removed in 3.5.
 			final ReplayProcessor<T> original = ReplayProcessor.create();
 			return wrapMany(original);
 		}
 
 		@Override
 		public <T> Many<T> all(int batchSize) {
-			@SuppressWarnings("deprecation")
+			@SuppressWarnings("deprecation") // ReplayProcessor will be removed in 3.5
 			final ReplayProcessor<T> original = ReplayProcessor.create(batchSize, true);
 			return wrapMany(original);
 		}
 
 		@Override
 		public <T> Many<T> latest() {
-			@SuppressWarnings("deprecation")
+			@SuppressWarnings("deprecation") // ReplayProcessor will be removed in 3.5.
 			final ReplayProcessor<T> original = ReplayProcessor.cacheLast();
 			return wrapMany(original);
 		}
 
 		@Override
 		public <T> Many<T> latestOrDefault(T value) {
-			@SuppressWarnings("deprecation")
+			@SuppressWarnings("deprecation") // ReplayProcessor will be removed in 3.5.
 			final ReplayProcessor<T> original = ReplayProcessor.cacheLastOrDefault(value);
 			return wrapMany(original);
 		}
 
 		@Override
 		public <T> Many<T> limit(int historySize) {
-			@SuppressWarnings("deprecation")
+			@SuppressWarnings("deprecation") // ReplayProcessor will be removed in 3.5.
 			final ReplayProcessor<T> original = ReplayProcessor.create(historySize);
 			return wrapMany(original);
 		}
 
 		@Override
 		public <T> Many<T> limit(Duration maxAge) {
-			@SuppressWarnings("deprecation")
+			@SuppressWarnings("deprecation") // ReplayProcessor will be removed in 3.5.
 			final ReplayProcessor<T> original = ReplayProcessor.createTimeout(maxAge);
 			return wrapMany(original);
 		}
 
 		@Override
 		public <T> Many<T> limit(Duration maxAge, Scheduler scheduler) {
-			@SuppressWarnings("deprecation")
+			@SuppressWarnings("deprecation") // ReplayProcessor will be removed in 3.5.
 			final ReplayProcessor<T> original = ReplayProcessor.createTimeout(maxAge, scheduler);
 			return wrapMany(original);
 		}
 
 		@Override
 		public <T> Many<T> limit(int historySize, Duration maxAge) {
-			@SuppressWarnings("deprecation")
+			@SuppressWarnings("deprecation") // ReplayProcessor will be removed in 3.5.
 			final ReplayProcessor<T> original = ReplayProcessor.createSizeAndTimeout(historySize, maxAge);
 			return wrapMany(original);
 		}
 
 		@Override
 		public <T> Many<T> limit(int historySize, Duration maxAge, Scheduler scheduler) {
-			@SuppressWarnings("deprecation")
+			@SuppressWarnings("deprecation") // ReplayProcessor will be removed in 3.5.
 			final ReplayProcessor<T> original = ReplayProcessor.createSizeAndTimeout(historySize, maxAge, scheduler);
 			return wrapMany(original);
 		}
@@ -226,21 +226,21 @@ final class SinksSpecs {
 
 		@Override
 		public <T> Many<T> onBackpressureBuffer() {
-			@SuppressWarnings("deprecation")
+			@SuppressWarnings("deprecation") // UnicastProcessor will be removed in 3.5.
 			final UnicastProcessor<T> original = UnicastProcessor.create();
 			return wrapMany(original);
 		}
 
 		@Override
 		public <T> Many<T> onBackpressureBuffer(Queue<T> queue) {
-			@SuppressWarnings("deprecation")
+			@SuppressWarnings("deprecation") // UnicastProcessor will be removed in 3.5.
 			final UnicastProcessor<T> original = UnicastProcessor.create(queue);
 			return wrapMany(original);
 		}
 
 		@Override
 		public <T> Many<T> onBackpressureBuffer(Queue<T> queue, Disposable endCallback) {
-			@SuppressWarnings("deprecation")
+			@SuppressWarnings("deprecation") // UnicastProcessor will be removed in 3.5.
 			final UnicastProcessor<T> original = UnicastProcessor.create(queue, endCallback);
 			return wrapMany(original);
 		}

--- a/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
@@ -51,6 +51,7 @@ import reactor.util.annotation.Nullable;
  * @author Stephane Maldini
  * @author Simon Baslé
  */
+// To be removed in 3.5
 final class ElasticScheduler implements Scheduler, Scannable {
 
 	static final AtomicLong COUNTER = new AtomicLong();

--- a/reactor-core/src/test/java/reactor/core/CurrentContextArchTest.java
+++ b/reactor-core/src/test/java/reactor/core/CurrentContextArchTest.java
@@ -36,6 +36,7 @@ public class CurrentContextArchTest {
 			.withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_JARS)
 			.importPackagesOf(CoreSubscriber.class);
 
+	// This is ok as this class tests the deprecated FluxProcessor. Will be removed with it in 3.5.
 	@SuppressWarnings("deprecation")
 	static JavaClasses FLUXPROCESSOR_CLASSES = new ClassFileImporter()
 			.withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
@@ -69,6 +70,7 @@ public class CurrentContextArchTest {
 	}
 
 	@Test
+	// This is ok as this class tests the deprecated FluxProcessor. Will be removed with it in 3.5.
 	@SuppressWarnings("deprecation")
 	public void fluxProcessorsShouldNotUseDefaultCurrentContext() {
 		classes()

--- a/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
@@ -268,7 +268,6 @@ public abstract class AbstractFluxConcatMapTest extends FluxOperatorTest<String,
 		    .verify(Duration.ofSeconds(5));
 	}
 
-	@SuppressWarnings("deprecation")
 	@Test
 	public void singleSubscriberOnlyBoundary() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();

--- a/reactor-core/src/test/java/reactor/core/publisher/DelegateProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/DelegateProcessorTest.java
@@ -24,6 +24,7 @@ import reactor.core.Scannable;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+// This is ok as this class tests the deprecated DelegateProcessor. Will be removed with it in 3.5.
 @SuppressWarnings("deprecation")
 public class DelegateProcessorTest {
 

--- a/reactor-core/src/test/java/reactor/core/publisher/DirectProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/DirectProcessorTest.java
@@ -27,6 +27,7 @@ import reactor.util.context.Context;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+// This is ok as this class tests the deprecated DirectProcessor. Will be removed with it in 3.5.
 @SuppressWarnings("deprecation")
 public class DirectProcessorTest {
 

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -60,6 +60,7 @@ import static reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST;
 /**
  * @author Stephane Maldini
  */
+// This is ok as this class tests the deprecated EmitterProcessor. Will be removed with it in 3.5.
 @SuppressWarnings("deprecation")
 public class EmitterProcessorTest {
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
@@ -31,9 +31,11 @@ import java.util.function.Supplier;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.core.publisher.FluxConcatMap.ErrorMode;
 import reactor.core.scheduler.Scheduler;
@@ -66,27 +68,7 @@ public class FluxMergeSequentialTest {
 		StepVerifier.create(Flux.range(1, 5)
 		                        .hide()
 		                        .flatMapSequential(t -> Flux.range(t, 2)))
-		            .expectNext(1, 2, 2, 3, 3, 4, 4, 5, 5, 6)
-		            .verifyComplete();
-	}
-
-	@Test
-	public void normalFusedSync() {
-		StepVerifier.create(Flux.range(1, 5)
-		                        .flatMapSequential(t -> Flux.range(t, 2)))
-		            .expectNext(1, 2, 2, 3, 3, 4, 4, 5, 5, 6)
-		            .verifyComplete();
-	}
-
-	@Test
-	@SuppressWarnings("deprecation")
-	public void normalFusedAsync() {
-		StepVerifier.create(Flux.range(1, 5)
-		                        //FIXME replace with a suitable construct that triggers ASYNC fusion
-		                        .subscribeWith(UnicastProcessor.create())
-		                        .flatMapSequential(t -> Flux.range(t, 2)))
-		            //TODO it seems even in 3.3.x it wasn't testing what we thought it was testing
-//		            .expectFusion(Fuseable.ASYNC)
+					.expectNoFusionSupport()
 		            .expectNext(1, 2, 2, 3, 3, 4, 4, 5, 5, 6)
 		            .verifyComplete();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxProcessorTest.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 
+// This is ok as this class tests the deprecated FluxProcessor. Will be removed with it in 3.5.
 @SuppressWarnings("deprecation")
 public class FluxProcessorTest {
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
@@ -1071,7 +1071,6 @@ public class FluxRetryWhenTest {
 		});
 	}
 
-	@SuppressWarnings("deprecation")
 	@Test
 	public void retryWhenThrowableCompanionIsComparableToRetryWhenRetryFromFunction() {
 		AtomicInteger sourceHelper = new AtomicInteger();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSourceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSourceTest.java
@@ -28,7 +28,6 @@ public class FluxSourceTest {
 
 	@Test
 	public void monoProcessor() {
-		@SuppressWarnings("deprecation")
 		NextProcessor<String> mp = new NextProcessor<>(null);
 		mp.onNext("test");
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFilterTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFilterTest.java
@@ -130,7 +130,7 @@ public class MonoFilterTest {
 	public void asyncFusion() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
 
-		@SuppressWarnings("deprecation") //TODO find a suitable source that can be async fused (MonoProcessor was never fuseable)
+		//TODO find a suitable source that can be async fused (MonoProcessor was never fuseable)
 		NextProcessor<Integer> up = new NextProcessor<>(null);
 
 		up.filter(v -> (v & 1) == 0)
@@ -147,7 +147,7 @@ public class MonoFilterTest {
 	public void asyncFusionBackpressured() {
 		AssertSubscriber<Object> ts = AssertSubscriber.create(1);
 
-		@SuppressWarnings("deprecation") //TODO find a suitable source that can be async fused (MonoProcessor was never fuseable)
+		//TODO find a suitable source that can be async fused (MonoProcessor was never fuseable)
 		NextProcessor<Integer> up = new NextProcessor<>(null);
 
 		Mono.just(1)

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPeekAfterTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPeekAfterTest.java
@@ -143,7 +143,7 @@ public class MonoPeekAfterTest {
 		AtomicBoolean completedEmpty = new AtomicBoolean();
 		AtomicReference<Throwable> error = new AtomicReference<>();
 
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // Because of doOnSuccessOrError, which will be removed in 3.5.0
 		Mono<Integer> mono = Flux
 				.range(1, 10)
 				.reduce((a, b) -> a + b)
@@ -171,7 +171,7 @@ public class MonoPeekAfterTest {
 		AtomicBoolean completedEmpty = new AtomicBoolean();
 		AtomicReference<Throwable> error = new AtomicReference<>();
 
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // Because of doOnSuccessOrError, which will be removed in 3.5.0
 		Mono<Integer> mono = Flux
 				.range(1, 10)
 				.reduce((a, b) -> a + b)
@@ -200,7 +200,7 @@ public class MonoPeekAfterTest {
 		AtomicBoolean completedEmpty = new AtomicBoolean();
 		AtomicReference<Throwable> error = new AtomicReference<>();
 
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // Because of doOnSuccessOrError, which will be removed in 3.5.0
 		Mono<Integer> mono = Flux
 				.range(1, 10)
 				.reduce((a, b) -> a + b)
@@ -227,7 +227,7 @@ public class MonoPeekAfterTest {
 		AtomicBoolean completedEmpty = new AtomicBoolean();
 		AtomicReference<Throwable> error = new AtomicReference<>();
 
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // Because of doOnSuccessOrError, which will be removed in 3.5.0
 		Mono<Integer> mono = Flux
 				.range(1, 10)
 				.reduce((a, b) -> a + b)
@@ -255,7 +255,7 @@ public class MonoPeekAfterTest {
 		AtomicBoolean completedEmpty = new AtomicBoolean();
 		AtomicReference<Throwable> error = new AtomicReference<>();
 
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // Because of doAfterSuccessOrError, which will be removed in 3.5.0
 		Mono<Integer> mono = Flux
 				.range(1, 10)
 				.reduce((a, b) -> a + b)
@@ -283,7 +283,7 @@ public class MonoPeekAfterTest {
 		AtomicBoolean completedEmpty = new AtomicBoolean();
 		AtomicReference<Throwable> error = new AtomicReference<>();
 
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // Because of doAfterSuccessOrError, which will be removed in 3.5.0
 		Mono<Integer> mono = Flux
 				.range(1, 10)
 				.reduce((a, b) -> a + b)
@@ -312,7 +312,7 @@ public class MonoPeekAfterTest {
 		AtomicBoolean completedEmpty = new AtomicBoolean();
 		AtomicReference<Throwable> error = new AtomicReference<>();
 
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // Because of doAfterSuccessOrError, which will be removed in 3.5.0
 		Mono<Integer> mono = Flux
 				.range(1, 10)
 				.reduce((a, b) -> a + b)
@@ -339,7 +339,7 @@ public class MonoPeekAfterTest {
 		AtomicBoolean completedEmpty = new AtomicBoolean();
 		AtomicReference<Throwable> error = new AtomicReference<>();
 
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // Because of doAfterSuccessOrError, which will be removed in 3.5.0
 		Mono<Integer> mono = Flux
 				.range(1, 10)
 				.reduce((a, b) -> a + b)
@@ -434,7 +434,7 @@ public class MonoPeekAfterTest {
 	@Test
 	public void onSuccessOrErrorCallbackFailureInterruptsOnNext() {
 		LongAdder invoked = new LongAdder();
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // Because of doOnSuccessOrError, which will be removed in 3.5.0
 		Mono<String> mono = Mono.just("foo")
 		                        .doOnSuccessOrError((v, t) -> {
 			                        invoked.increment();
@@ -454,7 +454,7 @@ public class MonoPeekAfterTest {
 		try {
 			LongAdder invoked = new LongAdder();
 			try {
-				@SuppressWarnings("deprecation")
+				@SuppressWarnings("deprecation") // Because of doAfterSuccessOrError, which will be removed in 3.5.0
 				Mono<String> mono = Mono.just("foo")
 				                        .doAfterSuccessOrError((v, t) -> {
 					                        invoked.increment();
@@ -490,7 +490,7 @@ public class MonoPeekAfterTest {
 		try {
 			LongAdder invoked = new LongAdder();
 			try {
-				@SuppressWarnings("deprecation")
+				@SuppressWarnings("deprecation") // Because of doAfterSuccessOrError, which will be removed in 3.5.0
 				Mono<String> mono = Mono.just("foo")
 				                        .doAfterSuccessOrError((v, t) -> {
 					                        invoked.increment();
@@ -541,7 +541,7 @@ public class MonoPeekAfterTest {
 
 		IllegalArgumentException err = new IllegalArgumentException("boom");
 
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // Because of doOnSuccessOrError, which will be removed in 3.5.0
 		Mono<String> test = Mono.<String>error(err)
 				.doOnSuccessOrError((v, t) -> {
 					invoked.increment();
@@ -565,7 +565,7 @@ public class MonoPeekAfterTest {
 
 		IllegalArgumentException err = new IllegalArgumentException("boom");
 
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // Because of doAfterSuccessOrError, which will be removed in 3.5.0
 		Mono<String> mono = Mono.<String>error(err).doAfterSuccessOrError((v, t) -> {
 			invoked.increment();
 			value.set(v);
@@ -618,7 +618,7 @@ public class MonoPeekAfterTest {
 		AtomicReference<String> value = new AtomicReference<>();
 		AtomicReference<Throwable> error = new AtomicReference<>();
 
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // Because of doOnSuccessOrError, which will be removed in 3.5.0
 		Mono<String> mono = Mono.<String>empty().doOnSuccessOrError((v, t) -> {
 			invoked.increment();
 			value.set(v);
@@ -640,7 +640,7 @@ public class MonoPeekAfterTest {
 		AtomicReference<String> value = new AtomicReference<>();
 		AtomicReference<Throwable> error = new AtomicReference<>();
 
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // Because of doAfterSuccessOrError, which will be removed in 3.5.0
 		Mono<String> mono = Mono.<String>empty()
 				.doAfterSuccessOrError((v, t) -> {
 					invoked.increment();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTest.java
@@ -37,7 +37,7 @@ public class MonoPeekTest {
 		Mono<String> mp = Mono.error(new Exception("test"));
 		AtomicReference<Throwable> ref = new AtomicReference<>();
 
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // Because of doOnSuccessOrError, which will be removed in 3.5.0
 		Mono<String> mono = mp.doOnSuccessOrError((s, f) -> ref.set(f));
 
 		mono.subscribe();
@@ -50,7 +50,7 @@ public class MonoPeekTest {
 		Mono<String> mp = Mono.just("test");
 		AtomicReference<String> ref = new AtomicReference<>();
 
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // Because of doOnSuccessOrError, which will be removed in 3.5.0
 		Mono<String> mono = mp.doOnSuccessOrError((s, f) -> ref.set(s));
 
 		mono.subscribe();

--- a/reactor-core/src/test/java/reactor/core/publisher/NextProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/NextProcessorTest.java
@@ -30,6 +30,7 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
 import reactor.core.Scannable;
 import reactor.test.LoggerUtils;
 import reactor.test.StepVerifier;
@@ -153,13 +154,14 @@ public class NextProcessorTest {
 		});
 	}
 
-	@SuppressWarnings("deprecation")
 	@Test
 	public void rejectedDoOnSuccessOrError() {
 		NextProcessor<String> mp = new NextProcessor<>(null);
 		AtomicReference<Throwable> ref = new AtomicReference<>();
 
-		mp.doOnSuccessOrError((s, f) -> ref.set(f)).subscribe(v -> {}, e -> {});
+		@SuppressWarnings("deprecation") // Because of doOnSuccessOrError, which will be removed in 3.5.0
+		Mono<String> mono = mp.doOnSuccessOrError((s, f) -> ref.set(f));
+		mono.subscribe(v -> {}, e -> {});
 		mp.onError(new Exception("test"));
 
 		assertThat(ref.get()).hasMessage("test");
@@ -193,13 +195,14 @@ public class NextProcessorTest {
 		assertThat(mp.isError()).isTrue();
 	}
 
-	@SuppressWarnings("deprecation")
 	@Test
 	public void successDoOnSuccessOrError() {
 		NextProcessor<String> mp = new NextProcessor<>(null);
 		AtomicReference<String> ref = new AtomicReference<>();
 
-		mp.doOnSuccessOrError((s, f) -> ref.set(s)).subscribe();
+		@SuppressWarnings("deprecation") // Because of doOnSuccessOrError, which will be removed in 3.5.0
+		Mono<String> mono = mp.doOnSuccessOrError((s, f) -> ref.set(s));
+		mono.subscribe();
 		mp.onNext("test");
 
 		assertThat(ref.get()).isEqualToIgnoringCase("test");

--- a/reactor-core/src/test/java/reactor/core/publisher/NextProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/NextProcessorTest.java
@@ -42,7 +42,6 @@ import reactor.util.function.Tuple2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-@SuppressWarnings("deprecation")
 public class NextProcessorTest {
 
 	@Test
@@ -116,7 +115,7 @@ public class NextProcessorTest {
 
 		assertThat(refFuture.get()).isNull();
 		assertThat(cycles).isNotZero()
-				.isPositive();
+		                  .isPositive();
 	}
 
 	@Test
@@ -330,7 +329,7 @@ public class NextProcessorTest {
 		mp.onNext(1);
 
 		NextProcessor<Integer> mp2 = mp.map(s -> s * 2)
-									   .cache()
+		                               .cache()
 		                               .subscribeWith(new NextProcessor<>(null));
 		mp2.subscribe();
 
@@ -505,8 +504,8 @@ public class NextProcessorTest {
 		NextProcessor<Integer> mp = new NextProcessor<>(null);
 		NextProcessor<Integer> mp2 = new NextProcessor<>(null);
 		StepVerifier.create(mp.filter(s -> {throw new RuntimeException("test"); })
-					.subscribeWith
-						(mp2))
+		                      .subscribeWith
+				                      (mp2))
 		            .then(() -> mp.onNext(2))
 		            .then(() -> assertThat(mp2.isError()).isTrue())
 		            .then(() -> assertThat(mp2.isSuccess()).isFalse())
@@ -523,8 +522,8 @@ public class NextProcessorTest {
 
 		StepVerifier.create(mp.doOnSuccess(s -> {throw new RuntimeException("test"); })
 		                      .doOnError(ref::set)
-					.subscribeWith
-						(mp2))
+		                      .subscribeWith
+				                      (mp2))
 		            .then(() -> mp.onNext(2))
 		            .then(() -> assertThat(mp2.isError()).isTrue())
 		            .then(() -> assertThat(ref.get()).hasMessage("test"))
@@ -549,8 +548,8 @@ public class NextProcessorTest {
 	public void monoNotCancelledByMonoProcessor() {
 		AtomicLong cancelCounter = new AtomicLong();
 		Mono.just("foo")
-			.doOnCancel(cancelCounter::incrementAndGet)
-			.subscribe();
+		    .doOnCancel(cancelCounter::incrementAndGet)
+		    .subscribe();
 
 		assertThat(cancelCounter).hasValue(0);
 	}
@@ -612,8 +611,8 @@ public class NextProcessorTest {
 	@SuppressWarnings("deprecated")
 	public void sharedMonoReusesInstance() {
 		Mono<String> sharedMono = Mono.just("foo")
-									  .hide()
-									  .share();
+		                              .hide()
+		                              .share();
 
 		assertThat(sharedMono)
 				.isSameAs(sharedMono.share())
@@ -678,7 +677,7 @@ public class NextProcessorTest {
 				                      .delayElement(Duration.ofMillis(500))
 				                      .share()
 				                      .block(Duration.ZERO))
-		        .withMessage("Timeout on Mono blocking read");
+				.withMessage("Timeout on Mono blocking read");
 
 		assertThat(Duration.ofNanos(System.nanoTime() - start))
 				.isLessThan(Duration.ofMillis(500));
@@ -714,7 +713,7 @@ public class NextProcessorTest {
 
 		NextProcessor.NextInner<String> test = new NextProcessor.NextInner<>(subscriber, processor);
 
-	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
+		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/ReplayProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ReplayProcessorTest.java
@@ -36,6 +36,7 @@ import reactor.test.util.TestLogger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+// This is ok as this class tests the deprecated ReplayProcessor. Will be removed with it in 3.5.
 @SuppressWarnings("deprecation")
 public class ReplayProcessorTest {
 

--- a/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/UnicastProcessorTest.java
@@ -46,6 +46,7 @@ import reactor.util.concurrent.Queues;
 import static org.assertj.core.api.Assertions.assertThat;
 import static reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST;
 
+// This is ok as this class tests the deprecated UnicastProcessor. Will be removed with it in 3.5.
 @SuppressWarnings("deprecation")
 public class UnicastProcessorTest {
 

--- a/reactor-core/src/test/java/reactor/core/publisher/tck/EmitterProcessorVerification.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/tck/EmitterProcessorVerification.java
@@ -27,7 +27,7 @@ import org.testng.SkipException;
 public class EmitterProcessorVerification extends AbstractProcessorVerification {
 
 	@Override
-	@SuppressWarnings("deprecation")
+	@SuppressWarnings("deprecation") // This is ok because this uses FluxProcessor and EmitterProcessor, to be removed in 3.5
 	public Processor<Long, Long> createIdentityProcessor(int bufferSize) {
 		reactor.core.publisher.FluxProcessor<Long, Long> p = reactor.core.publisher.EmitterProcessor.create(bufferSize);
 		return reactor.core.publisher.FluxProcessor.wrap(p, p.log("EmitterProcessorVerification", Level.FINE));

--- a/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Stephane Maldini
  * @author Simon Baslé
  */
-@SuppressWarnings("deprecation")
+@SuppressWarnings("deprecation") // This is because of #newElastic() calls, to be removed in 3.5. ElasticScheduler class would then also be removed.
 public class ElasticSchedulerTest extends AbstractSchedulerTest {
 
 	private static final Logger LOGGER = Loggers.getLogger(ElasticSchedulerTest.class);

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -59,7 +59,7 @@ public class SchedulersTest {
 
 	final static class TestSchedulers implements Schedulers.Factory {
 
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // to be removed with newElastic() in 3.5
 		final Scheduler elastic        = Schedulers.Factory.super.newElastic(60, Thread::new);
 		final Scheduler boundedElastic = Schedulers.Factory.super.newBoundedElastic(2, Integer.MAX_VALUE, Thread::new, 60);
 		final Scheduler single         = Schedulers.Factory.super.newSingle(Thread::new);

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -75,7 +75,7 @@ public class SchedulersTest {
 		}
 
 		@Override
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // to be removed with newElastic() in 3.5
 		public final Scheduler newElastic(int ttlSeconds, ThreadFactory threadFactory) {
 			assertThat(((ReactorThreadFactory)threadFactory).get()).isEqualTo("unused");
 			return elastic;
@@ -332,7 +332,7 @@ public class SchedulersTest {
 
 	@Test
 	public void elasticSchedulerDefaultBlockingOk() throws InterruptedException {
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // to be removed with newElastic() in 3.5
 		Scheduler scheduler = Schedulers.newElastic("elasticSchedulerDefaultNonBlocking");
 		CountDownLatch latch = new CountDownLatch(1);
 		AtomicReference<Throwable> errorRef = new AtomicReference<>();
@@ -540,7 +540,7 @@ public class SchedulersTest {
 		Schedulers.setFactory(ts);
 
 		assertThat(Schedulers.newSingle("unused")).isEqualTo(ts.single);
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // to be removed with newElastic() in 3.5
 		Scheduler elastic = Schedulers.newElastic("unused");
 		assertThat(elastic).isEqualTo(ts.elastic);
 		assertThat(Schedulers.newBoundedElastic(4, Integer.MAX_VALUE, "unused")).isEqualTo(ts.boundedElastic);
@@ -583,7 +583,7 @@ public class SchedulersTest {
 	@Test
 	public void shutdownNowClosesAllCachedSchedulers() {
 		Scheduler oldSingle = Schedulers.single();
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // to be removed with newElastic() in 3.5
 		Scheduler oldElastic = Schedulers.elastic();
 		Scheduler oldBoundedElastic = Schedulers.boundedElastic();
 		Scheduler oldParallel = Schedulers.parallel();
@@ -918,7 +918,7 @@ public class SchedulersTest {
 	@Test
 	@Timeout(5)
 	public void elasticSchedulerThreadCheck() throws Exception{
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // to be removed with newElastic() in 3.5
 		Scheduler s = Schedulers.newElastic("work");
 		try {
 			Scheduler.Worker w = s.createWorker();
@@ -1149,7 +1149,6 @@ public class SchedulersTest {
 	}
 
 	@Test
-	@SuppressWarnings("deprecation")
 	public void testDefaultMethods(){
 		EmptyScheduler s = new EmptyScheduler();
 
@@ -1181,8 +1180,10 @@ public class SchedulersTest {
 
 		};
 
+		@SuppressWarnings("deprecation") // to be removed in 3.5 alongside Schedulers.elastic()
+		Scheduler elastic = Schedulers.elastic();
 		//noop
-		Schedulers.elastic().dispose();
+		elastic.dispose();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/context/ContextTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextTest.java
@@ -535,7 +535,7 @@ public class ContextTest {
 		ContextView contextView = context;
 		Context receiver = Context.of("foo", "bar");
 
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // because of putAll(Context). This test method shall be removed in 3.5 alongside putAll(Context)
 		Context resultFromContext = receiver.putAll(context);
 		Context resultFromContextView = receiver.putAll(contextView);
 

--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -598,7 +598,6 @@ final class DefaultStepVerifierBuilder<T>
 	}
 
 	@Override
-	@SuppressWarnings("deprecation") //the API-level is deprecated to discourage direct use as first step
 	public DefaultStepVerifierBuilder<T> expectNoEvent(Duration duration) {
 		Objects.requireNonNull(duration, "duration");
 		if(this.script.size() == 1 && this.script.get(0) == defaultFirstStep){

--- a/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
+++ b/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
@@ -449,7 +449,7 @@ public class VirtualTimeScheduler implements Scheduler {
 		}
 
 		@Override
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // To be removed in 3.5.0
 		public Scheduler newElastic(int ttlSeconds, ThreadFactory threadFactory) {
 			return s;
 		}

--- a/reactor-test/src/test/java/reactor/test/scheduler/VirtualTimeSchedulerTests.java
+++ b/reactor-test/src/test/java/reactor/test/scheduler/VirtualTimeSchedulerTests.java
@@ -51,7 +51,7 @@ public class VirtualTimeSchedulerTests {
 	@Test
 	public void allEnabled() {
 		assertThat(Schedulers.newParallel("")).isNotInstanceOf(VirtualTimeScheduler.class);
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // To be removed in 3.5 alongside Schedulers.newElastic
 		Scheduler elastic1 = Schedulers.newElastic("");
 		assertThat(elastic1).isNotInstanceOf(VirtualTimeScheduler.class);
 		assertThat(Schedulers.newBoundedElastic(4, Integer.MAX_VALUE, "")).isNotInstanceOf(VirtualTimeScheduler.class);
@@ -60,7 +60,7 @@ public class VirtualTimeSchedulerTests {
 		VirtualTimeScheduler.getOrSet();
 
 		assertThat(Schedulers.newParallel("")).isInstanceOf(VirtualTimeScheduler.class);
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // To be removed in 3.5 alongside Schedulers.newElastic
 		Scheduler elastic2 = Schedulers.newElastic("");
 		assertThat(elastic2).isInstanceOf(VirtualTimeScheduler.class);
 		assertThat(Schedulers.newBoundedElastic(4, Integer.MAX_VALUE, "")).isInstanceOf(VirtualTimeScheduler.class);
@@ -69,7 +69,7 @@ public class VirtualTimeSchedulerTests {
 		VirtualTimeScheduler t = VirtualTimeScheduler.get();
 
 		assertThat(Schedulers.newParallel("")).isSameAs(t);
-		@SuppressWarnings("deprecation")
+		@SuppressWarnings("deprecation") // To be removed in 3.5 alongside Schedulers.newElastic
 		Scheduler elastic3 = Schedulers.newElastic("");
 		assertThat(elastic3).isSameAs(t);
 		assertThat(Schedulers.newBoundedElastic(5, Integer.MAX_VALUE, "")).isSameAs(t); //same even though different parameter


### PR DESCRIPTION
This PR touches every `@SuppressWarning("deprecation")` with the following ideas in mind:
- `NextProcessor` should not be marked as deprecated if it's here to stay (even though it __currently__ builds upon a deprecated class)
- every usage of `@SuppressWarning("deprecation")` that is sensible is commented with the reason why, including the text "removed in 3.5" that we should search for as soon as we start on 3.5 (will create an issue for that)
- did not touch `.kt` files. Same thing, may all go away as soon as we start on 3.5
- some tests were updated to use new constructs (namely `Sinks`)

