### PR TITLE
fix #2569 Enrich message of elementAt's IndexOutOfBoundsException

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoElementAt.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoElementAt.java
@@ -65,6 +65,8 @@ final class MonoElementAt<T> extends MonoFromFluxOperator<T, T>
 
 		long index;
 
+		final long target;
+
 		Subscription s;
 
 		boolean done;
@@ -73,6 +75,7 @@ final class MonoElementAt<T> extends MonoFromFluxOperator<T, T>
 											T defaultValue) {
 			super(actual);
 			this.index = index;
+			this.target = index;
 			this.defaultValue = defaultValue;
 		}
 
@@ -150,8 +153,10 @@ final class MonoElementAt<T> extends MonoFromFluxOperator<T, T>
 				complete(defaultValue);
 			}
 			else{
-				actual.onError(Operators.onOperatorError(new
-						IndexOutOfBoundsException(), actual.currentContext()));
+				long count = target - index;
+				actual.onError(Operators.onOperatorError(new IndexOutOfBoundsException(
+								"source had " + count + " elements, expected at least " + (target + 1)),
+						actual.currentContext()));
 			}
 		}
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoElementAtTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoElementAtTest.java
@@ -247,4 +247,26 @@ public class MonoElementAtTest {
 		test.cancel();
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
 	}
+
+	@Test
+	public void sourceShorter1() {
+		AssertSubscriber<Integer> ts = AssertSubscriber.create();
+
+		Flux.range(1, 10).elementAt(10).subscribe(ts);
+
+		ts.assertNoValues()
+		  .assertError(IndexOutOfBoundsException.class)
+		  .assertNotComplete();
+	}
+
+	@Test
+	public void sourceShorter2() {
+		AssertSubscriber<Integer> ts = AssertSubscriber.create();
+
+		Flux.range(1, 10).elementAt(1000).subscribe(ts);
+
+		ts.assertNoValues()
+		  .assertError(IndexOutOfBoundsException.class)
+		  .assertNotComplete();
+	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoElementAtTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoElementAtTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
+import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 
@@ -148,14 +149,11 @@ public class MonoElementAtTest {
 	}
 
 	@Test
-	public void empty() {
-		AssertSubscriber<Integer> ts = AssertSubscriber.create();
-
-		Flux.<Integer>empty().elementAt(0).subscribe(ts);
-
-		ts.assertNoValues()
-		  .assertError(IndexOutOfBoundsException.class)
-		  .assertNotComplete();
+	void empty() {
+		StepVerifier.create(Flux.<Integer>empty().elementAt(0))
+		            .expectErrorMatches(e -> e instanceof IndexOutOfBoundsException &&
+				            "source had 0 elements, expected at least 1".equals(e.getMessage()))
+		            .verify();
 	}
 
 	@Test
@@ -249,24 +247,22 @@ public class MonoElementAtTest {
 	}
 
 	@Test
-	public void sourceShorter1() {
-		AssertSubscriber<Integer> ts = AssertSubscriber.create();
-
-		Flux.range(1, 10).elementAt(10).subscribe(ts);
-
-		ts.assertNoValues()
-		  .assertError(IndexOutOfBoundsException.class)
-		  .assertNotComplete();
+	void sourceShorter1() {
+		StepVerifier.create(Flux.range(1, 10)
+		                        .elementAt(10))
+		            .expectNextCount(0)
+		            .expectErrorMatches(e -> e instanceof IndexOutOfBoundsException &&
+				            "source had 10 elements, expected at least 11".equals(e.getMessage()))
+		            .verify();
 	}
 
 	@Test
-	public void sourceShorter2() {
-		AssertSubscriber<Integer> ts = AssertSubscriber.create();
-
-		Flux.range(1, 10).elementAt(1000).subscribe(ts);
-
-		ts.assertNoValues()
-		  .assertError(IndexOutOfBoundsException.class)
-		  .assertNotComplete();
+	void sourceShorter2() {
+		StepVerifier.create(Flux.range(1, 10)
+		                        .elementAt(1000))
+		            .expectNextCount(0)
+		            .expectErrorMatches(e -> e instanceof IndexOutOfBoundsException &&
+				            "source had 10 elements, expected at least 1001".equals(e.getMessage()))
+		            .verify();
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoElementAtTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoElementAtTest.java
@@ -151,8 +151,9 @@ public class MonoElementAtTest {
 	@Test
 	void empty() {
 		StepVerifier.create(Flux.<Integer>empty().elementAt(0))
-		            .expectErrorMatches(e -> e instanceof IndexOutOfBoundsException &&
-				            "source had 0 elements, expected at least 1".equals(e.getMessage()))
+		            .expectErrorSatisfies(e -> assertThat(e)
+				            .isInstanceOf(IndexOutOfBoundsException.class)
+				            .hasMessage("source had 0 elements, expected at least 1"))
 		            .verify();
 	}
 
@@ -249,20 +250,22 @@ public class MonoElementAtTest {
 	@Test
 	void sourceShorter1() {
 		StepVerifier.create(Flux.range(1, 10)
-		                        .elementAt(10))
-		            .expectNextCount(0)
-		            .expectErrorMatches(e -> e instanceof IndexOutOfBoundsException &&
-				            "source had 10 elements, expected at least 11".equals(e.getMessage()))
-		            .verify();
+								.elementAt(10))
+					.expectNextCount(0)
+					.expectErrorSatisfies(e -> assertThat(e)
+							.isInstanceOf(IndexOutOfBoundsException.class)
+							.hasMessage("source had 10 elements, expected at least 11"))
+					.verify();
 	}
 
 	@Test
 	void sourceShorter2() {
 		StepVerifier.create(Flux.range(1, 10)
-		                        .elementAt(1000))
-		            .expectNextCount(0)
-		            .expectErrorMatches(e -> e instanceof IndexOutOfBoundsException &&
-				            "source had 10 elements, expected at least 1001".equals(e.getMessage()))
-		            .verify();
+								.elementAt(1000))
+					.expectNextCount(0)
+					.expectErrorSatisfies(e -> assertThat(e)
+							.isInstanceOf(IndexOutOfBoundsException.class)
+							.hasMessage("source had 10 elements, expected at least 1001"))
+					.verify();
 	}
 }


### PR DESCRIPTION
This commit changes to retain the requested index and the actual size of the source in MonoElementAt.ElementAtSubscriber.

The message has changed as follows.

### AS-IS
```
Caused by: java.lang.IndexOutOfBoundsException: null
	at reactor.core.publisher.MonoElementAt$ElementAtSubscriber.onComplete(MonoElementAt.java:160)
```

### TO-BE
```
Caused by: java.lang.IndexOutOfBoundsException: source had 3 elements, expected at least 9
	at reactor.core.publisher.MonoElementAt$ElementAtSubscriber.onComplete(MonoElementAt.java:157)
```

Is there something I missed?