### PR TITLE
Explore isolating some operators with many variants under API subgroups

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ApiGroup.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ApiGroup.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.reactivestreams.Publisher;
+
+/**
+ * @author Simon Baslé
+ */
+public interface ApiGroup {
+
+	/**
+	 * An {@link ApiGroup} that is explicitly <strong>combinable</strong>, allowing to set up
+	 * several operators in a row as long as all these operators maintain the original {@link Flux}
+	 * or {@link Mono} type.
+	 * <p>
+	 * In other words, instead of immediately returning a {@link Flux} or {@link Mono}, its methods
+	 * add new operators to the chain until {@link #apply()} is invoked (at which point
+	 * the outermost operator instance is returned).
+	 *
+	 * @param <T> the type of data
+	 * @param <P>
+	 */
+	interface Combinable<T, P extends Publisher<T>> extends ApiGroup {
+		P apply();
+	}
+
+	static <T> Buffers<T> bufferOf(Flux<T> source) {
+		return new Buffers<>(source);
+	}
+
+	static <T> FluxSideEffects<T> sideEffects(Flux<T> source) {
+		return new FluxSideEffects<>(source);
+	}
+
+	final class Buffers<T> implements ApiGroup {
+
+		final Flux<T> source;
+
+		public Buffers(Flux<T> source) {
+			this.source = source;
+		}
+
+		public Flux<List<T>> fixedSize(int size) {
+			return source.onAssembly(new FluxBuffer<>(this.source, size, ArrayList::new));
+		}
+	}
+
+	final class FluxSideEffects<T> implements ApiGroup.Combinable<T, Flux<T>> {
+
+		Flux<T> built;
+
+		public FluxSideEffects(Flux<T> source) {
+			this.built = source;
+		}
+
+		FluxSideEffects<T> log() {
+			this.built = this.built.log();
+			return this;
+		}
+
+		FluxSideEffects<T> doOnNext(Consumer<? super T> nextHandler) {
+			this.built = this.built.doOnNext(nextHandler);
+			return this;
+		}
+
+		FluxSideEffects<T> doOnComplete(Runnable completeHandler) {
+			this.built = this.built.doOnComplete(completeHandler);
+			return this;
+		}
+
+		@Override
+		public Flux<T> apply() {
+			return this.built;
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -118,7 +118,7 @@ import reactor.util.retry.Retry;
 public abstract class Flux<T> implements CorePublisher<T> {
 
 //	 ==============================================================================================================
-//	 Static Generators
+//	 Static Operators
 //	 ==============================================================================================================
 
 	/**
@@ -2520,6 +2520,58 @@ public abstract class Flux<T> implements CorePublisher<T> {
 			                    }
 		                    }));
 	}
+
+	//	 ==============================================================================================================
+	//	 Operator Groups
+	//	 ==============================================================================================================
+
+	static void test() {
+		Flux<List<Integer>> firstBuffering = Flux.just(1)
+			.op(ApiGroup::bufferOf).fixedSize(3);
+
+		Flux<List<List<Integer>>> secondBuffering = firstBuffering
+			.bufferOf().fixedSize(3);
+
+		Flux.just(1)
+			.sideEffects()
+			.log()
+			.doOnNext(v -> {})
+			.doOnComplete(() -> {})
+			.apply()
+			.map(Function.identity());
+
+		Flux.just(1)
+			.op(ApiGroup::sideEffects)
+			.log()
+			.doOnNext(v -> {})
+			.doOnComplete(() -> {})
+			.apply()
+			.map(Function.identity());
+	}
+
+	public <G extends ApiGroup> G op(Function<Flux<T>, G> groupFactory) {
+		/*
+		Implementation notes: we cannot avoid allocation, since the alternative would involve higher order functions
+		generated from a static factory class, which would create a new lambda on each call.
+		This alternative is also more clunky, as it doesn't really allow having "standard" groups like #buffers().
+		Thus, creating a new group instance per source Flux instance is deemed acceptable.
+		Hopefully, the method calls are small enough that they can be inlined by the JVM if a lot of grouped operators
+		are used in a chain.
+		 */
+		return groupFactory.apply(this);
+	}
+
+	public ApiGroup.Buffers<T> bufferOf() {
+		return new ApiGroup.Buffers<>(this);
+	}
+
+	public ApiGroup.FluxSideEffects<T> sideEffects() {
+		return new ApiGroup.FluxSideEffects<>(this);
+	}
+
+	//	 ==============================================================================================================
+	//	 Instance Operators
+	//	 ==============================================================================================================
 
 	/**
 	 *

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -2525,48 +2525,39 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	//	 Operator Groups
 	//	 ==============================================================================================================
 
-	static void test() {
-		Flux<List<Integer>> firstBuffering = Flux.just(1)
-			.op(ApiGroup::bufferOf).fixedSize(3);
+	//see examples in GuideTests
 
-		Flux<List<List<Integer>>> secondBuffering = firstBuffering
-			.bufferOf().fixedSize(3);
-
-		Flux.just(1)
-			.sideEffects()
-			.log()
-			.doOnNext(v -> {})
-			.doOnComplete(() -> {})
-			.apply()
-			.map(Function.identity());
-
-		Flux.just(1)
-			.op(ApiGroup::sideEffects)
-			.log()
-			.doOnNext(v -> {})
-			.doOnComplete(() -> {})
-			.apply()
-			.map(Function.identity());
+	public final Flux<List<T>> buffers(Function<ApiGroup.FluxBuffersV1<T>, Flux<List<T>>> bufferSpec) {
+		ApiGroup.FluxBuffersV1<T> b = new ApiGroup.FluxBuffersV1<>(this);
+		return bufferSpec.apply(b);
 	}
 
-	public <G extends ApiGroup> G op(Function<Flux<T>, G> groupFactory) {
-		/*
-		Implementation notes: we cannot avoid allocation, since the alternative would involve higher order functions
-		generated from a static factory class, which would create a new lambda on each call.
-		This alternative is also more clunky, as it doesn't really allow having "standard" groups like #buffers().
-		Thus, creating a new group instance per source Flux instance is deemed acceptable.
-		Hopefully, the method calls are small enough that they can be inlined by the JVM if a lot of grouped operators
-		are used in a chain.
-		 */
-		return groupFactory.apply(this);
+	public final ApiGroup.FluxBuffersV1<T> buffers_v1() {
+		return new ApiGroup.FluxBuffersV1<>(this);
 	}
 
-	public ApiGroup.Buffers<T> bufferOf() {
-		return new ApiGroup.Buffers<>(this);
+	public final ApiGroup.FluxBuffersV2<T> buffers_v2() {
+		return new ApiGroup.FluxBuffersV2<T>(this);
 	}
 
-	public ApiGroup.FluxSideEffects<T> sideEffects() {
-		return new ApiGroup.FluxSideEffects<>(this);
+	public final <R> Flux<R> buffers_v3(Function<ApiGroup.FluxBuffersV2<T>, ApiGroup.FluxBuffersV2<R>> bufferSpec) {
+		ApiGroup.FluxBuffersV2<T> initialSpec = new ApiGroup.FluxBuffersV2<T>(this);
+		ApiGroup.FluxBuffersV2<R> endSpec = bufferSpec.apply(initialSpec);
+		return endSpec.generateFlux();
+	}
+
+	public final ApiGroup.FluxSideEffectsV1<T> sideEffects_v1() {
+		return new ApiGroup.FluxSideEffectsV1<>(this);
+	}
+
+	public ApiGroup.FluxSideEffectsV2<T> sideEffects_v2() {
+		return new ApiGroup.FluxSideEffectsV2<>(this);
+	}
+
+	public final Flux<T> sideEffects_v3(Consumer<ApiGroup.FluxSideEffectsV2<T>> sideEffectSpec) {
+		ApiGroup.FluxSideEffectsV2<T> se = new ApiGroup.FluxSideEffectsV2<T>(this);
+		sideEffectSpec.accept(se);
+		return se.endSideEffects();
 	}
 
 	//	 ==============================================================================================================

--- a/reactor-core/src/test/java/reactor/guide/GuideTests.java
+++ b/reactor-core/src/test/java/reactor/guide/GuideTests.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -47,6 +48,7 @@ import org.reactivestreams.Subscription;
 
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
+import reactor.core.publisher.ApiGroup;
 import reactor.core.publisher.BaseSubscriber;
 import reactor.core.publisher.ConnectableFlux;
 import reactor.core.publisher.Flux;
@@ -1203,5 +1205,130 @@ Mono<String> put = doPut("www.example.com", Mono.just("Walter"))
 StepVerifier.create(put)
             .expectNext("PUT <Walter> sent to www.example.com")
             .verifyComplete();
+	}
+
+	@Test
+	void apiGroupBuffers() {
+		/*
+			V1: one operator == one call to the api group
+
+			PROS:
+			 - simplest to use
+			 - no juggling with generics: 1 call == 1 operator so we know the end return type when we get back to Flux
+			 - no need for macro fusion friendliness for this category of operators
+
+			CONS:
+			 - one extra allocation per operator
+			 - if formatter introduces newline before each dot, reads less like a typical reactive chain
+		 */
+		Flux<List<List<Integer>>> b1 = Flux.just(1)
+			.buffers_v1().fixedSize(3)
+			.buffers_v1().sizeAndTimeout(3, Duration.ofMillis(500));
+
+		/*
+			V2: allow to set up multiple operators in a row then explicitly switch back to Flux API
+
+			PROS:
+			 - less allocations: allows to reuse api group instance to avoid 1 extra allocation per operator
+
+			CONS:
+			 - clunky termination of the api group needed to switch back to top level Flux API
+			 - this is a pattern used nowhere else
+			 - no clear benefit in enabling macro-fusion scenarios since these operators are not easily fuseable
+		 */
+		Flux<List<List<Integer>>> b2 = Flux.just(1)
+			.buffers_v2()
+			.fixedSize(3)
+			.sizeAndTimeout(3, Duration.ofMillis(500))
+			.generateFlux();
+
+		/*
+			V3: allow to set up multiple operators in one api group call, materialized as a Consumer
+
+			PROS:
+			 - less allocations: allows to reuse api group instance to avoid 1 extra allocation per operator
+			 - no need to look for a `endSideEffects()` method / remember to switch back to Flux
+			 - this is an established pattern, notably in reactor-netty
+
+			CONS:
+			 - no benefit in terms of macro-fusion (these operators are not easily fused)
+			 - no benefit in terms of logical grouping vs transform (less likely that somebody would want
+			 	to provide a "standard" consumer that only deals with buffering)
+		 */
+		Flux<List<List<Integer>>> b3 = Flux.just(1)
+			.buffers_v3(it -> it
+				.fixedSize(3)
+				.sizeAndTimeout(3, Duration.ofMillis(500))
+			);
+	}
+
+	@Test
+	void apiGroupSideEffects() {
+		/*
+			V1: one operator == one call to the api group
+
+			PROS:
+			 - simplest to use
+
+			CONS:
+			 - one extra allocation per operator
+			 - if formatter introduces newline before each dot, reads less like a typical reactive chain
+			 - doesn't facilitate macro-fusion (although it is possible)
+		 */
+		Flux<Integer> se1 = Flux.just(1)
+			.sideEffects_v1().log()
+			.sideEffects_v1().doOnComplete(() -> {})
+			.sideEffects_v1().doOnNext(v -> {});
+
+		/*
+			V2: allow to set up multiple operators in a row then explicitly switch back to Flux API
+
+			PROS:
+			 - less allocations: allows to reuse api group instance to avoid 1 extra allocation per operator
+			 - can facilitate advanced macro-fusion (since we have boundaries and can assume that none of these intermediate
+			   steps will be used as independent Publisher)
+
+			CONS:
+			 - clunky termination of the api group needed to switch back to top level Flux API
+			 - this is a pattern used nowhere else
+		 */
+		Flux<Integer> se2 = Flux.just(1)
+			.sideEffects_v2()
+			.log()
+			.doOnComplete(() -> {})
+			.doOnNext(v -> {})
+			.endSideEffects();
+
+		/*
+			V3: allow to set up multiple operators in one api group call, materialized as a Consumer
+
+			PROS:
+			 - less allocations: allows to reuse api group instance to avoid 1 extra allocation per operator
+			 - no need to look for a `endSideEffects()` method / remember to switch back to Flux
+			 - this is an established pattern, notably in reactor-netty
+			 - can facilitate advanced macro-fusion (since we have boundaries and can assume that none of these intermediate
+			   steps will be used as independent Publisher)
+			 - "standard" consumers (aka combinations of side effects) can be externalized
+
+			CONS:
+			 - arguably `it -> it` is the ugly part
+		 */
+		Flux<Integer> se3 = Flux.just(1)
+			.sideEffects_v3(it -> it
+				.log()
+				.doOnComplete(() -> {})
+				.doOnNext(v -> {})
+			);
+		//the consumer can be externalized, or it can also be a method reference:
+		Consumer<ApiGroup.FluxSideEffectsV2<Integer>> logAndReactOnComplete = it ->
+			it.log().doOnComplete(() -> System.out.println("logged and reacted onComplete"));
+		Flux.just(1)
+			.sideEffects_v3(logAndReactOnComplete);
+		Flux.just(1)
+			.sideEffects_v3(this::logAndReactOnComplete);
+	}
+
+	<T> void logAndReactOnComplete(ApiGroup.FluxSideEffectsV2<T> it) {
+		it.log().doOnComplete(() -> System.out.println("logged and reacted onComplete"));
 	}
 }


### PR DESCRIPTION
- first iteration of API groups
- remove some unneeded code, introduce Consumer-based options
