### PR TITLE
fix #2542 metric tags are stored in map

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxName.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxName.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxName.java
@@ -17,7 +17,7 @@
 package reactor.core.publisher;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -71,7 +71,7 @@ final class FluxName<T> extends InternalFluxOperator<T, T> {
 		if (source instanceof FluxName) {
 			FluxName<T> s = (FluxName<T>) source;
 			if(s.tags != null) {
-				tags = new HashMap<>(s.tags);
+				tags = new LinkedHashMap<>(s.tags);
 				tags.put(tagName, tagValue);
 			}
 			return new FluxName<>(s.source, s.name, tags);
@@ -79,7 +79,7 @@ final class FluxName<T> extends InternalFluxOperator<T, T> {
 		if (source instanceof FluxNameFuseable) {
 			FluxNameFuseable<T> s = (FluxNameFuseable<T>) source;
 			if (s.tags != null) {
-				tags = new HashMap<>(s.tags);
+				tags = new LinkedHashMap<>(s.tags);
 				tags.put(tagName, tagValue);
 			}
 			return new FluxNameFuseable<>(s.source, s.name, tags);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxNameFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxNameFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxNameFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxNameFuseable.java
@@ -16,12 +16,12 @@
 
 package reactor.core.publisher;
 
-import java.util.Set;
+import java.util.Map;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.util.annotation.Nullable;
-import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
 import static reactor.core.Scannable.Attr.RUN_STYLE;
 import static reactor.core.Scannable.Attr.RunStyle.SYNC;
@@ -38,11 +38,11 @@ final class FluxNameFuseable<T> extends InternalFluxOperator<T, T> implements Fu
 
 	final String name;
 
-	final Set<Tuple2<String, String>> tags;
+	final Map<String, String> tags;
 
 	FluxNameFuseable(Flux<? extends T> source,
 			@Nullable String name,
-			@Nullable Set<Tuple2<String, String>> tags) {
+			@Nullable Map<String, String> tags) {
 		super(source);
 		this.name = name;
 		this.tags = tags;
@@ -61,7 +61,9 @@ final class FluxNameFuseable<T> extends InternalFluxOperator<T, T> implements Fu
 		}
 
 		if (key == Attr.TAGS && tags != null) {
-			return tags.stream();
+			return tags.entrySet()
+			           .stream()
+			           .map(entry -> Tuples.of(entry.getKey(), entry.getValue()));
 		}
 
 		if (key == RUN_STYLE) {
@@ -70,6 +72,4 @@ final class FluxNameFuseable<T> extends InternalFluxOperator<T, T> implements Fu
 
 		return super.scanUnsafe(key);
 	}
-
-
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoName.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoName.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoName.java
@@ -17,7 +17,7 @@
 package reactor.core.publisher;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -67,7 +67,7 @@ final class MonoName<T> extends InternalMonoOperator<T, T> {
 		if (source instanceof MonoName) {
 			MonoName<T> s = (MonoName<T>) source;
 			if(s.tags != null) {
-				tags = new HashMap<>(s.tags);
+				tags = new LinkedHashMap<>(s.tags);
 				tags.put(tagName, tagValue);
 			}
 			return new MonoName<>(s.source, s.name, tags);
@@ -75,7 +75,7 @@ final class MonoName<T> extends InternalMonoOperator<T, T> {
 		if (source instanceof MonoNameFuseable) {
 			MonoNameFuseable<T> s = (MonoNameFuseable<T>) source;
 			if (s.tags != null) {
-				tags = new HashMap<>(s.tags);
+				tags = new LinkedHashMap<>(s.tags);
 				tags.put(tagName, tagValue);
 			}
 			return new MonoNameFuseable<>(s.source, s.name, tags);

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoNameFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoNameFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoNameFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoNameFuseable.java
@@ -16,12 +16,12 @@
 
 package reactor.core.publisher;
 
-import java.util.Set;
+import java.util.Map;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.util.annotation.Nullable;
-import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
 import static reactor.core.Scannable.Attr.RUN_STYLE;
 import static reactor.core.Scannable.Attr.RunStyle.SYNC;
@@ -37,11 +37,11 @@ final class MonoNameFuseable<T> extends InternalMonoOperator<T, T> implements Fu
 
 	final String name;
 
-	final Set<Tuple2<String, String>> tags;
+	final Map<String, String> tags;
 
 	MonoNameFuseable(Mono<? extends T> source,
 			@Nullable String name,
-			@Nullable Set<Tuple2<String, String>> tags) {
+			@Nullable Map<String, String> tags) {
 		super(source);
 		this.name = name;
 		this.tags = tags;
@@ -60,7 +60,9 @@ final class MonoNameFuseable<T> extends InternalMonoOperator<T, T> implements Fu
 		}
 
 		if (key == Attr.TAGS && tags != null) {
-			return tags.stream();
+			return tags.entrySet()
+			           .stream()
+			           .map(entry -> Tuples.of(entry.getKey(), entry.getValue()));
 		}
 
 		if (key == RUN_STYLE) {
@@ -69,6 +71,4 @@ final class MonoNameFuseable<T> extends InternalMonoOperator<T, T> implements Fu
 
 		return super.scanUnsafe(key);
 	}
-
-
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxName.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxName.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxName.java
@@ -17,7 +17,7 @@
 package reactor.core.publisher;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -64,7 +64,7 @@ final class ParallelFluxName<T> extends ParallelFlux<T> implements Scannable{
 		if (source instanceof ParallelFluxName) {
 			ParallelFluxName<T> s = (ParallelFluxName<T>) source;
 			if(s.tags != null) {
-				tags = new HashMap<>(s.tags);
+				tags = new LinkedHashMap<>(s.tags);
 				tags.put(tagName, tagValue);
 			}
 			return new ParallelFluxName<>(s.source, s.name, tags);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxNameFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxNameFuseableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxNameFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxNameFuseableTest.java
@@ -16,10 +16,8 @@
 
 package reactor.core.publisher;
 
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -35,7 +33,7 @@ public class FluxNameFuseableTest {
 	public void scanOperator() throws Exception {
 		Tuple2<String, String> tag1 = Tuples.of("foo", "oof");
 		Tuple2<String, String> tag2 = Tuples.of("bar", "rab");
-		Map<String, String> tags = new HashMap<String, String>() {{
+		Map<String, String> tags = new LinkedHashMap<String, String>() {{
 			put(tag1.getT1(), tag1.getT2());
 			put(tag2.getT1(), tag2.getT2());
 		}};

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxNameFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxNameFuseableTest.java
@@ -16,7 +16,9 @@
 
 package reactor.core.publisher;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -33,9 +35,10 @@ public class FluxNameFuseableTest {
 	public void scanOperator() throws Exception {
 		Tuple2<String, String> tag1 = Tuples.of("foo", "oof");
 		Tuple2<String, String> tag2 = Tuples.of("bar", "rab");
-		Set<Tuple2<String, String>> tags = new HashSet<>();
-		tags.add(tag1);
-		tags.add(tag2);
+		Map<String, String> tags = new HashMap<String, String>() {{
+			put(tag1.getT1(), tag1.getT2());
+			put(tag2.getT1(), tag2.getT2());
+		}};
 
 		Flux<Integer> source = Flux.range(1, 4).map(i -> i);
 		FluxNameFuseable<Integer> test = new FluxNameFuseable<>(source, "foo", tags);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxNameTest.java
@@ -16,7 +16,9 @@
 
 package reactor.core.publisher;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -33,9 +35,10 @@ public class FluxNameTest {
 	public void scanOperator() throws Exception {
 		Tuple2<String, String> tag1 = Tuples.of("foo", "oof");
 		Tuple2<String, String> tag2 = Tuples.of("bar", "rab");
-		Set<Tuple2<String, String>> tags = new HashSet<>();
-		tags.add(tag1);
-		tags.add(tag2);
+		Map<String, String> tags = new HashMap<String, String>() {{
+			put(tag1.getT1(), tag1.getT2());
+			put(tag2.getT1(), tag2.getT2());
+		}};
 
 		Flux<Integer> source = Flux.range(1, 4).map(i -> i);
 		FluxName<Integer> test = new FluxName<>(source, "foo", tags);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxNameTest.java
@@ -16,10 +16,8 @@
 
 package reactor.core.publisher;
 
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -35,7 +33,7 @@ public class FluxNameTest {
 	public void scanOperator() throws Exception {
 		Tuple2<String, String> tag1 = Tuples.of("foo", "oof");
 		Tuple2<String, String> tag2 = Tuples.of("bar", "rab");
-		Map<String, String> tags = new HashMap<String, String>() {{
+		Map<String, String> tags = new LinkedHashMap<String, String>() {{
 			put(tag1.getT1(), tag1.getT2());
 			put(tag2.getT1(), tag2.getT2());
 		}};

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNameFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNameFuseableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNameFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNameFuseableTest.java
@@ -16,7 +16,9 @@
 
 package reactor.core.publisher;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -33,9 +35,10 @@ public class MonoNameFuseableTest {
 	public void scanOperator() throws Exception {
 		Tuple2<String, String> tag1 = Tuples.of("foo", "oof");
 		Tuple2<String, String> tag2 = Tuples.of("bar", "rab");
-		Set<Tuple2<String, String>> tags = new HashSet<>();
-		tags.add(tag1);
-		tags.add(tag2);
+		Map<String, String> tags = new HashMap<String, String>() {{
+			put(tag1.getT1(), tag1.getT2());
+			put(tag2.getT1(), tag2.getT2());
+		}};
 
 		Mono<Integer> source = Mono.just(1).map(i -> i);
 		MonoNameFuseable<Integer> test = new MonoNameFuseable<>(source, "foo", tags);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNameFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNameFuseableTest.java
@@ -16,10 +16,8 @@
 
 package reactor.core.publisher;
 
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -35,7 +33,7 @@ public class MonoNameFuseableTest {
 	public void scanOperator() throws Exception {
 		Tuple2<String, String> tag1 = Tuples.of("foo", "oof");
 		Tuple2<String, String> tag2 = Tuples.of("bar", "rab");
-		Map<String, String> tags = new HashMap<String, String>() {{
+		Map<String, String> tags = new LinkedHashMap<String, String>() {{
 			put(tag1.getT1(), tag1.getT2());
 			put(tag2.getT1(), tag2.getT2());
 		}};

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNameTest.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -33,7 +33,7 @@ public class MonoNameTest {
 	public void scanOperator() throws Exception {
 		Tuple2<String, String> tag1 = Tuples.of("foo", "oof");
 		Tuple2<String, String> tag2 = Tuples.of("bar", "rab");
-		Map<String, String> tags = new HashMap<String, String>() {{
+		Map<String, String> tags = new LinkedHashMap<String, String>() {{
 			put(tag1.getT1(), tag1.getT2());
 			put(tag2.getT1(), tag2.getT2());
 		}};

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNameTest.java
@@ -16,8 +16,8 @@
 
 package reactor.core.publisher;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -33,9 +33,10 @@ public class MonoNameTest {
 	public void scanOperator() throws Exception {
 		Tuple2<String, String> tag1 = Tuples.of("foo", "oof");
 		Tuple2<String, String> tag2 = Tuples.of("bar", "rab");
-		Set<Tuple2<String, String>> tags = new HashSet<>();
-		tags.add(tag1);
-		tags.add(tag2);
+		Map<String, String> tags = new HashMap<String, String>() {{
+			put(tag1.getT1(), tag1.getT2());
+			put(tag2.getT1(), tag2.getT2());
+		}};
 
 		Mono<Integer> source = Mono.just(1).map(i -> i);
 		MonoName<Integer> test = new MonoName<>(source, "foo", tags);

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxNameTest.java
@@ -16,7 +16,9 @@
 
 package reactor.core.publisher;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -43,9 +45,10 @@ public class ParallelFluxNameTest {
 	public void scanOperator() throws Exception {
 		Tuple2<String, String> tag1 = Tuples.of("foo", "oof");
 		Tuple2<String, String> tag2 = Tuples.of("bar", "rab");
-		Set<Tuple2<String, String>> tags = new HashSet<>();
-		tags.add(tag1);
-		tags.add(tag2);
+		Map<String, String> tags = new HashMap<String, String>() {{
+			put(tag1.getT1(), tag1.getT2());
+			put(tag2.getT1(), tag2.getT2());
+		}};
 
 		ParallelFlux<Integer> source = Flux.range(1, 4).parallel(3);
 		ParallelFluxName<Integer> test = new ParallelFluxName<>(source, "foo", tags);

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxNameTest.java
@@ -16,10 +16,8 @@
 
 package reactor.core.publisher;
 
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -45,7 +43,7 @@ public class ParallelFluxNameTest {
 	public void scanOperator() throws Exception {
 		Tuple2<String, String> tag1 = Tuples.of("foo", "oof");
 		Tuple2<String, String> tag2 = Tuples.of("bar", "rab");
-		Map<String, String> tags = new HashMap<String, String>() {{
+		Map<String, String> tags = new LinkedHashMap<String, String>() {{
 			put(tag1.getT1(), tag1.getT2());
 			put(tag2.getT1(), tag2.getT2());
 		}};

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
@@ -45,6 +45,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.CorePublisher;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
+import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.AutoDisposingExtension;
@@ -1066,6 +1067,18 @@ public class ParallelFluxTest {
 				"onComplete() Hello!",
 				"onComplete() Hello!"
 		);
+	}
+
+	@Test
+	void overwritingTag() {
+		final ParallelFlux<Object> source = Flux.empty().parallel().tag("1", "one");
+		final ParallelFlux<Object> modified = source.tag("1", "ein");
+
+		assertThat(Scannable.from(source).scan(Scannable.Attr.TAGS).map(t -> t.getT1()+t.getT2()))
+				.containsExactly("1one");
+
+		assertThat(Scannable.from(modified).scan(Scannable.Attr.TAGS).map(t -> t.getT1()+t.getT2()))
+				.containsExactly("1ein");
 	}
 
 	private void tryToSleep(long value)

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxMetricsTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxMetricsTest.java
@@ -165,6 +165,19 @@ public class FluxMetricsTest {
 	}
 
 	@Test
+	void overwritingTag() {
+		final Flux<Object> source = Flux.empty().tag("1", "one");
+
+		final Flux<Object> modified = source.tag("1", "ein");
+
+		assertThat(Scannable.from(source).scan(Scannable.Attr.TAGS).map(t -> t.getT1()+t.getT2()))
+				.containsExactly("1one");
+
+		assertThat(Scannable.from(modified).scan(Scannable.Attr.TAGS).map(t -> t.getT1()+t.getT2()))
+				.containsExactly("1ein");
+	}
+
+	@Test
 	public void onNextTimerCounts() {
 		Flux<Integer> source = Flux.range(1, 123)
 		                           .hide();

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoMetricsTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoMetricsTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoMetricsTest.java
@@ -175,6 +175,19 @@ public class MonoMetricsTest {
 	}
 
 	@Test
+	void overwritingTag() {
+		final Mono<Object> source = Mono.empty().tag("1", "one");
+
+		final Mono<Object> modified = source.tag("1", "ein");
+
+		assertThat(Scannable.from(source).scan(Scannable.Attr.TAGS).map(t -> t.getT1()+t.getT2()))
+				.containsExactly("1one");
+
+		assertThat(Scannable.from(modified).scan(Scannable.Attr.TAGS).map(t -> t.getT1()+t.getT2()))
+				.containsExactly("1ein");
+	}
+
+	@Test
 	public void noOnNextTimer() {
 		Mono<Integer> source = Mono.just(1).hide();
 


### PR DESCRIPTION
Metric tags are stored in a `Map<String,String>` instead of `Set<Tuple2<String,String>>` to avoid duplicated keys.

I've also changed the `scanUnsafe()` return type to the `Map.Entry<String,String>`. Happy to change that back if that's necessary, but wanted to see if within the package itself there is no blocker to do this change.