### PR TITLE
Add Mono.cacheInvalidate[If|When]

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -2017,12 +2017,6 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * The fact that COORDINATOR cancels its source when no more subscribers remain is important, because it prevents issues with a never() source
 	 * or a source that never produces a value passing the predicate (assuming timeouts on the subscriber).
 	 *
-	 *
-	 *
-	 *
-	 *
-	 *
-	 *
 	 * @param invalidationTriggerGenerator the {@link Function} that generates new {@link Mono Mono&lt;Void&gt;} triggers
 	 * used for invalidation
 	 * @return a new cached {@link Mono} which can be invalidated
@@ -2030,6 +2024,62 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	public final Mono<T> cacheInvalidateWhen(Function<? super T, Mono<Void>> invalidationTriggerGenerator) {
 		return onAssembly(new MonoCacheInvalidateWhen<>(this, invalidationTriggerGenerator, null));
 	}
+
+	/**
+	 * Cache {@link Subscriber#onNext(Object) onNext} signal received from the source and replay it to other subscribers,
+	 * while allowing invalidation via a {@link Mono Mono&lt;Void&gt;} companion trigger generated from the currently
+	 * cached value.
+	 * <p>
+	 * As this form of caching is explicitly value-oriented, empty source completion signals and error signals are NOT
+	 * cached. It is always possible to use {@link #materialize()} to cache these (further using {@link #filter(Predicate)}
+	 * if one wants to only consider empty sources or error sources). The exception is still propagated to the subscribers
+	 * that have accumulated between the time the source has been subscribed to and the time the onError/onComplete terminal
+	 * signal is received. An empty source is turned into a {@link NoSuchElementException} onError.
+	 * <p>
+	 * Completion of the trigger will invalidate the cached element, so the next subscriber that comes in will trigger
+	 * a new subscription to the source, re-populating the cache and re-creating a new trigger out of that value.
+	 * <p>
+	 * <ul>
+	 *     <li>
+	 *         If the trigger completes with an error, all registered subscribers are terminated with the same error.
+	 *     </li>
+	 *     <li>
+	 *         If all the subscribers are cancelled <strong>before</strong> the cache is populated (ie. an attempt to
+	 *         cache a {@link Mono#never()}), the source subscription is cancelled.
+	 *     </li>
+	 *     <li>
+	 *         Cancelling a downstream subscriber once the cache has been populated is not necessarily relevant,
+	 *         as the value will be immediately replayed on subscription, which usually means within onSubscribe (so
+	 *         earlier than any cancellation can happen). That said the operator will make best efforts to detect such
+	 *         cancellations and avoid propagating the value to these subscribers.
+	 *     </li>
+	 * </ul>
+	 * <p>
+	 * Once a cached value is invalidated, it is passed to the provided {@link Consumer} (which MUST complete normally).
+	 * Note that some downstream subscribers might still be using or storing the value, for example if they
+	 * haven't requested anything yet.
+	 *
+	 *
+	 * Trigger is generated only after a subscribers in the COORDINATOR have received the value, and only once.
+	 * The only way to get out of the POPULATED state is to use the trigger, so there cannot be multiple trigger subscriptions, nor concurrent triggering.
+	 *
+	 * Cancellation is only possible for downstream subscribers when they've been added to a COORDINATOR.
+	 * Subscribers that are received when POPULATED will either be completed right away or (if the predicate fails) end up being added to a COORDINATOR.
+	 *
+	 * when cancelling a COORDINATOR-issued subscription:
+	 *   - removes itself from batch
+	 *   - if 0 subscribers remaining
+	 *         - swap COORDINATOR with EMPTY
+	 *         - COORDINATOR cancels its source
+	 *
+	 * The fact that COORDINATOR cancels its source when no more subscribers remain is important, because it prevents issues with a never() source
+	 * or a source that never produces a value passing the predicate (assuming timeouts on the subscriber).
+	 *
+	 * @param invalidationTriggerGenerator the {@link Function} that generates new {@link Mono Mono&lt;Void&gt;} triggers
+	 * used for invalidation
+	 * @param onInvalidate the {@link Consumer} that will be applied to cached value upon invalidation
+	 * @return a new cached {@link Mono} which can be invalidated
+	 */
 	public final Mono<T> cacheInvalidateWhen(Function<? super T, Mono<Void>> invalidationTriggerGenerator,
 	                                         Consumer<? super T> onInvalidate) {
 		return onAssembly(new MonoCacheInvalidateWhen<>(this, invalidationTriggerGenerator, onInvalidate));

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1906,8 +1906,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * Note that the {@link Predicate} is only evaluated if the cache is currently populated, ie. it is not applied
 	 * upon receiving the source {@link Subscriber#onNext(Object) onNext} signal.
 	 * For late subscribers, if the predicate returns {@code true} the cache is invalidated and a new subscription is made
-	 * to the source in an effort to notify the new subscriber with a valid value.
-	 * Note that if the predicate continuously mark the incoming values as invalid, this becomes akin to an infinite retry loop.
+	 * to the source in an effort to refresh the cache with a more up-to-date value to be passed to the new subscriber.
 	 * <p>
 	 * The predicate is not strictly evaluated once per downstream subscriber. Rather, subscriptions happening in concurrent
 	 * batches  will trigger a single evaluation of the predicate. Similarly, a batch of subscriptions happening before
@@ -1960,14 +1959,12 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * The fact that COORDINATOR cancels its source when no more subscribers remain is important, because it prevents issues with a never() source
 	 * or a source that never produces a value passing the predicate (assuming timeouts on the subscriber).
 	 *
-	 *
-	 *
-	 *
-	 * @param validatingPredicate the {@link Predicate} used for cache invalidation
+	 * @param invalidationPredicate the {@link Predicate} used for cache invalidation. Returning {@code true} means the value is invalid and should be
+	 * removed from the cache.
 	 * @return a new cached {@link Mono} which can be invalidated
 	 */
-	public final Mono<T> cacheInvalidateIf(Predicate<? super T> validatingPredicate) {
-		return onAssembly(new MonoCacheInvalidateIf<>(this, validatingPredicate));
+	public final Mono<T> cacheInvalidateIf(Predicate<? super T> invalidationPredicate) {
+		return onAssembly(new MonoCacheInvalidateIf<>(this, invalidationPredicate));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateIf.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateIf.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateIf.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateIf.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.function.Predicate;
+
+/**
+ * @author Simon Baslé
+ */
+final class MonoCacheInvalidateIf<T> extends MonoCacheTime<T> {
+
+	final Predicate<? super T> validatingPredicate;
+
+	MonoCacheInvalidateIf(Mono<T> source, Predicate<? super T> validatingPredicate) {
+		super(source);
+		this.validatingPredicate = validatingPredicate;
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateIf.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateIf.java
@@ -16,17 +16,340 @@
 
 package reactor.core.publisher;
 
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Predicate;
+
+import org.reactivestreams.Subscription;
+
+import reactor.core.CoreSubscriber;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * @author Simon Baslé
  */
 final class MonoCacheInvalidateIf<T> extends MonoCacheTime<T> {
 
+	private static final Logger LOGGER = Loggers.getLogger(MonoCacheInvalidateIf.class);
+
+	static interface State<T> {
+
+		@Nullable
+		T get();
+
+		void clear();
+	}
+
+	static final class ValueState<T> implements State<T> {
+
+		@Nullable
+		T value;
+
+		ValueState(T value) {
+			this.value = value;
+		}
+
+		@Nullable
+		@Override
+		public T get() {
+			return value;
+		}
+
+		@Override
+		public void clear() {
+			this.value = null;
+		}
+	}
+	
 	final Predicate<? super T> validatingPredicate;
+	
+	volatile     State<T>                                                    state;
+	@SuppressWarnings("rawtypes")
+	static final AtomicReferenceFieldUpdater<MonoCacheInvalidateIf, State> STATE =
+			AtomicReferenceFieldUpdater.newUpdater(MonoCacheInvalidateIf.class, State.class, "state");
+	
+	static final State<?> EMPTY_STATE = new State<Object>() {
+		@Nullable
+		@Override
+		public Object get() {
+			return null;
+		}
+
+		@Override
+		public void clear() {
+			//NO-OP
+		}
+	};
 
 	MonoCacheInvalidateIf(Mono<T> source, Predicate<? super T> validatingPredicate) {
 		super(source);
 		this.validatingPredicate = validatingPredicate;
+		@SuppressWarnings("unchecked")
+		State<T> state = (State<T>) EMPTY_STATE;
+		this.state = state;
+	}
+
+
+//	boolean invalidate(Signal<?> expected) {
+//		if (STATE.compareAndSet(this, expected, EMPTY_STATE)) {
+//			LOGGER.trace("invalidated {}", expected);
+//			if (expected.isOnNext() && this.invalidateHandler != null) {
+//				//noinspection unchecked
+//				invalidateHandler.accept((T) expected.get());
+//			}
+//			return true;
+//		}
+//		return false;
+//	}
+
+	@Override
+	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
+		CacheMonoSubscriber<T> inner = new CacheMonoSubscriber<>(actual);
+		//important: onSubscribe should be deferred until we're sure we're in the Coordinator case OR the cached value passes the predicate
+//		actual.onSubscribe(inner);
+		for(;;) {
+			State<T> state = this.state;
+			if (state == EMPTY_STATE || state instanceof CoordinatorSubscriber) {
+				boolean subscribe = false;
+				CoordinatorSubscriber<T> coordinator;
+				if (state == EMPTY_STATE) {
+					coordinator = new CoordinatorSubscriber<>(this);
+					if (!STATE.compareAndSet(this, EMPTY_STATE, coordinator)) {
+						continue;
+					}
+					subscribe = true;
+				}
+				else {
+					coordinator = (CoordinatorSubscriber<T>) state;
+				}
+
+				if (coordinator.add(inner)) {
+					if (inner.isCancelled()) {
+						coordinator.remove(inner);
+					}
+					else {
+						inner.coordinator = coordinator;
+						actual.onSubscribe(inner);
+					}
+
+					if (subscribe) {
+						source.subscribe(coordinator);
+					}
+					return null;
+				}
+			}
+			else {
+				//state is an actual signal, cached
+				actual.onSubscribe(inner);
+				inner.complete(state.get());
+				return null;
+			}
+		}
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+		return super.scanUnsafe(key);
+	}
+
+	static final class CoordinatorSubscriber<T> implements InnerConsumer<T>, State<T> {
+
+		final MonoCacheInvalidateIf<T> main;
+
+		Subscription subscription;
+
+		volatile     CacheMonoSubscriber<T>[]                                                                         subscribers;
+		@SuppressWarnings("rawtypes")
+		static final AtomicReferenceFieldUpdater<CoordinatorSubscriber, CacheMonoSubscriber[]>SUBSCRIBERS =
+				AtomicReferenceFieldUpdater.newUpdater(CoordinatorSubscriber.class, CacheMonoSubscriber[].class, "subscribers");
+
+		@SuppressWarnings("rawtypes")
+		private static final CacheMonoSubscriber[] COORDINATOR_DONE = new CacheMonoSubscriber[0];
+		@SuppressWarnings("rawtypes")
+		private static final CacheMonoSubscriber[] COORDINATOR_INIT = new CacheMonoSubscriber[0];
+
+		@SuppressWarnings("unchecked")
+		CoordinatorSubscriber(MonoCacheInvalidateIf<T> main) {
+			this.main = main;
+			this.subscribers = COORDINATOR_INIT;
+		}
+
+		/**
+		 * unused in this context as the {@link State} interface is only
+		 * implemented for use in the main's STATE compareAndSet.
+		 */
+		@Nullable
+		@Override
+		public T get() {
+			throw new UnsupportedOperationException("coordinator State#get shouldn't be used");
+		}
+
+		/**
+		 * unused in this context as the {@link State} interface is only
+		 * implemented for use in the main's STATE compareAndSet.
+		 */
+		@Override
+		public void clear() {
+			//NO-OP
+		}
+
+		final boolean add(CacheMonoSubscriber<T> toAdd) {
+			for (; ; ) {
+				CacheMonoSubscriber<T>[] a = subscribers;
+				if (a == COORDINATOR_DONE) {
+					return false;
+				}
+				int n = a.length;
+				@SuppressWarnings("unchecked")
+				CacheMonoSubscriber<T>[] b = new CacheMonoSubscriber[n + 1];
+				System.arraycopy(a, 0, b, 0, n);
+				b[n] = toAdd;
+				if (SUBSCRIBERS.compareAndSet(this, a, b)) {
+					return true;
+				}
+			}
+		}
+
+		final void remove(CacheMonoSubscriber<T> toRemove) {
+			for (; ; ) {
+				CacheMonoSubscriber<T>[] a = subscribers;
+				if (a == COORDINATOR_DONE || a == COORDINATOR_INIT) {
+					return;
+				}
+				int n = a.length;
+				int j = -1;
+				for (int i = 0; i < n; i++) {
+					if (a[i] == toRemove) {
+						j = i;
+						break;
+					}
+				}
+
+				if (j < 0) {
+					return;
+				}
+
+				if (n == 1) {
+					if (SUBSCRIBERS.compareAndSet(this, a, COORDINATOR_DONE)) {
+						//cancel the subscription no matter what, at this point coordinator is done and cannot accept new subscribers
+						this.subscription.cancel();
+						//only switch to EMPTY_STATE if the current state is this coordinator
+						STATE.compareAndSet(this.main, this, EMPTY_STATE);
+						return;
+					}
+					//else loop back
+				}
+				else {
+					CacheMonoSubscriber<?>[] b = new CacheMonoSubscriber<?>[n - 1];
+					System.arraycopy(a, 0, b, 0, j);
+					System.arraycopy(a, j + 1, b, j, n - j - 1);
+					if (SUBSCRIBERS.compareAndSet(this, a, b)) {
+						return;
+					}
+					//else loop back
+				}
+			}
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			//this only happens if there was at least one incoming subscriber
+			if (Operators.validate(this.subscription, s)) {
+				this.subscription = s;
+				s.request(Long.MAX_VALUE);
+			}
+		}
+
+		volatile boolean gotOnNext = false;
+
+		@Override
+		public void onNext(T t) {
+			if (main.state != this || gotOnNext) {
+				Operators.onNextDropped(t, currentContext());
+				return;
+			}
+			gotOnNext = true;
+			boolean invalid = main.validatingPredicate.test(t);
+			if (invalid) {
+				//resubscribe
+			}
+			else {
+				State<T> valueState = new ValueState<>(t);
+				if (STATE.compareAndSet(main, this, valueState)) {
+					for (@SuppressWarnings("unchecked") CacheMonoSubscriber<T> inner : SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
+						inner.complete(t);
+					}
+				}
+			}
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			if (main.state != this || gotOnNext) {
+				Operators.onErrorDropped(t, currentContext());
+				return;
+			}
+			if (STATE.compareAndSet(main, this, EMPTY_STATE)) {
+				for (@SuppressWarnings("unchecked") CacheMonoSubscriber<T> inner : SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
+					inner.onError(t);
+				}
+			}
+		}
+
+		@Override
+		public void onComplete() {
+			if (gotOnNext) {
+				gotOnNext = false;
+				//FIXME should the resubscribe happen here?
+				return;
+			}
+			if (STATE.compareAndSet(main, this, EMPTY_STATE)) {
+				for (@SuppressWarnings("unchecked") CacheMonoSubscriber<T> inner : SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
+					inner.onError(new NoSuchElementException("cacheInvalidateWhen expects a value, source completed empty"));
+				}
+			}
+		}
+
+		@Override
+		public Context currentContext() {
+			return Operators.multiSubscribersContext(subscribers);
+		}
+
+		@Nullable
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+			return null;
+		}
+
+	}
+
+	static final class CacheMonoSubscriber<T> extends Operators.MonoSubscriber<T, T> {
+
+		CoordinatorSubscriber<T> coordinator;
+
+		CacheMonoSubscriber(CoreSubscriber<? super T> actual) {
+			super(actual);
+		}
+
+		@Override
+		public void cancel() {
+			super.cancel();
+			CoordinatorSubscriber<T> coordinator = this.coordinator;
+			if (coordinator != null) {
+				coordinator.remove(this);
+			}
+		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) return coordinator.main;
+			if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+			return super.scanUnsafe(key);
+		}
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateIf.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateIf.java
@@ -17,6 +17,7 @@
 package reactor.core.publisher;
 
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Predicate;
 
@@ -104,9 +105,9 @@ final class MonoCacheInvalidateIf<T> extends MonoCacheTime<T> {
 	static final AtomicReferenceFieldUpdater<MonoCacheInvalidateIf, State> STATE =
 			AtomicReferenceFieldUpdater.newUpdater(MonoCacheInvalidateIf.class, State.class, "state");
 
-	MonoCacheInvalidateIf(Mono<T> source, Predicate<? super T> shouldInvalidatePredicate) {
+	MonoCacheInvalidateIf(Mono<T> source, Predicate<? super T> invalidationPredicate) {
 		super(source);
-		this.shouldInvalidatePredicate = shouldInvalidatePredicate;
+		this.shouldInvalidatePredicate = Objects.requireNonNull(invalidationPredicate, "invalidationPredicate");
 		@SuppressWarnings("unchecked")
 		State<T> state = (State<T>) EMPTY_STATE;
 		this.state = state;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
@@ -34,6 +34,12 @@ import reactor.util.context.Context;
 import static reactor.core.publisher.MonoCacheInvalidateIf.EMPTY_STATE;
 
 /**
+ * A caching operator that uses a companion {@link Mono} as a trigger to invalidate the cached value.
+ * Subscribers accumulated between the upstream subscription is triggered and the actual value is received and stored
+ * don't get impacted by the generated trigger and will immediately receive the cached value.
+ * If after that the trigger completes immediately, the next incoming subscriber will lead to a resubscription to the
+ * source and a new caching cycle.
+ *
  * @author Simon Baslé
  */
 final class MonoCacheInvalidateWhen<T> extends InternalMonoOperator<T, T> {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
@@ -380,6 +380,11 @@ final class MonoCacheInvalidateWhen<T> extends InternalMonoOperator<T, T> {
 			main.invalidate();
 		}
 
+		@Override
+		public Context currentContext() {
+			return Context.empty();
+		}
+
 		@Nullable
 		@Override
 		public Object scanUnsafe(Attr key) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
@@ -16,74 +16,390 @@
 
 package reactor.core.publisher;
 
+import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.reactivestreams.Subscription;
 
 import reactor.core.CoreSubscriber;
+import reactor.util.Logger;
+import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+import reactor.util.context.ContextView;
 
 /**
  * @author Simon Baslé
  */
 final class MonoCacheInvalidateWhen<T> extends InternalMonoOperator<T, T> {
 
+	private static final Logger LOGGER = Loggers.getLogger(MonoCacheInvalidateWhen.class);
+
 	final Function<? super T, Mono<Void>> invalidationTriggerGenerator;
+	@Nullable
+	final Consumer<? super T>             invalidateHandler;
 
-	volatile InvalidateWhenCoordinator<T> coordinator;
-	static final AtomicReferenceFieldUpdater<MonoCacheInvalidateWhen, InvalidateWhenCoordinator> COORDINATOR =
-			AtomicReferenceFieldUpdater.newUpdater(MonoCacheInvalidateWhen.class, InvalidateWhenCoordinator.class, "coordinator");
+	volatile Signal<T> state;
+	static final AtomicReferenceFieldUpdater<MonoCacheInvalidateWhen, Signal> STATE =
+			AtomicReferenceFieldUpdater.newUpdater(MonoCacheInvalidateWhen.class, Signal.class, "state");
 
-	MonoCacheInvalidateWhen(Mono<T> source, Function<? super T, Mono<Void>> invalidationTriggerGenerator) {
+	static final Signal<?> EMPTY_STATE = new ImmutableSignal<>(Context.empty(), SignalType.ON_NEXT, null, null, null);
+
+	MonoCacheInvalidateWhen(Mono<T> source, Function<? super T, Mono<Void>> invalidationTriggerGenerator,
+	                        @Nullable Consumer<? super T> invalidateHandler) {
 		super(source);
 		this.invalidationTriggerGenerator = Objects.requireNonNull(invalidationTriggerGenerator, "invalidationTriggerGenerator");
+		this.invalidateHandler = invalidateHandler;
+		@SuppressWarnings("unchecked")
+		Signal<T> state = (Signal<T>) EMPTY_STATE;
+		this.state = state;
 	}
 
-	@Nullable
+	boolean invalidate(Signal<?> expected) {
+		if (STATE.compareAndSet(this, expected, EMPTY_STATE)) {
+			LOGGER.trace("invalidated {}", expected);
+			if (expected.isOnNext() && this.invalidateHandler != null) {
+				//noinspection unchecked
+				invalidateHandler.accept((T) expected.get());
+			}
+			return true;
+		}
+		return false;
+	}
+
 	@Override
-	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) throws Throwable {
-		InvalidateWhenCoordinator<T> c;
+	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
+		CacheMonoSubscriber<T> inner = new CacheMonoSubscriber<>(actual);
+		actual.onSubscribe(inner);
 		for(;;) {
-			c = this.coordinator;
-			if (c == null) {
-				c = new InvalidateWhenCoordinator<>();
-				if (COORDINATOR.compareAndSet(this, null, c)) {
-					break;
+			Signal<T> state = this.state;
+			if (state == EMPTY_STATE || state instanceof CoordinatorSubscriber) {
+				boolean subscribe = false;
+				CoordinatorSubscriber<T> coordinator;
+				if (state == EMPTY_STATE) {
+					coordinator = new CoordinatorSubscriber<>(this);
+					if (!STATE.compareAndSet(this, EMPTY_STATE, coordinator)) {
+						continue;
+					}
+					subscribe = true;
+				}
+				else {
+					coordinator = (CoordinatorSubscriber<T>) state;
+				}
+
+				if (coordinator.add(inner)) {
+					if (inner.isCancelled()) {
+						coordinator.remove(inner);
+					}
+					else {
+						inner.coordinator = coordinator;
+					}
+
+					if (subscribe) {
+						source.subscribe(coordinator);
+					}
+					return null;
+				}
+			}
+			else if (state.isOnNext()) {
+				//state is an actual signal, cached
+				inner.complete(state.get());
+				return null;
+			}
+			// else cached onError, means the state is about to be switched back to EMPTY => continue
+		}
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+		return super.scanUnsafe(key);
+	}
+
+	static final class CoordinatorSubscriber<T> implements InnerConsumer<T>, Signal<T> {
+
+		final MonoCacheInvalidateWhen<T> main;
+
+		Subscription subscription;
+
+		volatile     CacheMonoSubscriber<T>[]                                                  subscribers;
+		@SuppressWarnings("rawtypes")
+		static final AtomicReferenceFieldUpdater<CoordinatorSubscriber, CacheMonoSubscriber[]> SUBSCRIBERS =
+				AtomicReferenceFieldUpdater.newUpdater(CoordinatorSubscriber.class, CacheMonoSubscriber[].class, "subscribers");
+
+		@SuppressWarnings("rawtypes")
+		private static final CacheMonoSubscriber[] COORDINATOR_DONE = new CacheMonoSubscriber[0];
+		@SuppressWarnings("rawtypes")
+		private static final CacheMonoSubscriber[] COORDINATOR_INIT = new CacheMonoSubscriber[0];
+
+		@SuppressWarnings("unchecked")
+		CoordinatorSubscriber(MonoCacheInvalidateWhen<T> main) {
+			this.main = main;
+			this.subscribers = COORDINATOR_INIT;
+		}
+
+		/**
+		 * unused in this context as the {@link Signal} interface is only
+		 * implemented for use in the main's STATE compareAndSet.
+		 */
+		@Override
+		public Throwable getThrowable() {
+			throw new UnsupportedOperationException("illegal signal use");
+		}
+
+		/**
+		 * unused in this context as the {@link Signal} interface is only
+		 * implemented for use in the main's STATE compareAndSet.
+		 */
+		@Override
+		public Subscription getSubscription() {
+			throw new UnsupportedOperationException("illegal signal use");
+		}
+
+		/**
+		 * unused in this context as the {@link Signal} interface is only
+		 * implemented for use in the main's STATE compareAndSet.
+		 */
+		@Nullable
+		@Override
+		public T get() {
+			return null;
+		}
+
+		/**
+		 * Use of {@link SignalType#AFTER_TERMINATE} ensures that the isXxx methods
+		 * used by this operator (isOnNext, isOnError, isOnComplete) will all return
+		 * false for this class.
+		 */
+		@Override
+		public SignalType getType() {
+			return SignalType.AFTER_TERMINATE;
+		}
+
+		/**
+		 * unused in this context as the {@link Signal} interface is only
+		 * implemented for use in the main's STATE compareAndSet.
+		 */
+		@Override
+		public ContextView getContextView() {
+			throw new UnsupportedOperationException("illegal signal use: getContextView");
+		}
+
+		final boolean add(CacheMonoSubscriber<T> toAdd) {
+			for (; ; ) {
+				CacheMonoSubscriber<T>[] a = subscribers;
+				if (a == COORDINATOR_DONE) {
+					return false;
+				}
+				int n = a.length;
+				@SuppressWarnings("unchecked")
+				CacheMonoSubscriber<T>[] b = new CacheMonoSubscriber[n + 1];
+				System.arraycopy(a, 0, b, 0, n);
+				b[n] = toAdd;
+				if (SUBSCRIBERS.compareAndSet(this, a, b)) {
+					return true;
 				}
 			}
 		}
-		c.add(actual);
-		return null;
-	}
 
-	/**
-	 * The coordinator that keeps track of connection state, actually caches the value, tracks downstream subscribers
-	 * that come before resolution, etc...
-	 * @param <T> the type of cached value
-	 */
-	static final class InvalidateWhenCoordinator<T> extends AtomicReference<T> implements InnerOperator<T, T> {
+		final void remove(CacheMonoSubscriber<T> toRemove) {
+			for (; ; ) {
+				CacheMonoSubscriber<T>[] a = subscribers;
+				if (a == COORDINATOR_DONE || a == COORDINATOR_INIT) {
+					return;
+				}
+				int n = a.length;
+				int j = -1;
+				for (int i = 0; i < n; i++) {
+					if (a[i] == toRemove) {
+						j = i;
+						break;
+					}
+				}
 
-		Subscription s;
+				if (j < 0) {
+					return;
+				}
 
-		boolean add(CoreSubscriber<? super T> subscriber) {
-			T cached = get();
-			if (cached != null) {
-				Operators.terminate()
+				if (n == 1) {
+					if (SUBSCRIBERS.compareAndSet(this, a, COORDINATOR_DONE)) {
+						if (main.invalidate(this)) {
+							this.subscription.cancel();
+						}
+						return;
+					}
+					//else loop back
+				}
+				else {
+					CacheMonoSubscriber<?>[] b = new CacheMonoSubscriber<?>[n - 1];
+					System.arraycopy(a, 0, b, 0, j);
+					System.arraycopy(a, j + 1, b, j, n - j - 1);
+					if (SUBSCRIBERS.compareAndSet(this, a, b)) {
+						return;
+					}
+					//else loop back
+				}
 			}
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.validate(this.subscription, s)) {
+				this.subscription = s;
+				s.request(Long.MAX_VALUE);
+			}
+		}
+
+		void signalCached(Signal<T> signal) {
+			boolean invalidateAtEnd = false;
+			Signal<T> signalToPropagate = signal;
+			if (STATE.compareAndSet(main, this, signal)) {
+				if (signal.get() != null) {
+					Mono<Void> invalidateTrigger = null;
+					try {
+						invalidateTrigger = Objects.requireNonNull(
+								main.invalidationTriggerGenerator.apply(signal.get()),
+								"invalidationTriggerGenerator produced a null trigger");
+
+						invalidateTrigger.subscribe(new TriggerSubscriber(this.main));
+					}
+					catch (Throwable generatorError) {
+						signalToPropagate = Signal.error(generatorError);
+						if (STATE.compareAndSet(main, signal, signalToPropagate)) {
+							invalidateAtEnd = true;
+							Operators.onDiscard(signal.get(), currentContext());
+						}
+					}
+				}
+				else {
+					invalidateAtEnd = true;
+					if (signal.isOnComplete()) {
+						signalToPropagate = Signal.error(new NoSuchElementException("cacheInvalidateWhen expects a value, source completed empty"));
+						invalidateAtEnd = STATE.compareAndSet(main, signal, signalToPropagate);
+					}
+				}
+
+				for (@SuppressWarnings("unchecked") CacheMonoSubscriber<T> inner : SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
+					if (signalToPropagate.isOnNext()) {
+						inner.complete(signalToPropagate.get());
+					}
+					else if (signalToPropagate.getThrowable() != null) {
+						inner.onError(signalToPropagate.getThrowable());
+					}
+					else {
+						inner.onError(new IllegalStateException("unexpected signal cached " + signalToPropagate));
+					}
+				}
+				if (invalidateAtEnd) {
+					main.invalidate(signalToPropagate);
+				}
+			}
+		}
+
+		@Override
+		public void onNext(T t) {
+			if (main.state != this) {
+				Operators.onNextDroppedMulticast(t, subscribers);
+				return;
+			}
+			signalCached(Signal.next(t));
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			if (main.state != this) {
+				Operators.onErrorDroppedMulticast(t, subscribers);
+				return;
+			}
+			signalCached(Signal.error(t));
+		}
+
+		@Override
+		public void onComplete() {
+			signalCached(Signal.complete());
+		}
+
+		@Override
+		public Context currentContext() {
+			return Operators.multiSubscribersContext(subscribers);
+		}
+
+		@Nullable
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+			return null;
 		}
 
 	}
 
-	/**
-	 * The subscriber that watches the trigger and propagates that to the coordinator.
-	 */
-	static final class InvalidateTriggerSubscriber implements InnerConsumer<Void> {
+	static final class CacheMonoSubscriber<T> extends Operators.MonoSubscriber<T, T> {
 
+		CoordinatorSubscriber<T> coordinator;
+
+		CacheMonoSubscriber(CoreSubscriber<? super T> actual) {
+			super(actual);
+		}
+
+		@Override
+		public void cancel() {
+			super.cancel();
+			CoordinatorSubscriber<T> coordinator = this.coordinator;
+			if (coordinator != null) {
+				coordinator.remove(this);
+			}
+		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) return coordinator.main;
+			if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+			return super.scanUnsafe(key);
+		}
 	}
 
 
+	static final class TriggerSubscriber implements InnerConsumer<Void> {
 
+		final MonoCacheInvalidateWhen<?> main;
+
+		TriggerSubscriber(MonoCacheInvalidateWhen<?> main) {
+			this.main = main;
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			s.request(1);
+		}
+
+		@Override
+		public void onNext(Void unused) {
+			//NO-OP
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			LOGGER.warn("Invalidation triggered by onError(" + t + ")");
+			main.invalidate(main.state);
+		}
+
+		@Override
+		public void onComplete() {
+			main.invalidate(main.state);
+		}
+
+		@Nullable
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) return main;
+			//this is an approximation of TERMINATED, the trigger should only be active AFTER an actual value has been set as STATE
+			if (key == Attr.TERMINATED) return main.state == EMPTY_STATE || main.state instanceof CoordinatorSubscriber;
+			if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+			if (key == Attr.PREFETCH) return 1;
+			return null;
+		}
+	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Function;
+
+import org.reactivestreams.Subscription;
+
+import reactor.core.CoreSubscriber;
+import reactor.util.annotation.Nullable;
+
+/**
+ * @author Simon Baslé
+ */
+final class MonoCacheInvalidateWhen<T> extends InternalMonoOperator<T, T> {
+
+	final Function<? super T, Mono<Void>> invalidationTriggerGenerator;
+
+	volatile InvalidateWhenCoordinator<T> coordinator;
+	static final AtomicReferenceFieldUpdater<MonoCacheInvalidateWhen, InvalidateWhenCoordinator> COORDINATOR =
+			AtomicReferenceFieldUpdater.newUpdater(MonoCacheInvalidateWhen.class, InvalidateWhenCoordinator.class, "coordinator");
+
+	MonoCacheInvalidateWhen(Mono<T> source, Function<? super T, Mono<Void>> invalidationTriggerGenerator) {
+		super(source);
+		this.invalidationTriggerGenerator = Objects.requireNonNull(invalidationTriggerGenerator, "invalidationTriggerGenerator");
+	}
+
+	@Nullable
+	@Override
+	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) throws Throwable {
+		InvalidateWhenCoordinator<T> c;
+		for(;;) {
+			c = this.coordinator;
+			if (c == null) {
+				c = new InvalidateWhenCoordinator<>();
+				if (COORDINATOR.compareAndSet(this, null, c)) {
+					break;
+				}
+			}
+		}
+		c.add(actual);
+		return null;
+	}
+
+	/**
+	 * The coordinator that keeps track of connection state, actually caches the value, tracks downstream subscribers
+	 * that come before resolution, etc...
+	 * @param <T> the type of cached value
+	 */
+	static final class InvalidateWhenCoordinator<T> extends AtomicReference<T> implements InnerOperator<T, T> {
+
+		Subscription s;
+
+		boolean add(CoreSubscriber<? super T> subscriber) {
+			T cached = get();
+			if (cached != null) {
+				Operators.terminate()
+			}
+		}
+
+	}
+
+	/**
+	 * The subscriber that watches the trigger and propagates that to the coordinator.
+	 */
+	static final class InvalidateTriggerSubscriber implements InnerConsumer<Void> {
+
+	}
+
+
+
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
@@ -42,7 +42,8 @@ final class MonoCacheInvalidateWhen<T> extends InternalMonoOperator<T, T> {
 	@Nullable
 	final Consumer<? super T>             invalidateHandler;
 
-	volatile Signal<T> state;
+	volatile     Signal<T>                                                    state;
+	@SuppressWarnings("rawtypes")
 	static final AtomicReferenceFieldUpdater<MonoCacheInvalidateWhen, Signal> STATE =
 			AtomicReferenceFieldUpdater.newUpdater(MonoCacheInvalidateWhen.class, Signal.class, "state");
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCacheInvalidateIfTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCacheInvalidateIfTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import reactor.core.Disposable;
+import reactor.test.MemoryUtils;
+import reactor.test.StepVerifier;
+import reactor.test.publisher.TestPublisher;
+
+import static org.assertj.core.api.Assertions.*;
+
+class MonoCacheInvalidateIfTest {
+
+	@Test
+	void nullPredicate() {
+		assertThatNullPointerException()
+				.isThrownBy(() -> Mono.empty().cacheInvalidateIf(null))
+				.withMessage("invalidationPredicate");
+	}
+
+	@Test
+	void emptySourcePropagatesErrorAndTriggersResubscription() {
+		AtomicInteger counter = new AtomicInteger();
+		Mono<Integer> source = Mono.defer(() -> {
+			int v = counter.incrementAndGet();
+			if (v == 1) {
+				return Mono.empty();
+			}
+			return Mono.just(v);
+		});
+
+		Mono<Integer> cached = source.cacheInvalidateIf(it -> false);
+
+		assertThatExceptionOfType(NoSuchElementException.class)
+				.as("first subscribe")
+				.isThrownBy(cached::block)
+				.withMessage("cacheInvalidateWhen expects a value, source completed empty");
+
+		assertThat(cached.block())
+				.as("second subscribe")
+				.isEqualTo(2);
+	}
+
+	@Test
+	void predicateThrowsTriggersErrorDiscardAndInvalidate() throws InterruptedException {
+		AtomicInteger counter = new AtomicInteger();
+		Mono<Integer> source = Mono.fromCallable(counter::incrementAndGet);
+
+		Mono<Integer> cached = source.cacheInvalidateIf(it -> {
+			if (it < 3) throw new IllegalStateException("boom");
+			return false;
+		});
+
+		//first subscriber doesn't trigger the predicate
+		assertThat(cached.block()).as("first subscription")
+				.isEqualTo(1);
+
+		//second subscription triggers the predicate, which throws (resulting in onError)
+		StepVerifier.create(cached)
+				.expectErrorSatisfies(e -> assertThat(e)
+						.isInstanceOf(IllegalStateException.class)
+						.hasMessage("boom"))
+				.verifyThenAssertThat()
+				.hasDiscarded(1);
+
+		//third subscriber doesn't trigger the predicate
+		assertThat(cached.block()).as("third subscription")
+				.isEqualTo(2);
+
+		//fourth subscription triggers the predicate again, which throws
+		StepVerifier.create(cached)
+				.expectErrorSatisfies(e -> assertThat(e)
+						.isInstanceOf(IllegalStateException.class)
+						.hasMessage("boom"))
+				.verifyThenAssertThat()
+				.hasDiscarded(2);
+
+		//fifth and sixth subscriptions don't trigger the predicate anymore
+		assertThat(cached.block())
+				.as("5th subscribe")
+				.isEqualTo(3);
+
+		assertThat(cached.block())
+				.as("6th subscribe")
+				.isEqualTo(3);
+	}
+
+	@Test
+	void predicatePassingLeadsToInvalidation() {
+		AtomicInteger counter = new AtomicInteger();
+		Mono<MemoryUtils.Tracked> source = Mono.fromCallable(() -> {
+			String id = "tracked#" + counter.incrementAndGet();
+			return new MemoryUtils.Tracked(id);
+		});
+
+		Mono<MemoryUtils.Tracked> cached = source.cacheInvalidateIf(MemoryUtils.Tracked::isReleased);
+
+		MemoryUtils.Tracked first = cached.block();
+		assertThat(first.identifier).as("sub1").isEqualTo("tracked#1");
+		assertThat(cached.block()).as("sub2").isSameAs(first);
+		assertThat(cached.block()).as("sub3").isSameAs(first);
+
+		//trigger
+		first.release();
+
+		MemoryUtils.Tracked second = cached.block();
+		assertThat(second.identifier).as("sub4")
+				.isEqualTo("tracked#2")
+				.isNotSameAs(first);
+		assertThat(cached.block()).as("sub5").isSameAs(second);
+	}
+
+	@Test
+	void cancellingAllSubscribersBeforeOnNextInvalidates() {
+		TestPublisher<Integer> source = TestPublisher.create();
+
+		Mono<Integer> cached = source
+				.mono()
+				.cacheInvalidateIf(i -> false);
+
+		Disposable sub1 = cached.subscribe();
+		Disposable sub2 = cached.subscribe();
+		Disposable sub3 = cached.subscribe();
+
+		source.assertWasSubscribed();
+		source.assertNotCancelled();
+
+		sub1.dispose();
+		source.assertNotCancelled();
+
+		sub2.dispose();
+		source.assertNotCancelled();
+
+		sub3.dispose();
+		source.assertCancelled(1);
+	}
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCacheInvalidateWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCacheInvalidateWhenTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.*;
+
+class MonoCacheInvalidateWhenTest {
+
+	@Test
+	void nullGenerator() {
+		assertThatNullPointerException()
+				.isThrownBy(() -> Mono.empty().cacheInvalidateWhen(null))
+				.withMessage("invalidationTriggerGenerator");
+	}
+
+	@Test
+	void emptySourcePropagatesErrorAndTriggersResubscription() {
+		AtomicInteger counter = new AtomicInteger();
+		Mono<Integer> source = Mono.defer(() -> {
+			int v = counter.incrementAndGet();
+			if (v == 1) {
+				return Mono.empty();
+			}
+			return Mono.just(v);
+		});
+
+		Mono<Integer> cached = source.cacheInvalidateWhen(it -> Mono.never());
+
+		assertThatExceptionOfType(NoSuchElementException.class)
+				.as("first subscribe")
+				.isThrownBy(cached::block)
+				.withMessage("foo");
+
+		assertThat(cached.block())
+				.as("second subscribe")
+				.isEqualTo(2);
+	}
+
+	@Test
+	void generatorReturnsNullTriggersErrorDiscardAndResubscribe() {
+		AtomicInteger counter = new AtomicInteger();
+		Mono<Integer> source = Mono.fromCallable(counter::incrementAndGet);
+
+		Mono<Integer> cached = source.cacheInvalidateWhen(it -> {
+			if (it == 1) return null;
+			return Mono.never();
+		});
+
+		StepVerifier.create(cached)
+				.expectErrorSatisfies(e -> assertThat(e)
+				.isInstanceOf(NullPointerException.class)
+				.hasMessage(""))
+				.verifyThenAssertThat()
+				.hasDiscarded(1);
+
+		assertThatNullPointerException()
+				.as("first subscribe")
+				.isThrownBy(cached::block)
+				.withMessage("foo");
+
+		assertThat(cached.block())
+				.as("second subscribe")
+				.isEqualTo(2);
+	}
+
+	@Test
+	void generatorThrowsTriggersErrorDiscardAndResubscribe() {
+		AtomicInteger counter = new AtomicInteger();
+		Mono<Integer> source = Mono.fromCallable(counter::incrementAndGet);
+
+		Mono<Integer> cached = source.cacheInvalidateWhen(it -> {
+			if (it == 1) throw new IllegalStateException("boom");
+			return Mono.never();
+		});
+
+		StepVerifier.create(cached)
+				.expectErrorSatisfies(e -> assertThat(e)
+						.isInstanceOf(IllegalStateException.class)
+						.hasMessage("boom"))
+				.verifyThenAssertThat()
+				.hasDiscarded(1);
+
+		assertThatNullPointerException()
+				.as("first subscribe")
+				.isThrownBy(cached::block)
+				.withMessage("foo");
+
+		assertThat(cached.block())
+				.as("second subscribe")
+				.isEqualTo(2);
+	}
+
+	@Test
+	void triggerCompletingLeadsToInvalidation() {
+		AtomicInteger counter = new AtomicInteger();
+		Mono<Integer> source = Mono.fromCallable(counter::incrementAndGet);
+
+		final Sinks.Empty<Void> trigger = Sinks.empty();
+		Mono<Integer> cached = source.cacheInvalidateWhen(it -> trigger.asMono());
+
+		assertThat(cached.block()).as("sub1").isEqualTo(1);
+		assertThat(cached.block()).as("sub2").isEqualTo(1);
+		assertThat(cached.block()).as("sub3").isEqualTo(1);
+
+		//trigger (let's still assert the result)
+		Sinks.EmitResult triggerResult = trigger.tryEmitEmpty();
+		assertThat(triggerResult).isEqualTo(Sinks.EmitResult.OK);
+
+		assertThat(cached.block()).as("sub4").isEqualTo(2);
+		assertThat(cached.block()).as("sub5").isEqualTo(2);
+	}
+
+	@Test
+	void triggerFailingLeadsToInvalidation() {
+		AtomicInteger counter = new AtomicInteger();
+		Mono<Integer> source = Mono.fromCallable(counter::incrementAndGet);
+
+		final Sinks.Empty<Void> trigger = Sinks.empty();
+		Mono<Integer> cached = source.cacheInvalidateWhen(it -> trigger.asMono());
+
+		assertThat(cached.block()).as("sub1").isEqualTo(1);
+		assertThat(cached.block()).as("sub2").isEqualTo(1);
+		assertThat(cached.block()).as("sub3").isEqualTo(1);
+
+		List<Throwable> errorsDropped = new ArrayList<>();
+		Hooks.onErrorDropped(errorsDropped::add); //will be reset by ReactorTestExecutionListener
+
+		//trigger (let's still assert the result)
+		Sinks.EmitResult triggerResult = trigger.tryEmitError(new IllegalStateException("expected dropped"));
+		assertThat(triggerResult).isEqualTo(Sinks.EmitResult.OK);
+
+		assertThat(cached.block()).as("sub4").isEqualTo(2);
+		assertThat(cached.block()).as("sub5").isEqualTo(2);
+	}
+
+	@Test
+	void concurrentTriggerAndDownstreamSubscriber() {
+		//FIXME
+		fail("TO BE IMPLEMENTED");
+	}
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCacheInvalidateWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCacheInvalidateWhenTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCacheInvalidateWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCacheInvalidateWhenTest.java
@@ -17,17 +17,29 @@
 package reactor.core.publisher;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+import reactor.core.Disposable;
+import reactor.test.AutoDisposingExtension;
 import reactor.test.StepVerifier;
+import reactor.test.publisher.TestPublisher;
+import reactor.test.util.LoggerUtils;
+import reactor.test.util.TestLogger;
 
 import static org.assertj.core.api.Assertions.*;
 
 class MonoCacheInvalidateWhenTest {
+
+	@RegisterExtension
+	AutoDisposingExtension afterTest = new AutoDisposingExtension();
 
 	@Test
 	void nullGenerator() {
@@ -52,7 +64,7 @@ class MonoCacheInvalidateWhenTest {
 		assertThatExceptionOfType(NoSuchElementException.class)
 				.as("first subscribe")
 				.isThrownBy(cached::block)
-				.withMessage("foo");
+				.withMessage("cacheInvalidateWhen expects a value, source completed empty");
 
 		assertThat(cached.block())
 				.as("second subscribe")
@@ -72,27 +84,26 @@ class MonoCacheInvalidateWhenTest {
 		StepVerifier.create(cached)
 				.expectErrorSatisfies(e -> assertThat(e)
 				.isInstanceOf(NullPointerException.class)
-				.hasMessage(""))
+				.hasMessage("invalidationTriggerGenerator produced a null trigger"))
 				.verifyThenAssertThat()
 				.hasDiscarded(1);
-
-		assertThatNullPointerException()
-				.as("first subscribe")
-				.isThrownBy(cached::block)
-				.withMessage("foo");
 
 		assertThat(cached.block())
 				.as("second subscribe")
 				.isEqualTo(2);
+
+		assertThat(cached.block())
+				.as("third subscribe")
+				.isEqualTo(2);
 	}
 
 	@Test
-	void generatorThrowsTriggersErrorDiscardAndResubscribe() {
+	void generatorThrowsTriggersErrorDiscardAndInvalidate() {
 		AtomicInteger counter = new AtomicInteger();
 		Mono<Integer> source = Mono.fromCallable(counter::incrementAndGet);
 
 		Mono<Integer> cached = source.cacheInvalidateWhen(it -> {
-			if (it == 1) throw new IllegalStateException("boom");
+			if (it < 3) throw new IllegalStateException("boom");
 			return Mono.never();
 		});
 
@@ -103,14 +114,16 @@ class MonoCacheInvalidateWhenTest {
 				.verifyThenAssertThat()
 				.hasDiscarded(1);
 
-		assertThatNullPointerException()
-				.as("first subscribe")
-				.isThrownBy(cached::block)
-				.withMessage("foo");
+		StepVerifier.create(cached)
+				.expectErrorSatisfies(e -> assertThat(e)
+						.isInstanceOf(IllegalStateException.class)
+						.hasMessage("boom"))
+				.verifyThenAssertThat()
+				.hasDiscarded(2);
 
 		assertThat(cached.block())
-				.as("second subscribe")
-				.isEqualTo(2);
+				.as("third subscribe")
+				.isEqualTo(3);
 	}
 
 	@Test
@@ -118,16 +131,16 @@ class MonoCacheInvalidateWhenTest {
 		AtomicInteger counter = new AtomicInteger();
 		Mono<Integer> source = Mono.fromCallable(counter::incrementAndGet);
 
-		final Sinks.Empty<Void> trigger = Sinks.empty();
-		Mono<Integer> cached = source.cacheInvalidateWhen(it -> trigger.asMono());
+		//we want to be able to reset it
+		final TestPublisher<Void> trigger = TestPublisher.createNoncompliant(TestPublisher.Violation.CLEANUP_ON_TERMINATE);
+		Mono<Integer> cached = source.cacheInvalidateWhen(it -> trigger.mono());
 
 		assertThat(cached.block()).as("sub1").isEqualTo(1);
 		assertThat(cached.block()).as("sub2").isEqualTo(1);
 		assertThat(cached.block()).as("sub3").isEqualTo(1);
 
-		//trigger (let's still assert the result)
-		Sinks.EmitResult triggerResult = trigger.tryEmitEmpty();
-		assertThat(triggerResult).isEqualTo(Sinks.EmitResult.OK);
+		//trigger
+		trigger.complete();
 
 		assertThat(cached.block()).as("sub4").isEqualTo(2);
 		assertThat(cached.block()).as("sub5").isEqualTo(2);
@@ -135,11 +148,16 @@ class MonoCacheInvalidateWhenTest {
 
 	@Test
 	void triggerFailingLeadsToInvalidation() {
+		TestLogger testLogger = new TestLogger(false);
+		LoggerUtils.enableCaptureWith(testLogger);
+		afterTest.autoDispose(LoggerUtils::disableCapture);
+
 		AtomicInteger counter = new AtomicInteger();
 		Mono<Integer> source = Mono.fromCallable(counter::incrementAndGet);
 
-		final Sinks.Empty<Void> trigger = Sinks.empty();
-		Mono<Integer> cached = source.cacheInvalidateWhen(it -> trigger.asMono());
+		//we want to be able to reset it
+		final TestPublisher<Void> trigger = TestPublisher.createNoncompliant(TestPublisher.Violation.CLEANUP_ON_TERMINATE);
+		Mono<Integer> cached = source.cacheInvalidateWhen(it -> trigger.mono());
 
 		assertThat(cached.block()).as("sub1").isEqualTo(1);
 		assertThat(cached.block()).as("sub2").isEqualTo(1);
@@ -147,13 +165,44 @@ class MonoCacheInvalidateWhenTest {
 
 		List<Throwable> errorsDropped = new ArrayList<>();
 		Hooks.onErrorDropped(errorsDropped::add); //will be reset by ReactorTestExecutionListener
+		trigger.error(new IllegalStateException("expected logged"));
 
-		//trigger (let's still assert the result)
-		Sinks.EmitResult triggerResult = trigger.tryEmitError(new IllegalStateException("expected dropped"));
-		assertThat(triggerResult).isEqualTo(Sinks.EmitResult.OK);
+		assertThat(Arrays.stream(testLogger.getErrContent().split("\n")))
+				.as("trace log of trigger error")
+				.filteredOn(s -> s.contains("expected"))
+				.allMatch(s -> s.endsWith("Invalidation triggered by onError(java.lang.IllegalStateException: " +
+						"expected logged)"))
+				.hasSize(1);
 
 		assertThat(cached.block()).as("sub4").isEqualTo(2);
 		assertThat(cached.block()).as("sub5").isEqualTo(2);
+
+		assertThat(errorsDropped).as("errorsDropped").isEmpty();
+	}
+
+	@Test
+	void cancellingAllSubscribersBeforeOnNextInvalidates() {
+		TestPublisher<Integer> source = TestPublisher.create();
+
+		Mono<Integer> cached = source
+				.mono()
+				.cacheInvalidateWhen(i -> Mono.never());
+
+		Disposable sub1 = cached.subscribe();
+		Disposable sub2 = cached.subscribe();
+		Disposable sub3 = cached.subscribe();
+
+		source.assertWasSubscribed();
+		source.assertNotCancelled();
+
+		sub1.dispose();
+		source.assertNotCancelled();
+
+		sub2.dispose();
+		source.assertNotCancelled();
+
+		sub3.dispose();
+		source.assertCancelled(1);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/test/MemoryUtils.java
+++ b/reactor-core/src/test/java/reactor/test/MemoryUtils.java
@@ -185,14 +185,14 @@ public class MemoryUtils {
 		 */
 		public final String identifier;
 
-	    Tracked(String identifier) {
-	        this.identifier = identifier;
-	    }
+		public Tracked(String identifier) {
+			this.identifier = identifier;
+		}
 
-	    Tracked(String identifier, boolean preReleased) {
-	    	this.identifier = identifier;
-	    	set(preReleased);
-	    }
+		public Tracked(String identifier, boolean preReleased) {
+			this.identifier = identifier;
+			set(preReleased);
+		}
 
 		/**
 		 * Release this {@link Tracked} object.


### PR DESCRIPTION
This PR adds two variants of `Mono.cache` that make use of the received onNext:
 - `cacheInvalidateIf` will take a `Predicate` and validate the cached object
 each time a new subscriber comes in, potentially invalidating the cache and
 forcing a subscription BEFORE the subscriber is notified
 - `cacheInvalidateWhen` will take a `Function` that derives a trigger Mono from
 the value, allowing the invalidation of the cache once said trigger completes.
 this allows manual invalidation (passing in a `Sink` for instance, although
 this currently has limitation) or automatic invalidation if the value has a
 listener or exposes a Mono signalling termination.


Challenge: for manual invalidation, we'll need a resettable Sinks.empty().