### PR TITLE
Polish corner cases in FluxLimitRequest, complete fast on cap=0

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxLimitRequest.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxLimitRequest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.reactivestreams.Subscription;
 
 import reactor.core.CoreSubscriber;
+import reactor.util.annotation.Nullable;
 
 /**
  * @author Simon Baslé
@@ -39,6 +40,7 @@ final class FluxLimitRequest<T> extends InternalFluxOperator<T, T> {
 	}
 
 	@Override
+	@Nullable
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
 		if (this.cap == 0) {
 			Operators.complete(actual);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxLimitRequest.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxLimitRequest.java
@@ -19,6 +19,7 @@ package reactor.core.publisher;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import org.reactivestreams.Subscription;
+
 import reactor.core.CoreSubscriber;
 
 /**
@@ -31,11 +32,18 @@ final class FluxLimitRequest<T> extends InternalFluxOperator<T, T> {
 
 	FluxLimitRequest(Flux<T> flux, long cap) {
 		super(flux);
+		if (cap < 0) {
+			throw new IllegalArgumentException("cap >= 0 required but it was " + cap);
+		}
 		this.cap = cap;
 	}
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
+		if (this.cap == 0) {
+			Operators.complete(actual);
+			return null;
+		}
 		return new FluxLimitRequestSubscriber<>(actual, this.cap);
 	}
 
@@ -58,6 +66,7 @@ final class FluxLimitRequest<T> extends InternalFluxOperator<T, T> {
 
 		Subscription parent;
 		long toProduce;
+		boolean done;
 
 		volatile long requestRemaining;
 		static final AtomicLongFieldUpdater<FluxLimitRequestSubscriber> REQUEST_REMAINING =
@@ -77,12 +86,17 @@ final class FluxLimitRequest<T> extends InternalFluxOperator<T, T> {
 
 		@Override
 		public void onNext(T t) {
+			if (done) {
+				Operators.onNextDropped(t, actual.currentContext());
+				return;
+			}
 			long r = toProduce;
 			if (r > 0L) {
 				toProduce = --r;
 				actual.onNext(t);
 
 				if (r == 0) {
+					done = true;
 					parent.cancel();
 					actual.onComplete();
 				}
@@ -91,24 +105,29 @@ final class FluxLimitRequest<T> extends InternalFluxOperator<T, T> {
 
 		@Override
 		public void onError(Throwable throwable) {
-			if (toProduce != 0L) {
-				toProduce = 0L;
-				actual.onError(throwable);
+			if (done) {
+				Operators.onErrorDropped(throwable, currentContext());
+				return;
 			}
+			done = true;
+			actual.onError(throwable);
 		}
 
 		@Override
 		public void onComplete() {
-			if (toProduce != 0L) {
-				toProduce = 0L;
-				actual.onComplete();
+			if (done) {
+				return;
 			}
+			done = true;
+			actual.onComplete();
 		}
 
 		@Override
 		public void onSubscribe(Subscription s) {
-			parent = s;
-			actual.onSubscribe(this);
+			if (Operators.validate(this.parent, s)) {
+				parent = s;
+				actual.onSubscribe(this);
+			}
 		}
 
 		@Override
@@ -139,7 +158,7 @@ final class FluxLimitRequest<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public Object scanUnsafe(Attr key) {
 			if (key == Attr.PARENT) return parent;
-			if (key == Attr.TERMINATED) return toProduce == 0L;
+			if (key == Attr.TERMINATED) return done;
 
 			//InnerOperator defines ACTUAL
 			return InnerOperator.super.scanUnsafe(key);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxLimitRequestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxLimitRequestTest.java
@@ -34,10 +34,10 @@ import reactor.test.util.RaceTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FluxLimitRequestTest {
+class FluxLimitRequestTest {
 
 	@Test
-	public void apiCall() {
+	void apiCall() {
 		LongAdder rCount = new LongAdder();
 		final Flux<Integer> source = Flux.range(1, 100)
 		                                 .doOnRequest(rCount::add);
@@ -50,7 +50,7 @@ public class FluxLimitRequestTest {
 	}
 
 	@Test
-	public void unboundedDownstreamRequest() {
+	void unboundedDownstreamRequest() {
 		LongAdder rCount = new LongAdder();
 		final Flux<Integer> source = Flux.range(1, 100)
 		                                 .doOnRequest(rCount::add);
@@ -67,7 +67,7 @@ public class FluxLimitRequestTest {
 	}
 
 	@Test
-	public void boundedDownStreamRequestMatchesCap() {
+	void boundedDownStreamRequestMatchesCap() {
 		LongAdder rCount = new LongAdder();
 		final Flux<Integer> source = Flux.range(1, 100)
 		                                 .doOnRequest(rCount::add);
@@ -94,7 +94,7 @@ public class FluxLimitRequestTest {
 	}
 
 	@Test
-	public void boundedDownStreamRequestOverflowsCap() {
+	void boundedDownStreamRequestOverflowsCap() {
 		List<Long> requests = new ArrayList<>();
 		final Flux<Integer> source = Flux.range(1, 100)
 		                                 .doOnRequest(requests::add);
@@ -123,7 +123,7 @@ public class FluxLimitRequestTest {
 	}
 
 	@Test
-	public void extraneousSmallRequestsNotPropagatedAsZero() {
+	void extraneousSmallRequestsNotPropagatedAsZero() {
 		List<Long> requests = new ArrayList<>();
 		final Flux<Integer> source = Flux.range(1, 100)
 		                                 .doOnRequest(requests::add);
@@ -145,7 +145,7 @@ public class FluxLimitRequestTest {
 	}
 
 	@Test
-	public void largerSourceCancelled() {
+	void largerSourceCancelled() {
 		AtomicBoolean cancelled = new AtomicBoolean();
 
 		Flux<Integer> test = Flux.range(1, 1000)
@@ -160,7 +160,7 @@ public class FluxLimitRequestTest {
 	}
 
 	@Test
-	public void takeCancelsOperatorAndSource() {
+	void takeCancelsOperatorAndSource() {
 		AtomicBoolean sourceCancelled = new AtomicBoolean();
 		AtomicBoolean operatorCancelled = new AtomicBoolean();
 		LongAdder sourceRequested = new LongAdder();
@@ -179,20 +179,20 @@ public class FluxLimitRequestTest {
 		            .verifyComplete();
 
 		assertThat(operatorCancelled.get()).as("operator cancelled").isTrue();
-		assertThat(operatorRequested.longValue()).isEqualTo(Long.MAX_VALUE);
+		assertThat(operatorRequested.longValue()).as("operator request").isEqualTo(Long.MAX_VALUE);
 
 		assertThat(sourceCancelled.get()).as("source cancelled").isTrue();
-		assertThat(sourceRequested.longValue()).isEqualTo(10);
+		assertThat(sourceRequested.longValue()).as("source request").isEqualTo(10);
 	}
 
 	@Test
-	public void noPrefetch() {
+	void noPrefetch() {
 		assertThat(Flux.range(1, 10).limitRequest(3)
 				.getPrefetch()).isZero();
 	}
 
 	@Test
-	public void errorAtCapNotPropagated() {
+	void errorAtCapNotPropagated() {
 		TestPublisher<Integer> tp = TestPublisher.create();
 
 		StepVerifier.create(tp.flux().limitRequest(3))
@@ -202,7 +202,7 @@ public class FluxLimitRequestTest {
 	}
 
 	@Test
-	public void errorUnderCapPropagated() {
+	void errorUnderCapPropagated() {
 		TestPublisher<Integer> tp = TestPublisher.create();
 
 		StepVerifier.create(tp.flux().limitRequest(4))
@@ -212,7 +212,7 @@ public class FluxLimitRequestTest {
 	}
 
 	@Test
-	public void completeUnderCap() {
+	void completeUnderCap() {
 		TestPublisher<Integer> tp = TestPublisher.create();
 
 		StepVerifier.create(tp.flux().limitRequest(4))
@@ -222,17 +222,19 @@ public class FluxLimitRequestTest {
 	}
 
 	@Test
-	public void nextSignalDespiteAllProducedNotPropagated() {
-		TestPublisher<Integer> tp = TestPublisher.createNoncompliant(TestPublisher.Violation.CLEANUP_ON_TERMINATE);
+	void nextSignalDespiteAllProducedIsDropped() {
+		TestPublisher<Integer> tp = TestPublisher.createNoncompliant(TestPublisher.Violation.CLEANUP_ON_TERMINATE, TestPublisher.Violation.REQUEST_OVERFLOW);
 
 		StepVerifier.create(tp.flux().limitRequest(3))
-		            .then(() -> tp.emit(1, 2, 3, 4))
-		            .expectNext(1, 2, 3)
-		            .verifyComplete();
+				.then(() -> tp.emit(1, 2, 3, 4))
+				.expectNext(1, 2, 3)
+				.expectComplete()
+				.verifyThenAssertThat()
+				.hasDropped(4);
 	}
 
 	@Test
-	public void completeSignalDespiteAllProducedNotPropagated() {
+	void completeSignalDespiteAllProducedNotPropagated() {
 		TestPublisher<Integer> tp = TestPublisher.createNoncompliant(TestPublisher.Violation.CLEANUP_ON_TERMINATE);
 
 		StepVerifier.create(tp.flux().limitRequest(3))
@@ -242,17 +244,36 @@ public class FluxLimitRequestTest {
 	}
 
 	@Test
-	public void errorSignalDespiteAllProducedNotPropagated() {
+	void errorSignalDespiteAllProducedIsDropped() {
 		TestPublisher<Integer> tp = TestPublisher.createNoncompliant(TestPublisher.Violation.CLEANUP_ON_TERMINATE);
 
 		StepVerifier.create(tp.flux().limitRequest(3))
-		            .then(() -> tp.next(1, 2, 3).error(new IllegalStateException("boom")))
-		            .expectNext(1, 2, 3)
-		            .verifyComplete();
+				.then(() -> tp.next(1, 2, 3).error(new IllegalStateException("boom")))
+				.expectNext(1, 2, 3)
+				.expectComplete()
+				.verifyThenAssertThat()
+				.hasDroppedErrorWithMessage("boom");
 	}
 
 	@Test
-	public void scanOperator() {
+	void zeroCompletesImmediately() {
+		StepVerifier.create(Flux.range(1, 100).limitRequest(0))
+				.expectComplete()
+				.verify(Duration.ofSeconds(1));
+	}
+
+	@Test
+	void zeroDoesntEvenSubscribeToUpstream() {
+		AtomicBoolean subscribed = new AtomicBoolean();
+		StepVerifier.create(Flux.never().doOnSubscribe(sub -> subscribed.set(true)).limitRequest(0))
+				.expectComplete()
+				.verify(Duration.ofSeconds(1));
+
+		assertThat(subscribed).isFalse();
+	}
+
+	@Test
+	void scanOperator() {
 		Flux<String> source = Flux.just("foo").map(Function.identity());
 		FluxLimitRequest<String> operator = new FluxLimitRequest<>(source, 123);
 
@@ -262,7 +283,7 @@ public class FluxLimitRequestTest {
 	}
 
 	@Test
-	public void scanInner() {
+	void scanInner() {
 		CoreSubscriber<String> actual = new LambdaSubscriber<>(null, null, null, null);
 		FluxLimitRequest.FluxLimitRequestSubscriber<String> inner =
 				new FluxLimitRequest.FluxLimitRequestSubscriber<>(actual, 2);
@@ -279,7 +300,7 @@ public class FluxLimitRequestTest {
 	}
 
 	@Test
-	public void raceRequest() {
+	void raceRequest() {
 		List<Long> requests = Collections.synchronizedList(new ArrayList<>());
 		final Flux<Integer> flux = Flux.range(1, 1000)
 		                               .doOnRequest(requests::add)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxLimitRequestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxLimitRequestTest.java
@@ -33,6 +33,7 @@ import reactor.test.publisher.TestPublisher;
 import reactor.test.util.RaceTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 class FluxLimitRequestTest {
 
@@ -270,6 +271,12 @@ class FluxLimitRequestTest {
 				.verify(Duration.ofSeconds(1));
 
 		assertThat(subscribed).isFalse();
+	}
+
+	@Test
+	void negativeCapIsRejectedAtAssembly() {
+		assertThatIllegalArgumentException().isThrownBy(() -> Flux.empty().limitRequest(-1))
+				.withMessage("cap >= 0 required but it was -1");
 	}
 
 	@Test


### PR DESCRIPTION
This commit ensures that several corner cases are now covered in the
FluxLimitRequest operator:

 - a negative cap is rejected at assembly time
 - a zero cap leads to immediate completion of the actual during
 subscription. the source isn't even subscribed to.
 - extraneous onNext/onError are detected and dropped

Note that for eg. `limitRequest(3)`, if the source emits exactly 3
elements then an `onError`, the `limitRequest` operator will still
consider itself `onComplete`d (and will now drop the error).

Similarly, `Flux.error(th).limitRequest(0)` will immediately _complete_
and the error won't be dropped in that case (since the error Flux won't
be subscribed to).

Fixes #2698.
