### PR TITLE
Mono.tag and Flux.tag accepts set of tags

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -8460,6 +8460,26 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	}
 
 	/**
+	 * Tag this flux with a key/value pairs. These can be retrieved as a {@link Set} of
+	 * all tags throughout the publisher chain by using {@link Scannable#tags()} (as
+	 * traversed
+	 * by {@link Scannable#parents()}).
+	 * <p>
+	 * Note that some monitoring systems like Prometheus require to have the exact same set of
+	 * tags for each meter bearing the same name.
+	 *
+	 * @param tags are key value pairs
+	 *
+	 * @return the same sequence, but bearing tags
+	 *
+	 *@see #name(String)
+	 *@see #metrics()
+	 */
+	public final Flux<T> tag(Set<Tuple2<String, String>> tags) {
+		return FluxName.createOrAppend(this, tags);
+	}
+
+	/**
 	 * Take only the first N values from this {@link Flux}, if available.
 	 * <p>
 	 * If N is zero, the resulting {@link Flux} completes as soon as this {@link Flux}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxName.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxName.java
@@ -69,6 +69,13 @@ final class FluxName<T> extends InternalFluxOperator<T, T> {
 
 		Set<Tuple2<String, String>> tags = Collections.singleton(Tuples.of(tagName, tagValue));
 
+		return createOrAppend(source, tags);
+	}
+
+	@SuppressWarnings("unchecked")
+	static <T> Flux<T> createOrAppend(Flux<T> source, Set<Tuple2<String, String>> tags) {
+		Objects.requireNonNull(tags, "tags");
+
 		if (source instanceof FluxName) {
 			FluxName<T> s = (FluxName<T>) source;
 			if(s.tags != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -4165,6 +4165,26 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	}
 
 	/**
+	 * Tag this mono with a key/value pairs. These can be retrieved as a {@link Set} of
+	 * all tags throughout the publisher chain by using {@link Scannable#tags()} (as
+	 * traversed
+	 * by {@link Scannable#parents()}).
+	 * <p>
+	 * Note that some monitoring systems like Prometheus require to have the exact same set of
+	 * tags for each meter bearing the same name.
+	 *
+	 * @param tags are key value pairs
+	 *
+	 * @return the same sequence, but bearing tags
+	 *
+	 * @see #name(String)
+	 * @see #metrics()
+	 */
+	public final Mono<T> tag(Set<Tuple2<String, String>> tags) {
+		return MonoName.createOrAppend(this, tags);
+	}
+
+	/**
 	 * Give this Mono a chance to resolve within a specified time frame but complete if it
 	 * doesn't. This works a bit like {@link #timeout(Duration)} except that the resulting
 	 * {@link Mono} completes rather than errors when the timer expires.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoName.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoName.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -64,6 +65,13 @@ final class MonoName<T> extends InternalMonoOperator<T, T> {
 		Objects.requireNonNull(tagValue, "tagValue");
 
 		Set<Tuple2<String, String>> tags = Collections.singleton(Tuples.of(tagName, tagValue));
+
+		return createOrAppend(source, tags);
+	}
+
+	@SuppressWarnings("unchecked")
+	static <T> Mono<T> createOrAppend(Mono<T> source, Set<Tuple2<String, String>> tags) {
+		Objects.requireNonNull(tags, "tags");
 
 		if (source instanceof MonoName) {
 			MonoName<T> s = (MonoName<T>) source;

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoMetricsFuseableTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoMetricsFuseableTest.java
@@ -17,8 +17,12 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
@@ -42,6 +46,8 @@ import reactor.core.publisher.MonoMetricsFuseable.MetricsFuseableSubscriber;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.Metrics;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -270,10 +276,16 @@ public class MonoMetricsFuseableTest {
 
 	@Test
 	public void usesTagsFuseable() {
+		Set<Tuple2<String, String>> tags = Stream.of(
+				Tuples.of("tag3", "B"),
+				Tuples.of("tag4", "bar")
+		).collect(Collectors.toCollection(HashSet::new));
+
 		Mono<Integer> source = Mono.just(8)
 								   .name("usesTags")
 								   .tag("tag1", "A")
-		                           .tag("tag2", "foo");
+								   .tag("tag2", "foo")
+								   .tag(tags);
 
 		new MonoMetricsFuseable<>(source).block();
 
@@ -282,6 +294,8 @@ public class MonoMetricsFuseableTest {
 				.tags(Tags.of(TAG_ON_COMPLETE))
 				.tag("tag1", "A")
 				.tag("tag2", "foo")
+				.tag("tag3", "B")
+				.tag("tag4", "bar")
 				.timer();
 
 		assertThat(meter).isNotNull();

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoMetricsTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoMetricsTest.java
@@ -18,12 +18,14 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -39,6 +41,8 @@ import reactor.core.publisher.MonoMetrics.MetricsSubscriber;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.util.Metrics;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static reactor.core.publisher.FluxMetrics.*;
@@ -154,11 +158,17 @@ public class MonoMetricsTest {
 
 	@Test
 	public void usesTags() {
+		Set<Tuple2<String, String>> tags = Stream.of(
+				Tuples.of("tag3", "B"),
+				Tuples.of("tag4", "bar")
+		).collect(Collectors.toCollection(HashSet::new));
+
 		Mono<Integer> source = Mono.just(1)
 								   .name("usesTags")
 								   .tag("tag1", "A")
 								   .tag("tag2", "foo")
-		                           .hide();
+								   .tag(tags)
+								   .hide();
 
 		new MonoMetrics<>(source).block();
 
@@ -167,6 +177,8 @@ public class MonoMetricsTest {
 				.tags(Tags.of(TAG_ON_COMPLETE))
 				.tag("tag1", "A")
 				.tag("tag2", "foo")
+				.tag("tag3", "B")
+				.tag("tag4", "bar")
 				.timer();
 
 		assertThat(meter).isNotNull();


### PR DESCRIPTION
Suggesting to accept multiple tags in a single call.

In my use cases the set of tag is already available before building (or mapping) the mono. The current version requires to loop the tag set (which usually a `Map<String, String>`) and add the tags one by one. The proposed solution make this as a single step operation.

The implementation is just split the existing method into two parts and expose it to the `Mono` or the `Flux` classes.