### PR TITLE
fix #2513 ReplayProcessor now correctly pass nanos to buffer, not ms

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -302,7 +302,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 			throw new IllegalArgumentException("size > 0 required but it was " + size);
 		}
 		return new ReplayProcessor<>(new FluxReplay.SizeAndTimeBoundReplayBuffer<>(size,
-				maxAge.toMillis(),
+				maxAge.toNanos(),
 				scheduler));
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
@@ -169,10 +169,17 @@ class SinksTest {
 	class MulticastReplayDuration {
 
 		final Duration            duration = Duration.ofMillis(1000);
-		final Sinks.Many<Integer> replaySink = Sinks.many().replay().limit(duration);
-		final Flux<Integer>       flux = replaySink.asFlux();
 		final int 				  event = 12;
+		Sinks.Many<Integer>       replaySink;
+		Flux<Integer>             flux;
 
+		@BeforeEach
+		void setup() {
+			replaySink = Sinks.many().replay().limit(duration);
+			flux = replaySink.asFlux();
+		}
+
+		// fixes: https://github.com/reactor/reactor-core/issues/2513
 		@Test
 		void lateSubscriberReceivesEventInRetentionTime() {
 			replaySink.emitNext(event, FAIL_FAST);
@@ -185,6 +192,7 @@ class SinksTest {
 					.verify(Duration.ofMillis(20));
 		}
 
+		// fixes: https://github.com/reactor/reactor-core/issues/2513
 		@Test
 		void lateSubscriberDoesntReceiveEventOutsideRetentionTime() {
 			replaySink.emitNext(event, FAIL_FAST);


### PR DESCRIPTION
Fixes ReplayProcessor factory method by passing nanos instead of millis to SizeAndTimeBoundReplayBuffer constructor. This results in proper behavior of Sinks.many().replay(Duration) which now respects the retention time properly