### PR TITLE
[polish] Tag 3min worth of tests as 'slow'

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
@@ -36,6 +36,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -824,6 +825,7 @@ public class FluxBufferPredicateTest {
 	}
 
 	@Test
+	@Tag("slow")
 	public void requestRaceWithOnNextLoops() {
 		for (int i = 0; i < ROUNDS; i++) {
 			requestRaceWithOnNext();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferWhenTest.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
 import java.util.logging.Level;
 
 import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Subscription;
@@ -60,6 +61,7 @@ public class FluxBufferWhenTest {
 
 	//see https://github.com/reactor/reactor-core/issues/969
 	@Test
+	@Tag("slow")
 	public void bufferedCanCompleteIfOpenNeverCompletesDropping() {
 		//this test ensures that dropping buffers will complete if the source is exhausted before the open publisher finishes
 		Mono<Integer> buffered = Flux.range(1, 200)
@@ -78,6 +80,7 @@ public class FluxBufferWhenTest {
 
 	//see https://github.com/reactor/reactor-core/issues/969
 	@Test
+	@Tag("slow")
 	public void bufferedCanCompleteIfOpenNeverCompletesOverlapping() {
 		//this test ensures that overlapping buffers will complete if the source is exhausted before the open publisher finishes
 		Mono<Integer> buffered = Flux.range(1, 200)
@@ -96,6 +99,7 @@ public class FluxBufferWhenTest {
 
 	//see https://github.com/reactor/reactor-core/issues/969
 	@Test
+	@Tag("slow")
 	public void timedOutBuffersDontLeak() throws InterruptedException {
 		LongAdder created = new LongAdder();
 		MemoryUtils.RetainedDetector retainedDetector = new MemoryUtils.RetainedDetector();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Subscription;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
@@ -387,6 +387,7 @@ public class FluxGroupByTest extends
 	}
 
 	@Test
+	@Tag("slow")
 	public void twoGroupsLongAsyncMergeHidden2() {
 		ForkJoinPool forkJoinPool = new ForkJoinPool();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import reactor.core.Disposable;
 import reactor.core.Scannable;
@@ -270,6 +271,7 @@ public class FluxRefCountGraceTest {
 
 	//see https://github.com/reactor/reactor-core/issues/1260
 	@Test
+	@Tag("slow")
 	public void raceSubscribeAndCancelNoTimeout() {
 		final Flux<String> testFlux = Flux.<String>create(fluxSink -> fluxSink.next("Test").complete())
 				.replay(1)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
@@ -663,6 +664,7 @@ public class FluxTakeTest {
     }
 
     @Test
+	@Tag("slow")
 	public void onSubscribeRaceRequestingShouldBeConsistentForTakeFuseableTest() throws InterruptedException {
 		for (int i = 0; i < 5; i++) {
 			int take = 3000;
@@ -676,6 +678,7 @@ public class FluxTakeTest {
     }
 
 	@Test
+	@Tag("slow")
 	public void onSubscribeRaceRequestingShouldBeConsistentForTakeConditionalTest() throws InterruptedException {
 		for (int i = 0; i < 5; i++) {
 			int take = 3000;
@@ -690,6 +693,7 @@ public class FluxTakeTest {
 	}
 
 	@Test
+	@Tag("slow")
 	public void onSubscribeRaceRequestingShouldBeConsistentForTakeTest() throws InterruptedException {
 		for (int i = 0; i < 5; i++) {
 			int take = 3000;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.LongAdder;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
@@ -64,6 +65,7 @@ public class FluxWindowWhenTest {
 
 	//see https://github.com/reactor/reactor-core/issues/975
 	@Test
+	@Tag("slow")
 	public void noWindowRetained_gh975() throws InterruptedException {
 		LongAdder created = new LongAdder();
 		class Wrapper {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -43,6 +44,7 @@ import reactor.util.context.Context;
 import static org.assertj.core.api.Assertions.assertThat;
 import static reactor.test.publisher.TestPublisher.Violation.CLEANUP_ON_TERMINATE;
 
+@Tag("slow")
 public class MonoCollectListTest {
 
 	static final Logger LOGGER = Loggers.getLogger(MonoCollectListTest.class);
@@ -208,6 +210,7 @@ public class MonoCollectListTest {
 
 
 	@Test
+	@Tag("slow")
 	public void discardCancelNextRace() {
 		AtomicInteger doubleDiscardCounter = new AtomicInteger();
 		Context discardingContext = Operators.enableOnDiscard(null, o -> {
@@ -237,6 +240,7 @@ public class MonoCollectListTest {
 	}
 
 	@Test
+	@Tag("slow")
 	public void discardCancelCompleteRace() {
 		AtomicInteger doubleDiscardCounter = new AtomicInteger();
 		Context discardingContext = Operators.enableOnDiscard(null, o -> {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCompletionStageTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCompletionStageTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 
@@ -72,6 +73,7 @@ public class MonoCompletionStageTest {
 	}
 
 	@Test
+	@Tag("slow")
 	public void cancelFutureDelayedCancelledLoop() {
 		for (int i = 0; i < 500; i++) {
 			CompletableFuture<Integer> future = new CompletableFuture<>();
@@ -93,6 +95,7 @@ public class MonoCompletionStageTest {
 	}
 
 	@Test
+	@Tag("slow")
 	public void cancelFutureTimeoutCancelledLoop() {
 		for (int i = 0; i < 500; i++) {
 			CompletableFuture<Integer> future = new CompletableFuture<>();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreThenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreThenTest.java
@@ -19,6 +19,7 @@ package reactor.core.publisher;
 import java.time.Duration;
 
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import reactor.core.Disposable;
@@ -64,6 +65,7 @@ class MonoIgnoreThenTest {
 	}
 
 	@Test
+	@Tag("slow")
 	// https://github.com/reactor/reactor-core/issues/2561
 	void raceTest2561() {
 		final Scheduler scheduler = Schedulers.newSingle("non-test-thread");

--- a/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
@@ -27,6 +27,7 @@ import org.assertj.core.api.Assumptions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.reactivestreams.Publisher;
@@ -44,6 +45,7 @@ import reactor.util.concurrent.Queues;
 
 // TODO Junit 5: would maybe be better handled as a dynamic test, but  was migrated kind of "as is" to make sure
 // test count did not regress.
+@Tag("slow")
 public class OnDiscardShouldNotLeakTest {
 
 	private static final int NB_ITERATIONS = 100;

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.reactivestreams.Publisher;
@@ -62,6 +63,7 @@ public class ParallelFluxTest {
 	public AutoDisposingExtension afterTest = new AutoDisposingExtension();
 
 	@Test
+	@Tag("slow")
 	public void sequentialMode() {
 		Flux<Integer> source = Flux.range(1, 1_000_000)
 		                           .hide();
@@ -83,6 +85,7 @@ public class ParallelFluxTest {
 	}
 
 	@Test
+	@Tag("slow")
 	public void sequentialModeFused() {
 		Flux<Integer> source = Flux.range(1, 1_000_000);
 		for (int i = 1; i < 33; i++) {
@@ -103,6 +106,7 @@ public class ParallelFluxTest {
 	}
 
 	@Test
+	@Tag("slow")
 	public void parallelMode() {
 		Flux<Integer> source = Flux.range(1, 1_000_000)
 		                           .hide();
@@ -138,6 +142,7 @@ public class ParallelFluxTest {
 	}
 
 	@Test
+	@Tag("slow")
 	public void parallelModeFused() {
 		Flux<Integer> source = Flux.range(1, 1_000_000);
 		int ncpu = Math.max(8,

--- a/reactor-core/src/test/java/reactor/core/publisher/QueueDrainSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/QueueDrainSubscriberTest.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openjdk.jol.info.ClassLayout;
 import org.openjdk.jol.info.FieldLayout;
@@ -27,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class QueueDrainSubscriberTest {
 
 	@Test
+	@Tag("slow")
 	public void objectPadding() {
 		ClassLayout layout = ClassLayout.parseClass(QueueDrainSubscriber.class);
 		AtomicReference<FieldLayout> wip = new AtomicReference<>();

--- a/reactor-core/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SerializedSubscriberTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 
@@ -38,6 +39,7 @@ public class SerializedSubscriberTest {
 
 	//see https://github.com/reactor/reactor-core/issues/2077
 	@Test
+	@Tag("slow")
 	public void onNextRaceWithCancelDoesNotLeak() {
 		int loops = 0;
 		while (loops < 100_000) {

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -48,6 +48,7 @@ import java.util.stream.IntStream;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Publisher;
@@ -556,6 +557,7 @@ public class FluxTests extends AbstractReactorTest {
 	}
 
 	@Test
+	@Tag("slow")
 	public void parallelTests() throws InterruptedException {
 		parallelMapManyTest("sync", 1_000_000);
 		parallelMapManyTest("shared", 1_000_000);

--- a/reactor-core/src/test/java/reactor/core/scheduler/BoundedElasticSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/BoundedElasticSchedulerTest.java
@@ -48,6 +48,7 @@ import com.pivovarit.function.ThrowingSupplier;
 import org.awaitility.Awaitility;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
@@ -166,6 +167,7 @@ public class BoundedElasticSchedulerTest extends AbstractSchedulerTest {
 	}
 
 	@Test
+	@Tag("slow")
 	public void testLargeNumberOfWorkers() throws InterruptedException {
 		final int maxThreads = 3;
 		final int maxQueue = 10;
@@ -411,6 +413,7 @@ public class BoundedElasticSchedulerTest extends AbstractSchedulerTest {
 	}
 
 	@Test
+	@Tag("slow")
 	public void lifoEvictionNoThreadRegrowth() throws InterruptedException {
 		int otherThreads = Thread.activeCount(); //don't count the evictor at shutdown
 		Set<String> preExistingEvictors = dumpThreadNames().filter(s -> s.startsWith("boundedElastic-evictor")).collect(Collectors.toSet());
@@ -1087,6 +1090,7 @@ public class BoundedElasticSchedulerTest extends AbstractSchedulerTest {
 	}
 
 	@Test
+	@Tag("slow")
 	public void pickSetIdleRaceBusy() {
 		BoundedElasticScheduler scheduler = afterTest.autoDispose(new BoundedElasticScheduler(1, 1, r -> new Thread(r, "test"),
 				1000));
@@ -1104,6 +1108,7 @@ public class BoundedElasticSchedulerTest extends AbstractSchedulerTest {
 
 	}
 	@Test
+	@Tag("slow")
 	public void pickSetIdleRaceIdle() {
 		BoundedElasticScheduler scheduler = afterTest.autoDispose(new BoundedElasticScheduler(1, 1, r -> new Thread(r, "test"),
 				1000));
@@ -1137,6 +1142,7 @@ public class BoundedElasticSchedulerTest extends AbstractSchedulerTest {
 
 	//gh-1973 smoke test
 	@Test
+	@Tag("slow")
 	public void testGh1973() throws InterruptedException {
 		Scheduler scheduler = afterTest.autoDispose(Schedulers.newBoundedElastic(3, 100000, "subscriberElastic", 600, true));
 		LinkedList<MonoSink<String>> listeners = new LinkedList<>();

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersHooksTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersHooksTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import reactor.test.AutoDisposingExtension;
@@ -42,6 +43,7 @@ public class SchedulersHooksTest {
 	}
 
 	@Test
+	@Tag("slow")
 	public void onScheduleIsAdditive() throws Exception {
 		AtomicInteger tracker = new AtomicInteger();
 		Schedulers.onScheduleHook("k1", new TrackingDecorator(tracker, 1));
@@ -92,6 +94,7 @@ public class SchedulersHooksTest {
 	}
 
 	@Test
+	@Tag("slow")
 	public void onScheduleResetOne() throws InterruptedException {
 		AtomicInteger tracker = new AtomicInteger();
 		Schedulers.onScheduleHook("k1", new TrackingDecorator(tracker, 1));

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -38,6 +38,7 @@ import java.util.function.Consumer;
 
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -640,16 +641,19 @@ public class SchedulersTest {
 	}
 
 	@Test
+	@Tag("slow")
 	public void testRejectingSingleScheduler() {
 		assertRejectingScheduler(Schedulers.newSingle("test"));
 	}
 
 	@Test
+	@Tag("slow")
 	public void testRejectingParallelScheduler() {
 		assertRejectingScheduler(Schedulers.newParallel("test"));
 	}
 
 	@Test
+	@Tag("slow")
 	public void testRejectingExecutorServiceScheduler() {
 		assertRejectingScheduler(Schedulers.fromExecutorService(Executors.newSingleThreadExecutor()));
 	}


### PR DESCRIPTION
Note than in `main`, there is also `FluxSwitchMapTest.test2596﻿()` which is one
of the worst offenders.

For a while, ci workflow has been running a "core slow tests" job that filtered
on the `slow` tag... which had 0 matching tests.

This commit reintroduces the tag, marking several tests that each take more than
2 seconds, for a total of about 3min worth of tests.