### PR TITLE
[polish] Follow-up on #2722, copyright update in main

### DIFF
--- a/reactor-core/src/jcstress/java/reactor/core/publisher/ConditionalStressSubscriber.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/ConditionalStressSubscriber.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/ConditionalStressSubscriber.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/ConditionalStressSubscriber.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/ConditionalStressSubscriber.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/ConditionalStressSubscriber.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2020-Present Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxConcatMapNoPrefetchStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxConcatMapNoPrefetchStressTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxConcatMapNoPrefetchStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxConcatMapNoPrefetchStressTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxConcatMapNoPrefetchStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxConcatMapNoPrefetchStressTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2020-Present Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchMapStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchMapStressTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchMapStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchMapStressTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchMapStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchMapStressTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2020-Present Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkEmptySerializedStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkEmptySerializedStressTest.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2020-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkEmptySerializedStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkEmptySerializedStressTest.java
@@ -1,9 +1,12 @@
 /*
  * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  *   https://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkEmptySerializedStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkEmptySerializedStressTest.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkEmptySerializedStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkEmptySerializedStressTest.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManyBestEffortStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManyBestEffortStressTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManyBestEffortStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManyBestEffortStressTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManyBestEffortStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManyBestEffortStressTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2020-Present Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManySerializedStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManySerializedStressTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManySerializedStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManySerializedStressTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManySerializedStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManySerializedStressTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2020-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkOneSerializedStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkOneSerializedStressTest.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2020-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkOneSerializedStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkOneSerializedStressTest.java
@@ -1,9 +1,12 @@
 /*
  * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  *   https://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkOneSerializedStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkOneSerializedStressTest.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkOneSerializedStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkOneSerializedStressTest.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextHolder.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextHolder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextHolder.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextHolder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextHolder.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextHolder.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectInnerContainer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectInnerContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectInnerContainer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectInnerContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectInnerContainer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectInnerContainer.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2020-Present Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxErrorSupplied.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxErrorSupplied.java
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package reactor.core.publisher;
 
 import java.util.Objects;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFirstWithValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFirstWithValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFirstWithValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFirstWithValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFirstWithValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFirstWithValue.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxIndexFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxIndexFuseable.java
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package reactor.core.publisher;
 
 import java.util.Objects;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxLiftFuseable.java
@@ -13,22 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package reactor.core.publisher;
 
 import java.util.Objects;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMapNoPrefetch.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMapNoPrefetch.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMapNoPrefetch.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMapNoPrefetch.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMapNoPrefetch.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMapNoPrefetch.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2021-Present Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTimed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTimed.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTimed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTimed.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTimed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTimed.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalEmptySink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalEmptySink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalEmptySink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalEmptySink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalEmptySink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalEmptySink.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalManySink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalManySink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalManySink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalManySink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalManySink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalManySink.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalOneSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalOneSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalOneSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalOneSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalOneSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalOneSink.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoErrorSupplied.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoErrorSupplied.java
@@ -13,22 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package reactor.core.publisher;
 
 import java.time.Duration;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFirstWithValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFirstWithValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFirstWithValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFirstWithValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFirstWithValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFirstWithValue.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTimed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTimed.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTimed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTimed.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTimed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTimed.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkEmptyMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkEmptyMulticast.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkEmptyMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkEmptyMulticast.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkEmptyMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkEmptyMulticast.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkEmptySerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkEmptySerialized.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2020-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkEmptySerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkEmptySerialized.java
@@ -1,9 +1,12 @@
 /*
  * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  *   https://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkEmptySerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkEmptySerialized.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkEmptySerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkEmptySerialized.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManySerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManySerialized.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2020-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManySerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManySerialized.java
@@ -1,9 +1,12 @@
 /*
  * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  *   https://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManySerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManySerialized.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManySerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManySerialized.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkOneSerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkOneSerialized.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2020-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkOneSerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkOneSerialized.java
@@ -1,9 +1,12 @@
 /*
  * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  *   https://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkOneSerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkOneSerialized.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkOneSerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkOneSerialized.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/Timed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Timed.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/Timed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Timed.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/Timed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Timed.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastManySinkNoBackpressure.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastManySinkNoBackpressure.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastManySinkNoBackpressure.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastManySinkNoBackpressure.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastManySinkNoBackpressure.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastManySinkNoBackpressure.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/util/context/ContextView.java
+++ b/reactor-core/src/main/java/reactor/util/context/ContextView.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/util/context/ContextView.java
+++ b/reactor-core/src/main/java/reactor/util/context/ContextView.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/main/java/reactor/util/context/ContextView.java
+++ b/reactor-core/src/main/java/reactor/util/context/ContextView.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/FuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/FuseableTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/FuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/FuseableTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/FuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/FuseableTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2020-Present Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapNoPrefetchTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapNoPrefetchTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapNoPrefetchTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapNoPrefetchTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapNoPrefetchTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapNoPrefetchTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2020-Present Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFirstWithValueTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFirstWithValueTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFirstWithValueTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFirstWithValueTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFirstWithValueTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFirstWithValueTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMapNotNullTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMapNotNullTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMapNotNullTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMapNotNullTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMapNotNullTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMapNotNullTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTimedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTimedTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTimedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTimedTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTimedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTimedTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/InternalManySinkTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/InternalManySinkTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/InternalManySinkTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/InternalManySinkTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/InternalManySinkTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/InternalManySinkTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/InternalOneSinkTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/InternalOneSinkTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/InternalOneSinkTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/InternalOneSinkTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/InternalOneSinkTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/InternalOneSinkTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFirstWithValueTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFirstWithValueTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFirstWithValueTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFirstWithValueTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFirstWithValueTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFirstWithValueTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMapNotNullTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMapNotNullTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMapNotNullTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMapNotNullTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMapNotNullTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMapNotNullTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTimedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTimedTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTimedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTimedTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTimedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTimedTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkEmptyMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkEmptyMulticastTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkEmptyMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkEmptyMulticastTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkEmptyMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkEmptyMulticastTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkManyBestEffortTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkManyBestEffortTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkManyBestEffortTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkManyBestEffortTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkManyBestEffortTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkManyBestEffortTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkManySerializedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkManySerializedTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkManySerializedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkManySerializedTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkManySerializedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkManySerializedTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/UnicastManySinkNoBackpressureTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/UnicastManySinkNoBackpressureTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/UnicastManySinkNoBackpressureTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/UnicastManySinkNoBackpressureTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/core/publisher/UnicastManySinkNoBackpressureTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/UnicastManySinkNoBackpressureTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/util/context/ContextViewTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextViewTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/util/context/ContextViewTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextViewTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-core/src/test/java/reactor/util/context/ContextViewTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextViewTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-test/src/test/java/reactor/test/util/LoggerUtilsTest.java
+++ b/reactor-test/src/test/java/reactor/test/util/LoggerUtilsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   https://www.apache.org
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-test/src/test/java/reactor/test/util/LoggerUtilsTest.java
+++ b/reactor-test/src/test/java/reactor/test/util/LoggerUtilsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-test/src/test/java/reactor/test/util/LoggerUtilsTest.java
+++ b/reactor-test/src/test/java/reactor/test/util/LoggerUtilsTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit performs the same changes as in #2722, on files that were
introduced in the `main` branch (3.4.x) only.

Since the scope is far more restricted, the changes are done in a
single commit.

See reactor/reactor#682
