### PR TITLE
fix #2538 Let `TestLogger` be configured with simplified format

### DIFF
--- a/reactor-core/src/main/java/reactor/util/Logger.java
+++ b/reactor-core/src/main/java/reactor/util/Logger.java
@@ -65,6 +65,11 @@ public interface Logger {
 	void trace(String msg, Throwable t);
 
 	/**
+	 * Log a static message at the TRACE level.
+	 */
+	void trace();
+
+	/**
 	 * Is the logger instance enabled for the DEBUG level?
 	 *
 	 * @return True if this Logger is enabled for the DEBUG level,
@@ -101,6 +106,11 @@ public interface Logger {
 	 * @param t   the exception (throwable) to log
 	 */
 	void debug(String msg, Throwable t);
+
+	/**
+	 * Log a static message at the DEBUG level.
+	 */
+	void debug();
 
 	/**
 	 * Is the logger instance enabled for the INFO level?
@@ -141,6 +151,11 @@ public interface Logger {
 	void info(String msg, Throwable t);
 
 	/**
+	 * Log a static message at the INFO level.
+	 */
+	void info();
+
+	/**
 	 * Is the logger instance enabled for the WARN level?
 	 *
 	 * @return True if this Logger is enabled for the WARN level,
@@ -179,6 +194,11 @@ public interface Logger {
 	void warn(String msg, Throwable t);
 
 	/**
+	 * Log a static message at the WARN level.
+	 */
+	void warn();
+
+	/**
 	 * Is the logger instance enabled for the ERROR level?
 	 *
 	 * @return True if this Logger is enabled for the ERROR level,
@@ -215,5 +235,10 @@ public interface Logger {
 	 * @param t   the exception (throwable) to log
 	 */
 	void error(String msg, Throwable t);
+
+	/**
+	 * Log a static message at the ERROR level.
+	 */
+	void error();
 
 }

--- a/reactor-core/src/main/java/reactor/util/Logger.java
+++ b/reactor-core/src/main/java/reactor/util/Logger.java
@@ -65,11 +65,6 @@ public interface Logger {
 	void trace(String msg, Throwable t);
 
 	/**
-	 * Log a static message at the TRACE level.
-	 */
-	void trace();
-
-	/**
 	 * Is the logger instance enabled for the DEBUG level?
 	 *
 	 * @return True if this Logger is enabled for the DEBUG level,
@@ -106,11 +101,6 @@ public interface Logger {
 	 * @param t   the exception (throwable) to log
 	 */
 	void debug(String msg, Throwable t);
-
-	/**
-	 * Log a static message at the DEBUG level.
-	 */
-	void debug();
 
 	/**
 	 * Is the logger instance enabled for the INFO level?
@@ -151,11 +141,6 @@ public interface Logger {
 	void info(String msg, Throwable t);
 
 	/**
-	 * Log a static message at the INFO level.
-	 */
-	void info();
-
-	/**
 	 * Is the logger instance enabled for the WARN level?
 	 *
 	 * @return True if this Logger is enabled for the WARN level,
@@ -194,11 +179,6 @@ public interface Logger {
 	void warn(String msg, Throwable t);
 
 	/**
-	 * Log a static message at the WARN level.
-	 */
-	void warn();
-
-	/**
 	 * Is the logger instance enabled for the ERROR level?
 	 *
 	 * @return True if this Logger is enabled for the ERROR level,
@@ -235,10 +215,5 @@ public interface Logger {
 	 * @param t   the exception (throwable) to log
 	 */
 	void error(String msg, Throwable t);
-
-	/**
-	 * Log a static message at the ERROR level.
-	 */
-	void error();
 
 }

--- a/reactor-test/src/main/java/reactor/test/util/TestLogger.java
+++ b/reactor-test/src/main/java/reactor/test/util/TestLogger.java
@@ -97,6 +97,11 @@ public class TestLogger implements Logger {
 	}
 
 	@Override
+	public synchronized void trace() {
+		this.log.format("[TRACE] Message\n");
+	}
+
+	@Override
 	public boolean isDebugEnabled() {
 		return true;
 	}
@@ -115,6 +120,11 @@ public class TestLogger implements Logger {
 	public synchronized void debug(String msg, Throwable t) {
 		this.log.format("[DEBUG] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
 		t.printStackTrace(this.log);
+	}
+
+	@Override
+	public synchronized void debug() {
+		this.log.format("[DEBUG] Message\n");
 	}
 
 	@Override
@@ -139,6 +149,11 @@ public class TestLogger implements Logger {
 	}
 
 	@Override
+	public synchronized void info() {
+		this.log.format("[ INFO] Message\n");
+	}
+
+	@Override
 	public boolean isWarnEnabled() {
 		return true;
 	}
@@ -160,6 +175,11 @@ public class TestLogger implements Logger {
 	}
 
 	@Override
+	public synchronized void warn() {
+		this.err.format("[ WARN] Message\n");
+	}
+
+	@Override
 	public boolean isErrorEnabled() {
 		return true;
 	}
@@ -178,5 +198,10 @@ public class TestLogger implements Logger {
 	public synchronized void error(String msg, Throwable t) {
 		this.err.format("[ERROR] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
 		t.printStackTrace(this.err);
+	}
+
+	@Override
+	public synchronized void error() {
+		this.err.format("[ERROR] Message\n");
 	}
 }

--- a/reactor-test/src/main/java/reactor/test/util/TestLogger.java
+++ b/reactor-test/src/main/java/reactor/test/util/TestLogger.java
@@ -96,6 +96,7 @@ public class TestLogger implements Logger {
 		t.printStackTrace(this.log);
 	}
 
+	@Override
 	public synchronized void trace() {
 		this.log.format("[TRACE] Message\n");
 	}
@@ -121,6 +122,7 @@ public class TestLogger implements Logger {
 		t.printStackTrace(this.log);
 	}
 
+	@Override
 	public synchronized void debug() {
 		this.log.format("[DEBUG] Message\n");
 	}
@@ -146,6 +148,7 @@ public class TestLogger implements Logger {
 		t.printStackTrace(this.log);
 	}
 
+	@Override
 	public synchronized void info() {
 		this.log.format("[ INFO] Message\n");
 	}
@@ -171,6 +174,7 @@ public class TestLogger implements Logger {
 		t.printStackTrace(this.err);
 	}
 
+	@Override
 	public synchronized void warn() {
 		this.err.format("[ WARN] Message\n");
 	}
@@ -196,6 +200,7 @@ public class TestLogger implements Logger {
 		t.printStackTrace(this.err);
 	}
 
+	@Override
 	public synchronized void error() {
 		this.err.format("[ERROR] Message\n");
 	}

--- a/reactor-test/src/main/java/reactor/test/util/TestLogger.java
+++ b/reactor-test/src/main/java/reactor/test/util/TestLogger.java
@@ -36,7 +36,7 @@ public class TestLogger implements Logger {
 	private final ByteArrayOutputStream logContent;
 	private final PrintStream err;
 	private final PrintStream log;
-	private boolean logCurrentThreadName;
+	private final boolean logCurrentThreadName;
 
 	public TestLogger() {
 		this.logContent = new ByteArrayOutputStream();
@@ -44,6 +44,14 @@ public class TestLogger implements Logger {
 		this.errContent = new ByteArrayOutputStream();
 		this.err = new PrintStream(errContent);
 		this.logCurrentThreadName = true;
+	}
+
+	public TestLogger(boolean logCurrentThreadName){
+		this.logContent = new ByteArrayOutputStream();
+		this.log = new PrintStream(logContent);
+		this.errContent = new ByteArrayOutputStream();
+		this.err = new PrintStream(errContent);
+		this.logCurrentThreadName = logCurrentThreadName;
 	}
 
 	@Override
@@ -85,29 +93,17 @@ public class TestLogger implements Logger {
 
 	@Override
 	public synchronized void trace(String msg) {
-		if(logCurrentThreadName){
-			this.log.format("[TRACE] (%s) %s\n", Thread.currentThread().getName(), msg);
-		} else {
-			this.log.format("[TRACE] %s\n", msg);
-		}
+		this.log.format(logContent("TRACE", msg));
 	}
 
 	@Override
 	public synchronized void trace(String format, Object... arguments) {
-		if(logCurrentThreadName){
-			this.log.format("[TRACE] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
-		} else {
-			this.log.format("[TRACE] %s\n", format(format, arguments));
-		}
+		this.log.format(logContent("TRACE", format(format, arguments)));
 	}
 	@Override
 	public synchronized void trace(String msg, Throwable t) {
-		if(logCurrentThreadName){
-			this.log.format("[TRACE] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
-		} else {
-			this.log.format("[TRACE] %s - %s\n", msg, t);
-		}
-		t.printStackTrace(this.log);
+		this.log.format(logContent("TRACE", String.format("%s - %s", msg, t)));
+		t.printStackTrace(this.err);
 	}
 
 	@Override
@@ -117,30 +113,18 @@ public class TestLogger implements Logger {
 
 	@Override
 	public synchronized void debug(String msg) {
-		if(logCurrentThreadName){
-			this.log.format("[DEBUG] (%s) %s\n", Thread.currentThread().getName(), msg);
-		} else {
-			this.log.format("[DEBUG] %s\n", msg);
-		}
+		this.log.format(logContent("DEBUG", msg));
 	}
 
 	@Override
 	public synchronized void debug(String format, Object... arguments) {
-		if(logCurrentThreadName){
-			this.log.format("[DEBUG] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
-		} else {
-			this.log.format("[DEBUG] %s\n", format(format, arguments));
-		}
+		this.log.format(logContent("DEBUG", format(format, arguments)));
 	}
 
 	@Override
 	public synchronized void debug(String msg, Throwable t) {
-		if(logCurrentThreadName){
-			this.log.format("[DEBUG] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
-		} else {
-			this.log.format("[DEBUG] %s - %s\n", msg, t);
-		}
-		t.printStackTrace(this.log);
+		this.log.format(logContent("DEBUG", String.format("%s - %s", msg, t)));
+		t.printStackTrace(this.err);
 	}
 
 	@Override
@@ -150,30 +134,18 @@ public class TestLogger implements Logger {
 
 	@Override
 	public synchronized void info(String msg) {
-		if(logCurrentThreadName){
-			this.log.format("[ INFO] (%s) %s\n", Thread.currentThread().getName(), msg);
-		} else {
-			this.log.format("[ INFO] %s\n", msg);
-		}
+		this.log.format(logContent("INFO", msg));
 	}
 
 	@Override
 	public synchronized void info(String format, Object... arguments) {
-		if(logCurrentThreadName){
-			this.log.format("[ INFO] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
-		} else {
-			this.log.format("[ INFO] %s\n", format(format, arguments));
-		}
+		this.log.format(logContent("INFO", format(format, arguments)));
 	}
 
 	@Override
 	public synchronized void info(String msg, Throwable t) {
-		if(logCurrentThreadName){
-			this.log.format("[ INFO] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
-		} else {
-			this.log.format("[ INFO] %s - %s\n", msg, t);
-		}
-		t.printStackTrace(this.log);
+		this.log.format(logContent("INFO", String.format("%s - %s", msg, t)));
+		t.printStackTrace(this.err);
 	}
 
 	@Override
@@ -183,29 +155,17 @@ public class TestLogger implements Logger {
 
 	@Override
 	public synchronized void warn(String msg) {
-		if(logCurrentThreadName){
-			this.err.format("[ WARN] (%s) %s\n", Thread.currentThread().getName(), msg);
-		} else {
-			this.err.format("[ WARN] %s\n", msg);
-		}
+		this.err.format(logContent("WARN", msg));
 	}
 
 	@Override
 	public synchronized void warn(String format, Object... arguments) {
-		if(logCurrentThreadName){
-			this.err.format("[ WARN] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
-		} else {
-			this.err.format("[ WARN] %s\n", format(format, arguments));
-		}
+		this.err.format(logContent("WARN", format(format, arguments)));
 	}
 
 	@Override
 	public synchronized void warn(String msg, Throwable t) {
-		if(logCurrentThreadName){
-			this.err.format("[ WARN] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
-		} else {
-			this.err.format("[ WARN] %s - %s\n", msg, t);
-		}
+		this.err.format(logContent("WARN", String.format("%s - %s", msg, t)));
 		t.printStackTrace(this.err);
 	}
 
@@ -216,37 +176,30 @@ public class TestLogger implements Logger {
 
 	@Override
 	public synchronized void error(String msg) {
-		if(logCurrentThreadName){
-			this.err.format("[ERROR] (%s) %s\n", Thread.currentThread().getName(), msg);
-		} else {
-			this.err.format("[ERROR] %s\n", msg);
-		}
+		this.err.format(logContent("ERROR", msg));
 	}
 
 	@Override
 	public synchronized void error(String format, Object... arguments) {
-		if(logCurrentThreadName){
-			this.err.format("[ERROR] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
-		} else {
-			this.err.format("[ERROR] %s\n", format(format, arguments));
-		}
+		this.err.format(logContent("ERROR", format(format, arguments)));
 	}
 
 	@Override
 	public synchronized void error(String msg, Throwable t) {
-		if(logCurrentThreadName){
-			this.err.format("[ERROR] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
-		} else {
-			this.err.format("[ERROR] %s - %s\n", msg, t);
-		}
+		this.err.format(logContent("ERROR", String.format("%s - %s", msg, t)));
 		t.printStackTrace(this.err);
+	}
+
+	String logContent(String logType, String msg){
+		if(logCurrentThreadName){
+			return String.format("[%s] (%s) %s\n", logType,
+					Thread.currentThread().getName(), msg);
+		} else {
+			return String.format("[%s] %s\n", logType, msg);
+		}
 	}
 
 	public boolean isLogCurrentThreadName() {
 		return logCurrentThreadName;
-	}
-
-	public void setLogCurrentThreadName(boolean logCurrentThreadName) {
-		this.logCurrentThreadName = logCurrentThreadName;
 	}
 }

--- a/reactor-test/src/main/java/reactor/test/util/TestLogger.java
+++ b/reactor-test/src/main/java/reactor/test/util/TestLogger.java
@@ -134,17 +134,17 @@ public class TestLogger implements Logger {
 
 	@Override
 	public synchronized void info(String msg) {
-		this.log.format(logContent("INFO", msg));
+		this.log.format(logContent(" INFO", msg));
 	}
 
 	@Override
 	public synchronized void info(String format, Object... arguments) {
-		this.log.format(logContent("INFO", format(format, arguments)));
+		this.log.format(logContent(" INFO", format(format, arguments)));
 	}
 
 	@Override
 	public synchronized void info(String msg, Throwable t) {
-		this.log.format(logContent("INFO", String.format("%s - %s", msg, t)));
+		this.log.format(logContent(" INFO", String.format("%s - %s", msg, t)));
 		t.printStackTrace(this.err);
 	}
 
@@ -155,17 +155,17 @@ public class TestLogger implements Logger {
 
 	@Override
 	public synchronized void warn(String msg) {
-		this.err.format(logContent("WARN", msg));
+		this.err.format(logContent(" WARN", msg));
 	}
 
 	@Override
 	public synchronized void warn(String format, Object... arguments) {
-		this.err.format(logContent("WARN", format(format, arguments)));
+		this.err.format(logContent(" WARN", format(format, arguments)));
 	}
 
 	@Override
 	public synchronized void warn(String msg, Throwable t) {
-		this.err.format(logContent("WARN", String.format("%s - %s", msg, t)));
+		this.err.format(logContent(" WARN", String.format("%s - %s", msg, t)));
 		t.printStackTrace(this.err);
 	}
 

--- a/reactor-test/src/main/java/reactor/test/util/TestLogger.java
+++ b/reactor-test/src/main/java/reactor/test/util/TestLogger.java
@@ -96,7 +96,6 @@ public class TestLogger implements Logger {
 		t.printStackTrace(this.log);
 	}
 
-	@Override
 	public synchronized void trace() {
 		this.log.format("[TRACE] Message\n");
 	}
@@ -122,7 +121,6 @@ public class TestLogger implements Logger {
 		t.printStackTrace(this.log);
 	}
 
-	@Override
 	public synchronized void debug() {
 		this.log.format("[DEBUG] Message\n");
 	}
@@ -148,7 +146,6 @@ public class TestLogger implements Logger {
 		t.printStackTrace(this.log);
 	}
 
-	@Override
 	public synchronized void info() {
 		this.log.format("[ INFO] Message\n");
 	}
@@ -174,7 +171,6 @@ public class TestLogger implements Logger {
 		t.printStackTrace(this.err);
 	}
 
-	@Override
 	public synchronized void warn() {
 		this.err.format("[ WARN] Message\n");
 	}
@@ -200,7 +196,6 @@ public class TestLogger implements Logger {
 		t.printStackTrace(this.err);
 	}
 
-	@Override
 	public synchronized void error() {
 		this.err.format("[ERROR] Message\n");
 	}

--- a/reactor-test/src/main/java/reactor/test/util/TestLogger.java
+++ b/reactor-test/src/main/java/reactor/test/util/TestLogger.java
@@ -36,12 +36,14 @@ public class TestLogger implements Logger {
 	private final ByteArrayOutputStream logContent;
 	private final PrintStream err;
 	private final PrintStream log;
+	private boolean logCurrentThreadName;
 
 	public TestLogger() {
 		this.logContent = new ByteArrayOutputStream();
 		this.log = new PrintStream(logContent);
 		this.errContent = new ByteArrayOutputStream();
 		this.err = new PrintStream(errContent);
+		this.logCurrentThreadName = true;
 	}
 
 	@Override
@@ -83,22 +85,29 @@ public class TestLogger implements Logger {
 
 	@Override
 	public synchronized void trace(String msg) {
-		this.log.format("[TRACE] (%s) %s\n", Thread.currentThread().getName(), msg);
+		if(logCurrentThreadName){
+			this.log.format("[TRACE] (%s) %s\n", Thread.currentThread().getName(), msg);
+		} else {
+			this.log.format("[TRACE] %s\n", msg);
+		}
 	}
 
 	@Override
 	public synchronized void trace(String format, Object... arguments) {
-		this.log.format("[TRACE] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
+		if(logCurrentThreadName){
+			this.log.format("[TRACE] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
+		} else {
+			this.log.format("[TRACE] %s\n", format(format, arguments));
+		}
 	}
 	@Override
 	public synchronized void trace(String msg, Throwable t) {
-		this.log.format("[TRACE] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
+		if(logCurrentThreadName){
+			this.log.format("[TRACE] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
+		} else {
+			this.log.format("[TRACE] %s - %s\n", msg, t);
+		}
 		t.printStackTrace(this.log);
-	}
-
-	@Override
-	public synchronized void trace() {
-		this.log.format("[TRACE] Message\n");
 	}
 
 	@Override
@@ -108,23 +117,30 @@ public class TestLogger implements Logger {
 
 	@Override
 	public synchronized void debug(String msg) {
-		this.log.format("[DEBUG] (%s) %s\n", Thread.currentThread().getName(), msg);
+		if(logCurrentThreadName){
+			this.log.format("[DEBUG] (%s) %s\n", Thread.currentThread().getName(), msg);
+		} else {
+			this.log.format("[DEBUG] %s\n", msg);
+		}
 	}
 
 	@Override
 	public synchronized void debug(String format, Object... arguments) {
-		this.log.format("[DEBUG] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
+		if(logCurrentThreadName){
+			this.log.format("[DEBUG] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
+		} else {
+			this.log.format("[DEBUG] %s\n", format(format, arguments));
+		}
 	}
 
 	@Override
 	public synchronized void debug(String msg, Throwable t) {
-		this.log.format("[DEBUG] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
+		if(logCurrentThreadName){
+			this.log.format("[DEBUG] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
+		} else {
+			this.log.format("[DEBUG] %s - %s\n", msg, t);
+		}
 		t.printStackTrace(this.log);
-	}
-
-	@Override
-	public synchronized void debug() {
-		this.log.format("[DEBUG] Message\n");
 	}
 
 	@Override
@@ -134,23 +150,30 @@ public class TestLogger implements Logger {
 
 	@Override
 	public synchronized void info(String msg) {
-		this.log.format("[ INFO] (%s) %s\n", Thread.currentThread().getName(), msg);
+		if(logCurrentThreadName){
+			this.log.format("[ INFO] (%s) %s\n", Thread.currentThread().getName(), msg);
+		} else {
+			this.log.format("[ INFO] %s\n", msg);
+		}
 	}
 
 	@Override
 	public synchronized void info(String format, Object... arguments) {
-		this.log.format("[ INFO] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
+		if(logCurrentThreadName){
+			this.log.format("[ INFO] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
+		} else {
+			this.log.format("[ INFO] %s\n", format(format, arguments));
+		}
 	}
 
 	@Override
 	public synchronized void info(String msg, Throwable t) {
-		this.log.format("[ INFO] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
+		if(logCurrentThreadName){
+			this.log.format("[ INFO] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
+		} else {
+			this.log.format("[ INFO] %s - %s\n", msg, t);
+		}
 		t.printStackTrace(this.log);
-	}
-
-	@Override
-	public synchronized void info() {
-		this.log.format("[ INFO] Message\n");
 	}
 
 	@Override
@@ -160,23 +183,30 @@ public class TestLogger implements Logger {
 
 	@Override
 	public synchronized void warn(String msg) {
-		this.err.format("[ WARN] (%s) %s\n", Thread.currentThread().getName(), msg);
+		if(logCurrentThreadName){
+			this.err.format("[ WARN] (%s) %s\n", Thread.currentThread().getName(), msg);
+		} else {
+			this.err.format("[ WARN] %s\n", msg);
+		}
 	}
 
 	@Override
 	public synchronized void warn(String format, Object... arguments) {
-		this.err.format("[ WARN] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
+		if(logCurrentThreadName){
+			this.err.format("[ WARN] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
+		} else {
+			this.err.format("[ WARN] %s\n", format(format, arguments));
+		}
 	}
 
 	@Override
 	public synchronized void warn(String msg, Throwable t) {
-		this.err.format("[ WARN] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
+		if(logCurrentThreadName){
+			this.err.format("[ WARN] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
+		} else {
+			this.err.format("[ WARN] %s - %s\n", msg, t);
+		}
 		t.printStackTrace(this.err);
-	}
-
-	@Override
-	public synchronized void warn() {
-		this.err.format("[ WARN] Message\n");
 	}
 
 	@Override
@@ -186,22 +216,37 @@ public class TestLogger implements Logger {
 
 	@Override
 	public synchronized void error(String msg) {
-		this.err.format("[ERROR] (%s) %s\n", Thread.currentThread().getName(), msg);
+		if(logCurrentThreadName){
+			this.err.format("[ERROR] (%s) %s\n", Thread.currentThread().getName(), msg);
+		} else {
+			this.err.format("[ERROR] %s\n", msg);
+		}
 	}
 
 	@Override
 	public synchronized void error(String format, Object... arguments) {
-		this.err.format("[ERROR] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
+		if(logCurrentThreadName){
+			this.err.format("[ERROR] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
+		} else {
+			this.err.format("[ERROR] %s\n", format(format, arguments));
+		}
 	}
 
 	@Override
 	public synchronized void error(String msg, Throwable t) {
-		this.err.format("[ERROR] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
+		if(logCurrentThreadName){
+			this.err.format("[ERROR] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
+		} else {
+			this.err.format("[ERROR] %s - %s\n", msg, t);
+		}
 		t.printStackTrace(this.err);
 	}
 
-	@Override
-	public synchronized void error() {
-		this.err.format("[ERROR] Message\n");
+	public boolean isLogCurrentThreadName() {
+		return logCurrentThreadName;
+	}
+
+	public void setLogCurrentThreadName(boolean logCurrentThreadName) {
+		this.logCurrentThreadName = logCurrentThreadName;
 	}
 }

--- a/reactor-test/src/test/java/reactor/test/util/TestLoggerTest.java
+++ b/reactor-test/src/test/java/reactor/test/util/TestLoggerTest.java
@@ -1,0 +1,24 @@
+package reactor.test.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestLoggerTest {
+
+	@Test
+	void returnMessageWithoutThreadNameWhenLogCurrentThreadNameIsFalse() {
+		TestLogger testLogger = new TestLogger(false);
+
+		assertEquals("[ERROR] TestMessage\n", testLogger.logContent("ERROR",
+				"TestMessage"));
+	}
+
+	@Test
+	void returnMessageWithoutThreadNameWhenLogCurrentThreadNameIsTrue() {
+		TestLogger testLogger = new TestLogger(true);
+
+		assertEquals(String.format("[ERROR] (%s) TestMessage\n", Thread.currentThread().getName()),
+				testLogger.logContent("ERROR", "TestMessage"));
+	}
+}


### PR DESCRIPTION
Added a customization option for each log type to opt out of printing the current thread name.