### PR TITLE
Rework FluxConcatArray to avoid unexpected thread switch

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatArrayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatArrayTest.java
@@ -276,8 +276,7 @@ public class FluxConcatArrayTest {
 		Subscription parent = Operators.emptySubscription();
 		test.onSubscribe(parent);
 
-		test.missedRequested = 2;
-		test.requested = 3;
+		test.requested = 5;
 
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
@@ -299,8 +298,7 @@ public class FluxConcatArrayTest {
 
 		assertThat(test.scan(Scannable.Attr.DELAY_ERROR)).isTrue();
 
-		test.missedRequested = 2;
-		test.requested = 3;
+		test.requested = 5;
 		test.error = new IllegalStateException("boom");
 
 		assertThat(test.scan(Scannable.Attr.ERROR)).hasMessage("boom");

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatWithTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatWithTest.java
@@ -16,30 +16,37 @@
 
 package reactor.core.publisher;
 
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.jupiter.api.Test;
 
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
+import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxConcatWithTest {
 
 	@Test
 	public void noStackOverflow() {
 		int n = 5000;
-		
+
 		Flux<Integer> source = Flux.just(1);
-		
+
 		Flux<Integer> result = source;
-		
+
 		for (int i = 0; i < n; i++) {
 			result = result.concatWith(source);
 		}
-		
+
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
-		
+
 		result.subscribe(ts);
-		
+
 		ts.assertValueCount(n + 1)
 		.assertNoError()
 		.assertComplete();
@@ -48,20 +55,20 @@ public class FluxConcatWithTest {
 	@Test
 	public void noStackOverflow2() {
 		int n = 5000;
-		
+
 		Flux<Integer> source = Flux.just(1, 2).concatMap(Flux::just);
 		Flux<Integer> add = Flux.just(3);
-		
+
 		Flux<Integer> result = source;
-		
+
 		for (int i = 0; i < n; i++) {
 			result = result.concatWith(add);
 		}
-		
+
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
-		
+
 		result.subscribe(ts);
-		
+
 		ts.assertValueCount(n + 2)
 		.assertNoError()
 		.assertComplete();
@@ -70,34 +77,165 @@ public class FluxConcatWithTest {
 	@Test
 	public void noStackOverflow3() {
 		int n = 5000;
-		
+
 		Flux<Flux<Integer>> source = Flux.just(Flux.just(1), Flux.just(2));
 		Flux<Flux<Integer>> add = Flux.just(Flux.just(3));
-		
+
 		Flux<Flux<Integer>> result = source;
-		
+
 		for (int i = 0; i < n; i++) {
 			result = result.concatWith(add);
 		}
-		
+
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
-		
+
 		result.subscribe(ts);
-		
+
 		ts.assertValueCount(n + 2)
 		.assertNoError()
 		.assertComplete();
 	}
 
-	
+	@Test
+	public void noStackOverflow4() {
+		int n = 5000;
+
+		Flux<Integer> source =
+				Flux.just(1, 2)
+				    .concatMap(Flux::just)
+				    .concatMap(Flux::just)
+				    .concatWith(Flux.just(1).subscribeOn(Schedulers.single()));
+		Flux<Integer> add = Flux.just(3);
+
+		Flux<Integer> result = source;
+
+		for (int i = 0; i < n; i++) {
+			result = result.concatWith(add);
+		}
+
+		result = result.concatWith(add.subscribeOn(Schedulers.parallel()));
+
+		AssertSubscriber<Integer> ts = AssertSubscriber.create();
+
+		result.subscribe(ts);
+
+		ts.await()
+		  .assertValueCount(n + 4)
+		  .assertNoError()
+		  .assertComplete();
+	}
+
+	@Test
+	public void noUnexpectedThreadSwitch() {
+		final Scheduler scheduler = Schedulers.single();
+
+		for (int i = 0; i < 1000; i++) {
+			final TestPublisher<Object> testPublisher = TestPublisher.create();
+
+			AtomicReference<Thread> sendingThread1 = new AtomicReference<>();
+			AtomicReference<Thread> sendingThread2 = new AtomicReference<>();
+			AtomicReference<Thread> observedThread1 = new AtomicReference<>();
+			AtomicReference<Thread> observedThread2 = new AtomicReference<>();
+
+			final StepVerifier verifier = testPublisher.mono()
+			                                           .thenMany(Flux.defer(() -> {
+				                                           observedThread1.set(Thread.currentThread());
+				                                           return Flux.just(1, 2)
+				                                                      .publishOn(Schedulers.parallel())
+						                                              .doOnComplete(() -> sendingThread2.set(Thread.currentThread()));
+			                                           }))
+			                                           .thenMany(Flux.defer(() -> {
+				                                           observedThread2.set(Thread.currentThread());
+				                                           return Flux.just(1, 2);
+			                                           }))
+			                                           .as(StepVerifier::create)
+			                                           .expectSubscription()
+			                                           .expectNext(1, 2)
+			                                           .expectComplete()
+			                                           .verifyLater();
+
+			scheduler.schedule(() -> {
+				sendingThread1.set(Thread.currentThread());
+				testPublisher.complete();
+			});
+
+			verifier.verify();
+			assertThat(observedThread1)
+					.as("observedThread1")
+					.hasValue(sendingThread1.get());
+			assertThat(observedThread2)
+					.as("observedThread2")
+					.hasValue(sendingThread2.get())
+					.doesNotHaveValue(observedThread1.get());
+		}
+	}
+
+	@Test
+	public void noUnexpectedThreadSwitch2() {
+		final Scheduler single = Schedulers.single();
+
+		for (int i = 0; i < 1000; i++) {
+			final TestPublisher<Object> testPublisher = TestPublisher.create();
+
+			AtomicReference<Thread> sendingThread1 = new AtomicReference<>();
+			AtomicReference<Thread> sendingThread2 = new AtomicReference<>();
+			AtomicReference<Thread> sendingThread3 = new AtomicReference<>();
+			AtomicReference<Thread> observedThread1 = new AtomicReference<>();
+			AtomicReference<Thread> observedThread2 = new AtomicReference<>();
+			AtomicReference<Thread> observedThread3 = new AtomicReference<>();
+
+			final StepVerifier verifier = testPublisher.mono()
+			                                           .thenMany(Flux.defer(() -> {
+				                                           observedThread1.set(Thread.currentThread());
+				                                           return Flux.just(1, 2)
+				                                                      .publishOn(Schedulers.parallel())
+				                                                      .doOnComplete(() -> sendingThread2.set(Thread.currentThread()));
+			                                           }))
+			                                           .thenMany(Flux.defer(() -> {
+				                                           observedThread2.set(Thread.currentThread());
+				                                           return Flux.just(1, 2)
+				                                                      .publishOn(single)
+				                                                      .doOnComplete(() -> sendingThread3.set(Thread.currentThread()));
+			                                           }))
+			                                           .thenMany(Flux.defer(() -> {
+				                                           observedThread3.set(Thread.currentThread());
+				                                           return Flux.just(1, 2);
+			                                           }))
+			                                           .as(StepVerifier::create)
+			                                           .expectSubscription()
+			                                           .expectNext(1, 2)
+			                                           .expectComplete()
+			                                           .verifyLater();
+
+			single.schedule(() -> {
+				sendingThread1.set(Thread.currentThread());
+				testPublisher.complete();
+			});
+
+			verifier.verify(Duration.ofSeconds(10));
+			assertThat(observedThread1).as("observedThread1")
+			                           .hasValue(sendingThread1.get());
+			assertThat(observedThread2).as("observedThread2")
+			                           .hasValue(sendingThread2.get());
+			assertThat(observedThread3).as("observedThread3")
+			                           .hasValue(sendingThread3.get());
+
+			assertThat(observedThread2).as("observedThread2")
+			                           .doesNotHaveValue(observedThread1.get());
+			assertThat(observedThread3).as("observedThread2")
+			                           .doesNotHaveValue(observedThread2.get())
+			                           .hasValue(observedThread1.get());
+		}
+	}
+
 	@Test
 	public void dontBreakFluxArrayConcatMap() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
-		
+
 		Flux.just(1, 2).concatMap(Flux::just).concatWith(Flux.just(3))
 		.subscribe(ts);
 
-		
+
 		ts.assertValues(1, 2, 3)
 		.assertNoError()
 		.assertComplete();
@@ -109,7 +247,7 @@ public class FluxConcatWithTest {
           .expectNext(1, 2, 4, 5, 6)
           .verifyComplete();
     }
-	
+
 	@Test
 	public void testConcurrencyCausingOverflow() {
 		// See https://github.com/reactor/reactor-core/pull/2576
@@ -139,5 +277,5 @@ public class FluxConcatWithTest {
 			.blockLast();
 		}
 	}
-	
+
 }


### PR DESCRIPTION
closes #2735

In this PR:

* [NEW 🎉] eliminate WIP and replace with ThreadLocal as a robust approach to avoid StackOverflow in case we subscribe to the next subscriber in the same thread (this can be applied for a list of others operators as well such as retry / repeat / concatMap / etc
* eliminate the usage of `MultisubscriptionSubscriber` replacing it with a simpler mechanic

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>