### PR TITLE
Improve switchOnFirst race-safety by using single volatile state

### DIFF
--- a/reactor-core/src/jcstress/java/reactor/core/publisher/ConditionalStressSubscriber.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/ConditionalStressSubscriber.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.core.publisher;
+
+import java.util.function.Predicate;
+
+import org.reactivestreams.Subscription;
+import reactor.core.Fuseable;
+
+public class ConditionalStressSubscriber<T> extends StressSubscriber<T> implements Fuseable.ConditionalSubscriber<T> {
+
+
+	final Predicate<T> tryOnNextPredicate;
+
+	/**
+	 * Build a {@link ConditionalStressSubscriber} that makes an unbounded request upon subscription.
+	 */
+	public ConditionalStressSubscriber() {
+		this(Long.MAX_VALUE, (__) -> true);
+	}
+
+	/**
+	 * Build a {@link ConditionalStressSubscriber} that that makes an unbounded request upon
+	 * subscription.
+	 *
+	 * @param tryOnNextPredicate the tryOnNext predicate
+	 */
+	public ConditionalStressSubscriber(Predicate<T> tryOnNextPredicate) {
+		this(Long.MAX_VALUE, tryOnNextPredicate);
+	}
+
+	/**
+	 * Build a {@link ConditionalStressSubscriber} that requests the provided amount in
+	 * {@link #onSubscribe(Subscription)}. Use {@code 0} to avoid any initial request
+	 * upon subscription.
+	 *
+	 * @param initRequest the requested amount upon subscription, or zero to disable initial request
+	 */
+	public ConditionalStressSubscriber(long initRequest) {
+		this(initRequest, __ -> true);
+	}
+
+	/**
+	 * Build a {@link ConditionalStressSubscriber} that requests the provided amount in
+	 * {@link #onSubscribe(Subscription)}. Use {@code 0} to avoid any initial request
+	 * upon subscription.
+	 *
+	 * @param initRequest the requested amount upon subscription, or zero to disable initial request
+	 * @param tryOnNextPredicate the tryOnNext predicate
+	 */
+	public ConditionalStressSubscriber(long initRequest, Predicate<T> tryOnNextPredicate) {
+		super(initRequest);
+		this.tryOnNextPredicate = tryOnNextPredicate;
+	}
+
+	@Override
+	public boolean tryOnNext(T value) {
+		onNext(value);
+		return tryOnNextPredicate.test(value);
+	}
+}

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchOnFirstConditionalStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchOnFirstConditionalStressTest.java
@@ -1,0 +1,186 @@
+package reactor.core.publisher;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.LLLLL_Result;
+import org.openjdk.jcstress.infra.results.LLLL_Result;
+import reactor.core.CoreSubscriber;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+
+public abstract class FluxSwitchOnFirstConditionalStressTest {
+
+	final FluxSwitchOnFirstStressTest.StressSubscription<String> inboundSubscription =
+			new FluxSwitchOnFirstStressTest.StressSubscription<>();
+	final ConditionalStressSubscriber<String>                    inboundSubscriber   =
+			new ConditionalStressSubscriber<>(0);
+
+	final FluxSwitchOnFirstStressTest.StressSubscription<String> outboundSubscription =
+			new FluxSwitchOnFirstStressTest.StressSubscription<>();
+	final ConditionalStressSubscriber<String>                    outboundSubscriber   =
+			new ConditionalStressSubscriber<>(0);
+
+	final FluxSwitchOnFirst.SwitchOnFirstConditionalMain<String, String> main =
+			new FluxSwitchOnFirst.SwitchOnFirstConditionalMain<String, String>(
+					outboundSubscriber,
+					this::switchOnFirst,
+					false);
+
+	{
+		inboundSubscription.subscribe(main);
+	}
+
+	abstract Flux<String> switchOnFirst(Signal<? extends String> signal,
+			Flux<String> inbound);
+
+	@JCStressTest
+	@Outcome(id = {"1, 1, 1, 1, 1"}, expect = ACCEPTABLE)
+	@State
+	public static class OutboundOnSubscribeAndRequestStressTest
+			extends FluxSwitchOnFirstConditionalStressTest {
+
+		@Override
+		Flux<String> switchOnFirst(Signal<? extends String> signal,
+				Flux<String> inbound) {
+			return new Flux<String>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super String> actual) {
+					inbound.subscribe(inboundSubscriber);
+					inboundSubscriber.request(1);
+					outboundSubscription.subscribe(actual);
+				}
+			};
+		}
+
+		@Actor
+		public void next() {
+			main.tryOnNext("test");
+		}
+
+		@Actor
+		public void request() {
+			outboundSubscriber.request(1);
+		}
+
+		@Arbiter
+		public void arbiter(LLLLL_Result result) {
+			result.r1 = outboundSubscription.requestsCount;
+			result.r2 = outboundSubscription.requested;
+			result.r3 = inboundSubscription.requestsCount;
+			result.r4 = inboundSubscription.requested;
+			result.r5 = inboundSubscriber.onNextCalls;
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {
+			"1, 2, 0, 1"}, expect = ACCEPTABLE, desc = "inbound next with error happens first")
+	@Outcome(id = {
+			"1, 0, 0, 1"}, expect = ACCEPTABLE, desc = "cancellation happened first")
+	@Outcome(id = {"1, 3, 0, 1"}, expect = ACCEPTABLE, desc = "cancellation in between")
+	@State
+	public static class InboundNextLeadingToErrorAndOutboundCancelStressTest
+			extends FluxSwitchOnFirstConditionalStressTest {
+
+		static final RuntimeException DUMMY_ERROR = new RuntimeException("dummy");
+
+		@Override
+		Flux<String> switchOnFirst(Signal<? extends String> signal,
+				Flux<String> inbound) {
+			throw DUMMY_ERROR;
+		}
+
+		@Actor
+		public void nextInbound() {
+			main.tryOnNext("value");
+		}
+
+		@Actor
+		public void cancelOutbound() {
+			outboundSubscriber.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(LLLL_Result result) {
+			result.r1 = inboundSubscription.cancelled ? 1 : 0;
+			result.r2 =
+					outboundSubscriber.onCompleteCalls.get() + outboundSubscriber.onErrorCalls.get() * 2 + outboundSubscriber.droppedErrors.size() * 3;
+			result.r3 = outboundSubscriber.onNextCalls;
+			result.r4 = outboundSubscriber.onNextDiscarded;
+
+			if (outboundSubscriber.concurrentOnError.get()) {
+				throw new RuntimeException("Concurrent OnError");
+			}
+			if (outboundSubscriber.concurrentOnNext.get()) {
+				throw new RuntimeException("Concurrent OnNext");
+			}
+			if (outboundSubscriber.concurrentOnComplete.get()) {
+				throw new RuntimeException("Concurrent OnComplete");
+			}
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {
+			"1, 1, 2, 1, 1"}, expect = ACCEPTABLE, desc = "outbound cancel happened before inbound next")
+	@Outcome(id = {
+			"1, 1, 2, 2, 0"}, expect = ACCEPTABLE, desc = "inbound next happened before outbound cancel")
+	@State
+	public static class OutboundCancelAndInboundNextStressTest
+			extends FluxSwitchOnFirstConditionalStressTest {
+
+		Flux<String> inboundStream;
+
+		@Override
+		Flux<String> switchOnFirst(Signal<? extends String> signal,
+				Flux<String> inbound) {
+			return new Flux<String>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super String> actual) {
+					inboundStream = inbound;
+					outboundSubscription.subscribe(actual);
+				}
+			};
+		}
+
+		{
+			main.tryOnNext("value");
+			inboundStream.subscribe(inboundSubscriber);
+			inboundSubscriber.request(2);
+		}
+
+		@Actor
+		public void nextInbound() {
+			main.tryOnNext("value2");
+		}
+
+		@Actor
+		public void cancelOutbound() {
+			outboundSubscriber.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(LLLLL_Result result) {
+			result.r1 = outboundSubscription.cancelled ? 1 : 0;
+			result.r2 = inboundSubscription.cancelled ? 1 : 0;
+
+			result.r3 =
+					inboundSubscriber.onCompleteCalls.get() + inboundSubscriber.onErrorCalls.get() * 2 + outboundSubscriber.droppedErrors.size() * 3;
+			result.r4 = inboundSubscriber.onNextCalls;
+			result.r5 = outboundSubscriber.onNextDiscarded;
+
+			if (inboundSubscriber.concurrentOnError.get()) {
+				throw new RuntimeException("Concurrent OnError");
+			}
+			if (inboundSubscriber.concurrentOnNext.get()) {
+				throw new RuntimeException("Concurrent OnNext");
+			}
+			if (inboundSubscriber.concurrentOnComplete.get()) {
+				throw new RuntimeException("Concurrent OnComplete");
+			}
+		}
+	}
+}

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchOnFirstStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchOnFirstStressTest.java
@@ -1,0 +1,588 @@
+package reactor.core.publisher;
+
+import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.Result;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.LLLLL_Result;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+
+public abstract class FluxSwitchOnFirstStressTest {
+
+	final StressSubscription<String> inboundSubscription = new StressSubscription<>();
+	final StressSubscriber<String>   inboundSubscriber   = new StressSubscriber<>(0);
+
+	final StressSubscription<String> outboundSubscription = new StressSubscription<>();
+	final StressSubscriber<String>   outboundSubscriber   = new StressSubscriber<>(0);
+
+	final FluxSwitchOnFirst.SwitchOnFirstMain<String, String> main =
+			new FluxSwitchOnFirst.SwitchOnFirstMain<String, String>(outboundSubscriber,
+					this::switchOnFirst,
+					false);
+
+	{
+		inboundSubscription.subscribe(main);
+	}
+
+	abstract Flux<String> switchOnFirst(Signal<? extends String> signal,
+			Flux<String> inbound);
+
+	@JCStressTest
+	@Outcome(id = {"1, 1, 1, 1, 1"}, expect = ACCEPTABLE)
+	@State
+	public static class OutboundOnSubscribeAndRequestStressTest
+			extends FluxSwitchOnFirstStressTest {
+
+		@Override
+		Flux<String> switchOnFirst(Signal<? extends String> signal,
+				Flux<String> inbound) {
+			return new Flux<String>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super String> actual) {
+					inbound.subscribe(inboundSubscriber);
+					inboundSubscriber.request(1);
+					outboundSubscription.subscribe(actual);
+				}
+			};
+		}
+
+		@Actor
+		public void next() {
+			main.onNext("test");
+		}
+
+		@Actor
+		public void request() {
+			outboundSubscriber.request(1);
+		}
+
+		@Arbiter
+		public void arbiter(LLLLL_Result result) {
+			result.r1 = outboundSubscription.requestsCount;
+			result.r2 = outboundSubscription.requested;
+			result.r3 = inboundSubscription.requestsCount;
+			result.r4 = inboundSubscription.requested;
+			result.r5 = inboundSubscriber.onNextCalls;
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {
+			"0, 0, 1, 2, 2, 0, 1, 1, 0"}, expect = ACCEPTABLE, desc = "Inbound got second request, delivered onNext('value') and delivered onComplete() before cancellation")
+	@Outcome(id = {
+			"0, 0, 1, 2, 2, 1, 2, 1, 0"}, expect = ACCEPTABLE, desc = "Inbound got second request, delivered onNext('value') but got cancel before onComplete(). CancellationException was propagated to the inboundSubscriber")
+	@Outcome(id = {
+			"0, 0, 1, 1, 1, 1, 2, 0, 1"}, expect = ACCEPTABLE, desc = "Cancellation happened as the earliest event. firstValue is discarded")
+	@State
+	public static class InboundSubscribeAndOutboundCancelAndInboundCompleteStressTest
+			extends FluxSwitchOnFirstStressTest {
+
+		Flux<String> inboundStream;
+
+		@Override
+		Flux<String> switchOnFirst(Signal<? extends String> signal,
+				Flux<String> inbound) {
+			return new Flux<String>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super String> actual) {
+					inboundStream = inbound;
+					outboundSubscription.subscribe(actual);
+				}
+			};
+		}
+
+		{
+			main.onNext("value");
+		}
+
+		@Actor
+		public void CompleteInbound() {
+			main.onComplete();
+		}
+
+		@Actor
+		public void subscribeInbound() {
+			inboundStream.subscribe(inboundSubscriber);
+			inboundSubscriber.request(2);
+		}
+
+		@Actor
+		public void cancelOutbound() {
+			outboundSubscriber.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(LLLLLLLLL_Result result) {
+			result.r1 = outboundSubscription.requestsCount;
+			result.r2 = outboundSubscription.requested;
+			result.r3 = outboundSubscription.cancelled ? 1 : 0;
+
+			result.r4 = inboundSubscription.requestsCount;
+			result.r5 = inboundSubscription.requested;
+			result.r6 = inboundSubscription.cancelled ? 1 : 0;
+
+			result.r7 =
+					inboundSubscriber.onCompleteCalls.get() + inboundSubscriber.onErrorCalls.get() * 2;
+			result.r8 = inboundSubscriber.onNextCalls;
+			result.r9 = outboundSubscriber.onNextDiscarded;
+
+			if (inboundSubscriber.concurrentOnError.get()) {
+				throw new RuntimeException("Concurrent OnError");
+			}
+			if (inboundSubscriber.concurrentOnNext.get()) {
+				throw new RuntimeException("Concurrent OnNext");
+			}
+			if (inboundSubscriber.concurrentOnComplete.get()) {
+				throw new RuntimeException("Concurrent OnComplete");
+			}
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {
+			"0, 0, 1, 2, 2, 0, 2, 1, 0"}, expect = ACCEPTABLE, desc = "Inbound got second request, delivered onNext('value') and delivered onError() before cancellation")
+	@Outcome(id = {
+			"0, 0, 1, 2, 2, 1, 5, 1, 0"}, expect = ACCEPTABLE, desc = "Inbound got second request, delivered onNext('value') but got cancel before onError(). CancellationException was propagated to the inboundSubscriber")
+	@Outcome(id = {
+			"0, 0, 1, 1, 1, 1, 5, 0, 1"}, expect = ACCEPTABLE, desc = "Cancellation happened as the earliest event. firstValue is discarded")
+	@State
+	public static class InboundSubscribeAndOutboundCancelAndInboundErrorStressTest
+			extends FluxSwitchOnFirstStressTest {
+
+		static final RuntimeException DUMMY_ERROR = new RuntimeException("dummy");
+		Flux<String> inboundStream;
+
+		@Override
+		Flux<String> switchOnFirst(Signal<? extends String> signal,
+				Flux<String> inbound) {
+			return new Flux<String>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super String> actual) {
+					inboundStream = inbound;
+					outboundSubscription.subscribe(actual);
+				}
+			};
+		}
+
+		{
+			main.onNext("value");
+		}
+
+		@Actor
+		public void errorInbound() {
+			main.onError(DUMMY_ERROR);
+		}
+
+		@Actor
+		public void subscribeInbound() {
+			inboundStream.subscribe(inboundSubscriber);
+			inboundSubscriber.request(2);
+		}
+
+		@Actor
+		public void cancelOutbound() {
+			outboundSubscriber.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(LLLLLLLLL_Result result) {
+			result.r1 = outboundSubscription.requestsCount;
+			result.r2 = outboundSubscription.requested;
+			result.r3 = outboundSubscription.cancelled ? 1 : 0;
+
+			result.r4 = inboundSubscription.requestsCount;
+			result.r5 = inboundSubscription.requested;
+			result.r6 = inboundSubscription.cancelled ? 1 : 0;
+
+			result.r7 =
+					inboundSubscriber.onCompleteCalls.get() + inboundSubscriber.onErrorCalls.get() * 2 + outboundSubscriber.droppedErrors.size() * 3;
+			result.r8 = inboundSubscriber.onNextCalls;
+			result.r9 = outboundSubscriber.onNextDiscarded;
+
+			if (inboundSubscriber.concurrentOnError.get()) {
+				throw new RuntimeException("Concurrent OnError");
+			}
+			if (inboundSubscriber.concurrentOnNext.get()) {
+				throw new RuntimeException("Concurrent OnNext");
+			}
+			if (inboundSubscriber.concurrentOnComplete.get()) {
+				throw new RuntimeException("Concurrent OnComplete");
+			}
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {
+			"0, 0, 1, 2, 2, 1, 0, 1, 0"}, expect = ACCEPTABLE, desc = "inbound request happened first. then inbound cancel. then outbound cancel")
+	@Outcome(id = {
+			"0, 0, 1, 2, 2, 1, 2, 1, 0"}, expect = ACCEPTABLE, desc = "inbound request happened first. then outbound cancel with error")
+	@Outcome(id = {
+			"0, 0, 1, 1, 1, 1, 0, 0, 1"}, expect = ACCEPTABLE, desc = "inbound cancel first")
+	@Outcome(id = {
+			"0, 0, 1, 1, 1, 1, 2, 0, 1"}, expect = ACCEPTABLE, desc = "outbound cancel with error first")
+	@State
+	public static class OutboundCancelAndInboundCancelStressTest
+			extends FluxSwitchOnFirstStressTest {
+
+		Flux<String> inboundStream;
+
+		@Override
+		Flux<String> switchOnFirst(Signal<? extends String> signal,
+				Flux<String> inbound) {
+			return new Flux<String>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super String> actual) {
+					inboundStream = inbound;
+					outboundSubscription.subscribe(actual);
+				}
+			};
+		}
+
+		{
+			main.onNext("value");
+			inboundStream.subscribe(inboundSubscriber);
+		}
+
+		@Actor
+		public void cancelInbound() {
+			inboundSubscriber.cancel();
+		}
+
+		@Actor
+		public void requestInbound() {
+			inboundSubscriber.request(2);
+		}
+
+		@Actor
+		public void cancelOutbound() {
+			outboundSubscriber.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(LLLLLLLLL_Result result) {
+			result.r1 = outboundSubscription.requestsCount;
+			result.r2 = outboundSubscription.requested;
+			result.r3 = outboundSubscription.cancelled ? 1 : 0;
+
+			result.r4 = inboundSubscription.requestsCount;
+			result.r5 = inboundSubscription.requested;
+			result.r6 = inboundSubscription.cancelled ? 1 : 0;
+
+			result.r7 =
+					inboundSubscriber.onCompleteCalls.get() + inboundSubscriber.onErrorCalls.get() * 2 + outboundSubscriber.droppedErrors.size() * 3;
+			result.r8 = inboundSubscriber.onNextCalls;
+			result.r9 = outboundSubscriber.onNextDiscarded;
+
+			if (inboundSubscriber.concurrentOnError.get()) {
+				throw new RuntimeException("Concurrent OnError");
+			}
+			if (inboundSubscriber.concurrentOnNext.get()) {
+				throw new RuntimeException("Concurrent OnNext");
+			}
+			if (inboundSubscriber.concurrentOnComplete.get()) {
+				throw new RuntimeException("Concurrent OnComplete");
+			}
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {
+			"1, 1, 2, 1, 1"}, expect = ACCEPTABLE, desc = "outbound cancel happened before inbound next")
+	@Outcome(id = {
+			"1, 1, 2, 2, 0"}, expect = ACCEPTABLE, desc = "inbound next happened before outbound cancel")
+	@State
+	public static class OutboundCancelAndInboundNextStressTest extends FluxSwitchOnFirstStressTest {
+
+		Flux<String> inboundStream;
+
+		@Override
+		Flux<String> switchOnFirst(Signal<? extends String> signal,
+				Flux<String> inbound) {
+			return new Flux<String>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super String> actual) {
+					inboundStream = inbound;
+					outboundSubscription.subscribe(actual);
+				}
+			};
+		}
+
+		{
+			main.onNext("value");
+			inboundStream.subscribe(inboundSubscriber);
+			inboundSubscriber.request(2);
+		}
+
+		@Actor
+		public void nextInbound() {
+			main.onNext("value2");
+		}
+
+		@Actor
+		public void cancelOutbound() {
+			outboundSubscriber.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(LLLLL_Result result) {
+			result.r1 = outboundSubscription.cancelled ? 1 : 0;
+			result.r2 = inboundSubscription.cancelled ? 1 : 0;
+
+			result.r3 =
+					inboundSubscriber.onCompleteCalls.get() + inboundSubscriber.onErrorCalls.get() * 2 + outboundSubscriber.droppedErrors.size() * 3;
+			result.r4 = inboundSubscriber.onNextCalls;
+			result.r5 = outboundSubscriber.onNextDiscarded;
+
+			if (inboundSubscriber.concurrentOnError.get()) {
+				throw new RuntimeException("Concurrent OnError");
+			}
+			if (inboundSubscriber.concurrentOnNext.get()) {
+				throw new RuntimeException("Concurrent OnNext");
+			}
+			if (inboundSubscriber.concurrentOnComplete.get()) {
+				throw new RuntimeException("Concurrent OnComplete");
+			}
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {
+			"1, 0, 1, 1, 0"}, expect = ACCEPTABLE, desc = "inbound complete happened before outbound cancel")
+	@Outcome(id = {
+			"1, 1, 2, 1, 0"}, expect = ACCEPTABLE, desc = "outbound cancel happened before inbound complete")
+	@State
+	public static class OutboundCancelAndInboundCompleteStressTest extends FluxSwitchOnFirstStressTest {
+
+		Flux<String> inboundStream;
+
+		@Override
+		Flux<String> switchOnFirst(Signal<? extends String> signal,
+				Flux<String> inbound) {
+			return new Flux<String>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super String> actual) {
+					inboundStream = inbound;
+					outboundSubscription.subscribe(actual);
+				}
+			};
+		}
+
+		{
+			main.onNext("value");
+			inboundStream.subscribe(inboundSubscriber);
+			inboundSubscriber.request(2);
+		}
+
+		@Actor
+		public void nextInbound() {
+			main.onComplete();
+		}
+
+		@Actor
+		public void cancelOutbound() {
+			outboundSubscriber.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(LLLLL_Result result) {
+			result.r1 = outboundSubscription.cancelled ? 1 : 0;
+			result.r2 = inboundSubscription.cancelled ? 1 : 0;
+
+			result.r3 =
+					inboundSubscriber.onCompleteCalls.get() + inboundSubscriber.onErrorCalls.get() * 2 + outboundSubscriber.droppedErrors.size() * 3;
+			result.r4 = inboundSubscriber.onNextCalls;
+			result.r5 = outboundSubscriber.onNextDiscarded;
+
+			if (inboundSubscriber.concurrentOnError.get()) {
+				throw new RuntimeException("Concurrent OnError");
+			}
+			if (inboundSubscriber.concurrentOnNext.get()) {
+				throw new RuntimeException("Concurrent OnNext");
+			}
+			if (inboundSubscriber.concurrentOnComplete.get()) {
+				throw new RuntimeException("Concurrent OnComplete");
+			}
+		}
+	}
+
+
+	@JCStressTest
+	@Outcome(id = {
+			"1, 0, 2, 1, 0"}, expect = ACCEPTABLE, desc = "inbound error happened before outbound cancel")
+	@Outcome(id = {
+			"1, 1, 5, 1, 0"}, expect = ACCEPTABLE, desc = "outbound cancel happened before inbound error")
+	@State
+	public static class OutboundCancelAndInboundErrorStressTest extends FluxSwitchOnFirstStressTest {
+
+		static final RuntimeException DUMMY_ERROR = new RuntimeException("dummy");
+
+		Flux<String> inboundStream;
+
+		@Override
+		Flux<String> switchOnFirst(Signal<? extends String> signal,
+				Flux<String> inbound) {
+			return new Flux<String>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super String> actual) {
+					inboundStream = inbound;
+					outboundSubscription.subscribe(actual);
+				}
+			};
+		}
+
+		{
+			main.onNext("value");
+			inboundStream.subscribe(inboundSubscriber);
+			inboundSubscriber.request(2);
+		}
+
+		@Actor
+		public void nextInbound() {
+			main.onError(DUMMY_ERROR);
+		}
+
+		@Actor
+		public void cancelOutbound() {
+			outboundSubscriber.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(LLLLL_Result result) {
+			result.r1 = outboundSubscription.cancelled ? 1 : 0;
+			result.r2 = inboundSubscription.cancelled ? 1 : 0;
+
+			result.r3 =
+					inboundSubscriber.onCompleteCalls.get() + inboundSubscriber.onErrorCalls.get() * 2 + outboundSubscriber.droppedErrors.size() * 3;
+			result.r4 = inboundSubscriber.onNextCalls;
+			result.r5 = outboundSubscriber.onNextDiscarded;
+
+			if (inboundSubscriber.concurrentOnError.get()) {
+				throw new RuntimeException("Concurrent OnError");
+			}
+			if (inboundSubscriber.concurrentOnNext.get()) {
+				throw new RuntimeException("Concurrent OnNext");
+			}
+			if (inboundSubscriber.concurrentOnComplete.get()) {
+				throw new RuntimeException("Concurrent OnComplete");
+			}
+		}
+	}
+
+	static class StressSubscription<T> implements Subscription {
+
+		CoreSubscriber<? super T> actual;
+
+		public volatile int subscribes;
+
+		@SuppressWarnings("rawtypes")
+		static final AtomicIntegerFieldUpdater<StressSubscription> SUBSCRIBES =
+				AtomicIntegerFieldUpdater.newUpdater(StressSubscription.class,
+						"subscribes");
+
+		public volatile long requested;
+
+		@SuppressWarnings("rawtypes")
+		static final AtomicLongFieldUpdater<StressSubscription> REQUESTED =
+				AtomicLongFieldUpdater.newUpdater(StressSubscription.class, "requested");
+
+		public volatile int requestsCount;
+
+		@SuppressWarnings("rawtypes")
+		static final AtomicIntegerFieldUpdater<StressSubscription> REQUESTS_COUNT =
+				AtomicIntegerFieldUpdater.newUpdater(StressSubscription.class,
+						"requestsCount");
+
+		public volatile boolean cancelled;
+
+		void subscribe(CoreSubscriber<? super T> actual) {
+			this.actual = actual;
+			actual.onSubscribe(this);
+			SUBSCRIBES.getAndIncrement(this);
+		}
+
+		@Override
+		public void request(long n) {
+			REQUESTS_COUNT.incrementAndGet(this);
+			Operators.addCap(REQUESTED, this, n);
+		}
+
+		@Override
+		public void cancel() {
+			cancelled = true;
+		}
+
+	}
+
+	@Result
+	public static final class LLLLLLLLL_Result implements Serializable {
+
+		@sun.misc.Contended
+		@jdk.internal.vm.annotation.Contended
+		public Object r1;
+
+		@sun.misc.Contended
+		@jdk.internal.vm.annotation.Contended
+		public Object r2;
+
+		@sun.misc.Contended
+		@jdk.internal.vm.annotation.Contended
+		public Object r3;
+
+		@sun.misc.Contended
+		@jdk.internal.vm.annotation.Contended
+		public Object r4;
+
+		@sun.misc.Contended
+		@jdk.internal.vm.annotation.Contended
+		public Object r5;
+
+		@sun.misc.Contended
+		@jdk.internal.vm.annotation.Contended
+		public Object r6;
+
+		@sun.misc.Contended
+		@jdk.internal.vm.annotation.Contended
+		public Object r7;
+
+		@sun.misc.Contended
+		@jdk.internal.vm.annotation.Contended
+		public Object r8;
+
+		@sun.misc.Contended
+		@jdk.internal.vm.annotation.Contended
+		public Object r9;
+
+		@sun.misc.Contended
+		@jdk.internal.vm.annotation.Contended
+		public int jcstress_trap; // reserved for infrastructure use
+
+		public int hashCode() {
+			return 0 + 0 << 1 + 0 << 2 + 0 << 3 + 0 << 4 + 0 << 5 + 0 << 6 + 0 << 7 + 0 << 8;
+		}
+
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+
+			LLLLLLLLL_Result that = (LLLLLLLLL_Result) o;
+			return true;
+		}
+
+		public String toString() {
+			return "" + r1 + ", " + r2 + ", " + r3 + ", " + r4 + ", " + r5 + ", " + r6 + ", " + r7 + ", " + r8 + ", " + r9;
+		}
+	}
+}

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/StressSubscriber.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/StressSubscriber.java
@@ -102,12 +102,12 @@ public class StressSubscriber<T> implements CoreSubscriber<T> {
 		if (!guard.compareAndSet(null, Operation.ON_SUBSCRIBE)) {
 			concurrentOnSubscribe.set(true);
 		} else {
-			if (Operators.setOnce(S, this, subscription)) {
-				if (initRequest > 0) {
-					subscription.request(initRequest);
-				}
-			}
+			final boolean wasSet = Operators.setOnce(S, this, subscription);
 			guard.compareAndSet(Operation.ON_SUBSCRIBE, null);
+
+			if (wasSet && initRequest > 0) {
+				subscription.request(initRequest);
+			}
 		}
 		onSubscribeCalls.incrementAndGet();
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
@@ -896,7 +896,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 
 		@Override
 		public final void cancel() {
-			REQUESTED.lazySet(this, STATE_CANCELLED);
+			Operators.DeferredSubscription.REQUESTED.lazySet(this, STATE_CANCELLED);
 
 			final long previousState = markOutboundCancelled(this.parent);
 			if (hasOutboundCancelled(previousState) || hasOutboundTerminated(previousState)) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
@@ -253,7 +253,12 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 	}
 	/**
 	 * Adds flags which indicate that the inbound has cancelled upstream and errored
-	 * the outbound downstream. Fails if either inbound is cancelled or terminated.
+	 * the outbound downstream. Fails if either inbound is cancelled or outbound is
+	 * cancelled.
+	 *
+	 * Note, this is a rare case needed to add cancellation for inbound and
+	 * termination for outbound and can only be occurred during the onNext calling
+	 * transformation function which then throws unexpected error.
 	 *
 	 * @return previous observed state
 	 */

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
@@ -409,17 +409,9 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 		@Override
 		@Nullable
 		public final Object scanUnsafe(Attr key) {
-			final boolean isCancelled = this.inboundSubscriber == Operators.EMPTY_SUBSCRIBER;
-
-			if (key == Attr.CANCELLED) {
-				return isCancelled && !this.done;
-			}
-			if (key == Attr.TERMINATED) {
-				return this.done || isCancelled;
-			}
-			if (key == Attr.RUN_STYLE) {
-				return Attr.RunStyle.SYNC;
-			}
+			if (key == Attr.CANCELLED) return hasInboundCancelled(this.state);
+			if (key == Attr.TERMINATED) return hasInboundTerminated(this.state);
+			if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
 
 			return InnerOperator.super.scanUnsafe(key);
 		}
@@ -921,15 +913,11 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 
 		@Override
 		public final Object scanUnsafe(Attr key) {
-			if (key == Attr.PARENT) {
-				return parent;
-			}
-			if (key == Attr.ACTUAL) {
-				return delegate;
-			}
-			if (key == Attr.RUN_STYLE) {
-				return Attr.RunStyle.SYNC;
-			}
+			if (key == Attr.PARENT) return parent;
+			if (key == Attr.ACTUAL) return delegate;
+			if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+			if (key == Attr.CANCELLED) return hasOutboundCancelled(this.parent.state);
+			if (key == Attr.TERMINATED) return hasOutboundTerminated(this.parent.state);
 
 			return null;
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
@@ -618,14 +618,14 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 				if (!this.isInboundRequestedOnce) {
 					this.isInboundRequestedOnce = true;
 
-					final T first = this.firstValue;
-					if (first != null) {
-						this.firstValue = null;
-
+					if (this.isFirstOnNextReceivedOnce) {
 						final long previousState = markInboundRequestedOnce(this);
 						if (hasInboundCancelled(previousState)) {
 							return;
 						}
+
+						final T first = this.firstValue;
+						this.firstValue = null;
 
 						final boolean wasDelivered = sendFirst(first);
 						if (wasDelivered) {
@@ -753,8 +753,9 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 				return false;
 			}
 
-			final T f = this.firstValue;
-			if (f == null) {
+
+			if (!this.isFirstOnNextReceivedOnce) {
+				this.isFirstOnNextReceivedOnce = true;
 				this.firstValue = t;
 
 				long previousState = markFirstValueReceived(this);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
@@ -499,7 +499,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 					result = Objects.requireNonNull(this.transformer.apply(signal, this), "The transformer returned a null value");
 				}
 				catch (Throwable e) {
-					o.onError(Exceptions.addSuppressed(e, t));
+					o.onError(Exceptions.addSuppressed(t, e));
 					return;
 				}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
@@ -251,6 +251,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 			}
 		}
 	}
+
 	/**
 	 * Adds flags which indicate that the inbound has cancelled upstream and errored
 	 * the outbound downstream. Fails if either inbound is cancelled or outbound is

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
@@ -19,610 +19,1037 @@ package reactor.core.publisher;
 import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.BiFunction;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.util.annotation.Nullable;
 
 /**
- * @author Oleh Dokuka
  * @param <T>
  * @param <R>
+ * @author Oleh Dokuka
  */
 final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 
-
-    final BiFunction<Signal<? extends T>, Flux<T>, Publisher<? extends R>> transformer;
-    final boolean cancelSourceOnComplete;
-
-    FluxSwitchOnFirst(
-            Flux<? extends T> source,
-            BiFunction<Signal<? extends T>, Flux<T>, Publisher<? extends R>> transformer,
-            boolean cancelSourceOnComplete) {
-        super(source);
-        this.transformer = Objects.requireNonNull(transformer, "transformer");
-        this.cancelSourceOnComplete = cancelSourceOnComplete;
-    }
-
-    @Override
-    public int getPrefetch() {
-        return 1;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
-        if (actual instanceof Fuseable.ConditionalSubscriber) {
-            return new SwitchOnFirstConditionalMain<>((Fuseable.ConditionalSubscriber<? super R>) actual, transformer, cancelSourceOnComplete);
-        }
-        return new SwitchOnFirstMain<>(actual, transformer, cancelSourceOnComplete);
-    }
-
-    @Override
-    public Object scanUnsafe(Attr key) {
-        if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
-        return super.scanUnsafe(key);
-    }
-
-    static abstract class AbstractSwitchOnFirstMain<T, R> extends Flux<T>
-            implements InnerOperator<T, R> {
-
-        final ControlSubscriber<? super R>                                     outer;
-        final BiFunction<Signal<? extends T>, Flux<T>, Publisher<? extends R>> transformer;
-
-        Subscription s;
-        Throwable    throwable;
-        T            first;
-        boolean      requestedOnce;
-        boolean      done;
-
-        volatile CoreSubscriber<? super T> inner;
-        @SuppressWarnings("rawtypes")
-        static final AtomicReferenceFieldUpdater<AbstractSwitchOnFirstMain, CoreSubscriber> INNER =
-                AtomicReferenceFieldUpdater.newUpdater(AbstractSwitchOnFirstMain.class, CoreSubscriber.class, "inner");
-
-        volatile int wip;
-        @SuppressWarnings("rawtypes")
-        static final AtomicIntegerFieldUpdater<AbstractSwitchOnFirstMain> WIP =
-                AtomicIntegerFieldUpdater.newUpdater(AbstractSwitchOnFirstMain.class, "wip");
-
-        @SuppressWarnings("unchecked")
-        AbstractSwitchOnFirstMain(
-                CoreSubscriber<? super R> outer,
-                BiFunction<Signal<? extends T>, Flux<T>, Publisher<? extends R>> transformer,
-                boolean cancelSourceOnComplete) {
-            this.outer = outer instanceof Fuseable.ConditionalSubscriber
-                ? new SwitchOnFirstConditionalControlSubscriber<>(this, (Fuseable.ConditionalSubscriber<R>) outer, cancelSourceOnComplete)
-                : new SwitchOnFirstControlSubscriber<>(this, outer, cancelSourceOnComplete);
-            this.transformer = transformer;
-        }
-
-        @Override
-        @Nullable
-        public Object scanUnsafe(Attr key) {
-            final boolean isCancelled = this.inner == Operators.EMPTY_SUBSCRIBER;
-
-            if (key == Attr.CANCELLED) return isCancelled && !this.done;
-            if (key == Attr.TERMINATED) return this.done || isCancelled;
-            if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
-
-            return InnerOperator.super.scanUnsafe(key);
-        }
-
-        @Override
-        public CoreSubscriber<? super R> actual() {
-            return this.outer;
-        }
-
-        @Override
-        public void onSubscribe(Subscription s) {
-            if (Operators.validate(this.s, s)) {
-                this.s = s;
-                this.outer.sendSubscription();
-                if (this.inner != Operators.EMPTY_SUBSCRIBER) {
-                    s.request(1);
-                }
-            }
-        }
-
-        @Override
-        public void onNext(T t) {
-            final CoreSubscriber<? super T> i = this.inner;
-            if (this.done || i == Operators.EMPTY_SUBSCRIBER) {
-                Operators.onNextDropped(t, currentContext());
-                return;
-            }
-
-            if (i == null) {
-                final Publisher<? extends R> result;
-                final CoreSubscriber<? super R> o = this.outer;
-
-                try {
-                    result = Objects.requireNonNull(
-                        this.transformer.apply(Signal.next(t, o.currentContext()), this),
-                        "The transformer returned a null value"
-                    );
-                }
-                catch (Throwable e) {
-                    this.done = true;
-                    Operators.error(o, Operators.onOperatorError(this.s, e, t, o.currentContext()));
-                    return;
-                }
-
-                this.first = t;
-                result.subscribe(o);
-                return;
-            }
-
-            i.onNext(t);
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            // read of the first should occur before the read of inner since otherwise
-            // first may be nulled while the previous read has shown that inner is still
-            // null hence double invocation of transformer occurs
-            final T f = this.first;
-            final CoreSubscriber<? super T> i = this.inner;
-            if (this.done || i == Operators.EMPTY_SUBSCRIBER) {
-                Operators.onErrorDropped(t, currentContext());
-                return;
-            }
-
-            this.throwable = t;
-            this.done = true;
-
-            if (f == null && i == null) {
-                final Publisher<? extends R> result;
-                final CoreSubscriber<? super R> o = this.outer;
-                try {
-                    result = Objects.requireNonNull(
-                        this.transformer.apply(Signal.error(t, o.currentContext()), this),
-                        "The transformer returned a null value"
-                    );
-                }
-                catch (Throwable e) {
-                    this.done = true;
-                    Operators.error(o, Operators.onOperatorError(this.s, e, t, o.currentContext()));
-                    return;
-                }
-
-                result.subscribe(o);
-                return;
-            }
-
-            drain();
-        }
-
-        @Override
-        public void onComplete() {
-            // read of the first should occur before the read of inner since otherwise
-            // first may be nulled while the previous read has shown that inner is still
-            // null hence double invocation of transformer occurs
-            final T f = this.first;
-            final CoreSubscriber<? super T> i = this.inner;
-            if (this.done || i == Operators.EMPTY_SUBSCRIBER) {
-                return;
-            }
-
-            this.done = true;
-
-            if (f == null && i == null) {
-                final Publisher<? extends R> result;
-                final CoreSubscriber<? super R> o = outer;
-
-                try {
-                    result = Objects.requireNonNull(
-                            this.transformer.apply(Signal.complete(o.currentContext()), this),
-                        "The transformer returned a null value"
-                    );
-                }
-                catch (Throwable e) {
-                    this.done = true;
-                    Operators.error(o, Operators.onOperatorError(this.s, e, null, o.currentContext()));
-                    return;
-                }
-
-                result.subscribe(o);
-                return;
-            }
-
-            drain();
-        }
-
-        @Override
-        public void cancel() {
-            if (INNER.getAndSet(this, Operators.EMPTY_SUBSCRIBER) == Operators.EMPTY_SUBSCRIBER) {
-                return;
-            }
-
-            this.s.cancel();
-
-            if (WIP.getAndIncrement(this) == 0) {
-                final T f = this.first;
-                if (f != null) {
-                    this.first = null;
-                    Operators.onDiscard(f, currentContext());
-                }
-            }
-        }
-
-        @Override
-        public void request(long n) {
-            if (Operators.validate(n)) {
-                if (this.first != null) {
-                    this.requestedOnce = true;
-                    if (drain() && n != Long.MAX_VALUE) {
-                        if (--n > 0) {
-                            this.s.request(n);
-                            return;
-                        }
-
-                        return;
-                    }
-                }
-
-                this.s.request(n);
-            }
-        }
-
-        @SuppressWarnings("unchecked")
-        boolean drain() {
-            if (WIP.getAndIncrement(this) != 0) {
-                return false;
-            }
-
-            T f = this.first;
-            int m = 1;
-            boolean sent = false;
-            CoreSubscriber<? super T> a;
-
-            for (;;) {
-                a = this.inner;
-
-                // check for the case where upstream terminates before downstream has subscribed at all
-                if (a != null) {
-                    if (f != null && this.requestedOnce) {
-                        this.first = null;
-
-                        if (a == Operators.EMPTY_SUBSCRIBER) {
-                            Operators.onDiscard(f, currentContext());
-                            return false;
-                        }
-
-                        sent = tryOnNext(a, f);
-                        f = null;
-                        // check if not cancelled if it has just been sent (next + cancel case)
-                        a = this.inner;
-                    }
-
-                    if (a == Operators.EMPTY_SUBSCRIBER) {
-                        return false;
-                    }
-
-                    if (this.done && f == null) {
-                        Throwable t = this.throwable;
-                        if (t != null) {
-                            a.onError(t);
-                        } else {
-                            a.onComplete();
-                        }
-                        INNER.lazySet(this, Operators.EMPTY_SUBSCRIBER);
-                        return sent;
-                    }
-                }
-
-                m = WIP.addAndGet(this, -m);
-                if (m == 0) {
-                    return sent;
-                }
-            }
-        }
-
-        abstract boolean tryOnNext(CoreSubscriber<? super T> actual, T value);
-
-    }
-
-    static final class SwitchOnFirstMain<T, R> extends AbstractSwitchOnFirstMain<T, R> {
-
-        SwitchOnFirstMain(
-                CoreSubscriber<? super R> outer,
-                BiFunction<Signal<? extends T>, Flux<T>, Publisher<? extends R>> transformer,
-                boolean cancelSourceOnComplete) {
-            super(outer, transformer, cancelSourceOnComplete);
-        }
-
-        @Override
-        public void subscribe(CoreSubscriber<? super T> actual) {
-            if (this.inner == null && INNER.compareAndSet(this, null, actual)) {
-                if (this.first == null && this.done) {
-                    final Throwable t = this.throwable;
-                    if (t != null) {
-                        Operators.error(actual, t);
-                    }
-                    else {
-                        Operators.complete(actual);
-                    }
-                    return;
-                }
-                actual.onSubscribe(this);
-            }
-            else if (this.inner != Operators.EMPTY_SUBSCRIBER) {
-                Operators.error(actual, new IllegalStateException("FluxSwitchOnFirst allows only one Subscriber"));
-            } else {
-                Operators.error(actual, new CancellationException("FluxSwitchOnFirst has already been cancelled"));
-            }
-        }
-
-        @Override
-        boolean tryOnNext(CoreSubscriber<? super T> actual, T t) {
-            actual.onNext(t);
-            return true;
-        }
-    }
-
-    static final class SwitchOnFirstConditionalMain<T, R> extends AbstractSwitchOnFirstMain<T, R>
-            implements Fuseable.ConditionalSubscriber<T> {
-
-        SwitchOnFirstConditionalMain(
-                Fuseable.ConditionalSubscriber<? super R> outer,
-                BiFunction<Signal<? extends T>, Flux<T>, Publisher<? extends R>> transformer,
-                boolean cancelSourceOnComplete) {
-            super(outer, transformer, cancelSourceOnComplete);
-        }
-
-        @Override
-        public void subscribe(CoreSubscriber<? super T> actual) {
-            if (this.inner == null && INNER.compareAndSet(this, null, Operators.toConditionalSubscriber(actual))) {
-                if (this.first == null && this.done) {
-                    final Throwable t = this.throwable;
-                    if (t != null) {
-                        Operators.error(actual, t);
-                    }
-                    else {
-                        Operators.complete(actual);
-                    }
-                    return;
-                }
-                actual.onSubscribe(this);
-            }
-            else if (this.inner != Operators.EMPTY_SUBSCRIBER) {
-                Operators.error(actual, new IllegalStateException("FluxSwitchOnFirst allows only one Subscriber"));
-            } else {
-                Operators.error(actual, new CancellationException("FluxSwitchOnFirst has already been cancelled"));
-            }
-        }
-
-        @Override
-        public boolean tryOnNext(T t) {
-            @SuppressWarnings("unchecked")
-            final Fuseable.ConditionalSubscriber<? super T> i =
-                    (Fuseable.ConditionalSubscriber<? super T>) this.inner;
-            if (this.done || i == Operators.EMPTY_SUBSCRIBER) {
-                Operators.onNextDropped(t, currentContext());
-                return false;
-            }
-
-            if (i == null) {
-                final Publisher<? extends R> result;
-                final CoreSubscriber<? super R> o = this.outer;
-
-                try {
-                    result = Objects.requireNonNull(
-                        this.transformer.apply(Signal.next(t, o.currentContext()), this),
-                        "The transformer returned a null value"
-                    );
-                }
-                catch (Throwable e) {
-                    this.done = true;
-                    Operators.error(o, Operators.onOperatorError(this.s, e, t, o.currentContext()));
-                    return false;
-                }
-
-                this.first = t;
-                result.subscribe(o);
-                return true;
-            }
-
-            return i.tryOnNext(t);
-        }
-
-        @Override
-        @SuppressWarnings("unchecked")
-        boolean tryOnNext(CoreSubscriber<? super T> actual, T t) {
-            return ((Fuseable.ConditionalSubscriber<? super T>) actual).tryOnNext(t);
-        }
-    }
-
-    static final class SwitchOnFirstControlSubscriber<T> extends Operators.DeferredSubscription implements InnerOperator<T,
-            T>, ControlSubscriber<T> {
-
-        final AbstractSwitchOnFirstMain<?, T> parent;
-        final CoreSubscriber<? super T> delegate;
-        final boolean cancelSourceOnComplete;
-
-        SwitchOnFirstControlSubscriber(
-                AbstractSwitchOnFirstMain<?, T> parent,
-                CoreSubscriber<? super T> delegate,
-                boolean cancelSourceOnComplete) {
-            this.parent = parent;
-            this.delegate = delegate;
-            this.cancelSourceOnComplete = cancelSourceOnComplete;
-        }
-
-        @Override
-        public void sendSubscription() {
-            delegate.onSubscribe(this);
-        }
-
-        @Override
-        public void onSubscribe(Subscription s) {
-            set(s);
-        }
-
-        @Override
-        public CoreSubscriber<? super T> actual() {
-            return this.delegate;
-        }
-
-        @Override
-        public void onNext(T t) {
-            this.delegate.onNext(t);
-        }
-
-        @Override
-        public void onError(Throwable throwable) {
-            if (this.requested == STATE_CANCELLED) {
-                Operators.onErrorDropped(throwable, currentContext());
-                return;
-            }
-
-            final AbstractSwitchOnFirstMain<?, T> parent = this.parent;
-            if (!parent.done) {
-                parent.cancel();
-            }
-
-            this.delegate.onError(throwable);
-        }
-
-        @Override
-        public void onComplete() {
-            if (this.requested == STATE_CANCELLED) {
-                return;
-            }
-
-            final AbstractSwitchOnFirstMain<?, T> parent = this.parent;
-            if (!parent.done && cancelSourceOnComplete) {
-                parent.cancel();
-            }
-
-            this.delegate.onComplete();
-        }
-
-        @Override
-        public void cancel() {
-            final long state = REQUESTED.getAndSet(this, STATE_CANCELLED);
-            if (state == STATE_CANCELLED) {
-                return;
-            }
-
-            if (state == STATE_SUBSCRIBED) {
-                this.s.cancel();
-            }
-
-            this.parent.cancel();
-        }
-
-        @Override
-        public Object scanUnsafe(Attr key) {
-            if (key == Attr.PARENT) return parent;
-            if (key == Attr.ACTUAL) return delegate;
-            if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
-
-            return null;
-        }
-    }
-
-    static final class SwitchOnFirstConditionalControlSubscriber<T> extends Operators.DeferredSubscription implements InnerOperator<T, T>, ControlSubscriber<T>,
-                                                                             Fuseable.ConditionalSubscriber<T> {
-
-        final AbstractSwitchOnFirstMain<?, T> parent;
-        final Fuseable.ConditionalSubscriber<? super T> delegate;
-        final boolean terminateUpstreamOnComplete;
-
-        SwitchOnFirstConditionalControlSubscriber(
-                AbstractSwitchOnFirstMain<?, T> parent,
-                Fuseable.ConditionalSubscriber<? super T> delegate,
-                boolean terminateUpstreamOnComplete) {
-            this.parent = parent;
-            this.delegate = delegate;
-            this.terminateUpstreamOnComplete = terminateUpstreamOnComplete;
-        }
-
-        @Override
-        public void sendSubscription() {
-            delegate.onSubscribe(this);
-        }
-
-        @Override
-        public void onSubscribe(Subscription s) {
-            set(s);
-        }
-
-        @Override
-        public CoreSubscriber<? super T> actual() {
-            return this.delegate;
-        }
-
-        @Override
-        public void onNext(T t) {
-            this.delegate.onNext(t);
-        }
-
-        @Override
-        public boolean tryOnNext(T t) {
-            return this.delegate.tryOnNext(t);
-        }
-
-        @Override
-        public void onError(Throwable throwable) {
-            if (this.requested == STATE_CANCELLED) {
-                Operators.onErrorDropped(throwable, currentContext());
-                return;
-            }
-
-            final AbstractSwitchOnFirstMain<?, T> parent = this.parent;
-            if (!parent.done) {
-                parent.cancel();
-            }
-
-            this.delegate.onError(throwable);
-        }
-
-        @Override
-        public void onComplete() {
-            if (this.requested == STATE_CANCELLED) {
-                return;
-            }
-
-            final AbstractSwitchOnFirstMain<?, T> parent = this.parent;
-            if (!parent.done && terminateUpstreamOnComplete) {
-                parent.cancel();
-            }
-
-            this.delegate.onComplete();
-        }
-
-        @Override
-        public void cancel() {
-            final long state = REQUESTED.getAndSet(this, STATE_CANCELLED);
-            if (state == STATE_CANCELLED) {
-                return;
-            }
-
-            if (state == STATE_SUBSCRIBED) { // mean subscription happened so we can just cancel upstream only
-                this.s.cancel();
-            }
-
-            this.parent.cancel();
-        }
-
-        @Override
-        public Object scanUnsafe(Attr key) {
-            if (key == Attr.PARENT) return parent;
-            if (key == Attr.ACTUAL) return delegate;
-            if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
-
-            return null;
-        }
-    }
-
-    interface ControlSubscriber<T> extends CoreSubscriber<T> {
-
-        void sendSubscription();
-    }
+	final BiFunction<Signal<? extends T>, Flux<T>, Publisher<? extends R>> transformer;
+	final boolean cancelSourceOnComplete;
+
+	FluxSwitchOnFirst(Flux<? extends T> source,
+			BiFunction<Signal<? extends T>, Flux<T>, Publisher<? extends R>> transformer,
+			boolean cancelSourceOnComplete) {
+		super(source);
+		this.transformer = Objects.requireNonNull(transformer, "transformer");
+		this.cancelSourceOnComplete = cancelSourceOnComplete;
+	}
+
+	@Override
+	public int getPrefetch() {
+		return 1;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
+		if (actual instanceof Fuseable.ConditionalSubscriber) {
+			return new SwitchOnFirstConditionalMain<>((Fuseable.ConditionalSubscriber<? super R>) actual,
+					transformer,
+					cancelSourceOnComplete);
+		}
+		return new SwitchOnFirstMain<>(actual, transformer, cancelSourceOnComplete);
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_STYLE) {
+			return Attr.RunStyle.SYNC;
+		}
+		return super.scanUnsafe(key);
+	}
+
+	static final int HAS_FIRST_VALUE_RECEIVED_FLAG    =
+			0b0000_0000_0000_0000_0000_0000_0000_0001;
+	static final int HAS_INBOUND_SUBSCRIBED_ONCE_FLAG =
+			0b0000_0000_0000_0000_0000_0000_0000_0010;
+	static final int HAS_INBOUND_SUBSCRIBER_SET_FLAG =
+			0b0000_0000_0000_0000_0000_0000_0000_0100;
+	static final int HAS_INBOUND_REQUESTED_ONCE_FLAG  =
+			0b0000_0000_0000_0000_0000_0000_0000_1000;
+	static final int HAS_FIRST_VALUE_SENT_FLAG        =
+			0b0000_0000_0000_0000_0000_0000_0001_0000;
+	static final int HAS_INBOUND_CANCELLED_FLAG       =
+			0b0000_0000_0000_0000_0000_0000_0010_0000;
+	static final int HAS_INBOUND_TERMINATED_FLAG      =
+			0b0000_0000_0000_0000_0000_0000_0100_0000;
+
+	static final int HAS_OUTBOUND_SUBSCRIBED_FLAG =
+			0b0000_0000_0000_0000_0000_0000_1000_0000;
+	static final int HAS_OUTBOUND_CANCELLED_FLAG  =
+			0b0000_0000_0000_0000_0000_0001_0000_0000;
+	static final int HAS_OUTBOUND_TERMINATED_FLAG =
+			0b0000_0000_0000_0000_0000_0010_0000_0000;
+
+	/**
+	 * Adds a flag which indicate that the first inbound onNext signal has already been
+	 * received. Fails if inbound is cancelled
+	 *
+	 * @return previous observed state
+	 */
+	static <T, R> long markFirstValueReceived(AbstractSwitchOnFirstMain<T, R> instance) {
+		for (;;) {
+			final int state = instance.state;
+
+			if (hasInboundCancelled(state)) {
+				return state;
+			}
+
+			if (AbstractSwitchOnFirstMain.STATE.compareAndSet(instance, state, state | HAS_FIRST_VALUE_RECEIVED_FLAG)) {
+				return state;
+			}
+		}
+	}
+
+	/**
+	 * Adds a flag which indicate that the inbound has already been
+	 * subscribed once. Fails if inbound has already been subscribed once
+	 *
+	 * @return previous observed state
+	 */
+	static <T, R> long markInboundSubscribedOnce(AbstractSwitchOnFirstMain<T, R> instance) {
+		for (;;) {
+			final int state = instance.state;
+
+			if (hasInboundSubscribedOnce(state)) {
+				return state;
+			}
+
+			if (AbstractSwitchOnFirstMain.STATE.compareAndSet(instance, state, state | HAS_INBOUND_SUBSCRIBED_ONCE_FLAG)) {
+				return state;
+			}
+		}
+	}
+
+	/**
+	 * Adds a flag which indicate that the inbound has already been
+	 * subscriber was set. Fails if inbound is cancelled
+	 *
+	 * @return previous observed state
+	 */
+	static <T, R> long markInboundSubscriberSet(AbstractSwitchOnFirstMain<T, R> instance) {
+		for (;;) {
+			final int state = instance.state;
+
+			if (hasInboundCancelled(state)) {
+				return state;
+			}
+
+			if (AbstractSwitchOnFirstMain.STATE.compareAndSet(instance, state, state | HAS_INBOUND_SUBSCRIBER_SET_FLAG)) {
+				return state;
+			}
+		}
+	}
+
+	/**
+	 * Adds a flag which indicate that the inbound has already been
+	 * requested once. Fails if inbound is cancelled
+	 *
+	 * @return previous observed state
+	 */
+	static <T, R> long markInboundRequestedOnce(AbstractSwitchOnFirstMain<T, R> instance) {
+		for (;;) {
+			final int state = instance.state;
+
+			if (hasInboundCancelled(state)) {
+				return state;
+			}
+
+			if (AbstractSwitchOnFirstMain.STATE.compareAndSet(instance, state, state | HAS_INBOUND_REQUESTED_ONCE_FLAG)) {
+				return state;
+			}
+		}
+	}
+
+	/**
+	 * Adds a flag which indicate that the first onNext value has been successfully
+	 * delivered. Fails if inbound is cancelled
+	 *
+	 * @return previous observed state
+	 */
+	static <T, R> long markFirstValueSent(AbstractSwitchOnFirstMain<T, R> instance) {
+		for (;;) {
+			final int state = instance.state;
+
+			if (hasInboundCancelled(state)) {
+				return state;
+			}
+
+			if (AbstractSwitchOnFirstMain.STATE.compareAndSet(instance, state, state | HAS_FIRST_VALUE_SENT_FLAG)) {
+				return state;
+			}
+		}
+	}
+
+	/**
+	 * Adds a flag which indicate that the inbound has already been
+	 * terminated with onComplete or onError. Fails if inbound is cancelled
+	 *
+	 * @return previous observed state
+	 */
+	static <T, R> long markInboundTerminated(AbstractSwitchOnFirstMain<T, R> instance) {
+		for (;;) {
+			final int state = instance.state;
+
+			if (hasInboundCancelled(state)) {
+				return state;
+			}
+
+			if (AbstractSwitchOnFirstMain.STATE.compareAndSet(instance, state, state | HAS_INBOUND_TERMINATED_FLAG)) {
+				return state;
+			}
+		}
+	}
+
+	/**
+	 * Adds a flag which indicate that the inbound has already been
+	 * requested once. Fails if inbound is cancelled or terminated
+	 *
+	 * @return previous observed state
+	 */
+	static <T, R> long markInboundCancelled(AbstractSwitchOnFirstMain<T, R> instance) {
+		for (;;) {
+			final int state = instance.state;
+
+			if (hasInboundTerminated(state) || hasInboundCancelled(state)) {
+				return state;
+			}
+
+			if (AbstractSwitchOnFirstMain.STATE.compareAndSet(instance, state, state | HAS_INBOUND_CANCELLED_FLAG)) {
+				return state;
+			}
+		}
+	}
+
+	static <T, R> long markInboundCancelledAndErrored(AbstractSwitchOnFirstMain<T, R> instance) {
+		for (;;) {
+			final int state = instance.state;
+
+			if (hasInboundTerminated(state) || hasInboundCancelled(state)) {
+				return state;
+			}
+
+			if (AbstractSwitchOnFirstMain.STATE.compareAndSet(instance, state, state | HAS_INBOUND_CANCELLED_FLAG | HAS_INBOUND_TERMINATED_FLAG)) {
+				return state;
+			}
+		}
+	}
+
+	/**
+	 * Adds a flag which indicate that the outbound has already been
+	 * terminated with onComplete or onError. Fails if inbound is cancelled or terminated
+	 *
+	 * @return previous observed state
+	 */
+	static <T, R> long markOutboundSubscribed(AbstractSwitchOnFirstMain<T, R> instance) {
+		for (;;) {
+			final int state = instance.state;
+
+			if (hasOutboundCancelled(state)) {
+				return state;
+			}
+
+			if (AbstractSwitchOnFirstMain.STATE.compareAndSet(instance, state, state | HAS_OUTBOUND_SUBSCRIBED_FLAG)) {
+				return state;
+			}
+		}
+	}
+
+
+	/**
+	 * Adds a flag which indicate that the outbound has already been
+	 * terminated with onComplete or onError. Fails if inbound is cancelled or terminated
+	 *
+	 * @return previous observed state
+	 */
+	static <T, R> long markOutboundTerminated(AbstractSwitchOnFirstMain<T, R> instance) {
+		for (;;) {
+			final int state = instance.state;
+
+			if (hasOutboundCancelled(state)) {
+				return state;
+			}
+
+			if (AbstractSwitchOnFirstMain.STATE.compareAndSet(instance, state, state | HAS_OUTBOUND_TERMINATED_FLAG)) {
+				return state;
+			}
+		}
+	}
+
+	/**
+	 * Adds a flag which indicate that the outbound has already been
+	 * cancelled. Fails if inbound is cancelled or terminated
+	 *
+	 * @return previous observed state
+	 */
+	static <T, R> long markOutboundCancelled(AbstractSwitchOnFirstMain<T, R> instance) {
+		for (;;) {
+			final int state = instance.state;
+
+			if (hasOutboundTerminated(state) || hasOutboundCancelled(state)) {
+				return state;
+			}
+
+			if (AbstractSwitchOnFirstMain.STATE.compareAndSet(instance, state, state | HAS_OUTBOUND_CANCELLED_FLAG)) {
+				return state;
+			}
+		}
+	}
+
+	static boolean hasInboundCancelled(long state) {
+		return (state & HAS_INBOUND_CANCELLED_FLAG) == HAS_INBOUND_CANCELLED_FLAG;
+	}
+
+
+	static boolean hasInboundTerminated(long state) {
+		return (state & HAS_INBOUND_TERMINATED_FLAG) == HAS_INBOUND_TERMINATED_FLAG;
+	}
+
+	static boolean hasFirstValueReceived(long state) {
+		return (state & HAS_FIRST_VALUE_RECEIVED_FLAG) == HAS_FIRST_VALUE_RECEIVED_FLAG;
+	}
+
+	static boolean hasFirstValueSent(long state) {
+		return (state & HAS_FIRST_VALUE_SENT_FLAG) == HAS_FIRST_VALUE_SENT_FLAG;
+	}
+
+	static boolean hasInboundSubscribedOnce(long state) {
+		return (state & HAS_INBOUND_SUBSCRIBED_ONCE_FLAG) == HAS_INBOUND_SUBSCRIBED_ONCE_FLAG;
+	}
+
+	static boolean hasInboundSubscriberSet(long state) {
+		return (state & HAS_INBOUND_SUBSCRIBER_SET_FLAG) == HAS_INBOUND_SUBSCRIBER_SET_FLAG;
+	}
+
+	static boolean hasInboundRequestedOnce(long state) {
+		return (state & HAS_INBOUND_REQUESTED_ONCE_FLAG) == HAS_INBOUND_REQUESTED_ONCE_FLAG;
+	}
+
+	static boolean hasOutboundSubscribed(long state) {
+		return (state & HAS_OUTBOUND_SUBSCRIBED_FLAG) == HAS_OUTBOUND_SUBSCRIBED_FLAG;
+	}
+
+	static boolean hasOutboundCancelled(long state) {
+		return (state & HAS_OUTBOUND_CANCELLED_FLAG) == HAS_OUTBOUND_CANCELLED_FLAG;
+	}
+
+	static boolean hasOutboundTerminated(long state) {
+		return (state & HAS_OUTBOUND_TERMINATED_FLAG) == HAS_OUTBOUND_TERMINATED_FLAG;
+	}
+
+	static abstract class AbstractSwitchOnFirstMain<T, R> extends Flux<T>
+			implements InnerOperator<T, R> {
+
+		final ControlSubscriber<? super R>                                     outer;
+		final BiFunction<Signal<? extends T>, Flux<T>, Publisher<? extends R>>
+		                                                                       transformer;
+
+		Subscription s;
+
+		boolean isInboundRequestedOnce;
+		T       firstValue;
+
+		Throwable throwable;
+		boolean   done;
+
+		CoreSubscriber<? super T> inner;
+
+		volatile     int                                                  state;
+		@SuppressWarnings("rawtypes")
+		static final AtomicIntegerFieldUpdater<AbstractSwitchOnFirstMain> STATE =
+				AtomicIntegerFieldUpdater.newUpdater(AbstractSwitchOnFirstMain.class, "state");
+
+		@SuppressWarnings("unchecked")
+		AbstractSwitchOnFirstMain(CoreSubscriber<? super R> outer,
+				BiFunction<Signal<? extends T>, Flux<T>, Publisher<? extends R>> transformer,
+				boolean cancelSourceOnComplete) {
+			this.outer = outer instanceof Fuseable.ConditionalSubscriber ?
+					new SwitchOnFirstConditionalControlSubscriber<>(this,
+							(Fuseable.ConditionalSubscriber<R>) outer,
+							cancelSourceOnComplete) :
+					new SwitchOnFirstControlSubscriber<>(this,
+							outer,
+							cancelSourceOnComplete);
+			this.transformer = transformer;
+		}
+
+		@Override
+		@Nullable
+		public Object scanUnsafe(Attr key) {
+			final boolean isCancelled = this.inner == Operators.EMPTY_SUBSCRIBER;
+
+			if (key == Attr.CANCELLED) {
+				return isCancelled && !this.done;
+			}
+			if (key == Attr.TERMINATED) {
+				return this.done || isCancelled;
+			}
+			if (key == Attr.RUN_STYLE) {
+				return Attr.RunStyle.SYNC;
+			}
+
+			return InnerOperator.super.scanUnsafe(key);
+		}
+
+		@Override
+		public final CoreSubscriber<? super R> actual() {
+			return this.outer;
+		}
+
+		@Override
+		public final void onSubscribe(Subscription s) {
+			if (Operators.validate(this.s, s)) {
+				this.s = s;
+				this.outer.sendSubscription();
+				if (!hasInboundCancelled(this.state)) {
+					s.request(1);
+				}
+			}
+		}
+
+		@Override
+		public final void onNext(T t) {
+			if (this.done) {
+				Operators.onNextDropped(t, currentContext());
+				return;
+			}
+
+			final T f = this.firstValue;
+			if (f == null) {
+				this.firstValue = t;
+
+				final long previousState = markFirstValueReceived(this);
+				if (hasInboundCancelled(previousState)) {
+					Operators.onDiscard(t, this.outer.currentContext());
+					return;
+				}
+
+				final Publisher<? extends R> result;
+				final CoreSubscriber<? super R> o = this.outer;
+
+				try {
+					result = Objects.requireNonNull(
+						this.transformer.apply(Signal.next(t, o.currentContext()), this),
+						"The transformer returned a null value"
+					);
+				}
+				catch (Throwable e) {
+					this.done = true;
+					o.onError(Operators.onOperatorError(this.s, e, t, o.currentContext()));
+					return;
+				}
+
+				result.subscribe(o);
+				return;
+			}
+
+			synchronized (this) {
+				this.inner.onNext(t);
+			}
+		}
+
+		@Override
+		public final void onError(Throwable t) {
+			if (this.done) {
+				Operators.onErrorDropped(t, this.outer.currentContext());
+				return;
+			}
+
+			this.done = true;
+			this.throwable = t;
+
+			final long previousState = markInboundTerminated(this);
+			if (hasInboundCancelled(previousState) || hasInboundTerminated(previousState)) {
+				Operators.onErrorDropped(t, this.outer.currentContext());
+				return;
+			}
+
+			if (hasFirstValueSent(previousState)) {
+				synchronized (this) {
+					this.inner.onError(t);
+				}
+				return;
+			}
+
+			if (!hasFirstValueReceived(previousState)) {
+				final Publisher<? extends R> result;
+				final CoreSubscriber<? super R> o = this.outer;
+				try {
+					result = Objects.requireNonNull(this.transformer.apply(Signal.error(t,
+							o.currentContext()), this),
+							"The transformer returned a null value");
+				}
+				catch (Throwable e) {
+					o.onError(Exceptions.addSuppressed(e, t));
+					return;
+				}
+
+				result.subscribe(o);
+			}
+		}
+
+		@Override
+		public final void onComplete() {
+			if (this.done) {
+				return;
+			}
+
+			this.done = true;
+
+			final long previousState = markInboundTerminated(this);
+			if (hasInboundCancelled(previousState) || hasInboundTerminated(previousState)) {
+				return;
+			}
+
+			if (hasFirstValueSent(previousState)) {
+				synchronized (this) {
+					this.inner.onComplete();
+				}
+				return;
+			}
+
+			if (!hasFirstValueReceived(previousState)) {
+				final Publisher<? extends R> result;
+				final CoreSubscriber<? super R> o = this.outer;
+
+				try {
+					result =
+							Objects.requireNonNull(this.transformer.apply(Signal.complete(
+									o.currentContext()), this),
+									"The transformer returned a null value");
+				}
+				catch (Throwable e) {
+					o.onError(e);
+					return;
+				}
+
+				result.subscribe(o);
+			}
+		}
+
+		@Override
+		public final void cancel() {
+			long previousState = markInboundCancelled(this);
+			if (hasInboundCancelled(previousState) || hasInboundTerminated(previousState)) {
+				return;
+			}
+
+			this.s.cancel();
+
+			if (hasFirstValueReceived(previousState) && !hasInboundRequestedOnce(previousState)) {
+				final T f = this.firstValue;
+				Operators.onDiscard(f, currentContext());
+			}
+		}
+
+		final void cancelAndError() {
+			long previousState = markInboundCancelledAndErrored(this);
+			if (hasInboundCancelled(previousState) || hasInboundTerminated(previousState)) {
+				return;
+			}
+
+			this.s.cancel();
+
+			if (hasFirstValueReceived(previousState) && !hasFirstValueSent(previousState)) {
+				if (!hasInboundRequestedOnce(previousState)) {
+					final T f = this.firstValue;
+					Operators.onDiscard(f, currentContext());
+
+					if (hasInboundSubscriberSet(previousState)) {
+						this.inner.onError(new CancellationException(
+								"FluxSwitchOnFirst has already been cancelled"));
+					}
+				}
+				return;
+			}
+
+			if (hasInboundSubscriberSet(previousState)) {
+				synchronized (this) {
+					this.inner.onError(new CancellationException(
+							"FluxSwitchOnFirst has already been cancelled"));
+				}
+			}
+		}
+
+		@Override
+		public final void request(long n) {
+			if (Operators.validate(n)) {
+				// This is a sanity check to avoid extra volatile read in the request
+				// context
+				if (!this.isInboundRequestedOnce) {
+					this.isInboundRequestedOnce = true;
+
+					final T first = this.firstValue;
+					if (first != null) {
+						final long previousState = markInboundRequestedOnce(this);
+						if (hasInboundCancelled(previousState)) {
+							return;
+						}
+
+						final boolean wasDelivered = sendFirst(first);
+						if (wasDelivered) {
+							if (n != Long.MAX_VALUE) {
+								if (--n > 0) {
+									this.s.request(n);
+								}
+								return;
+							}
+						}
+					}
+				}
+
+				this.s.request(n);
+			}
+		}
+
+		@Override
+		public final void subscribe(CoreSubscriber<? super T> actual) {
+			long previousState = markInboundSubscribedOnce(this);
+			if (hasInboundSubscribedOnce(previousState)) {
+				Operators.error(actual,
+						new IllegalStateException(
+								"FluxSwitchOnFirst allows only one Subscriber"));
+				return;
+			}
+
+			if (hasInboundCancelled(previousState)) {
+				Operators.error(actual,
+						new CancellationException(
+								"FluxSwitchOnFirst has already been cancelled"));
+				return;
+			}
+
+			if (!hasFirstValueReceived(previousState)) {
+				final Throwable t = this.throwable;
+				if (t != null) {
+					Operators.error(actual, t);
+				}
+				else {
+					Operators.complete(actual);
+				}
+				return;
+			}
+
+			this.inner = convert(actual);
+
+			actual.onSubscribe(this);
+
+			previousState = markInboundSubscriberSet(this);
+			if (hasInboundCancelled(previousState)) {
+				actual.onError(
+						new CancellationException(
+								"FluxSwitchOnFirst has already been cancelled"));
+			}
+		}
+
+		abstract CoreSubscriber<? super T> convert(CoreSubscriber<? super T> inboundSubscriber);
+
+
+		boolean sendFirst(T firstValue) {
+			final CoreSubscriber<? super T> a = this.inner;
+
+			final boolean sent = tryOnNext(a, firstValue);
+
+			final long previousState = markFirstValueSent(this);
+			if (hasInboundCancelled(previousState)) {
+				if (hasInboundTerminated(previousState)) {
+					a.onError(new CancellationException(
+							"FluxSwitchOnFirst has already been cancelled"));
+				}
+				return sent;
+			}
+
+			if (hasInboundTerminated(previousState)) {
+				Throwable t = this.throwable;
+				if (t != null) {
+					a.onError(t);
+				}
+				else {
+					a.onComplete();
+				}
+			}
+
+			return sent;
+		}
+
+		abstract boolean tryOnNext(CoreSubscriber<? super T> actual, T value);
+
+	}
+
+	static final class SwitchOnFirstMain<T, R> extends AbstractSwitchOnFirstMain<T, R> {
+
+		SwitchOnFirstMain(CoreSubscriber<? super R> outer,
+				BiFunction<Signal<? extends T>, Flux<T>, Publisher<? extends R>> transformer,
+				boolean cancelSourceOnComplete) {
+			super(outer, transformer, cancelSourceOnComplete);
+		}
+
+		@Override
+		CoreSubscriber<? super T> convert(CoreSubscriber<? super T> inboundSubscriber) {
+			return inboundSubscriber;
+		}
+
+		@Override
+		boolean tryOnNext(CoreSubscriber<? super T> actual, T t) {
+			actual.onNext(t);
+			return true;
+		}
+	}
+
+	static final class SwitchOnFirstConditionalMain<T, R>
+			extends AbstractSwitchOnFirstMain<T, R>
+			implements Fuseable.ConditionalSubscriber<T> {
+
+		SwitchOnFirstConditionalMain(Fuseable.ConditionalSubscriber<? super R> outer,
+				BiFunction<Signal<? extends T>, Flux<T>, Publisher<? extends R>> transformer,
+				boolean cancelSourceOnComplete) {
+			super(outer, transformer, cancelSourceOnComplete);
+		}
+
+		@Override
+		CoreSubscriber<? super T> convert(CoreSubscriber<? super T> inboundSubscriber) {
+			return Operators.toConditionalSubscriber(inboundSubscriber);
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public boolean tryOnNext(T t) {
+			if (this.done) {
+				Operators.onNextDropped(t, currentContext());
+				return false;
+			}
+
+			final T f = this.firstValue;
+			if (f == null) {
+				this.firstValue = t;
+
+				final long state = markFirstValueReceived(this);
+				if (hasInboundCancelled(state)) {
+					Operators.onDiscard(t, this.outer.currentContext());
+					return true;
+				}
+
+				final Publisher<? extends R> result;
+				final CoreSubscriber<? super R> o = this.outer;
+
+				try {
+					result = Objects.requireNonNull(this.transformer.apply(Signal.next(t,
+							o.currentContext()), this),
+							"The transformer returned a null value");
+				}
+				catch (Throwable e) {
+					this.done = true;
+					o.onError(Operators.onOperatorError(this.s,
+							e,
+							t,
+							o.currentContext()));
+					return false;
+				}
+
+				result.subscribe(o);
+				return true;
+			}
+
+			return ((Fuseable.ConditionalSubscriber<? super T>) this.inner).tryOnNext(t);
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		boolean tryOnNext(CoreSubscriber<? super T> actual, T t) {
+			return ((Fuseable.ConditionalSubscriber<? super T>) actual).tryOnNext(t);
+		}
+	}
+
+	static final class SwitchOnFirstControlSubscriber<T>
+			extends Operators.DeferredSubscription
+			implements InnerOperator<T, T>, ControlSubscriber<T> {
+
+		final AbstractSwitchOnFirstMain<?, T> parent;
+		final CoreSubscriber<? super T>       delegate;
+		final boolean                         cancelSourceOnComplete;
+
+		boolean done;
+
+		SwitchOnFirstControlSubscriber(AbstractSwitchOnFirstMain<?, T> parent,
+				CoreSubscriber<? super T> delegate,
+				boolean cancelSourceOnComplete) {
+			this.parent = parent;
+			this.delegate = delegate;
+			this.cancelSourceOnComplete = cancelSourceOnComplete;
+		}
+
+		@Override
+		public void sendSubscription() {
+			delegate.onSubscribe(this);
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (set(s)) {
+				long previousState = markOutboundSubscribed(this.parent);
+
+				if (hasOutboundCancelled(previousState)) {
+					s.cancel();
+				}
+			}
+		}
+
+		@Override
+		public CoreSubscriber<? super T> actual() {
+			return this.delegate;
+		}
+
+		@Override
+		public void onNext(T t) {
+			if (this.done) {
+				Operators.onNextDropped(t, currentContext());
+				return;
+			}
+
+			this.delegate.onNext(t);
+		}
+
+		@Override
+		public void onError(Throwable throwable) {
+			if (this.done) {
+				Operators.onErrorDropped(throwable, currentContext());
+				return;
+			}
+
+			this.done = true;
+
+			final AbstractSwitchOnFirstMain<?, T> parent = this.parent;
+			long previousState = markOutboundTerminated(parent);
+
+			if (hasOutboundCancelled(previousState) || hasOutboundTerminated(previousState)) {
+				return;
+			}
+
+			if (!hasInboundCancelled(previousState) && !hasInboundTerminated(previousState)) {
+				parent.cancelAndError();
+			}
+
+			this.delegate.onError(throwable);
+		}
+
+		@Override
+		public void onComplete() {
+			if (this.done) {
+				return;
+			}
+
+			this.done = true;
+
+			final AbstractSwitchOnFirstMain<?, T> parent = this.parent;
+			long previousState = markOutboundTerminated(parent);
+
+			if (cancelSourceOnComplete && !hasInboundCancelled(previousState) && !hasInboundTerminated(previousState)) {
+				parent.cancelAndError();
+			}
+
+			this.delegate.onComplete();
+		}
+
+		@Override
+		public void cancel() {
+			REQUESTED.lazySet(this, STATE_CANCELLED);
+
+			final long previousState = markOutboundCancelled(this.parent);
+			if (hasOutboundCancelled(previousState) || hasOutboundTerminated(previousState)) {
+				return;
+			}
+
+			final boolean shouldCancelInbound =
+					!hasInboundTerminated(previousState) && !hasInboundCancelled(
+							previousState);
+
+			if (!hasOutboundSubscribed(previousState)) {
+				if (shouldCancelInbound) {
+					this.parent.cancel();
+				}
+				return;
+			}
+
+			this.s.cancel();
+
+			if (shouldCancelInbound) {
+				this.parent.cancelAndError();
+			}
+		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) {
+				return parent;
+			}
+			if (key == Attr.ACTUAL) {
+				return delegate;
+			}
+			if (key == Attr.RUN_STYLE) {
+				return Attr.RunStyle.SYNC;
+			}
+
+			return null;
+		}
+	}
+
+	static final class SwitchOnFirstConditionalControlSubscriber<T>
+			extends Operators.DeferredSubscription
+			implements InnerOperator<T, T>, ControlSubscriber<T>,
+			           Fuseable.ConditionalSubscriber<T> {
+
+		final AbstractSwitchOnFirstMain<?, T>           parent;
+		final Fuseable.ConditionalSubscriber<? super T> delegate;
+		final boolean                                   cancelSourceOnComplete;
+
+		boolean done;
+
+		SwitchOnFirstConditionalControlSubscriber(AbstractSwitchOnFirstMain<?, T> parent,
+				Fuseable.ConditionalSubscriber<? super T> delegate,
+				boolean cancelSourceOnComplete) {
+			this.parent = parent;
+			this.delegate = delegate;
+			this.cancelSourceOnComplete = cancelSourceOnComplete;
+		}
+
+		@Override
+		public void sendSubscription() {
+			delegate.onSubscribe(this);
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (set(s)) {
+				final long previousState = markOutboundSubscribed(this.parent);
+
+				if (hasOutboundCancelled(previousState)) {
+					s.cancel();
+				}
+			}
+		}
+
+		@Override
+		public CoreSubscriber<? super T> actual() {
+			return this.delegate;
+		}
+
+		@Override
+		public boolean tryOnNext(T t) {
+			if (this.done) {
+				Operators.onNextDropped(t, currentContext());
+				return true;
+			}
+
+			return this.delegate.tryOnNext(t);
+		}
+
+		@Override
+		public void onNext(T t) {
+			if (this.done) {
+				Operators.onNextDropped(t, currentContext());
+				return;
+			}
+
+			this.delegate.onNext(t);
+		}
+
+		@Override
+		public void onError(Throwable throwable) {
+			if (this.done) {
+				Operators.onErrorDropped(throwable, currentContext());
+				return;
+			}
+
+			this.done = true;
+
+			final AbstractSwitchOnFirstMain<?, T> parent = this.parent;
+			long previousState = markOutboundTerminated(parent);
+
+			if (hasOutboundCancelled(previousState) || hasOutboundTerminated(previousState)) {
+				return;
+			}
+
+			if (!hasInboundCancelled(previousState) && !hasInboundTerminated(previousState)) {
+				parent.cancelAndError();
+			}
+
+			this.delegate.onError(throwable);
+		}
+
+		@Override
+		public void onComplete() {
+			if (this.done) {
+				return;
+			}
+
+			this.done = true;
+
+			final AbstractSwitchOnFirstMain<?, T> parent = this.parent;
+			long previousState = markOutboundTerminated(parent);
+
+			if (cancelSourceOnComplete && !hasInboundCancelled(previousState) && !hasInboundTerminated(previousState)) {
+				parent.cancelAndError();
+			}
+
+			this.delegate.onComplete();
+		}
+
+		@Override
+		public void cancel() {
+			REQUESTED.lazySet(this, STATE_CANCELLED);
+
+			final long previousState = markOutboundCancelled(this.parent);
+			if (hasOutboundCancelled(previousState) || hasOutboundTerminated(previousState)) {
+				return;
+			}
+
+			final boolean shouldCancelInbound =
+					!hasInboundTerminated(previousState) && !hasInboundCancelled(
+							previousState);
+
+			if (!hasOutboundSubscribed(previousState)) {
+				if (shouldCancelInbound) {
+					this.parent.cancel();
+				}
+				return;
+			}
+
+			this.s.cancel();
+
+			if (shouldCancelInbound) {
+				this.parent.cancelAndError();
+			}
+		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) {
+				return parent;
+			}
+			if (key == Attr.ACTUAL) {
+				return delegate;
+			}
+			if (key == Attr.RUN_STYLE) {
+				return Attr.RunStyle.SYNC;
+			}
+
+			return null;
+		}
+	}
+
+	interface ControlSubscriber<T> extends CoreSubscriber<T> {
+
+		void sendSubscription();
+	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchOnFirstTest.java
@@ -1490,7 +1490,7 @@ public class FluxSwitchOnFirstTest {
 
             RaceTestUtils.race(() -> f.subscribe(subscriber), () -> assertSubscriber.cancel());
 
-            assertThat(sofSubscriber[0].inner).isEqualTo(Operators.EMPTY_SUBSCRIBER);
+            assertThat(sofSubscriber[0].inboundSubscriber).isEqualTo(Operators.EMPTY_SUBSCRIBER);
 
             // if cancel first then the upstream observes request(1) and request(1) if cancel later then only a single request
             assertThat(requested.get()).isBetween(1L, 2L);
@@ -1546,7 +1546,7 @@ public class FluxSwitchOnFirstTest {
 
             RaceTestUtils.race(() -> f.subscribe(subscriber), () -> assertSubscriber.cancel());
 
-            assertThat(sofSubscriber[0].inner).isEqualTo(Operators.EMPTY_SUBSCRIBER);
+            assertThat(sofSubscriber[0].inboundSubscriber).isEqualTo(Operators.EMPTY_SUBSCRIBER);
 
             // if cancel first then the upstream observes request(1) and request(1) if cancel later then only a single request
             assertThat(requested.get()).isBetween(1L, 2L);


### PR DESCRIPTION
Signed-off-by: Oleh Dokuka <odokuka@vmware.com>