### PR TITLE
Polish logging: test scenario name, verbosity of discard logs

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -22,6 +22,8 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Spliterator;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -440,7 +442,7 @@ public abstract class Operators {
 				hook.accept(element);
 			}
 			catch (Throwable t) {
-				log.warn("Error in discard hook", t);
+				DISCARD_LOGGER.warn("Error in discard hook", t);
 			}
 		}
 	}
@@ -489,12 +491,12 @@ public abstract class Operators {
 								       hook.accept(elementToDiscard);
 							       }
 							       catch (Throwable t) {
-								       log.warn("Error while discarding item extracted from a queue element, continuing with next item", t);
+								       DISCARD_LOGGER.trace("Error while discarding item extracted from a queue element, continuing with next item", t);
 							       }
 						       });
 					}
 					catch (Throwable t) {
-						log.warn("Error while extracting items to discard from queue element, continuing with next queue element", t);
+						DISCARD_LOGGER.trace("Error while extracting items to discard from queue element, continuing with next queue element", t);
 					}
 				}
 				else {
@@ -502,13 +504,13 @@ public abstract class Operators {
 						hook.accept(toDiscard);
 					}
 					catch (Throwable t) {
-						log.warn("Error while discarding a queue element, continuing with next queue element", t);
+						DISCARD_LOGGER.trace("Error while discarding a queue element, continuing with next queue element", t);
 					}
 				}
 			}
 		}
 		catch (Throwable t) {
-			log.warn("Cannot further apply discard hook while discarding and clearing a queue", t);
+			DISCARD_LOGGER.warn("Cannot further apply discard hook while discarding and clearing a queue", t);
 		}
 	}
 
@@ -534,12 +536,12 @@ public abstract class Operators {
 				        		hook.accept(v);
 					        }
 				        	catch (Throwable t) {
-				        		log.warn("Error while discarding a stream element, continuing with next element", t);
+								DISCARD_LOGGER.trace("Error while discarding a stream element, continuing with next element", t);
 					        }
 				        });
 			}
 			catch (Throwable t) {
-				log.warn("Error while discarding stream, stopping", t);
+				DISCARD_LOGGER.warn("Error while discarding stream, stopping", t);
 			}
 		}
 	}
@@ -569,13 +571,13 @@ public abstract class Operators {
 							hook.accept(o);
 						}
 						catch (Throwable t) {
-							log.warn("Error while discarding element from a Collection, continuing with next element", t);
+							DISCARD_LOGGER.trace("Error while discarding element from a Collection, continuing with next element", t);
 						}
 					}
 				}
 			}
 			catch (Throwable t) {
-				log.warn("Error while discarding collection, stopping", t);
+				DISCARD_LOGGER.warn("Error while discarding collection, stopping", t);
 			}
 		}
 	}
@@ -606,13 +608,13 @@ public abstract class Operators {
 							hook.accept(o);
 						}
 						catch (Throwable t) {
-							log.warn("Error while discarding element from an Iterator, continuing with next element", t);
+							DISCARD_LOGGER.trace("Error while discarding element from an Iterator, continuing with next element", t);
 						}
 					}
 				});
 			}
 			catch (Throwable t) {
-				log.warn("Error while discarding Iterator, stopping", t);
+				DISCARD_LOGGER.warn("Error while discarding Iterator, stopping", t);
 			}
 		}
 	}
@@ -2817,4 +2819,5 @@ public abstract class Operators {
 
 
 	final static Logger log = Loggers.getLogger(Operators.class);
+	final static Logger DISCARD_LOGGER = Loggers.getLogger(Operators.class.getName()+"-discard");
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -22,8 +22,6 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Spliterator;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -442,7 +440,7 @@ public abstract class Operators {
 				hook.accept(element);
 			}
 			catch (Throwable t) {
-				DISCARD_LOGGER.warn("Error in discard hook", t);
+				log.warn("Error in discard hook", t);
 			}
 		}
 	}
@@ -491,12 +489,12 @@ public abstract class Operators {
 								       hook.accept(elementToDiscard);
 							       }
 							       catch (Throwable t) {
-								       DISCARD_LOGGER.trace("Error while discarding item extracted from a queue element, continuing with next item", t);
+								       log.warn("Error while discarding item extracted from a queue element, continuing with next item", t);
 							       }
 						       });
 					}
 					catch (Throwable t) {
-						DISCARD_LOGGER.trace("Error while extracting items to discard from queue element, continuing with next queue element", t);
+						log.warn("Error while extracting items to discard from queue element, continuing with next queue element", t);
 					}
 				}
 				else {
@@ -504,13 +502,13 @@ public abstract class Operators {
 						hook.accept(toDiscard);
 					}
 					catch (Throwable t) {
-						DISCARD_LOGGER.trace("Error while discarding a queue element, continuing with next queue element", t);
+						log.warn("Error while discarding a queue element, continuing with next queue element", t);
 					}
 				}
 			}
 		}
 		catch (Throwable t) {
-			DISCARD_LOGGER.warn("Cannot further apply discard hook while discarding and clearing a queue", t);
+			log.warn("Cannot further apply discard hook while discarding and clearing a queue", t);
 		}
 	}
 
@@ -536,12 +534,12 @@ public abstract class Operators {
 				        		hook.accept(v);
 					        }
 				        	catch (Throwable t) {
-								DISCARD_LOGGER.trace("Error while discarding a stream element, continuing with next element", t);
+				        		log.warn("Error while discarding a stream element, continuing with next element", t);
 					        }
 				        });
 			}
 			catch (Throwable t) {
-				DISCARD_LOGGER.warn("Error while discarding stream, stopping", t);
+				log.warn("Error while discarding stream, stopping", t);
 			}
 		}
 	}
@@ -571,13 +569,13 @@ public abstract class Operators {
 							hook.accept(o);
 						}
 						catch (Throwable t) {
-							DISCARD_LOGGER.trace("Error while discarding element from a Collection, continuing with next element", t);
+							log.warn("Error while discarding element from a Collection, continuing with next element", t);
 						}
 					}
 				}
 			}
 			catch (Throwable t) {
-				DISCARD_LOGGER.warn("Error while discarding collection, stopping", t);
+				log.warn("Error while discarding collection, stopping", t);
 			}
 		}
 	}
@@ -608,13 +606,13 @@ public abstract class Operators {
 							hook.accept(o);
 						}
 						catch (Throwable t) {
-							DISCARD_LOGGER.trace("Error while discarding element from an Iterator, continuing with next element", t);
+							log.warn("Error while discarding element from an Iterator, continuing with next element", t);
 						}
 					}
 				});
 			}
 			catch (Throwable t) {
-				DISCARD_LOGGER.warn("Error while discarding Iterator, stopping", t);
+				log.warn("Error while discarding Iterator, stopping", t);
 			}
 		}
 	}
@@ -2819,5 +2817,4 @@ public abstract class Operators {
 
 
 	final static Logger log = Loggers.getLogger(Operators.class);
-	final static Logger DISCARD_LOGGER = Loggers.getLogger(Operators.class.getName()+"-discard");
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
@@ -217,7 +217,6 @@ class MonoCollectListTest {
 			AtomicBoolean ab = (AtomicBoolean) o;
 			if (ab.getAndSet(true)) {
 				doubleDiscardCounter.incrementAndGet();
-				throw new RuntimeException("test");
 			}
 		});
 		for (int i = 0; i < 100_000; i++) {
@@ -247,7 +246,6 @@ class MonoCollectListTest {
 			AtomicBoolean ab = (AtomicBoolean) o;
 			if (ab.getAndSet(true)) {
 				doubleDiscardCounter.incrementAndGet();
-				throw new RuntimeException("test");
 			}
 		});
 		for (int i = 0; i < 100_000; i++) {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
@@ -19,7 +19,6 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -29,6 +28,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
+
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Scannable;
@@ -45,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static reactor.test.publisher.TestPublisher.Violation.CLEANUP_ON_TERMINATE;
 
 @Tag("slow")
-public class MonoCollectListTest {
+class MonoCollectListTest {
 
 	static final Logger LOGGER = Loggers.getLogger(MonoCollectListTest.class);
 
@@ -236,7 +236,7 @@ public class MonoCollectListTest {
 			}
 			assertThat(extraneous).as("released %d", i).isTrue();
 		}
-		LOGGER.info("discarded twice or more: {}", doubleDiscardCounter.get());
+		LOGGER.info("{} discarded twice or more in discardCancelNextRace", doubleDiscardCounter.get());
 	}
 
 	@Test
@@ -264,7 +264,7 @@ public class MonoCollectListTest {
 				assertThat(resource).as("not completed and released %d", i).isTrue();
 			}
 		}
-		LOGGER.info("discarded twice or more: {}", doubleDiscardCounter.get());
+		LOGGER.info("{} discarded twice or more in discardCancelCompleteRace", doubleDiscardCounter.get());
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCollectTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCollectTest.java
@@ -313,7 +313,6 @@ public class MonoCollectTest {
 			AtomicBoolean ab = (AtomicBoolean) o;
 			if (ab.getAndSet(true)) {
 				doubleDiscardCounter.incrementAndGet();
-				throw new RuntimeException("test");
 			}
 		});
 		for (int i = 0; i < 100_000; i++) {
@@ -345,7 +344,6 @@ public class MonoCollectTest {
 			AtomicBoolean ab = (AtomicBoolean) o;
 			if (ab.getAndSet(true)) {
 				doubleDiscardCounter.incrementAndGet();
-				throw new RuntimeException("test");
 			}
 		});
 		for (int i = 0; i < 100_000; i++) {

--- a/reactor-core/src/test/java/reactor/test/publisher/BaseOperatorTest.java
+++ b/reactor-core/src/test/java/reactor/test/publisher/BaseOperatorTest.java
@@ -42,6 +42,8 @@ import reactor.core.publisher.ParallelFlux;
 import reactor.core.publisher.ReplayProcessor;
 import reactor.core.publisher.UnicastProcessor;
 import reactor.test.StepVerifier;
+import reactor.util.Logger;
+import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
@@ -53,6 +55,8 @@ import static reactor.core.Fuseable.*;
  * @author Stephane Maldini
  */
 public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, PO extends Publisher<? extends O>> {
+
+	static final Logger LOGGER = Loggers.getLogger(BaseOperatorTest.class);
 
 	OperatorScenario<I, PI, O, PO> defaultScenario;
 
@@ -1104,8 +1108,8 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 
 	private DynamicTest toDynamicTest(OperatorScenario<I, PI, O, PO> scenario, Executable runnable) {
 		return DynamicTest.dynamicTest(scenario.description(), () -> {
-			if (scenario.stack != null) {
-				System.out.println("\tat " + scenario.stack.getStackTrace()[2]);
+			if (LOGGER.isTraceEnabled() && scenario.stack != null) {
+				LOGGER.trace("executing anonymous scenario at {} ", scenario.stack.getStackTrace()[2]);
 			}
 			runnable.execute();
 		});

--- a/reactor-core/src/test/java/reactor/test/publisher/OperatorScenario.java
+++ b/reactor-core/src/test/java/reactor/test/publisher/OperatorScenario.java
@@ -284,7 +284,7 @@ public class OperatorScenario<I, PI extends Publisher<? extends I>, O, PO extend
 
 		if (stack != null) {
 			StackTraceElement element = stack.getStackTrace()[2];
-			return element.getFileName() + ":" + element.getLineNumber();
+			return "scenario[" + element.getFileName() + ":" + element.getLineNumber() + "]";
 		}
 
 		return toString();


### PR DESCRIPTION
This commit improves the verbosity of some logs in two categories.

1) Anonymous test scenarii dumping their class and line upon running:

This was confusing when looking at logs because it looked like part of
a stack trace. Now made clearer that this is a pseudo-name for a test
scenario that is missing a description.

The Scenario#description() method also makes it clear the stack element
returned is identifying a test scenario.

2) Operators now has a dedicated Logger for discard, and multidiscarding
uses the TRACE level:

As seen when running MonoCollectListTest, discarding a big collection
with a failing extractor or failing inner handler (the ones that are
invoked at least once per element in the collection) can lead to very
verbose logs.

All discarding logs are now depending on a dedicated Logger named
after the Operators.class + "-discard" suffix. Top level discarding
errors are logged at WARN level, but inner element discarding errors
are logged at TRACE level.

Additionally, two very similar messages in MonoCollectListTest were
amended to better reflect which test they originate from.
