### PR TITLE
Prevent infinite recursion of MonoMaterialize#request

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMaterialize.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMaterialize.java
@@ -139,8 +139,8 @@ final class MonoMaterialize<T> extends InternalMonoOperator<T, Signal<T>> {
 
 		@Override
 		public void request(long l) {
-			if (Operators.validate(l)) {
-				this.requested = true;
+			if (!this.requested && Operators.validate(l)) {
+				this.requested = true; //ignore further requests
 				if (drain()) {
 					return; //there was an early completion
 				}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMaterializeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMaterializeTest.java
@@ -29,6 +29,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class MonoMaterializeTest {
 
+	// see https://github.com/reactor/reactor-core/issues/2674
+	@Test
+	void materializeOnlyRequestsOnce() {
+		Mono.error(new RuntimeException("boom"))
+		    .materialize()
+		    .filter(signal -> !signal.isOnError()) // filtering will cause re-request
+		    .as(StepVerifier::create)
+		    .expectSubscription()
+		    .expectComplete()
+		    .verify();
+	}
+
 	@Test
 	void nextOnlyBackpressured() {
 		AssertSubscriber<Signal<Integer>> ts = AssertSubscriber.create(0L);


### PR DESCRIPTION
MonoMaterialize calls downstream `onNext` from its `request` method
without properly guarding against recursion there. So if downstream
calls `s.request(1)` from its `onNext` method, the state isn't updated
and cannot prevent further recursion.

This commit checks that the mono was never requested before entering
the drain method which triggers downstream onNext.

Fixes #2674.
