### PR TITLE
Polish MonoSingleCallableTest and MonoThenIgnoreTest

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSingleCallableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSingleCallableTest.java
@@ -191,12 +191,4 @@ class MonoSingleCallableTest {
 		assertThat(single.call()).isEqualTo(2);
 	}
 
-	@Test
-	void scanOperator(){
-		MonoSingleCallable<String> test = new MonoSingleCallable<>(() -> "foo");
-
-		//FIXME scan for RUN_STYLE in master
-//		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
-	}
-
 }


### PR DESCRIPTION
 - Removed FIXME in MonoSingleCallableTest

This FIXME was intended as a reminder to add the scan(RUN_STYLE) test in master,
which has now been done.

 - Renamed MonoThenIgnoreTest to MonoIgnoreThenTest

This polishes the tests around Mono `then` family of operators: since
most tests pertain to the MonoIgnoreThen class, the test class is
renamed to reflect this.

Additionally, the few tests that don't actually rely on MonoIgnoreThen
but rather use alias `then()` are extracted in a Nested test set.


PR Note: will create conflicts (MonoSingleCallable has the full scan test in
master, MonoIgnoreThenTest exists already in master with the scan tests...).