### PR TITLE
MonoDelayUntil now subscribes each trigger from the last trigger

### DIFF
--- a/reactor-core/src/jcstress/java/reactor/core/publisher/MonoDelayStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/MonoDelayStressTest.java
@@ -1,0 +1,175 @@
+package reactor.core.publisher;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.IIIII_Result;
+import org.openjdk.jcstress.infra.results.IIII_Result;
+import reactor.core.CoreSubscriber;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+
+public abstract class MonoDelayStressTest {
+
+	@JCStressTest
+	@Outcome(id = {"1, 1, 0, 0, 0"}, expect = ACCEPTABLE, desc = "No error dropped, composite error delivered. Cancel signal is late in that case")
+	@Outcome(id = {"1, 1, 1, 1, 0", "1, 1, 0, 1, 0"}, expect = ACCEPTABLE, desc = "Main error possibly dropped, inner or composite error delivered. Main is cancelled. Cancel signal is late")
+	@Outcome(id = {"1, 1, 1, 0, 1", "1, 1, 0, 0, 1"}, expect = ACCEPTABLE, desc = "Inner error possibly dropped, main or composite error delivered. Inner is cancelled. Cancel signal is late")
+	@Outcome(id = {"1, 0, 1, 1, 1", "1, 0, 2, 1, 1"}, expect = ACCEPTABLE, desc = "No error delivered. One composite error delivered or both errors are dropped. Cancel signal is propagated to both")
+	@State
+	public static class InnerOnErrorAndOuterOnErrorAndCancelStressTest {
+
+		final StressSubscriber<Integer> subscriber = new StressSubscriber<Integer>(1L);
+
+		StressSubscription<Integer> subscriptionOuter;
+		StressSubscription<Integer> subscriptionInner;
+
+		{
+			new Mono<Integer>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super Integer> actual) {
+					subscriptionOuter = new StressSubscription<>(actual);
+					actual.onSubscribe(subscriptionOuter);
+					actual.onNext(1);
+				}
+			}
+			.delayUntil(__ -> new Mono<Integer>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super Integer> actual) {
+					subscriptionInner = new StressSubscription<>(actual);
+					actual.onSubscribe(subscriptionInner);
+				}
+			})
+			.subscribe(subscriber);
+		}
+
+		@Actor
+		public void errorOuter() {
+			subscriptionOuter.actual.onError(new RuntimeException("test1"));
+		}
+
+		@Actor
+		public void errorInner() {
+			subscriptionInner.actual.onError(new RuntimeException("test2"));
+		}
+
+		@Actor
+		public void cancelFromActual() {
+			subscriber.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(IIIII_Result r) {
+			r.r1 = subscriber.onNextDiscarded.get();
+			r.r2 = subscriber.onErrorCalls.get();
+			r.r3 = subscriber.droppedErrors.size();
+			r.r4 = subscriptionOuter.cancelled.get() ? 1 : 0;
+			r.r5 = subscriptionInner.cancelled.get() ? 1 : 0;
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"1, 0, 1, 1"}, expect = ACCEPTABLE, desc = "Value discarded. Subscriptions cancelled")
+	@Outcome(id = {"0, 1, 0, 0"}, expect = ACCEPTABLE, desc = "Value delivered. Cancel signal is late")
+	@State
+	public static class CompleteVsCancelStressTest {
+
+		final StressSubscriber<Integer> subscriber = new StressSubscriber<Integer>(1L);
+
+		StressSubscription<Integer> subscriptionOuter;
+		StressSubscription<Integer> subscriptionInner;
+
+		{
+			new Mono<Integer>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super Integer> actual) {
+					subscriptionOuter = new StressSubscription<>(actual);
+					actual.onSubscribe(subscriptionOuter);
+					actual.onNext(1);
+				}
+			}
+					.delayUntil(__ -> new Mono<Integer>() {
+						@Override
+						public void subscribe(CoreSubscriber<? super Integer> actual) {
+							subscriptionInner = new StressSubscription<>(actual);
+							actual.onSubscribe(subscriptionInner);
+						}
+					})
+					.subscribe(subscriber);
+		}
+
+		@Actor
+		public void completeOuter() {
+			subscriptionOuter.actual.onComplete();
+		}
+
+		@Actor
+		public void completeInner() {
+			subscriptionInner.actual.onComplete();
+		}
+
+		@Actor
+		public void cancelFromActual() {
+			subscriber.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(IIII_Result r) {
+			r.r1 = subscriber.onNextDiscarded.get();
+			r.r2 = subscriber.onNextCalls.get();
+			r.r3 = subscriptionOuter.cancelled.get() ? 1 : 0;
+			r.r4 = subscriptionInner.cancelled.get() ? 1 : 0;
+		}
+	}
+
+
+
+	@JCStressTest
+	@Outcome(id = {"1, 0, 1, 1"}, expect = ACCEPTABLE, desc = "Value discarded. Subscriptions cancelled")
+	@State
+	public static class OnNextVsCancelStressTest {
+
+		final StressSubscriber<Integer> subscriber = new StressSubscriber<Integer>(1L);
+
+		StressSubscription<Integer> subscriptionOuter;
+		StressSubscription<Integer> subscriptionInner;
+
+		{
+			new Mono<Integer>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super Integer> actual) {
+					subscriptionOuter = new StressSubscription<>(actual);
+					actual.onSubscribe(subscriptionOuter);
+				}
+			}
+					.delayUntil(__ -> new Mono<Integer>() {
+						@Override
+						public void subscribe(CoreSubscriber<? super Integer> actual) {
+							subscriptionInner = new StressSubscription<>(actual);
+							actual.onSubscribe(subscriptionInner);
+						}
+					})
+					.subscribe(subscriber);
+		}
+
+		@Actor
+		public void nextOuter() {
+			subscriptionOuter.actual.onNext(1);
+		}
+
+		@Actor
+		public void cancelFromActual() {
+			subscriber.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(IIII_Result r) {
+			r.r1 = subscriber.onNextDiscarded.get();
+			r.r2 = subscriber.onNextCalls.get();
+			r.r3 = subscriptionOuter.cancelled.get() ? 1 : 0;
+			r.r4 = subscriptionInner.cancelled.get() ? 1 : 0;
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
@@ -534,6 +534,9 @@ final class MonoDelayUntil<T> extends Mono<T> implements Scannable,
 				return;
 			}
 
+			// we have to reset the state since we reuse the same object for the
+			// optimization purpose and at this stage we know that there is another
+			// delayer Publisher to subscribe to
 			this.done = false;
 			this.s = null;
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
@@ -187,7 +187,6 @@ final class MonoDelayUntil<T> extends Mono<T> implements Scannable,
 		}
 
 		@Override
-		@SuppressWarnings("ConstantConditions")
 		public void onError(Throwable t) {
 			if (this.done) {
 				Operators.onErrorDropped(t, this.actual.currentContext());
@@ -217,6 +216,7 @@ final class MonoDelayUntil<T> extends Mono<T> implements Scannable,
 			}
 
 			final Throwable e = Exceptions.terminate(ERROR, this);
+			//noinspection ConstantConditions
 			this.actual.onError(e);
 		}
 
@@ -481,7 +481,6 @@ final class MonoDelayUntil<T> extends Mono<T> implements Scannable,
 		}
 
 		@Override
-		@SuppressWarnings("ConstantConditions")
 		public void onError(Throwable t) {
 			if (this.done) {
 				Operators.onErrorDropped(t, parent.currentContext());
@@ -508,6 +507,7 @@ final class MonoDelayUntil<T> extends Mono<T> implements Scannable,
 			parent.s.cancel();
 
 			final Throwable e = Exceptions.terminate(DelayUntilCoordinator.ERROR, parent);
+			//noinspection ConstantConditions
 			parent.actual.onError(e);
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
@@ -326,7 +326,12 @@ final class MonoDelayUntil<T> extends Mono<T> implements Scannable,
 			return subscriber == null ? Stream.empty() : Stream.of(subscriber);
 		}
 
-
+		/**
+		 * Sets flag has subscription to indicate that we have already received
+		 * subscription from the value upstream
+		 *
+		 * @return previous state
+		 */
 		int markHasSubscription() {
 			for (;;) {
 				final int state = this.state;
@@ -341,6 +346,12 @@ final class MonoDelayUntil<T> extends Mono<T> implements Scannable,
 			}
 		}
 
+		/**
+		 * Sets {@link #HAS_REQUEST} flag which indicates that there is a demand from
+		 * the downstream
+		 *
+		 * @return previous state
+		 */
 		int markHasRequest() {
 			for (; ; ) {
 				final int state = this.state;
@@ -366,6 +377,11 @@ final class MonoDelayUntil<T> extends Mono<T> implements Scannable,
 			}
 		}
 
+		/**
+		 * Sets current state to {@link #TERMINATED}
+		 *
+		 * @return previous state
+		 */
 		int markTerminated() {
 			for (;;) {
 				final int state = this.state;
@@ -380,6 +396,11 @@ final class MonoDelayUntil<T> extends Mono<T> implements Scannable,
 			}
 		}
 
+		/**
+		 * Terminates execution if there is a demand from the downstream or sets
+		 * {@link #HAS_VALUE} flag indicating that the delay process is completed
+		 * however there is no demand from the downstream yet
+		 */
 		void complete() {
 			for (; ; ) {
 				int s = this.state;
@@ -523,6 +544,12 @@ final class MonoDelayUntil<T> extends Mono<T> implements Scannable,
 			this.s.cancel();
 		}
 
+		/**
+		 * Sets flag {@link DelayUntilCoordinator#HAS_INNER} which indicates that there
+		 * is an active delayer Publisher
+		 *
+		 * @return previous state
+		 */
 		int markInnerActive() {
 			final DelayUntilCoordinator<?> parent = this.parent;
 			for (;;) {
@@ -542,6 +569,11 @@ final class MonoDelayUntil<T> extends Mono<T> implements Scannable,
 			}
 		}
 
+		/**
+		 * Unsets flag {@link DelayUntilCoordinator#HAS_INNER}
+		 *
+		 * @return previous state
+		 */
 		int markInnerInactive() {
 			final DelayUntilCoordinator<?> parent = this.parent;
 			for (;;) {
@@ -562,7 +594,9 @@ final class MonoDelayUntil<T> extends Mono<T> implements Scannable,
 		}
 	}
 
-
+	/**
+	 * Indicates if state is ended with cancellation | error | complete
+	 */
 	static boolean isTerminated(int state) {
 		return state == DelayUntilCoordinator.TERMINATED;
 	}


### PR DESCRIPTION
This commit reworks MonoDelayUntil so that each consecutive trigger is
subscribed from the previous trigger. This helps to ensure that all
completions are detected correctly and fixes a bug where fused trigger
completion wouldn't be picked up, leading to code hanging.

Additionally, the internal implementation is switched to a state machine
approach and fusion is temporarily removed for simplification.

See also #2643.
Fixes #2597.

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>