### PR TITLE
Polish after #2576: ScalarSubscription scanUnsafe

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -2379,12 +2379,8 @@ public abstract class Operators {
 		@Override
 		@Nullable
 		public Object scanUnsafe(Attr key) {
-			if (key == Attr.TERMINATED) {
-				return once == 1 || once == 2;
-			}
-			if (key == Attr.CANCELLED) {
-				return once == 2;
-			}
+			if (key == Attr.TERMINATED) return once == 1;
+			if (key == Attr.CANCELLED) return once == 2;
 
 			return InnerProducer.super.scanUnsafe(key);
 		}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxJustTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxJustTest.java
@@ -106,11 +106,14 @@ public class FluxJustTest {
 		ScalarSubscription<Integer> test = new ScalarSubscription<>(actual, 1);
 
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
-		assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
-		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).as("TERMINATED initial").isFalse();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).as("CANCELLED initial").isFalse();
+		test.poll();
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).as("TERMINATED after poll").isTrue();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).as("CANCELLED after poll").isFalse();
 		test.cancel();
-		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
-		assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).as("TERMINATED after cancel").isFalse();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).as("CANCELLED after cancel").isTrue();
 	}
 	
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
@@ -287,14 +287,14 @@ public class OperatorsTest {
 
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
 
-		assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
-		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).as("TERMINATED when initially filled").isFalse();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).as("CANCELLED when initially filled").isFalse();
 		test.poll();
-		assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
-		assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).as("TERMINATED after poll").isTrue();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).as("CANCELLED after poll").isFalse();
 		test.cancel();
-		assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
-		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).as("TERMINATED after cancel").isFalse();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).as("CANCELLED after cancel").isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
 - ScalarSubscription scan of TERMINATED shouldn't take the cancelled
 state into account (none of the other operators do that when the two
 states can be distinguished)
 - tests have been amended accordingly (including FluxJustTest)
