### PR TITLE
Fix OverflowException in MultiSubscriptionSubscriber

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxJust.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxJust.java
@@ -65,7 +65,7 @@ final class FluxJust<T> extends Flux<T>
 
 	@Override
 	public void subscribe(final CoreSubscriber<? super T> actual) {
-		actual.onSubscribe(Operators.scalarSubscription(actual, value));
+		actual.onSubscribe(Operators.scalarSubscription(actual, value, "just"));
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -2354,8 +2354,12 @@ public abstract class Operators {
 		@Override
 		@Nullable
 		public Object scanUnsafe(Attr key) {
-			if (key == Attr.TERMINATED || key == Attr.CANCELLED)
-				return once == 1;
+			if (key == Attr.TERMINATED) {
+				return once == 1 || once == 2;
+			}
+			if (key == Attr.CANCELLED) {
+				return once == 2;
+			}
 
 			return InnerProducer.super.scanUnsafe(key);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -2204,6 +2204,7 @@ public abstract class Operators {
 		    int missed = 1;
 
 	        long requestAmount = 0L;
+	        long alreadyInRequestAmount = 0L;
 	        Subscription requestTarget = null;
 
 	        for (; ; ) {
@@ -2258,11 +2259,12 @@ public abstract class Operators {
 	                    }
 		                subscription = ms;
 		                if (r != 0L) {
-			                requestAmount = addCap(requestAmount, r);
+			                requestAmount = addCap(requestAmount, r - alreadyInRequestAmount);
 	                        requestTarget = ms;
 	                    }
 	                } else if (mr != 0L && a != null) {
 	                    requestAmount = addCap(requestAmount, mr);
+	                    alreadyInRequestAmount += mr; 
 	                    requestTarget = a;
 	                }
 	            }

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -1099,11 +1099,12 @@ public abstract class Operators {
 
 	/**
 	 * Represents a fuseable Subscription that emits a single constant value synchronously
-	 * to a Subscriber or consumer.
+	 * to a Subscriber or consumer. Also give the subscription a user-defined {@code stepName}
+	 * for the purpose of {@link Scannable#stepName()}.
 	 *
 	 * @param subscriber the delegate {@link Subscriber} that will be requesting the value
 	 * @param value the single value to be emitted
-	 * @param stepName step name
+	 * @param stepName the {@link String} to represent the {@link Subscription} in {@link Scannable#stepName()}
 	 * @param <T> the value type
 	 * @return a new scalar {@link Subscription}
 	 */
@@ -2324,10 +2325,11 @@ public abstract class Operators {
 
 		final T value;
 
+		@Nullable
+		final String stepName;
+
 		volatile int once;
-		
-		String stepName;
-		
+
 		ScalarSubscription(CoreSubscriber<? super T> actual, T value) {
 			this(actual, value, null);
 		}
@@ -2337,7 +2339,7 @@ public abstract class Operators {
 			this.actual = Objects.requireNonNull(actual, "actual");
 			this.stepName = stepName;
 		}
-		
+
 		@Override
 		public void cancel() {
 			if (once == 0) {

--- a/reactor-core/src/test/java/reactor/core/ScannableTest.java
+++ b/reactor-core/src/test/java/reactor/core/ScannableTest.java
@@ -587,7 +587,7 @@ public class ScannableTest {
 
 		Stream<String> chain = lastSubscriber.steps();
 
-		assertThat(chain).containsExactly("just", "map", "filter", "reduce", "peek", "lambda");
+		assertThat(chain).containsExactly("scalarSubscription(foo)", "map", "filter", "reduce", "peek", "lambda");
 	}
 
 	@Test
@@ -687,7 +687,7 @@ public class ScannableTest {
 		 .blockLast();
 		assertThat(Scannable.from(subRef.get()).steps())
 				.as("subscriber chain")
-				.containsExactly("just", "filter", "map", "peek", "blockLast");
+				.containsExactly("scalarSubscription(foo)", "filter", "map", "peek", "blockLast");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/ScannableTest.java
+++ b/reactor-core/src/test/java/reactor/core/ScannableTest.java
@@ -587,7 +587,7 @@ public class ScannableTest {
 
 		Stream<String> chain = lastSubscriber.steps();
 
-		assertThat(chain).containsExactly("scalarSubscription(foo)", "map", "filter", "reduce", "peek", "lambda");
+		assertThat(chain).containsExactly("just", "map", "filter", "reduce", "peek", "lambda");
 	}
 
 	@Test
@@ -687,7 +687,7 @@ public class ScannableTest {
 		 .blockLast();
 		assertThat(Scannable.from(subRef.get()).steps())
 				.as("subscriber chain")
-				.containsExactly("scalarSubscription(foo)", "filter", "map", "peek", "blockLast");
+				.containsExactly("just", "filter", "map", "peek", "blockLast");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxJustTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxJustTest.java
@@ -19,9 +19,12 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscription;
+
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
+import reactor.core.publisher.Operators.ScalarSubscription;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.subscriber.AssertSubscriber;
 
@@ -100,7 +103,7 @@ public class FluxJustTest {
 	@Test
 	public void scanSubscription() {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, sub -> sub.request(100));
-		FluxJust.WeakScalarSubscription<Integer> test = new FluxJust.WeakScalarSubscription<>(1, actual);
+		ScalarSubscription<Integer> test = new ScalarSubscription<>(actual, 1);
 
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
 		assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxJustTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxJustTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -108,4 +109,26 @@ public class FluxJustTest {
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
 		assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
 	}
+	
+	@Test
+	public void testConcurrencyCausingDuplicate() {
+		// See https://github.com/reactor/reactor-core/pull/2576
+		// reactor.core.Exceptions$OverflowException: Queue is full: Reactive Streams source doesn't respect backpressure
+		for (int round = 0; round < 20000; round++) {
+			Mono.just(0).flatMapMany(i -> {
+				return Flux.range(0, 10)
+						.publishOn(Schedulers.boundedElastic())
+						.concatWithValues(10)
+						.concatWithValues(11)
+						.concatWithValues(12)
+						.concatWithValues(13)
+						.concatWithValues(14)
+						.concatWithValues(15)
+						.concatWithValues(16)
+						.concatWithValues(17)
+						.concatWith(Flux.range(18, 100 - 18));
+			}).publishOn(Schedulers.boundedElastic(), 16).subscribeOn(Schedulers.boundedElastic()).blockLast();
+		}
+	}
+
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
@@ -16,7 +16,6 @@
 
 package reactor.core.publisher;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -52,7 +51,6 @@ import reactor.core.publisher.Operators.EmptySubscription;
 import reactor.core.publisher.Operators.MonoSubscriber;
 import reactor.core.publisher.Operators.MultiSubscriptionSubscriber;
 import reactor.core.publisher.Operators.ScalarSubscription;
-import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.test.util.RaceTestUtils;
 import reactor.util.context.Context;
@@ -292,6 +290,9 @@ public class OperatorsTest {
 		assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
 		test.poll();
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+		test.cancel();
 		assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
 	}


### PR DESCRIPTION
Fixes:

```java
public class FFTest {
    private static final Logger log = LoggerFactory.getLogger(FFTest.class);

    @Test
    public void test() {
        int round = 0;
        try {
            while (true) {
                Flux.range(0, 10)
                    .concatWithValues(10, 11, 12, 13)
                    .concatWith(Flux.range(14, 100 - 14))
                    .limitRate(16, 2)
                    .publishOn(Schedulers.boundedElastic(), 16)
                    .subscribeOn(Schedulers.boundedElastic())
                    .blockLast();
                log.info("Round : " + (round++));
            }
        } catch(Exception e) {
            log.error("", e);
        }
    }
}
```

```
13:06:20.429 [main] INFO com.ca.apm.tas.FFTest - Round : 0
......
13:06:20.442 [main] INFO com.ca.apm.tas.FFTest - Round : 38
13:06:20.442 [main] INFO com.ca.apm.tas.FFTest - Round : 39
13:06:20.450 [main] ERROR com.ca.apm.tas.FFTest - 
reactor.core.Exceptions$OverflowException: Queue is full: Reactive Streams source doesn't respect backpressure
	at reactor.core.Exceptions.failWithOverflow(Exceptions.java:234)
	at reactor.core.publisher.FluxPublishOn$PublishOnSubscriber.onNext(FluxPublishOn.java:232)
	at reactor.core.publisher.FluxConcatArray$ConcatArraySubscriber.onNext(FluxConcatArray.java:183)
	at reactor.core.publisher.FluxRange$RangeSubscription.slowPath(FluxRange.java:154)
	at reactor.core.publisher.FluxRange$RangeSubscription.request(FluxRange.java:109)
```

Problem is that reactor.core.publisher.Operators.MultiSubscriptionSubscriber.drainLoop() is double counting missedRequested in case that missedSubscription happens during evaluation (two cycles). Example values:

First iteration in drainLoop:
missedRequested = 12, missedProduced = 0, requested = 2, missedSubscription = null,
requestTarget = log
requestAmount = 12 

Second iteration in drainLoop:
missedRequested = 0, missedProduced = 0, requested = 14, missedSubscription = range  
requestTarget = range
requestAmount = 26

See that missedRequested (12) was counted twice so requestAmount is 26 instead of 14.

