### PR TITLE
Add StepVerifierOptions.copy(), withVirtualTime uses default vts

### DIFF
--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -291,6 +291,10 @@ public interface StepVerifier {
 	static <T> FirstStep<T> withVirtualTime(
 			Supplier<? extends Publisher<? extends T>> scenarioSupplier,
 			StepVerifierOptions options) {
+
+		DefaultStepVerifierBuilder.checkPositive(options.getInitialRequest());
+		Objects.requireNonNull(scenarioSupplier, "scenarioSupplier");
+
 		//force the default VTS supplier if the provided options doesn't define a VTS supplier.
 		//note we make a copy just in case the original options are reused.
 		if (options.getVirtualTimeSchedulerSupplier() == null) {
@@ -298,10 +302,6 @@ public interface StepVerifier {
 					.copy()
 					.virtualTimeSchedulerSupplier(() -> VirtualTimeScheduler.getOrSet(true));
 		}
-
-		DefaultStepVerifierBuilder.checkPositive(options.getInitialRequest());
-		Objects.requireNonNull(scenarioSupplier, "scenarioSupplier");
-
 		return DefaultStepVerifierBuilder.newVerifier(options, scenarioSupplier);
 	}
 

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -267,6 +267,10 @@ public interface StepVerifier {
 	 * The verification will request a specified amount of values according to
 	 * the provided {@link StepVerifierOptions options}.
 	 * <p>
+	 * If no {@link VirtualTimeScheduler} {@link Supplier} is set in the options, this
+	 * method will make a {@link StepVerifierOptions#copy() copy} of said options and
+	 * set up the default supplier (like the one in {@link #withVirtualTime(Supplier)}).
+	 * <p>
 	 * Note that virtual time, {@link Step#thenAwait(Duration)} sources that are
 	 * subscribed on a different {@link reactor.core.scheduler.Scheduler} (eg. a source
 	 * that is initialized outside of the lambda with a dedicated Scheduler) and
@@ -278,7 +282,8 @@ public interface StepVerifier {
 	 * to and verify. In order for operators to use virtual time, they must be invoked
 	 * from within the lambda.
 	 * @param options the verification options, including the supplier of the
-	 * {@link VirtualTimeScheduler} to inject and manipulate during verification.
+	 * {@link VirtualTimeScheduler} to inject and manipulate during verification
+	 * (see note above in case options doesn't define such a supplier)
 	 * @param <T> the type of the subscriber
 	 *
 	 * @return a builder for expectation declaration and ultimately verification.
@@ -286,12 +291,18 @@ public interface StepVerifier {
 	static <T> FirstStep<T> withVirtualTime(
 			Supplier<? extends Publisher<? extends T>> scenarioSupplier,
 			StepVerifierOptions options) {
+		//force the default VTS supplier if the provided options doesn't define a VTS supplier.
+		//note we make a copy just in case the original options are reused.
+		if (options.getVirtualTimeSchedulerSupplier() == null) {
+			options = options
+					.copy()
+					.virtualTimeSchedulerSupplier(() -> VirtualTimeScheduler.getOrSet(true));
+		}
+
 		DefaultStepVerifierBuilder.checkPositive(options.getInitialRequest());
-		Objects.requireNonNull(options.getVirtualTimeSchedulerSupplier(), "vtsLookup");
 		Objects.requireNonNull(scenarioSupplier, "scenarioSupplier");
 
-		return DefaultStepVerifierBuilder.newVerifier(options,
-				scenarioSupplier);
+		return DefaultStepVerifierBuilder.newVerifier(options, scenarioSupplier);
 	}
 
 	/**

--- a/reactor-test/src/main/java/reactor/test/StepVerifierOptions.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifierOptions.java
@@ -61,6 +61,24 @@ public class StepVerifierOptions {
 	private StepVerifierOptions() { } //disable constructor
 
 	/**
+	 * Make a copy of this {@link StepVerifierOptions} instance.
+	 *
+	 * @return a copy of the options that can be further mutated without impacting the original
+	 */
+	public StepVerifierOptions copy() {
+		StepVerifierOptions copy = new StepVerifierOptions();
+		copy.scenarioName = this.scenarioName;
+		copy.checkUnderRequesting = this.checkUnderRequesting;
+		copy.initialRequest = this.initialRequest;
+		copy.vtsLookup = this.vtsLookup;
+		copy.initialContext = this.initialContext;
+		copy.objectFormatter = this.objectFormatter;
+		copy.extractorMap.putAll(this.extractorMap);
+
+		return copy;
+	}
+
+	/**
 	 * Activate or deactivate the {@link StepVerifier} check of request amount
 	 * being too low. Defauts to true.
 	 *

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -1155,13 +1155,6 @@ public class StepVerifierTests {
 	}
 
 	@Test
-	public void verifyVirtualTimeNoLookupFails() {
-		assertThatExceptionOfType(NullPointerException.class)
-				.isThrownBy(() -> StepVerifier.withVirtualTime(Flux::empty, null, 1))
-	            .withMessage("vtsLookup");
-	}
-
-	@Test
 	public void verifyVirtualTimeNoScenarioFails() {
 		assertThatExceptionOfType(NullPointerException.class)
 				.isThrownBy(() -> StepVerifier.withVirtualTime(null, 1))

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -2408,4 +2408,23 @@ public class StepVerifierTests {
                     .hasMessage("ErrorInSubscribeFlux");
         });
 	}
+
+	@Test
+	void withVirtualTimeCopiesOptionsAddsDefaultVtsIfNoSupplier() {
+		StepVerifierOptions options = StepVerifierOptions.create()
+				.initialRequest(123L);
+
+		assertThatCode(() -> StepVerifier.withVirtualTime(() -> Mono.delay(Duration.ofSeconds(1)), options)
+				.expectSubscription()
+				.expectNoEvent(Duration.ofSeconds(1))
+				.expectNext(0L)
+				.expectComplete()
+				.verify(Duration.ofMillis(500))
+		)
+				.doesNotThrowAnyException();
+
+		assertThat(options.getVirtualTimeSchedulerSupplier())
+				.as("copy didn't influence original")
+				.isNull();
+	}
 }


### PR DESCRIPTION
This commit adds a method to make a copy of a StepVerifierOptions. It
is used by `StepVerifier#withVirtualTime(Supplier, StepVerifierOptions)`
to make a copy and augment the provided options with a default supplier
of the VirtualTimeScheduler if none has been defined in the original
options.

This approach is preferable to throwing an NPE when one simply wants
to use default virtual time but change other unrelated specific options.
