### PR TITLE
Avoid backpressure error with tiny MonoDelay/emit on 1st request

### DIFF
--- a/reactor-core/src/jcstress/java/reactor/core/publisher/MonoDelayStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/MonoDelayStressTest.java
@@ -40,7 +40,7 @@ public abstract class MonoDelayStressTest {
 		final VirtualTimeScheduler   virtualTimeScheduler;
 		final MonoDelay              monoDelay;
 
-		MonoDelay.MonoDelayRunnable> subscription;
+		MonoDelay.MonoDelayRunnable subscription;
 
 		{
 			virtualTimeScheduler = VirtualTimeScheduler.create();

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/MonoDelayStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/MonoDelayStressTest.java
@@ -1,18 +1,13 @@
 package reactor.core.publisher;
 
-import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.openjdk.jcstress.annotations.Actor;
 import org.openjdk.jcstress.annotations.Arbiter;
 import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
-import org.openjdk.jcstress.infra.results.IIII_Result;
 import org.openjdk.jcstress.infra.results.III_Result;
-import org.reactivestreams.Subscription;
-
 import reactor.test.scheduler.VirtualTimeScheduler;
 
 import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
@@ -44,17 +39,18 @@ public abstract class MonoDelayStressTest {
 		final StressSubscriber<Long> subscriber = new StressSubscriber<>(0L);
 		final VirtualTimeScheduler   virtualTimeScheduler;
 		final MonoDelay              monoDelay;
-		final AtomicReference<MonoDelay.MonoDelayRunnable> subscriptionRef = new AtomicReference<>();
+
+		MonoDelay.MonoDelayRunnable> subscription;
 
 		{
 			virtualTimeScheduler = VirtualTimeScheduler.create();
 			monoDelay = new MonoDelay(Long.MAX_VALUE, TimeUnit.MILLISECONDS, virtualTimeScheduler);
-			monoDelay.doOnSubscribe(s -> subscriptionRef.set((MonoDelay.MonoDelayRunnable) s)).subscribe(subscriber);
+			monoDelay.doOnSubscribe(s -> subscription = (MonoDelay.MonoDelayRunnable) s).subscribe(subscriber);
 		}
 
 		@Actor
 		public void delayTrigger() {
-			subscriptionRef.get().run();
+			subscription.run();
 		}
 
 		@Actor
@@ -66,7 +62,7 @@ public abstract class MonoDelayStressTest {
 		public void arbiter(III_Result r) {
 			r.r1 = subscriber.onNextCalls.get();
 			r.r2 = subscriber.onErrorCalls.get();
-			r.r3 = subscriptionRef.get().state;
+			r.r3 = subscription.state;
 		}
 	}
 
@@ -90,13 +86,13 @@ public abstract class MonoDelayStressTest {
 		final StressSubscriber<Long>                       subscriber      = new StressSubscriber<>(0L);
 		final VirtualTimeScheduler                         virtualTimeScheduler;
 		final MonoDelay                                    monoDelay;
-		final AtomicReference<MonoDelay.MonoDelayRunnable> subscriptionRef = new AtomicReference<>();
+		MonoDelay.MonoDelayRunnable subscription;
 
 		{
 			virtualTimeScheduler = VirtualTimeScheduler.create();
 			monoDelay = new MonoDelay(Long.MAX_VALUE, TimeUnit.MILLISECONDS, virtualTimeScheduler);
 			monoDelay
-					.doOnSubscribe(s -> subscriptionRef.set((MonoDelay.MonoDelayRunnable) s))
+					.doOnSubscribe(s -> subscription = (MonoDelay.MonoDelayRunnable) s)
 					.subscribe(subscriber);
 		}
 
@@ -107,7 +103,7 @@ public abstract class MonoDelayStressTest {
 
 		@Actor
 		public void delayTrigger() {
-			subscriptionRef.get().run();
+			subscription.run();
 		}
 
 		@Actor
@@ -119,7 +115,7 @@ public abstract class MonoDelayStressTest {
 		public void arbiter(III_Result r) {
 			r.r1 = subscriber.onNextCalls.get();
 			r.r2 = subscriber.onErrorCalls.get();
-			r.r3 = subscriptionRef.get().state;
+			r.r3 = subscription.state;
 		}
 	}
 }

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/MonoDelayUntilStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/MonoDelayUntilStressTest.java
@@ -1,0 +1,176 @@
+package reactor.core.publisher;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.IIIII_Result;
+import org.openjdk.jcstress.infra.results.IIII_Result;
+
+import reactor.core.CoreSubscriber;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+
+public abstract class MonoDelayUntilStressTest {
+
+	@JCStressTest
+	@Outcome(id = {"1, 1, 0, 0, 0"}, expect = ACCEPTABLE, desc = "No error dropped, composite error delivered. Cancel signal is late in that case")
+	@Outcome(id = {"1, 1, 1, 1, 0", "1, 1, 0, 1, 0"}, expect = ACCEPTABLE, desc = "Main error possibly dropped, inner or composite error delivered. Main is cancelled. Cancel signal is late")
+	@Outcome(id = {"1, 1, 1, 0, 1", "1, 1, 0, 0, 1"}, expect = ACCEPTABLE, desc = "Inner error possibly dropped, main or composite error delivered. Inner is cancelled. Cancel signal is late")
+	@Outcome(id = {"1, 0, 1, 1, 1", "1, 0, 2, 1, 1"}, expect = ACCEPTABLE, desc = "No error delivered. One composite error delivered or both errors are dropped. Cancel signal is propagated to both")
+	@State
+	public static class InnerOnErrorAndOuterOnErrorAndCancelStressTest {
+
+		final StressSubscriber<Integer> subscriber = new StressSubscriber<Integer>(1L);
+
+		StressSubscription<Integer> subscriptionOuter;
+		StressSubscription<Integer> subscriptionInner;
+
+		{
+			new Mono<Integer>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super Integer> actual) {
+					subscriptionOuter = new StressSubscription<>(actual);
+					actual.onSubscribe(subscriptionOuter);
+					actual.onNext(1);
+				}
+			}
+			.delayUntil(__ -> new Mono<Integer>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super Integer> actual) {
+					subscriptionInner = new StressSubscription<>(actual);
+					actual.onSubscribe(subscriptionInner);
+				}
+			})
+			.subscribe(subscriber);
+		}
+
+		@Actor
+		public void errorOuter() {
+			subscriptionOuter.actual.onError(new RuntimeException("test1"));
+		}
+
+		@Actor
+		public void errorInner() {
+			subscriptionInner.actual.onError(new RuntimeException("test2"));
+		}
+
+		@Actor
+		public void cancelFromActual() {
+			subscriber.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(IIIII_Result r) {
+			r.r1 = subscriber.onNextDiscarded.get();
+			r.r2 = subscriber.onErrorCalls.get();
+			r.r3 = subscriber.droppedErrors.size();
+			r.r4 = subscriptionOuter.cancelled.get() ? 1 : 0;
+			r.r5 = subscriptionInner.cancelled.get() ? 1 : 0;
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"1, 0, 1, 1"}, expect = ACCEPTABLE, desc = "Value discarded. Subscriptions cancelled")
+	@Outcome(id = {"0, 1, 0, 0"}, expect = ACCEPTABLE, desc = "Value delivered. Cancel signal is late")
+	@State
+	public static class CompleteVsCancelStressTest {
+
+		final StressSubscriber<Integer> subscriber = new StressSubscriber<Integer>(1L);
+
+		StressSubscription<Integer> subscriptionOuter;
+		StressSubscription<Integer> subscriptionInner;
+
+		{
+			new Mono<Integer>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super Integer> actual) {
+					subscriptionOuter = new StressSubscription<>(actual);
+					actual.onSubscribe(subscriptionOuter);
+					actual.onNext(1);
+				}
+			}
+					.delayUntil(__ -> new Mono<Integer>() {
+						@Override
+						public void subscribe(CoreSubscriber<? super Integer> actual) {
+							subscriptionInner = new StressSubscription<>(actual);
+							actual.onSubscribe(subscriptionInner);
+						}
+					})
+					.subscribe(subscriber);
+		}
+
+		@Actor
+		public void completeOuter() {
+			subscriptionOuter.actual.onComplete();
+		}
+
+		@Actor
+		public void completeInner() {
+			subscriptionInner.actual.onComplete();
+		}
+
+		@Actor
+		public void cancelFromActual() {
+			subscriber.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(IIII_Result r) {
+			r.r1 = subscriber.onNextDiscarded.get();
+			r.r2 = subscriber.onNextCalls.get();
+			r.r3 = subscriptionOuter.cancelled.get() ? 1 : 0;
+			r.r4 = subscriptionInner.cancelled.get() ? 1 : 0;
+		}
+	}
+
+
+
+	@JCStressTest
+	@Outcome(id = {"1, 0, 1, 1"}, expect = ACCEPTABLE, desc = "Value discarded. Subscriptions cancelled")
+	@State
+	public static class OnNextVsCancelStressTest {
+
+		final StressSubscriber<Integer> subscriber = new StressSubscriber<Integer>(1L);
+
+		StressSubscription<Integer> subscriptionOuter;
+		StressSubscription<Integer> subscriptionInner;
+
+		{
+			new Mono<Integer>() {
+				@Override
+				public void subscribe(CoreSubscriber<? super Integer> actual) {
+					subscriptionOuter = new StressSubscription<>(actual);
+					actual.onSubscribe(subscriptionOuter);
+				}
+			}
+					.delayUntil(__ -> new Mono<Integer>() {
+						@Override
+						public void subscribe(CoreSubscriber<? super Integer> actual) {
+							subscriptionInner = new StressSubscription<>(actual);
+							actual.onSubscribe(subscriptionInner);
+						}
+					})
+					.subscribe(subscriber);
+		}
+
+		@Actor
+		public void nextOuter() {
+			subscriptionOuter.actual.onNext(1);
+		}
+
+		@Actor
+		public void cancelFromActual() {
+			subscriber.cancel();
+		}
+
+		@Arbiter
+		public void arbiter(IIII_Result r) {
+			r.r1 = subscriber.onNextDiscarded.get();
+			r.r2 = subscriber.onNextCalls.get();
+			r.r3 = subscriptionOuter.cancelled.get() ? 1 : 0;
+			r.r4 = subscriptionInner.cancelled.get() ? 1 : 0;
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
@@ -272,7 +272,7 @@ final class MonoDelay extends Mono<Long> implements Scannable,  SourceProducer<L
 		@Override
 		public void cancel() {
 			int previousState = markCancelled(this);
-			if (wasCancelled(previousState) || wasPropagated(this.state)) {
+			if (wasCancelled(previousState) || wasPropagated(previousState)) {
 				//ignore
 				return;
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
@@ -81,14 +81,19 @@ final class MonoDelay extends Mono<Long> implements Scannable,  SourceProducer<L
 		Disposable cancel;
 
 		volatile int state;
-
 		static final AtomicIntegerFieldUpdater<MonoDelayRunnable> STATE = AtomicIntegerFieldUpdater.newUpdater(MonoDelayRunnable.class, "state");
 
+		/** This bit marks the subscription as cancelled */
 		static final byte FLAG_CANCELLED       = 0b0100_0_000;
+		/** This bit marks the subscription as requested (once) */
 		static final byte FLAG_REQUESTED       = 0b0010_0_000;
+		/** This bit indicates that a request happened before the delay timer was done (utility, especially in tests) */
 		static final byte FLAG_REQUESTED_EARLY = 0b0001_0_000;
+		/** This bit indicates that a Disposable was set corresponding to the timer */
 		static final byte FLAG_CANCEL_SET      = 0b0000_0_001;
+		/** This bit indicates that the timer has expired */
 		static final byte FLAG_DELAY_DONE      = 0b0000_0_010;
+		/** This bit indicates that, following expiry of the timer AND request, onNext(0L) has been propagated downstream */
 		static final byte FLAG_PROPAGATED      = 0b0000_0_100;
 
 		MonoDelayRunnable(CoreSubscriber<? super Long> actual, boolean failOnBackpressure) {
@@ -114,6 +119,9 @@ final class MonoDelay extends Mono<Long> implements Scannable,  SourceProducer<L
 			}
 		}
 
+		/**
+		 * @return true if the {@link #FLAG_CANCEL_SET} bit is set on the given state
+		 */
 		static boolean wasCancelFutureSet(int state) {
 			return (state & FLAG_CANCEL_SET) == FLAG_CANCEL_SET;
 		}
@@ -135,6 +143,9 @@ final class MonoDelay extends Mono<Long> implements Scannable,  SourceProducer<L
 			}
 		}
 
+		/**
+		 * @return true if the {@link #FLAG_CANCELLED} bit is set on the given state
+		 */
 		static boolean wasCancelled(int state) {
 			return (state & FLAG_CANCELLED) == FLAG_CANCELLED;
 		}
@@ -157,6 +168,9 @@ final class MonoDelay extends Mono<Long> implements Scannable,  SourceProducer<L
 			}
 		}
 
+		/**
+		 * @return true if the {@link #FLAG_DELAY_DONE} bit is set on the given state
+		 */
 		static boolean wasDelayDone(int state) {
 			return (state & FLAG_DELAY_DONE) == FLAG_DELAY_DONE;
 		}
@@ -184,6 +198,9 @@ final class MonoDelay extends Mono<Long> implements Scannable,  SourceProducer<L
 			}
 		}
 
+		/**
+		 * @return true if the {@link #FLAG_REQUESTED} bit is set on the given state
+		 */
 		static boolean wasRequested(int state) {
 			return (state & FLAG_REQUESTED) == FLAG_REQUESTED;
 		}
@@ -205,6 +222,9 @@ final class MonoDelay extends Mono<Long> implements Scannable,  SourceProducer<L
 			}
 		}
 
+		/**
+		 * @return true if the {@link #FLAG_PROPAGATED} bit is set on the given state
+		 */
 		static boolean wasPropagated(int state) {
 			return (state & FLAG_PROPAGATED) == FLAG_PROPAGATED;
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
@@ -188,10 +188,6 @@ final class MonoDelay extends Mono<Long> implements Scannable,  SourceProducer<L
 			return (state & FLAG_REQUESTED) == FLAG_REQUESTED;
 		}
 
-		static boolean wasRequestedEarly(int state) {
-			return (state & FLAG_REQUESTED) == FLAG_REQUESTED && (state & FLAG_REQUESTED_EARLY) == FLAG_REQUESTED_EARLY;
-		}
-
 		/**
 		 * Mark the operator has emitted the tick. Immediately returns if it
 		 * {@link #wasCancelled(int) was already cancelled}.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
@@ -50,7 +50,9 @@ final class MonoDelay extends Mono<Long> implements Scannable,  SourceProducer<L
 
 	@Override
 	public void subscribe(CoreSubscriber<? super Long> actual) {
-		MonoDelayRunnable r = new MonoDelayRunnable(actual);
+		boolean failOnBackpressure = actual.currentContext().getOrDefault(CONTEXT_OPT_OUT_NOBACKPRESSURE, false) == Boolean.TRUE;
+
+		MonoDelayRunnable r = new MonoDelayRunnable(actual, failOnBackpressure);
 
 		actual.onSubscribe(r);
 
@@ -75,6 +77,7 @@ final class MonoDelay extends Mono<Long> implements Scannable,  SourceProducer<L
 
 	static final class MonoDelayRunnable implements Runnable, InnerProducer<Long> {
 		final CoreSubscriber<? super Long> actual;
+		final boolean failOnBackpressure;
 
 		volatile Disposable cancel;
 		static final AtomicReferenceFieldUpdater<MonoDelayRunnable, Disposable> CANCEL =
@@ -85,9 +88,11 @@ final class MonoDelay extends Mono<Long> implements Scannable,  SourceProducer<L
 		volatile boolean requested;
 
 		static final Disposable FINISHED = Disposables.disposed();
+		static final Disposable DONE_BEFORE_REQUEST = Disposables.disposed();
 
-		MonoDelayRunnable(CoreSubscriber<? super Long> actual) {
+		MonoDelayRunnable(CoreSubscriber<? super Long> actual, boolean failOnBackpressure) {
 			this.actual = actual;
+			this.failOnBackpressure = failOnBackpressure;
 		}
 
 		public void setCancel(Disposable cancel) {
@@ -111,26 +116,43 @@ final class MonoDelay extends Mono<Long> implements Scannable,  SourceProducer<L
 			return InnerProducer.super.scanUnsafe(key);
 		}
 
+		private void delayDone() {
+			try {
+				actual.onNext(0L);
+				actual.onComplete();
+			}
+			catch (Throwable t){
+				actual.onError(Operators.onOperatorError(t, actual.currentContext()));
+			}
+		}
+
 		@Override
 		public void run() {
 			if (requested) {
-				try {
-					if (CANCEL.getAndSet(this, FINISHED) != OperatorDisposables.DISPOSED) {
-						actual.onNext(0L);
-						actual.onComplete();
+				if (CANCEL.getAndSet(this, FINISHED) != OperatorDisposables.DISPOSED) {
+					delayDone();
+				}
+			} else if (failOnBackpressure) {
+				actual.onError(Exceptions.failWithOverflow("Could not emit value due to lack of requests"));
+			}
+			else {
+				for(;;) {
+					//either null or Disposable from scheduling
+					//can't be FINISHED, can't be DONE_BEFORE_REQUEST
+					Disposable c = CANCEL.get(this);
+					if (c == OperatorDisposables.DISPOSED //cancelled
+							|| CANCEL.compareAndSet(this, c, DONE_BEFORE_REQUEST)) { //managed to update
+						return;
 					}
 				}
-				catch (Throwable t){
-					actual.onError(Operators.onOperatorError(t, actual.currentContext()));
-				}
-			} else {
-				actual.onError(Exceptions.failWithOverflow("Could not emit value due to lack of requests"));
 			}
 		}
 
 		@Override
 		public void cancel() {
 			Disposable c = cancel;
+			//we'll allow turning DONE_BEFORE_REQUEST to CANCELLED
+			//(note that DONE_BEFORE_REQUEST can be disposed, it is a NO-OP)
 			if (c != OperatorDisposables.DISPOSED && c != FINISHED) {
 				c =  CANCEL.getAndSet(this, OperatorDisposables.DISPOSED);
 				if (c != null && c != OperatorDisposables.DISPOSED && c != FINISHED) {
@@ -143,7 +165,12 @@ final class MonoDelay extends Mono<Long> implements Scannable,  SourceProducer<L
 		public void request(long n) {
 			if (Operators.validate(n)) {
 				requested = true;
+				if (!failOnBackpressure && CANCEL.compareAndSet(this, DONE_BEFORE_REQUEST, FINISHED)) {
+					delayDone();
+				}
 			}
 		}
 	}
+
+	private static final String CONTEXT_OPT_OUT_NOBACKPRESSURE = "reactor.core.publisher.MonoDelay.failOnBackpressure";
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelay.java
@@ -172,5 +172,5 @@ final class MonoDelay extends Mono<Long> implements Scannable,  SourceProducer<L
 		}
 	}
 
-	private static final String CONTEXT_OPT_OUT_NOBACKPRESSURE = "reactor.core.publisher.MonoDelay.failOnBackpressure";
+	static final String CONTEXT_OPT_OUT_NOBACKPRESSURE = "reactor.core.publisher.MonoDelay.failOnBackpressure";
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoDelayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoDelayTest.java
@@ -52,9 +52,13 @@ public class MonoDelayTest {
 
 	@Test
 	public void delayedSourceError() {
-		StepVerifier.withVirtualTime(this::scenario_delayedSourceError, 0L)
-		            .thenAwait(Duration.ofSeconds(5))
-		            .verifyErrorMatches(Exceptions::isOverflow);
+		StepVerifier.withVirtualTime(this::scenario_delayedSourceError, StepVerifierOptions.create()
+				.initialRequest(0)
+				.virtualTimeSchedulerSupplier(VirtualTimeScheduler::create)
+				.withInitialContext(Context.of(MonoDelay.CONTEXT_OPT_OUT_NOBACKPRESSURE, true))
+		)
+				.thenAwait(Duration.ofSeconds(5))
+				.verifyErrorMatches(Exceptions::isOverflow);
 	}
 
 	@Test
@@ -129,6 +133,7 @@ public class MonoDelayTest {
 				.create()
 				.initialRequest(0L)
 				.virtualTimeSchedulerSupplier(VirtualTimeScheduler::create)
+				// MonoDelay.CONTEXT_OPT_OUT_NOBACKPRESSURE: true
 				.withInitialContext(Context.of("reactor.core.publisher.MonoDelay.failOnBackpressure", true));
 
 		StepVerifier.withVirtualTime(() -> Mono.delay(Duration.ofNanos(1)), options)

--- a/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
+++ b/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
@@ -396,7 +396,7 @@ public class VirtualTimeScheduler implements Scheduler {
 					//for the benefit of tasks that call `now()`
 					// if scheduled time is 0 (immediate) use current virtual time
 					nanoTime = current.time == 0 ? nanoTime : current.time;
-					queue.remove();
+					queue.poll();
 
 					// Only execute if not unsubscribed
 					if (!current.scheduler.shutdown) {


### PR DESCRIPTION
This PR makes `MonoDelay` behavior _slightly_ different to avoid a backpressure overflow error.

If the delay runs before the first request has had a chance to happen,
the operator will now wait for the first request and deliver the tick immediately upon it,
rather than failing early with a backpressure overflow error.

The old behavior of failing early is probably counterintuitive to most people,
but in case someone relies on it it can be opted back in by using an undocumented
`Context` key, `reactor.core.publisher.MonoDelay.failOnBackpressure` with value `true`. ﻿