### PR TITLE
GitHub Actions Release Process:  Back to single publication

### DIFF
--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -83,13 +83,19 @@ publishing {
 	}
 
 	publications {
-		extras(MavenPublication) {
-//			other project-specific artifacts must be added to this publication, in each project's builds
-		}
 		mavenJava(MavenPublication) {
 			from components.java
 			artifact sourcesJar
 			artifact javadocJar
+			//consider adding extra artifacts here, conditionally on submodule's name and perhaps in an afterEvaluate block
+			afterEvaluate {
+				if (project.name == 'reactor-core') {
+					artifact rootProject.tasks.docsZip
+				}
+				// note that reactor-tools has more involved stuff, so we kept it in the submodule's build:
+				// (it replaces the original jar with shadow jar and adds the former as -original.jar)
+			}
+
 
 			pom {
 				afterEvaluate {
@@ -156,11 +162,11 @@ if (rootProject.hasProperty("artifactory_publish_password")) {
 	apply plugin: "com.jfrog.artifactory"
 
 	artifactoryPublish {
-		publications(publishing.publications.mavenJava, publishing.publications.extras)
+		publications(publishing.publications.mavenJava)
 	}
 }
 
-if (qualifyVersion("$version") in ["RELEASE", "MILESTONE"]) {
+if (qualifyVersion("$version") in ["RELEASE", "MILESTONE"] || rootProject.hasProperty("forceSigning")) {
 	apply plugin: 'signing'
 
 	signing {

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -282,5 +282,4 @@ else {
 	}
 }
 
-//add docs.zip to the extras publication
-publishing.publications.extras.artifact(rootProject.tasks.docsZip)
+// docs.zip is added in afterEvaluate block in setup.gradle


### PR DESCRIPTION
This commit removes the extras publication, which caused issues
in the distribution of the pom.xml.

In order for the build file to be a bit more readable, the extra
artifact of docs.zip is added from `setup.gradle` rather than the
submodule's `reactor-core/build.gradle`. This implies checking
the project name and using `afterEvaluate` block, since setup is
applied to all submodules.

We also add a `-PforceSigning` option for debugging purposes.

Fixes #2672.