### PR TITLE
ensures `Mono#single` works in `Callable` fusion scenario

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -4057,7 +4057,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 			}
 			@SuppressWarnings("unchecked")
 			Callable<T> thiz = (Callable<T>)this;
-			return Mono.onAssembly(new MonoCallable<>(thiz));
+			return Mono.onAssembly(new MonoSingleCallable<>(thiz));
 		}
 		return Mono.onAssembly(new MonoSingleMono<>(this));
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSingleCallable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSingleCallable.java
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package reactor.core.publisher;
 
 import java.time.Duration;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSingleCallable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSingleCallable.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.util.NoSuchElementException;
+import java.util.concurrent.Callable;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
+import reactor.core.Fuseable;
+
+/**
+ * Expects and emits a single item from the source Callable or signals
+ * NoSuchElementException for empty source.
+ *
+ * @param <T> the value type
+ * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
+ */
+final class MonoSingleCallable<T> extends Mono<T>
+		implements Callable<T>, Fuseable, SourceProducer<T> {
+
+	final Callable<? extends T> callable;
+
+	MonoSingleCallable(Callable<? extends T> source) {
+		this.callable = source;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super T> actual) {
+		Operators.MonoInnerProducerBase<T>
+				sds = new Operators.MonoInnerProducerBase<>(actual);
+
+		actual.onSubscribe(sds);
+
+		if (sds.isCancelled()) {
+			return;
+		}
+
+		try {
+			T t = callable.call();
+			if (t == null) {
+				actual.onError(new NoSuchElementException("Source was empty"));
+			}
+			else {
+				sds.complete(t);
+			}
+		}
+		catch (Throwable e) {
+			actual.onError(Operators.onOperatorError(e, actual.currentContext()));
+		}
+
+	}
+
+	@Override
+	public T block() {
+		//duration is ignored below
+		return block(Duration.ZERO);
+	}
+
+	@Override
+	public T block(Duration m) {
+		final T v;
+
+		try {
+			 v = callable.call();
+		}
+		catch (Throwable e) {
+			throw Exceptions.propagate(e);
+		}
+
+		if (v == null) {
+			throw new NoSuchElementException("Source was empty");
+		}
+
+		return v;
+	}
+
+	@Override
+	public T call() throws Exception {
+		final T v = callable.call();
+
+		if (v == null) {
+			throw new NoSuchElementException("Source was empty");
+		}
+
+		return v;
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		return null;  //no particular key to be represented, still useful in hooks
+	}
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSingleTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSingleTest.java
@@ -17,6 +17,7 @@
 package reactor.core.publisher;
 
 import java.util.NoSuchElementException;
+import java.util.concurrent.Callable;
 
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
@@ -27,8 +28,35 @@ import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MonoSingleTest {
+
+	@Test
+	//  https://github.com/reactor/reactor-core/issues/2635
+	void ensureCallableFusedSingleFailOnEmptySource() {
+		StepVerifier.create(
+				Mono.fromSupplier(() -> null)
+				    .single())
+		            .expectFusion()
+		            .expectErrorMatches(err -> err instanceof NoSuchElementException)
+		            .verify();
+	}
+
+	@Test
+	void ensureCallableFusedSingleFailOnEmptySourceOnBlock() {
+		assertThatThrownBy(Mono.fromSupplier(() -> null)
+		                       .single()::block)
+						.isInstanceOf(NoSuchElementException.class);
+	}
+
+	@Test
+	void ensureCallableFusedSingleFailOnEmptySourceOnCall() {
+		assertThatThrownBy(((Callable)Mono.fromSupplier(() -> null)
+		                                 .single())::call)
+				.isInstanceOf(NoSuchElementException.class);
+	}
+
 	@Test
 	public void source1Null() {
 		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSingleTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSingleTest.java
@@ -38,7 +38,6 @@ public class MonoSingleTest {
 		StepVerifier.create(
 				Mono.fromSupplier(() -> null)
 				    .single())
-		            .expectFusion()
 		            .expectErrorMatches(err -> err instanceof NoSuchElementException)
 		            .verify();
 	}


### PR DESCRIPTION
fixes #2635 

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>
Signed-off-by: Oleh Dokuka <shadowgun@i.ua>
