### PR TITLE
Fix Mono.publish(Function) not propagating onError

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPublishMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPublishMulticast.java
@@ -226,28 +226,29 @@ final class MonoPublishMulticast<T, R> extends InternalMonoOperator<T, R> implem
 							return;
 						}
 
-						if (v == null) {
-							@SuppressWarnings("unchecked")
-							PublishMulticastInner<T>[] castedArray = SUBSCRIBERS.getAndSet(this, TERMINATED);
-							a = castedArray;
-							n = a.length;
+						@SuppressWarnings("unchecked")
+						PublishMulticastInner<T>[] castedArray = SUBSCRIBERS.getAndSet(this, TERMINATED);
+						a = castedArray;
+						n = a.length;
+						Throwable ex = error;
+						if (ex != null) {
+							for (int i = 0; i < n; i++) {
+								a[i].actual.onError(ex);
+							}
+						}
+						else if (v == null) {
 							for (int i = 0; i < n; i++) {
 								a[i].actual.onComplete();
 							}
-							return;
 						}
 						else {
-							@SuppressWarnings("unchecked")
-							PublishMulticastInner<T>[] castedArray = SUBSCRIBERS.getAndSet(this, TERMINATED);
-							a = castedArray;
-							n = a.length;
 							for (int i = 0; i < n; i++) {
 								a[i].actual.onNext(v);
 								a[i].actual.onComplete();
 							}
 							value = null;
-							return;
 						}
+						return;
 					}
 				}
 


### PR DESCRIPTION
This commit fixes the drain loop of MonoPublishMulticast so that it now
correctly takes captured `onError` into account.

The operator would previously only propagate the error to late
subscribers, but not live ones.

The unit tests have also been cleared (removal of unnecessary public
modifiers, small amount of formatting) and the normal+fused case has
been fixed to actually trigger a fused path.

Fixes #2600.
