### PR TITLE
Avoid infinite discard loop on fused fromIterable/fromStream

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxIterable.java
@@ -395,6 +395,9 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable, SourceProducer<
 			if (s == STATE_NO_NEXT) {
 				return true;
 			}
+			else if (cancelled && !knownToBeFinite) {
+				return true; //interrupts poll in discard loops due to cancellation
+			}
 			else if (s == STATE_HAS_NEXT_HAS_VALUE || s == STATE_HAS_NEXT_NO_VALUE) {
 				return false;
 			}
@@ -672,6 +675,9 @@ final class FluxIterable<T> extends Flux<T> implements Fuseable, SourceProducer<
 			int s = state;
 			if (s == STATE_NO_NEXT) {
 				return true;
+			}
+			else if (cancelled && !knownToBeFinite) {
+				return true; //interrupts poll() during discard loop if cancelled
 			}
 			else if (s == STATE_HAS_NEXT_HAS_VALUE || s == STATE_HAS_NEXT_NO_VALUE) {
 				return false;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxStreamTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxStreamTest.java
@@ -16,6 +16,7 @@
 
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -24,6 +25,8 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
@@ -452,5 +455,23 @@ public class FluxStreamTest {
 		            .verifyComplete();
 
 		assertThat(closed).hasValue(1); //no double close
+	}
+
+	@Test
+	void infiniteStreamDoesntHangDiscardFused() {
+		AtomicInteger source = new AtomicInteger();
+		Stream<Integer> stream = Stream.generate(source::incrementAndGet);
+
+		//note: we cannot check the spliterator, otherwise the stream will be considered used up
+
+		Flux.fromStream(stream)
+		    .publishOn(Schedulers.single())
+		    .take(10)
+		    .doOnDiscard(Integer.class, i -> {})
+		    .blockLast(Duration.ofSeconds(1));
+
+		assertThat(source)
+				.as("polled (avoid discard loop)")
+				.hasValue(10);
 	}
 }


### PR DESCRIPTION
This commit reworks the `FluxIterableSubscription` and its conditional
counterpart to consider that the `QueueSubscription` `isEmpty()` in
the case where the subscription has been cancelled and the backing
iterator cannot safely be assumed to be finite.

This fixes an issue where fusing over these operators when wrapping an
infinite generator-style of `Iterable` or `Stream` would lead to an
infinit loop, because `poll()` would always produce a value and
`Operators.onDiscardQueueWithClear` performs its discard loop until
polling returns null.

Fixes #2654.
