### PR TITLE
Add links to "Which operator do I need?" documentation

### DIFF
--- a/docs/asciidoc/apdx-operatorChoice.adoc
+++ b/docs/asciidoc/apdx-operatorChoice.adoc
@@ -1,7 +1,7 @@
 [[which-operator]]
 = Which operator do I need?
 
-TIP: In this section, if an operator is specific to `Flux` or `Mono`, it is
+TIP: In this section, if an operator is specific to https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html[Flux] or https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html[Mono], it is
 prefixed accordingly. Common operators have no prefix. When a specific use case
 is covered by a combination of operators, it is presented as a method call, with
 leading dot and parameters in parentheses, as follows: `.methodCall(parameter)`.
@@ -33,298 +33,298 @@ I want to deal with:
 [[which.create]]
 == Creating a New Sequence...
 
-* that emits a `T`, and I already have: `just`
-** ...from an `Optional<T>`: `Mono#justOrEmpty(Optional<T>)`
-** ...from a potentially `null` T: `Mono#justOrEmpty(T)`
-* that emits a `T` returned by a method: `just` as well
-** ...but lazily captured: use `Mono#fromSupplier` or wrap `just` inside `defer`
-* that emits several `T` I can explicitly enumerate: `Flux#just(T...)`
+* that emits a `T`, and I already have: `just` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#just-T%2E%2E%2E-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#just-T-[Mono])
+** ...from an https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html[Optional<T>]: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#justOrEmpty-java.util.Optional-[Mono#justOrEmpty(Optional<T>)]
+** ...from a potentially `null` T: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#justOrEmpty-T-[Mono#justOrEmpty(T)]
+* that emits a `T` returned by a method: `just` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#just-T%2E%2E%2E-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#just-T-[Mono]) as well
+** ...but lazily captured: use https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#fromSupplier-java.util.function.Supplier-[Mono#fromSupplier] or wrap `just` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#just-T%2E%2E%2E-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#just-T-[Mono]) inside `defer` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#defer-java.util.function.Supplier-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#defer-java.util.function.Supplier-[Mono])
+* that emits several `T` I can explicitly enumerate: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#just-T%2E%2E%2E-[Flux#just(T...)]
 * that iterates over:
-** an array: `Flux#fromArray`
-** a collection or iterable: `Flux#fromIterable`
-** a range of integers: `Flux#range`
-** a `Stream` supplied for each Subscription: `Flux#fromStream(Supplier<Stream>)`
+** an array: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#fromArray-T:A-[Flux#fromArray]
+** a collection or iterable: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#fromIterable-java.lang.Iterable-[Flux#fromIterable]
+** a range of integers: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#range-int-int-[Flux#range]
+** a https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html[Stream] supplied for each Subscription: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#fromStream-java.util.function.Supplier-[Flux#fromStream(Supplier<Stream>)]
 * that emits from various single-valued sources such as:
-** a `Supplier<T>`: `Mono#fromSupplier`
-** a task: `Mono#fromCallable`, `Mono#fromRunnable`
-** a `CompletableFuture<T>`: `Mono#fromFuture`
-* that completes: `empty`
-* that errors immediately: `error`
-** ...but lazily build the `Throwable`: `error(Supplier<Throwable>)`
-* that never does anything: `never`
-* that is decided at subscription: `defer`
-* that depends on a disposable resource: `using`
+** a https://docs.oracle.com/javase/8/docs/api/java/util/function/Supplier.html[Supplier<T>]: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#fromSupplier-java.util.function.Supplier-[Mono#fromSupplier]
+** a task: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#fromCallable-java.util.concurrent.Callable-[Mono#fromCallable], https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#fromRunnable-java.lang.Runnable-[Mono#fromRunnable]
+** a https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html[CompletableFuture<T>]: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#fromFuture-java.util.concurrent.CompletableFuture-[Mono#fromFuture]
+* that completes: `empty` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#empty--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#empty--[Mono])
+* that errors immediately: `error` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#error-java.lang.Throwable-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#error-java.lang.Throwable-[Mono])
+** ...but lazily build the https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html[Throwable]: `error(Supplier<Throwable>)` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#error-java.util.function.Supplier-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#error-java.util.function.Supplier-[Mono])
+* that never does anything: `never` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#never--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#never--[Mono])
+* that is decided at subscription: `defer` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#defer-java.util.function.Supplier-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#defer-java.util.function.Supplier-[Mono])
+* that depends on a disposable resource: `using` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#using-java.util.concurrent.Callable-java.util.function.Function-java.util.function.Consumer-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#using-java.util.concurrent.Callable-java.util.function.Function-java.util.function.Consumer-[Mono])
 * that generates events programmatically (can use state):
-** synchronously and one-by-one: `Flux#generate`
-** asynchronously (can also be sync), multiple emissions possible in one pass: `Flux#create`
-(`Mono#create` as well, without the multiple emission aspect)
+** synchronously and one-by-one: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#generate-java.util.concurrent.Callable-java.util.function.BiFunction-[Flux#generate]
+** asynchronously (can also be sync), multiple emissions possible in one pass: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#create-java.util.function.Consumer-[Flux#create]
+(https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#create-java.util.function.Consumer-[Mono#create] as well, without the multiple emission aspect)
 
 [[which.values]]
 == Transforming an Existing Sequence
 
 * I want to transform existing data:
-** on a 1-to-1 basis (eg. strings to their length): `map`
-*** ...by just casting it: `cast`
-*** ...in order to materialize each source value's index: `Flux#index`
-** on a 1-to-n basis (eg. strings to their characters): `flatMap` + use a factory method
-** on a 1-to-n basis with programmatic behavior for each source element and/or state: `handle`
-** running an asynchronous task for each source item (eg. urls to http request): `flatMap` + an async `Publisher`-returning method
-*** ...ignoring some data: conditionally return a `Mono.empty()` in the flatMap lambda
-*** ...retaining the original sequence order: `Flux#flatMapSequential` (this triggers the async processes immediately but reorders the results)
-*** ...where the async task can return multiple values, from a `Mono` source: `Mono#flatMapMany`
+** on a 1-to-1 basis (eg. strings to their length): `map` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#map-java.util.function.Function-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#map-java.util.function.Function-[Mono])
+*** ...by just casting it: `cast` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#cast-java.lang.Class-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#cast-java.lang.Class-[Mono])
+*** ...in order to materialize each source value's index: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#index--[Flux#index]
+** on a 1-to-n basis (eg. strings to their characters): `flatMap` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#flatMap-java.util.function.Function-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#flatMap-java.util.function.Function-[Mono]) + use a factory method
+** on a 1-to-n basis with programmatic behavior for each source element and/or state: `handle` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#handle-java.util.function.BiConsumer-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#handle-java.util.function.BiConsumer-[Mono])
+** running an asynchronous task for each source item (eg. urls to http request): `flatMap` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#flatMap-java.util.function.Function-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#flatMap-java.util.function.Function-[Mono]) + an async https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/org/reactivestreams/Publisher.html?is-external=true[Publisher]-returning method
+*** ...ignoring some data: conditionally return a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#empty--[Mono.empty()] in the flatMap lambda
+*** ...retaining the original sequence order: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#flatMapSequential-java.util.function.Function-[Flux#flatMapSequential] (this triggers the async processes immediately but reorders the results)
+*** ...where the async task can return multiple values, from a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html[Mono] source: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#flatMapMany-java.util.function.Function-[Mono#flatMapMany]
 
 * I want to add pre-set elements to an existing sequence:
-** at the start: `Flux#startWith(T...)`
-** at the end: `Flux#concatWithValues(T...)`
+** at the start: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#startWith-T%2E%2E%2E-[Flux#startWith(T...)]
+** at the end: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#concatWithValues-T%2E%2E%2E-[Flux#concatWithValues(T...)]
 
-* I want to aggregate a `Flux`: (the `Flux#` prefix is assumed below)
-** into a List: `collectList`, `collectSortedList`
-** into a Map: `collectMap`, `collectMultiMap`
-** into an arbitrary container: `collect`
-** into the size of the sequence: `count`
-** by applying a function between each element (eg. running sum): `reduce`
-*** ...but emitting each intermediary value: `scan`
+* I want to aggregate a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html[Flux]: (the `Flux#` prefix is assumed below)
+** into a List: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#collectList--[collectList], https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#collectSortedList--[collectSortedList]
+** into a Map: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#collectMap-java.util.function.Function-[collectMap], https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#collectMultimap-java.util.function.Function-[collectMultiMap]
+** into an arbitrary container: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#collect-java.util.stream.Collector-[collect]
+** into the size of the sequence: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#count--[count]
+** by applying a function between each element (eg. running sum): https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#reduce-A-java.util.function.BiFunction-[reduce]
+*** ...but emitting each intermediary value: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#scan-A-java.util.function.BiFunction-[scan]
 ** into a boolean value from a predicate:
-*** applied to all values (AND): `all`
-*** applied to at least one value (OR): `any`
-*** testing the presence of any value: `hasElements`
-*** testing the presence of a specific value: `hasElement`
+*** applied to all values (AND): https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#all-java.util.function.Predicate-[all]
+*** applied to at least one value (OR): https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#any-java.util.function.Predicate-[any]
+*** testing the presence of any value: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#hasElement--[hasElements]
+*** testing the presence of a specific value: `hasElement` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#hasElement-T-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#hasElement--[Mono])
 
 
 * I want to combine publishers...
-** in sequential order: `Flux#concat` or `.concatWith(other)`
-*** ...but delaying any error until remaining publishers have been emitted: `Flux#concatDelayError`
-*** ...but eagerly subscribing to subsequent publishers: `Flux#mergeSequential`
-** in emission order (combined items emitted as they come): `Flux#merge` / `.mergeWith(other)`
-*** ...with different types (transforming merge): `Flux#zip` / `Flux#zipWith`
+** in sequential order: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#concat-org.reactivestreams.Publisher%2E%2E%2E-[Flux#concat] or `.concatWith(other)` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#concatWith-org.reactivestreams.Publisher-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#concatWith-org.reactivestreams.Publisher-[Mono])
+*** ...but delaying any error until remaining publishers have been emitted: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#concatDelayError-org.reactivestreams.Publisher-[Flux#concatDelayError]
+*** ...but eagerly subscribing to subsequent publishers: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#mergeSequential-int-org.reactivestreams.Publisher%2E%2E%2E-[Flux#mergeSequential]
+** in emission order (combined items emitted as they come): https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#merge-int-org.reactivestreams.Publisher%2E%2E%2E-[Flux#merge] / `.mergeWith(other)` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#mergeWith-org.reactivestreams.Publisher-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#mergeWith-org.reactivestreams.Publisher-[Mono])
+*** ...with different types (transforming merge): https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#zip-java.util.function.Function-org.reactivestreams.Publisher%2E%2E%2E-[Flux#zip] / https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#zipWith-org.reactivestreams.Publisher-[Flux#zipWith]
 ** by pairing values:
-*** from 2 Monos into a `Tuple2`: `Mono#zipWith`
-*** from n Monos when they all completed: `Mono#zip`
+*** from 2 Monos into a https://projectreactor.io/docs/core/release/api/reactor/util/function/Tuple2.html[Tuple2]: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#zipWith-reactor.core.publisher.Mono-[Mono#zipWith]
+*** from n Monos when they all completed: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#zip-java.util.function.Function-reactor.core.publisher.Mono%2E%2E%2E-[Mono#zip]
 ** by coordinating their termination:
-*** from 1 Mono and any source into a `Mono<Void>`: `Mono#and`
-*** from n sources when they all completed: `Mono#when`
+*** from 1 Mono and any source into a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html[Mono<Void>]: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#and-org.reactivestreams.Publisher-[Mono#and]
+*** from n sources when they all completed: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#when-java.lang.Iterable-[Mono#when]
 *** into an arbitrary container type:
-**** each time all sides have emitted: `Flux#zip` (up to the smallest cardinality)
-**** each time a new value arrives at either side: `Flux#combineLatest`
+**** each time all sides have emitted: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#zip-java.util.function.Function-org.reactivestreams.Publisher%2E%2E%2E-[Flux#zip] (up to the smallest cardinality)
+**** each time a new value arrives at either side: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#combineLatest-java.util.function.Function-int-org.reactivestreams.Publisher%2E%2E%2E-[Flux#combineLatest]
 ** selecting the first publisher which...
-*** produces a _value_ (`onNext`): `firstWithValue`
-*** produces _any signal_: `firstWithSignal`
-** triggered by the elements in a source sequence: `switchMap` (each source element is mapped to a Publisher)
-** triggered by the start of the next publisher in a sequence of publishers: `switchOnNext`
+*** produces a _value_ (`onNext`): `firstWithValue` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#firstWithValue-java.lang.Iterable-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#firstWithValue-java.lang.Iterable-[Mono])
+*** produces _any signal_: `firstWithSignal` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#firstWithSignal-java.lang.Iterable-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#firstWithSignal-java.lang.Iterable-[Mono])
+** triggered by the elements in a source sequence: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#switchMap-java.util.function.Function-[switchMap] (each source element is mapped to a Publisher)
+** triggered by the start of the next publisher in a sequence of publishers: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#switchOnNext-org.reactivestreams.Publisher-[switchOnNext]
 
-* I want to repeat an existing sequence: `repeat`
+* I want to repeat an existing sequence: `repeat` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#repeat--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#repeat--[Mono])
 ** ...but at time intervals: `Flux.interval(duration).flatMap(tick -> myExistingPublisher)`
 
 * I have an empty sequence but...
-** I want a value instead: `defaultIfEmpty`
-** I want another sequence instead: `switchIfEmpty`
+** I want a value instead: `defaultIfEmpty` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#defaultIfEmpty-T-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#defaultIfEmpty-T-[Mono])
+** I want another sequence instead: `switchIfEmpty` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#switchIfEmpty-org.reactivestreams.Publisher-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#switchIfEmpty-reactor.core.publisher.Mono-[Mono])
 
-* I have a sequence but I am not interested in values: `ignoreElements`
-** ...and I want the completion represented as a `Mono`: `then`
-** ...and I want to wait for another task to complete at the end: `thenEmpty`
-** ...and I want to switch to another `Mono` at the end: `Mono#then(mono)`
-** ...and I want to emit a single value at the end: `Mono#thenReturn(T)`
-** ...and I want to switch to a `Flux` at the end: `thenMany`
+* I have a sequence but I am not interested in values: `ignoreElements` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#ignoreElements--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#ignoreElements-org.reactivestreams.Publisher-[Mono])
+** ...and I want the completion represented as a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html[Mono]: `then` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#then--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#then--[Mono])
+** ...and I want to wait for another task to complete at the end: `thenEmpty` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#thenEmpty-org.reactivestreams.Publisher-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#thenEmpty-org.reactivestreams.Publisher-[Mono])
+** ...and I want to switch to another https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html[Mono] at the end: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#then-reactor.core.publisher.Mono-[Mono#then(mono)]
+** ...and I want to emit a single value at the end: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#thenReturn-V-[Mono#thenReturn(T)]
+** ...and I want to switch to a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html[Flux] at the end: `thenMany` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#thenMany-org.reactivestreams.Publisher-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#thenMany-org.reactivestreams.Publisher-[Mono])
 
 * I have a Mono for which I want to defer completion...
-** ...until another publisher, which is derived from this value, has completed: `Mono#delayUntil(Function)`
+** ...until another publisher, which is derived from this value, has completed: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#delayUntil-java.util.function.Function-[Mono#delayUntil(Function)]
 
 * I want to expand elements recursively into a graph of sequences and emit the combination...
-** ...expanding the graph breadth first: `expand(Function)`
-** ...expanding the graph depth first: `expandDeep(Function)`
+** ...expanding the graph breadth first: `expand(Function)` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#expand-java.util.function.Function-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#expand-java.util.function.Function-[Mono])
+** ...expanding the graph depth first: `expandDeep(Function)` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#expandDeep-java.util.function.Function-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#expandDeep-java.util.function.Function-[Mono])
 
 [[which.peeking]]
 == Peeking into a Sequence
 
 * Without modifying the final sequence, I want to:
 ** get notified of / execute additional behavior (sometimes referred to as "side-effects") on:
-*** emissions: `doOnNext`
-*** completion: `Flux#doOnComplete`, `Mono#doOnSuccess` (includes the result, if any)
-*** error termination: `doOnError`
-*** cancellation: `doOnCancel`
-*** "start" of the sequence: `doFirst`
-**** this is tied to `Publisher#subscribe(Subscriber)`
-*** post-subscription : `doOnSubscribe`
-**** as in `Subscription` acknowledgment after `subscribe`
-**** this is tied to `Subscriber#onSubscribe(Subscription)`
-*** request: `doOnRequest`
-*** completion or error: `doOnTerminate` (Mono version includes the result, if any)
-**** but *after* it has been propagated downstream: `doAfterTerminate`
-*** any type of signal, represented as a `Signal`: `Flux#doOnEach`
-*** any terminating condition (complete, error, cancel): `doFinally`
-** log what happens internally: `log`
+*** emissions: `doOnNext` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#doOnNext-java.util.function.Consumer-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#doOnNext-java.util.function.Consumer-[Mono])
+*** completion: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#doOnComplete-java.lang.Runnable-[Flux#doOnComplete], https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#doOnSuccess-java.util.function.Consumer-[Mono#doOnSuccess] (includes the result, if any)
+*** error termination: `doOnError` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#doOnError-java.util.function.Consumer-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#doOnError-java.util.function.Consumer-[Mono])
+*** cancellation: `doOnCancel` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#doOnCancel-java.lang.Runnable-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#doOnCancel-java.lang.Runnable-[Mono])
+*** "start" of the sequence: `doFirst` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#doFirst-java.lang.Runnable-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#doFirst-java.lang.Runnable-[Mono])
+**** this is tied to https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/org/reactivestreams/Publisher.html?is-external=true#subscribe(org.reactivestreams.Subscriber)[Publisher#subscribe(Subscriber)]
+*** post-subscription : `doOnSubscribe` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#doOnSubscribe-java.util.function.Consumer-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#doOnSubscribe-java.util.function.Consumer-[Mono])
+**** as in https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/org/reactivestreams/Subscription.html[Subscription] acknowledgment after `subscribe` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#subscribe--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#subscribe--[Mono])
+**** this is tied to https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/org/reactivestreams/Subscriber.html?is-external=true#onSubscribe(org.reactivestreams.Subscription)[Subscriber#onSubscribe(Subscription)]
+*** request: `doOnRequest` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#doOnRequest-java.util.function.LongConsumer-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#doOnRequest-java.util.function.LongConsumer-[Mono])
+*** completion or error: `doOnTerminate` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#doOnTerminate-java.lang.Runnable-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#doOnTerminate-java.lang.Runnable-[Mono]) (Mono version includes the result, if any)
+**** but *after* it has been propagated downstream: `doAfterTerminate` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#doAfterTerminate-java.lang.Runnable-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#doAfterTerminate-java.lang.Runnable-[Mono])
+*** any type of signal, represented as a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Signal.html[Signal]: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#doOnEach-java.util.function.Consumer-[Flux#doOnEach]
+*** any terminating condition (complete, error, cancel): `doFinally` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#doFinally-java.util.function.Consumer-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#doFinally-java.util.function.Consumer-[Mono])
+** log what happens internally: `log` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#log--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#log--[Mono])
 
 * I want to know of all events:
-** each represented as `Signal` object:
-*** in a callback outside the sequence: `doOnEach`
-*** instead of the original onNext emissions: `materialize`
-**** ...and get back to the onNexts: `dematerialize`
-** as a line in a log: `log`
+** each represented as https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Signal.html[Signal] object:
+*** in a callback outside the sequence: `doOnEach` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#doOnEach-java.util.function.Consumer-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#doOnEach-java.util.function.Consumer-[Mono])
+*** instead of the original onNext emissions: `materialize` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#materialize--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#materialize--[Mono])
+**** ...and get back to the onNexts: `dematerialize` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#dematerialize--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#dematerialize--[Mono])
+** as a line in a log: `log` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#log--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#log--[Mono])
 
 [[which.filtering]]
 == Filtering a Sequence
 
 * I want to filter a sequence:
-** based on an arbitrary criteria: `filter`
-*** ...that is asynchronously computed: `filterWhen`
-** restricting on the type of the emitted objects: `ofType`
-** by ignoring the values altogether: `ignoreElements`
+** based on an arbitrary criteria: `filter` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#filter-java.util.function.Predicate-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#filter-java.util.function.Predicate-[Mono])
+*** ...that is asynchronously computed: `filterWhen` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#filterWhen-java.util.function.Function-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#filterWhen-java.util.function.Function-[Mono])
+** restricting on the type of the emitted objects: `ofType` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#ofType-java.lang.Class-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#ofType-java.lang.Class-[Mono])
+** by ignoring the values altogether: `ignoreElements` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#ignoreElements--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#ignoreElements-org.reactivestreams.Publisher-[Mono])
 ** by ignoring duplicates:
-*** in the whole sequence (logical set): `Flux#distinct`
-*** between subsequently emitted items (deduplication): `Flux#distinctUntilChanged`
+*** in the whole sequence (logical set): https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#distinct--[Flux#distinct]
+*** between subsequently emitted items (deduplication): https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#distinctUntilChanged--[Flux#distinctUntilChanged]
 
 * I want to keep only a subset of the sequence:
 ** by taking N elements:
-*** at the beginning of the sequence: `Flux#take(long)`
-**** ...based on a duration: `Flux#take(Duration)`
-**** ...only the first element, as a `Mono`: `Flux#next()`
-**** ...using `request(N)` rather than cancellation: `Flux#limitRequest(long)`
-*** at the end of the sequence: `Flux#takeLast`
-*** until a criteria is met (inclusive): `Flux#takeUntil` (predicate-based), `Flux#takeUntilOther` (companion publisher-based)
-*** while a criteria is met (exclusive): `Flux#takeWhile`
+*** at the beginning of the sequence: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#take-long-[Flux#take(long)]
+**** ...based on a duration: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#take-java.time.Duration-[Flux#take(Duration)]
+**** ...only the first element, as a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html[Mono]: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#next--[Flux#next()]
+**** ...using https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/org/reactivestreams/Subscription.html#request(long)[request(N)] rather than cancellation: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#limitRequest-long-[Flux#limitRequest(long)]
+*** at the end of the sequence: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#takeLast-int-[Flux#takeLast]
+*** until a criteria is met (inclusive): https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#takeUntilOther-org.reactivestreams.Publisher-[Flux#takeUntil] (predicate-based), https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#takeUntilOther-org.reactivestreams.Publisher-[Flux#takeUntilOther] (companion publisher-based)
+*** while a criteria is met (exclusive): https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#takeWhile-java.util.function.Predicate-[Flux#takeWhile]
 ** by taking at most 1 element:
-*** at a specific position: `Flux#elementAt`
-*** at the end: `.takeLast(1)`
-**** ...and emit an error if empty: `Flux#last()`
-**** ...and emit a default value if empty: `Flux#last(T)`
+*** at a specific position: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#elementAt-int-[Flux#elementAt]
+*** at the end: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#takeLast-int-[.takeLast(1)]
+**** ...and emit an error if empty: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#last--[Flux#last()]
+**** ...and emit a default value if empty: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#last-T-[Flux#last(T)]
 ** by skipping elements:
-*** at the beginning of the sequence: `Flux#skip(long)`
-**** ...based on a duration: `Flux#skip(Duration)`
-*** at the end of the sequence: `Flux#skipLast`
-*** until a criteria is met (inclusive): `Flux#skipUntil` (predicate-based), `Flux#skipUntilOther` (companion publisher-based)
-*** while a criteria is met (exclusive): `Flux#skipWhile`
+*** at the beginning of the sequence: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#skip-long-[Flux#skip(long)]
+**** ...based on a duration: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#skip-java.time.Duration-[Flux#skip(Duration)]
+*** at the end of the sequence: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#skipLast-int-[Flux#skipLast]
+*** until a criteria is met (inclusive): https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#skipUntil-java.util.function.Predicate-[Flux#skipUntil] (predicate-based), https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#skipUntilOther-org.reactivestreams.Publisher-[Flux#skipUntilOther] (companion publisher-based)
+*** while a criteria is met (exclusive): https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#skipWhile-java.util.function.Predicate-[Flux#skipWhile]
 ** by sampling items:
-*** by duration: `Flux#sample(Duration)`
-**** but keeping the first element in the sampling window instead of the last: `sampleFirst`
-*** by a publisher-based window: `Flux#sample(Publisher)`
-*** based on a publisher "timing out": `Flux#sampleTimeout` (each element triggers a publisher, and is emitted if that publisher does not overlap with the next)
+*** by duration: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#sample-java.time.Duration-[Flux#sample(Duration)]
+**** but keeping the first element in the sampling window instead of the last: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#sampleFirst-java.time.Duration-[sampleFirst]
+*** by a publisher-based window: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#sample-java.time.Duration-[Flux#sample(Publisher)]
+*** based on a publisher "timing out": https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#sampleTimeout-java.util.function.Function-[Flux#sampleTimeout] (each element triggers a publisher, and is emitted if that publisher does not overlap with the next)
 
 * I expect at most 1 element (error if more than one)...
-** and I want an error if the sequence is empty: `Flux#single()`
-** and I want a default value if the sequence is empty: `Flux#single(T)`
-** and I accept an empty sequence as well: `Flux#singleOrEmpty`
+** and I want an error if the sequence is empty: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#single--[Flux#single()]
+** and I want a default value if the sequence is empty: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#single-T-[Flux#single(T)]
+** and I accept an empty sequence as well: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#singleOrEmpty--[Flux#singleOrEmpty]
 
 
 
 [[which.errors]]
 == Handling Errors
 
-* I want to create an erroring sequence: `error`...
-** ...to replace the completion of a successful `Flux`: `.concat(Flux.error(e))`
-** ...to replace the *emission* of a successful `Mono`: `.then(Mono.error(e))`
-** ...if too much time elapses between onNexts: `timeout`
-** ...lazily: `error(Supplier<Throwable>)`
+* I want to create an erroring sequence: `error` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#error-java.lang.Throwable-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#error-java.lang.Throwable-[Mono])...
+** ...to replace the completion of a successful https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html[Flux]: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#concat-org.reactivestreams.Publisher%2E%2E%2E-[.concat(Flux.error(e))]
+** ...to replace the *emission* of a successful https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html[Mono]: `.then(Mono.error(e))` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#then-reactor.core.publisher.Mono-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#then-reactor.core.publisher.Mono-[Mono])
+** ...if too much time elapses between onNexts: `timeout` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#timeout-java.time.Duration-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#timeout-java.time.Duration-[Mono])
+** ...lazily: `error(Supplier<Throwable>)` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#error-java.util.function.Supplier-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#error-java.util.function.Supplier-[Mono])
 
 * I want the try/catch equivalent of:
-** throwing: `error`
+** throwing: `error` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#error-java.lang.Throwable-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#error-java.lang.Throwable-[Mono])
 ** catching an exception:
-*** and falling back to a default value: `onErrorReturn`
-*** and falling back to another `Flux` or `Mono`: `onErrorResume`
-*** and wrapping and re-throwing: `.onErrorMap(t -> new RuntimeException(t))`
-** the finally block: `doFinally`
-** the using pattern from Java 7: `using` factory method
+*** and falling back to a default value: `onErrorReturn` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#onErrorReturn-java.lang.Class-T-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#onErrorReturn-java.lang.Class-T-[Mono])
+*** and falling back to another https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html[Flux] or https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html[Mono]: `onErrorResume` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#onErrorResume-java.lang.Class-java.util.function.Function-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#onErrorResume-java.lang.Class-java.util.function.Function-[Mono])
+*** and wrapping and re-throwing: `.onErrorMap(t -> new RuntimeException(t))` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#onErrorMap-java.util.function.Function-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#onErrorMap-java.util.function.Function-[Mono])
+** the finally block: `doFinally` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#doFinally-java.util.function.Consumer-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#doFinally-java.util.function.Consumer-[Mono])
+** the using pattern from Java 7: `using` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#using-java.util.concurrent.Callable-java.util.function.Function-java.util.function.Consumer-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#using-java.util.concurrent.Callable-java.util.function.Function-java.util.function.Consumer-[Mono]) factory method
 
 * I want to recover from errors...
 ** by falling back:
-*** to a value: `onErrorReturn`
-*** to a `Publisher` or `Mono`, possibly different ones depending on the error: `Flux#onErrorResume` and `Mono#onErrorResume`
+*** to a value: `onErrorReturn` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#onErrorReturn-java.lang.Class-T-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#onErrorReturn-java.lang.Class-T-[Mono])
+*** to a https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/org/reactivestreams/Publisher.html?is-external=true[Publisher] or https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html[Mono], possibly different ones depending on the error: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#onErrorResume-java.lang.Class-java.util.function.Function-[Flux#onErrorResume] and https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#onErrorResume-java.lang.Class-java.util.function.Function-[Mono#onErrorResume]
 ** by retrying...
-*** ...with a simple policy (max number of attempts): `retry()`, `retry(long)`
-*** ...triggered by a companion control Flux: `retryWhen`
-*** ...using a standard backoff strategy (exponential backoff with jitter): `retryWhen(Retry.backoff(...))` (see also other factory methods in `Retry`)
+*** ...with a simple policy (max number of attempts): `retry()` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#retry--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#retry--[Mono]), `retry(long)` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#retry-long-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#retry-long-[Mono])
+*** ...triggered by a companion control Flux: `retryWhen` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#retry--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#retry--[Mono])
+*** ...using a standard backoff strategy (exponential backoff with jitter): `retryWhen(Retry.backoff(...))` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#retry--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#retry--[Mono]) (see also other factory methods in https://projectreactor.io/docs/core/release/api/reactor/util/retry/Retry.html[Retry])
 
 * I want to deal with backpressure "errors" (request max from upstream and apply the strategy when downstream does not produce enough request)...
-** by throwing a special `IllegalStateException`: `Flux#onBackpressureError`
-** by dropping excess values: `Flux#onBackpressureDrop`
-*** ...except the last one seen: `Flux#onBackpressureLatest`
-** by buffering excess values (bounded or unbounded): `Flux#onBackpressureBuffer`
-*** ...and applying a strategy when bounded buffer also overflows: `Flux#onBackpressureBuffer` with a `BufferOverflowStrategy`
+** by throwing a special https://docs.oracle.com/javase/8/docs/api/java/lang/IllegalStateException.html?is-external=true[IllegalStateException]: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#onBackpressureError--[Flux#onBackpressureError]
+** by dropping excess values: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#onBackpressureDrop--[Flux#onBackpressureDrop]
+*** ...except the last one seen: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#onBackpressureLatest--[Flux#onBackpressureLatest]
+** by buffering excess values (bounded or unbounded): https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#onBackpressureBuffer--[Flux#onBackpressureBuffer]
+*** ...and applying a strategy when bounded buffer also overflows: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#onBackpressureBuffer--[Flux#onBackpressureBuffer] with a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/BufferOverflowStrategy.html[BufferOverflowStrategy]
 
 [[which.time]]
 == Working with Time
 
 * I want to associate emissions with a timing measured...
-** ...with best available precision and versatility of provided data: `timed`
-*** `Timed<T>#elapsed()` for `Duration` since last `onNext`
-*** `Timed<T>#timestamp()` for `Instant` representation of the epoch timestamp (milliseconds resolution)
-*** `Timed<T>#elapsedSinceSubcription()` for `Duration` since subscription (rather than last onNext)
-*** can have nanoseconds resolution for elapsed `Duration`s
-** ...as a (legacy) `Tuple2<Long, T>`...
-*** since last onNext: `elapsed`
-*** since the dawn of time (well, computer time): `timestamp`
+** ...with best available precision and versatility of provided data: `timed` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#timed--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#timed--[Mono])
+*** https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Timed.html#elapsed--[Timed<T>#elapsed()] for https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html?is-external=true[Duration] since last `onNext`
+*** https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Timed.html#timestamp--[Timed<T>#timestamp()] for https://docs.oracle.com/javase/8/docs/api/java/time/Instant.html?is-external=true[Instant] representation of the epoch timestamp (milliseconds resolution)
+*** https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Timed.html#elapsedSinceSubscription--[Timed<T>#elapsedSinceSubcription()] for https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html?is-external=true[Duration] since subscription (rather than last onNext)
+*** can have nanoseconds resolution for elapsed https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html?is-external=true[Duration]s
+** ...as a (legacy) https://projectreactor.io/docs/core/release/api/reactor/util/function/Tuple2.html[Tuple2<Long, T>]...
+*** since last onNext: `elapsed` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#elapsed--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#elapsed--[Mono])
+*** since the dawn of time (well, computer time): `timestamp` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#timestamp--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#timestamp--[Mono])
 
 
-* I want my sequence to be interrupted if there is too much delay between emissions: `timeout`
+* I want my sequence to be interrupted if there is too much delay between emissions: `timeout` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#timeout-java.time.Duration-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#timeout-java.time.Duration-[Mono])
 
-* I want to get ticks from a clock, regular time intervals: `Flux#interval`
+* I want to get ticks from a clock, regular time intervals: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#interval-java.time.Duration-[Flux#interval]
 
-* I want to emit a single `0` after an initial delay: static `Mono.delay`.
+* I want to emit a single `0` after an initial delay: static https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#delay-java.time.Duration-[Mono.delay].
 
 * I want to introduce a delay:
-** between each onNext signal: `Mono#delayElement`, `Flux#delayElements`
-** before the subscription happens: `delaySubscription`
+** between each onNext signal: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#delayElement-java.time.Duration-[Mono#delayElement], https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#delayElements-java.time.Duration-[Flux#delayElements]
+** before the subscription happens: `delaySubscription` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#delaySubscription-java.time.Duration-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#delaySubscription-java.time.Duration-[Mono])
 
 [[which.window]]
-== Splitting a `Flux`
+== Splitting a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html[Flux]
 
-* I want to split a `Flux<T>` into a `Flux<Flux<T>>`, by a boundary criteria:
-** of size: `window(int)`
-*** ...with overlapping or dropping windows: `window(int, int)`
-** of time `window(Duration)`
-*** ...with overlapping or dropping windows: `window(Duration, Duration)`
-** of size OR time (window closes when count is reached or timeout elapsed): `windowTimeout(int, Duration)`
-** based on a predicate on elements: `windowUntil`
-*** ...…emitting the element that triggered the boundary in the next window (`cutBefore` variant): `.windowUntil(predicate, true)`
-*** ...keeping the window open while elements match a predicate: `windowWhile` (non-matching elements are not emitted)
-** driven by an arbitrary boundary represented by onNexts in a control Publisher: `window(Publisher)`, `windowWhen`
+* I want to split a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html[Flux<T>] into a `Flux<Flux<T>>`, by a boundary criteria:
+** of size: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#window-int-[window(int)]
+*** ...with overlapping or dropping windows: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#window-int-int-[window(int, int)]
+** of time https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#window-java.time.Duration-[window(Duration)]
+*** ...with overlapping or dropping windows: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#window-java.time.Duration-java.time.Duration-[window(Duration, Duration)]
+** of size OR time (window closes when count is reached or timeout elapsed): https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#windowTimeout-int-java.time.Duration-[windowTimeout(int, Duration)]
+** based on a predicate on elements: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#windowUntil-java.util.function.Predicate-[windowUntil]
+*** ...…emitting the element that triggered the boundary in the next window (`cutBefore` variant): https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#windowUntil-java.util.function.Predicate-boolean-[.windowUntil(predicate, true)]
+*** ...keeping the window open while elements match a predicate: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#windowWhile-java.util.function.Predicate-[windowWhile] (non-matching elements are not emitted)
+** driven by an arbitrary boundary represented by onNexts in a control Publisher: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#window-org.reactivestreams.Publisher-[window(Publisher)], https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#windowWhen-org.reactivestreams.Publisher-java.util.function.Function-[windowWhen]
 
-* I want to split a `Flux<T>` and buffer elements within boundaries together...
-** into `List`:
-*** by a size boundary: `buffer(int)`
-**** ...with overlapping or dropping buffers: `buffer(int, int)`
-*** by a duration boundary: `buffer(Duration)`
-**** ...with overlapping or dropping buffers: `buffer(Duration, Duration)`
-*** by a size OR duration boundary: `bufferTimeout(int, Duration)`
-*** by an arbitrary criteria boundary: `bufferUntil(Predicate)`
-**** ...putting the element that triggered the boundary in the next buffer: `.bufferUntil(predicate, true)`
-**** ...buffering while predicate matches and dropping the element that triggered the boundary: `bufferWhile(Predicate)`
-*** driven by an arbitrary boundary represented by onNexts in a control Publisher: `buffer(Publisher)`, `bufferWhen`
-** into an arbitrary "collection" type `C`: use variants like `buffer(int, Supplier<C>)`
+* I want to split a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html[Flux<T>] and buffer elements within boundaries together...
+** into https://docs.oracle.com/javase/8/docs/api/java/util/List.html?is-external=true[List]:
+*** by a size boundary: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#buffer-int-[buffer(int)]
+**** ...with overlapping or dropping buffers: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#buffer-int-int-[buffer(int, int)]
+*** by a duration boundary: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#buffer-java.time.Duration-java.time.Duration-[buffer(Duration)]
+**** ...with overlapping or dropping buffers: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#buffer-java.time.Duration-java.time.Duration-[buffer(Duration, Duration)]
+*** by a size OR duration boundary: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#bufferTimeout-int-java.time.Duration-[bufferTimeout(int, Duration)]
+*** by an arbitrary criteria boundary: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#bufferUntil-java.util.function.Predicate-[bufferUntil(Predicate)]
+**** ...putting the element that triggered the boundary in the next buffer: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#bufferUntil-java.util.function.Predicate-boolean-[.bufferUntil(predicate, true)]
+**** ...buffering while predicate matches and dropping the element that triggered the boundary: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#bufferWhile-java.util.function.Predicate-[bufferWhile(Predicate)]
+*** driven by an arbitrary boundary represented by onNexts in a control Publisher: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#buffer-org.reactivestreams.Publisher-[buffer(Publisher)], https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#bufferWhen-org.reactivestreams.Publisher-java.util.function.Function-[bufferWhen]
+** into an arbitrary "collection" type `C`: use variants like https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#buffer-int-java.util.function.Supplier-[buffer(int, Supplier<C>)]
 
-* I want to split a `Flux<T>` so that element that share a characteristic end up in the same sub-flux: `groupBy(Function<T,K>)`
-TIP: Note that this returns a `Flux<GroupedFlux<K, T>>`, each inner `GroupedFlux` shares the same `K` key accessible through `key()`.
+* I want to split a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html[Flux<T>] so that element that share a characteristic end up in the same sub-flux: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#flatMap-java.util.function.Function-[groupBy(Function<T,K>)]
+TIP: Note that this returns a `Flux<GroupedFlux<K, T>>`, each inner https://projectreactor.io/docs/core/release/api/reactor/core/publisher/GroupedFlux.html[GroupedFlux] shares the same `K` key accessible through https://projectreactor.io/docs/core/release/api/reactor/core/publisher/GroupedFlux.html#key--[key()].
 
 [[which.blocking]]
 == Going Back to the Synchronous World
 
-Note: all of these methods except `Mono#toFuture` will throw an `UnsupportedOperatorException` if called from
-within a `Scheduler` marked as "non-blocking only" (by default `parallel()` and `single()`).
+Note: all of these methods except https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#toFuture--[Mono#toFuture] will throw an https://docs.oracle.com/javase/8/docs/api/java/lang/UnsupportedOperationException.html?is-external=true[UnsupportedOperatorException] if called from
+within a https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Scheduler.html[Scheduler] marked as "non-blocking only" (by default https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Schedulers.html#parallel--[parallel()] and `single()` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#single--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#single--[Mono])).
 
-* I have a `Flux<T>` and I want to:
-** block until I can get the first element: `Flux#blockFirst`
-*** ...with a timeout: `Flux#blockFirst(Duration)`
-** block until I can get the last element (or null if empty): `Flux#blockLast`
-*** ...with a timeout: `Flux#blockLast(Duration)`
-** synchronously switch to an `Iterable<T>`: `Flux#toIterable`
-** synchronously switch to a Java 8 `Stream<T>`: `Flux#toStream`
+* I have a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html[Flux<T>] and I want to:
+** block until I can get the first element: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#blockFirst--[Flux#blockFirst]
+*** ...with a timeout: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#blockFirst-java.time.Duration-[Flux#blockFirst(Duration)]
+** block until I can get the last element (or null if empty): https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#blockLast--[Flux#blockLast]
+*** ...with a timeout: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#blockLast-java.time.Duration-[Flux#blockLast(Duration)]
+** synchronously switch to an https://docs.oracle.com/javase/8/docs/api/java/lang/Iterable.html?is-external=true[Iterable<T>]: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#toIterable--[Flux#toIterable]
+** synchronously switch to a Java 8 https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html[Stream<T>]: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#toStream--[Flux#toStream]
 
-* I have a `Mono<T>` and I want:
-** to block until I can get the value: `Mono#block`
-*** ...with a timeout: `Mono#block(Duration)`
-** a `CompletableFuture<T>`: `Mono#toFuture`
+* I have a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html[Mono<T>] and I want:
+** to block until I can get the value: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#block--[Mono#block]
+*** ...with a timeout: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#block-java.time.Duration-[Mono#block(Duration)]
+** a https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html[CompletableFuture<T>]: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#toFuture--[Mono#toFuture]
 
 [[which.multicasting]]
-== Multicasting a `Flux` to several `Subscribers`
+== Multicasting a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html[Flux] to several https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/org/reactivestreams/Subscriber.html?is-external=true[Subscribers]
 
-* I want to connect multiple `Subscriber` to a `Flux`:
-** and decide when to trigger the source with `connect()`: `publish()` (returns a `ConnectableFlux`)
-** and trigger the source immediately (late subscribers see later data): `share()`
-** and permanently connect the source when enough subscribers have registered: `.publish().autoConnect(n)`
-** and automatically connect and cancel the source when subscribers go above/below the threshold: `.publish().refCount(n)`
-*** ...but giving a chance for new subscribers to come in before cancelling: `.publish().refCount(n, Duration)`
+* I want to connect multiple https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/org/reactivestreams/Subscriber.html?is-external=true[Subscriber] to a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html[Flux]:
+** and decide when to trigger the source with https://projectreactor.io/docs/core/release/api/reactor/core/publisher/ConnectableFlux.html#connect--[connect()]: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#publish--[publish()] (returns a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/ConnectableFlux.html[ConnectableFlux])
+** and trigger the source immediately (late subscribers see later data): `share()` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#share--[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#share--[Mono])
+** and permanently connect the source when enough subscribers have registered: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/ConnectableFlux.html#autoConnect-int-[.publish().autoConnect(n)]
+** and automatically connect and cancel the source when subscribers go above/below the threshold: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/ConnectableFlux.html#refCount-int-[.publish().refCount(n)]
+*** ...but giving a chance for new subscribers to come in before cancelling: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/ConnectableFlux.html#refCount-int-[.publish().refCount(n, Duration)]
 
-* I want to cache data from a `Publisher` and replay it to later subscribers:
-** up to `n` elements: `cache(int)`
-** caching latest elements seen within a `Duration` (Time-To-Live): `cache(Duration)`
-*** ...but retain no more than `n` elements: `cache(int, Duration)`
-** but without immediately triggering the source: `Flux#replay` (returns a `ConnectableFlux`)
+* I want to cache data from a https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/org/reactivestreams/Publisher.html?is-external=true[Publisher] and replay it to later subscribers:
+** up to `n` elements: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#cache-int-[cache(int)]
+** caching latest elements seen within a https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html?is-external=true[Duration] (Time-To-Live): `cache(Duration)` (https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#cache-java.time.Duration-[Flux]|link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#cache-java.time.Duration-[Mono])
+*** ...but retain no more than `n` elements: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#cache-int-java.time.Duration-[cache(int, Duration)]
+** but without immediately triggering the source: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#replay--[Flux#replay] (returns a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/ConnectableFlux.html[ConnectableFlux])

--- a/docs/asciidoc/apdx-operatorChoice.adoc
+++ b/docs/asciidoc/apdx-operatorChoice.adoc
@@ -75,7 +75,7 @@ I want to deal with:
 
 * I want to add pre-set elements to an existing sequence:
 ** at the start: `Flux#startWith(T...)`
-** at the end: `Flux#concatWith(T...)`
+** at the end: `Flux#concatWithValues(T...)`
 
 * I want to aggregate a `Flux`: (the `Flux#` prefix is assumed below)
 ** into a List: `collectList`, `collectSortedList`
@@ -321,7 +321,7 @@ within a `Scheduler` marked as "non-blocking only" (by default `parallel()` and 
 ** and trigger the source immediately (late subscribers see later data): `share()`
 ** and permanently connect the source when enough subscribers have registered: `.publish().autoConnect(n)`
 ** and automatically connect and cancel the source when subscribers go above/below the threshold: `.publish().refCount(n)`
-*** ...but giving a chance for new subscribers to come in before cancelling: `.publish().refCountGrace(n, Duration)`
+*** ...but giving a chance for new subscribers to come in before cancelling: `.publish().refCount(n, Duration)`
 
 * I want to cache data from a `Publisher` and replay it to later subscribers:
 ** up to `n` elements: `cache(int)`


### PR DESCRIPTION
As requested in #2371.

So, the approach for this was basically

- Grab all words/expressions surrounded by `ticks`.
- use them as keys in a json doc, with lists as values, where each list...
	- is empty if it's something that shouldn't be linked, like a standalone `T` or `null`.
	- has one link if it's just one thing that should be linked, like `Flux#range` or `Supplier<T>`
	- has two links if it's a generic operator present in both `Flux` and `Mono`, like `just`.

That was the tedious/boring part. When that was finished, I wrote a script that takes the `adoc`-file and replaces stuff accordingly. 

Since the mapping part is done, it's easy to just change the script if you want to change something (how the links are presented, if they should be opened in a new window or not, other asciidoc settings etc) and run the script against the file again (I haven't committed the script, this feels like a one time thing and then the script is likely useless)

If you want, I can do this for the other `adoc`-files as well, I might have to add a few mappings but I guess most of it is done.