### PR TITLE
Avoid LoggerUtils.CapturingFactory nesting, reset capture logger after LoggersTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,6 @@ configure(subprojects) { p ->
 			events "FAILED"
 			showExceptions true
 			exceptionFormat "FULL"
-			stackTraceFilters "ENTRY_POINT"
 			maxGranularity -1
 		}
 
@@ -151,27 +150,6 @@ configure(subprojects) { p ->
 			if (last != td.getParent()) {
 				last = td.getParent()
 				println last
-			}
-		}
-
-		if (isCiServer) {
-			def stdout = new LinkedList<TestOutputEvent>()
-			beforeTest { TestDescriptor td ->
-				stdout.clear()
-			}
-			onOutput { TestDescriptor td, TestOutputEvent toe ->
-				stdout.add(toe)
-			}
-			afterTest { TestDescriptor td, TestResult tr ->
-				if (tr.resultType == TestResult.ResultType.FAILURE && stdout.size() > 0) {
-					def stdOutput = stdout.collect {
-						it.getDestination().name() == "StdErr"
-							? "STD_ERR: ${it.getMessage()}"
-							: "STD_OUT: ${it.getMessage()}"
-					}
-						.join()
-					println "This is the console output of the failing test below:\n$stdOutput"
-				}
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/util/Loggers.java
+++ b/reactor-core/src/main/java/reactor/util/Loggers.java
@@ -15,7 +15,6 @@
  */
 package reactor.util;
 
-import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.function.Function;
@@ -47,7 +46,7 @@ public abstract class Loggers {
 	 */
 	public static final String FALLBACK_PROPERTY = "reactor.logging.fallback";
 
-	private static LoggerFactory LOGGER_FACTORY;
+	private static Function<String, ? extends Logger> LOGGER_FACTORY;
 
 	static {
 		resetLoggerFactory();
@@ -100,9 +99,9 @@ public abstract class Loggers {
 	 * any particular clean-up.
 	 */
 	public static void useConsoleLoggers() {
-		String name = LoggerFactory.class.getName();
-		LoggerFactory loggerFactory = new ConsoleLoggerFactory(false);
-		loggerFactory.getLogger(name).debug("Using Console logging");
+		String name = Loggers.class.getName();
+		Function<String, Logger> loggerFactory = new ConsoleLoggerFactory(false);
+		loggerFactory.apply(name).debug("Using Console logging");
 		LOGGER_FACTORY = loggerFactory;
 	}
 
@@ -116,9 +115,9 @@ public abstract class Loggers {
 	 * any particular clean-up.
 	 */
 	public static void useVerboseConsoleLoggers() {
-		String name = LoggerFactory.class.getName();
-		LoggerFactory loggerFactory = new ConsoleLoggerFactory(true);
-		loggerFactory.getLogger(name).debug("Using Verbose Console logging");
+		String name = Loggers.class.getName();
+		Function<String, Logger> loggerFactory = new ConsoleLoggerFactory(true);
+		loggerFactory.apply(name).debug("Using Verbose Console logging");
 		LOGGER_FACTORY = loggerFactory;
 	}
 
@@ -133,9 +132,9 @@ public abstract class Loggers {
 	 * given a name.
 	 */
 	public static void useCustomLoggers(final Function<String, ? extends Logger> loggerFactory) {
-		String name = LoggerFactory.class.getName();
+		String name = Loggers.class.getName();
 		loggerFactory.apply(name).debug("Using custom logging");
-		LOGGER_FACTORY = loggerFactory::apply;
+		LOGGER_FACTORY = loggerFactory;
 	}
 
 	/**
@@ -146,9 +145,9 @@ public abstract class Loggers {
 	 * any particular clean-up.
 	 */
 	public static void useJdkLoggers() {
-		String name = LoggerFactory.class.getName();
-		LoggerFactory loggerFactory = new JdkLoggerFactory();
-		loggerFactory.getLogger(name).debug("Using JDK logging framework");
+		String name = Loggers.class.getName();
+		Function<String, Logger> loggerFactory = new JdkLoggerFactory();
+		loggerFactory.apply(name).debug("Using JDK logging framework");
 		LOGGER_FACTORY = loggerFactory;
 	}
 
@@ -161,9 +160,9 @@ public abstract class Loggers {
 	 * any particular clean-up.
 	 */
 	public static void useSl4jLoggers() {
-		String name = LoggerFactory.class.getName();
-		LoggerFactory loggerFactory = new Slf4JLoggerFactory();
-		loggerFactory.getLogger(name).debug("Using Slf4j logging framework");
+		String name = Loggers.class.getName();
+		Function<String, Logger> loggerFactory = new Slf4JLoggerFactory();
+		loggerFactory.apply(name).debug("Using Slf4j logging framework");
 		LOGGER_FACTORY = loggerFactory;
 	}
 
@@ -179,7 +178,7 @@ public abstract class Loggers {
 	 * @return a new {@link Logger} instance
 	 */
 	public static Logger getLogger(String name) {
-		return LOGGER_FACTORY.getLogger(name);
+		return LOGGER_FACTORY.apply(name);
 	}
 
 	/**
@@ -191,17 +190,13 @@ public abstract class Loggers {
 	 * @return a new {@link Logger} instance
 	 */
 	public static Logger getLogger(Class<?> cls) {
-		return LOGGER_FACTORY.getLogger(cls.getName());
+		return LOGGER_FACTORY.apply(cls.getName());
 	}
 
-	private interface LoggerFactory {
-		Logger getLogger(String name);
-	}
-
-	private static class Slf4JLoggerFactory implements LoggerFactory {
+	private static class Slf4JLoggerFactory implements Function<String, Logger> {
 
 		@Override
-		public Logger getLogger(String name) {
+		public Logger apply(String name) {
 			return new Slf4JLogger(org.slf4j.LoggerFactory.getLogger(name));
 		}
 	}
@@ -451,10 +446,10 @@ public abstract class Loggers {
 		}
 	}
 
-	private static class JdkLoggerFactory implements LoggerFactory {
+	private static class JdkLoggerFactory implements Function<String, Logger> {
 
 		@Override
-		public Logger getLogger(String name) {
+		public Logger apply(String name) {
 			return new JdkLogger(java.util.logging.Logger.getLogger(name));
 		}
 	}
@@ -623,7 +618,7 @@ public abstract class Loggers {
 		}
 	}
 
-	private static final class ConsoleLoggerFactory implements LoggerFactory {
+	private static final class ConsoleLoggerFactory implements Function<String, Logger> {
 
 		private static final HashMap<String, Logger> consoleLoggers = new HashMap<>();
 
@@ -634,7 +629,7 @@ public abstract class Loggers {
 		}
 
 		@Override
-		public Logger getLogger(String name) {
+		public Logger apply(String name) {
 			return consoleLoggers.computeIfAbsent(name, n -> new ConsoleLogger(n, verbose));
 		}
 	}

--- a/reactor-core/src/test/java/reactor/ReactorTestExecutionListener.java
+++ b/reactor-core/src/test/java/reactor/ReactorTestExecutionListener.java
@@ -27,6 +27,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.AssertionsUtils;
 import reactor.test.util.LoggerUtils;
 import reactor.util.Logger;
+import reactor.util.Loggers;
 
 /**
  * A custom TestExecutionListener that helps with tests in reactor:<ul>
@@ -58,6 +59,15 @@ public class ReactorTestExecutionListener implements TestExecutionListener {
 		// TODO capture non-default schedulers and shutdown them
 	}
 
+	/**
+	 * Reset the {@link Loggers} factory to defaults suitable for reactor-core tests.
+	 * Notably, it installs an indirection via {@link LoggerUtils#useCurrentLoggersWithCapture()}.
+	 */
+	public static void resetLoggersFactory() {
+		Loggers.resetLoggerFactory();
+		LoggerUtils.useCurrentLoggersWithCapture();
+	}
+
 	@Override
 	public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
 		resetHooksAndSchedulers();
@@ -66,6 +76,6 @@ public class ReactorTestExecutionListener implements TestExecutionListener {
 	@Override
 	public void testPlanExecutionStarted(TestPlan testPlan) {
 		AssertionsUtils.installAssertJTestRepresentation();
-		LoggerUtils.useCurrentLoggersWithCapture();
+		resetLoggersFactory();
 	}
 }

--- a/reactor-core/src/test/java/reactor/util/LoggersTest.java
+++ b/reactor-core/src/test/java/reactor/util/LoggersTest.java
@@ -16,14 +16,23 @@
 
 package reactor.util;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+
+import reactor.ReactorTestExecutionListener;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LoggersTest {
+class LoggersTest {
+
+	@AfterAll
+	static void resetLoggerFactory() {
+		//delegate to ReactorTestExecutionListener to centralize the logic
+		ReactorTestExecutionListener.resetLoggersFactory();
+	}
 
 	@Test
-	public void dontFallbackToJdk() throws Exception {
+	void dontFallbackToJdk() throws Exception {
 		String oldValue = System.getProperty(Loggers.FALLBACK_PROPERTY);
 
 		System.setProperty(Loggers.FALLBACK_PROPERTY, "something");
@@ -37,7 +46,7 @@ public class LoggersTest {
 	}
 
 	@Test
-	public void fallbackToJdk() throws Exception {
+	void fallbackToJdk() throws Exception {
 		String oldValue = System.getProperty(Loggers.FALLBACK_PROPERTY);
 
 		System.setProperty(Loggers.FALLBACK_PROPERTY, "JdK");
@@ -51,7 +60,7 @@ public class LoggersTest {
 	}
 
 	@Test
-	public void useConsoleLoggers() throws Exception {
+	void useConsoleLoggers() throws Exception {
 		try {
 			Loggers.useConsoleLoggers();
 			Logger l = Loggers.getLogger("test");
@@ -64,7 +73,7 @@ public class LoggersTest {
 	}
 
 	@Test
-	public void useVerboseConsoleLoggers() throws Exception {
+	void useVerboseConsoleLoggers() throws Exception {
 		try {
 			Loggers.useVerboseConsoleLoggers();
 			Logger l = Loggers.getLogger("test");
@@ -77,7 +86,7 @@ public class LoggersTest {
 	}
 
 	@Test
-	public void useJdkLoggers() throws Exception {
+	void useJdkLoggers() throws Exception {
 		try {
 			Loggers.useJdkLoggers();
 			Logger l = Loggers.getLogger("test");
@@ -90,7 +99,7 @@ public class LoggersTest {
 	}
 
 	@Test
-	public void useSl4jLoggers() throws Exception {
+	void useSl4jLoggers() throws Exception {
 		try {
 			Loggers.useSl4jLoggers();
 			Logger l = Loggers.getLogger("test");

--- a/reactor-test/src/main/java/reactor/test/util/LoggerUtils.java
+++ b/reactor-test/src/main/java/reactor/test/util/LoggerUtils.java
@@ -73,7 +73,7 @@ public final class LoggerUtils {
 			Field lfField = Loggers.class.getDeclaredField("LOGGER_FACTORY");
 			lfField.setAccessible(true);
 			orginalFactory = lfField.get(Loggers.class);
-			originalFactoryMethod = orginalFactory.getClass().getMethod("getLogger", String.class);
+			originalFactoryMethod = orginalFactory.getClass().getMethod("apply", String.class);
 			originalFactoryMethod.setAccessible(true);
 		}
 


### PR DESCRIPTION
This PR fixes failing tests on CI that don't fail locally because the order of execution seems to be different in GHA. (Gradle/JUnit5 order of execution is non-deterministic anyway).

It also fixes a potential issue with `LoggerUtils` where continuous installation of the factory on top of itself could lead to `StackOverflowException`.