### PR TITLE
Account for source disconnection in refCountGrace

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
@@ -74,7 +74,7 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 		boolean connect = false;
 		synchronized (this) {
 			conn = connection;
-			if (conn == null || conn.terminated) {
+			if (conn == null || conn.isTerminated()) {
 				conn = new RefConnection(this);
 				connection = conn;
 			}
@@ -167,6 +167,15 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 
 		RefConnection(FluxRefCountGrace<?> parent) {
 			this.parent = parent;
+		}
+
+		/**
+		 * Indicates whether the RefConnection is terminated OR the source's connection has been disposed
+		 * @return true if the connection can be considered as terminated, either by this operator or by the source
+		 */
+		boolean isTerminated() {
+			Disposable sd = sourceDisconnector;
+			return terminated || (sd != null && sd.isDisposed());
 		}
 
 		@Override

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
@@ -165,23 +165,6 @@ public class FluxRefCountGraceTest {
 		assertThat(sourceSubscriptions).as("source subscriptions").hasValue(1);
 	}
 
-	@Test
-	void shouldReconnect() {
-		StepVerifier.withVirtualTime(() -> Flux.concat(Flux.just("hello"),
-				Flux.error(() -> new RuntimeException("boom"))
-				    .delayElements(Duration.ofSeconds(5)))
-                                               .publish()
-                                               .refCount(1, Duration.ofSeconds(10))
-                                               .take(1)
-                                               .repeat(1)
-		)
-		            .expectNext("hello")
-		            .thenAwait(Duration.ofSeconds(7))
-		            .expectNext("hello")
-		            .expectComplete()
-		            .verify(Duration.ofSeconds(1));
-	}
-
 	//see https://github.com/reactor/reactor-core/issues/1738
 	@Test
 	public void avoidUnexpectedDoubleCancel() {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
@@ -35,6 +35,153 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxRefCountGraceTest {
 
+	@Test
+	void errorInterruptsGracePeriodPublish() {
+		AtomicInteger sourceSubscriptions = new AtomicInteger();
+		StepVerifier.withVirtualTime(() -> {
+			Flux<String> multiplex = Flux
+					.concat(
+							Flux.just("hello"),
+							Mono.delay(Duration.ofSeconds(3))
+							    .then(Mono.error(new RuntimeException("boom")))
+					)
+					.doOnSubscribe(s -> sourceSubscriptions.incrementAndGet())
+					//here we use publish
+					.publish()
+					.refCount(1, Duration.ofSeconds(200));
+
+			return Flux.merge(
+					multiplex.take(1),
+					Mono.delay(Duration.ofSeconds(5))
+					    .flatMapMany(ignore -> multiplex
+					    .materialize().elapsed().map(Object::toString))
+			);
+				})
+		            .expectNext("hello")
+		            .thenAwait(Duration.ofSeconds(5))
+		            //here we expect that there is a reconnection, so the hello is followed by a 3s pause and onError
+		            .expectNext("[0,onNext(hello)]")
+		            .expectNoEvent(Duration.ofSeconds(3))
+		            .expectNext("[3000,onError(java.lang.RuntimeException: boom)]")
+		            .expectComplete()
+		            .verify(Duration.ofMillis(500));
+
+		assertThat(sourceSubscriptions).as("source subscriptions").hasValue(2);
+	}
+
+	@Test
+	void errorInterruptsGracePeriodReplay() {
+		AtomicInteger sourceSubscriptions = new AtomicInteger();
+		StepVerifier.withVirtualTime(() -> {
+			Flux<String> multiplex = Flux
+					.concat(
+							Flux.just("hello"),
+							Mono.delay(Duration.ofSeconds(3))
+							    .then(Mono.error(new RuntimeException("boom")))
+					)
+					.doOnSubscribe(s -> sourceSubscriptions.incrementAndGet())
+					//here we use replay
+					.replay()
+					.refCount(1, Duration.ofSeconds(200));
+
+			return Flux.merge(
+					multiplex.take(1),
+					Mono.delay(Duration.ofSeconds(5)).flatMapMany(ignore -> multiplex
+							.materialize().elapsed().map(Object::toString))
+			);
+		})
+		            .expectNext("hello")
+		            .thenAwait(Duration.ofSeconds(5))
+		            //here we expect an immediate replay of the hello + error
+		            .expectNext("[0,onNext(hello)]")
+		            .expectNext("[0,onError(java.lang.RuntimeException: boom)]")
+		            .expectComplete()
+		            .verify(Duration.ofMillis(500));
+
+		assertThat(sourceSubscriptions).as("source subscriptions").hasValue(1);
+	}
+
+	@Test
+	void completeInterruptsGracePeriodPublish() {
+		AtomicInteger sourceSubscriptions = new AtomicInteger();
+		StepVerifier.withVirtualTime(() -> {
+			Flux<Object> multiplex = Flux
+					.concat(
+							Flux.just("hello"),
+							Mono.delay(Duration.ofSeconds(3)).then()
+					)
+					.doOnSubscribe(s -> sourceSubscriptions.incrementAndGet())
+					//here we use publish
+					.publish()
+					.refCount(1, Duration.ofSeconds(200));
+
+			return Flux.merge(
+					multiplex.take(1),
+					Mono.delay(Duration.ofSeconds(5))
+					    .flatMapMany(ignore -> multiplex
+					    .materialize().elapsed().map(Object::toString))
+			);
+				})
+		            .expectNext("hello")
+		            .thenAwait(Duration.ofSeconds(5))
+		            //here we expect that there is a reconnection, so the hello is followed by a 3s pause and onComplete
+		            .expectNext("[0,onNext(hello)]")
+		            .expectNoEvent(Duration.ofSeconds(3))
+		            .expectNext("[3000,onComplete()]")
+		            .expectComplete()
+		            .verify(Duration.ofMillis(500));
+
+		assertThat(sourceSubscriptions).as("source subscriptions").hasValue(2);
+	}
+
+	@Test
+	void completeInterruptsGracePeriodReplay() {
+		AtomicInteger sourceSubscriptions = new AtomicInteger();
+		StepVerifier.withVirtualTime(() -> {
+			Flux<Object> multiplex = Flux
+					.concat(
+							Flux.just("hello"),
+							Mono.delay(Duration.ofSeconds(3)).then()
+					)
+					.doOnSubscribe(s -> sourceSubscriptions.incrementAndGet())
+					//here we use replay
+					.replay()
+					.refCount(1, Duration.ofSeconds(200));
+
+			return Flux.merge(
+					multiplex.take(1),
+					Mono.delay(Duration.ofSeconds(5)).flatMapMany(ignore -> multiplex
+							.materialize().elapsed().map(Object::toString))
+			);
+		})
+		            .expectNext("hello")
+		            .thenAwait(Duration.ofSeconds(5))
+		            //here we expect an immediate replay of the hello + complete
+		            .expectNext("[0,onNext(hello)]")
+		            .expectNext("[0,onComplete()]")
+		            .expectComplete()
+		            .verify(Duration.ofMillis(500));
+
+		assertThat(sourceSubscriptions).as("source subscriptions").hasValue(1);
+	}
+
+	@Test
+	void shouldReconnect() {
+		StepVerifier.withVirtualTime(() -> Flux.concat(Flux.just("hello"),
+				Flux.error(() -> new RuntimeException("boom"))
+				    .delayElements(Duration.ofSeconds(5)))
+                                               .publish()
+                                               .refCount(1, Duration.ofSeconds(10))
+                                               .take(1)
+                                               .repeat(1)
+		)
+		            .expectNext("hello")
+		            .thenAwait(Duration.ofSeconds(7))
+		            .expectNext("hello")
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(1));
+	}
+
 	//see https://github.com/reactor/reactor-core/issues/1738
 	@Test
 	public void avoidUnexpectedDoubleCancel() {


### PR DESCRIPTION
This commit changes how FluxRefCountGrace evaluates if the connection
is terminated, by taking into account the case where the source
ConnectableFlux has itself disposed the connection (by checking if
the held `Disposable` that represents said connection is disposed).

This fixes a hanging situation when used in combination with publish.

Fixes #2649.