### PR TITLE
Prevent ordered merge hanging due to badly sized queue

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -1449,7 +1449,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 		if (sources.length == 1) {
 			return from(sources[0]);
 		}
-		return onAssembly(new FluxMergeOrdered<>(prefetch, Queues.get(prefetch), comparator, sources));
+		return onAssembly(new FluxMergeOrdered<>(prefetch, comparator, sources));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMergeOrdered.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMergeOrdered.java
@@ -23,13 +23,11 @@ import java.util.Queue;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import java.util.function.Supplier;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
-import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
 
@@ -47,13 +45,11 @@ import reactor.util.concurrent.Queues;
 final class FluxMergeOrdered<T> extends Flux<T> implements SourceProducer<T> {
 
 	final int                      prefetch;
-	final Supplier<Queue<T>>       queueSupplier;
 	final Comparator<? super T>    valueComparator;
 	final Publisher<? extends T>[] sources;
 
 	@SafeVarargs
 	FluxMergeOrdered(int prefetch,
-			Supplier<Queue<T>> queueSupplier,
 			Comparator<? super T> valueComparator,
 			Publisher<? extends T>... sources) {
 		if (prefetch <= 0) {
@@ -69,7 +65,6 @@ final class FluxMergeOrdered<T> extends Flux<T> implements SourceProducer<T> {
 		}
 
 		this.prefetch = prefetch;
-		this.queueSupplier = queueSupplier;
 		this.valueComparator = valueComparator;
 	}
 
@@ -95,9 +90,9 @@ final class FluxMergeOrdered<T> extends Flux<T> implements SourceProducer<T> {
 			@SuppressWarnings("unchecked")
 			Comparator<T> currentComparator = (Comparator<T>) this.valueComparator;
 			final Comparator<T> newComparator = currentComparator.thenComparing(otherComparator);
-			return new FluxMergeOrdered<>(prefetch, queueSupplier, newComparator, newArray);
+			return new FluxMergeOrdered<>(prefetch, newComparator, newArray);
 		}
-		return new FluxMergeOrdered<>(prefetch, queueSupplier, valueComparator, newArray);
+		return new FluxMergeOrdered<>(prefetch, valueComparator, newArray);
 	}
 
 	@Override
@@ -346,16 +341,16 @@ final class FluxMergeOrdered<T> extends Flux<T> implements SourceProducer<T> {
 
 		volatile boolean done;
 
-		volatile Subscription s;
-		AtomicReferenceFieldUpdater<MergeOrderedInnerSubscriber, Subscription> S =
+		volatile     Subscription                                                           s;
+		@SuppressWarnings("rawtypes")
+		static final AtomicReferenceFieldUpdater<MergeOrderedInnerSubscriber, Subscription> S =
 				AtomicReferenceFieldUpdater.newUpdater(MergeOrderedInnerSubscriber.class, Subscription.class, "s");
 
-		MergeOrderedInnerSubscriber(MergeOrderedMainProducer<T> parent,
-				int prefetch) {
+		MergeOrderedInnerSubscriber(MergeOrderedMainProducer<T> parent, int prefetch) {
 			this.parent = parent;
 			this.prefetch = prefetch;
 			this.limit = prefetch - (prefetch >> 2);
-			this.queue = Queues.<T>small().get();
+			this.queue = Queues.<T>get(prefetch).get();
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -797,7 +797,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 * @see ParallelFlux#ordered(Comparator)
 	 */
 	public final Flux<T> ordered(Comparator<? super T> comparator, int prefetch) {
-		return new ParallelMergeOrdered<>(this, prefetch, Queues.get(prefetch), comparator);
+		return new ParallelMergeOrdered<>(this, prefetch, comparator);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeOrdered.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeOrdered.java
@@ -36,17 +36,15 @@ final class ParallelMergeOrdered<T> extends Flux<T> implements Scannable {
 
 	final ParallelFlux<? extends T> source;
 	final int                       prefetch;
-	final Supplier<Queue<T>>        queueSupplier;
 	final Comparator<? super T>     valueComparator;
 
 	ParallelMergeOrdered(ParallelFlux<? extends T> source, int prefetch,
-			Supplier<Queue<T>> queueSupplier, Comparator<? super T> valueComparator) {
+			Comparator<? super T> valueComparator) {
 		if (prefetch <= 0) {
 			throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
 		}
 		this.source = source;
 		this.prefetch = prefetch;
-		this.queueSupplier = queueSupplier;
 		this.valueComparator = valueComparator;
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelMergeOrderedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelMergeOrderedTest.java
@@ -16,22 +16,58 @@
 
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+import reactor.util.concurrent.Queues;
 import reactor.util.function.Tuple2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
-public class ParallelMergeOrderedTest {
+class ParallelMergeOrderedTest {
+
+	// see https://github.com/reactor/reactor-core/issues/1958
+	@Test
+	void dealsWithPrefetchLargerThanSmallBufferSize() {
+		int parallelism = 2;  // parallelism must be > 1 to expose issue
+		int bufferS = Queues.SMALL_BUFFER_SIZE;
+		int orderedPrefetch = bufferS + 128; // if orderedPrefetch > bufferS then operator used to drop elements and eventually hang
+
+		final AtomicInteger prev = new AtomicInteger(-1);
+
+		Flux.range(0, 200_000)
+		    .subscribeOn(Schedulers.newSingle("init", true))
+		    .parallel(parallelism, bufferS)
+		    .runOn(Schedulers.newParallel("process", parallelism, true), bufferS)
+		    .map(i -> i)
+		    .ordered(Comparator.comparing(i -> i), orderedPrefetch)
+		    .as(StepVerifier::create)
+		    .thenConsumeWhile(current -> {
+			    int previous = prev.getAndSet(current);
+			    try {
+				    assertThat(current)
+						    .withFailMessage("elements dropped: prev: %d, next: %d, lost: %d\n", previous, current, current - previous)
+						    .isEqualTo(previous + 1);
+			    }
+			    catch (AssertionError ae) {
+				    ae.printStackTrace();
+			    }
+			    return true;
+		    })
+		    .expectComplete()
+		    .verify(Duration.ofSeconds(5)); //should run in 3s
+	}
 
 	@Test
 	public void reorderingByIndex() {
@@ -81,20 +117,20 @@ public class ParallelMergeOrderedTest {
 	@Test
 	public void rejectPrefetchZero() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new ParallelMergeOrdered<>(null, 0, null, null))
+				.isThrownBy(() -> new ParallelMergeOrdered<>(null, 0, null))
 				.withMessage("prefetch > 0 required but it was 0");
 	}
 
 	@Test
 	public void rejectPrefetchNegative() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new ParallelMergeOrdered<>(null,-1, null, null))
+				.isThrownBy(() -> new ParallelMergeOrdered<>(null,-1, null))
 				.withMessage("prefetch > 0 required but it was -1");
 	}
 
 	@Test
 	public void getPrefetch() {
-		ParallelMergeOrdered<Integer> test = new ParallelMergeOrdered<>(null, 123, null, null);
+		ParallelMergeOrdered<Integer> test = new ParallelMergeOrdered<>(null, 123, null);
 
 		assertThat(test.getPrefetch()).isEqualTo(123);
 	}
@@ -112,7 +148,7 @@ public class ParallelMergeOrderedTest {
 	public void scanUnsafe() {
 		ParallelFlux<Integer> source = Flux.range(1, 10)
 		                                   .parallel(2);
-		ParallelMergeOrdered<Integer> test = new ParallelMergeOrdered<>(source, 123, null, null);
+		ParallelMergeOrdered<Integer> test = new ParallelMergeOrdered<>(source, 123, null);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);
 		assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(123);


### PR DESCRIPTION
This commit ensures that the inner queues used by mergeOrdered operators are congruent with the prefetch size. Since this is kind of an internal requirement, the queue supplier isn't accepted through the constructors anymore, but rather derived from the prefetch size in the inner subscribers' initialization.

Previously, the supplier was actually ignored but the hardcoded supplier wouldn't take the `prefetch` size into account, leading to data drops and hanging when prefetch was larger than the queue size.

Fixes #1958.