### PR TITLE
GroupBy request 1 more group when last active group is cancelled

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
@@ -87,6 +87,18 @@ public class FluxGroupByTest extends
 	}
 
 	@Test
+	void gh2675() {
+		StepVerifier.create(
+				Flux.just(0, 1, 2, 3)
+				    .log()
+				    .groupBy(f -> f / 2, 1)
+				    .flatMap(a -> a.log("group " + a.key()).takeUntil(i -> i % 2 == 1)))
+		            .expectNext(0, 1, 2, 3)
+		            .expectComplete()
+		            .verify(Duration.ofMillis(5000));
+	}
+
+	@Test
 	public void normal() {
 		AssertSubscriber<GroupedFlux<Integer, Integer>> ts = AssertSubscriber.create();
 


### PR DESCRIPTION
This commit prevents a hang when the last active group of a groupBy
is cancelled, by requesting one additional element from the source in
such a case. This is not applied if the main sequence itself has been
cancelled.

Fixes #2675.
