### PR TITLE
Clarify onErrorContinue() caveats and alternatives

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -6539,10 +6539,14 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * that didn't anticipate it (resulting in unintended behaviour.)
 	 * <p>
 	 * In most cases, you should instead handle the error inside the specific function which may cause
-	 * it. Specifically, you can use `onErrorResume(e -> Mono.empty())` on each inner flatMap
-	 * publisher to drop erroneous elements:
+	 * it. Specifically, on each inner publisher you can use {@code doOnError} to log the error, and
+	 * {@code onErrorResume(e -> Mono.empty())} to drop erroneous elements:
 	 * <p>
-	 * <pre>.flatMap(id -> repository.retrieveById(id).onErrorResume(e -> Mono.empty()))</pre>
+	 * <pre>
+	 * .flatMap(id -> repository.retrieveById(id)
+	 *                          .doOnError(System.err::println)
+	 *                          .onErrorResume(e -> Mono.empty()))
+	 * </pre>
 	 * <p>
 	 * This has the advantage of being much clearer, has no ambiguity with regards to operator support,
 	 * and cannot leak upstream.
@@ -6575,10 +6579,14 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * that didn't anticipate it (resulting in unintended behaviour.)
 	 * <p>
 	 * In most cases, you should instead handle the error inside the specific function which may cause
-	 * it. Specifically, you can use `onErrorResume(e -> Mono.empty())` on each inner flatMap
-	 * publisher to drop erroneous elements:
+	 * it. Specifically, on each inner publisher you can use {@code doOnError} to log the error, and
+	 * {@code onErrorResume(e -> Mono.empty())} to drop erroneous elements:
 	 * <p>
-	 * <pre>.flatMap(id -> repository.retrieveById(id).onErrorResume(e -> Mono.empty()))</pre>
+	 * <pre>
+	 * .flatMap(id -> repository.retrieveById(id)
+	 *                          .doOnError(MyException.class, System.err::println)
+	 *                          .onErrorResume(MyException.class, e -> Mono.empty()))
+	 * </pre>
 	 * <p>
 	 * This has the advantage of being much clearer, has no ambiguity with regards to operator support,
 	 * and cannot leak upstream.
@@ -6609,10 +6617,14 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * that didn't anticipate it (resulting in unintended behaviour.)
 	 * <p>
 	 * In most cases, you should instead handle the error inside the specific function which may cause
-	 * it. Specifically, you can use `onErrorResume(e -> Mono.empty())` on each inner flatMap
-	 * publisher to drop erroneous elements:
+	 * it. Specifically, on each inner publisher you can use {@code doOnError} to log the error, and
+	 * {@code onErrorResume(e -> Mono.empty())} to drop erroneous elements:
 	 * <p>
-	 * <pre>.flatMap(id -> repository.retrieveById(id).onErrorResume(e -> Mono.empty()))</pre>
+	 * <pre>
+	 * .flatMap(id -> repository.retrieveById(id)
+	 *                          .doOnError(errorPredicate, System.err::println)
+	 *                          .onErrorResume(errorPredicate, e -> Mono.empty()))
+	 * </pre>
 	 * <p>
 	 * This has the advantage of being much clearer, has no ambiguity with regards to operator support,
 	 * and cannot leak upstream.

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -6533,9 +6533,19 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/onErrorContinue.svg" alt="">
 	 * <p>
-	 * Note that this error handling mode is not necessarily implemented by all operators
-	 * (look for the <strong>Error Mode Support</strong> javadoc section to find operators that
-	 * support it).
+	 * Note that onErrorContinue() is a specialist operator that can make the behaviour of your
+	 * reactive chain unclear. It operates on upstream, not downstream operators, it requires specific
+	 * operator support to work, and the scope can easily propagate upstream into library code
+	 * that didn't anticipate it (resulting in unintended behaviour.)
+	 * <p>
+	 * In most cases, you should instead handle the error inside the specific function which may cause
+	 * it. Specifically, you can use `onErrorResume(e -> Mono.empty())` on each inner flatMap
+	 * publisher to drop erroneous elements:
+	 * <p>
+	 * <pre>.flatMap(id -> repository.retrieveById(id).onErrorResume(e -> Mono.empty()))</pre>
+	 * <p>
+	 * This has the advantage of being much clearer, has no ambiguity with regards to operator support,
+	 * and cannot leak upstream.
 	 *
 	 * @param errorConsumer a {@link BiConsumer} fed with errors matching the predicate and the value
 	 * that triggered the error.
@@ -6559,9 +6569,19 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/onErrorContinueWithClassPredicate.svg" alt="">
 	 * <p>
-	 * Note that this error handling mode is not necessarily implemented by all operators
-	 * (look for the <strong>Error Mode Support</strong> javadoc section to find operators that
-	 * support it).
+	 * Note that onErrorContinue() is a specialist operator that can make the behaviour of your
+	 * reactive chain unclear. It operates on upstream, not downstream operators, it requires specific
+	 * operator support to work, and the scope can easily propagate upstream into library code
+	 * that didn't anticipate it (resulting in unintended behaviour.)
+	 * <p>
+	 * In most cases, you should instead handle the error inside the specific function which may cause
+	 * it. Specifically, you can use `onErrorResume(e -> Mono.empty())` on each inner flatMap
+	 * publisher to drop erroneous elements:
+	 * <p>
+	 * <pre>.flatMap(id -> repository.retrieveById(id).onErrorResume(e -> Mono.empty()))</pre>
+	 * <p>
+	 * This has the advantage of being much clearer, has no ambiguity with regards to operator support,
+	 * and cannot leak upstream.
 	 *
 	 * @param type the {@link Class} of {@link Exception} that are resumed from.
 	 * @param errorConsumer a {@link BiConsumer} fed with errors matching the {@link Class}
@@ -6583,9 +6603,19 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/onErrorContinueWithPredicate.svg" alt="">
 	 * <p>
-	 * Note that this error handling mode is not necessarily implemented by all operators
-	 * (look for the <strong>Error Mode Support</strong> javadoc section to find operators that
-	 * support it).
+	 * Note that onErrorContinue() is a specialist operator that can make the behaviour of your
+	 * reactive chain unclear. It operates on upstream, not downstream operators, it requires specific
+	 * operator support to work, and the scope can easily propagate upstream into library code
+	 * that didn't anticipate it (resulting in unintended behaviour.)
+	 * <p>
+	 * In most cases, you should instead handle the error inside the specific function which may cause
+	 * it. Specifically, you can use `onErrorResume(e -> Mono.empty())` on each inner flatMap
+	 * publisher to drop erroneous elements:
+	 * <p>
+	 * <pre>.flatMap(id -> repository.retrieveById(id).onErrorResume(e -> Mono.empty()))</pre>
+	 * <p>
+	 * This has the advantage of being much clearer, has no ambiguity with regards to operator support,
+	 * and cannot leak upstream.
 	 *
 	 * @param errorPredicate a {@link Predicate} used to filter which errors should be resumed from.
 	 * This MUST be idempotent, as it can be used several times.

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -3317,9 +3317,28 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * Alternatively, throwing from that biconsumer will propagate the thrown exception downstream
 	 * in place of the original error, which is added as a suppressed exception to the new one.
 	 * <p>
-	 * Note that this error handling mode is not necessarily implemented by all operators
-	 * (look for the <strong>Error Mode Support</strong> javadoc section to find operators that
-	 * support it).
+	 * This operator is offered on {@link Mono}	mainly as a way to propagate the configuration to
+	 * upstream {@link Flux}. The mode doesn't really make sense on a {@link Mono}, since we're sure
+	 * there will be no further value to continue with.
+	 * {@link #onErrorResume(Function)} is a more classical fit.
+	 * <p>
+	 * Note that onErrorContinue() is a specialist operator that can make the behaviour of your
+	 * reactive chain unclear. It operates on upstream, not downstream operators, it requires specific
+	 * operator support to work, and the scope can easily propagate upstream into library code
+	 * that didn't anticipate it (resulting in unintended behaviour.)
+	 * <p>
+	 * In most cases, you should instead handle the error inside the specific function which may cause
+	 * it. Specifically, on each inner publisher you can use {@code doOnError} to log the error, and
+	 * {@code onErrorResume(e -> Mono.empty())} to drop erroneous elements:
+	 * <p>
+	 * <pre>
+	 * .flatMap(id -> repository.retrieveById(id)
+	 *                          .doOnError(System.err::println)
+	 *                          .onErrorResume(e -> Mono.empty()))
+	 * </pre>
+	 * <p>
+	 * This has the advantage of being much clearer, has no ambiguity with regards to operator support,
+	 * and cannot leak upstream.
 	 *
 	 * @param errorConsumer a {@link BiConsumer} fed with errors matching the {@link Class}
 	 * and the value that triggered the error.
@@ -3341,12 +3360,28 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * Alternatively, throwing from that biconsumer will propagate the thrown exception downstream
 	 * in place of the original error, which is added as a suppressed exception to the new one.
 	 * <p>
-	 * Note that this error handling mode is not necessarily implemented by all operators
-	 * (look for the <strong>Error Mode Support</strong> javadoc section to find operators that
-	 * support it). In particular, this operator is offered on {@link Mono} mainly as a
-	 * way to propagate the configuration to upstream {@link Flux}. The mode doesn't really
-	 * make sense on a {@link Mono}, since we're sure there will be no further value to
-	 * continue with: {@link #onErrorResume(Function)} is a more classical fit then.
+	 * This operator is offered on {@link Mono}	mainly as a way to propagate the configuration to
+	 * upstream {@link Flux}. The mode doesn't really make sense on a {@link Mono}, since we're sure
+	 * there will be no further value to continue with.
+	 * {@link #onErrorResume(Function)} is a more classical fit.
+	 * <p>
+	 * Note that onErrorContinue() is a specialist operator that can make the behaviour of your
+	 * reactive chain unclear. It operates on upstream, not downstream operators, it requires specific
+	 * operator support to work, and the scope can easily propagate upstream into library code
+	 * that didn't anticipate it (resulting in unintended behaviour.)
+	 * <p>
+	 * In most cases, you should instead handle the error inside the specific function which may cause
+	 * it. Specifically, on each inner publisher you can use {@code doOnError} to log the error, and
+	 * {@code onErrorResume(e -> Mono.empty())} to drop erroneous elements:
+	 * <p>
+	 * <pre>
+	 * .flatMap(id -> repository.retrieveById(id)
+	 *                          .doOnError(MyException.class, System.err::println)
+	 *                          .onErrorResume(MyException.class, e -> Mono.empty()))
+	 * </pre>
+	 * <p>
+	 * This has the advantage of being much clearer, has no ambiguity with regards to operator support,
+	 * and cannot leak upstream.
 	 *
 	 * @param type the {@link Class} of {@link Exception} that are resumed from.
 	 * @param errorConsumer a {@link BiConsumer} fed with errors matching the {@link Class}
@@ -3366,12 +3401,28 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * Alternatively, throwing from that biconsumer will propagate the thrown exception downstream
 	 * in place of the original error, which is added as a suppressed exception to the new one.
 	 * <p>
-	 * Note that this error handling mode is not necessarily implemented by all operators
-	 * (look for the <strong>Error Mode Support</strong> javadoc section to find operators that
-	 * support it). In particular, this operator is offered on {@link Mono} mainly as a
-	 * way to propagate the configuration to upstream {@link Flux}. The mode doesn't really
-	 * make sense on a {@link Mono}, since we're sure there will be no further value to
-	 * continue with: {@link #onErrorResume(Function)} is a more classical fit then.
+	 * This operator is offered on {@link Mono}	mainly as a way to propagate the configuration to
+	 * upstream {@link Flux}. The mode doesn't really make sense on a {@link Mono}, since we're sure
+	 * there will be no further value to continue with.
+	 * {@link #onErrorResume(Function)} is a more classical fit.
+	 * <p>
+	 * Note that onErrorContinue() is a specialist operator that can make the behaviour of your
+	 * reactive chain unclear. It operates on upstream, not downstream operators, it requires specific
+	 * operator support to work, and the scope can easily propagate upstream into library code
+	 * that didn't anticipate it (resulting in unintended behaviour.)
+	 * <p>
+	 * In most cases, you should instead handle the error inside the specific function which may cause
+	 * it. Specifically, on each inner publisher you can use {@code doOnError} to log the error, and
+	 * {@code onErrorResume(e -> Mono.empty())} to drop erroneous elements:
+	 * <p>
+	 * <pre>
+	 * .flatMap(id -> repository.retrieveById(id)
+	 *                          .doOnError(errorPredicate, System.err::println)
+	 *                          .onErrorResume(errorPredicate, e -> Mono.empty()))
+	 * </pre>
+	 * <p>
+	 * This has the advantage of being much clearer, has no ambiguity with regards to operator support,
+	 * and cannot leak upstream.
 	 *
 	 * @param errorPredicate a {@link Predicate} used to filter which errors should be resumed from.
 	 * This MUST be idempotent, as it can be used several times.


### PR DESCRIPTION
From discussions around `onErrorContinue()`, it was agreed that it'd be helpful if the documentation more clearly referenced the fact that it's a specialist operator, and highlighted some of the potential problems with it (as well as the `onErrorResume()` on the inner flatmap publisher pattern which could be used instead.)

I've written some documentation which I hope explains this without being *too* wordy, though very open to suggestions!