### PR TITLE
Add fusionModeName static utility to Fuseable

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Fuseable.java
+++ b/reactor-core/src/main/java/reactor/core/Fuseable.java
@@ -47,7 +47,59 @@ public interface Fuseable {
 	 * whereas the unfused sequence would have invoked the mapper on the previous thread.
 	 * If such mapper invocation is costly, it would escape its thread boundary this way.
 	 */
-	int THREAD_BARRIER = 4;
+	int THREAD_BARRIER = 0b100; //4
+
+	/**
+	 * Attempt to convert a fusion mode int code into a human-readable representation.
+	 * Note that this can include the {@link #THREAD_BARRIER} flag, as an appended {@code +THREAD_BARRIER}.
+	 * <p>
+	 * This method accepts negative codes, mainly for the benefit of supporting testing scenarios where
+	 * fusion can be entirely deactivated (returns {@code Disabled}).
+	 * Unknown positive codes on the other hand return {@code Unknown(x)}.
+	 *
+	 * @param mode the fusion mode int code
+	 * @return a human-readable {@link String} representation of the code
+	 */
+	static String fusionModeName(int mode) {
+		return fusionModeName(mode, false);
+	}
+
+	/**
+	 * Attempt to convert a fusion mode int code into a human-readable representation.
+	 * Note that this can include the {@link #THREAD_BARRIER} flag, as an appended {@code +THREAD_BARRIER},
+	 * unless the {@code ignoreThreadBarrier} parameter is set to {@literal true}.
+	 * <p>
+	 * This method accepts negative codes, mainly for the benefit of supporting testing scenarios where
+	 * fusion can be entirely deactivated (returns {@code Disabled}).
+	 * Unknown positive codes on the other hand return {@code Unknown(x)}.
+	 *
+	 * @param mode the fusion mode int code
+	 * @param ignoreThreadBarrier whether or not to ignore the {@link #THREAD_BARRIER} flag in the representation
+	 * @return a human-readable {@link String} representation of the code
+	 */
+	static String fusionModeName(int mode, boolean ignoreThreadBarrier) {
+		int evaluated = mode;
+		String threadBarrierSuffix = "";
+		if (mode >= 0) {
+			evaluated = mode & ~THREAD_BARRIER; //erase the THREAD_BARRIER bit;
+			if ((mode & THREAD_BARRIER) == THREAD_BARRIER) {
+				threadBarrierSuffix = "+THREAD_BARRIER";
+			}
+		}
+
+		switch (evaluated) {
+			case -1:
+				return "Disabled"; //this is more specific for tests or things that can entirely skip the fusion negotiation
+			case Fuseable.NONE:
+				return "NONE";
+			case Fuseable.SYNC:
+				return "SYNC" + threadBarrierSuffix;
+			case Fuseable.ASYNC:
+				return "ASYNC" + threadBarrierSuffix;
+			default:
+				return "Unknown(" + mode + ")";
+		}
+	}
 
 	/**
 	 * A subscriber variant that can immediately tell if it consumed

--- a/reactor-core/src/main/java/reactor/core/Fuseable.java
+++ b/reactor-core/src/main/java/reactor/core/Fuseable.java
@@ -82,7 +82,7 @@ public interface Fuseable {
 		String threadBarrierSuffix = "";
 		if (mode >= 0) {
 			evaluated = mode & ~THREAD_BARRIER; //erase the THREAD_BARRIER bit;
-			if ((mode & THREAD_BARRIER) == THREAD_BARRIER) {
+			if (!ignoreThreadBarrier && (mode & THREAD_BARRIER) == THREAD_BARRIER) {
 				threadBarrierSuffix = "+THREAD_BARRIER";
 			}
 		}
@@ -91,13 +91,13 @@ public interface Fuseable {
 			case -1:
 				return "Disabled"; //this is more specific for tests or things that can entirely skip the fusion negotiation
 			case Fuseable.NONE:
-				return "NONE";
+				return "NONE" + threadBarrierSuffix;
 			case Fuseable.SYNC:
 				return "SYNC" + threadBarrierSuffix;
 			case Fuseable.ASYNC:
 				return "ASYNC" + threadBarrierSuffix;
 			default:
-				return "Unknown(" + mode + ")";
+				return "Unknown(" + evaluated + ")" + threadBarrierSuffix;
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/Fuseable.java
+++ b/reactor-core/src/main/java/reactor/core/Fuseable.java
@@ -53,9 +53,13 @@ public interface Fuseable {
 	 * Attempt to convert a fusion mode int code into a human-readable representation.
 	 * Note that this can include the {@link #THREAD_BARRIER} flag, as an appended {@code +THREAD_BARRIER}.
 	 * <p>
-	 * This method accepts negative codes, mainly for the benefit of supporting testing scenarios where
+	 * This method accepts {@code -1} as a special code, mainly for the benefit of supporting testing scenarios where
 	 * fusion can be entirely deactivated (returns {@code Disabled}).
-	 * Unknown positive codes on the other hand return {@code Unknown(x)}.
+	 * Other negative values and unknown positive codes on the other hand return {@code Unknown(x)}.
+	 * <p>
+	 * Note that as this is a human-facing representation, the different values could evolve in the future.
+	 * As such, never compare the returned string to a constant, but always use this method on both sides of
+	 * a comparison.
 	 *
 	 * @param mode the fusion mode int code
 	 * @return a human-readable {@link String} representation of the code
@@ -69,9 +73,13 @@ public interface Fuseable {
 	 * Note that this can include the {@link #THREAD_BARRIER} flag, as an appended {@code +THREAD_BARRIER},
 	 * unless the {@code ignoreThreadBarrier} parameter is set to {@literal true}.
 	 * <p>
-	 * This method accepts negative codes, mainly for the benefit of supporting testing scenarios where
+	 * This method accepts {@code -1} as a special code, mainly for the benefit of supporting testing scenarios where
 	 * fusion can be entirely deactivated (returns {@code Disabled}).
-	 * Unknown positive codes on the other hand return {@code Unknown(x)}.
+	 * Other negative values and unknown positive codes on the other hand return {@code Unknown(x)}.
+	 * <p>
+	 * Note that as this is a human-facing representation, the different values could evolve in the future.
+	 * As such, never compare the returned string to a constant, but always use this method on both sides of
+	 * a comparison.
 	 *
 	 * @param mode the fusion mode int code
 	 * @param ignoreThreadBarrier whether or not to ignore the {@link #THREAD_BARRIER} flag in the representation

--- a/reactor-core/src/test/java/reactor/core/FuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/FuseableTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Simon Baslé
+ */
+class FuseableTest {
+
+	@Test
+	void fusionModeName_syncVariants() {
+		int mode = Fuseable.SYNC | Fuseable.THREAD_BARRIER;
+		assertThat(Fuseable.fusionModeName(mode)).isEqualTo("SYNC+THREAD_BARRIER");
+		assertThat(Fuseable.fusionModeName(mode, true)).isEqualTo("SYNC");
+	}
+
+	@Test
+	void fusionModeName_asyncVariants() {
+		int mode = Fuseable.ASYNC | Fuseable.THREAD_BARRIER;
+		assertThat(Fuseable.fusionModeName(mode)).isEqualTo("ASYNC+THREAD_BARRIER");
+		assertThat(Fuseable.fusionModeName(mode, true)).isEqualTo("ASYNC");
+	}
+
+	@Test
+	void fusionModeName_unknownThreadBarrier() {
+		int mode = 10 | Fuseable.THREAD_BARRIER;
+		assertThat(Fuseable.fusionModeName(mode)).isEqualTo("Unknown(10)+THREAD_BARRIER");
+		assertThat(Fuseable.fusionModeName(mode, true)).isEqualTo("Unknown(10)");
+	}
+
+	@Test
+	void fusionModeName_unknownNegative() {
+		int mode = -2;
+		assertThat(Fuseable.fusionModeName(mode)).isEqualTo("Unknown(-2)");
+		assertThat(Fuseable.fusionModeName(mode, true)).isEqualTo("Unknown(-2)");
+	}
+
+	@Test
+	void fusionModeName_disabled() {
+		int mode = -1;
+		assertThat(Fuseable.fusionModeName(mode)).isEqualTo("Disabled");
+		assertThat(Fuseable.fusionModeName(mode, true)).isEqualTo("Disabled");
+	}
+
+	@Test
+	void fusionModeName_noneVariants() {
+		int mode = Fuseable.NONE | Fuseable.THREAD_BARRIER;
+		assertThat(Fuseable.fusionModeName(mode)).isEqualTo("NONE+THREAD_BARRIER");
+		assertThat(Fuseable.fusionModeName(mode, true)).isEqualTo("NONE");
+	}
+
+}

--- a/reactor-core/src/test/java/reactor/core/FuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/FuseableTest.java
@@ -26,6 +26,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 class FuseableTest {
 
 	@Test
+	void fusionModeName_sync() {
+		int mode = Fuseable.SYNC;
+		assertThat(Fuseable.fusionModeName(mode)).isEqualTo("SYNC");
+		assertThat(Fuseable.fusionModeName(mode, true)).isEqualTo("SYNC");
+	}
+
+	@Test
+	void fusionModeName_async() {
+		int mode = Fuseable.ASYNC;
+		assertThat(Fuseable.fusionModeName(mode)).isEqualTo("ASYNC");
+		assertThat(Fuseable.fusionModeName(mode, true)).isEqualTo("ASYNC");
+	}
+
+	@Test
 	void fusionModeName_syncVariants() {
 		int mode = Fuseable.SYNC | Fuseable.THREAD_BARRIER;
 		assertThat(Fuseable.fusionModeName(mode)).isEqualTo("SYNC+THREAD_BARRIER");

--- a/reactor-core/src/test/java/reactor/test/subscriber/AssertSubscriber.java
+++ b/reactor-core/src/test/java/reactor/test/subscriber/AssertSubscriber.java
@@ -449,8 +449,9 @@ public class AssertSubscriber<T>
 
 	public final AssertSubscriber<T> assertFusionMode(int expectedMode) {
 		if (establishedFusionMode != expectedMode) {
-			throw new AssertionError("Wrong fusion mode: expected: " + fusionModeName(
-					expectedMode) + ", actual: " + fusionModeName(establishedFusionMode));
+			throw new AssertionError("Wrong fusion mode: expected: " +
+					Fuseable.fusionModeName(expectedMode) +
+					", actual: " + Fuseable.fusionModeName(establishedFusionMode));
 		}
 		return this;
 	}
@@ -1105,21 +1106,6 @@ public class AssertSubscriber<T>
 		}
 
 		throw e;
-	}
-
-	protected final String fusionModeName(int mode) {
-		switch (mode) {
-			case -1:
-				return "Disabled";
-			case Fuseable.NONE:
-				return "None";
-			case Fuseable.SYNC:
-				return "Sync";
-			case Fuseable.ASYNC:
-				return "Async";
-			default:
-				return "Unknown(" + mode + ")";
-		}
 	}
 
 	protected final String valueAndClass(Object o) {


### PR DESCRIPTION
Something similar is already present in `AssertSubscriber`, but it kind of make sense to have `Fuseable` support that kind of utility method, as long as we're clear this is for human-readable representation (ie. users shouldn't compare the result to a constant, but rather to the expected fusion code passed to that same method).