### PR TITLE
improves `MonoProducerBase` and removes `Fusion` from MonoSingle

### DIFF
--- a/reactor-core/src/jcstress/java/reactor/core/publisher/MonoInnerProducerBaseStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/MonoInnerProducerBaseStressTest.java
@@ -1,0 +1,142 @@
+package reactor.core.publisher;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.III_Result;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+
+public abstract class MonoInnerProducerBaseStressTest {
+
+	@JCStressTest
+	@Outcome(id = {"1, 1, 0"}, expect = ACCEPTABLE, desc = "onNext and OnComplete delivered")
+	@State
+	public static class RequestAndCompleteWithValueRace {
+
+		final StressSubscriber<Integer> subscriber = new StressSubscriber<Integer>(0L);
+		final Operators.MonoInnerProducerBase<Integer> producer = new Operators.MonoInnerProducerBase<>(subscriber);
+
+		{
+			subscriber.onSubscribe(producer);
+		}
+
+		@Actor
+		public void complete() {
+			producer.complete(1);
+		}
+
+		@Actor
+		public void request() {
+			subscriber.request(1);
+		}
+
+		@Arbiter
+		public void arbiter(III_Result r) {
+			r.r1 = subscriber.onNextCalls.get();
+			r.r2 = subscriber.onCompleteCalls.get();
+			r.r3 = subscriber.onNextDiscarded.get();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"1, 1, 0"}, expect = ACCEPTABLE, desc = "onNext and OnComplete delivered. Cancel late")
+	@Outcome(id = {"0, 0, 1"}, expect = ACCEPTABLE, desc = "Cancel delivered, complete(v) late")
+	@State
+	public static class CancelAndCompleteWithValueRace {
+
+		final StressSubscriber<Integer> subscriber = new StressSubscriber<Integer>(1L);
+		final Operators.MonoInnerProducerBase<Integer> producer = new Operators.MonoInnerProducerBase<>(subscriber);
+
+		{
+			subscriber.onSubscribe(producer);
+		}
+
+		@Actor
+		public void complete() {
+			producer.complete(1);
+		}
+
+		@Actor
+		public void cancel() {
+			subscriber.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(III_Result r) {
+			r.r1 = subscriber.onNextCalls.get();
+			r.r2 = subscriber.onCompleteCalls.get();
+			r.r3 = subscriber.onNextDiscarded.get();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"1, 1, 0"}, expect = ACCEPTABLE, desc = "onNext and OnComplete delivered. Cancel late")
+	@Outcome(id = {"0, 0, 1"}, expect = ACCEPTABLE, desc = "Cancel delivered, complete(v) late")
+	@State
+	public static class CancelAndRequestAndCompleteWithValueRace {
+
+		final StressSubscriber<Integer> subscriber = new StressSubscriber<Integer>(0L);
+		final Operators.MonoInnerProducerBase<Integer> producer = new Operators.MonoInnerProducerBase<>(subscriber);
+
+		{
+			subscriber.onSubscribe(producer);
+		}
+
+		@Actor
+		public void complete() {
+			producer.complete(1);
+		}
+
+		@Actor void request() {
+			producer.request(1);
+		}
+
+		@Actor
+		public void cancel() {
+			subscriber.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(III_Result r) {
+			r.r1 = subscriber.onNextCalls.get();
+			r.r2 = subscriber.onCompleteCalls.get();
+			r.r3 = subscriber.onNextDiscarded.get();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"1, 1, 0"}, expect = ACCEPTABLE, desc = "onNext and OnComplete delivered. Cancel late")
+	@Outcome(id = {"0, 0, 1"}, expect = ACCEPTABLE, desc = "Cancel delivered, complete(v) late")
+	@State
+	public static class CancelAndSetValueWithCompleteRace {
+
+		final StressSubscriber<Integer> subscriber = new StressSubscriber<Integer>(1L);
+		final Operators.MonoInnerProducerBase<Integer> producer = new Operators.MonoInnerProducerBase<>(subscriber);
+
+		{
+			subscriber.onSubscribe(producer);
+		}
+
+		@Actor
+		public void complete() {
+			producer.setValue(1);
+			producer.complete();
+		}
+
+		@Actor
+		public void cancel() {
+			subscriber.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(III_Result r) {
+			r.r1 = subscriber.onNextCalls.get();
+			r.r2 = subscriber.onCompleteCalls.get();
+			r.r3 = subscriber.onNextDiscarded.get();
+		}
+	}
+
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSingle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSingle.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
-import reactor.core.Fuseable;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
@@ -33,8 +32,7 @@ import reactor.util.context.Context;
  * @param <T> the value type
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
-final class MonoSingle<T> extends MonoFromFluxOperator<T, T>
-		implements Fuseable {
+final class MonoSingle<T> extends MonoFromFluxOperator<T, T> {
 
 	final T       defaultValue;
 	final boolean completeOnEmpty;

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -2582,7 +2582,6 @@ public abstract class Operators {
 		/**
 		 * The value stored by this Mono operator.
 		 */
-		@Nullable
 		private O value;
 
 		private volatile  int state; //see STATE field updater
@@ -2611,7 +2610,6 @@ public abstract class Operators {
 		 * @param v the value to emit
 		 */
 		public final void complete(O v) {
-			doOnComplete(v);
 			for (; ; ) {
 				int s = this.state;
 				if (isCancelled(s)) {
@@ -2620,7 +2618,10 @@ public abstract class Operators {
 				}
 
 				if (hasRequest(s) && STATE.compareAndSet(this, s, s | (HAS_VALUE | HAS_COMPLETED))) {
-					discardTheValue();
+					this.value = null;
+
+					doOnComplete(v);
+
 					actual.onNext(v);
 					actual.onComplete();
 					return;
@@ -2634,21 +2635,11 @@ public abstract class Operators {
 		}
 
 		/**
-		 * Hook for subclasses, called as the first operation when {@link #complete(Object)} is called. Default
-		 * implementation is a no-op.
-		 * @param v the value passed to {@code onComplete(Object)}
-		 */
-		protected void doOnComplete(O v) {
-
-		}
-
-		/**
 		 * Tries to emit the {@link #value} stored if any, and complete the underlying subscriber.
 		 * <p>
 		 * Make sure this method is called at most once. Can't be used in addition to {@link #complete(Object)}.
 		 */
 		public final void complete() {
-			doOnComplete();
 			for (; ; ) {
 				int s = this.state;
 				if (isCancelled(s)) {
@@ -2658,6 +2649,9 @@ public abstract class Operators {
 					if (hasValue(s) && hasRequest(s)) {
 						O v = this.value;
 						this.value = null; // aggressively null value to prevent strong ref after complete
+
+						doOnComplete(v);
+
 						actual.onNext(v);
 						actual.onComplete();
 						return;
@@ -2674,10 +2668,11 @@ public abstract class Operators {
 		}
 
 		/**
-		 * Hook for subclasses, called as the first operation when {@link #complete()} is called. Default
-		 * implementation is a no-op.
+		 * Hook for subclasses when the actual completion appears
+		 *
+		 * @param v the value passed to {@code onComplete(Object)}
 		 */
-		protected void doOnComplete() {
+		protected void doOnComplete(O v) {
 
 		}
 
@@ -2715,7 +2710,6 @@ public abstract class Operators {
 		@Override
 		public void request(long n) {
 			if (validate(n)) {
-				doOnRequest(n);
 				for (; ; ) {
 					int s = state;
 					if (isCancelled(s)) {
@@ -2725,22 +2719,24 @@ public abstract class Operators {
 						return;
 					}
 					if (STATE.compareAndSet(this, s, s | HAS_REQUEST)) {
+						doOnRequest(n);
 						if (hasValue(s) && hasCompleted(s)) {
 							O v = this.value;
 							this.value = null; // aggressively null value to prevent strong ref after complete
+
+							doOnComplete(v);
+
 							actual.onNext(v);
 							actual.onComplete();
-							return;
 						}
-
+						return;
 					}
 				}
 			}
 		}
 
 		/**
-		 * Hook for subclasses, called as the first operation when {@link #request(long)} is called. Default
-		 * implementation is a no-op.
+		 * Hook for subclasses on the first request successfully marked on the state
 		 * @param n the value passed to {@code request(long)}
 		 */
 		protected void doOnRequest(long n) {
@@ -2770,8 +2766,14 @@ public abstract class Operators {
 
 		@Override
 		public final void cancel() {
-			doOnCancel();
 			int previous = STATE.getAndSet(this, CANCELLED);
+
+			if (isCancelled(previous)) {
+				return;
+			}
+
+			doOnCancel();
+
 			if (hasValue(previous) // Had a value...
 					&& (previous & (HAS_COMPLETED|HAS_REQUEST)) != (HAS_COMPLETED|HAS_REQUEST) // ... but did not use it
 			) {


### PR DESCRIPTION
Some improvements for MonoProducerBase:

1. Ensure infinite loop exits in case of request appears earlier than the value
2. Ensure doOnXXX called exactly once (usually that is what is needed in subclasses) 
3. Removes Fusion interface from MonoSingle to avoid ClassCastException on downstream receiving non `QueueSubscription` type of `Subscription`

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>
Signed-off-by: Oleh Dokuka <shadowgun@i.ua>