### PR TITLE
Fix some metrics tests to avoid implicit use of globalRegistry

### DIFF
--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxMetricsTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxMetricsTest.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -498,28 +499,35 @@ public class FluxMetricsTest {
 
 	@Test
 	void ensureMetricsUsesTheTagValueClosestToItWhenCalledMultipleTimes() {
-		Flux<String> source = Flux
-				.range(1, 10)
-				.name("pipeline")
-				.tag("operation", "range")
-				.metrics()
-				.map(Object::toString)
-				.name("pipeline")
-				.tag("operation", "map")
-				.metrics()
-				.filter(i -> i.length() > 3)
-				.name("pipeline")
-				.tag("operation", "filter")
-				.metrics();
+		Flux<Integer> level1 = new FluxMetrics<>(
+				Flux.range(1, 10)
+				    .name("pipelineFlux")
+				    .tag("operation", "rangeFlux"),
+				registry);
 
-		new FluxMetrics<>(source, registry).blockLast();
+		Flux<String> level2 = new FluxMetricsFuseable<>(
+				level1.map(Object::toString)
+				      .name("pipelineFlux")
+				      .tag("operation", "mapFlux"),
+				registry);
 
-		Meter meter = registry
+		Flux<String> level3 = new FluxMetrics<>(
+				level2.filter(i -> i.length() > 3)
+				      .name("pipelineFlux")
+				      .tag("operation", "filterFlux"),
+				registry);
+
+		level3.blockLast();
+
+		Collection<Meter> meters = registry
 				.find(METER_FLOW_DURATION)
-				.tag(TAG_SEQUENCE_NAME, "pipeline")
-				.tag("operation", "filter")
-				.meter();
+				.tag(TAG_SEQUENCE_NAME, "pipelineFlux")
+				.tagKeys("operation")
+				.meters();
 
-		assertThat(meter).isNotNull();
+		assertThat(meters)
+				.isNotEmpty()
+				.extracting(m -> m.getId().getTag("operation"))
+				.containsExactlyInAnyOrder("rangeFlux", "mapFlux", "filterFlux");
 	}
 }


### PR DESCRIPTION
This commit is a follow-up to #2564 and as such relates to #2560.

The added test was using the `metrics()` operator directly, which in
3.3.x implicitly uses the globalRegistry. As a result, it leaks meters
in the registry that get picked up by unrelated tests, causing failures
in SchedulersMetricsTest.
