### PR TITLE
fix #2498 Exception thrown in Flux.handle causes hanging in fused case

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
@@ -105,7 +105,7 @@ final class FluxHandleFuseable<T, R> extends FluxOperator<T, R> implements Fusea
 				handler.accept(t, this);
 			}
 			catch (Throwable e) {
-				Throwable e_ = Operators.onNextError(t, error, actual.currentContext(), s);
+				Throwable e_ = Operators.onNextError(t, e, actual.currentContext(), s);
 				if (e_ != null) {
 					onError(e_);
 					return true;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxHandleTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxHandleTest.java
@@ -16,6 +16,7 @@
 
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -39,6 +40,7 @@ import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static reactor.core.Fuseable.ASYNC;
 import static reactor.core.Fuseable.SYNC;
 
@@ -665,6 +667,18 @@ public class FluxHandleTest extends FluxOperatorTest<String, String> {
 		                                                    .hasMessage("Cannot emit after a complete or error"));
 	}
 
+    @Test
+    public void runtimeExceptionFused() {
+        // Check issue that for fuseable and Exception thrown inside handle it did not propagate signal -> hanging flux
+        //  and throws IllegalStateException: Timeout on blocking read
+        assertThatNullPointerException().isThrownBy(() -> {
+            Flux.range(0, 10)
+                .handle((v, sink) -> {
+                    throw new NullPointerException("boom");
+                })
+                .blockLast(Duration.ofSeconds(1));
+        }).withMessage("boom");
+    }
 
 	@Test
 	public void errorAfterCompleteFused() {


### PR DESCRIPTION
Fixes hanging flux when there is a runtime exception thrown inside of handle operator. I guess it was a copy paste error as for fusion version it does not uses thrown throwable at all.

Reopened #2497