### PR TITLE
fix #2538 Let `TestLogger` be configured with static message

### DIFF
--- a/reactor-core/src/main/java/reactor/util/Logger.java
+++ b/reactor-core/src/main/java/reactor/util/Logger.java
@@ -65,6 +65,11 @@ public interface Logger {
 	void trace(String msg, Throwable t);
 
 	/**
+	 * Log a static message at the TRACE level.
+	 */
+	void trace();
+
+	/**
 	 * Is the logger instance enabled for the DEBUG level?
 	 *
 	 * @return True if this Logger is enabled for the DEBUG level,
@@ -101,6 +106,11 @@ public interface Logger {
 	 * @param t   the exception (throwable) to log
 	 */
 	void debug(String msg, Throwable t);
+
+	/**
+	 * Log a static message at the DEBUG level.
+	 */
+	void debug();
 
 	/**
 	 * Is the logger instance enabled for the INFO level?
@@ -141,6 +151,11 @@ public interface Logger {
 	void info(String msg, Throwable t);
 
 	/**
+	 * Log a static message at the INFO level.
+	 */
+	void info();
+
+	/**
 	 * Is the logger instance enabled for the WARN level?
 	 *
 	 * @return True if this Logger is enabled for the WARN level,
@@ -179,6 +194,11 @@ public interface Logger {
 	void warn(String msg, Throwable t);
 
 	/**
+	 * Log a static message at the WARN level.
+	 */
+	void warn();
+
+	/**
 	 * Is the logger instance enabled for the ERROR level?
 	 *
 	 * @return True if this Logger is enabled for the ERROR level,
@@ -215,5 +235,10 @@ public interface Logger {
 	 * @param t   the exception (throwable) to log
 	 */
 	void error(String msg, Throwable t);
+
+	/**
+	 * Log a static message at the ERROR level.
+	 */
+	void error();
 
 }

--- a/reactor-core/src/main/java/reactor/util/Logger.java
+++ b/reactor-core/src/main/java/reactor/util/Logger.java
@@ -65,11 +65,6 @@ public interface Logger {
 	void trace(String msg, Throwable t);
 
 	/**
-	 * Log a static message at the TRACE level.
-	 */
-	void trace();
-
-	/**
 	 * Is the logger instance enabled for the DEBUG level?
 	 *
 	 * @return True if this Logger is enabled for the DEBUG level,
@@ -106,11 +101,6 @@ public interface Logger {
 	 * @param t   the exception (throwable) to log
 	 */
 	void debug(String msg, Throwable t);
-
-	/**
-	 * Log a static message at the DEBUG level.
-	 */
-	void debug();
 
 	/**
 	 * Is the logger instance enabled for the INFO level?
@@ -151,11 +141,6 @@ public interface Logger {
 	void info(String msg, Throwable t);
 
 	/**
-	 * Log a static message at the INFO level.
-	 */
-	void info();
-
-	/**
 	 * Is the logger instance enabled for the WARN level?
 	 *
 	 * @return True if this Logger is enabled for the WARN level,
@@ -194,11 +179,6 @@ public interface Logger {
 	void warn(String msg, Throwable t);
 
 	/**
-	 * Log a static message at the WARN level.
-	 */
-	void warn();
-
-	/**
 	 * Is the logger instance enabled for the ERROR level?
 	 *
 	 * @return True if this Logger is enabled for the ERROR level,
@@ -235,10 +215,5 @@ public interface Logger {
 	 * @param t   the exception (throwable) to log
 	 */
 	void error(String msg, Throwable t);
-
-	/**
-	 * Log a static message at the ERROR level.
-	 */
-	void error();
 
 }

--- a/reactor-test/src/main/java/reactor/test/util/TestLogger.java
+++ b/reactor-test/src/main/java/reactor/test/util/TestLogger.java
@@ -97,6 +97,11 @@ public class TestLogger implements Logger {
 	}
 
 	@Override
+	public synchronized void trace() {
+		this.log.format("[TRACE] Message\n");
+	}
+
+	@Override
 	public boolean isDebugEnabled() {
 		return true;
 	}
@@ -115,6 +120,11 @@ public class TestLogger implements Logger {
 	public synchronized void debug(String msg, Throwable t) {
 		this.log.format("[DEBUG] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
 		t.printStackTrace(this.log);
+	}
+
+	@Override
+	public synchronized void debug() {
+		this.log.format("[DEBUG] Message\n");
 	}
 
 	@Override
@@ -139,6 +149,11 @@ public class TestLogger implements Logger {
 	}
 
 	@Override
+	public synchronized void info() {
+		this.log.format("[ INFO] Message\n");
+	}
+
+	@Override
 	public boolean isWarnEnabled() {
 		return true;
 	}
@@ -160,6 +175,11 @@ public class TestLogger implements Logger {
 	}
 
 	@Override
+	public synchronized void warn() {
+		this.err.format("[ WARN] Message\n");
+	}
+
+	@Override
 	public boolean isErrorEnabled() {
 		return true;
 	}
@@ -178,5 +198,10 @@ public class TestLogger implements Logger {
 	public synchronized void error(String msg, Throwable t) {
 		this.err.format("[ERROR] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
 		t.printStackTrace(this.err);
+	}
+
+	@Override
+	public synchronized void error() {
+		this.err.format("[ERROR] Message\n");
 	}
 }

--- a/reactor-test/src/main/java/reactor/test/util/TestLogger.java
+++ b/reactor-test/src/main/java/reactor/test/util/TestLogger.java
@@ -96,7 +96,6 @@ public class TestLogger implements Logger {
 		t.printStackTrace(this.log);
 	}
 
-	@Override
 	public synchronized void trace() {
 		this.log.format("[TRACE] Message\n");
 	}
@@ -122,7 +121,6 @@ public class TestLogger implements Logger {
 		t.printStackTrace(this.log);
 	}
 
-	@Override
 	public synchronized void debug() {
 		this.log.format("[DEBUG] Message\n");
 	}
@@ -148,7 +146,6 @@ public class TestLogger implements Logger {
 		t.printStackTrace(this.log);
 	}
 
-	@Override
 	public synchronized void info() {
 		this.log.format("[ INFO] Message\n");
 	}
@@ -174,7 +171,6 @@ public class TestLogger implements Logger {
 		t.printStackTrace(this.err);
 	}
 
-	@Override
 	public synchronized void warn() {
 		this.err.format("[ WARN] Message\n");
 	}
@@ -200,7 +196,6 @@ public class TestLogger implements Logger {
 		t.printStackTrace(this.err);
 	}
 
-	@Override
 	public synchronized void error() {
 		this.err.format("[ERROR] Message\n");
 	}


### PR DESCRIPTION
Added an additional option for each log type which logs a static message.