### PR TITLE
Extend RaceTestUtils to support N runnables

### DIFF
--- a/reactor-core/src/test/java/reactor/core/DisposablesTest.java
+++ b/reactor-core/src/test/java/reactor/core/DisposablesTest.java
@@ -105,7 +105,7 @@ public class DisposablesTest {
 				}
 			};
 
-			RaceTestUtils.race(r, r, Schedulers.elastic());
+			RaceTestUtils.race(r, r);
 		}
 	}
 
@@ -120,7 +120,7 @@ public class DisposablesTest {
 				}
 			};
 
-			RaceTestUtils.race(r, r, Schedulers.elastic());
+			RaceTestUtils.race(r, r);
 		}
 	}
 
@@ -134,7 +134,7 @@ public class DisposablesTest {
 				}
 			};
 
-			RaceTestUtils.race(r, r, Schedulers.elastic());
+			RaceTestUtils.race(r, r);
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/core/ListCompositeDisposableTest.java
+++ b/reactor-core/src/test/java/reactor/core/ListCompositeDisposableTest.java
@@ -226,7 +226,7 @@ public class ListCompositeDisposableTest {
 			final Disposable d1 = new FakeDisposable();
 			final Disposable.Composite cd = new ListCompositeDisposable(d1);
 
-			RaceTestUtils.race(cd::dispose, cd::dispose, Schedulers.elastic());
+			RaceTestUtils.race(cd::dispose, cd::dispose);
 		}
 	}
 
@@ -236,7 +236,7 @@ public class ListCompositeDisposableTest {
 			final Disposable d1 = new FakeDisposable();
 			final Disposable.Composite cd = new ListCompositeDisposable(d1);
 
-			RaceTestUtils.race(() -> cd.remove(d1), cd::dispose, Schedulers.elastic());
+			RaceTestUtils.race(() -> cd.remove(d1), cd::dispose);
 		}
 	}
 
@@ -246,7 +246,7 @@ public class ListCompositeDisposableTest {
 			final Disposable d1 = new FakeDisposable();
 			final Disposable.Composite cd = new ListCompositeDisposable(d1);
 
-			RaceTestUtils.race(cd::size, cd::dispose, Schedulers.elastic());
+			RaceTestUtils.race(cd::size, cd::dispose);
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
@@ -296,8 +296,7 @@ public class FluxBufferTimeoutTest {
 		for (int i = 0; i < 500; i++) {
 			RaceTestUtils.race(
 					() -> test.onNext(counter.getAndIncrement()),
-					() -> test.flushCallback(null),
-					Schedulers.elastic()
+					() -> test.flushCallback(null)
 			);
 		}
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxExpandTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxExpandTest.java
@@ -424,7 +424,7 @@ public class FluxExpandTest {
 			Runnable r1 = () -> ts.request(1);
 			Runnable r2 = ts::cancel;
 
-			RaceTestUtils.race(r1, r2, Schedulers.single());
+			RaceTestUtils.race(r1, r2);
 		}
 	}
 
@@ -443,7 +443,7 @@ public class FluxExpandTest {
 			Runnable r1 = () -> pp.next(1);
 			Runnable r2 = ts::cancel;
 
-			RaceTestUtils.race(r1, r2, Schedulers.single());
+			RaceTestUtils.race(r1, r2);
 		}
 	}
 
@@ -461,7 +461,7 @@ public class FluxExpandTest {
 			Runnable r1 = pp::complete;
 			Runnable r2 = ts::cancel;
 
-			RaceTestUtils.race(r1, r2, Schedulers.single());
+			RaceTestUtils.race(r1, r2);
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
@@ -1612,7 +1612,7 @@ public class FluxSwitchOnFirstTest {
                 InnerOperator switchOnFirstControlSubscriber = factory.apply(mockParent, Operators.toConditionalSubscriber(subscriber));
 
                 switchOnFirstControlSubscriber.request(10);
-                RaceTestUtils.race(() -> switchOnFirstControlSubscriber.request(10), () -> switchOnFirstControlSubscriber.onSubscribe(mockSubscription), Schedulers.parallel());
+                RaceTestUtils.race(() -> switchOnFirstControlSubscriber.request(10), () -> switchOnFirstControlSubscriber.onSubscribe(mockSubscription));
 
                 assertThat(longArgumentCaptor.getAllValues().size()).isBetween(1, 2);
                 if (longArgumentCaptor.getAllValues().size() == 1) {
@@ -1655,8 +1655,7 @@ public class FluxSwitchOnFirstTest {
                             switchOnFirstControlSubscriber.request(10);
                             switchOnFirstControlSubscriber.request(10);
                         },
-                        () -> switchOnFirstControlSubscriber.onSubscribe(mockSubscription),
-                        Schedulers.parallel());
+                        () -> switchOnFirstControlSubscriber.onSubscribe(mockSubscription));
 
                 switchOnFirstControlSubscriber.request(10);
                 assertThat(valueHolder[0])
@@ -1687,7 +1686,7 @@ public class FluxSwitchOnFirstTest {
                 InnerOperator switchOnFirstControlSubscriber = factory.apply(mockParent, Operators.toConditionalSubscriber(subscriber));
 
                 switchOnFirstControlSubscriber.request(10);
-                RaceTestUtils.race(() -> switchOnFirstControlSubscriber.cancel(), () -> switchOnFirstControlSubscriber.onSubscribe(mockSubscription), Schedulers.parallel());
+                RaceTestUtils.race(() -> switchOnFirstControlSubscriber.cancel(), () -> switchOnFirstControlSubscriber.onSubscribe(mockSubscription));
 
                 assertThat(longArgumentCaptor.getAllValues().size()).isBetween(0, 1);
                 Mockito.verify(mockParent).cancel();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoExpandTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoExpandTest.java
@@ -403,7 +403,7 @@ public class MonoExpandTest {
 			Runnable r1 = () -> ts.request(1);
 			Runnable r2 = ts::cancel;
 
-			RaceTestUtils.race(r1, r2, Schedulers.single());
+			RaceTestUtils.race(r1, r2);
 		}
 	}
 
@@ -422,7 +422,7 @@ public class MonoExpandTest {
 			Runnable r1 = () -> pp.next(1);
 			Runnable r2 = ts::cancel;
 
-			RaceTestUtils.race(r1, r2, Schedulers.single());
+			RaceTestUtils.race(r1, r2);
 		}
 	}
 
@@ -440,7 +440,7 @@ public class MonoExpandTest {
 			Runnable r1 = pp::complete;
 			Runnable r2 = ts::cancel;
 
-			RaceTestUtils.race(r1, r2, Schedulers.single());
+			RaceTestUtils.race(r1, r2);
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
@@ -27,7 +27,6 @@ import org.assertj.core.api.Assumptions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.reactivestreams.Publisher;
@@ -51,40 +50,40 @@ public class OnDiscardShouldNotLeakTest {
 	// add DiscardScenarios here to test more operators
 	private static final DiscardScenario[] SCENARIOS = new DiscardScenario[] {
 			DiscardScenario.allFluxSourceArray("merge", 4, Flux::merge),
-			DiscardScenario.fluxSource("onBackpressureBuffer", 1, Flux::onBackpressureBuffer),
-			DiscardScenario.fluxSource("onBackpressureBufferAndPublishOn", 1, f -> f
+			DiscardScenario.fluxSource("onBackpressureBuffer", Flux::onBackpressureBuffer),
+			DiscardScenario.fluxSource("onBackpressureBufferAndPublishOn", f -> f
 					.onBackpressureBuffer()
 					.publishOn(Schedulers.immediate())),
-			DiscardScenario.fluxSource("onBackpressureBufferAndPublishOnWithMaps", 1, f -> f
+			DiscardScenario.fluxSource("onBackpressureBufferAndPublishOnWithMaps", f -> f
 					.onBackpressureBuffer()
 					.map(Function.identity())
 					.map(Function.identity())
 					.map(Function.identity())
 					.publishOn(Schedulers.immediate())),
-			DiscardScenario.rawSource("flatMapInner", 1, raw -> Flux.just(1).flatMap(f -> raw)),
-			DiscardScenario.fluxSource("flatMap", 1, main -> main.flatMap(f -> Mono.just(f).hide().flux())),
-			DiscardScenario.fluxSource("flatMapIterable", 1, f -> f.flatMapIterable(Arrays::asList)),
-			DiscardScenario.fluxSource("publishOnDelayErrors", 1, f -> f.publishOn(Schedulers.immediate())),
-			DiscardScenario.fluxSource("publishOnImmediateErrors", 1, f -> f.publishOn(Schedulers.immediate(), false, Queues.SMALL_BUFFER_SIZE)),
-			DiscardScenario.fluxSource("publishOnAndPublishOn", 1, main -> main
+			DiscardScenario.rawSource("flatMapInner", raw -> Flux.just(1).flatMap(f -> raw)),
+			DiscardScenario.fluxSource("flatMap", main -> main.flatMap(f -> Mono.just(f).hide().flux())),
+			DiscardScenario.fluxSource("flatMapIterable", f -> f.flatMapIterable(Arrays::asList)),
+			DiscardScenario.fluxSource("publishOnDelayErrors", f -> f.publishOn(Schedulers.immediate())),
+			DiscardScenario.fluxSource("publishOnImmediateErrors", f -> f.publishOn(Schedulers.immediate(), false, Queues.SMALL_BUFFER_SIZE)),
+			DiscardScenario.fluxSource("publishOnAndPublishOn", main -> main
 					.publishOn(Schedulers.immediate())
 					.publishOn(Schedulers.immediate())),
-			DiscardScenario.fluxSource("publishOnAndPublishOnWithMaps", 1, main -> main
+			DiscardScenario.fluxSource("publishOnAndPublishOnWithMaps", main -> main
 					.publishOn(Schedulers.immediate())
 					.map(Function.identity())
 					.map(Function.identity())
 					.map(Function.identity())
 					.publishOn(Schedulers.immediate())),
-			DiscardScenario.fluxSource("unicastProcessor", 1, f -> f.subscribeWith(UnicastProcessor.create())),
-			DiscardScenario.fluxSource("unicastProcessorAndPublishOn", 1, f -> f
+			DiscardScenario.fluxSource("unicastProcessor", f -> f.subscribeWith(UnicastProcessor.create())),
+			DiscardScenario.fluxSource("unicastProcessorAndPublishOn", f -> f
 					.subscribeWith(UnicastProcessor.create())
 					.publishOn(Schedulers.immediate())),
 			//FIXME known issue in 3.3.14.RELEASE and 3.4.3
-//			DiscardScenario.fluxSource("singleOrEmpty", 1, f -> f.singleOrEmpty().onErrorReturn(Tracked.RELEASED)),
-			DiscardScenario.fluxSource("collect", 1, f -> f.collect(ArrayList::new, ArrayList::add)
+//			DiscardScenario.fluxSource("singleOrEmpty", f -> f.singleOrEmpty().onErrorReturn(Tracked.RELEASED)),
+			DiscardScenario.fluxSource("collect", f -> f.collect(ArrayList::new, ArrayList::add)
 			                                               .doOnSuccess(l -> l.forEach(Tracked::safeRelease))
 			                                               .thenReturn(Tracked.RELEASED)),
-			DiscardScenario.fluxSource("collectList", 1, f -> f.collectList()
+			DiscardScenario.fluxSource("collectList", f -> f.collectList()
 			                                                   .doOnSuccess(l -> l.forEach(Tracked::safeRelease))
 			                                                   .thenReturn(Tracked.RELEASED))
 	};
@@ -524,12 +523,12 @@ public class OnDiscardShouldNotLeakTest {
 
 	static class DiscardScenario {
 
-		static DiscardScenario rawSource(String desc, int subs, Function<TestPublisher<Tracked>, Publisher<Tracked>> rawToPublisherProducer) {
-			return new DiscardScenario(desc, subs, (main, others) -> rawToPublisherProducer.apply(main));
+		static DiscardScenario rawSource(String desc, Function<TestPublisher<Tracked>, Publisher<Tracked>> rawToPublisherProducer) {
+			return new DiscardScenario(desc, 1, (main, others) -> rawToPublisherProducer.apply(main));
 		}
 
-		static DiscardScenario fluxSource(String desc, int subs, Function<Flux<Tracked>, Publisher<Tracked>> fluxToPublisherProducer) {
-			return new DiscardScenario(desc, subs, (main, others) -> fluxToPublisherProducer.apply(main.flux()));
+		static DiscardScenario fluxSource(String desc, Function<Flux<Tracked>, Publisher<Tracked>> fluxToPublisherProducer) {
+			return new DiscardScenario(desc, 1, (main, others) -> fluxToPublisherProducer.apply(main.flux()));
 		}
 
 		static DiscardScenario allFluxSourceArray(String desc, int subs,

--- a/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
@@ -177,12 +177,12 @@ public class OnDiscardShouldNotLeakTest {
 			if (subscriptionsNumber == 1) {
 				Tracked value = tracker.track(1);
 				RaceTestUtils.race(
-						() -> RaceTestUtils.race(
-								assertSubscriber::cancel,
-								() -> assertSubscriber.request(Long.MAX_VALUE),
-								scheduler),
-						() -> testPublishers[0].next(value),
-						scheduler);
+						scheduler, () -> RaceTestUtils.race(
+								scheduler, assertSubscriber::cancel,
+								() -> assertSubscriber.request(Long.MAX_VALUE)
+						),
+						() -> testPublishers[0].next(value)
+				);
 			}
 			else {
 				int startIndex = --index[0];
@@ -190,26 +190,26 @@ public class OnDiscardShouldNotLeakTest {
 				int secondIndex = --index[0];
 				Tracked value2 = tracker.track(secondIndex);
 				Runnable action = () -> RaceTestUtils.race(
-						() -> testPublishers[startIndex].next(value1),
-						() -> testPublishers[secondIndex].next(value2),
-						scheduler);
+						scheduler, () -> testPublishers[startIndex].next(value1),
+						() -> testPublishers[secondIndex].next(value2)
+				);
 
 				while (index[0] > 0) {
 					int nextIndex = --index[0];
 					Tracked nextValue = tracker.track(nextIndex);
 					Runnable nextAction = action;
 					action = () -> RaceTestUtils.race(
-							nextAction,
-							() -> testPublishers[nextIndex].next(nextValue),
-							scheduler);
+							scheduler, nextAction,
+							() -> testPublishers[nextIndex].next(nextValue)
+					);
 				}
-				RaceTestUtils.race(() ->
+				RaceTestUtils.race(scheduler, () ->
 						RaceTestUtils.race(
-								assertSubscriber::cancel,
-								() -> assertSubscriber.request(Long.MAX_VALUE),
-								scheduler),
-						action,
-						scheduler);
+								scheduler, assertSubscriber::cancel,
+								() -> assertSubscriber.request(Long.MAX_VALUE)
+						),
+						action
+				);
 			}
 
 			List<Tracked> values = assertSubscriber.values();
@@ -266,9 +266,9 @@ public class OnDiscardShouldNotLeakTest {
 			Tracked value23 = tracker.track(secondIndex+"3");
 			Tracked value24 = tracker.track(secondIndex+"4");
 			Runnable action = () -> RaceTestUtils.race(
-					() -> testPublishers[startIndex].next(value11, value12, value13, value14),
-					() -> testPublishers[secondIndex].next(value21, value22, value23, value24),
-					scheduler);
+					scheduler, () -> testPublishers[startIndex].next(value11, value12, value13, value14),
+					() -> testPublishers[secondIndex].next(value21, value22, value23, value24)
+			);
 
 			while (index[0] > 0) {
 				int nextIndex = --index[0];
@@ -278,17 +278,17 @@ public class OnDiscardShouldNotLeakTest {
 				Tracked nextValue4 = tracker.track(nextIndex+"4");
 				Runnable nextAction = action;
 				action = () -> RaceTestUtils.race(
-						nextAction,
-						() -> testPublishers[nextIndex].next(nextValue1, nextValue2, nextValue3, nextValue4),
-						scheduler);
+						scheduler, nextAction,
+						() -> testPublishers[nextIndex].next(nextValue1, nextValue2, nextValue3, nextValue4)
+				);
 			}
-			RaceTestUtils.race(() ->
+			RaceTestUtils.race(scheduler, () ->
 					RaceTestUtils.race(
-							assertSubscriber::cancel,
-							() -> assertSubscriber.request(Long.MAX_VALUE),
-							scheduler),
-					action,
-					scheduler);
+							scheduler, assertSubscriber::cancel,
+							() -> assertSubscriber.request(Long.MAX_VALUE)
+					),
+					action
+			);
 			List<Tracked> values = assertSubscriber.values();
 			values.forEach(Tracked::release);
 
@@ -337,11 +337,11 @@ public class OnDiscardShouldNotLeakTest {
 			Tracked value4 = tracker.track(4);
 			Tracked value5 = tracker.track(5);
 
-			RaceTestUtils.race(assertSubscriber::cancel, () -> {
+			RaceTestUtils.race(scheduler, assertSubscriber::cancel, () -> {
 				testPublisher.next(value3);
 				testPublisher.next(value4);
 				testPublisher.next(value5);
-			}, scheduler);
+			});
 
 			List<Tracked> values = assertSubscriber.values();
 			values.forEach(Tracked::release);
@@ -390,9 +390,9 @@ public class OnDiscardShouldNotLeakTest {
 			testPublisher.next(tracker.track(4));
 
 			RaceTestUtils.race(
-					assertSubscriber::cancel,
-					() -> testPublisher.complete(),
-					scheduler);
+					scheduler, assertSubscriber::cancel,
+					() -> testPublisher.complete()
+			);
 
 			List<Tracked> values = assertSubscriber.values();
 			values.forEach(Tracked::release);
@@ -442,9 +442,9 @@ public class OnDiscardShouldNotLeakTest {
 			testPublisher.next(tracker.track(4));
 
 			RaceTestUtils.race(
-					assertSubscriber::cancel,
-					() -> testPublisher.error(new RuntimeException("test")),
-					scheduler);
+					scheduler, assertSubscriber::cancel,
+					() -> testPublisher.error(new RuntimeException("test"))
+			);
 
 			List<Tracked> values = assertSubscriber.values();
 			values.forEach(Tracked::release);
@@ -560,9 +560,9 @@ public class OnDiscardShouldNotLeakTest {
 			testPublisher.next(tracker.track(4));
 
 			RaceTestUtils.race(
-					assertSubscriber::cancel,
-					() -> assertSubscriber.request(Long.MAX_VALUE),
-					scheduler);
+					scheduler, assertSubscriber::cancel,
+					() -> assertSubscriber.request(Long.MAX_VALUE)
+			);
 
 			List<Tracked> values = assertSubscriber.values();
 			values.forEach(Tracked::release);

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorDisposablesTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorDisposablesTest.java
@@ -76,7 +76,7 @@ public class OperatorDisposablesTest {
 				}
 			};
 
-			RaceTestUtils.race(r, r, Schedulers.elastic());
+			RaceTestUtils.race(Schedulers.elastic(), r, r);
 		}
 	}
 
@@ -91,7 +91,7 @@ public class OperatorDisposablesTest {
 				}
 			};
 
-			RaceTestUtils.race(r, r, Schedulers.elastic());
+			RaceTestUtils.race(Schedulers.elastic(), r, r);
 		}
 	}
 
@@ -105,7 +105,7 @@ public class OperatorDisposablesTest {
 				}
 			};
 
-			RaceTestUtils.race(r, r, Schedulers.elastic());
+			RaceTestUtils.race(Schedulers.elastic(), r, r);
 		}
 	}
 

--- a/reactor-test/src/main/java/reactor/test/util/RaceTestUtils.java
+++ b/reactor-test/src/main/java/reactor/test/util/RaceTestUtils.java
@@ -107,7 +107,7 @@ public class RaceTestUtils {
 	 * @param rs the runnables to execute
 	 */
 	public static void race(final Runnable... rs) {
-		race(Schedulers.elastic(), rs);
+		race(Schedulers.boundedElastic(), rs);
 	}
 
 	/**
@@ -116,7 +116,7 @@ public class RaceTestUtils {
 	 * Kept for binary compatibility, see the varargs variant.
 	 * @param r1 the first runnable to execute
 	 * @param r2 the second runnable to execute
-	 * @see #race(Runnable...)    
+	 * @see #race(Runnable...)
 	 */
 	public static void race(final Runnable r1, final Runnable r2) {
 		race(new Runnable[]{r1, r2});
@@ -128,7 +128,7 @@ public class RaceTestUtils {
 	 * @param s the {@link Scheduler} on which to execute the runnables
 	 * @param r1 the first runnable
 	 * @param r2 the second runnable
-	 * @deprecated use {@link #race(Scheduler, Runnable...)}. To be removed no sooner than 3.6.0.
+	 * @deprecated Use {@link #race(Scheduler, Runnable...)}. To be removed in 3.6.0, at the earliest.
 	 */
 	@Deprecated
 	public static void race(final Runnable r1, final Runnable r2, Scheduler s) {

--- a/reactor-test/src/main/java/reactor/test/util/RaceTestUtils.java
+++ b/reactor-test/src/main/java/reactor/test/util/RaceTestUtils.java
@@ -99,24 +99,39 @@ public class RaceTestUtils {
 		}
 	}
 
+	public static void race(final Runnable r1, final Runnable r2) {
+		race(new Runnable[]{r1, r2});
+	}
+	
 	/**
 	 * Synchronizes the execution of two {@link Runnable} as much as possible
 	 * to test race conditions. The method blocks until both have run to completion.
-	 * @param r1 the first runnable
-	 * @param r2 the second runnable
 	 */
-	public static void race(final Runnable r1, final Runnable r2) {
-		race(r1, r2, Schedulers.single());
+	public static void race(final Runnable... rs) {
+		race(Schedulers.boundedElastic(), rs);
 	}
 
 	/**
 	 * Synchronizes the execution of two {@link Runnable} as much as possible
 	 * to test race conditions. The method blocks until both have run to completion.
+	 * @param s the {@link Scheduler} on which to execute the runnables
 	 * @param r1 the first runnable
 	 * @param r2 the second runnable
+	 * @deprecated use {@link #race(Scheduler, Runnable...)}
+	 */
+	@Deprecated
+	public static void race(final Runnable r1, final Runnable r2, Scheduler s) {
+		race(s, r1, r2);
+	}
+
+	/**
+	 * Synchronizes the execution of two {@link Runnable} as much as possible
+	 * to test race conditions. The method blocks until both have run to completion.
 	 * @param s the {@link Scheduler} on which to execute the runnables
 	 */
-	public static void race(final Runnable r1, final Runnable r2, Scheduler s) {
+	public static void race(Scheduler s, final Runnable... rs) {
+		Runnable r1 = rs[0];
+		Runnable r2 = rs[1];
 		final AtomicInteger count = new AtomicInteger(2);
 		final CountDownLatch cdl = new CountDownLatch(2);
 

--- a/reactor-test/src/main/java/reactor/test/util/RaceTestUtils.java
+++ b/reactor-test/src/main/java/reactor/test/util/RaceTestUtils.java
@@ -16,6 +16,8 @@
 
 package reactor.test.util;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -102,13 +104,13 @@ public class RaceTestUtils {
 	public static void race(final Runnable r1, final Runnable r2) {
 		race(new Runnable[]{r1, r2});
 	}
-	
+
 	/**
 	 * Synchronizes the execution of two {@link Runnable} as much as possible
 	 * to test race conditions. The method blocks until both have run to completion.
 	 */
 	public static void race(final Runnable... rs) {
-		race(Schedulers.boundedElastic(), rs);
+		race(Schedulers.parallel(), rs);
 	}
 
 	/**
@@ -130,61 +132,46 @@ public class RaceTestUtils {
 	 * @param s the {@link Scheduler} on which to execute the runnables
 	 */
 	public static void race(Scheduler s, final Runnable... rs) {
-		Runnable r1 = rs[0];
-		Runnable r2 = rs[1];
-		final AtomicInteger count = new AtomicInteger(2);
-		final CountDownLatch cdl = new CountDownLatch(2);
-
-		final Throwable[] errors = { null, null };
-
-		s.schedule(() -> {
-			if (count.decrementAndGet() != 0) {
-				while (count.get() != 0) { }
-			}
-
-			try {
-				try {
-					r1.run();
-				} catch (Throwable ex) {
-					errors[0] = ex;
+		final AtomicInteger count = new AtomicInteger(rs.length);
+		final CountDownLatch cdl = new CountDownLatch(rs.length);
+		final Throwable[] errors = new Throwable[rs.length];
+		for (int i = 0; i < rs.length; i++) {
+			final int index = i;
+			s.schedule(() -> {
+				if (count.decrementAndGet() != 0) {
+					while (count.get() != 0) { }
 				}
-			} finally {
-				cdl.countDown();
-			}
-		});
 
-		if (count.decrementAndGet() != 0) {
-			while (count.get() != 0) { }
+				try {
+					try {
+						rs[index].run();
+					} catch (Throwable ex) {
+						errors[index] = ex;
+					}
+				} finally {
+					cdl.countDown();
+				}
+			});
 		}
 
 		try {
-			try {
-				r2.run();
-			} catch (Throwable ex) {
-				errors[1] = ex;
-			}
-		} finally {
-			cdl.countDown();
-		}
-
-		try {
-			if (!cdl.await(5, TimeUnit.SECONDS)) {
+			if (!cdl.await(50, TimeUnit.SECONDS)) {
 				throw new AssertionError("The wait timed out!");
 			}
 		} catch (InterruptedException ex) {
 			throw new RuntimeException(ex);
 		}
-		if (errors[0] != null && errors[1] == null) {
-			throw Exceptions.propagate(errors[0]);
-		}
 
-		if (errors[0] == null && errors[1] != null) {
-			throw Exceptions.propagate(errors[1]);
+		List<Throwable> es = new ArrayList<>(rs.length);
+		for (Throwable t : errors) {
+			if (t != null) {
+				es.add(t);
+			}
 		}
-
-		if (errors[0] != null && errors[1] != null) {
-			throw Exceptions.multiple(errors);
+		if (es.size() == 1) {
+			throw Exceptions.propagate(es.get(0));
+		} else if (es.size() > 1) {
+			throw Exceptions.multiple(es.toArray(new Throwable[0]));
 		}
 	}
-
 }

--- a/reactor-test/src/main/java/reactor/test/util/RaceTestUtils.java
+++ b/reactor-test/src/main/java/reactor/test/util/RaceTestUtils.java
@@ -116,6 +116,7 @@ public class RaceTestUtils {
 	 * Kept for binary compatibility, see the varargs variant.
 	 * @param r1 the first runnable to execute
 	 * @param r2 the second runnable to execute
+	 * @see #race(Runnable...)    
 	 */
 	public static void race(final Runnable r1, final Runnable r2) {
 		race(new Runnable[]{r1, r2});
@@ -127,7 +128,7 @@ public class RaceTestUtils {
 	 * @param s the {@link Scheduler} on which to execute the runnables
 	 * @param r1 the first runnable
 	 * @param r2 the second runnable
-	 * @deprecated use {@link #race(Scheduler, Runnable...)}
+	 * @deprecated use {@link #race(Scheduler, Runnable...)}. To be removed no sooner than 3.6.0.
 	 */
 	@Deprecated
 	public static void race(final Runnable r1, final Runnable r2, Scheduler s) {

--- a/reactor-test/src/main/java/reactor/test/util/RaceTestUtils.java
+++ b/reactor-test/src/main/java/reactor/test/util/RaceTestUtils.java
@@ -106,8 +106,9 @@ public class RaceTestUtils {
 	}
 
 	/**
-	 * Synchronizes the execution of two {@link Runnable} as much as possible
-	 * to test race conditions. The method blocks until both have run to completion.
+	 * Synchronizes the execution of several {@link Runnable}s as much as possible
+	 * to test race conditions. The method blocks until all have run to completion.
+	 * @param rs the runnables to execute
 	 */
 	public static void race(final Runnable... rs) {
 		race(Schedulers.parallel(), rs);
@@ -127,9 +128,10 @@ public class RaceTestUtils {
 	}
 
 	/**
-	 * Synchronizes the execution of two {@link Runnable} as much as possible
+	 * Synchronizes the execution of several {@link Runnable}s as much as possible
 	 * to test race conditions. The method blocks until both have run to completion.
 	 * @param s the {@link Scheduler} on which to execute the runnables
+	 * @param rs the runnables to execute
 	 */
 	public static void race(Scheduler s, final Runnable... rs) {
 		final AtomicInteger count = new AtomicInteger(rs.length);

--- a/reactor-test/src/main/java/reactor/test/util/RaceTestUtils.java
+++ b/reactor-test/src/main/java/reactor/test/util/RaceTestUtils.java
@@ -101,17 +101,24 @@ public class RaceTestUtils {
 		}
 	}
 
-	public static void race(final Runnable r1, final Runnable r2) {
-		race(new Runnable[]{r1, r2});
-	}
-
 	/**
 	 * Synchronizes the execution of several {@link Runnable}s as much as possible
 	 * to test race conditions. The method blocks until all have run to completion.
 	 * @param rs the runnables to execute
 	 */
 	public static void race(final Runnable... rs) {
-		race(Schedulers.parallel(), rs);
+		race(Schedulers.elastic(), rs);
+	}
+
+	/**
+	 * Synchronizes the execution of two {@link Runnable}s as much as possible
+	 * to test race conditions. The method blocks until both have run to completion.
+	 * Kept for binary compatibility, see the varargs variant.
+	 * @param r1 the first runnable to execute
+	 * @param r2 the second runnable to execute
+	 */
+	public static void race(final Runnable r1, final Runnable r2) {
+		race(new Runnable[]{r1, r2});
 	}
 
 	/**
@@ -129,7 +136,7 @@ public class RaceTestUtils {
 
 	/**
 	 * Synchronizes the execution of several {@link Runnable}s as much as possible
-	 * to test race conditions. The method blocks until both have run to completion.
+	 * to test race conditions. The method blocks until all have run to completion.
 	 * @param s the {@link Scheduler} on which to execute the runnables
 	 * @param rs the runnables to execute
 	 */
@@ -157,7 +164,7 @@ public class RaceTestUtils {
 		}
 
 		try {
-			if (!cdl.await(50, TimeUnit.SECONDS)) {
+			if (!cdl.await(5, TimeUnit.SECONDS)) {
 				throw new AssertionError("The wait timed out!");
 			}
 		} catch (InterruptedException ex) {


### PR DESCRIPTION
This PR fixes the way we race() more than 2 runnables.

In doing so, this now consistently highlights a failure in `OnDiscardShouldNotLeakTest.singleOrEmpty` (left failing in this PR for now), which is good news. This can also fail consistently with way less iterations than before, so this PR drops the number of iterations to 100 as well.

