### PR TITLE
fix #2502 Generate OSGI Bundle-Version from Europium+ scheme

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.util.VersionNumber
+
 /*
  * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
@@ -47,6 +49,20 @@ ext {
 		jdkJavadoc = "https://docs.oracle.com/en/java/javase/$jdk/docs/api/"
 	}
 	println "JDK Javadoc link for this build is ${rootProject.jdkJavadoc}"
+
+	versionNumber = VersionNumber.parse(version.toString())
+	if (versionNumber.qualifier == null || versionNumber.qualifier.size() == 0) {
+		osgiVersion = "${version}.RELEASE"
+		println "$version is a release, will use $osgiVersion for bnd"
+	}
+	else if (versionNumber.qualifier.equalsIgnoreCase("SNAPSHOT")) {
+		osgiVersion = "${versionNumber.major}.${versionNumber.minor}.${versionNumber.micro}.BUILD-SNAPSHOT"
+		println "$version is a snapshot, will use $osgiVersion for bnd"
+	}
+	else {
+		osgiVersion = "${versionNumber.major}.${versionNumber.minor}.${versionNumber.micro}.${versionNumber.qualifier}"
+		println "$version is neither release nor snapshot, will use $osgiVersion for bnd"
+	}
 
 	/*
 	 * Note that some versions can be bumped by a script.

--- a/build.gradle
+++ b/build.gradle
@@ -55,14 +55,13 @@ ext {
 		osgiVersion = "${version}.RELEASE"
 		println "$version is a release, will use $osgiVersion for bnd"
 	}
-	else if (!versionNumber.qualifier.equalsIgnoreCase("SNAPSHOT")) {
-		osgiVersion = "${versionNumber.major}.${versionNumber.minor}.${versionNumber.micro}.${versionNumber.qualifier}"
-		println "$version is neither release nor snapshot, will use $osgiVersion for bnd"
+	else if (versionNumber.qualifier.equalsIgnoreCase("SNAPSHOT")) {
 		osgiVersion = "${versionNumber.major}.${versionNumber.minor}.${versionNumber.micro}.BUILD-SNAPSHOT"
+		println "$version is a snapshot, will use $osgiVersion for bnd"
 	}
 	else {
-		osgiVersion = version
-		println "$version is a snapshot, will interpolate timestamp using bnd -snapshot BUILD-\${tstamp} flag"
+		osgiVersion = "${versionNumber.major}.${versionNumber.minor}.${versionNumber.micro}.${versionNumber.qualifier}"
+		println "$version is neither release nor snapshot, will use $osgiVersion for bnd"
 	}
 
 	/*

--- a/build.gradle
+++ b/build.gradle
@@ -55,13 +55,14 @@ ext {
 		osgiVersion = "${version}.RELEASE"
 		println "$version is a release, will use $osgiVersion for bnd"
 	}
-	else if (versionNumber.qualifier.equalsIgnoreCase("SNAPSHOT")) {
-		osgiVersion = "${versionNumber.major}.${versionNumber.minor}.${versionNumber.micro}.BUILD-SNAPSHOT"
-		println "$version is a snapshot, will use $osgiVersion for bnd"
-	}
-	else {
+	else if (!versionNumber.qualifier.equalsIgnoreCase("SNAPSHOT")) {
 		osgiVersion = "${versionNumber.major}.${versionNumber.minor}.${versionNumber.micro}.${versionNumber.qualifier}"
 		println "$version is neither release nor snapshot, will use $osgiVersion for bnd"
+		osgiVersion = "${versionNumber.major}.${versionNumber.minor}.${versionNumber.micro}.BUILD-SNAPSHOT"
+	}
+	else {
+		osgiVersion = version
+		println "$version is a snapshot, will interpolate timestamp using bnd -snapshot BUILD-\${tstamp} flag"
 	}
 
 	/*

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 import org.gradle.util.VersionNumber
 
+import java.text.SimpleDateFormat
+
 /*
  * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
@@ -56,7 +58,10 @@ ext {
 		println "$version is a release, will use $osgiVersion for bnd"
 	}
 	else if (versionNumber.qualifier.equalsIgnoreCase("SNAPSHOT")) {
-		osgiVersion = "${versionNumber.major}.${versionNumber.minor}.${versionNumber.micro}.BUILD-SNAPSHOT"
+		def sdf = new SimpleDateFormat("yyyyMMddHHmm");
+		sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+		def buildTimestamp = sdf.format(new Date())
+		osgiVersion = "${versionNumber.major}.${versionNumber.minor}.${versionNumber.micro}.BUILD-$buildTimestamp"
 		println "$version is a snapshot, will use $osgiVersion for bnd"
 	}
 	else {

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -51,8 +51,7 @@ ext {
 		].join(","),
 		"Bundle-Name" : "reactor-core",
 		"Bundle-SymbolicName" : "io.projectreactor.reactor-core",
-		"Bundle-Version" : "$osgiVersion",
-		"-snapshot" : 'BUILD-${tstamp}' //using bnd's own interpolation here
+		"Bundle-Version" : "$osgiVersion"
 	]
 }
 

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -50,7 +50,8 @@ ext {
 			"*"
 		].join(","),
 		"Bundle-Name" : "reactor-core",
-		"Bundle-SymbolicName" : "io.projectreactor.reactor-core"
+		"Bundle-SymbolicName" : "io.projectreactor.reactor-core",
+		"Bundle-Version" : "$osgiVersion"
 	]
 }
 

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -51,7 +51,8 @@ ext {
 		].join(","),
 		"Bundle-Name" : "reactor-core",
 		"Bundle-SymbolicName" : "io.projectreactor.reactor-core",
-		"Bundle-Version" : "$osgiVersion"
+		"Bundle-Version" : "$osgiVersion",
+		"-snapshot" : 'BUILD-${tstamp}' //using bnd's own interpolation here
 	]
 }
 

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -38,7 +38,7 @@ ext {
 		"Export-Package": [
 			"!*internal*",
 			"!reactor.blockhound*",
-			"reactor.*"
+			"reactor.*;version=$osgiVersion"
 		].join(","),
 		"Import-Package": [
 			"!javax.annotation",

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -24,7 +24,7 @@ ext {
 	bndOptions = [
 		"Export-Package": [
 			"!*internal*",
-			"reactor.test*;-noimport:=true"
+			"reactor.test*;version=$osgiVersion;-noimport:=true"
 		].join(","),
 		"Import-Package": [
 			"!javax.annotation",

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -32,8 +32,7 @@ ext {
 		].join(","),
 		"Bundle-Name" : "reactor-test",
 		"Bundle-SymbolicName" : "io.projectreactor.reactor-test",
-		"Bundle-Version" : "$osgiVersion",
-		"-snapshot" : '${tstamp}' //using bnd's own interpolation here
+		"Bundle-Version" : "$osgiVersion"
 	]
 }
 

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -31,7 +31,8 @@ ext {
 			"kotlin.*;resolution:=optional,*"
 		].join(","),
 		"Bundle-Name" : "reactor-test",
-		"Bundle-SymbolicName" : "io.projectreactor.reactor-test"
+		"Bundle-SymbolicName" : "io.projectreactor.reactor-test",
+		"Bundle-Version" : "$osgiVersion"
 	]
 }
 

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -32,7 +32,8 @@ ext {
 		].join(","),
 		"Bundle-Name" : "reactor-test",
 		"Bundle-SymbolicName" : "io.projectreactor.reactor-test",
-		"Bundle-Version" : "$osgiVersion"
+		"Bundle-Version" : "$osgiVersion",
+		"-snapshot" : '${tstamp}' //using bnd's own interpolation here
 	]
 }
 


### PR DESCRIPTION
This commit ensures that the OSGI Bundle-Version is consistently
comparable between snapshots, milestones and release versions using
the new versioning scheme introduced in Europium/2020.0, by forcing
a Bundle-Version similar to the old scheme for OSGI.

See reactor/reactor#689 for context.
