### PR TITLE
Mirror the SUPPORT health file in reference guide

### DIFF
--- a/docs/asciidoc/gettingStarted.adoc
+++ b/docs/asciidoc/gettingStarted.adoc
@@ -257,3 +257,10 @@ repositories {
 }
 ----
 ====
+
+[[support]]
+== Support and policies
+
+The entries below are mirroring https://github.com/reactor/.github/blob/master/SUPPORT.adoc
+
+include::https://raw.githubusercontent.com/reactor/.github/master/SUPPORT.adoc[leveloffset=3]


### PR DESCRIPTION
Common .github/SUPPORT.md is included in the reference guide.
This allows to make the deprecation policy more prominent.

See reactor/reactor#692