### PR TITLE
Add Mono.cache(ttl, ttl, ttl) overload with Scheduler

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
@@ -17,6 +17,7 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
@@ -57,6 +58,9 @@ class MonoCacheTime<T> extends InternalMonoOperator<T, T> implements Runnable {
 
 	MonoCacheTime(Mono<? extends T> source, Duration ttl, Scheduler clock) {
 		super(source);
+        Objects.requireNonNull(ttl, "ttl must not be null");
+        Objects.requireNonNull(clock, "clock must not be null");
+
 		this.ttlGenerator = ignoredSignal -> ttl;
 		this.clock = clock;
 		@SuppressWarnings("unchecked")
@@ -84,6 +88,11 @@ class MonoCacheTime<T> extends InternalMonoOperator<T, T> implements Runnable {
 			Supplier<Duration> emptyTtlGenerator,
 			Scheduler clock) {
 		super(source);
+		Objects.requireNonNull(valueTtlGenerator, "valueTtlGenerator must not be null");
+        Objects.requireNonNull(errorTtlGenerator, "errorTtlGenerator must not be null");
+        Objects.requireNonNull(emptyTtlGenerator, "emptyTtlGenerator must not be null");
+        Objects.requireNonNull(clock, "clock must not be null");
+
 		this.ttlGenerator = sig -> {
 			if (sig.isOnNext()) return valueTtlGenerator.apply(sig.get());
 			if (sig.isOnError()) return errorTtlGenerator.apply(sig.getThrowable());

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
@@ -58,8 +58,8 @@ class MonoCacheTime<T> extends InternalMonoOperator<T, T> implements Runnable {
 
 	MonoCacheTime(Mono<? extends T> source, Duration ttl, Scheduler clock) {
 		super(source);
-        Objects.requireNonNull(ttl, "ttl must not be null");
-        Objects.requireNonNull(clock, "clock must not be null");
+		Objects.requireNonNull(ttl, "ttl must not be null");
+		Objects.requireNonNull(clock, "clock must not be null");
 
 		this.ttlGenerator = ignoredSignal -> ttl;
 		this.clock = clock;
@@ -89,9 +89,9 @@ class MonoCacheTime<T> extends InternalMonoOperator<T, T> implements Runnable {
 			Scheduler clock) {
 		super(source);
 		Objects.requireNonNull(valueTtlGenerator, "valueTtlGenerator must not be null");
-        Objects.requireNonNull(errorTtlGenerator, "errorTtlGenerator must not be null");
-        Objects.requireNonNull(emptyTtlGenerator, "emptyTtlGenerator must not be null");
-        Objects.requireNonNull(clock, "clock must not be null");
+		Objects.requireNonNull(errorTtlGenerator, "errorTtlGenerator must not be null");
+		Objects.requireNonNull(emptyTtlGenerator, "emptyTtlGenerator must not be null");
+		Objects.requireNonNull(clock, "clock must not be null");
 
 		this.ttlGenerator = sig -> {
 			if (sig.isOnNext()) return valueTtlGenerator.apply(sig.get());

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
@@ -21,9 +21,15 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.Test;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
@@ -34,7 +40,6 @@ import reactor.test.publisher.MonoOperatorTest;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.scheduler.VirtualTimeScheduler;
 import reactor.test.util.RaceTestUtils;
-import reactor.util.context.Context;
 import reactor.util.context.ContextView;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -900,4 +905,57 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
 	}
 
+	@Test
+    public void signalDependentWithSchedulerOperatorTests() {
+	    Duration valueTtl = Duration.ofMillis(1000);
+        Duration errorTtl = Duration.ofMillis(2000);
+        Duration emptyTtl = Duration.ofMillis(3000);
+
+        AtomicInteger subCount = new AtomicInteger();
+        Supplier<Mono<Integer>> valueMonoSupplier = () -> Mono.just(subCount.incrementAndGet());
+        Supplier<Mono<Integer>> errorMonoSupplier = () -> Mono.error(new RuntimeException("Boom #" + subCount.incrementAndGet()));
+        Supplier<Mono<Integer>> emptyMonoSupplier = () -> { subCount.incrementAndGet(); return Mono.empty(); };
+
+        VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+        Function<Supplier<Mono<Integer>>, Mono<Integer>> monoFunction = monoSupplier -> Mono.defer(monoSupplier)
+                .cache(value -> valueTtl, error -> errorTtl, () -> emptyTtl, vts);
+
+        assertCacheTtl(monoFunction.apply(valueMonoSupplier), valueTtl, subCount, vts);
+        assertCacheTtl(monoFunction.apply(errorMonoSupplier), errorTtl, subCount, vts);
+        assertCacheTtl(monoFunction.apply(emptyMonoSupplier), emptyTtl, subCount, vts);
+    }
+
+    private void assertCacheTtl(Mono<Integer> mono, Duration ttl, AtomicInteger subCount, VirtualTimeScheduler vts) {
+	    subCount.set(0);
+
+        mono.subscribe();
+        vts.advanceTimeBy(ttl.minusNanos(1));
+        mono.subscribe();
+        assertThat(subCount.get()).isEqualTo(1);
+
+        vts.advanceTimeBy(Duration.ofNanos(1));
+        mono.subscribe();
+        assertThat(subCount.get()).isEqualTo(2);
+    }
+
+    @ParameterizedTest
+    @MethodSource("nullInvocations")
+    public void nullArgumentsToCacheOperatorsAreImmediatelyRejected(ThrowableAssert.ThrowingCallable nullInvocation) {
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(nullInvocation);
+    }
+
+    private static Stream<ThrowableAssert.ThrowingCallable> nullInvocations() {
+	    return Stream.of(
+                () -> Mono.empty().cache(null),
+                () -> Mono.empty().cache(null, Schedulers.parallel()),
+                () -> Mono.empty().cache(Duration.ZERO, null),
+                () -> Mono.empty().cache(null, e -> Duration.ZERO, () -> Duration.ZERO),
+                () -> Mono.empty().cache(v -> Duration.ZERO, null, () -> Duration.ZERO),
+                () -> Mono.empty().cache(v -> Duration.ZERO, e -> Duration.ZERO, null),
+                () -> Mono.empty().cache(null, e -> Duration.ZERO, () -> Duration.ZERO, Schedulers.parallel()),
+                () -> Mono.empty().cache(v -> Duration.ZERO, null, () -> Duration.ZERO, Schedulers.parallel()),
+                () -> Mono.empty().cache(v -> Duration.ZERO, e -> Duration.ZERO, null, Schedulers.parallel()),
+                () -> Mono.empty().cache(v -> Duration.ZERO, e -> Duration.ZERO, () -> Duration.ZERO, null)
+        );
+    }
 }


### PR DESCRIPTION
Fix for #2580.

I could not find any tests for the other overloaded cache-operators. Please point me in the right direction if you want tests for this.