### PR TITLE
Improves fuse-enabled operator

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -17,6 +17,7 @@ package reactor.core.publisher;
 
 import java.util.Objects;
 import java.util.Queue;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -169,23 +170,29 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 	static final AtomicReferenceFieldUpdater<UnicastProcessor, Disposable> ON_TERMINATE =
 			AtomicReferenceFieldUpdater.newUpdater(UnicastProcessor.class, Disposable.class, "onTerminate");
 
-	volatile boolean done;
+	boolean   cancelled;
+	boolean   done;
 	Throwable error;
 
-	boolean hasDownstream; //important to not loose the downstream too early and miss discard hook, while having relevant hasDownstreams()
-	volatile CoreSubscriber<? super T> actual;
+	CoreSubscriber<? super T> actual;
 
-	volatile boolean cancelled;
+	static final long FLAG_TERMINATED      =
+			0b1000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;
+	static final long FLAG_DISPOSED        =
+			0b0100_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;
+	static final long FLAG_CANCELLED       =
+			0b0010_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;
+	static final long FLAG_SUBSCRIBER_READY =
+			0b0001_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;
+	static final long FLAG_SUBSCRIBED_ONCE =
+			0b0000_1000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;
+	static final long MAX_WIP_VALUE        =
+			0b0000_0111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111L;
 
-	volatile int once;
+	volatile long state;
 	@SuppressWarnings("rawtypes")
-	static final AtomicIntegerFieldUpdater<UnicastProcessor> ONCE =
-			AtomicIntegerFieldUpdater.newUpdater(UnicastProcessor.class, "once");
-
-	volatile int wip;
-	@SuppressWarnings("rawtypes")
-	static final AtomicIntegerFieldUpdater<UnicastProcessor> WIP =
-			AtomicIntegerFieldUpdater.newUpdater(UnicastProcessor.class, "wip");
+	static final AtomicLongFieldUpdater<UnicastProcessor> STATE =
+			AtomicLongFieldUpdater.newUpdater(UnicastProcessor.class, "state");
 
 	volatile int discardGuard;
 	@SuppressWarnings("rawtypes")
@@ -227,7 +234,10 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 
 	@Override
 	public Stream<Scannable> inners() {
-		return hasDownstream ? Stream.of(Scannable.from(actual)) : Stream.empty();
+		final long state = this.state;
+		final CoreSubscriber<? super T> actual = this.actual;
+		return isSubscriberReady(state) ? Stream.of(Scannable.from(actual)) :
+				Stream.empty();
 	}
 
 	@Override
@@ -235,7 +245,10 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 		if (Attr.ACTUAL == key) return actual();
 		if (Attr.BUFFERED == key) return queue.size();
 		if (Attr.PREFETCH == key) return Integer.MAX_VALUE;
-		if (Attr.CANCELLED == key) return cancelled;
+		if (Attr.CANCELLED == key) {
+			final long state = this.state;
+			return isCancelled(state) || isDisposed(state);
+		}
 
 		//TERMINATED and ERROR covered in super
 		return super.scanUnsafe(key);
@@ -249,18 +262,18 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 
 	@Override
 	public EmitResult tryEmitComplete() {
-		if (done) {
+		if (this.done) {
 			return EmitResult.FAIL_TERMINATED;
 		}
-		if (cancelled) {
+		if (this.cancelled) {
 			return EmitResult.FAIL_CANCELLED;
 		}
 
-		done = true;
+		this.done = true;
 
 		doTerminate();
 
-		drain(null);
+		drain();
 		return Sinks.EmitResult.OK;
 	}
 
@@ -271,19 +284,19 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 
 	@Override
 	public Sinks.EmitResult tryEmitError(Throwable t) {
-		if (done) {
+		if (this.done) {
 			return Sinks.EmitResult.FAIL_TERMINATED;
 		}
-		if (cancelled) {
+		if (this.cancelled) {
 			return EmitResult.FAIL_CANCELLED;
 		}
 
-		error = t;
-		done = true;
+		this.error = t;
+		this.done = true;
 
 		doTerminate();
 
-		drain(null);
+		drain();
 		return EmitResult.OK;
 	}
 
@@ -294,7 +307,7 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 
 	@Override
 	public void emitNext(T value, Sinks.EmitFailureHandler failureHandler) {
-		if (onOverflow == null) {
+		if (this.onOverflow == null) {
 			InternalManySink.super.emitNext(value, failureHandler);
 			return;
 		}
@@ -308,7 +321,7 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 							case FAIL_ZERO_SUBSCRIBER:
 							case FAIL_OVERFLOW:
 								try {
-									onOverflow.accept(value);
+									this.onOverflow.accept(value);
 								}
 								catch (Throwable e) {
 									Exceptions.throwIfFatal(e);
@@ -324,23 +337,25 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 
 	@Override
 	public EmitResult tryEmitNext(T t) {
-		if (done) {
+		if (this.done) {
 			return EmitResult.FAIL_TERMINATED;
 		}
-		if (cancelled) {
+		if (this.cancelled) {
 			return EmitResult.FAIL_CANCELLED;
 		}
 
-		if (!queue.offer(t)) {
-			return (once > 0) ? EmitResult.FAIL_OVERFLOW : EmitResult.FAIL_ZERO_SUBSCRIBER;
+		if (!this.queue.offer(t)) {
+			return isSubscriberReady(this.state) ? EmitResult.FAIL_OVERFLOW :
+					EmitResult.FAIL_ZERO_SUBSCRIBER;
 		}
-		drain(t);
+		drain();
 		return EmitResult.OK;
 	}
 
 	@Override
 	public int currentSubscriberCount() {
-		return hasDownstream ? 1 : 0;
+		final long state = this.state;
+		return isSubscriberReady(state) ? 1 : 0;
 	}
 
 	@Override
@@ -360,23 +375,77 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 		}
 	}
 
-	void drainRegular(CoreSubscriber<? super T> a) {
-		int missed = 1;
+	void drain() {
+		long previousState = wipIncrement(this);
+		if (isTerminated(previousState)) {
+			this.clearSafely();
+			return;
+		}
 
-		final Queue<T> q = queue;
+		if (isWorkInProgress(previousState)) {
+			return;
+		}
+
+		long expectedState = previousState + 1;
+		for (;;) {
+			if (isSubscriberReady(expectedState)) {
+				final boolean outputFused = this.outputFused;
+				final CoreSubscriber<? super T> a = this.actual;
+
+				if (outputFused) {
+					drainFused(expectedState, a);
+				}
+				else {
+					if (isCancelled(expectedState)) {
+						clearAndTerminate(this);
+						return;
+					}
+
+					if (isDisposed(expectedState)) {
+						clearAndTerminate(this);
+						a.onError(new CancellationException("Disposed"));
+						return;
+					}
+
+					drainRegular(expectedState, a);
+				}
+				return;
+			}
+			else {
+				if (isCancelled(expectedState) || isDisposed(expectedState)) {
+					clearAndTerminate(this);
+					return;
+				}
+			}
+
+			expectedState = wipRemoveMissing(this, expectedState);
+			if (!isWorkInProgress(expectedState)) {
+				return;
+			}
+		}
+	}
+
+	void drainRegular(long expectedState, CoreSubscriber<? super T> a) {
+		final Queue<T> q = this.queue;
 
 		for (;;) {
 
-			long r = requested;
+			long r = this.requested;
 			long e = 0L;
 
 			while (r != e) {
-				boolean d = done;
+				// done has to be read before queue.poll to ensure there was no racing:
+				// Thread1: <#drain>: queue.poll(null) --------------------> this.done(true)
+				// Thread2: ------------------> <#onNext(V)> --> <#onComplete()>
+				boolean done = this.done;
 
-				T t = q.poll();
-				boolean empty = t == null;
+				T t;
+				boolean empty;
 
-				if (checkTerminated(d, empty, a, q, t)) {
+				t = q.poll();
+				empty = t == null;
+
+				if (checkTerminated(done, empty, a, t)) {
 					return;
 				}
 
@@ -390,7 +459,10 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 			}
 
 			if (r == e) {
-				if (checkTerminated(done, q.isEmpty(), a, q, null)) {
+				// done has to be read before queue.isEmpty to ensure there was no racing:
+				// Thread1: <#drain>: queue.isEmpty(true) --------------------> this.done(true)
+				// Thread2: --------------------> <#onNext(V)> ---> <#onComplete()>
+				if (checkTerminated(this.done, q.isEmpty(), a, null)) {
 					return;
 				}
 			}
@@ -399,98 +471,88 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 				REQUESTED.addAndGet(this, -e);
 			}
 
-			missed = WIP.addAndGet(this, -missed);
-			if (missed == 0) {
+			expectedState = wipRemoveMissing(this, expectedState);
+			if (isCancelled(expectedState)) {
+				clearAndTerminate(this);
+				return;
+			}
+
+			if (isDisposed(expectedState)) {
+				clearAndTerminate(this);
+				a.onError(new CancellationException("Disposed"));
+				return;
+			}
+
+			if (!isWorkInProgress(expectedState)) {
 				break;
 			}
 		}
 	}
 
-	void drainFused(CoreSubscriber<? super T> a) {
-		int missed = 1;
-
+	void drainFused(long expectedState, CoreSubscriber<? super T> a) {
 		for (;;) {
-
-			if (cancelled) {
-				// We are the holder of the queue, but we still have to perform discarding under the guarded block
-				// to prevent any racing done by downstream
-				this.clear();
-				hasDownstream = false;
-				return;
-			}
-
-			boolean d = done;
+			// done has to be read before queue.poll to ensure there was no racing:
+			// Thread1: <#drain>: queue.poll(null) --------------------> this.done(true)
+			boolean d = this.done;
 
 			a.onNext(null);
 
 			if (d) {
-				hasDownstream = false;
-
-				Throwable ex = error;
+				Throwable ex = this.error;
 				if (ex != null) {
 					a.onError(ex);
-				} else {
+				}
+				else {
 					a.onComplete();
 				}
 				return;
 			}
 
-			missed = WIP.addAndGet(this, -missed);
-			if (missed == 0) {
-				break;
-			}
-		}
-	}
-
-	void drain(@Nullable T dataSignalOfferedBeforeDrain) {
-		if (WIP.getAndIncrement(this) != 0) {
-			if (dataSignalOfferedBeforeDrain != null) {
-				if (cancelled) {
-					Operators.onDiscard(dataSignalOfferedBeforeDrain,
-							actual.currentContext());
-				}
-				else if (done) {
-					Operators.onNextDropped(dataSignalOfferedBeforeDrain,
-							currentContext());
-				}
-			}
-			return;
-		}
-
-		int missed = 1;
-
-		for (;;) {
-			CoreSubscriber<? super T> a = actual;
-			if (a != null) {
-
-				if (outputFused) {
-					drainFused(a);
-				} else {
-					drainRegular(a);
-				}
+			expectedState = wipRemoveMissing(this, expectedState);
+			if (isCancelled(expectedState)) {
 				return;
 			}
 
-			missed = WIP.addAndGet(this, -missed);
-			if (missed == 0) {
+			if (isDisposed(expectedState)) {
+				a.onError(new CancellationException("Disposed"));
+				return;
+			}
+
+			if (!isWorkInProgress(expectedState)) {
 				break;
 			}
 		}
 	}
 
-	boolean checkTerminated(boolean d, boolean empty, CoreSubscriber<? super T> a, Queue<T> q, @Nullable T t) {
-		if (cancelled) {
-			Operators.onDiscard(t, a.currentContext());
-			Operators.onDiscardQueueWithClear(q, a.currentContext(), null);
-			hasDownstream = false;
+	boolean checkTerminated(boolean done,
+			boolean empty,
+			CoreSubscriber<? super T> a,
+			@Nullable T value) {
+		final long state = this.state;
+		if (isCancelled(state)) {
+			if (!empty) {
+				Operators.onDiscard(value, currentContext());
+			}
+			clearAndTerminate(this);
 			return true;
 		}
-		if (d && empty) {
-			Throwable e = error;
-			hasDownstream = false;
+
+		if (isDisposed(state)) {
+			if (!empty) {
+				Operators.onDiscard(value, currentContext());
+			}
+			clearAndTerminate(this);
+			a.onError(new CancellationException("Disposed"));
+			return true;
+		}
+
+		if (done && empty) {
+			clearAndTerminate(this);
+			Throwable e = this.error;
 			if (e != null) {
 				a.onError(e);
-			} else {
+			}
+			else {
 				a.onComplete();
 			}
 			return true;
@@ -501,9 +563,11 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 
 	@Override
 	public void onSubscribe(Subscription s) {
-		if (done || cancelled) {
+		final long state = this.state;
+		if (this.done || isTerminated(state) || isCancelled(state) || isDisposed(state)) {
 			s.cancel();
-		} else {
+		}
+		else {
 			s.request(Long.MAX_VALUE);
 		}
 	}
@@ -515,26 +579,38 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 
 	@Override
 	public Context currentContext() {
-		CoreSubscriber<? super T> actual = this.actual;
-		return actual != null ? actual.currentContext() : Context.empty();
+		final long state = this.state;
+		if (isSubscriberReady(state) || isTerminated(state)) {
+			final CoreSubscriber<? super T> actual = this.actual;
+			return actual != null ? actual.currentContext() : Context.empty();
+		}
+
+		return Context.empty();
 	}
 
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
 		Objects.requireNonNull(actual, "subscribe");
-		if (once == 0 && ONCE.compareAndSet(this, 0, 1)) {
-
-			this.hasDownstream = true;
+		if (markSubscribedOnce(this)) {
 			actual.onSubscribe(this);
 			this.actual = actual;
-			if (cancelled) {
-				this.hasDownstream = false;
-			} else {
-				drain(null);
+			long previousState = markSubscriberReady(this);
+			if (isCancelled(previousState)) {
+				return;
 			}
-		} else {
-			Operators.error(actual, new IllegalStateException("UnicastProcessor " +
-					"allows only a single Subscriber"));
+			if (isDisposed(previousState)) {
+				actual.onError(new CancellationException("Disposed"));
+				return;
+			}
+			if (isWorkInProgress(previousState)) {
+				return;
+			}
+			drain();
+		}
+		else {
+			Operators.error(actual,
+					new IllegalStateException(
+							"UnicastProcessor allows only a single Subscriber"));
 		}
 	}
 
@@ -542,76 +618,99 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 	public void request(long n) {
 		if (Operators.validate(n)) {
 			Operators.addCap(REQUESTED, this, n);
-			drain(null);
+			drain();
 		}
 	}
 
 	@Override
 	public void cancel() {
-		if (cancelled) {
+		this.cancelled = true;
+
+		final long previousState = markCancelled(this);
+		if (isTerminated(previousState) || isCancelled(previousState) || isDisposed(
+				previousState) || isWorkInProgress(previousState)) {
 			return;
 		}
-		cancelled = true;
 
-		doTerminate();
-
-		if (WIP.getAndIncrement(this) == 0) {
-			if (!outputFused) {
-				// discard MUST be happening only and only if there is no racing on elements consumption
-				// which is guaranteed by the WIP guard here in case non-fused output
-				Operators.onDiscardQueueWithClear(queue, currentContext(), null);
-			}
-			hasDownstream = false;
+		if (!isSubscriberReady(previousState) || !this.outputFused) {
+			clearAndTerminate(this);
 		}
+	}
+
+	@Override
+	public void dispose() {
+		this.cancelled = true;
+
+		final long previousState = markDisposed(this);
+		if (isTerminated(previousState) || isCancelled(previousState) || isDisposed(
+				previousState) || isWorkInProgress(previousState)) {
+			return;
+		}
+
+		if (!isSubscriberReady(previousState)) {
+			clearAndTerminate(this);
+			return;
+		}
+
+		if (!this.outputFused) {
+			clearAndTerminate(this);
+		}
+		this.actual.onError(new CancellationException("Disposed"));
 	}
 
 	@Override
 	@Nullable
 	public T poll() {
-		return queue.poll();
+		return this.queue.poll();
 	}
 
 	@Override
 	public int size() {
-		return queue.size();
+		return this.queue.size();
 	}
 
 	@Override
 	public boolean isEmpty() {
-		return queue.isEmpty();
+		return this.queue.isEmpty();
 	}
 
+	/**
+	 * Clears all elements from queues and set state to terminate. This method MUST be
+	 * called only by the downstream subscriber which has enabled {@link Fuseable#ASYNC}
+	 * fusion with the given {@link UnicastProcessor} and is and indicator that the
+	 * downstream is done with draining, it has observed any terminal signal (ON_COMPLETE
+	 * or ON_ERROR or CANCEL) and will never be interacting with SingleConsumer queue
+	 * anymore.
+	 */
 	@Override
 	public void clear() {
-		// use guard on the queue instance as the best way to ensure there is no racing on draining
-		// the call to this method must be done only during the ASYNC fusion so all the callers will be waiting
-		// this should not be performance costly with the assumption the cancel is rare operation
+		clearAndTerminate(this);
+	}
+
+	void clearSafely() {
 		if (DISCARD_GUARD.getAndIncrement(this) != 0) {
 			return;
 		}
 
 		int missed = 1;
-
 		for (;;) {
-			Operators.onDiscardQueueWithClear(queue, currentContext(), null);
+			clearUnsafely();
 
-			int dg = discardGuard;
-			if (missed == dg) {
-				missed = DISCARD_GUARD.addAndGet(this, -missed);
-				if (missed == 0) {
-					break;
-				}
-			}
-			else {
-				missed = dg;
+			missed = DISCARD_GUARD.addAndGet(this, -missed);
+			if (missed == 0) {
+				break;
 			}
 		}
+	}
+
+	void clearUnsafely() {
+		Operators.onDiscardQueueWithClear(this.queue, currentContext(), null);
 	}
 
 	@Override
 	public int requestFusion(int requestedMode) {
 		if ((requestedMode & Fuseable.ASYNC) != 0) {
-			outputFused = true;
+			this.outputFused = true;
 			return Fuseable.ASYNC;
 		}
 		return Fuseable.NONE;
@@ -619,33 +718,247 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 
 	@Override
 	public boolean isDisposed() {
-		return cancelled || done;
+		final long state = this.state;
+		return isTerminated(state) || isCancelled(state) || isDisposed(state) || this.done || this.cancelled;
 	}
 
 	@Override
 	public boolean isTerminated() {
-		return done;
+		//noinspection unused
+		final long state = this.state;
+		return this.done;
 	}
 
 	@Override
 	@Nullable
 	public Throwable getError() {
-		return error;
+		//noinspection unused
+		final long state = this.state;
+		if (this.done) {
+			return this.error;
+		}
+		else {
+			return null;
+		}
 	}
 
 	@Override
 	public CoreSubscriber<? super T> actual() {
-		return actual;
+		return isSubscriberReady(this.state) ? this.actual : null;
 	}
 
 	@Override
 	public long downstreamCount() {
-		return hasDownstreams() ? 1L : 0L;
+		return isSubscriberReady(this.state) ? 1L : 0L;
 	}
 
 	@Override
 	public boolean hasDownstreams() {
-		return hasDownstream;
+		return isSubscriberReady(this.state);
+	}
+
+	/**
+	 * Sets {@link #FLAG_SUBSCRIBED_ONCE} flag if it was not set before and if
+	 * flags {@link #FLAG_TERMINATED}, {@link #FLAG_CANCELLED} or
+	 * {@link #FLAG_DISPOSED} are unset
+	 *
+	 * @return {@code true} if {@link #FLAG_SUBSCRIBED_ONCE} was successfully set
+	 */
+	static boolean markSubscribedOnce(UnicastProcessor<?> instance) {
+		for (; ; ) {
+			long state = instance.state;
+
+			if ((state & FLAG_TERMINATED) == FLAG_TERMINATED || (state & FLAG_SUBSCRIBED_ONCE) == FLAG_SUBSCRIBED_ONCE || (state & FLAG_CANCELLED) == FLAG_CANCELLED || (state & FLAG_DISPOSED) == FLAG_DISPOSED) {
+				return false;
+			}
+
+			if (STATE.compareAndSet(instance, state, state | FLAG_SUBSCRIBED_ONCE)) {
+				return true;
+			}
+		}
+	}
+
+	/**
+	 * Sets {@link #FLAG_SUBSCRIBER_READY} flag if
+	 * flags {@link #FLAG_TERMINATED}, {@link #FLAG_CANCELLED} or
+	 * {@link #FLAG_DISPOSED} are unset
+	 *
+	 * @return previous state
+	 */
+	static long markSubscriberReady(UnicastProcessor<?> instance) {
+		for (; ; ) {
+			long state = instance.state;
+
+			if ((state & FLAG_TERMINATED) == FLAG_TERMINATED || (state & FLAG_CANCELLED) == FLAG_CANCELLED || (state & FLAG_DISPOSED) == FLAG_DISPOSED) {
+				return state;
+			}
+
+			if (STATE.compareAndSet(instance, state, state | FLAG_SUBSCRIBER_READY)) {
+				return state;
+			}
+		}
+	}
+
+	/**
+	 * Sets {@link #FLAG_CANCELLED} flag if it was not set before and if flag
+	 * {@link #FLAG_TERMINATED} is unset. Also, this method increments number of work in
+	 * progress (WIP)
+	 *
+	 * @return previous state
+	 */
+	static long markCancelled(UnicastProcessor<?> instance) {
+		for (; ; ) {
+			long state = instance.state;
+
+			if ((state & FLAG_TERMINATED) == FLAG_TERMINATED || (state & FLAG_CANCELLED) == FLAG_CANCELLED) {
+				return state;
+			}
+
+			long nextState = state + 1;
+			if ((nextState & MAX_WIP_VALUE) == 0) {
+				nextState = state;
+			}
+
+			if (STATE.compareAndSet(instance, state, nextState | FLAG_CANCELLED)) {
+				return state;
+			}
+		}
+	}
+
+	/**
+	 * Sets {@link #FLAG_DISPOSED} flag if it was not set before and if flags
+	 * {@link #FLAG_TERMINATED}, {@link #FLAG_CANCELLED} are unset. Also,
+	 * this method increments number of work in progress (WIP)
+	 *
+	 * @return previous state
+	 */
+	static long markDisposed(UnicastProcessor<?> instance) {
+		for (; ; ) {
+			long state = instance.state;
+
+			if ((state & FLAG_TERMINATED) == FLAG_TERMINATED || (state & FLAG_CANCELLED) == FLAG_CANCELLED || (state & FLAG_DISPOSED) == FLAG_DISPOSED) {
+				return state;
+			}
+
+			long nextState = state + 1;
+			if ((nextState & MAX_WIP_VALUE) == 0) {
+				nextState = state;
+			}
+
+			if (STATE.compareAndSet(instance, state, nextState | FLAG_DISPOSED)) {
+				return state;
+			}
+		}
+	}
+
+	/**
+	 * Tries to increment the amount of work in progress (max value is {@link
+	 * #MAX_WIP_VALUE} on the given state. Fails if flag {@link #FLAG_TERMINATED} is set.
+	 *
+	 * @return previous state
+	 */
+	static long wipIncrement(UnicastProcessor<?> instance) {
+		for (; ; ) {
+			long state = instance.state;
+
+			if ((state & FLAG_TERMINATED) == FLAG_TERMINATED) {
+				return state;
+			}
+
+			final long nextState = state + 1;
+			if ((nextState & MAX_WIP_VALUE) == 0) {
+				return state;
+			}
+
+			if (STATE.compareAndSet(instance, state, nextState)) {
+				return state;
+			}
+		}
+	}
+
+	/**
+	 * Tries to decrement the amount of work in progress by the given amount on the given
+	 * state. Fails if flag is {@link #FLAG_TERMINATED} is set or if fusion disabled and
+	 * flags {@link #FLAG_CANCELLED} or {@link #FLAG_DISPOSED} are set.
+	 *
+	 * <p>Note, if fusion is enabled, the decrement should work if flags
+	 * {@link #FLAG_CANCELLED} or {@link #FLAG_DISPOSED} are set, since, while the
+	 * operator was not terminate by the downstream, we still have to propagate
+	 * notifications that new elements are enqueued
+	 *
+	 * @return state after changing WIP or current state if update failed
+	 */
+	static long wipRemoveMissing(UnicastProcessor<?> instance, long previousState) {
+		long missed = previousState & MAX_WIP_VALUE;
+		for (; ; ) {
+			final long state = instance.state;
+
+			if ((state & FLAG_TERMINATED) == FLAG_TERMINATED) {
+				return state;
+			}
+
+			if ((!isSubscriberReady(state) || !instance.outputFused) && ((state & FLAG_CANCELLED) == FLAG_CANCELLED || (state & FLAG_DISPOSED) == FLAG_DISPOSED)) {
+				return state;
+			}
+
+			final long nextState = state - missed;
+			if (STATE.compareAndSet(instance, state, nextState)) {
+				return nextState;
+			}
+		}
+	}
+
+	/**
+	 * Set flag {@link #FLAG_TERMINATED} and discards all the elements from {@link
+	 * #queue}.
+	 *
+	 * <p>This method may be called concurrently only if the given {@link
+	 * UnicastProcessor} has no
+	 * output fusion ({@link #outputFused} {@code == true}). Otherwise this method MUST be
+	 * called once and only by the downstream calling method {@link #clear()}
+	 */
+	static void clearAndTerminate(UnicastProcessor<?> instance) {
+		for (; ; ) {
+			final long state = instance.state;
+
+			if (!isSubscriberReady(state) || !instance.outputFused) {
+				instance.clearSafely();
+			}
+			else {
+				instance.clearUnsafely();
+			}
+
+			if ((state & FLAG_TERMINATED) == FLAG_TERMINATED) {
+				return;
+			}
+
+			if (STATE.compareAndSet(instance,
+					state,
+					(state & ~MAX_WIP_VALUE) | FLAG_TERMINATED)) {
+				instance.doTerminate();
+				break;
+			}
+		}
+	}
+
+	static boolean isCancelled(long state) {
+		return (state & FLAG_CANCELLED) == FLAG_CANCELLED;
+	}
+
+	static boolean isDisposed(long state) {
+		return (state & FLAG_DISPOSED) == FLAG_DISPOSED;
+	}
+
+	static boolean isWorkInProgress(long state) {
+		return (state & MAX_WIP_VALUE) != 0;
+	}
+
+	static boolean isTerminated(long state) {
+		return (state & FLAG_TERMINATED) == FLAG_TERMINATED;
+	}
+
+	static boolean isSubscriberReady(long state) {
+		return !isTerminated(state) && (state & FLAG_SUBSCRIBER_READY) == FLAG_SUBSCRIBER_READY;
 	}
 
 }


### PR DESCRIPTION
This PR is intended to consolide fusion-enabled operators and their relationships with each other if fusion is enabled and the downstream gets access to the queue of the upstream.

The following is simple rules I built up to ensure we are not leaking values, is not getting into dead-lock if multiple threads get access to ScQueue draining/cleaning:

If `ASYNC` fusion is established between upstream and downstream, the downstream get full access to `Queue` draining, and only downstream MUST anyhow interact with that queue until the interaction is considered terminated. 
To terminate interaction and notify the upstream there will no more interaction with `Queue`, the downstream MUST call `queue#clear` (this call must be done in all the terminal scenarios includes COMPLETE / ERROR / CANCEL).
Once, the backfused upstream received `Queue#clear` call, it MUST clear and discard all the value from the queue and set terminate state which indicate that now the upstream is ready to manage `Queue` on its own and no more interactions with that queue are expected from the downstream

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>
Signed-off-by: Oleh Dokuka <shadowgun@i.ua>