### PR TITLE
Fix hanging flux when there is a runtime exception

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
@@ -109,7 +109,7 @@ final class FluxHandleFuseable<T, R> extends InternalFluxOperator<T, R> implemen
 				handler.accept(t, this);
 			}
 			catch (Throwable e) {
-				Throwable e_ = Operators.onNextError(t, error, actual.currentContext(), s);
+				Throwable e_ = Operators.onNextError(t, e, actual.currentContext(), s);
 				if (e_ != null) {
 					onError(e_);
 					return true;


### PR DESCRIPTION
Fixes hanging flux when there is a runtime exception thrown inside of handle operator. I guess it was a copy paste error as for fusion version it does not uses thrown throwable at all.