### PR TITLE
Introduce MonoInnerProducerBase

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -2583,7 +2583,7 @@ public abstract class Operators {
 		 * The value stored by this Mono operator.
 		 */
 		@Nullable
-		private volatile O   value;
+		private O value;
 
 		private volatile  int state; //see STATE field updater
 		@SuppressWarnings("rawtypes")

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -483,14 +483,14 @@ public abstract class Operators {
 				if (extract != null) {
 					try {
 						extract.apply(toDiscard)
-								.forEach(elementToDiscard -> {
-									try {
-										hook.accept(elementToDiscard);
-									}
-									catch (Throwable t) {
-										log.warn("Error while discarding item extracted from a queue element, continuing with next item", t);
-									}
-								});
+						       .forEach(elementToDiscard -> {
+							       try {
+								       hook.accept(elementToDiscard);
+							       }
+							       catch (Throwable t) {
+								       log.warn("Error while discarding item extracted from a queue element, continuing with next item", t);
+							       }
+						       });
 					}
 					catch (Throwable t) {
 						log.warn("Error while extracting items to discard from queue element, continuing with next queue element", t);
@@ -511,31 +511,31 @@ public abstract class Operators {
 		}
 	}
 
-	/**
-	 * Invoke a (local or global) hook that processes elements that get discarded en masse.
-	 * This includes elements that are buffered but subsequently discarded due to
-	 * cancellation or error.
-	 *
-	 * @param multiple the collection of elements to discard (possibly extracted from other
-	 * collections/arrays/queues)
-	 * @param context the {@link Context} in which to look for local hook
-	 * @see #onDiscard(Object, Context)
-	 * @see #onDiscardMultiple(Collection, Context)
-	 * @see #onDiscardQueueWithClear(Queue, Context, Function)
-	 */
-	public static void onDiscardMultiple(Stream<?> multiple, Context context) {
+  /**
+   * Invoke a (local or global) hook that processes elements that get discarded en masse.
+   * This includes elements that are buffered but subsequently discarded due to
+   * cancellation or error.
+   *
+   * @param multiple the collection of elements to discard (possibly extracted from other
+   * collections/arrays/queues)
+   * @param context the {@link Context} in which to look for local hook
+   * @see #onDiscard(Object, Context)
+   * @see #onDiscardMultiple(Collection, Context)
+   * @see #onDiscardQueueWithClear(Queue, Context, Function)
+   */
+  public static void onDiscardMultiple(Stream<?> multiple, Context context) {
 		Consumer<Object> hook = context.getOrDefault(Hooks.KEY_ON_DISCARD, null);
 		if (hook != null) {
 			try {
 				multiple.filter(Objects::nonNull)
-						.forEach(v -> {
-							try {
-								hook.accept(v);
-							}
-							catch (Throwable t) {
-								log.warn("Error while discarding a stream element, continuing with next element", t);
-							}
-						});
+				        .forEach(v -> {
+				        	try {
+				        		hook.accept(v);
+					        }
+				        	catch (Throwable t) {
+				        		log.warn("Error while discarding a stream element, continuing with next element", t);
+					        }
+				        });
 			}
 			catch (Throwable t) {
 				log.warn("Error while discarding stream, stopping", t);
@@ -543,17 +543,17 @@ public abstract class Operators {
 		}
 	}
 
-	/**
-	 * Invoke a (local or global) hook that processes elements that get discarded en masse.
-	 * This includes elements that are buffered but subsequently discarded due to
-	 * cancellation or error.
-	 *
-	 * @param multiple the collection of elements to discard
-	 * @param context the {@link Context} in which to look for local hook
-	 * @see #onDiscard(Object, Context)
-	 * @see #onDiscardMultiple(Stream, Context)
-	 * @see #onDiscardQueueWithClear(Queue, Context, Function)
-	 */
+  /**
+   * Invoke a (local or global) hook that processes elements that get discarded en masse.
+   * This includes elements that are buffered but subsequently discarded due to
+   * cancellation or error.
+   *
+   * @param multiple the collection of elements to discard
+   * @param context the {@link Context} in which to look for local hook
+   * @see #onDiscard(Object, Context)
+   * @see #onDiscardMultiple(Stream, Context)
+   * @see #onDiscardQueueWithClear(Queue, Context, Function)
+   */
 	public static void onDiscardMultiple(@Nullable Collection<?> multiple, Context context) {
 		if (multiple == null) return;
 		Consumer<Object> hook = context.getOrDefault(Hooks.KEY_ON_DISCARD, null);
@@ -579,19 +579,19 @@ public abstract class Operators {
 		}
 	}
 
-	/**
-	 * Invoke a (local or global) hook that processes elements that remains in an {@link java.util.Iterator}.
-	 * Since iterators can be infinite, this method requires that you explicitly ensure the iterator is
-	 * {@code knownToBeFinite}. Typically, operating on an {@link Iterable} one can get such a
-	 * guarantee by looking at the {@link Iterable#spliterator() Spliterator's} {@link Spliterator#getExactSizeIfKnown()}.
-	 *
-	 * @param multiple the {@link Iterator} whose remainder to discard
-	 * @param knownToBeFinite is the caller guaranteeing that the iterator is finite and can be iterated over
-	 * @param context the {@link Context} in which to look for local hook
-	 * @see #onDiscard(Object, Context)
-	 * @see #onDiscardMultiple(Collection, Context)
-	 * @see #onDiscardQueueWithClear(Queue, Context, Function)
-	 */
+  /**
+   * Invoke a (local or global) hook that processes elements that remains in an {@link java.util.Iterator}.
+   * Since iterators can be infinite, this method requires that you explicitly ensure the iterator is
+   * {@code knownToBeFinite}. Typically, operating on an {@link Iterable} one can get such a
+   * guarantee by looking at the {@link Iterable#spliterator() Spliterator's} {@link Spliterator#getExactSizeIfKnown()}.
+   *
+   * @param multiple the {@link Iterator} whose remainder to discard
+   * @param knownToBeFinite is the caller guaranteeing that the iterator is finite and can be iterated over
+   * @param context the {@link Context} in which to look for local hook
+   * @see #onDiscard(Object, Context)
+   * @see #onDiscardMultiple(Collection, Context)
+   * @see #onDiscardQueueWithClear(Queue, Context, Function)
+   */
 	public static void onDiscardMultiple(@Nullable Iterator<?> multiple, boolean knownToBeFinite, Context context) {
 		if (multiple == null) return;
 		if (!knownToBeFinite) return;
@@ -998,7 +998,7 @@ public abstract class Operators {
 	 * the amount produced by the operator. Any concurrent write will "happen before"
 	 * this operation.
 	 *
-	 * @param <T> the parent instance type
+     * @param <T> the parent instance type
 	 * @param updater  current field updater
 	 * @param instance current instance to update
 	 * @param toSub    delta to subtract
@@ -1112,7 +1112,7 @@ public abstract class Operators {
 			T value, String stepName){
 		return new ScalarSubscription<>(subscriber, value, stepName);
 	}
-
+	
 	/**
 	 * Safely gate a {@link Subscriber} by making sure onNext signals are delivered
 	 * sequentially (serialized).
@@ -1436,7 +1436,7 @@ public abstract class Operators {
 	}
 
 	static final class CorePublisherAdapter<T> implements CorePublisher<T>,
-			OptimizableOperator<T, T> {
+	                                                      OptimizableOperator<T, T> {
 
 		final Publisher<T> publisher;
 
@@ -1735,8 +1735,8 @@ public abstract class Operators {
 	 */
 	public static class MonoSubscriber<I, O>
 			implements InnerOperator<I, O>,
-			Fuseable, //for constants only
-			QueueSubscription<O> {
+			           Fuseable, //for constants only
+			           QueueSubscription<O> {
 
 		protected final CoreSubscriber<? super O> actual;
 
@@ -2130,74 +2130,74 @@ public abstract class Operators {
 
 		@Override
 		public final void request(long n) {
-			if (validate(n)) {
-				if (unbounded) {
-					return;
-				}
-				if (wip == 0 && WIP.compareAndSet(this, 0, 1)) {
-					long r = requested;
+		    if (validate(n)) {
+	            if (unbounded) {
+	                return;
+	            }
+	            if (wip == 0 && WIP.compareAndSet(this, 0, 1)) {
+	                long r = requested;
 
-					if (r != Long.MAX_VALUE) {
-						r = addCap(r, n);
-						requested = r;
-						if (r == Long.MAX_VALUE) {
-							unbounded = true;
-						}
-					}
-					Subscription a = subscription;
+	                if (r != Long.MAX_VALUE) {
+	                    r = addCap(r, n);
+	                    requested = r;
+	                    if (r == Long.MAX_VALUE) {
+	                        unbounded = true;
+	                    }
+	                }
+		            Subscription a = subscription;
 
-					if (WIP.decrementAndGet(this) != 0) {
-						drainLoop();
-					}
+	                if (WIP.decrementAndGet(this) != 0) {
+	                    drainLoop();
+	                }
 
-					if (a != null) {
-						a.request(n);
-					}
+	                if (a != null) {
+	                    a.request(n);
+	                }
 
-					return;
-				}
+	                return;
+	            }
 
-				addCap(MISSED_REQUESTED, this, n);
+	            addCap(MISSED_REQUESTED, this, n);
 
-				drain();
-			}
+	            drain();
+	        }
 		}
 
 		public final void set(Subscription s) {
-			if (cancelled) {
-				s.cancel();
-				return;
-			}
+		    if (cancelled) {
+	            s.cancel();
+	            return;
+	        }
 
-			Objects.requireNonNull(s);
+	        Objects.requireNonNull(s);
 
-			if (wip == 0 && WIP.compareAndSet(this, 0, 1)) {
-				Subscription a = subscription;
+	        if (wip == 0 && WIP.compareAndSet(this, 0, 1)) {
+		        Subscription a = subscription;
 
-				if (a != null && shouldCancelCurrent()) {
-					a.cancel();
-				}
+	            if (a != null && shouldCancelCurrent()) {
+	                a.cancel();
+	            }
 
-				subscription = s;
+		        subscription = s;
 
-				long r = requested;
+	            long r = requested;
 
-				if (WIP.decrementAndGet(this) != 0) {
-					drainLoop();
-				}
+	            if (WIP.decrementAndGet(this) != 0) {
+	                drainLoop();
+	            }
 
-				if (r != 0L) {
-					s.request(r);
-				}
+	            if (r != 0L) {
+	                s.request(r);
+	            }
 
-				return;
-			}
+	            return;
+	        }
 
-			Subscription a = MISSED_SUBSCRIPTION.getAndSet(this, s);
-			if (a != null && shouldCancelCurrent()) {
-				a.cancel();
-			}
-			drain();
+	        Subscription a = MISSED_SUBSCRIPTION.getAndSet(this, s);
+	        if (a != null && shouldCancelCurrent()) {
+	            a.cancel();
+	        }
+	        drain();
 		}
 
 		/**
@@ -2217,99 +2217,99 @@ public abstract class Operators {
 		}
 
 		final void drainLoop() {
-			int missed = 1;
+		    int missed = 1;
 
-			long requestAmount = 0L;
-			long alreadyInRequestAmount = 0L;
-			Subscription requestTarget = null;
+	        long requestAmount = 0L;
+	        long alreadyInRequestAmount = 0L;
+	        Subscription requestTarget = null;
 
-			for (; ; ) {
+	        for (; ; ) {
 
-				Subscription ms = missedSubscription;
+	            Subscription ms = missedSubscription;
 
-				if (ms != null) {
-					ms = MISSED_SUBSCRIPTION.getAndSet(this, null);
-				}
+	            if (ms != null) {
+	                ms = MISSED_SUBSCRIPTION.getAndSet(this, null);
+	            }
 
-				long mr = missedRequested;
-				if (mr != 0L) {
-					mr = MISSED_REQUESTED.getAndSet(this, 0L);
-				}
+	            long mr = missedRequested;
+	            if (mr != 0L) {
+	                mr = MISSED_REQUESTED.getAndSet(this, 0L);
+	            }
 
-				long mp = missedProduced;
-				if (mp != 0L) {
-					mp = MISSED_PRODUCED.getAndSet(this, 0L);
-				}
+	            long mp = missedProduced;
+	            if (mp != 0L) {
+	                mp = MISSED_PRODUCED.getAndSet(this, 0L);
+	            }
 
-				Subscription a = subscription;
+		        Subscription a = subscription;
 
-				if (cancelled) {
-					if (a != null) {
-						a.cancel();
-						subscription = null;
-					}
-					if (ms != null) {
-						ms.cancel();
-					}
-				} else {
-					long r = requested;
-					if (r != Long.MAX_VALUE) {
-						long u = addCap(r, mr);
+	            if (cancelled) {
+	                if (a != null) {
+	                    a.cancel();
+		                subscription = null;
+	                }
+	                if (ms != null) {
+	                    ms.cancel();
+	                }
+	            } else {
+	                long r = requested;
+	                if (r != Long.MAX_VALUE) {
+	                    long u = addCap(r, mr);
 
-						if (u != Long.MAX_VALUE) {
-							long v = u - mp;
-							if (v < 0L) {
-								reportMoreProduced();
-								v = 0;
-							}
-							r = v;
-						} else {
-							r = u;
-						}
-						requested = r;
-					}
+	                    if (u != Long.MAX_VALUE) {
+	                        long v = u - mp;
+	                        if (v < 0L) {
+	                            reportMoreProduced();
+	                            v = 0;
+	                        }
+	                        r = v;
+	                    } else {
+	                        r = u;
+	                    }
+	                    requested = r;
+	                }
 
-					if (ms != null) {
-						if (a != null && shouldCancelCurrent()) {
-							a.cancel();
-						}
-						subscription = ms;
-						if (r != 0L) {
-							requestAmount = addCap(requestAmount, r - alreadyInRequestAmount);
-							requestTarget = ms;
-						}
-					} else if (mr != 0L && a != null) {
-						requestAmount = addCap(requestAmount, mr);
-						alreadyInRequestAmount += mr;
-						requestTarget = a;
-					}
-				}
+	                if (ms != null) {
+	                    if (a != null && shouldCancelCurrent()) {
+	                        a.cancel();
+	                    }
+		                subscription = ms;
+		                if (r != 0L) {
+			                requestAmount = addCap(requestAmount, r - alreadyInRequestAmount);
+	                        requestTarget = ms;
+	                    }
+	                } else if (mr != 0L && a != null) {
+	                    requestAmount = addCap(requestAmount, mr);
+	                    alreadyInRequestAmount += mr; 
+	                    requestTarget = a;
+	                }
+	            }
 
-				missed = WIP.addAndGet(this, -missed);
-				if (missed == 0) {
-					if (requestAmount != 0L) {
-						requestTarget.request(requestAmount);
-					}
-					return;
-				}
-			}
+	            missed = WIP.addAndGet(this, -missed);
+	            if (missed == 0) {
+	                if (requestAmount != 0L) {
+	                    requestTarget.request(requestAmount);
+	                }
+	                return;
+	            }
+	        }
 		}
 		@SuppressWarnings("rawtypes")
 		static final AtomicReferenceFieldUpdater<MultiSubscriptionSubscriber, Subscription>
 				MISSED_SUBSCRIPTION =
-				AtomicReferenceFieldUpdater.newUpdater(MultiSubscriptionSubscriber.class,
-						Subscription.class,
-						"missedSubscription");
+		  AtomicReferenceFieldUpdater.newUpdater(MultiSubscriptionSubscriber.class,
+			Subscription.class,
+			"missedSubscription");
 		@SuppressWarnings("rawtypes")
 		static final AtomicLongFieldUpdater<MultiSubscriptionSubscriber>
 				MISSED_REQUESTED =
-				AtomicLongFieldUpdater.newUpdater(MultiSubscriptionSubscriber.class, "missedRequested");
+		  AtomicLongFieldUpdater.newUpdater(MultiSubscriptionSubscriber.class, "missedRequested");
 		@SuppressWarnings("rawtypes")
 		static final AtomicLongFieldUpdater<MultiSubscriptionSubscriber> MISSED_PRODUCED =
-				AtomicLongFieldUpdater.newUpdater(MultiSubscriptionSubscriber.class, "missedProduced");
+		  AtomicLongFieldUpdater.newUpdater(MultiSubscriptionSubscriber.class, "missedProduced");
 		@SuppressWarnings("rawtypes")
 		static final AtomicIntegerFieldUpdater<MultiSubscriptionSubscriber> WIP =
-				AtomicIntegerFieldUpdater.newUpdater(MultiSubscriptionSubscriber.class, "wip");
+		  AtomicIntegerFieldUpdater.newUpdater(MultiSubscriptionSubscriber.class, "wip");
 	}
 
 	/**
@@ -2771,7 +2771,6 @@ public abstract class Operators {
 		private static final int CANCELLED =      0b10000000;
 
 	}
-
 
 
 	final static Logger log = Loggers.getLogger(Operators.class);

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -483,14 +483,14 @@ public abstract class Operators {
 				if (extract != null) {
 					try {
 						extract.apply(toDiscard)
-						       .forEach(elementToDiscard -> {
-							       try {
-								       hook.accept(elementToDiscard);
-							       }
-							       catch (Throwable t) {
-								       log.warn("Error while discarding item extracted from a queue element, continuing with next item", t);
-							       }
-						       });
+								.forEach(elementToDiscard -> {
+									try {
+										hook.accept(elementToDiscard);
+									}
+									catch (Throwable t) {
+										log.warn("Error while discarding item extracted from a queue element, continuing with next item", t);
+									}
+								});
 					}
 					catch (Throwable t) {
 						log.warn("Error while extracting items to discard from queue element, continuing with next queue element", t);
@@ -511,31 +511,31 @@ public abstract class Operators {
 		}
 	}
 
-  /**
-   * Invoke a (local or global) hook that processes elements that get discarded en masse.
-   * This includes elements that are buffered but subsequently discarded due to
-   * cancellation or error.
-   *
-   * @param multiple the collection of elements to discard (possibly extracted from other
-   * collections/arrays/queues)
-   * @param context the {@link Context} in which to look for local hook
-   * @see #onDiscard(Object, Context)
-   * @see #onDiscardMultiple(Collection, Context)
-   * @see #onDiscardQueueWithClear(Queue, Context, Function)
-   */
-  public static void onDiscardMultiple(Stream<?> multiple, Context context) {
+	/**
+	 * Invoke a (local or global) hook that processes elements that get discarded en masse.
+	 * This includes elements that are buffered but subsequently discarded due to
+	 * cancellation or error.
+	 *
+	 * @param multiple the collection of elements to discard (possibly extracted from other
+	 * collections/arrays/queues)
+	 * @param context the {@link Context} in which to look for local hook
+	 * @see #onDiscard(Object, Context)
+	 * @see #onDiscardMultiple(Collection, Context)
+	 * @see #onDiscardQueueWithClear(Queue, Context, Function)
+	 */
+	public static void onDiscardMultiple(Stream<?> multiple, Context context) {
 		Consumer<Object> hook = context.getOrDefault(Hooks.KEY_ON_DISCARD, null);
 		if (hook != null) {
 			try {
 				multiple.filter(Objects::nonNull)
-				        .forEach(v -> {
-				        	try {
-				        		hook.accept(v);
-					        }
-				        	catch (Throwable t) {
-				        		log.warn("Error while discarding a stream element, continuing with next element", t);
-					        }
-				        });
+						.forEach(v -> {
+							try {
+								hook.accept(v);
+							}
+							catch (Throwable t) {
+								log.warn("Error while discarding a stream element, continuing with next element", t);
+							}
+						});
 			}
 			catch (Throwable t) {
 				log.warn("Error while discarding stream, stopping", t);
@@ -543,17 +543,17 @@ public abstract class Operators {
 		}
 	}
 
-  /**
-   * Invoke a (local or global) hook that processes elements that get discarded en masse.
-   * This includes elements that are buffered but subsequently discarded due to
-   * cancellation or error.
-   *
-   * @param multiple the collection of elements to discard
-   * @param context the {@link Context} in which to look for local hook
-   * @see #onDiscard(Object, Context)
-   * @see #onDiscardMultiple(Stream, Context)
-   * @see #onDiscardQueueWithClear(Queue, Context, Function)
-   */
+	/**
+	 * Invoke a (local or global) hook that processes elements that get discarded en masse.
+	 * This includes elements that are buffered but subsequently discarded due to
+	 * cancellation or error.
+	 *
+	 * @param multiple the collection of elements to discard
+	 * @param context the {@link Context} in which to look for local hook
+	 * @see #onDiscard(Object, Context)
+	 * @see #onDiscardMultiple(Stream, Context)
+	 * @see #onDiscardQueueWithClear(Queue, Context, Function)
+	 */
 	public static void onDiscardMultiple(@Nullable Collection<?> multiple, Context context) {
 		if (multiple == null) return;
 		Consumer<Object> hook = context.getOrDefault(Hooks.KEY_ON_DISCARD, null);
@@ -579,19 +579,19 @@ public abstract class Operators {
 		}
 	}
 
-  /**
-   * Invoke a (local or global) hook that processes elements that remains in an {@link java.util.Iterator}.
-   * Since iterators can be infinite, this method requires that you explicitly ensure the iterator is
-   * {@code knownToBeFinite}. Typically, operating on an {@link Iterable} one can get such a
-   * guarantee by looking at the {@link Iterable#spliterator() Spliterator's} {@link Spliterator#getExactSizeIfKnown()}.
-   *
-   * @param multiple the {@link Iterator} whose remainder to discard
-   * @param knownToBeFinite is the caller guaranteeing that the iterator is finite and can be iterated over
-   * @param context the {@link Context} in which to look for local hook
-   * @see #onDiscard(Object, Context)
-   * @see #onDiscardMultiple(Collection, Context)
-   * @see #onDiscardQueueWithClear(Queue, Context, Function)
-   */
+	/**
+	 * Invoke a (local or global) hook that processes elements that remains in an {@link java.util.Iterator}.
+	 * Since iterators can be infinite, this method requires that you explicitly ensure the iterator is
+	 * {@code knownToBeFinite}. Typically, operating on an {@link Iterable} one can get such a
+	 * guarantee by looking at the {@link Iterable#spliterator() Spliterator's} {@link Spliterator#getExactSizeIfKnown()}.
+	 *
+	 * @param multiple the {@link Iterator} whose remainder to discard
+	 * @param knownToBeFinite is the caller guaranteeing that the iterator is finite and can be iterated over
+	 * @param context the {@link Context} in which to look for local hook
+	 * @see #onDiscard(Object, Context)
+	 * @see #onDiscardMultiple(Collection, Context)
+	 * @see #onDiscardQueueWithClear(Queue, Context, Function)
+	 */
 	public static void onDiscardMultiple(@Nullable Iterator<?> multiple, boolean knownToBeFinite, Context context) {
 		if (multiple == null) return;
 		if (!knownToBeFinite) return;
@@ -998,7 +998,7 @@ public abstract class Operators {
 	 * the amount produced by the operator. Any concurrent write will "happen before"
 	 * this operation.
 	 *
-     * @param <T> the parent instance type
+	 * @param <T> the parent instance type
 	 * @param updater  current field updater
 	 * @param instance current instance to update
 	 * @param toSub    delta to subtract
@@ -1112,7 +1112,7 @@ public abstract class Operators {
 			T value, String stepName){
 		return new ScalarSubscription<>(subscriber, value, stepName);
 	}
-	
+
 	/**
 	 * Safely gate a {@link Subscriber} by making sure onNext signals are delivered
 	 * sequentially (serialized).
@@ -1436,7 +1436,7 @@ public abstract class Operators {
 	}
 
 	static final class CorePublisherAdapter<T> implements CorePublisher<T>,
-	                                                      OptimizableOperator<T, T> {
+			OptimizableOperator<T, T> {
 
 		final Publisher<T> publisher;
 
@@ -1735,8 +1735,8 @@ public abstract class Operators {
 	 */
 	public static class MonoSubscriber<I, O>
 			implements InnerOperator<I, O>,
-			           Fuseable, //for constants only
-			           QueueSubscription<O> {
+			Fuseable, //for constants only
+			QueueSubscription<O> {
 
 		protected final CoreSubscriber<? super O> actual;
 
@@ -2130,74 +2130,74 @@ public abstract class Operators {
 
 		@Override
 		public final void request(long n) {
-		    if (validate(n)) {
-	            if (unbounded) {
-	                return;
-	            }
-	            if (wip == 0 && WIP.compareAndSet(this, 0, 1)) {
-	                long r = requested;
+			if (validate(n)) {
+				if (unbounded) {
+					return;
+				}
+				if (wip == 0 && WIP.compareAndSet(this, 0, 1)) {
+					long r = requested;
 
-	                if (r != Long.MAX_VALUE) {
-	                    r = addCap(r, n);
-	                    requested = r;
-	                    if (r == Long.MAX_VALUE) {
-	                        unbounded = true;
-	                    }
-	                }
-		            Subscription a = subscription;
+					if (r != Long.MAX_VALUE) {
+						r = addCap(r, n);
+						requested = r;
+						if (r == Long.MAX_VALUE) {
+							unbounded = true;
+						}
+					}
+					Subscription a = subscription;
 
-	                if (WIP.decrementAndGet(this) != 0) {
-	                    drainLoop();
-	                }
+					if (WIP.decrementAndGet(this) != 0) {
+						drainLoop();
+					}
 
-	                if (a != null) {
-	                    a.request(n);
-	                }
+					if (a != null) {
+						a.request(n);
+					}
 
-	                return;
-	            }
+					return;
+				}
 
-	            addCap(MISSED_REQUESTED, this, n);
+				addCap(MISSED_REQUESTED, this, n);
 
-	            drain();
-	        }
+				drain();
+			}
 		}
 
 		public final void set(Subscription s) {
-		    if (cancelled) {
-	            s.cancel();
-	            return;
-	        }
+			if (cancelled) {
+				s.cancel();
+				return;
+			}
 
-	        Objects.requireNonNull(s);
+			Objects.requireNonNull(s);
 
-	        if (wip == 0 && WIP.compareAndSet(this, 0, 1)) {
-		        Subscription a = subscription;
+			if (wip == 0 && WIP.compareAndSet(this, 0, 1)) {
+				Subscription a = subscription;
 
-	            if (a != null && shouldCancelCurrent()) {
-	                a.cancel();
-	            }
+				if (a != null && shouldCancelCurrent()) {
+					a.cancel();
+				}
 
-		        subscription = s;
+				subscription = s;
 
-	            long r = requested;
+				long r = requested;
 
-	            if (WIP.decrementAndGet(this) != 0) {
-	                drainLoop();
-	            }
+				if (WIP.decrementAndGet(this) != 0) {
+					drainLoop();
+				}
 
-	            if (r != 0L) {
-	                s.request(r);
-	            }
+				if (r != 0L) {
+					s.request(r);
+				}
 
-	            return;
-	        }
+				return;
+			}
 
-	        Subscription a = MISSED_SUBSCRIPTION.getAndSet(this, s);
-	        if (a != null && shouldCancelCurrent()) {
-	            a.cancel();
-	        }
-	        drain();
+			Subscription a = MISSED_SUBSCRIPTION.getAndSet(this, s);
+			if (a != null && shouldCancelCurrent()) {
+				a.cancel();
+			}
+			drain();
 		}
 
 		/**
@@ -2217,99 +2217,99 @@ public abstract class Operators {
 		}
 
 		final void drainLoop() {
-		    int missed = 1;
+			int missed = 1;
 
-	        long requestAmount = 0L;
-	        long alreadyInRequestAmount = 0L;
-	        Subscription requestTarget = null;
+			long requestAmount = 0L;
+			long alreadyInRequestAmount = 0L;
+			Subscription requestTarget = null;
 
-	        for (; ; ) {
+			for (; ; ) {
 
-	            Subscription ms = missedSubscription;
+				Subscription ms = missedSubscription;
 
-	            if (ms != null) {
-	                ms = MISSED_SUBSCRIPTION.getAndSet(this, null);
-	            }
+				if (ms != null) {
+					ms = MISSED_SUBSCRIPTION.getAndSet(this, null);
+				}
 
-	            long mr = missedRequested;
-	            if (mr != 0L) {
-	                mr = MISSED_REQUESTED.getAndSet(this, 0L);
-	            }
+				long mr = missedRequested;
+				if (mr != 0L) {
+					mr = MISSED_REQUESTED.getAndSet(this, 0L);
+				}
 
-	            long mp = missedProduced;
-	            if (mp != 0L) {
-	                mp = MISSED_PRODUCED.getAndSet(this, 0L);
-	            }
+				long mp = missedProduced;
+				if (mp != 0L) {
+					mp = MISSED_PRODUCED.getAndSet(this, 0L);
+				}
 
-		        Subscription a = subscription;
+				Subscription a = subscription;
 
-	            if (cancelled) {
-	                if (a != null) {
-	                    a.cancel();
-		                subscription = null;
-	                }
-	                if (ms != null) {
-	                    ms.cancel();
-	                }
-	            } else {
-	                long r = requested;
-	                if (r != Long.MAX_VALUE) {
-	                    long u = addCap(r, mr);
+				if (cancelled) {
+					if (a != null) {
+						a.cancel();
+						subscription = null;
+					}
+					if (ms != null) {
+						ms.cancel();
+					}
+				} else {
+					long r = requested;
+					if (r != Long.MAX_VALUE) {
+						long u = addCap(r, mr);
 
-	                    if (u != Long.MAX_VALUE) {
-	                        long v = u - mp;
-	                        if (v < 0L) {
-	                            reportMoreProduced();
-	                            v = 0;
-	                        }
-	                        r = v;
-	                    } else {
-	                        r = u;
-	                    }
-	                    requested = r;
-	                }
+						if (u != Long.MAX_VALUE) {
+							long v = u - mp;
+							if (v < 0L) {
+								reportMoreProduced();
+								v = 0;
+							}
+							r = v;
+						} else {
+							r = u;
+						}
+						requested = r;
+					}
 
-	                if (ms != null) {
-	                    if (a != null && shouldCancelCurrent()) {
-	                        a.cancel();
-	                    }
-		                subscription = ms;
-		                if (r != 0L) {
-			                requestAmount = addCap(requestAmount, r - alreadyInRequestAmount);
-	                        requestTarget = ms;
-	                    }
-	                } else if (mr != 0L && a != null) {
-	                    requestAmount = addCap(requestAmount, mr);
-	                    alreadyInRequestAmount += mr; 
-	                    requestTarget = a;
-	                }
-	            }
+					if (ms != null) {
+						if (a != null && shouldCancelCurrent()) {
+							a.cancel();
+						}
+						subscription = ms;
+						if (r != 0L) {
+							requestAmount = addCap(requestAmount, r - alreadyInRequestAmount);
+							requestTarget = ms;
+						}
+					} else if (mr != 0L && a != null) {
+						requestAmount = addCap(requestAmount, mr);
+						alreadyInRequestAmount += mr;
+						requestTarget = a;
+					}
+				}
 
-	            missed = WIP.addAndGet(this, -missed);
-	            if (missed == 0) {
-	                if (requestAmount != 0L) {
-	                    requestTarget.request(requestAmount);
-	                }
-	                return;
-	            }
-	        }
+				missed = WIP.addAndGet(this, -missed);
+				if (missed == 0) {
+					if (requestAmount != 0L) {
+						requestTarget.request(requestAmount);
+					}
+					return;
+				}
+			}
 		}
 		@SuppressWarnings("rawtypes")
 		static final AtomicReferenceFieldUpdater<MultiSubscriptionSubscriber, Subscription>
 				MISSED_SUBSCRIPTION =
-		  AtomicReferenceFieldUpdater.newUpdater(MultiSubscriptionSubscriber.class,
-			Subscription.class,
-			"missedSubscription");
+				AtomicReferenceFieldUpdater.newUpdater(MultiSubscriptionSubscriber.class,
+						Subscription.class,
+						"missedSubscription");
 		@SuppressWarnings("rawtypes")
 		static final AtomicLongFieldUpdater<MultiSubscriptionSubscriber>
 				MISSED_REQUESTED =
-		  AtomicLongFieldUpdater.newUpdater(MultiSubscriptionSubscriber.class, "missedRequested");
+				AtomicLongFieldUpdater.newUpdater(MultiSubscriptionSubscriber.class, "missedRequested");
 		@SuppressWarnings("rawtypes")
 		static final AtomicLongFieldUpdater<MultiSubscriptionSubscriber> MISSED_PRODUCED =
-		  AtomicLongFieldUpdater.newUpdater(MultiSubscriptionSubscriber.class, "missedProduced");
+				AtomicLongFieldUpdater.newUpdater(MultiSubscriptionSubscriber.class, "missedProduced");
 		@SuppressWarnings("rawtypes")
 		static final AtomicIntegerFieldUpdater<MultiSubscriptionSubscriber> WIP =
-		  AtomicIntegerFieldUpdater.newUpdater(MultiSubscriptionSubscriber.class, "wip");
+				AtomicIntegerFieldUpdater.newUpdater(MultiSubscriptionSubscriber.class, "wip");
 	}
 
 	/**
@@ -2573,6 +2573,205 @@ public abstract class Operators {
 			}
 		}
 	}
+
+	/*package*/ static class MonoInnerProducerBase<O>
+			implements InnerProducer<O> {
+
+		private final CoreSubscriber<? super O> actual;
+
+		/**
+		 * The value stored by this Mono operator.
+		 */
+		@Nullable
+		private volatile O   value;
+
+		private volatile  int state; //see STATE field updater
+		@SuppressWarnings("rawtypes")
+		private static final AtomicIntegerFieldUpdater<MonoInnerProducerBase> STATE =
+				AtomicIntegerFieldUpdater.newUpdater(MonoInnerProducerBase.class, "state");
+
+		public MonoInnerProducerBase(CoreSubscriber<? super O> actual) {
+			this.actual = actual;
+		}
+
+		@Override
+		@Nullable
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.CANCELLED) return isCancelled();
+			if (key == Attr.TERMINATED) return (state & HAS_COMPLETED) == HAS_COMPLETED ;
+			if (key == Attr.PREFETCH) return Integer.MAX_VALUE;
+			return InnerProducer.super.scanUnsafe(key);
+		}
+
+		/**
+		 * Tries to emit the value and complete the underlying subscriber or
+		 * stores the value away until there is a request for it.
+		 * <p>
+		 * Make sure this method is called at most once
+		 * @param v the value to emit
+		 */
+		public final void complete(O v) {
+			doOnComplete(v);
+			while(true) {
+				int s = this.state;
+				if (s == CANCELLED) {
+					discard(v);
+					return;
+				}
+
+				if ((s & HAS_REQUEST) == HAS_REQUEST && STATE.compareAndSet(this, s, s | (HAS_VALUE | HAS_COMPLETED))) {
+					discardTheValue();
+					actual.onNext(v);
+					actual.onComplete();
+					return;
+				}
+
+				this.value = v;
+				if ( /*((state & HAS_REQUEST) == 0) && */ STATE.compareAndSet(this, s, s | (HAS_VALUE | HAS_COMPLETED))) {
+					return;
+				}
+			}
+		}
+
+		protected void doOnComplete(O v) {
+
+		}
+
+		protected void doOnComplete() {
+
+		}
+
+		public final void complete() {
+			doOnComplete();
+			while(true) {
+				int s = this.state;
+				if (s == CANCELLED) {
+					return;
+				}
+				if (STATE.compareAndSet(this, s, s | HAS_COMPLETED)) {
+					if ((s & HAS_VALUE) == HAS_VALUE && (s & HAS_REQUEST) == HAS_REQUEST) {
+						O v = this.value;
+						this.value = null;
+						actual.onNext(v);
+						actual.onComplete();
+						return;
+					}
+					if ((s & HAS_VALUE) == 0) {
+						actual.onComplete();
+						return;
+					}
+					if ((s & HAS_REQUEST) == 0) {
+						return;
+					}
+				}
+			}
+		}
+
+		/**
+		 * Discard the given value, generally this.value field. Lets derived subscriber with further knowledge about
+		 * the possible types of the value discard such values in a specific way. Note that fields should generally be
+		 * nulled out along the discard call.
+		 *
+		 * @param v the value to discard
+		 */
+		protected final void discard(@Nullable O v) {
+			Operators.onDiscard(v, actual.currentContext());
+		}
+
+		protected final void discardTheValue() {
+			discard(this.value);
+			this.value = null;
+		}
+
+		@Override
+		public final CoreSubscriber<? super O> actual() {
+			return actual;
+		}
+
+		/**
+		 * Returns true if this Subscription has been cancelled.
+		 * @return true if this Subscription has been cancelled
+		 */
+		public final boolean isCancelled() {
+			return state == CANCELLED;
+		}
+
+
+		@Override
+		public void request(long n) {
+			if (validate(n)) {
+				doOnRequest(n);
+				while (true) {
+					int s = state;
+					if (s == CANCELLED) {
+						return;
+					}
+					if ((s & HAS_REQUEST) == HAS_REQUEST) {
+						return;
+					}
+					if (STATE.compareAndSet(this, s, s | HAS_REQUEST)) {
+						if ((s & HAS_VALUE) == HAS_VALUE && (s & HAS_COMPLETED) == HAS_COMPLETED) {
+							O v = this.value;
+							this.value = null; // aggressively null value to prevent strong ref after complete
+							actual.onNext(v);
+							actual.onComplete();
+							return;
+						}
+
+					}
+				}
+			}
+		}
+
+		protected void doOnRequest(long n) {
+
+		}
+
+		/**
+		 * Set the value internally, without impacting request tracking state.
+		 * This however discards the provided value when detecting a cancellation.
+		 *
+		 * @param value the new value.
+		 * @see #complete(Object)
+		 */
+		protected final void setValue(@Nullable O value) {
+			this.value = value;
+			while(true) {
+				int s = this.state;
+				if (s == CANCELLED) {
+					discardTheValue();
+					return;
+				}
+				if (STATE.compareAndSet(this, s, s|HAS_VALUE)) {
+					return;
+				}
+			}
+		}
+
+		@Override
+		public final void cancel() {
+			doOnCancel();
+			int previous = STATE.getAndSet(this, CANCELLED);
+			if ((previous & HAS_VALUE) == HAS_VALUE // Had a value...
+					&& (previous & (HAS_COMPLETED|HAS_REQUEST)) != (HAS_COMPLETED|HAS_REQUEST) // ... but did not use it
+			) {
+				discardTheValue();
+			}
+		}
+
+		protected void doOnCancel() {
+
+		}
+
+		// The following are to be used as bit masks, not as values per se.
+		private static final int HAS_VALUE =      0b00000001;
+		private static final int HAS_REQUEST =    0b00000010;
+		private static final int HAS_COMPLETED =  0b00000100;
+		// The following are to be used as value (ie using == or !=).
+		private static final int CANCELLED =      0b10000000;
+
+	}
+
 
 
 	final static Logger log = Loggers.getLogger(Operators.class);

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -2651,7 +2651,7 @@ public abstract class Operators {
 				if (STATE.compareAndSet(this, s, s | HAS_COMPLETED)) {
 					if ((s & HAS_VALUE) == HAS_VALUE && (s & HAS_REQUEST) == HAS_REQUEST) {
 						O v = this.value;
-						this.value = null;
+						this.value = null; // aggressively null value to prevent strong ref after complete
 						actual.onNext(v);
 						actual.onComplete();
 						return;
@@ -2668,7 +2668,8 @@ public abstract class Operators {
 		}
 
 		/**
-		 * Discard the given value, generally this.value field. Lets derived subscriber with further knowledge about
+		 * Discard the given value, if the value to discard is not the one held by this instance
+		 * (see {@link #discardTheValue()} for that purpose. Lets derived subscriber with further knowledge about
 		 * the possible types of the value discard such values in a specific way. Note that fields should generally be
 		 * nulled out along the discard call.
 		 *
@@ -2680,7 +2681,7 @@ public abstract class Operators {
 
 		protected final void discardTheValue() {
 			discard(this.value);
-			this.value = null;
+			this.value = null; // aggressively null value to prevent strong ref after complete
 		}
 
 		@Override

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoInnerProducerBaseTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoInnerProducerBaseTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2011-2021 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Operators.MonoInnerProducerBase;
+import reactor.test.subscriber.AssertSubscriber;
+import reactor.test.util.RaceTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MonoInnerProducerBaseTest {
+
+	public static final int ITERATION_COUNT = 10_000;
+
+	@Test
+	public void completeWithValueCancelRace() {
+		for (int i = 0; i < ITERATION_COUNT; i++) {
+			AtomicInteger discarded = new AtomicInteger();
+			AssertSubscriber<Integer> ts = new AssertSubscriber<>(Operators
+					.enableOnDiscard(null, v -> discarded.incrementAndGet()), Long.MAX_VALUE);
+			final MonoInnerProducerBase<Integer> ds = new MonoInnerProducerBase<>(ts);
+			ts.onSubscribe(ds);
+
+			Runnable r1 = () -> ds.complete(1);
+			Runnable r2 = ds::cancel;
+
+			RaceTestUtils.race(r1, r2);
+
+			if (ts.values().size() == 1) {
+				ts.assertValues(1);
+			}
+			else if (ts.values().size() > 1) {
+				throw new AssertionError("Too many values received");
+			}
+			else {
+				assertThat(discarded.get()).isEqualTo(1);
+			}
+		}
+	}
+
+	@Test
+	public void requestCancelRaceAfterCompleteWithValue() {
+		for (int i = 0; i < ITERATION_COUNT; i++) {
+			AtomicInteger discarded = new AtomicInteger();
+			AssertSubscriber<Integer> ts = new AssertSubscriber<>(Operators
+					.enableOnDiscard(null, v -> discarded.incrementAndGet()), 0L);
+
+			final MonoInnerProducerBase<Integer> ds = new MonoInnerProducerBase<>(ts);
+			ts.onSubscribe(ds);
+			ds.complete(1);
+
+			Runnable r1 = () -> ds.request(1);
+			Runnable r2 = ds::cancel;
+
+			RaceTestUtils.race(r1, r2);
+
+			if (ts.values().size() >= 1) {
+				ts.assertValues(1);
+			}
+			else {
+				assertThat(discarded.get()).isEqualTo(1);
+			}
+		}
+	}
+
+	@Test
+	public void requestCancelCompleteWithValueRace() {
+		for (int i = 0; i < ITERATION_COUNT; i++) {
+			AtomicInteger discarded = new AtomicInteger();
+			AssertSubscriber<Integer> ts = new AssertSubscriber<>(Operators
+					.enableOnDiscard(null, v -> discarded.incrementAndGet()), 0L);
+
+			final MonoInnerProducerBase<Integer> ds = new MonoInnerProducerBase<>(ts);
+			ts.onSubscribe(ds);
+
+			Runnable r1 = () -> ds.request(1);
+			Runnable r2 = ds::cancel;
+			Runnable r3 = () -> ds.complete(1);
+
+			RaceTestUtils.race(r1, r2, r3);
+
+			if (ts.values().size() >= 1) {
+				ts.assertValues(1);
+			}
+			else {
+				assertThat(discarded.get()).isEqualTo(1);
+			}
+		}
+	}
+
+
+
+	@Test
+	public void completeWithoutValueCancelRace() {
+		for (int i = 0; i < ITERATION_COUNT; i++) {
+			AtomicInteger discarded = new AtomicInteger();
+			AssertSubscriber<Integer> ts = new AssertSubscriber<>(Operators
+					.enableOnDiscard(null, v -> discarded.incrementAndGet()), Long.MAX_VALUE);
+			final MonoInnerProducerBase<Integer> ds = new MonoInnerProducerBase<>(ts);
+			ts.onSubscribe(ds);
+			ds.setValue(1);
+
+			Runnable r1 = ds::complete;
+			Runnable r2 = ds::cancel;
+
+			RaceTestUtils.race(r1, r2);
+
+			if (ts.values().size() == 1) {
+				ts.assertValues(1);
+			}
+			else if (ts.values().size() > 1) {
+				throw new AssertionError("Too many values received");
+			}
+			else {
+				assertThat(discarded.get()).isEqualTo(1);
+			}
+		}
+	}
+
+	@Test
+	public void requestCancelRaceAfterSetValueAndComplete() {
+		for (int i = 0; i < ITERATION_COUNT; i++) {
+			AtomicInteger discarded = new AtomicInteger();
+			AssertSubscriber<Integer> ts = new AssertSubscriber<>(Operators
+					.enableOnDiscard(null, v -> discarded.incrementAndGet()), 0L);
+
+			final MonoInnerProducerBase<Integer> ds = new MonoInnerProducerBase<>(ts);
+			ts.onSubscribe(ds);
+			ds.setValue(1);
+			ds.complete();
+
+			Runnable r1 = () -> ds.request(1);
+			Runnable r2 = ds::cancel;
+
+			RaceTestUtils.race(r1, r2);
+
+			if (ts.values().size() >= 1) {
+				ts.assertValues(1);
+			}
+			else {
+				assertThat(discarded.get()).isEqualTo(1);
+			}
+		}
+	}
+
+	@Test
+	public void requestCancelCompleteWithoutValueRace() {
+		for (int i = 0; i < ITERATION_COUNT; i++) {
+			AtomicInteger discarded = new AtomicInteger();
+			AssertSubscriber<Integer> ts = new AssertSubscriber<>(Operators
+					.enableOnDiscard(null, v -> discarded.incrementAndGet()), 0L);
+
+			final MonoInnerProducerBase<Integer> ds = new MonoInnerProducerBase<>(ts);
+			ts.onSubscribe(ds);
+			ds.setValue(1);
+
+			Runnable r1 = () -> ds.request(1);
+			Runnable r2 = ds::cancel;
+			Runnable r3 = ds::complete;
+
+			RaceTestUtils.race(r1, r2, r3);
+
+			if (ts.values().size() >= 1) {
+				ts.assertValues(1);
+			}
+			else {
+				assertThat(discarded.get()).isEqualTo(1);
+			}
+		}
+	}
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSubscriberTest.java
@@ -184,8 +184,8 @@ public class MonoSubscriberTest {
 					(sink) -> Schedulers.elastic().schedule(() -> sink.success(2))));
 			input.put("three", Mono.just(3));
 			int sum = Flux.fromIterable(input.entrySet())
-			              .flatMap((entry) -> Mono.zip(Mono.just(entry.getKey()), entry.getValue()))
-			              .collectMap(Tuple2::getT1, Tuple2::getT2).map((items) -> {
+					.flatMap((entry) -> Mono.zip(Mono.just(entry.getKey()), entry.getValue()))
+					.collectMap(Tuple2::getT1, Tuple2::getT2).map((items) -> {
 						AtomicInteger result = new AtomicInteger();
 						items.values().forEach(result::addAndGet);
 						return result.get();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSubscriberTest.java
@@ -184,8 +184,8 @@ public class MonoSubscriberTest {
 					(sink) -> Schedulers.elastic().schedule(() -> sink.success(2))));
 			input.put("three", Mono.just(3));
 			int sum = Flux.fromIterable(input.entrySet())
-					.flatMap((entry) -> Mono.zip(Mono.just(entry.getKey()), entry.getValue()))
-					.collectMap(Tuple2::getT1, Tuple2::getT2).map((items) -> {
+			              .flatMap((entry) -> Mono.zip(Mono.just(entry.getKey()), entry.getValue()))
+			              .collectMap(Tuple2::getT1, Tuple2::getT2).map((items) -> {
 						AtomicInteger result = new AtomicInteger();
 						items.values().forEach(result::addAndGet);
 						return result.get();

--- a/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
@@ -46,7 +46,7 @@ import reactor.util.concurrent.Queues;
 // test count did not regress.
 public class OnDiscardShouldNotLeakTest {
 
-	private static final int NB_ITERATIONS = 10_000;
+	private static final int NB_ITERATIONS = 100;
 	// add DiscardScenarios here to test more operators
 	private static final DiscardScenario[] SCENARIOS = new DiscardScenario[] {
 			DiscardScenario.allFluxSourceArray("merge", 4, Flux::merge),

--- a/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
@@ -46,7 +46,7 @@ import reactor.util.concurrent.Queues;
 // test count did not regress.
 public class OnDiscardShouldNotLeakTest {
 
-	private static final int NB_ITERATIONS = 100;
+	private static final int NB_ITERATIONS = 10_000;
 	// add DiscardScenarios here to test more operators
 	private static final DiscardScenario[] SCENARIOS = new DiscardScenario[] {
 			DiscardScenario.allFluxSourceArray("merge", 4, Flux::merge),
@@ -78,8 +78,7 @@ public class OnDiscardShouldNotLeakTest {
 			DiscardScenario.fluxSource("unicastProcessorAndPublishOn", f -> f
 					.subscribeWith(UnicastProcessor.create())
 					.publishOn(Schedulers.immediate())),
-			//FIXME known issue in 3.3.14.RELEASE and 3.4.3
-//			DiscardScenario.fluxSource("singleOrEmpty", f -> f.singleOrEmpty().onErrorReturn(Tracked.RELEASED)),
+			DiscardScenario.fluxSource("singleOrEmpty", f -> f.singleOrEmpty().onErrorReturn(Tracked.RELEASED)),
 			DiscardScenario.fluxSource("collect", f -> f.collect(ArrayList::new, ArrayList::add)
 			                                               .doOnSuccess(l -> l.forEach(Tracked::safeRelease))
 			                                               .thenReturn(Tracked.RELEASED)),


### PR DESCRIPTION
Introduce MonoInnerProducerBase as a tighter alternative to MonoSubscriber, with stronger encapsulation and stricter contract with
regard to its state machine. Derive MonoSingle's subscriber from it.

Fixes #2616