### PR TITLE
Add take(int, boolean), prep for new default behavior in 3.5

### DIFF
--- a/docs/asciidoc/apdx-operatorChoice.adoc
+++ b/docs/asciidoc/apdx-operatorChoice.adoc
@@ -172,7 +172,8 @@ I want to deal with:
 
 * I want to keep only a subset of the sequence:
 ** by taking N elements:
-*** at the beginning of the sequence: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#take-long-[Flux#take(long)]
+*** at the beginning of the sequence: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#takeEager-long-[Flux#takeEager(long)]
+**** ...requesting exactly the desired number of elements: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#limitRequest-long-[Flux#limitRequest(long)]
 **** ...based on a duration: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#take-java.time.Duration-[Flux#take(Duration)]
 **** ...only the first element, as a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html[Mono]: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#next--[Flux#next()]
 **** ...using https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/org/reactivestreams/Subscription.html#request(long)[request(N)] rather than cancellation: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#limitRequest-long-[Flux#limitRequest(long)]

--- a/docs/asciidoc/apdx-operatorChoice.adoc
+++ b/docs/asciidoc/apdx-operatorChoice.adoc
@@ -172,8 +172,8 @@ I want to deal with:
 
 * I want to keep only a subset of the sequence:
 ** by taking N elements:
-*** at the beginning of the sequence: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#takeEager-long-[Flux#takeEager(long)]
-**** ...requesting exactly the desired number of elements: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#limitRequest-long-[Flux#limitRequest(long)]
+*** at the beginning of the sequence: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#take-long-boolean-[Flux#take(long, true)]
+**** ...requesting an unbounded amount from upstream: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#take-long-boolean-[Flux#take(long, false)]
 **** ...based on a duration: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#take-java.time.Duration-[Flux#take(Duration)]
 **** ...only the first element, as a https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html[Mono]: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#next--[Flux#next()]
 **** ...using https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/org/reactivestreams/Subscription.html#request(long)[request(N)] rather than cancellation: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#limitRequest-long-[Flux#limitRequest(long)]

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -8589,9 +8589,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 
 	/**
 	 * Take only the first N values from this {@link Flux}, if available.
-	 * <p>
-	 * If N is zero, the resulting {@link Flux} completes as soon as this {@link Flux}
-	 * signals its first value (which is not not relayed, though).
+	 * If n is zero, the source is subscribed to but immediately cancelled, then the operator completes.
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/take.svg" alt="">
 	 * <p>
@@ -8617,23 +8615,26 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	/**
 	 * Take only the first N values from this {@link Flux}, if available.
 	 * <p>
-	 * If N is zero, the resulting {@link Flux} completes as soon as this {@link Flux}
-	 * signals its first value (which is not not relayed, though).
-	 * <p>
 	 * <img class="marble" src="doc-files/marbles/takeLimitRequestTrue.svg" alt="">
 	 * <p>
 	 * If {@code limitRequest == true}, ensure that the total amount requested upstream is capped
 	 * at {@code n}. In that configuration, this operator never let the upstream produce more elements
 	 * than the cap, and it can be used to more strictly adhere to backpressure.
-	 * Typically useful for cases where a race between request and cancellation can lead the upstream to
-	 * producing a lot of extraneous data, and such a production is undesirable (e.g.
+	 * If n is zero, the source isn't even subscribed to and the operator completes immediately
+	 * upon subscription.
+	 * <p>
+	 * This mode is typically useful for cases where a race between request and cancellation can lead
+	 * the upstream to producing a lot of extraneous data, and such a production is undesirable (e.g.
 	 * a source that would send the extraneous data over the network).
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/takeLimitRequestFalse.svg" alt="takeLimitRequestFalse">
 	 * <p>
 	 * If {@code limitRequest == false} this operator doesn't propagate the backpressure requested amount.
 	 * Rather, it makes an unbounded request and cancels once N elements have been emitted.
-	 * As a result, the source could produce a lot of extraneous elements in the meantime.
+	 * If n is zero, the source is subscribed to but immediately cancelled, then the operator completes
+	 * (the behavior inherited from {@link #take(long)}).
+	 * <p>
+	 * In this mode, the source could produce a lot of extraneous elements despite cancellation.
 	 * If that behavior is undesirable and you do not own the request from downstream
 	 * (e.g. prefetching operators), consider using {@code limitRequest = true} instead.
 	 *

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeEager.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeEager.svg
@@ -1,0 +1,77 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 -5 685 315" width="685" height="315" id="svg127">
+ <defs id="defs23">
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma-Bold"/>
+   </font-face-src>
+  </font-face>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face4" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma"/>
+   </font-face-src>
+  </font-face>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
+   <g id="g8">
+    <path d="M12 0L0-4v9z" id="path6" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-miterlimit="10" viewBox="-10 -5 11 10" markerWidth="11" markerHeight="10" color="#797979" stroke-linejoin="miter">
+   <g id="g13">
+    <path d="M-8 0l8 3v-6z" id="path11" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#34302c" stroke-linejoin="miter">
+   <g id="g18">
+    <path d="M8 0L0-3v6z" id="path16" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="16" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face21" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma"/>
+   </font-face-src>
+  </font-face>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-0" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g16-6">
+    <path d="M8 0L0-3v6z" id="path14-1" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+ </defs>
+ <path d="M44 130h380l1 1v65l-1 1H44l-1-1v-65z" id="path33" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <text id="text41" x="-48" y="149" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="24" font-weight="700" x="162" y="171" id="tspan35" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c">takeEager (</tspan> <tspan font-size="21" font-weight="400" y="171" id="tspan37" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c">3</tspan> <tspan font-size="24" font-weight="700" y="171" id="tspan39" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c">)</tspan>
+ </text>
+ <path id="line52" d="M27 279h391" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
+ <path id="path55" d="M332 255l2 2v44c0 2-1 2-2 2s-2 0-2-2v-44z" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line58" d="M27 24h387" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
+ <path id="line86" d="M129 44v66" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000002,6.00000009" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3)"/>
+ <path id="line89" d="M199 44v66" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000002,6.00000009" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3)"/>
+ <path id="line92" d="M270 44l-1 66" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000002,6.00000009" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3)"/>
+ <path id="line110" d="M129 197v39" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3)"/>
+ <path id="line113" d="M200 197v39" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3)"/>
+ <path id="line116" d="M269 197v39" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2,6" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3)"/>
+ <path id="line918" d="M332 200v33" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000001,6.00000001" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3)"/>
+ <path id="line1406" d="M332 127V45" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000009,6.00000028" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-0)"/>
+ <text y="312" x="-117" transform="rotate(-90)" id="text1410" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="14" font-weight="400" x="-117" y="325" id="tspan1408" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">cancel()</tspan>
+ </text>
+ <path id="path984" d="M510 131h192v68H510z" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <text y="150" x="324" id="text992" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan986" y="172" x="524" font-weight="700" font-size="24" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c">takeEager (<tspan id="tspan6328" font-weight="400">0</tspan> )</tspan>
+ </text>
+ <path id="line994" d="M518 281h156" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
+ <path d="M600 256h1l2 2v45l-2 2h-1l-2-2v-45z" id="path996" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
+ <path id="line998" d="M511 26h162" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
+ <path id="line1012" d="M560 45v66" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000002,6.00000009" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3)"/>
+ <path id="line1036" d="M600 201v33" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000001,6.00000001" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3)"/>
+ <path id="line907" d="M601 127l-1-82" fill="none" fill-opacity="1" stroke="#45b8de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00000009,6.00000028" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_3-0)"/>
+ <text id="text911" transform="rotate(-90)" x="-117" y="576" fill="#45b8de" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan909" y="589" x="-117" font-weight="400" font-size="14" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">cancel()</tspan>
+ </text>
+ <circle r="23" id="ellipse37" cy="24" cx="128" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="23" id="ellipse42" cy="24" cx="199" fill="#e6ba31" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="23" id="ellipse47" cy="24" cx="269" fill="#45b8de" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle r="23" cx="560" cy="26" id="ellipse1151" fill="#ff5a01" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="128" cy="278" id="circle11176" r="23" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="199" cy="278" id="circle11178" r="23" fill="#e6ba31" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+ <circle cx="269" cy="278" id="circle11180" r="23" fill="#45b8de" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
+</svg>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeLimitRequestFalse.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeLimitRequestFalse.svg
@@ -1,15 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="21 -5 685 315" width="685" height="315" id="svg127">
  <defs id="defs23">
-  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
-   <font-face-src>
-    <font-face-name name="Tahoma-Bold"/>
-   </font-face-src>
-  </font-face>
-  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face4" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
-   <font-face-src>
-    <font-face-name name="Tahoma"/>
-   </font-face-src>
-  </font-face>
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g8">
     <path d="M12 0L0-4v9z" id="path6" fill="currentColor" stroke="currentColor" stroke-width="1"/>
@@ -25,20 +15,30 @@
     <path d="M8 0L0-3v6z" id="path16" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="16" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face21" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
-   <font-face-src>
-    <font-face-name name="Tahoma"/>
-   </font-face-src>
-  </font-face>
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-0" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
    <g id="g16-6">
     <path d="M8 0L0-3v6z" id="path14-1" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face2" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma-Bold"/>
+   </font-face-src>
+  </font-face>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face4" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma"/>
+   </font-face-src>
+  </font-face>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="16" panose-1="2 11 5 2 2 1 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="450" cap-height="687" ascent="918" descent="-230" font-weight="400" id="font-face21" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma"/>
+   </font-face-src>
+  </font-face>
  </defs>
  <path d="M44 130h380l1 1v65l-1 1H44l-1-1v-65z" id="path33" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <text id="text41" x="-48" y="149" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
-  <tspan font-size="24" font-weight="700" x="162" y="171" id="tspan35" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c">takeEager (</tspan> <tspan font-size="21" font-weight="400" y="171" id="tspan37" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c">3</tspan> <tspan font-size="24" font-weight="700" y="171" id="tspan39" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c">)</tspan>
+ <text id="text41" x="-54.68" y="149" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan font-size="24" font-weight="700" x="155.32" y="171" id="tspan35" font-family="Tahoma, 'Nimbus Sans L'" fill="#34302c">take(</tspan><tspan font-size="21" font-weight="400" y="171" id="tspan37" font-family="Tahoma, 'Nimbus Sans L'" fill="#34302c">3</tspan><tspan font-size="24" font-weight="700" y="171" id="tspan39" font-family="Tahoma, 'Nimbus Sans L'" fill="#34302c">, false)</tspan>
  </text>
  <path id="line52" d="M27 279h391" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
  <path id="path55" d="M332 255l2 2v44c0 2-1 2-2 2s-2 0-2-2v-44z" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>
@@ -55,8 +55,8 @@
   <tspan font-size="14" font-weight="400" x="-117" y="325" id="tspan1408" font-family="Tahoma,'Nimbus Sans L'" fill="#45b8de">cancel()</tspan>
  </text>
  <path id="path984" d="M510 131h192v68H510z" fill="#fff" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
- <text y="150" x="324" id="text992" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan986" y="172" x="524" font-weight="700" font-size="24" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c">takeEager (<tspan id="tspan6328" font-weight="400">0</tspan> )</tspan>
+ <text y="150" x="325.42" id="text992" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan986" y="172" x="525.42" font-weight="700" font-size="24" font-family="Tahoma, 'Nimbus Sans L'" fill="#34302c">take(0, false)</tspan>
  </text>
  <path id="line994" d="M518 281h156" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
  <path d="M600 256h1l2 2v45l-2 2h-1l-2-2v-45z" id="path996" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1"/>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeLimitRequestTrue.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/takeLimitRequestTrue.svg
@@ -10,11 +10,6 @@
     <path d="M8 0L0-3v6z" id="path7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
-  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face12" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
-   <font-face-src>
-    <font-face-name name="Tahoma-Bold"/>
-   </font-face-src>
-  </font-face>
   <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3" stroke-miterlimit="10" viewBox="-1 -6 14 12" markerWidth="14" markerHeight="12" color="#34302c" stroke-linejoin="miter">
    <g id="g16">
     <path d="M12 0L0-4v9z" id="path14" fill="currentColor" stroke="currentColor" stroke-width="1"/>
@@ -25,6 +20,34 @@
     <path d="M8 0L0-3v6z" id="path19" fill="currentColor" stroke="currentColor" stroke-width="1"/>
    </g>
   </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-3" stroke-miterlimit="10" viewBox="-6 -3 7 6" markerWidth="7" markerHeight="6" color="#45b8de" stroke-linejoin="miter">
+   <g id="g9-6">
+    <path d="M-5 0l5 2v-4z" id="path7-7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" refY="0" refX="0" id="Arrow2Lend" overflow="visible">
+   <path id="path5247" d="M-11-4L1 0l-12 4c2-2 2-6 0-8z" fill="#000" fill-opacity="1" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linejoin="round" stroke-opacity="1"/>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3-5" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g16-6-9">
+    <path d="M8 0L0-3v6z" id="path14-7-1" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3-5-6" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g16-6-9-1">
+    <path d="M8 0L0-3v6z" id="path14-7-1-7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3-5-0" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
+   <g id="g16-6-9-9">
+    <path d="M8 0L0-3v6z" id="path14-7-1-2" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+   </g>
+  </marker>
+  <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="24" panose-1="2 11 9 2 3 0 4 2 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="501" cap-height="682" ascent="923" descent="-235" font-weight="700" id="font-face12" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
+   <font-face-src>
+    <font-face-name name="Tahoma-Bold"/>
+   </font-face-src>
+  </font-face>
   <font-face font-family="'Tahoma','Nimbus Sans L'" font-size="28" panose-1="2 11 9 2 3 0 4 9 2 3" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="-286" x-height="501" cap-height="682" ascent="921" descent="-235" font-style="italic" font-weight="700" id="font-face24" stemv="0" stemh="0" accent-height="0" ideographic="0" alphabetic="0" mathematical="0" hanging="0" v-ideographic="0" v-alphabetic="0" v-mathematical="0" v-hanging="0" strikethrough-position="0" strikethrough-thickness="0" overline-position="0" overline-thickness="0">
    <font-face-src>
     <font-face-name name="Tahoma-BoldItalic"/>
@@ -50,29 +73,6 @@
     <font-face-name name="FontAwesome"/>
    </font-face-src>
   </font-face>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2-3" stroke-miterlimit="10" viewBox="-6 -3 7 6" markerWidth="7" markerHeight="6" color="#45b8de" stroke-linejoin="miter">
-   <g id="g9-6">
-    <path d="M-5 0l5 2v-4z" id="path7-7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" refY="0" refX="0" id="Arrow2Lend" overflow="visible">
-   <path id="path5247" d="M-11-4L1 0l-12 4c2-2 2-6 0-8z" fill="#000" fill-opacity="1" fill-rule="evenodd" stroke="#000" stroke-width="1" stroke-linejoin="round" stroke-opacity="1"/>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3-5" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
-   <g id="g16-6-9">
-    <path d="M8 0L0-3v6z" id="path14-7-1" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3-5-6" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
-   <g id="g16-6-9-1">
-    <path d="M8 0L0-3v6z" id="path14-7-1-7" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
-  <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3-3-5-0" stroke-miterlimit="10" viewBox="-1 -5 11 10" markerWidth="11" markerHeight="10" color="#45b8de" stroke-linejoin="miter">
-   <g id="g16-6-9-9">
-    <path d="M8 0L0-3v6z" id="path14-7-1-2" fill="currentColor" stroke="currentColor" stroke-width="1"/>
-   </g>
-  </marker>
  </defs>
  <path id="line42" d="M31.01 73h557" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1" marker-end="url(#FilledArrow_Marker)"/>
  <circle id="ellipse47" cy="73" cx="217.01" r="23" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
@@ -88,8 +88,8 @@
  <path d="M217.47 96.39v60.79" id="path1310" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2.33" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.33373478,7.00120433" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_4)"/>
  <path d="M276.6 96.39v60.79" id="path1312" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2.33" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.33373478,7.00120433" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_4)"/>
  <path d="M414.56 96.39v60.79" id="path1314" fill="none" fill-opacity="1" stroke="#34302c" stroke-width="2.33" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.33373478,7.00120433" stroke-opacity="1" marker-end="url(#FilledArrow_Marker_4)"/>
- <text y="194.7" x="-15.96" id="text81" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
-  <tspan id="tspan79" y="216.7" x="227.04" font-weight="700" font-size="24" font-family="Tahoma,'Nimbus Sans L'" fill="#34302c">limitRequest(3)</tspan>
+ <text y="194.7" x="2.58" id="text81" fill="#34302c" fill-opacity="1" stroke="none" stroke-dasharray="none" stroke-opacity="1">
+  <tspan id="tspan79" y="216.7" x="245.58" font-weight="700" font-size="24" font-family="Tahoma, 'Nimbus Sans L'" fill="#34302c">take(3, true)</tspan>
  </text>
  <circle r="23" cx="217.01" cy="356.14" id="circle1487" fill="#6cb33e" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>
  <circle r="23" cx="276.01" cy="356.14" id="circle1489" fill="#e6ba31" fill-opacity="1" stroke="#34302c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" stroke-opacity="1"/>

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
@@ -53,7 +53,7 @@ public class FluxTakeTest {
 	public void numberIsInvalid() {
 		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
 			Flux.never()
-					.take(-1);
+					.take(-1, false);
 		});
 	}
 
@@ -61,7 +61,7 @@ public class FluxTakeTest {
 	public void numberIsInvalidFused() {
 		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
 			Flux.just(1)
-					.take(-1);
+					.take(-1, false);
 		});
 	}
 
@@ -70,7 +70,7 @@ public class FluxTakeTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		Flux.range(1, 10)
-		    .take(5)
+		    .take(5, false)
 		    .subscribe(ts);
 
 		ts.assertValues(1, 2, 3, 4, 5)
@@ -83,7 +83,7 @@ public class FluxTakeTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
 		Flux.range(1, 10)
-		    .take(5)
+		    .take(5, false)
 		    .subscribe(ts);
 
 		ts.assertNoValues()
@@ -108,7 +108,7 @@ public class FluxTakeTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create(0);
 
 		Flux.range(1, 10)
-		    .take(0)
+		    .take(0, false)
 		    .subscribe(ts);
 
 		ts.assertNoValues()
@@ -119,7 +119,7 @@ public class FluxTakeTest {
 	@Test
 	public void takeNever() {
 		StepVerifier.create(
-				Flux.never().take(1))
+				Flux.never().take(1, false))
 		            .expectSubscription()
 		            .expectNoEvent(Duration.ofSeconds(1))
 		            .thenCancel()
@@ -129,7 +129,7 @@ public class FluxTakeTest {
 	@Test
 	public void takeNeverZero() {
 		PublisherProbe<Object> probe = PublisherProbe.of(Flux.never());
-		StepVerifier.create(probe.flux().take(0))
+		StepVerifier.create(probe.flux().take(0, false))
 		            .expectSubscription()
 		            .expectComplete()
 		            .verify(Duration.ofSeconds(1));
@@ -146,7 +146,7 @@ public class FluxTakeTest {
 			s.onNext(3);
 		};
 
-		StepVerifier.create(Flux.from(p).take(2))
+		StepVerifier.create(Flux.from(p).take(2, false))
 		            .expectNext(1, 2)
 		            .expectComplete()
 		            .verifyThenAssertThat()
@@ -156,7 +156,7 @@ public class FluxTakeTest {
 	@Test
 	public void aFluxCanBeLimited(){
 		StepVerifier.create(Flux.just("test", "test2", "test3")
-		                        .take(2)
+		                        .take(2, false)
 		)
 		            .expectNext("test", "test2")
 		            .verifyComplete();
@@ -184,7 +184,7 @@ public class FluxTakeTest {
 				}
 			});
 		})
-		                        .take(3), 0)
+		                        .take(3, false), 0)
 		            .thenAwait()
 		            .thenRequest(2)
 		            .expectNext("test", "test")
@@ -197,7 +197,7 @@ public class FluxTakeTest {
 	public void takeFusedBackpressured() {
 		Sinks.Many<String> up = Sinks.many().unicast().onBackpressureBuffer();
 		StepVerifier.create(up.asFlux()
-							  .take(3), 0)
+							  .take(3, false), 0)
 		            .expectFusion()
 		            .then(() -> up.emitNext("test", FAIL_FAST))
 		            .then(() -> up.emitNext("test2", FAIL_FAST))
@@ -215,7 +215,7 @@ public class FluxTakeTest {
 	public void takeFusedBackpressuredCancelled() {
 		Sinks.Many<String> up = Sinks.many().unicast().onBackpressureBuffer();
 		StepVerifier.create(up.asFlux()
-							  .take(3).doOnSubscribe(s -> {
+							  .take(3, false).doOnSubscribe(s -> {
 			assertThat(((Fuseable.QueueSubscription)s).size()).isEqualTo(0);
 		}), 0)
 		            .expectFusion()
@@ -251,7 +251,7 @@ public class FluxTakeTest {
 				}
 			});
 		})
-		                        .take(3)
+		                        .take(3, false)
 								.filter("test"::equals), 0)
 		            .thenAwait()
 		            .thenRequest(2)
@@ -286,7 +286,7 @@ public class FluxTakeTest {
 				}
 			});
 		})
-		                        .take(3)
+		                        .take(3, false)
 								.filter("test"::equals), 0)
 		            .thenAwait()
 		            .thenRequest(2)
@@ -302,7 +302,7 @@ public class FluxTakeTest {
 		Flux.range(1, 100)
 				.hide()
 				.doOnRequest(requested::set)
-				.takeEager(5)
+				.take(5, false)
 				.as(f -> StepVerifier.create(f, 40))
 				.expectNextCount(5)
 				.verifyComplete();
@@ -318,7 +318,7 @@ public class FluxTakeTest {
 			s.onComplete();
 			s.onNext(1);
 		})
-		                        .take(2))
+		                        .take(2, false))
 		            .verifyComplete();
 		Hooks.resetOnNextDropped();
 	}
@@ -327,7 +327,7 @@ public class FluxTakeTest {
 	public void failNextIfTerminatedTakeFused() {
 		TestPublisher<Integer> up = TestPublisher.createNoncompliant(TestPublisher.Violation.CLEANUP_ON_TERMINATE);
 		Hooks.onNextDropped(t -> assertThat(t).isEqualTo(1));
-		StepVerifier.create(up.flux().take(2))
+		StepVerifier.create(up.flux().take(2, false))
 		            .then(up::complete)
 		            .then(() -> up.next(1))
 		            .verifyComplete();
@@ -342,7 +342,7 @@ public class FluxTakeTest {
 			s.onComplete();
 			s.onNext(1);
 		})
-		                        .take(2)
+		                        .take(2, false)
 		                        .filter("test2"::equals))
 		            .verifyComplete();
 		Hooks.resetOnNextDropped();
@@ -357,7 +357,7 @@ public class FluxTakeTest {
 			s.onComplete();
 			((Fuseable.ConditionalSubscriber)s).tryOnNext(1);
 		})
-		                        .take(2)
+		                        .take(2, false)
 		                        .filter("test2"::equals))
 		            .verifyComplete();
 		Hooks.resetOnNextDropped();
@@ -367,7 +367,7 @@ public class FluxTakeTest {
 	public void take() {
 		StepVerifier.create(Flux.just("test", "test2", "test3")
 		                        .hide()
-		                        .take(2))
+		                        .take(2, false))
 		            .expectNext("test", "test2")
 		            .verifyComplete();
 	}
@@ -376,7 +376,7 @@ public class FluxTakeTest {
 	public void takeCancel() {
 		StepVerifier.create(Flux.just("test", "test2", "test3")
 		                        .hide()
-		                        .take(3), 2)
+		                        .take(3, false), 2)
 		            .expectNext("test", "test2")
 		            .thenCancel()
 		            .verify();
@@ -385,7 +385,7 @@ public class FluxTakeTest {
 	@Test
 	public void takeFused() {
 		StepVerifier.create(Flux.just("test", "test2", "test3")
-		                        .take(2))
+		                        .take(2, false))
 		            .expectNext("test", "test2")
 		            .verifyComplete();
 	}
@@ -393,7 +393,7 @@ public class FluxTakeTest {
 	@Test
 	public void takeFusedSync() {
 		StepVerifier.create(Flux.just("test", "test2", "test3")
-		                        .take(2))
+		                        .take(2, false))
 		            .expectFusion(Fuseable.SYNC)
 		            .expectNext("test", "test2")
 		            .verifyComplete();
@@ -403,7 +403,7 @@ public class FluxTakeTest {
 	public void takeFusedAsync() {
 		Sinks.Many<String> up = Sinks.many().unicast().onBackpressureBuffer();
 		StepVerifier.create(up.asFlux()
-							  .take(2))
+							  .take(2, false))
 		            .expectFusion(Fuseable.ASYNC)
 		            .then(() -> {
 			            up.emitNext("test", FAIL_FAST);
@@ -416,7 +416,7 @@ public class FluxTakeTest {
 	@Test
 	public void takeFusedCancel() {
 		StepVerifier.create(Flux.just("test", "test2", "test3")
-		                        .take(3), 2)
+		                        .take(3, false), 2)
 		            .expectNext("test", "test2")
 		            .thenCancel()
 		            .verify();
@@ -427,7 +427,7 @@ public class FluxTakeTest {
 	public void takeConditional() {
 		StepVerifier.create(Flux.just("test", "test2", "test3")
 		                        .hide()
-		                        .take(2)
+		                        .take(2, false)
 		                        .filter("test2"::equals))
 		            .expectNext("test2")
 		            .verifyComplete();
@@ -437,7 +437,7 @@ public class FluxTakeTest {
 	public void takeConditionalCancel() {
 		StepVerifier.create(Flux.just("test", "test2", "test3")
 		                        .hide()
-		                        .take(3)
+		                        .take(3, false)
 		                        .filter("test2"::equals), 2)
 		            .thenCancel()
 		            .verify();
@@ -446,7 +446,7 @@ public class FluxTakeTest {
 	@Test
 	public void takeConditionalFused() {
 		StepVerifier.create(Flux.just("test", "test2", "test3")
-		                        .take(2)
+		                        .take(2, false)
 		                        .filter("test2"::equals))
 		            .expectNext("test2")
 		            .verifyComplete();
@@ -455,7 +455,7 @@ public class FluxTakeTest {
 	@Test
 	public void takeConditionalFusedCancel() {
 		StepVerifier.create(Flux.just("test", "test2", "test3")
-		                        .take(3)
+		                        .take(3, false)
 		                        .filter("test2"::equals), 2)
 		            .expectNext("test2")
 		            .thenCancel()
@@ -487,7 +487,7 @@ public class FluxTakeTest {
 			assertTrackableAfterOnComplete((InnerOperator)s);
 			s.onError(new Exception("test2"));
 		})
-		                        .take(2))
+		                        .take(2, false))
 		            .verifyErrorMessage("test");
 	}
 
@@ -503,7 +503,7 @@ public class FluxTakeTest {
 			assertTrackableAfterOnComplete((InnerOperator)s);
 			s.onError(new Exception("test2"));
 		})
-		                        .take(2).filter(d -> true))
+		                        .take(2, false).filter(d -> true))
 		            .verifyErrorMessage("test");
 	}
 
@@ -514,7 +514,7 @@ public class FluxTakeTest {
 		Sinks.Many<Integer> up = Sinks.many().unicast().onBackpressureBuffer();
 		Hooks.onErrorDropped(e -> assertThat(e).hasMessage("test2"));
 		StepVerifier.create(up.asFlux()
-							  .take(2))
+							  .take(2, false))
 		            .consumeSubscriptionWith(s -> {
 			            assertTrackableBeforeOnSubscribe((InnerOperator)s);
 		            })
@@ -532,7 +532,7 @@ public class FluxTakeTest {
 	public void ignoreFusedDoubleComplete() {
 		Sinks.Many<Integer> up = Sinks.many().unicast().onBackpressureBuffer();
 		StepVerifier.create(up.asFlux()
-							  .take(2).filter(d -> true))
+							  .take(2, false).filter(d -> true))
 		            .consumeSubscriptionWith(s -> {
 			            assertTrackableAfterOnSubscribe((InnerOperator)s);
 		            })
@@ -553,7 +553,7 @@ public class FluxTakeTest {
 			s.onComplete();
 			s.onComplete();
 		})
-		                        .take(2))
+		                        .take(2, false))
 		            .verifyComplete();
 	}
 
@@ -561,7 +561,7 @@ public class FluxTakeTest {
 	public void assertPrefetch() {
 		assertThat(Flux.just("test", "test2", "test3")
 		               .hide()
-		               .take(2)
+		               .take(2, false)
 		               .getPrefetch()).isEqualTo(Integer.MAX_VALUE);
 	}
 
@@ -572,7 +572,7 @@ public class FluxTakeTest {
 			s.onSubscribe(Operators.emptySubscription());
 			s.onComplete();
 		})
-		                        .take(2))
+		                        .take(2, false))
 		            .verifyComplete();
 	}
 	@Test
@@ -582,7 +582,7 @@ public class FluxTakeTest {
 			s.onSubscribe(Operators.emptySubscription());
 			s.onComplete();
 		})
-		                        .take(2)
+		                        .take(2, false)
 		                        .filter(d -> true))
 		            .verifyComplete();
 	}
@@ -591,7 +591,7 @@ public class FluxTakeTest {
 	public void takeZeroCancelsWhenNoRequest() {
 		TestPublisher<Integer> ts = TestPublisher.create();
 		StepVerifier.create(ts.flux()
-		                      .take(0), 0)
+		                      .take(0, false), 0)
 		            .thenAwait()
 		            .verifyComplete();
 
@@ -603,7 +603,7 @@ public class FluxTakeTest {
 	public void takeZeroIgnoresRequestAndCancels() {
 		TestPublisher<Integer> ts = TestPublisher.create();
 		StepVerifier.create(ts.flux()
-		                      .take(0), 3)
+		                      .take(0, false), 3)
 		            .thenAwait()
 		            .verifyComplete();
 
@@ -615,7 +615,7 @@ public class FluxTakeTest {
 	public void takeConditionalZeroCancelsWhenNoRequest() {
 		TestPublisher<Integer> ts = TestPublisher.create();
 		StepVerifier.create(ts.flux()
-		                      .take(0)
+		                      .take(0, false)
 		                      .filter(d -> true), 0)
 		            .thenAwait()
 		            .verifyComplete();
@@ -628,7 +628,7 @@ public class FluxTakeTest {
 	public void takeConditionalZeroIgnoresRequestAndCancels() {
 		TestPublisher<Integer> ts = TestPublisher.create();
 		StepVerifier.create(ts.flux()
-		                      .take(0)
+		                      .take(0, false)
 		                      .filter(d -> true), 3)
 		            .thenAwait()
 		            .verifyComplete();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
@@ -297,17 +297,17 @@ public class FluxTakeTest {
 	}
 
 	@Test
-	void propagatesBoundedDemandGreaterThanTakeLimit() {
+	void propagatesUnboundedDemand() {
 		AtomicLong requested = new AtomicLong();
 		Flux.range(1, 100)
 				.hide()
 				.doOnRequest(requested::set)
-				.take(5)
+				.takeEager(5)
 				.as(f -> StepVerifier.create(f, 40))
 				.expectNextCount(5)
 				.verifyComplete();
 
-		assertThat(requested).hasValue(40L);
+		assertThat(requested).hasValue(Long.MAX_VALUE);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
@@ -19,6 +19,7 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -293,6 +294,20 @@ public class FluxTakeTest {
 		            .thenRequest(1)
 		            .expectNext("test")
 		            .verifyComplete();
+	}
+
+	@Test
+	void propagatesBoundedDemandGreaterThanTakeLimit() {
+		AtomicLong requested = new AtomicLong();
+		Flux.range(1, 100)
+				.hide()
+				.doOnRequest(requested::set)
+				.take(5)
+				.as(f -> StepVerifier.create(f, 40))
+				.expectNextCount(5)
+				.verifyComplete();
+
+		assertThat(requested).hasValue(40L);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
@@ -767,7 +767,7 @@ public class HooksTest {
 			Hooks.onNextDroppedFail();
 
 			assertThatExceptionOfType(RuntimeException.class)
-					.isThrownBy(() -> Flux.from(p).take(2).subscribe(seen::add))
+					.isThrownBy(() -> Flux.from(p).take(2, false).subscribe(seen::add))
 					.isInstanceOf(RuntimeException.class)
 					.matches(Exceptions::isCancel);
 


### PR DESCRIPTION
This commit introduces the `takeEager` operator and makes `take` an
alias for it. `takeEager` is the new canonical way of obtaining the
current take behavior (unbounded upstream request, cancels when enough
elements have been emitted).

Furthermore, it reflects in `take` javadoc that the behavior will change
in 3.5.0 so that `take` becomes the new official name for `limitRequest`
behavior (still cancel whenever enough elements have been emitted,
but limit the upstream request to what is strictly necessary).
See #2690 for planned changes.

Fixes #2339.
