### PR TITLE
fix #2519 Cancel propagation on empty collectXxx

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollect.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollect.java
@@ -170,6 +170,9 @@ final class MonoCollect<T, R> extends MonoFromFluxOperator<T, R>
 			R c;
 			synchronized (this) {
 				state = STATE.getAndSet(this, CANCELLED);
+				if (state != CANCELLED) {
+					s.cancel();
+				}
 				if (state <= HAS_REQUEST_NO_VALUE) {
 					c = container;
 					value = null;
@@ -180,7 +183,6 @@ final class MonoCollect<T, R> extends MonoFromFluxOperator<T, R>
 				}
 			}
 			if (c != null) {
-				s.cancel();
 				discard(c);
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
@@ -133,6 +133,9 @@ final class MonoCollectList<T> extends MonoFromFluxOperator<T, List<T>> implemen
 			List<T> l;
 			synchronized (this) {
 				state = STATE.getAndSet(this, CANCELLED);
+				if (state != CANCELLED) {
+					s.cancel();
+				}
 				if (state <= HAS_REQUEST_NO_VALUE) {
 					l = list;
 					value = null;
@@ -143,7 +146,6 @@ final class MonoCollectList<T> extends MonoFromFluxOperator<T, List<T>> implemen
 				}
 			}
 			if (l != null) {
-				s.cancel();
 				discard(l);
 			}
 		}


### PR DESCRIPTION
When fusion happens, the MonoCollect incorrecly skips cancel propagation.
Correctly call cancel() on the first pass, irrespective of internal
fusion state.