### PR TITLE
[chores] Polish #2732 and fix start years of new files in 3.4.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,3 @@
-import org.gradle.util.VersionNumber
-
-import java.text.SimpleDateFormat
-
 /*
  * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
@@ -17,6 +13,10 @@ import java.text.SimpleDateFormat
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import org.gradle.util.VersionNumber
+import java.text.SimpleDateFormat
+
 buildscript {
 	// we define kotlin version for benefit of both core and test (see kotlin-gradle-plugin below)
 	ext.kotlinVersion = '1.3.72'

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -1,7 +1,3 @@
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
-import java.time.temporal.ChronoField
-
 /*
  * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
@@ -18,6 +14,9 @@ import java.time.temporal.ChronoField
  * limitations under the License.
  */
 
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoField
 
 if (rootProject.hasProperty("releaserDryRun") && rootProject.findProperty("releaserDryRun") != "false") {
 	println "Adding MavenLocal() for benefit of releaser dry run"

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/ConditionalStressSubscriber.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/ConditionalStressSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import java.util.function.Predicate;

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxConcatMapNoPrefetchStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxConcatMapNoPrefetchStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import org.openjdk.jcstress.annotations.Actor;

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchMapStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchMapStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import org.openjdk.jcstress.annotations.Actor;

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchOnFirstConditionalStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchOnFirstConditionalStressTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import org.openjdk.jcstress.annotations.Actor;

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchOnFirstStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchOnFirstStressTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import java.io.Serializable;

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/MonoDelayUntilStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/MonoDelayUntilStressTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import org.openjdk.jcstress.annotations.Actor;

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkEmptySerializedStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkEmptySerializedStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManyBestEffortStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManyBestEffortStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import org.openjdk.jcstress.annotations.Actor;

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManySerializedStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManySerializedStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkOneSerializedStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkOneSerializedStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextHolder.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import reactor.util.context.Context;

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectInnerContainer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectInnerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import java.time.Duration;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import java.util.Objects;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFirstWithSignal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFirstWithSignal.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import java.util.Iterator;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFirstWithValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFirstWithValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import org.reactivestreams.Publisher;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMapNoPrefetch.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMapNoPrefetch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTimed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTimed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalEmptySink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalEmptySink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalManySink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalManySink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalOneSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalOneSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import java.time.Duration;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFirstWithSignal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFirstWithSignal.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import java.util.Iterator;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFirstWithValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFirstWithValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import org.reactivestreams.Publisher;

--- a/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016-2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import java.time.Duration;

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkEmptyMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkEmptyMulticast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkEmptySerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkEmptySerialized.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManySerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManySerialized.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkOneSerialized.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkOneSerialized.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import java.time.Duration;

--- a/reactor-core/src/main/java/reactor/core/publisher/Timed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Timed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastManySinkNoBackpressure.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastManySinkNoBackpressure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import java.util.Objects;

--- a/reactor-core/src/main/java/reactor/util/context/ContextView.java
+++ b/reactor-core/src/main/java/reactor/util/context/ContextView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/FuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/FuseableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapNoPrefetchTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatMapNoPrefetchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxContextWriteTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxContextWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxContextWriteTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxContextWriteTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import org.junit.jupiter.api.Test;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDeferContextualTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDeferContextualTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDeferContextualTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDeferContextualTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import org.junit.jupiter.api.Test;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxErrorOnRequestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxErrorOnRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxErrorOnRequestTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxErrorOnRequestTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import org.junit.jupiter.api.Test;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFirstWithValueTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFirstWithValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import java.time.Duration;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxLogTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxLogTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxLogTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMapNotNullTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMapNotNullTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSourceMonoTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSourceMonoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSourceMonoTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSourceMonoTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import org.junit.jupiter.api.Test;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTimedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTimedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/InternalManySinkTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/InternalManySinkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/InternalOneSinkTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/InternalOneSinkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoContextWriteTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoContextWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoContextWriteTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoContextWriteTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCurrentContextTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCurrentContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCurrentContextTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCurrentContextTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import org.junit.jupiter.api.Test;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFirstWithSignalTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFirstWithSignalTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import java.time.Duration;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFirstWithValueTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFirstWithValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import java.time.Duration;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFlattenIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFlattenIterableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFlattenIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFlattenIterableTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import org.junit.jupiter.api.Test;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFromPublisherTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFromPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFromPublisherTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFromPublisherTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import org.junit.jupiter.api.Test;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreElementTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreElementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreElementTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreElementTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import org.junit.jupiter.api.Test;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreElementsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreElementsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreElementsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreElementsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import org.junit.jupiter.api.Test;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoIgnorePublisherTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoIgnorePublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoIgnorePublisherTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoIgnorePublisherTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import org.junit.jupiter.api.Test;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoLogTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoLogTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import org.junit.jupiter.api.Test;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoMapNotNullTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoMapNotNullTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSourceFluxTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSourceFluxTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import org.junit.jupiter.api.Test;

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoTimedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoTimedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelDoOnEachTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelDoOnEachTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import org.junit.jupiter.api.Test;

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkEmptyMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkEmptyMulticastTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkManyBestEffortTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkManyBestEffortTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkManySerializedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkManySerializedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/UnicastManySinkNoBackpressureTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/UnicastManySinkNoBackpressureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.core.publisher;
 
 import java.time.Duration;

--- a/reactor-core/src/test/java/reactor/util/context/ContextViewTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-test/src/main/java/reactor/test/util/LoggerUtils.java
+++ b/reactor-test/src/main/java/reactor/test/util/LoggerUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.test.util;
 
 import java.lang.reflect.Field;

--- a/reactor-test/src/test/java/reactor/test/util/LoggerUtilsTest.java
+++ b/reactor-test/src/test/java/reactor/test/util/LoggerUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.test.util;
 
 import java.util.ArrayList;

--- a/reactor-test/src/test/java/reactor/test/util/TestLoggerTest.java
+++ b/reactor-test/src/test/java/reactor/test/util/TestLoggerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.test.util;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This commit polishes the merge of #2732 and reviews the start year
of copyright notice headers for files that have been introduced in 3.4.x
or otherwise differ from 3.3.x (for example main's NextProcessor derives
from 3.3.x's MonoProcessor).
