### PR TITLE
GitHub Actions Release Process: signing, artifactory, sonatype

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,5 @@
 name: CI
 on:
-  push:
-    branches:
-      - master
-      - "[0-9].[0-9]+.x"
   pull_request: {}
 jobs:
   core-fast:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,107 @@
+name: publish
+on:
+  push:
+    branches: # For branches, better to list them explicitly than regexp include
+      - master
+      - 3.3.x
+jobs:
+  # General job notes: we DON'T want to cancel any previous runs, especially in the case of a "back to snapshots" build right after a release push
+  # We specify the ubuntu version to minimize the chances we have to deal with a migration during a release
+  prepare:
+    # Notes on prepare: this job has no access to secrets, only github token. As a result, all non-core actions are centralized here
+    # This includes the tagging and drafting of release notes. Still, when possible we favor plain run of gradle tasks
+    name: prepare
+    runs-on: ubuntu-20.04
+    outputs:
+      versionType: ${{ steps.version.outputs.versionType }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: setup java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: interpret version
+      id: version
+      #we only run the qualifyVersionGha task so that no other console printing can hijack this step's output
+      #output: versionType, fullVersion
+      #fails if versionType is BAD, which interrupts the workflow
+      run: ./gradlew qualifyVersionGha
+    - name: run checks
+      id: checks
+      run: ./gradlew check
+    - name: tag
+      if: steps.version.outputs.versionType == 'RELEASE' || steps.version.outputs.versionType == 'MILESTONE'
+      with:
+        tag_name: "v${{ steps.version.outputs.fullVersion }}"
+        tag_comment: "Release version ${{ steps.version.outputs.fullVersion }}"
+      run: |
+        git config --local user.name 'reactorbot'
+        git config --local user.email '32325210+reactorbot@users.noreply.github.com'
+        git tag -m "${{ tag_comment }}" ${{ tag_name }} ${{ github.sha }}
+        git push --tags
+
+  #deploy the snapshot artifacts to Artifactory
+  deploySnapshot:
+    name: deploySnapshot
+    runs-on: ubuntu-20.04
+    needs: prepare
+    if: needs.prepare.outputs.versionType == 'SNAPSHOT'
+    environment: snapshots
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: deploy
+      env:
+        ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ARTIFACTORY_SNAPSHOT_USERNAME}}
+        ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ARTIFACTORY_PASSWORD}}
+      run: |
+          ./gradlew assemble artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io -Partifactory_publish_repoKey=libs-snapshot-local
+
+  #sign the milestone artifacts and deploy them to Artifactory
+  deployMilestone:
+    name: deployMilestone
+    runs-on: ubuntu-20.04
+    needs: prepare
+    if: needs.prepare.outputs.versionType == 'MILESTONE'
+    environment: releases
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: deploy
+      env:
+        ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ARTIFACTORY_USERNAME}}
+        ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ARTIFACTORY_PASSWORD}}
+        ORG_GRADLE_PROJECT_signingKey: ${{secrets.SIGNING_KEY}}
+        ORG_GRADLE_PROJECT_signingPassword: ${{secrets.SIGNING_PASSPHRASE}}
+      run: |
+          ./gradlew assemble sign artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io -Partifactory_publish_repoKey=libs-milestone-local
+
+  #sign the release artifacts and deploy them to Artifactory
+  deployRelease:
+    name: deployRelease
+    runs-on: ubuntu-20.04
+    needs: prepare
+    if: needs.prepare.outputs.versionType == 'RELEASE'
+    environment: releases
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: deploy
+      env:
+        ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ARTIFACTORY_USERNAME}}
+        ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ARTIFACTORY_PASSWORD}}
+        ORG_GRADLE_PROJECT_signingKey: ${{secrets.SIGNING_KEY}}
+        ORG_GRADLE_PROJECT_signingPassword: ${{secrets.SIGNING_PASSPHRASE}}
+        ORG_GRADLE_PROJECT_sonatypeUsername: ${{secrets.SONATYPE_USERNAME}}
+        ORG_GRADLE_PROJECT_sonatypePassword: ${{secrets.SONATYPE_PASSWORD}}
+      run: |
+          ./gradlew assemble sign artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io  -Partifactory_publish_repoKey=libs-release-local publishMavenJavaPublicationToSonatypeRepository
+
+# For Gradle configuration of signing, see https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
+# publishMavenJavaPublicationToSonatypeRepository only sends to a staging repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,13 +31,10 @@ jobs:
       run: ./gradlew check
     - name: tag
       if: steps.version.outputs.versionType == 'RELEASE' || steps.version.outputs.versionType == 'MILESTONE'
-      with:
-        tag_name: "v${{ steps.version.outputs.fullVersion }}"
-        tag_comment: "Release version ${{ steps.version.outputs.fullVersion }}"
       run: |
         git config --local user.name 'reactorbot'
         git config --local user.email '32325210+reactorbot@users.noreply.github.com'
-        git tag -m "${{ tag_comment }}" ${{ tag_name }} ${{ github.sha }}
+        git tag -m "Release version ${{ steps.version.outputs.fullVersion }}" v${{ steps.version.outputs.fullVersion }} ${{ github.sha }}
         git push --tags
 
   #deploy the snapshot artifacts to Artifactory

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -81,9 +81,9 @@ String getOrGenerateBuildNumber() {
 	if (project.hasProperty("buildNumber")) {
 		return project.findProperty("buildNumber")
 	}
-	def jenkinsNumber = System.getenv("BUILD_NUMBER")
-	if (jenkinsNumber != null) {
-		return jenkinsNumber
+	def ciNumber = System.getenv("GITHUB_RUN_ID")
+	if (ciNumber != null) {
+		return ciNumber
 	}
 	ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC)
 	long secondsInDay = now.toEpochSecond() - ZonedDateTime.now(ZoneOffset.UTC).withSecond(0).withHour(0).withMinute(0).toEpochSecond()
@@ -112,8 +112,12 @@ if (project.hasProperty("artifactory_publish_password")) {
 				}
 			}
 			clientConfig.setIncludeEnvVars(false)
-			clientConfig.info.setBuildName('Reactor - Releaser - Core')
+			clientConfig.info.setBuildName('Reactor - Core')
 			clientConfig.info.setBuildNumber(buildNumber)
+			if (System.getenv("GITHUB_ACTIONS") == "true") {
+				clientConfig.info.setBuildUrl(System.getenv("GITHUB_SERVER_URL") + "/" + System.getenv("GITHUB_REPOSITORY") + "/actions/runs/" + System.getenv("GITHUB_RUN_ID"))
+				clientConfig.info.setVcsRevision(System.getenv("GITHUB_SHA"))
+			}
 		}
 	}
 }

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import org.gradle.util.VersionNumber
+
 if (project.name == 'benchmarks')
 	return
 
 apply plugin: 'maven-publish'
-apply plugin: "com.jfrog.artifactory"
+//we also conditionally apply artifactory and signing plugins below
 
 jar {
 	manifest.attributes["Created-By"] = "${System.getProperty("java.version")} (${System.getProperty("java.specification.vendor")})"
@@ -36,19 +38,58 @@ task javadocJar(type: Jar) {
 	from javadoc
 }
 
+static def qualifyVersion(String v) {
+	def versionNumber = VersionNumber.parse(v)
+
+	if (versionNumber == VersionNumber.UNKNOWN) return "BAD";
+
+	if (versionNumber.qualifier == null || versionNumber.qualifier.size() == 0) return "RELEASE" //new scheme
+	if (versionNumber.qualifier == "RELEASE") return "RELEASE" //old scheme
+	if (versionNumber.qualifier.matches("(?:M|RC)\\d+")) return "MILESTONE"
+	if (versionNumber.qualifier == "SNAPSHOT" || versionNumber.qualifier == "BUILD-SNAPSHOT") return "SNAPSHOT"
+
+	return "BAD"
+}
+
+task qualifyVersionGha() {
+	doLast {
+		def versionType = qualifyVersion("$version")
+
+		println "::set-output name=versionType::$versionType"
+		println "::set-output name=fullVersion::$version"
+		if (versionType == "BAD") {
+			println "::error ::Unable to parse $version to a VersionNumber with recognizable qualifier"
+			throw new TaskExecutionException(tasks.getByName("qualifyVersionGha"), new IllegalArgumentException("Unable to parse $version to a VersionNumber with recognizable qualifier"))
+		}
+	}
+}
+
 publishing {
-    repositories {
-        maven {
-           name = "mock"
-           url = "${rootProject.buildDir}/repo"
-        }
-    }
+	repositories {
+		maven {
+			name = "mock"
+			url = "${rootProject.buildDir}/repo"
+		}
+		if (qualifyVersion("$version") == "RELEASE") {
+			maven {
+				name = "sonatype"
+				url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2"
+				credentials {
+					username findProperty("sonatypeUsername")
+					password findProperty("sonatypePassword")
+				}
+			}
+		}
+	}
+
 	publications {
+		extras(MavenPublication) {
+//			other project-specific artifacts must be added to this publication, in each project's builds
+		}
 		mavenJava(MavenPublication) {
 			from components.java
 			artifact sourcesJar
 			artifact javadocJar
-			//other project-specific artifacts are added in each project's builds
 
 			pom {
 				afterEvaluate {
@@ -111,8 +152,27 @@ publishing {
 	}
 }
 
-artifactoryPublish {
-	//don't activate the onlyIf clause below yet, so that Bamboo builds will publish stuff...
-	//onlyIf { project.hasProperty("artifactory_publish_password")") }
-	publications(publishing.publications.mavenJava)
+if (rootProject.hasProperty("artifactory_publish_password")) {
+	apply plugin: "com.jfrog.artifactory"
+
+	artifactoryPublish {
+		publications(publishing.publications.mavenJava, publishing.publications.extras)
+	}
+}
+
+if (qualifyVersion("$version") in ["RELEASE", "MILESTONE"]) {
+	apply plugin: 'signing'
+
+	signing {
+		//requiring signature if there is a publish task that is not to MavenLocal
+		required {  gradle.taskGraph.allTasks.any { it.name.toLowerCase().contains("publish")	&& !it.name.contains("MavenLocal") } }
+		def signingKey = findProperty("signingKey")
+		def signingPassword = findProperty("signingPassword")
+
+		useInMemoryPgpKeys(signingKey, signingPassword)
+
+		afterEvaluate {
+			sign publishing.publications.mavenJava
+		}
+	}
 }

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -282,5 +282,5 @@ else {
 	}
 }
 
-//add docs.zip to the publication
-publishing.publications.mavenJava.artifact(rootProject.tasks.docsZip)
+//add docs.zip to the extras publication
+publishing.publications.extras.artifact(rootProject.tasks.docsZip)


### PR DESCRIPTION
 - add `qualifyVersion` function and `qualifyVersionGha` task﻿ to build
 - conditionally apply signing and artifactory plugins
 - add support for publishing to Maven Central / sonatype for RELEASEs
 - remove push target from CI workflow
 - introduce publish.yml workflow with isolated jobs with different amounts of
 "privileges" via github environments: snapshots, milestones and releases.