### PR TITLE
fix double discard case in PublishOnSubscriber

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
@@ -232,8 +232,13 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 						Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL),
 						t, actual.currentContext());
 				done = true;
+				trySchedule(this, null, t);
 			}
-			trySchedule(this, null, t);
+			else {
+				//the element has been offered to the queue, so we shouldn't try to discard it
+				//individually from a cancelled trySchedule (queue-discarding will suffice)
+				trySchedule(this, null, t, false);
+			}
 		}
 
 		@Override
@@ -293,6 +298,13 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 				@Nullable Subscription subscription,
 				@Nullable Throwable suppressed,
 				@Nullable Object dataSignal) {
+			trySchedule(subscription, suppressed, dataSignal, true);
+		}
+		void trySchedule(
+				@Nullable Subscription subscription,
+				@Nullable Throwable suppressed,
+				@Nullable Object dataSignal,
+				boolean discardDataSignalIfCancelled) {
 			if (WIP.getAndIncrement(this) != 0) {
 				if (cancelled) {
 					if (sourceMode == ASYNC) {
@@ -301,7 +313,9 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 					}
 					else {
 						// discard given dataSignal since no more is enqueued (spec guarantees serialised onXXX calls)
-						Operators.onDiscard(dataSignal, actual.currentContext());
+						if (discardDataSignalIfCancelled) {
+							Operators.onDiscard(dataSignal, actual.currentContext());
+						}
 					}
 				}
 				return;

--- a/reactor-core/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
@@ -30,6 +30,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.test.util.RaceTestUtils;
 import reactor.util.context.Context;
+import reactor.util.retry.Retry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.with;
@@ -82,52 +83,71 @@ public class SerializedSubscriberTest {
 		}
 	}
 
-	//direct transcription of test case exposed in https://github.com/reactor/reactor-core/issues/2077
+	//adaptation of test case exposed in https://github.com/reactor/reactor-core/issues/2077
+	//we further attempt to detect double discards
 	@Test
-	public void testLeakWithRetryWhenImmediatelyCancelled() throws InterruptedException {
+	void testLeakWithRetryWhenImmediatelyCancelled() throws InterruptedException {
 		AtomicInteger counter = new AtomicInteger();
 		AtomicInteger discarded = new AtomicInteger();
 		AtomicInteger seen = new AtomicInteger();
+		AtomicInteger doubleDiscarded = new AtomicInteger();
+		AtomicInteger seenAndDiscarded = new AtomicInteger();
 
 		final CountDownLatch latch = new CountDownLatch(4);
-		Flux.<Integer>generate(s -> {
+		Flux.<AtomicInteger>generate(s -> {
 			int i = counter.incrementAndGet();
 			if (i == 100_000) {
-				s.next(i);
+				s.next(new AtomicInteger(i));
 				s.complete();
 			}
 			else {
-				s.next(i);
+				s.next(new AtomicInteger(i));
 			}
 		})
 			.doFinally(sig -> latch.countDown())
-		    .publishOn(Schedulers.single())
+			.publishOn(Schedulers.single())
 			.doFinally(sig -> latch.countDown())
-		    .retryWhen(p -> p.take(3))
+			.retryWhen(Retry.from(p -> p.take(3)))
 			.doFinally(sig -> latch.countDown())
-		    .cancelOn(Schedulers.parallel())
-		    .doOnDiscard(Integer.class, i -> discarded.incrementAndGet())
-		    .doFinally(sig -> latch.countDown())
-            .subscribeWith(new BaseSubscriber<Integer>() {
-	            @Override
-	            protected void hookOnNext(Integer value) {
+			.cancelOn(Schedulers.parallel())
+			.doOnDiscard(AtomicInteger.class, i -> {
+				discarded.incrementAndGet();
+				int status = i.getAndSet(-10);
+				//here we could switch to printing stacktraces with System.identityHashcode to identify where double discard happens
+				if (status == -10) {
+					doubleDiscarded.incrementAndGet();
+				}
+				else if (status == -1) {
+					seenAndDiscarded.incrementAndGet();
+				}
+			})
+			.doFinally(sig -> latch.countDown())
+			.subscribeWith(new BaseSubscriber<AtomicInteger>() {
+				@Override
+				protected void hookOnNext(AtomicInteger value) {
 					seen.incrementAndGet();
-		            cancel();
-	            }
-            });
+					cancel();
+					if (value.getAndSet(-1) < 0) {
+						seenAndDiscarded.incrementAndGet();
+					}
+				}
+			});
 
 		assertThat(latch.await(5, TimeUnit.SECONDS)).as("latch 5s").isTrue();
 		with().pollInterval(50, TimeUnit.MILLISECONDS)
-		      .await().atMost(500, TimeUnit.MILLISECONDS)
-		      .untilAsserted(() -> {
+			  .await().atMost(500, TimeUnit.MILLISECONDS)
+			  .untilAsserted(() -> {
 				  int expectedCnt = counter.get();
 				  int snn = seen.get();
 				  int discrdd = discarded.get();
+				  assertThat(doubleDiscarded).as("double discarded").hasValue(0);
+				  assertThat(seenAndDiscarded).as("seen and discarded").hasValue(0);
 				  assertThat(expectedCnt)
-					      .withFailMessage("counter not equal to seen+discarded: Expected <%s>, got <%s+%s>=<%s>",
-							      expectedCnt, seen, discarded, snn + discrdd)
-					      .isEqualTo(snn + discrdd);
-		      });
+						  .withFailMessage("counter not equal to seen+discarded: Expected <%s>, got <%s+%s>=<%s>",
+								  expectedCnt, snn, discrdd, snn + discrdd)
+						  .isEqualTo(snn + discrdd);
+			  });
+
 	}
 
 	@Test


### PR DESCRIPTION
This commit fixes an issue often leading to a double discard of an
enqueued onNext value along the cancel signal.

The issue was making one `SerializedSubscriberTest` flaky, which
has been improved to better surface double discard issues (and should
be consistently green with this change).