### PR TITLE
Rework FluxReplay to avoid hanging, but reject 0 size

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -64,7 +64,6 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Scheduler.Worker;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.Logger;
-import reactor.util.Loggers;
 import reactor.util.Metrics;
 import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
@@ -117,8 +116,6 @@ import reactor.util.retry.Retry;
  * @see Mono
  */
 public abstract class Flux<T> implements CorePublisher<T> {
-
-	private static final Logger LOGGER = Loggers.getLogger(Flux.class);
 
 //	 ==============================================================================================================
 //	 Static Generators
@@ -7474,7 +7471,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final ConnectableFlux<T> replay(int history) {
 		if (history == 0) {
-			LOGGER.warn("Flux.replay with history == 0 doesn't make much sense. This was replaced by Flux.publish, but such calls will be rejected in a future version");
+			//TODO Flux.replay with history == 0 doesn't make much sense. This was replaced by Flux.publish, but such calls will be rejected in a future version
 			return onAssembly(new FluxPublish<>(this, Queues.SMALL_BUFFER_SIZE, Queues.get(Queues.SMALL_BUFFER_SIZE)));
 		}
 		return onAssembly(new FluxReplay<>(this, history, 0L, null));
@@ -7557,7 +7554,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	public final ConnectableFlux<T> replay(int history, Duration ttl, Scheduler timer) {
 		Objects.requireNonNull(timer, "timer");
 		if (history == 0) {
-			LOGGER.warn("Flux.replay with history == 0 doesn't make much sense. This was replaced by Flux.publish, but such calls will be rejected in a future version");
+			//TODO Flux.replay with history == 0 doesn't make much sense. This was replaced by Flux.publish, but such calls will be rejected in a future version
 			return onAssembly(new FluxPublish<>(this, Queues.SMALL_BUFFER_SIZE, Queues.get(Queues.SMALL_BUFFER_SIZE)));
 		}
 		return onAssembly(new FluxReplay<>(this, history, ttl.toNanos(), timer));

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -64,6 +64,7 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Scheduler.Worker;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.Logger;
+import reactor.util.Loggers;
 import reactor.util.Metrics;
 import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
@@ -116,6 +117,8 @@ import reactor.util.retry.Retry;
  * @see Mono
  */
 public abstract class Flux<T> implements CorePublisher<T> {
+
+	private static final Logger LOGGER = Loggers.getLogger(Flux.class);
 
 //	 ==============================================================================================================
 //	 Static Generators
@@ -7470,6 +7473,10 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 *
 	 */
 	public final ConnectableFlux<T> replay(int history) {
+		if (history == 0) {
+			LOGGER.warn("Flux.replay with history == 0 doesn't make much sense. This was replaced by Flux.publish, but such calls will be rejected in a future version");
+			return onAssembly(new FluxPublish<>(this, Queues.SMALL_BUFFER_SIZE, Queues.get(Queues.SMALL_BUFFER_SIZE)));
+		}
 		return onAssembly(new FluxReplay<>(this, history, 0L, null));
 	}
 
@@ -7549,6 +7556,10 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final ConnectableFlux<T> replay(int history, Duration ttl, Scheduler timer) {
 		Objects.requireNonNull(timer, "timer");
+		if (history == 0) {
+			LOGGER.warn("Flux.replay with history == 0 doesn't make much sense. This was replaced by Flux.publish, but such calls will be rejected in a future version");
+			return onAssembly(new FluxPublish<>(this, Queues.SMALL_BUFFER_SIZE, Queues.get(Queues.SMALL_BUFFER_SIZE)));
+		}
 		return onAssembly(new FluxReplay<>(this, history, ttl.toNanos(), timer));
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -1606,7 +1606,9 @@ final class FluxReplay<T> extends ConnectableFlux<T>
 		}
 
 		/**
-		 * Check if state has {@link #CONNECTED_FLAG} flag indicating subscription reception
+		 * Check if state has {@link #CONNECTED_FLAG} flag indicating that the
+		 * {@link #connect(Consumer)} method was called and we have already connected
+		 * to the upstream
 		 *
 		 * @param state to check flag presence
 		 * @return true if flag is set
@@ -1616,7 +1618,8 @@ final class FluxReplay<T> extends ConnectableFlux<T>
 		}
 
 		/**
-		 * Check if state has {@link #SUBSCRIBED_FLAG} flag indicating subscription reception
+		 * Check if state has {@link #SUBSCRIBED_FLAG} flag indicating subscription
+		 * reception from the upstream
 		 *
 		 * @param state to check flag presence
 		 * @return true if flag is set

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -1606,7 +1606,7 @@ final class FluxReplay<T> extends ConnectableFlux<T>
 		}
 
 		/**
-		 * Check if state has subscribed flag indicating subscription reception
+		 * Check if state has {@link #CONNECTED_FLAG} flag indicating subscription reception
 		 *
 		 * @param state to check flag presence
 		 * @return true if flag is set
@@ -1616,7 +1616,7 @@ final class FluxReplay<T> extends ConnectableFlux<T>
 		}
 
 		/**
-		 * Check if state has subscribed flag indicating subscription reception
+		 * Check if state has {@link #SUBSCRIBED_FLAG} flag indicating subscription reception
 		 *
 		 * @param state to check flag presence
 		 * @return true if flag is set
@@ -1636,7 +1636,7 @@ final class FluxReplay<T> extends ConnectableFlux<T>
 		}
 
 		/**
-		 * Check if state has disposed flag
+		 * Check if state has {@link #DISPOSED_FLAG} flag
 		 *
 		 * @param state to check flag presence
 		 * @return true if flag is set

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -567,11 +567,6 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 		}
 
 		@Override
-		public long signalConnectAndGetRequested() {
-			return requested;
-		}
-
-		@Override
 		public boolean isCancelled() {
 			return requested == Long.MIN_VALUE;
 		}
@@ -619,6 +614,11 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 				}
 				buffer.replay(this);
 			}
+		}
+
+		@Override
+		public void requestMore(int index) {
+			this.index = index;
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -564,7 +564,7 @@ public final class Sinks {
 		 *     Older elements are discarded.</li>
 		 * </ul>
 		 *
-		 * @param historySize maximum number of elements able to replayed
+		 * @param historySize maximum number of elements able to replayed, strictly positive
 		 */
 		<T> Sinks.Many<T> limit(int historySize);
 
@@ -612,7 +612,7 @@ public final class Sinks {
 		 * </ul>
 		 * Note: Age is checked when a signal occurs, not using a background task.
 		 *
-		 * @param historySize maximum number of elements able to replayed
+		 * @param historySize maximum number of elements able to replayed, strictly positive
 		 * @param maxAge maximum retention time for elements to be retained
 		 */
 		<T> Sinks.Many<T> limit(int historySize, Duration maxAge);
@@ -629,7 +629,7 @@ public final class Sinks {
 		 * </ul>
 		 * Note: Age is checked when a signal occurs, not using a background task.
 		 *
-		 * @param historySize maximum number of elements able to replayed
+		 * @param historySize maximum number of elements able to replayed, strictly positive
 		 * @param maxAge maximum retention time for elements to be retained
 		 * @param scheduler a {@link Scheduler} to derive the time from
 		 */

--- a/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
@@ -191,6 +191,9 @@ final class SinksSpecs {
 
 		@Override
 		public <T> Many<T> limit(int historySize) {
+			if (historySize <= 0) {
+				throw new IllegalArgumentException("historySize must be > 0");
+			}
 			@SuppressWarnings("deprecation") // ReplayProcessor will be removed in 3.5.
 			final ReplayProcessor<T> original = ReplayProcessor.create(historySize);
 			return wrapMany(original);
@@ -212,6 +215,9 @@ final class SinksSpecs {
 
 		@Override
 		public <T> Many<T> limit(int historySize, Duration maxAge) {
+			if (historySize <= 0) {
+				throw new IllegalArgumentException("historySize must > 0");
+			}
 			@SuppressWarnings("deprecation") // ReplayProcessor will be removed in 3.5.
 			final ReplayProcessor<T> original = ReplayProcessor.createSizeAndTimeout(historySize, maxAge);
 			return wrapMany(original);
@@ -219,6 +225,9 @@ final class SinksSpecs {
 
 		@Override
 		public <T> Many<T> limit(int historySize, Duration maxAge, Scheduler scheduler) {
+			if (historySize <= 0) {
+				throw new IllegalArgumentException("historySize must be > 0");
+			}
 			@SuppressWarnings("deprecation") // ReplayProcessor will be removed in 3.5.
 			final ReplayProcessor<T> original = ReplayProcessor.createSizeAndTimeout(historySize, maxAge, scheduler);
 			return wrapMany(original);

--- a/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
@@ -216,7 +216,7 @@ final class SinksSpecs {
 		@Override
 		public <T> Many<T> limit(int historySize, Duration maxAge) {
 			if (historySize <= 0) {
-				throw new IllegalArgumentException("historySize must > 0");
+				throw new IllegalArgumentException("historySize must be > 0");
 			}
 			@SuppressWarnings("deprecation") // ReplayProcessor will be removed in 3.5.
 			final ReplayProcessor<T> original = ReplayProcessor.createSizeAndTimeout(historySize, maxAge);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxReplayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxReplayTest.java
@@ -447,9 +447,9 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 		TwoRequestsSubscriber fiveThenEightSubscriber = new TwoRequestsSubscriber(5, 8);
 
 		ConnectableFlux<Integer> replay =
-				Flux.range(1, 5)
+				Flux.range(1, 11)
 				    .doOnRequest(requests::add)
-				    .replay(3);
+				    .replay(8);
 
 		assertThat(requests).isEmpty();
 
@@ -457,7 +457,7 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 		replay.subscribe(); //unbounded
 		replay.connect();
 
-		assertThat(requests).containsExactly(3L, 3L);
+		assertThat(requests).containsExactly(8L, 6L);
 	}
 
 	@Test
@@ -466,9 +466,9 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 		TwoRequestsSubscriber fiveThenEightSubscriber = new TwoRequestsSubscriber(5, 8);
 
 		ConnectableFlux<Integer> replay =
-				Flux.range(1, 5)
+				Flux.range(1, 11)
 				    .doOnRequest(requests::add)
-				    .replay(3);
+				    .replay(8);
 
 		assertThat(requests).isEmpty();
 
@@ -476,7 +476,7 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 		replay.subscribe(); //unbounded
 		replay.connect();
 
-		assertThat(requests).containsExactly(3L, 3L);
+		assertThat(requests).containsExactly(8L, 6L);
 	}
 
 	@Test
@@ -485,9 +485,9 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 		TwoRequestsSubscriber fiveThenEightSubscriber = new TwoRequestsSubscriber(5, 8);
 
 		ConnectableFlux<Integer> replay =
-				Flux.range(1, 5)
+				Flux.range(1, 11)
 				    .doOnRequest(requests::add)
-				    .replay(3);
+				    .replay(8);
 
 		assertThat(requests).isEmpty();
 
@@ -497,8 +497,8 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		replay.subscribe(ts); //unbounded
 
-		assertThat(requests).containsExactly(3L, 3L);
-		ts.assertValueCount(3); //despite unbounded, as it was late it only sees the replay capacity
+		assertThat(requests).containsExactly(8L, 6L);
+		ts.assertValueCount(8); //despite unbounded, as it was late it only sees the replay capacity
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
@@ -141,18 +141,6 @@ class SinksTest {
 		}
 
 		@TestFactory
-		Stream<DynamicContainer> checkSemanticsSize0() {
-			final int historySize = 0;
-			final Supplier<Sinks.Many<Integer>> supplier = () -> Sinks.many().replay().limit(historySize);
-
-			return Stream.of(
-					expectMulticast(supplier, Integer.MAX_VALUE),
-					expectReplay(supplier, historySize),
-					expectBufferingBeforeFirstSubscriber(supplier, historySize)
-			);
-		}
-
-		@TestFactory
 		Stream<DynamicContainer> checkSemanticsSize100() {
 			final int historySize = 100;
 			final Supplier<Sinks.Many<Integer>> supplier = () -> Sinks.many().replay().limit(historySize);

--- a/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
@@ -35,12 +35,12 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.StepVerifierOptions;
 import reactor.test.subscriber.AssertSubscriber;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.DynamicContainer.dynamicContainer;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 import static reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST;
@@ -128,6 +128,13 @@ class SinksTest {
 	@Nested
 	class MulticastReplayN {
 
+		@Test
+		void limitZeroIsRejected() {
+			assertThatIllegalArgumentException()
+				.isThrownBy(() -> Sinks.many().replay().limit(0))
+				.withMessage("historySize must be > 0");
+		}
+
 		@TestFactory
 		Stream<DynamicContainer> checkSemanticsSize5() {
 			final int historySize = 5;
@@ -165,6 +172,17 @@ class SinksTest {
 		void setup() {
 			replaySink = Sinks.many().replay().limit(duration);
 			flux = replaySink.asFlux();
+		}
+
+		@Test
+		void historySizeZeroIsRejected() {
+			assertThatIllegalArgumentException()
+				.isThrownBy(() -> Sinks.many().replay().limit(0, Duration.ofSeconds(1)))
+				.withMessage("historySize must be > 0");
+
+			assertThatIllegalArgumentException()
+				.isThrownBy(() -> Sinks.many().replay().limit(0, Duration.ofSeconds(1), Schedulers.immediate()))
+				.withMessage("historySize must be > 0");
 		}
 
 		// fixes: https://github.com/reactor/reactor-core/issues/2513


### PR DESCRIPTION
closes #1921 

This PR adds a prefetch strategy driven by active subscribers so the next prefetch happens only when all the subscribers have consumed a particular element. To enable that, now every impl has an index actively utilized to identify if specific element is a trigger for the next prefetch.

In case there are no subscribers, the prefetch strategy is self-driven and requests more when there are produced N elements into the cache 

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>