### PR TITLE
fix #2510 Rework asciidoctor integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,8 @@ buildscript {
 
 plugins {
 	id "com.github.johnrengelman.shadow" version "4.0.2"
-	id 'org.asciidoctor.convert' version '1.5.11'
+	id 'org.asciidoctor.jvm.convert' version '3.3.0' apply false
+	id 'org.asciidoctor.jvm.pdf' version '3.3.0' apply false
 	id "me.champeau.gradle.japicmp" version "0.2.6"
 	id "de.undercouch.download" version "3.4.3"
 	id "org.unbroken-dome.test-sets" version "3.0.0" apply false

--- a/docs/asciidoc/advancedFeatures.adoc
+++ b/docs/asciidoc/advancedFeatures.adoc
@@ -46,7 +46,7 @@ Flux.fromIterable(Arrays.asList("blue", "green", "orange", "purple"))
 
 The following image shows how the `transform` operator encapsulates flows:
 
-image::https://raw.githubusercontent.com/reactor/reactor-core/v3.0.7.RELEASE/src/docs/marble/gs-transform.png[Transform Operator : encapsulate flows]
+image::images/gs-transform.png[Transform Operator : encapsulate flows]
 
 The preceding example produces the following output:
 
@@ -95,7 +95,7 @@ composedFlux.subscribe(d -> System.out.println("Subscriber 2 to Composed MapAndF
 
 The following image shows how the `transformDeferred` operator works with per-subscriber transformations:
 
-image::https://raw.githubusercontent.com/reactor/reactor-core/v3.0.7.RELEASE/src/docs/marble/gs-compose.png[Compose Operator : Per Subscriber transformation]
+image::images/gs-compose.png[Compose Operator : Per Subscriber transformation]
 
 The preceding example produces the following output:
 
@@ -179,7 +179,7 @@ Subscriber 2: PURPLE
 
 The following image shows the replay behavior:
 
-image::https://raw.githubusercontent.com/reactor/reactor-core/v3.0.7.RELEASE/src/docs/marble/gs-cold.png[Replaying behavior]
+image::images/gs-cold.png[Replaying behavior]
 
 Both subscribers catch all four colors, because each subscriber causes the
 process defined by the operators on the `Flux` to run.
@@ -222,7 +222,7 @@ Subscriber 2 to Hot Source: PURPLE
 
 The following image shows how a subscription is broadcast:
 
-image::https://raw.githubusercontent.com/reactor/reactor-core/v3.0.7.RELEASE/src/docs/marble/gs-hot.png[Broadcasting a subscription]
+image::images/gs-hot.png[Broadcasting a subscription]
 
 Subscriber 1 catches all four colors. Subscriber 2, having been created after the first
 two colors were produced, catches only the last two colors. This difference accounts for

--- a/docs/asciidoc/coreFeatures.adoc
+++ b/docs/asciidoc/coreFeatures.adoc
@@ -25,7 +25,7 @@ relevant type. For instance, the `count` operator exists in `Flux`, but it retur
 
 The following image shows how a `Flux` transforms items:
 
-image::https://raw.githubusercontent.com/reactor/reactor-core/v3.0.7.RELEASE/src/docs/marble/flux.png[Flux]
+image::images/flux.svg[Flux]
 
 A `Flux<T>` is a standard `Publisher<T>` that represents an asynchronous sequence of 0 to N
 emitted items, optionally terminated by either a completion signal or an error.
@@ -44,7 +44,7 @@ produces a `Flux<Long>` that is infinite and emits regular ticks from a clock.
 
 The following image shows how a `Mono` transforms an item:
 
-image::https://raw.githubusercontent.com/reactor/reactor-core/v3.4.0/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mono.svg[Mono]
+image::images/mono.svg[Mono]
 
 A `Mono<T>` is a specialized `Publisher<T>` that emits at most one item _via_ the
 `onNext` signal then terminates with an `onComplete` signal (successful `Mono`,
@@ -201,9 +201,9 @@ immediate scheduling, and so on).
 The https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Schedulers.html[`Schedulers`]
 class has static methods that give access to the following execution contexts:
 
- * No execution context (`Schedulers.immediate()`): at processing time, the submitted `Runnable`
+* No execution context (`Schedulers.immediate()`): at processing time, the submitted `Runnable`
 will be directly executed, effectively running them on the current `Thread` (can be seen as a "null object" or no-op `Scheduler`).
- * A single, reusable thread (`Schedulers.single()`). Note that this method reuses the
+* A single, reusable thread (`Schedulers.single()`). Note that this method reuses the
 same thread for all callers, until the Scheduler is disposed. If you want a per-call
 dedicated thread, use `Schedulers.newSingle()` for each call.
 * An unbounded elastic thread pool (`Schedulers.elastic()`). This one is no longer preferred

--- a/docs/asciidoc/images/flux.svg
+++ b/docs/asciidoc/images/flux.svg
@@ -1,0 +1,1 @@
+../../../reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/flux.svg

--- a/docs/asciidoc/images/mono.svg
+++ b/docs/asciidoc/images/mono.svg
@@ -1,0 +1,1 @@
+../../../reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mono.svg

--- a/gradle/asciidoc.gradle
+++ b/gradle/asciidoc.gradle
@@ -13,64 +13,69 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 configure(rootProject) {
-	apply plugin: 'org.asciidoctor.convert'
+	repositories {
+		jcenter()
+	}
+
+	apply plugin: 'org.asciidoctor.jvm.convert'
+	apply plugin: 'org.asciidoctor.jvm.pdf'
+
+	// This configuration applies both to the asciidoctor & asciidoctorPdf tasks
+	asciidoctorj {
+		options = [doctype: 'book']
+		attributes 'allow-uri-read': '',
+				'attribute-missing': 'warn',
+				'project-version': "${project.version}",
+				'reactorReleaseTrain': "${bomVersion}"
+	}
 
 	asciidoctor {
-		inputs.dir("docs/asciidoc/")
-			.withPropertyName("asciidocFiles")
-			.withPathSensitivity(PathSensitivity.RELATIVE)
-
-		if (isCiServer || !rootProject.version.toString().endsWith(".BUILD-SNAPSHOT")) {
-			backends = ["html5", "pdf"]
-		}
-		else {
-			backends = ["html5"]
-		}
-
-		sourceDir "$rootDir/docs/asciidoc/"
+		sourceDir "docs/asciidoc/"
 		sources {
 			include "index.asciidoc"
 		}
+		baseDirFollowsSourceDir()
 		resources {
 			from(sourceDir) {
 				include 'images/**'
 				include 'highlight/**/*'
 			}
+
 		}
-		outputDir file("$buildDir/docs/asciidoc")
+		outputDir file("$buildDir/docs/asciidoc/html")
 		logDocuments = true
-		options = [
-			doctype: 'book'
-		]
-		attributes 'allow-uri-read': '',
-			reactorReleaseTrain: "$bomVersion",
-			imagesdir: "images/",
-			stylesdir: "stylesheets/",
-			stylesheet: 'reactor.css',
-			'source-highlighter': 'highlightjs',
-			'highlightjsdir': "./highlight",
-			'highlightjs-theme': 'railscasts'
+		attributes stylesdir: "stylesheets/",
+				stylesheet: 'reactor.css',
+				'source-highlighter': 'highlightjs',
+				'highlightjsdir': "./highlight",
+				'highlightjs-theme': 'railscasts'
 	}
 
-	dependencies {
-		asciidoctor 'org.jruby:jruby-complete:9.2.5.0'
-		asciidoctor 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16'
+	asciidoctorPdf {
+		onlyIf { isCiServer || !rootProject.version.toString().endsWith("-SNAPSHOT") }
+		sourceDir "docs/asciidoc/"
+		sources {
+			include "index.asciidoc"
+		}
+		baseDirFollowsSourceDir()
+		outputDir file("$buildDir/docs/asciidoc/pdf")
+		logDocuments = true
+		attributes 'source-highlighter': 'rouge'
 	}
 
-	task docsZip(type: Zip, dependsOn: asciidoctor) {
+	task docsZip(type: Zip, dependsOn: [asciidoctor, asciidoctorPdf]) {
 		archiveBaseName.set("reactor-core")
 		archiveClassifier.set('docs')
 		afterEvaluate() {
-			//we copy the pdf late, when a potential customVersion has been applied to rootProject
-			from("$buildDir/docs/asciidoc/pdf/index.pdf") {
+			//we configure the pdf copy late, when a potential customVersion has been applied to rootProject
+			from(asciidoctorPdf) {
 				into ("docs/")
 				rename("index.pdf", "reactor-core-reference-guide-${rootProject.version}.pdf")
 			}
 		}
-		from("$buildDir/docs/asciidoc/html5/index.html") { into("docs/") }
-		from("$buildDir/docs/asciidoc/html5/images") { into("docs/images/") }
-		from("$buildDir/docs/asciidoc/html5/highlight") { into("docs/highlight/") }
+		from(asciidoctor) { into("docs/") }
 	}
 }
 


### PR DESCRIPTION
* upgrade to current, new generation of plugin
* fix images to use local versions instead of online
* fix way images are referenced, allows inline view even when a single
  file is rendered in IDE and unaware of attributes
* fix missing project version attribute
* add syntax highlighting in pdf with rouge