### PR TITLE
Fix both `Flux.single` variants when applied to a `Callable`

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -7859,28 +7859,28 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 *
 	 * @return a {@link Mono} with the single item or an error signal
 	 */
-    public final Mono<T> single() {
-	    if (this instanceof Callable) {
-	        if (this instanceof Fuseable.ScalarCallable) {
-		        @SuppressWarnings("unchecked")
-                Fuseable.ScalarCallable<T> scalarCallable = (Fuseable.ScalarCallable<T>) this;
+	public final Mono<T> single() {
+		if (this instanceof Callable) {
+			if (this instanceof Fuseable.ScalarCallable) {
+				@SuppressWarnings("unchecked")
+				Fuseable.ScalarCallable<T> scalarCallable = (Fuseable.ScalarCallable<T>) this;
 
-		        T v;
-		        try {
-			        v = scalarCallable.call();
-		        }
-		        catch (Exception e) {
-			        return Mono.error(Exceptions.unwrap(e));
-		        }
-		        if (v == null) {
-                    return Mono.error(new NoSuchElementException("Source was a (constant) empty"));
-                }
-                return Mono.just(v);
-	        }
-		    @SuppressWarnings("unchecked")
-		    Callable<T> thiz = (Callable<T>)this;
-		    return Mono.onAssembly(new MonoCallable<>(thiz));
-	    }
+				T v;
+				try {
+					v = scalarCallable.call();
+				}
+				catch (Exception e) {
+					return Mono.error(Exceptions.unwrap(e));
+				}
+				if (v == null) {
+					return Mono.error(new NoSuchElementException("Source was a (constant) empty"));
+				}
+				return Mono.just(v);
+			}
+			@SuppressWarnings("unchecked")
+			Callable<T> thiz = (Callable<T>)this;
+			return Mono.onAssembly(new MonoSingleCallable<>(thiz));
+		}
 		return Mono.onAssembly(new MonoSingle<>(this));
 	}
 
@@ -7897,28 +7897,28 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @return a {@link Mono} with the expected single item, the supplied default value or
 	 * an error signal
 	 */
-    public final Mono<T> single(T defaultValue) {
-        if (this instanceof Callable) {
-            if (this instanceof Fuseable.ScalarCallable) {
-	            @SuppressWarnings("unchecked")
-                Fuseable.ScalarCallable<T> scalarCallable = (Fuseable.ScalarCallable<T>) this;
+	public final Mono<T> single(T defaultValue) {
+		if (this instanceof Callable) {
+			if (this instanceof Fuseable.ScalarCallable) {
+				@SuppressWarnings("unchecked")
+				Fuseable.ScalarCallable<T> scalarCallable = (Fuseable.ScalarCallable<T>) this;
 
-	            T v;
-	            try {
-		            v = scalarCallable.call();
-	            }
-	            catch (Exception e) {
-		            return Mono.error(Exceptions.unwrap(e));
-	            }
-	            if (v == null) {
-	                return Mono.just(defaultValue);
-                }
-                return Mono.just(v);
-            }
-	        @SuppressWarnings("unchecked")
-	        Callable<T> thiz = (Callable<T>)this;
-	        return Mono.onAssembly(new MonoCallable<>(thiz));
-        }
+				T v;
+				try {
+					v = scalarCallable.call();
+				}
+				catch (Exception e) {
+					return Mono.error(Exceptions.unwrap(e));
+				}
+				if (v == null) {
+					return Mono.just(defaultValue);
+				}
+				return Mono.just(v);
+			}
+			@SuppressWarnings("unchecked")
+			Callable<T> thiz = (Callable<T>)this;
+			return Mono.onAssembly(new MonoSingleCallable<>(thiz, defaultValue));
+		}
 		return Mono.onAssembly(new MonoSingle<>(this, defaultValue, false));
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSingleCallableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSingleCallableTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.util.NoSuchElementException;
+import java.util.concurrent.Callable;
+
+import org.junit.jupiter.api.Test;
+
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.*;
+
+class MonoSingleCallableTest {
+
+	@Test
+	void apiFluxCallableGivesDefaultValue() {
+		Flux<Integer> source = Mono.<Integer>fromSupplier(() -> null).flux();
+
+		source.single(2)
+		      .as(StepVerifier::create)
+		      .expectNext(2)
+		      .verifyComplete();
+
+		assertThat(source.single(2)).isInstanceOf(MonoSingleCallable.class);
+	}
+
+	//  https://github.com/reactor/reactor-core/issues/2635
+	@Test
+	void ensureCallableFusedSingleFailOnEmptySource() {
+		Mono<Integer> mono = Mono
+				.<Integer>fromSupplier(() -> null)
+				.single();
+
+		StepVerifier.create(mono)
+		            .expectErrorMatches(err -> err instanceof NoSuchElementException)
+		            .verify();
+	}
+
+	@Test
+	void ensureCallableFusedSingleFailOnEmptySourceOnBlock() {
+		Mono<Integer> mono = Mono
+				.<Integer>fromSupplier(() -> null)
+				.single();
+
+		assertThatThrownBy(mono::block)
+				.isInstanceOf(NoSuchElementException.class);
+	}
+
+	@Test
+	void ensureCallableFusedSingleFailOnEmptySourceOnCall() {
+		Mono<Integer> mono = Mono
+				.<Integer>fromSupplier(() -> null)
+				.single();
+
+		assertThat(mono).isInstanceOf(MonoSingleCallable.class);
+
+		assertThatThrownBy(((Callable<?>) mono)::call)
+				.isInstanceOf(NoSuchElementException.class);
+	}
+
+	@Test
+	void sourceNull() {
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoSingleCallable<>(null);
+		});
+	}
+
+	@Test
+	void sourceNullWithDefaultValue() {
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoSingleCallable<>(null, 1);
+		});
+	}
+
+	@Test
+	void defaultValueNull() {
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			new MonoSingleCallable<>(() -> 1, null);
+		});
+	}
+
+	@Test
+	void normal() {
+		StepVerifier.create(new MonoSingleCallable<>(() -> 1))
+		            .expectNext(1)
+		            .verifyComplete();
+	}
+
+	@Test
+	void normalBackpressured() {
+		StepVerifier.create(new MonoSingleCallable<>(() -> 1), 0)
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofMillis(50))
+		            .thenRequest(1)
+		            .expectNext(1)
+		            .verifyComplete();
+	}
+
+	//scalarCallable empty/error/just are not instantiating MonoSingleCallable and are covered in MonoSingleTest
+	//we still cover the case where a callable source throws
+
+	@Test
+	void failingCallable() {
+		StepVerifier.create(new MonoSingleCallable<>(() -> { throw new IllegalStateException("test"); } ))
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	void failingCallableWithDefaultValue() {
+		StepVerifier.create(new MonoSingleCallable<>(() -> { throw new IllegalStateException("test"); },
+				"bla"))
+		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	void emptyCallable() {
+		StepVerifier.create(new MonoSingleCallable<>(() -> null))
+		            .verifyErrorSatisfies(e -> assertThat(e)
+				            .isInstanceOf(NoSuchElementException.class)
+				            .hasMessage("Source was empty")
+		            );
+	}
+
+	@Test
+	void emptyCallableWithDefaultValue() {
+		StepVerifier.create(new MonoSingleCallable<>(() -> null, "bla"))
+		            .expectNext("bla")
+		            .verifyComplete();
+	}
+
+	@Test
+	void emptyCallableWithDefaultValueBackpressured() {
+		StepVerifier.create(new MonoSingleCallable<>(() -> null, "bla"), 0)
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofMillis(50))
+		            .thenRequest(1)
+		            .expectNext("bla")
+		            .verifyComplete();
+	}
+
+	@Test
+	void valuedCallable() {
+		@SuppressWarnings("unchecked")
+		Callable<Integer> fluxCallable = (Callable<Integer>) Mono.fromCallable(() -> 1).flux();
+
+
+		StepVerifier.create(new MonoSingleCallable<>(fluxCallable))
+		            .expectNext(1)
+		            .verifyComplete();
+	}
+
+	@Test
+	void valuedCallableWithDefaultValue() {
+		@SuppressWarnings("unchecked")
+		Callable<Integer> fluxCallable = (Callable<Integer>) Mono.fromCallable(() -> 1).flux();
+
+		StepVerifier.create(new MonoSingleCallable<>(fluxCallable, 2))
+		            .expectNext(1)
+		            .verifyComplete();
+	}
+
+	@Test
+	void defaultValueReturnedInBlock() {
+		Callable<Integer> source = () -> null;
+		Mono<Integer> single = new MonoSingleCallable<>(source, 2);
+
+		assertThat(single.block()).isEqualTo(2);
+	}
+
+	@Test
+	void defaultValueReturnedInCall() throws Exception {
+		Callable<Integer> source = () -> null;
+		Callable<Integer> single = new MonoSingleCallable<>(source, 2);
+
+		assertThat(single.call()).isEqualTo(2);
+	}
+
+	@Test
+	void scanOperator(){
+		MonoSingleCallable<String> test = new MonoSingleCallable<>(() -> "foo");
+
+		//FIXME scan for RUN_STYLE in master
+//		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
+	}
+
+}


### PR DESCRIPTION
This fixes two issues:
 - Flux.single() doesn't detect empty source if it is a Callable
 (excluding scalarCallables)
 - default value is currently not returned with the same source when
 using the single(T) variant

The reason is that in these cases Flux.single produces a `MonoCallable`
just like the Mono counterpart did before #2635 was fixed.

This commit ensures a `MonoSingleCallable` is returned, as introduced
in #2648.

In order to support `Flux.single(T)` (use case with a default value),
a relevant field is added to `MonoSingleCallable`.

Additionally, some tests have been moved to MonoSingleCallableTest and
the test coverage of MonoSingleCallable has been increased.
MonoSingleTest has a smoke test of the consistency of returned concrete
classes for all three types of sources, for all three variants of the
single operator/API (flux, flux with fallback, mono).
