### PR TITLE
[build] Use Spotless plugin to enforce/update copyright headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,20 @@ jobs:
         wrapper-cache-enabled: true
         dependencies-cache-enabled: true
         configuration-cache-enabled: true
+  spotless:
+    name: spotless
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: eskatos/gradle-command-action@v1
+      name: gradle
+      with:
+        arguments: spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
+        wrapper-cache-enabled: true
+        dependencies-cache-enabled: true
+        configuration-cache-enabled: true
   core-slow:
     name: core slower tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         dependencies-cache-enabled: true
         configuration-cache-enabled: true
   other:
-    name: other tests and checks
+    name: other tests
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -61,4 +61,3 @@ jobs:
         wrapper-cache-enabled: true
         dependencies-cache-enabled: true
         configuration-cache-enabled: true
-#the above should exclude jcstress in master, adding a 3rd job below for jcstress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,20 +22,6 @@ jobs:
         wrapper-cache-enabled: true
         dependencies-cache-enabled: true
         configuration-cache-enabled: true
-  spotless:
-    name: spotless
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - uses: eskatos/gradle-command-action@v1
-      name: gradle
-      with:
-        arguments: spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
-        wrapper-cache-enabled: true
-        dependencies-cache-enabled: true
-        configuration-cache-enabled: true
   core-slow:
     name: core slower tests
     runs-on: ubuntu-latest
@@ -52,15 +38,24 @@ jobs:
         dependencies-cache-enabled: true
         configuration-cache-enabled: true
   other:
-    name: other tests
+    name: other tests and checks
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - uses: actions/setup-java@v1
       with:
         java-version: 8
     - uses: eskatos/gradle-command-action@v1
-      name: gradle
+      name: license header
+      with:
+        arguments: spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
+        wrapper-cache-enabled: true
+        dependencies-cache-enabled: true
+        configuration-cache-enabled: true
+    - uses: eskatos/gradle-command-action@v1
+      name: other tests
       with:
         arguments: check -x :reactor-core:test --no-daemon
         wrapper-cache-enabled: true

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ plugins {
 	id 'biz.aQute.bnd.builder' version '5.0.1' apply false
 	id 'io.spring.nohttp' version '0.0.5.RELEASE'
 	id "io.github.reyerizo.gradle.jcstress" version "0.8.11" apply false
+	id "com.diffplug.spotless" version "5.14.0"
 }
 
 apply plugin: "io.reactor.gradle.detect-ci"
@@ -104,6 +105,27 @@ nohttp {
 	source.exclude "docs/asciidoc/highlight/**"
 	source.exclude "**/build/reports/tests/**/*.html"
 	allowlistFile = project.file('codequality/nohttp/allowlist.lines')
+}
+
+spotless {
+	if (project.hasProperty("spotlessFrom")) {
+		println "[Spotless] Ratchet from $project.spotlessFrom"
+		ratchetFrom project.spotlessFrom
+	}
+	else if (isCiServer) {
+		println "[Spotless] CI detected without explicit branch, not enforcing check"
+		enforceCheck false
+	}
+	else {
+		String spotlessBranch = "origin/3.3.x"
+		println "[Spotless] Local run detected, ratchet from $spotlessBranch"
+		ratchetFrom spotlessBranch
+	}
+	java {
+		target '**/*.java'
+		targetExclude '**/java8stubs/**/*', '**/java9stubs/**/*'
+		licenseHeaderFile('codequality/spotless/licenseSlashstarStyle.txt')
+	}
 }
 
 configure(subprojects) { p ->

--- a/codequality/spotless/licenseSlashstarStyle.txt
+++ b/codequality/spotless/licenseSlashstarStyle.txt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2011-$today.year VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+


### PR DESCRIPTION
This only applies to .java files changed compared to the origin base
branch (3.3.x), and excluding JDK stubs.

This allows to enforce license header with up-to-date end year only when
a file get touched (no need for a big bang update of the end year in
all files comes new year).

The year variable in the template is compatible with IntelliJ's own
template format (velocity), although IntelliJ doesn't typically include
the comment characters like in the added template file.

The template includes 2 blank lines at the end so that one blank line
remains after the license header once spotless is applied.

The ratchet (apply spotless only to files that changed between current
commit and the specified branch) is adapted depending on local build,
CI build without any specific parameter and CI build explicitly intended
for spotless (thanks to `-PspotlessFrom=branch`). The later is necessary
because spotless needs a full checkout, which is typically not done by
default by CI platforms like GitHub Actions.

See reactor/reactor#701

See also reactor/reactor#700 for the initial goal of including basic
formatting.
