### PR TITLE
Make Mono.then execution model more deterministic

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoIgnoreThen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoIgnoreThen.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
-import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
 
@@ -34,7 +33,7 @@ import reactor.util.annotation.Nullable;
  *
  * @param <T> the final value type
  */
-final class MonoIgnoreThen<T> extends Mono<T> implements Fuseable, Scannable {
+final class MonoIgnoreThen<T> extends Mono<T> implements Scannable {
 
     final Publisher<?>[] ignore;
     
@@ -322,7 +321,7 @@ final class MonoIgnoreThen<T> extends Mono<T> implements Fuseable, Scannable {
                     return state;
                 }
 
-                if (STATE.compareAndSet(this, state, state | HAS_SUBSCRIPTION)) {
+                if (STATE.compareAndSet(this, state, state &~ HAS_SUBSCRIPTION)) {
                     return state;
                 }
             }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoIgnoreThen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoIgnoreThen.java
@@ -19,8 +19,6 @@ package reactor.core.publisher;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import java.util.stream.Stream;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
@@ -28,7 +26,6 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
-import reactor.util.context.Context;
 
 /**
  * Concatenates a several Mono sources with a final Mono source by
@@ -50,10 +47,9 @@ final class MonoIgnoreThen<T> extends Mono<T> implements Fuseable, Scannable {
     
     @Override
     public void subscribe(CoreSubscriber<? super T> actual) {
-        ThenIgnoreMain<T> manager = new ThenIgnoreMain<>(actual, ignore, last);
+        ThenIgnoreMain<T> manager = new ThenIgnoreMain<>(actual, this.ignore, this.last);
         actual.onSubscribe(manager);
-        
-        manager.drain();
+        manager.subscribeNext();
     }
     
     /**
@@ -64,11 +60,11 @@ final class MonoIgnoreThen<T> extends Mono<T> implements Fuseable, Scannable {
      */
     <U> MonoIgnoreThen<U> shift(Mono<U> newLast) {
         Objects.requireNonNull(newLast, "newLast");
-        Publisher<?>[] a = ignore;
+        Publisher<?>[] a = this.ignore;
         int n = a.length;
         Publisher<?>[] b = new Publisher[n + 1];
         System.arraycopy(a, 0, b, 0, n);
-        b[n] = last;
+        b[n] = this.last;
         
         return new MonoIgnoreThen<>(b, newLast);
     }
@@ -78,244 +74,289 @@ final class MonoIgnoreThen<T> extends Mono<T> implements Fuseable, Scannable {
         return null; //no particular key to be represented, still useful in hooks
     }
     
-    static final class ThenIgnoreMain<T>
-            extends Operators.MonoSubscriber<T, T> {
-        final ThenIgnoreInner ignore;
-        
-        final ThenAcceptInner<T> accept;
+    static final class ThenIgnoreMain<T> implements InnerOperator<T, T> {
         
         final Publisher<?>[] ignoreMonos;
-
         final Mono<T> lastMono;
+        final CoreSubscriber<? super T> actual;
 
-        int index;
-        
-        volatile boolean active;
-        
-        volatile int wip;
+        T value;
+
+        int          index;
+        Subscription activeSubscription;
+        boolean      done;
+
+        volatile int state;
         @SuppressWarnings("rawtypes")
-        static final AtomicIntegerFieldUpdater<ThenIgnoreMain> WIP =
-                AtomicIntegerFieldUpdater.newUpdater(ThenIgnoreMain.class, "wip");
-        
+        private static final AtomicIntegerFieldUpdater<ThenIgnoreMain> STATE =
+                AtomicIntegerFieldUpdater.newUpdater(ThenIgnoreMain.class, "state");
+        // The following are to be used as bit masks, not as values per se.
+        static final int HAS_REQUEST      = 0b00000010;
+        static final int HAS_SUBSCRIPTION = 0b00000100;
+        static final int HAS_VALUE        = 0b00001000;
+        static final int HAS_COMPLETION   = 0b00010000;
+        // The following are to be used as value (ie using == or !=).
+        static final int CANCELLED        = 0b10000000;
+
         ThenIgnoreMain(CoreSubscriber<? super T> subscriber,
 		        Publisher<?>[] ignoreMonos, Mono<T> lastMono) {
-            super(subscriber);
+            this.actual = subscriber;
             this.ignoreMonos = ignoreMonos;
             this.lastMono = lastMono;
-            this.ignore = new ThenIgnoreInner(this);
-            this.accept = new ThenAcceptInner<>(this);
-        }
-
-	    @Override
-	    public Stream<? extends Scannable> inners() {
-		    return Stream.of(ignore, accept);
-	    }
-
-	    @SuppressWarnings("unchecked")
-        void drain() {
-            if (WIP.getAndIncrement(this) != 0) {
-                return;
-            }
-            
-            for (;;) {
-                if (isCancelled()) {
-                    return;
-                }
-                
-                if (!active) {
-
-                    Publisher<?>[] a = ignoreMonos;
-                    int i = index;
-                    if (i == a.length) {
-                        ignore.clear();
-                        Mono<T> m = lastMono;
-                        if (m instanceof Callable) {
-                            T v;
-                            try {
-                                v = ((Callable<T>)m).call();
-                            }
-                            catch (Throwable ex) {
-	                            actual.onError(Operators.onOperatorError(ex,
-                                        actual.currentContext()));
-	                            return;
-                            }
-                            
-                            if (v == null) {
-                                actual.onComplete();
-                            }
-                            else {
-                                complete(v);
-                            }
-                            return;
-                        }
-                        
-                        active = true;
-                        m.subscribe(accept);
-                    } else {
-                        Publisher<?> m = a[i];
-                        index = i + 1;
-                        
-                        if (m instanceof Callable) {
-                            try {
-                                ((Callable<?>)m).call();
-                            }
-                            catch (Throwable ex) {
-	                            actual.onError(Operators.onOperatorError(ex,
-                                        actual.currentContext()));
-	                            return;
-                            }
-                            
-                            continue;
-                        }
-                        
-                        active = true;
-                        m.subscribe(ignore);
-                    }
-                }
-                if (WIP.decrementAndGet(this) == 0) {
-                    break;
-                }
-            }
-        }
-        
-        @Override
-        public void cancel() {
-            super.cancel();
-            ignore.cancel();
-            accept.cancel();
-        }
-        
-        void ignoreDone() {
-            active = false;
-            drain();
-        }
-    }
-    
-    static final class ThenIgnoreInner implements InnerConsumer<Object> {
-        final ThenIgnoreMain<?> parent;
-        
-        volatile Subscription s;
-        static final AtomicReferenceFieldUpdater<ThenIgnoreInner, Subscription> S =
-                AtomicReferenceFieldUpdater.newUpdater(ThenIgnoreInner.class, Subscription.class, "s");
-        
-        ThenIgnoreInner(ThenIgnoreMain<?> parent) {
-            this.parent = parent;
-        }
-
-	    @Override
-        @Nullable
-	    public Object scanUnsafe(Attr key) {
-            if (key == Attr.PARENT) return s;
-            if (key == Attr.ACTUAL) return parent;
-            if (key == Attr.CANCELLED) return s == Operators.cancelledSubscription();
-
-		    return null;
-	    }
-
-        @Override
-        public void onSubscribe(Subscription s) {
-            if (Operators.replace(S, this, s)) {
-                s.request(Long.MAX_VALUE);
-            }
-        }
-
-	    @Override
-	    public Context currentContext() {
-		    return parent.currentContext();
-	    }
-
-        @Override
-        public void onNext(Object t) {
-            // ignored
-            Operators.onDiscard(t, parent.currentContext()); //FIXME cache Context
-        }
-        
-        @Override
-        public void onError(Throwable t) {
-            this.parent.onError(t);
-        }
-        
-        @Override
-        public void onComplete() {
-            this.parent.ignoreDone();
-        }
-        
-        void cancel() {
-            Operators.terminate(S, this);
-        }
-        
-        void clear() {
-            S.lazySet(this, null);
-        }
-    }
-    
-    static final class ThenAcceptInner<T> implements InnerConsumer<T> {
-        final ThenIgnoreMain<T> parent;
-        
-        volatile Subscription s;
-        @SuppressWarnings("rawtypes")
-        static final AtomicReferenceFieldUpdater<ThenAcceptInner, Subscription> S =
-                AtomicReferenceFieldUpdater.newUpdater(ThenAcceptInner.class, Subscription.class, "s");
-
-        boolean done;
-        
-        ThenAcceptInner(ThenIgnoreMain<T> parent) {
-            this.parent = parent;
         }
 
         @Override
         @Nullable
         public Object scanUnsafe(Attr key) {
-            if (key == Attr.PARENT) return s;
-            if (key == Attr.ACTUAL) return parent;
-            if (key == Attr.TERMINATED) return done;
-            if (key == Attr.CANCELLED) return s == Operators.cancelledSubscription();
+            if (key == Attr.PARENT) return this.activeSubscription;
+            if (key == Attr.CANCELLED) return isCancelled(this.state);
 
-            return null;
+            return InnerOperator.super.scanUnsafe(key);
         }
 
         @Override
-        public Context currentContext() {
-            return parent.currentContext();
+        public CoreSubscriber<? super T> actual() {
+            return this.actual;
         }
 
         @Override
         public void onSubscribe(Subscription s) {
-            if (Operators.setOnce(S, this, s)) {
+            if (Operators.validate(this.activeSubscription, s)) {
+                this.activeSubscription = s;
+
+                final int previousState = markHasSubscription();
+                if (isCancelled(previousState)) {
+                    s.cancel();
+                    return;
+                }
+
                 s.request(Long.MAX_VALUE);
             }
         }
-        
+
+        @Override
+        public void cancel() {
+            int previousState = markCancelled();
+
+            if (hasSubscription(previousState)) {
+                this.activeSubscription.cancel();
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            if (Operators.validate(n)) {
+                for (; ; ) {
+                    final int state = this.state;
+                    if (isCancelled(state)) {
+                        return;
+                    }
+                    if (hasRequest(state)) {
+                        return;
+                    }
+                    if (STATE.compareAndSet(this, state, state | HAS_REQUEST)) {
+                        if (hasValue(state)) {
+                            final CoreSubscriber<? super T> actual = this.actual;
+                            final T v = this.value;
+
+                            actual.onNext(v);
+                            actual.onComplete();
+                        }
+                        return;
+                    }
+                }
+            }
+        }
+
         @Override
         public void onNext(T t) {
-            if (done) {
-                Operators.onNextDropped(t, parent.currentContext());
+            if (this.done) {
+                Operators.onDiscard(t, currentContext());
                 return;
             }
-            done = true;
-            this.parent.complete(t);
-        }
-        
-        @Override
-        public void onError(Throwable t) {
-            if (done) {
-                Operators.onErrorDropped(t, parent.currentContext());
+
+            if (this.index != this.ignoreMonos.length) {
+                // ignored
+                Operators.onDiscard(t, currentContext());
                 return;
             }
-            done = true;
-            this.parent.onError(t);
+
+            this.done = true;
+
+            complete(t);
         }
-        
+
         @Override
         public void onComplete() {
-            if (done) {
+            if (this.done) {
                 return;
             }
-            this.parent.onComplete();
+
+            if (this.index != this.ignoreMonos.length) {
+                final int previousState = markUnsubscribed();
+                if (isCancelled(previousState)) {
+                    return;
+                }
+                this.activeSubscription = null;
+                this.index++;
+                subscribeNext();
+                return;
+            }
+
+            this.done = true;
+
+            this.actual.onComplete();
         }
-        
-        void cancel() {
-            Operators.terminate(S, this);
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        void subscribeNext() {
+            final Publisher<?>[] a = this.ignoreMonos;
+
+            for (;;) {
+                final int i = this.index;
+
+                if (i == a.length) {
+                    Mono<T> m = this.lastMono;
+                    if (m instanceof Callable) {
+                        T v;
+                        try {
+                            v = ((Callable<T>)m).call();
+                        }
+                        catch (Throwable ex) {
+                            onError(Operators.onOperatorError(ex, currentContext()));
+                            return;
+                        }
+
+                        if (v != null) {
+                            onNext(v);
+                        }
+                        onComplete();
+                    } else {
+                        m.subscribe(this);
+                    }
+                    return;
+                } else {
+                    final Publisher<?> m = a[i];
+
+                    if (m instanceof Callable) {
+                        try {
+                            Operators.onDiscard(((Callable<?>) m).call(), currentContext());
+                        }
+                        catch (Throwable ex) {
+                            onError(Operators.onOperatorError(ex, currentContext()));
+                            return;
+                        }
+
+                        this.index = i + 1;
+                        continue;
+                    }
+
+                    m.subscribe((CoreSubscriber) this);
+                    return;
+                }
+            }
         }
+
+        @Override
+        public void onError(Throwable t) {
+            if (this.done) {
+                Operators.onErrorDropped(t, actual().currentContext());
+                return;
+            }
+
+            this.done = true;
+
+            this.actual.onError(t);
+        }
+
+        final void complete(T value) {
+            for (; ; ) {
+                int s = this.state;
+                if (isCancelled(s)) {
+                    Operators.onDiscard(value, this.actual.currentContext());
+                    return;
+                }
+
+                if (hasRequest(s) && STATE.compareAndSet(this, s, s | (HAS_VALUE | HAS_COMPLETION))) {
+                    final CoreSubscriber<? super T> actual = this.actual;
+
+                    actual.onNext(value);
+                    actual.onComplete();
+                    return;
+                }
+
+                this.value = value;
+                if (STATE.compareAndSet(this, s, s | (HAS_VALUE | HAS_COMPLETION))) {
+                    return;
+                }
+            }
+        }
+
+        final int markHasSubscription() {
+            for (;;) {
+                final int state = this.state;
+
+                if (state == CANCELLED) {
+                    return state;
+                }
+
+                if ((state & HAS_SUBSCRIPTION) == HAS_SUBSCRIPTION) {
+                    return state;
+                }
+
+                if (STATE.compareAndSet(this, state, state | HAS_SUBSCRIPTION)) {
+                    return state;
+                }
+            }
+        }
+
+        final int markUnsubscribed() {
+            for (;;) {
+                final int state = this.state;
+
+                if (isCancelled(state)) {
+                    return state;
+                }
+
+                if (!hasSubscription(state)) {
+                    return state;
+                }
+
+                if (STATE.compareAndSet(this, state, state | HAS_SUBSCRIPTION)) {
+                    return state;
+                }
+            }
+        }
+
+        final int markCancelled() {
+            for (;;) {
+                final int state = this.state;
+
+                if (state == CANCELLED) {
+                    return state;
+                }
+
+                if (STATE.compareAndSet(this, state, CANCELLED)) {
+                    return state;
+                }
+            }
+        }
+
+        static boolean isCancelled(int s) {
+            return s == CANCELLED;
+        }
+
+        static boolean hasSubscription(int s) {
+            return (s & HAS_SUBSCRIPTION) == HAS_SUBSCRIPTION;
+        }
+
+        static boolean hasRequest(int s) {
+            return (s & HAS_REQUEST) == HAS_REQUEST;
+        }
+
+        static boolean hasValue(int s) {
+            return (s & HAS_VALUE) == HAS_VALUE;
+        }
+
     }
 }


### PR DESCRIPTION
This PR draft and alternative impl of MonoIgnore which does not require drain loop and wip guard and only uses a single volatile field for catching cancelation scenario.

Though the advantages are obvious, the main disadvantage of this impl is a possibly too long stack track due to subscription to the then(source) on the producer stack, which in the case of synchronous invocation can be too long.

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>
Signed-off-by: Oleh Dokuka <shadowgun@i.ua>