### PR TITLE
Explain deprecation workaround for Context#putAll(Context)

### DIFF
--- a/reactor-core/src/main/java/reactor/util/context/Context.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context.java
@@ -284,13 +284,15 @@ public interface Context extends ContextView {
 	}
 
 	/**
-	 * Convenience alternative to {@link #putAll(ContextView)} where one wants to specify several key-value pairs,
-	 * since a common way of providing such pairs is via {@link Context#of(Object, Object, Object, Object, Object, Object, Object, Object, Object, Object)}.
-	 * This method simply calls the {@link Context#readOnly()}, which generally casts the {@link Context} as a {@link ContextView}.
+	 * See {@link #putAll(ContextView)}.
 	 *
+	 * @deprecated will be removed in 3.5, kept for backward compatibility with 3.3. Until
+	 * then if you need to work around the deprecation, use {@link #putAll(ContextView)}
+	 * combined with {@link #readOnly()}
 	 * @param context the {@link Context} from which to copy entries
 	 * @return a new {@link Context} with a merge of the entries from this context and the given context.
 	 */
+	@Deprecated
 	default Context putAll(Context context) {
 		return this.putAll(context.readOnly());
 	}

--- a/reactor-core/src/main/java/reactor/util/context/Context.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context.java
@@ -284,14 +284,14 @@ public interface Context extends ContextView {
 	}
 
 	/**
-	 * See {@link #putAll(ContextView)}.
+	 * Convenience alternative to {@link #putAll(ContextView)} where one wants to specify several key-value pairs,
+	 * since a common way of providing such pairs is via {@link Context#of(Object, Object, Object, Object, Object, Object, Object, Object, Object, Object)}.
+	 * This method simply calls the {@link Context#readOnly()}, which generally casts the {@link Context} as a {@link ContextView}.
 	 *
-	 * @deprecated will be removed in 3.5, kept for backward compatibility with 3.3
 	 * @param context the {@link Context} from which to copy entries
 	 * @return a new {@link Context} with a merge of the entries from this context and the given context.
 	 */
-	@Deprecated
 	default Context putAll(Context context) {
-		return this.putAll((ContextView) context);
+		return this.putAll(context.readOnly());
 	}
 }

--- a/reactor-core/src/main/java/reactor/util/context/ContextView.java
+++ b/reactor-core/src/main/java/reactor/util/context/ContextView.java
@@ -32,6 +32,7 @@ import reactor.util.annotation.Nullable;
  * a write API that returns new instances on each write.
  *
  * @author Simon Baslé
+ * @since 3.4.0
  */
 public interface ContextView {
 

--- a/reactor-core/src/test/java/reactor/util/context/ContextTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextTest.java
@@ -20,16 +20,11 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
-
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -540,6 +535,7 @@ class ContextTest {
 		ContextView contextView = context;
 		Context receiver = Context.of("foo", "bar");
 
+		@SuppressWarnings("deprecation") // because of putAll(Context). This test method shall be removed in 3.5 alongside putAll(Context)
 		Context resultFromContext = receiver.putAll(context);
 		Context resultFromContextView = receiver.putAll(contextView);
 
@@ -551,10 +547,13 @@ class ContextTest {
 	void putAllContextOfNoAmbiguity() {
 		Context receiver = Context.of("foo", "bar");
 
+		@SuppressWarnings("deprecation") // because of putAll(Context). This test method shall be removed in 3.5 alongside putAll(Context)
 		Context resultFromContext = receiver.putAll(Context.of("key", "value"));
+		Context resultFromContextView = receiver.putAll(Context.of("key", "value").readOnly());
 
-		assertThat(resultFromContext.stream().map(e -> e.getKey() + ":" + e.getValue()).collect(Collectors.toList()))
-				.containsExactly("foo:bar", "key:value");
+
+		assertThat(resultFromContext.stream().collect(Collectors.toList()))
+				.containsExactlyElementsOf(resultFromContextView.stream().collect(Collectors.toList()));
 	}
 
 	static class ForeignContext extends ForeignContextView implements Context {


### PR DESCRIPTION
This commit reverts the deprecation of Context#putAll(Context) method,
which was slated for removal in 3.5.0 at the earliest.

It is instead kept as a convenience, eliminating the artificial warnings
caused by the deprecation in 3.4, especially in cases where one seeks
a short-hand way of adding several key-pairs to a `Context` (typically,
this is done via `context.putAll(Context.of(k1, v1, k2, v2, ...))`).

The added value is low, but the risk of keeping it is low too and the
compiler/JIT should be pretty efficient in simplifying that code.

Fixes #2718.
