### PR TITLE
drafts alternative implementation of MonoIgnore without wip drain

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreThenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreThenTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.Scannable;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -12,61 +15,77 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MonoIgnoreThenTest {
 
     @Test
+    public void race() {
+        final Scheduler scheduler = Schedulers.newSingle("non-test-thread");
+        final Mono<String> getCurrentThreadName =
+                Mono.fromSupplier(() -> Thread.currentThread().getName());
+        for (int i = 0; i < 1000000; i++) {
+            StepVerifier.create(getCurrentThreadName.publishOn(scheduler)
+                                                    .then(getCurrentThreadName)
+                                                    .then(getCurrentThreadName)
+                                                    .then(getCurrentThreadName))
+                        .assertNext(threadName -> assertThat(threadName).startsWith(
+                                "non-test-thread"))
+                        .verifyComplete();
+        }
+    }
+
+    @Test
     public void scanOperator() {
         MonoIgnoreThen<String> test = new MonoIgnoreThen<>(new Publisher[]{Mono.just("foo")}, Mono.just("bar"));
 
         assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
     }
-
-    @Test
-    public void scanThenIgnoreMain() {
-        AssertSubscriber<String> actual = new AssertSubscriber<>();
-        MonoIgnoreThen.ThenIgnoreMain<String> test = new MonoIgnoreThen.ThenIgnoreMain<>(actual, new Publisher[]{Mono.just("foo")}, Mono.just("bar"));
-
-        assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
-    }
-
-    @Test
-    public void scanThenIgnoreInner() {
-        AssertSubscriber<String> actual = new AssertSubscriber<>();
-        MonoIgnoreThen.ThenIgnoreMain<String> main =
-                new MonoIgnoreThen.ThenIgnoreMain<>(actual, new Publisher[]{Mono.just("foo")}, Mono.just("bar"));
-        MonoIgnoreThen.ThenIgnoreInner test = new MonoIgnoreThen.ThenIgnoreInner(main);
-
-        Subscription innerSubscription = Operators.emptySubscription();
-        test.onSubscribe(innerSubscription);
-
-        assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(main);
-        assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(innerSubscription);
-        assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
-
-        assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
-        test.cancel();
-        assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
-    }
-
-
-    @Test
-    public void scanThenAcceptInner() {
-        AssertSubscriber<String> actual = new AssertSubscriber<>();
-        MonoIgnoreThen.ThenIgnoreMain<String> main =
-                new MonoIgnoreThen.ThenIgnoreMain<>(actual, new Publisher[]{Mono.just("foo")}, Mono.just("bar"));
-        MonoIgnoreThen.ThenAcceptInner<String> test = new MonoIgnoreThen.ThenAcceptInner<>(main);
-
-        Subscription innerSubscription = Operators.emptySubscription();
-        test.onSubscribe(innerSubscription);
-
-        assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(main);
-        assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(innerSubscription);
-        assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
-
-        assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
-        test.onError(new IllegalStateException("boom"));
-        assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
-
-        assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
-        test.cancel();
-        assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
-    }
+//
+//    @Test
+//    public void scanThenIgnoreMain() {
+//        AssertSubscriber<String> actual = new AssertSubscriber<>();
+//        MonoIgnoreThen.ThenIgnoreMain<String> test = new MonoIgnoreThen.ThenIgnoreMain<>(actual, new Publisher[]{Mono.just("foo")}, Mono.just("bar"));
+//
+//        assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
+//    }
+//
+//    @Test
+//    public void scanThenIgnoreInner() {
+//        AssertSubscriber<String> actual = new AssertSubscriber<>();
+//        MonoIgnoreThen.ThenIgnoreMain<String> main =
+//                new MonoIgnoreThen.ThenIgnoreMain<>(actual, new Publisher[]{Mono.just("foo")}, Mono.just("bar"));
+//        MonoIgnoreThen.ThenIgnoreInner test = new MonoIgnoreThen.ThenIgnoreInner(main);
+//
+//        Subscription innerSubscription = Operators.emptySubscription();
+//        test.onSubscribe(innerSubscription);
+//
+//        assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(main);
+//        assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(innerSubscription);
+//        assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
+//
+//        assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+//        test.cancel();
+//        assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
+//    }
+//
+//
+//    @Test
+//    public void scanThenAcceptInner() {
+//        AssertSubscriber<String> actual = new AssertSubscriber<>();
+//        MonoIgnoreThen.ThenIgnoreMain<String> main =
+//                new MonoIgnoreThen.ThenIgnoreMain<>(actual, new Publisher[]{Mono.just("foo")}, Mono.just("bar"));
+//        MonoIgnoreThen.ThenAcceptInner<String> test = new MonoIgnoreThen.ThenAcceptInner<>(main);
+//
+//        Subscription innerSubscription = Operators.emptySubscription();
+//        test.onSubscribe(innerSubscription);
+//
+//        assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(main);
+//        assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(innerSubscription);
+//        assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
+//
+//        assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
+//        test.onError(new IllegalStateException("boom"));
+//        assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
+//
+//        assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+//        test.cancel();
+//        assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
+//    }
 
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoThenIgnoreTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoThenIgnoreTest.java
@@ -84,43 +84,43 @@ public class MonoThenIgnoreTest {
 		cancelTester.assertCancelled();
 	}
 
-	@Test
-	public void scanThenAcceptInner() {
-		CoreSubscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
-		MonoIgnoreThen.ThenIgnoreMain<String> main = new MonoIgnoreThen.ThenIgnoreMain<>(actual, new Publisher[0], Mono.just("foo"));
-
-		MonoIgnoreThen.ThenAcceptInner<String> test = new MonoIgnoreThen.ThenAcceptInner<>(main);
-		Subscription parent = Operators.emptySubscription();
-		test.onSubscribe(parent);
-
-		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
-		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(main);
-
-		assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
-		test.onError(new IllegalStateException("boom"));
-		assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
-
-		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
-		test.cancel();
-		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
-	}
-
-	@Test
-	public void scanThenIgnoreInner() {
-		CoreSubscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
-		MonoIgnoreThen.ThenIgnoreMain<String> main = new MonoIgnoreThen.ThenIgnoreMain<>(actual, new Publisher[0], Mono.just("foo"));
-
-		MonoIgnoreThen.ThenIgnoreInner test = new MonoIgnoreThen.ThenIgnoreInner(main);
-		Subscription parent = Operators.emptySubscription();
-		test.onSubscribe(parent);
-
-		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
-		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(main);
-
-		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
-		test.cancel();
-		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
-	}
+//	@Test
+//	public void scanThenAcceptInner() {
+//		CoreSubscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+//		MonoIgnoreThen.ThenIgnoreMain<String> main = new MonoIgnoreThen.ThenIgnoreMain<>(actual, new Publisher[0], Mono.just("foo"));
+//
+//		MonoIgnoreThen.ThenAcceptInner<String> test = new MonoIgnoreThen.ThenAcceptInner<>(main);
+//		Subscription parent = Operators.emptySubscription();
+//		test.onSubscribe(parent);
+//
+//		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
+//		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(main);
+//
+//		assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
+//		test.onError(new IllegalStateException("boom"));
+//		assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
+//
+//		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+//		test.cancel();
+//		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
+//	}
+//
+//	@Test
+//	public void scanThenIgnoreInner() {
+//		CoreSubscriber<String> actual = new LambdaMonoSubscriber<>(null, e -> {}, null, null);
+//		MonoIgnoreThen.ThenIgnoreMain<String> main = new MonoIgnoreThen.ThenIgnoreMain<>(actual, new Publisher[0], Mono.just("foo"));
+//
+//		MonoIgnoreThen.ThenIgnoreInner test = new MonoIgnoreThen.ThenIgnoreInner(main);
+//		Subscription parent = Operators.emptySubscription();
+//		test.onSubscribe(parent);
+//
+//		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
+//		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(main);
+//
+//		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+//		test.cancel();
+//		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
+//	}
 
 	//see https://github.com/reactor/reactor-core/issues/661
 	@Test


### PR DESCRIPTION
This PR draft and alternative impl of MonoIgnore which does not require drain loop and wip guard and only uses a single volatile field for catching cancelation scenario.

Though the advantages are obvious, the main disadvantage of this impl is a possibly too long stack track due to subscription to the `then(source)` on the producer stack, which in the case of synchronous invocation can be too long.

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>