### PR TITLE
Align Mono#share() behavior with Flux#share, split sink impl out

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/InternalOneSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalOneSink.java
@@ -49,7 +49,7 @@ interface InternalOneSink<T> extends Sinks.One<T>, InternalEmptySink<T> {
 				case FAIL_OVERFLOW:
 					Operators.onDiscard(value, currentContext());
 					//the emitError will onErrorDropped if already terminated
-					emitError(Exceptions.failWithOverflow("Backpressure overflow during Sinks.Many#emitNext"),
+					emitError(Exceptions.failWithOverflow("Backpressure overflow during Sinks.One#emitValue"),
 							failureHandler);
 					return;
 				case FAIL_CANCELLED:

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -4185,6 +4185,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 			// `Sinks.one().subscribe()` case is now split into a separate implementation.
 			// Otherwise, this is a (legacy) #toProcessor() usage, and we return the processor itself below (and don't forget to connect() it):
 			if (s.source != null && !s.isRefCounted) {
+				s.subscribe(new LambdaMonoSubscriber<>(null, null, null, null, null));
 				s.connect();
 				return s;
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkEmptyMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkEmptyMulticast.java
@@ -21,27 +21,27 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.stream.Stream;
 
-import org.reactivestreams.Subscription;
-
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.core.publisher.Sinks.EmitResult;
+import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
-final class SinkEmptyMulticast<T> extends Mono<T> implements InternalEmptySink<T> {
+//intentionally not final
+class SinkEmptyMulticast<T> extends Mono<T> implements InternalEmptySink<T> {
 
-	volatile VoidInner<T>[] subscribers;
+	volatile Inner<T>[]                                                   subscribers;
+	@SuppressWarnings("rawtypes")
+	static final AtomicReferenceFieldUpdater<SinkEmptyMulticast, Inner[]> SUBSCRIBERS =
+		AtomicReferenceFieldUpdater.newUpdater(SinkEmptyMulticast.class, Inner[].class, "subscribers");
 
 	@SuppressWarnings("rawtypes")
-	static final AtomicReferenceFieldUpdater<SinkEmptyMulticast, VoidInner[]> SUBSCRIBERS =
-			AtomicReferenceFieldUpdater.newUpdater(SinkEmptyMulticast.class, VoidInner[].class, "subscribers");
+	static final Inner[] EMPTY = new Inner[0];
 
 	@SuppressWarnings("rawtypes")
-	static final VoidInner[] EMPTY = new VoidInner[0];
+	static final Inner[] TERMINATED = new Inner[0];
 
-	@SuppressWarnings("rawtypes")
-	static final VoidInner[] TERMINATED = new VoidInner[0];
-
+	@Nullable
 	Throwable error;
 
 	SinkEmptyMulticast() {
@@ -60,33 +60,42 @@ final class SinkEmptyMulticast<T> extends Mono<T> implements InternalEmptySink<T
 
 	@Override
 	public EmitResult tryEmitEmpty() {
-		VoidInner<?>[] array = SUBSCRIBERS.getAndSet(this, TERMINATED);
+		Inner<?>[] array = SUBSCRIBERS.getAndSet(this, TERMINATED);
 
 		if (array == TERMINATED) {
 			return Sinks.EmitResult.FAIL_TERMINATED;
 		}
 
-		for (VoidInner<?> as : array) {
-			as.onComplete();
+		for (Inner<?> as : array) {
+			as.complete();
 		}
 		return EmitResult.OK;
 	}
 
 	@Override
-	public Sinks.EmitResult tryEmitError(Throwable cause) {
+	@SuppressWarnings("unchecked")
+	public EmitResult tryEmitError(Throwable cause) {
 		Objects.requireNonNull(cause, "onError cannot be null");
 
-		if (subscribers == TERMINATED) {
-			return Sinks.EmitResult.FAIL_TERMINATED;
+		Inner<T>[] prevSubscribers = SUBSCRIBERS.getAndSet(this, TERMINATED);
+		if (prevSubscribers == TERMINATED) {
+			return EmitResult.FAIL_TERMINATED;
 		}
 
-		//guarded by a read memory barrier (isTerminated) and a subsequent write with getAndSet
 		error = cause;
 
-		for (VoidInner<?> as : SUBSCRIBERS.getAndSet(this, TERMINATED)) {
-			as.onError(cause);
+		for (Inner<T> as : prevSubscribers) {
+			as.error(cause);
 		}
-		return Sinks.EmitResult.OK;
+		return EmitResult.OK;
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.TERMINATED) return subscribers == TERMINATED;
+		if (key == Attr.ERROR) return error;
+
+		return null;
 	}
 
 	@Override
@@ -94,17 +103,16 @@ final class SinkEmptyMulticast<T> extends Mono<T> implements InternalEmptySink<T
 		return Operators.multiSubscribersContext(subscribers);
 	}
 
-	boolean add(VoidInner<T> ps) {
+	boolean add(Inner<T> ps) {
 		for (; ; ) {
-			VoidInner<T>[] a = subscribers;
+			Inner<T>[] a = subscribers;
 
 			if (a == TERMINATED) {
 				return false;
 			}
 
 			int n = a.length;
-			@SuppressWarnings("unchecked")
-			VoidInner<T>[] b = new VoidInner[n + 1];
+			@SuppressWarnings("unchecked") Inner<T>[] b = new Inner[n + 1];
 			System.arraycopy(a, 0, b, 0, n);
 			b[n] = ps;
 
@@ -114,9 +122,10 @@ final class SinkEmptyMulticast<T> extends Mono<T> implements InternalEmptySink<T
 		}
 	}
 
-	void remove(VoidInner<T> ps) {
+	@SuppressWarnings("unchecked")
+	void remove(Inner<T> ps) {
 		for (; ; ) {
-			VoidInner<T>[] a = subscribers;
+			Inner<T>[] a = subscribers;
 			int n = a.length;
 			if (n == 0) {
 				return;
@@ -134,13 +143,13 @@ final class SinkEmptyMulticast<T> extends Mono<T> implements InternalEmptySink<T
 				return;
 			}
 
-			VoidInner<?>[] b;
+			Inner<T>[] b;
 
 			if (n == 1) {
 				b = EMPTY;
 			}
 			else {
-				b = new VoidInner[n - 1];
+				b = new Inner[n - 1];
 				System.arraycopy(a, 0, b, 0, j);
 				System.arraycopy(a, j + 1, b, j, n - j - 1);
 			}
@@ -150,25 +159,23 @@ final class SinkEmptyMulticast<T> extends Mono<T> implements InternalEmptySink<T
 		}
 	}
 
+	//redefined in SinkOneMulticast
 	@Override
 	public void subscribe(final CoreSubscriber<? super T> actual) {
-		VoidInner<T> as = new VoidInner<T>(actual, this);
+		Inner<T> as = new VoidInner<>(actual, this);
 		actual.onSubscribe(as);
 		if (add(as)) {
-			if (as.get()) {
+			if (as.isCancelled()) {
 				remove(as);
 			}
 		}
 		else {
-			if (as.get()) {
-				return;
-			}
 			Throwable ex = error;
 			if (ex != null) {
 				actual.onError(ex);
 			}
 			else {
-				actual.onComplete();
+				as.complete();
 			}
 		}
 	}
@@ -178,15 +185,18 @@ final class SinkEmptyMulticast<T> extends Mono<T> implements InternalEmptySink<T
 		return Stream.of(subscribers);
 	}
 
-	@Override
-	public Object scanUnsafe(Attr key) {
-		if (key == Attr.TERMINATED) return subscribers == TERMINATED;
-		if (key == Attr.ERROR) return error;
+	static interface Inner<T> extends InnerProducer<T> {
+		//API must be compatible with Operators.MonoInnerProducerBase
 
-		return null;
+		void error(Throwable t);
+		void complete(T value);
+		void complete();
+		boolean isCancelled();
 	}
 
-	final static class VoidInner<T> extends AtomicBoolean implements InnerOperator<Void, T> {
+	//VoidInner is optimized for not storing request / value
+	final static class VoidInner<T> extends AtomicBoolean implements Inner<T> {
+
 		final SinkEmptyMulticast<T> parent;
 		final CoreSubscriber<? super T> actual;
 
@@ -205,22 +215,22 @@ final class SinkEmptyMulticast<T> extends Mono<T> implements InternalEmptySink<T
 		}
 
 		@Override
+		public boolean isCancelled() {
+			return get();
+		}
+
+		@Override
 		public void request(long l) {
 			Operators.validate(l);
 		}
 
 		@Override
-		public void onSubscribe(Subscription s) {
-			Objects.requireNonNull(s);
+		public void complete(T value) {
+			//NO-OP
 		}
 
 		@Override
-		public void onNext(Void aVoid) {
-
-		}
-
-		@Override
-		public void onComplete() {
+		public void complete() {
 			if (get()) {
 				return;
 			}
@@ -228,9 +238,9 @@ final class SinkEmptyMulticast<T> extends Mono<T> implements InternalEmptySink<T
 		}
 
 		@Override
-		public void onError(Throwable t) {
+		public void error(Throwable t) {
 			if (get()) {
-				Operators.onOperatorError(t, currentContext());
+				Operators.onOperatorError(t, actual.currentContext());
 				return;
 			}
 			actual.onError(t);
@@ -252,7 +262,7 @@ final class SinkEmptyMulticast<T> extends Mono<T> implements InternalEmptySink<T
 			if (key == Attr.RUN_STYLE) {
 				return Attr.RunStyle.SYNC;
 			}
-			return InnerOperator.super.scanUnsafe(key);
+			return Inner.super.scanUnsafe(key);
 		}
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkEmptyMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkEmptyMulticast.java
@@ -94,6 +94,7 @@ class SinkEmptyMulticast<T> extends Mono<T> implements InternalEmptySink<T> {
 	public Object scanUnsafe(Attr key) {
 		if (key == Attr.TERMINATED) return subscribers == TERMINATED;
 		if (key == Attr.ERROR) return error;
+		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
 
 		return null;
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkOneMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkOneMulticast.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Objects;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Sinks.EmitResult;
+import reactor.util.annotation.Nullable;
+
+final class SinkOneMulticast<O> extends SinkEmptyMulticast<O> implements InternalOneSink<O> {
+
+	@Nullable
+	O value;
+
+	@Override
+	public EmitResult tryEmitEmpty() {
+		return tryEmitValue(null);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public EmitResult tryEmitError(Throwable cause) {
+		Objects.requireNonNull(cause, "onError cannot be null");
+
+		Inner<O>[] prevSubscribers = SUBSCRIBERS.getAndSet(this, TERMINATED);
+		if (prevSubscribers == TERMINATED) {
+			return EmitResult.FAIL_TERMINATED;
+		}
+
+		error = cause;
+		value = null;
+
+		for (Inner<O> as : prevSubscribers) {
+			as.error(cause);
+		}
+		return EmitResult.OK;
+	}
+
+	@Override
+	public EmitResult tryEmitValue(@Nullable O value) {
+		@SuppressWarnings("unchecked") Inner<O>[] array = SUBSCRIBERS.getAndSet(this, TERMINATED);
+		if (array == TERMINATED) {
+			return EmitResult.FAIL_TERMINATED;
+		}
+
+		this.value = value;
+		if (value == null) {
+			for (Inner<O> as : array) {
+				as.complete();
+			}
+		}
+		else {
+			for (Inner<O> as : array) {
+				as.complete(value);
+			}
+		}
+		return EmitResult.OK;
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.TERMINATED) return subscribers == TERMINATED;
+		if (key == Attr.ERROR) return error;
+
+		return null;
+	}
+
+	@Override
+	public void subscribe(final CoreSubscriber<? super O> actual) {
+		NextInner<O> as = new NextInner<>(actual, this);
+		actual.onSubscribe(as);
+		if (add(as)) {
+			if (as.isCancelled()) {
+				remove(as);
+			}
+		}
+		else {
+			Throwable ex = error;
+			if (ex != null) {
+				actual.onError(ex);
+			}
+			else {
+				O v = value;
+				if (v != null) {
+					as.complete(v);
+				}
+				else {
+					as.complete();
+				}
+			}
+		}
+	}
+
+	final static class NextInner<T> extends Operators.MonoInnerProducerBase<T> implements Inner<T> {
+
+		final SinkOneMulticast<T> parent;
+
+		NextInner(CoreSubscriber<? super T> actual, SinkOneMulticast<T> parent) {
+			super(actual);
+			this.parent = parent;
+		}
+
+		@Override
+		public void error(Throwable t) {
+			if (!isCancelled()) {
+				actual().onError(t);
+			}
+		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.RUN_STYLE) {
+				return Attr.RunStyle.SYNC;
+			}
+			return super.scanUnsafe(key);
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkOneMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkOneMulticast.java
@@ -16,6 +16,7 @@
 
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.Objects;
 
 import reactor.core.CoreSubscriber;
@@ -76,6 +77,7 @@ final class SinkOneMulticast<O> extends SinkEmptyMulticast<O> implements Interna
 	public Object scanUnsafe(Attr key) {
 		if (key == Attr.TERMINATED) return subscribers == TERMINATED;
 		if (key == Attr.ERROR) return error;
+		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
 
 		return null;
 	}
@@ -104,6 +106,15 @@ final class SinkOneMulticast<O> extends SinkEmptyMulticast<O> implements Interna
 				}
 			}
 		}
+	}
+
+	@Nullable
+	@Override
+	public O block(Duration timeout) {
+		if (timeout.isNegative()) {
+			return super.block(Duration.ZERO);
+		}
+		return super.block(timeout);
 	}
 
 	final static class NextInner<T> extends Operators.MonoInnerProducerBase<T> implements Inner<T> {

--- a/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
@@ -108,8 +108,7 @@ final class SinksSpecs {
 
 		@Override
 		public <T> One<T> one() {
-			final NextProcessor<T> original = new NextProcessor<>(null);
-			return wrapOne(original);
+			return wrapOne(new SinkOneMulticast<>());
 		}
 
 		@Override

--- a/reactor-core/src/test/java/reactor/core/publisher/NextProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/NextProcessorTest.java
@@ -149,16 +149,15 @@ class NextProcessorTest {
 
 	@Test
 	void downstreamCount() {
-		NextProcessor<Integer> processor = new NextProcessor<>(Flux.empty());
+		//using never() as source, otherwise subscribers get immediately completed and removed
+		NextProcessor<Integer> processor = new NextProcessor<>(Flux.never());
 
 		assertThat(processor.downstreamCount()).isZero();
 
 		processor.subscribe();
-
 		assertThat(processor.downstreamCount()).isOne();
 
 		processor.subscribe();
-
 		assertThat(processor.downstreamCount()).isEqualTo(2);
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/NextProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/NextProcessorTest.java
@@ -148,18 +148,18 @@ class NextProcessorTest {
 	}
 
 	@Test
-	void currentSubscriberCount() {
-		Sinks.One<Integer> sink = new SinkOneMulticast<>();
+	void downstreamCount() {
+		NextProcessor<Integer> processor = new NextProcessor<>(Flux.empty());
 
-		assertThat(sink.currentSubscriberCount()).isZero();
+		assertThat(processor.downstreamCount()).isZero();
 
-		sink.asMono().subscribe();
+		processor.subscribe();
 
-		assertThat(sink.currentSubscriberCount()).isOne();
+		assertThat(processor.downstreamCount()).isOne();
 
-		sink.asMono().subscribe();
+		processor.subscribe();
 
-		assertThat(sink.currentSubscriberCount()).isEqualTo(2);
+		assertThat(processor.downstreamCount()).isEqualTo(2);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkEmptyMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkEmptyMulticastTest.java
@@ -137,6 +137,7 @@ class SinkEmptyMulticastTest {
 		Sinks.Empty<Integer> sinkTerminated = new SinkEmptyMulticast<>();
 
 		assertThat(sinkTerminated.scan(Scannable.Attr.TERMINATED)).as("not yet terminated").isFalse();
+		assertThat(sinkTerminated.scan(Scannable.Attr.RUN_STYLE)).as("run_style").isSameAs(Scannable.Attr.RunStyle.SYNC);
 
 		sinkTerminated.tryEmitError(new IllegalStateException("boom")).orThrow();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkOneMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkOneMulticastTest.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.reactivestreams.Subscriber;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Scannable;
+import reactor.core.publisher.Sinks.EmitResult;
+import reactor.test.StepVerifier;
+import reactor.test.util.LoggerUtils;
+import reactor.test.util.TestLogger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * @author Simon Baslé
+ */
+class SinkOneMulticastTest {
+
+	@Test
+	void currentSubscriberCount() {
+		Sinks.One<Integer> sink = new SinkOneMulticast<>();
+
+		assertThat(sink.currentSubscriberCount()).isZero();
+
+		sink.asMono().subscribe();
+
+		assertThat(sink.currentSubscriberCount()).isOne();
+
+		sink.asMono().subscribe();
+
+		assertThat(sink.currentSubscriberCount()).isEqualTo(2);
+	}
+
+	@Test
+	void resultNotAvailable() {
+		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> {
+			SinkOneMulticast<String> sink = new SinkOneMulticast<>();
+			sink.block(Duration.ofMillis(1));
+		});
+	}
+
+	@Test
+	void rejectedDoOnTerminate() {
+		SinkOneMulticast<String> sink = new SinkOneMulticast<>();
+		AtomicInteger invoked = new AtomicInteger();
+
+		sink.doOnTerminate(invoked::incrementAndGet).subscribe(v -> {}, e -> {});
+		EmitResult emitResult = sink.tryEmitError(new Exception("test"));
+
+		assertThat(emitResult).isEqualTo(EmitResult.OK);
+
+		assertThat(invoked).hasValue(1);
+		assertThat(sink.scan(Scannable.Attr.ERROR)).hasMessage("test");
+		assertThat(sink.scan(Scannable.Attr.TERMINATED)).isTrue();
+	}
+
+	@Test
+	void rejectedSubscribeCallback() {
+		SinkOneMulticast<String> sink = new SinkOneMulticast<>();
+		AtomicReference<Throwable> ref = new AtomicReference<>();
+
+		sink.subscribe(v -> {}, ref::set);
+		EmitResult emitResult = sink.tryEmitError(new Exception("test"));
+
+		assertThat(emitResult).isEqualTo(EmitResult.OK);
+
+		assertThat(ref.get()).hasMessage("test");
+		assertThat(sink.scan(Scannable.Attr.ERROR)).hasMessage("test");
+		assertThat(sink.scan(Scannable.Attr.TERMINATED)).isTrue();
+	}
+
+	@Test
+	void successDoOnTerminate() {
+		SinkOneMulticast<String> sink = new SinkOneMulticast<>();
+		AtomicInteger invoked = new AtomicInteger();
+
+		sink.doOnTerminate(invoked::incrementAndGet).subscribe();
+		EmitResult emitResult = sink.tryEmitValue("test");
+
+		assertThat(emitResult).isEqualTo(EmitResult.OK);
+
+		assertThat(invoked).hasValue(1);
+		assertThat(sink.scan(Scannable.Attr.ERROR)).isNull();
+		assertThat(sink.scan(Scannable.Attr.TERMINATED)).isTrue();
+	}
+
+	@Test
+	void successSubscribeCallback() {
+		SinkOneMulticast<String> sink = new SinkOneMulticast<>();
+		AtomicReference<String> ref = new AtomicReference<>();
+
+		sink.subscribe(ref::set);
+		EmitResult emitResult = sink.tryEmitValue("test");
+
+		assertThat(emitResult).isEqualTo(EmitResult.OK);
+
+		assertThat(ref.get()).isEqualToIgnoringCase("test");
+		assertThat(sink.scan(Scannable.Attr.ERROR)).isNull();
+		assertThat(sink.scan(Scannable.Attr.TERMINATED)).isTrue();
+	}
+
+	@Test
+	void rejectedDoOnError() {
+		SinkOneMulticast<String> sink = new SinkOneMulticast<>();
+		AtomicReference<Throwable> ref = new AtomicReference<>();
+
+		sink.doOnError(ref::set).subscribe(v -> {}, e -> {});
+		EmitResult emitResult = sink.tryEmitError(new Exception("test"));
+
+		assertThat(emitResult).isEqualTo(EmitResult.OK);
+
+		assertThat(ref.get()).hasMessage("test");
+		assertThat(sink.scan(Scannable.Attr.ERROR)).hasMessage("test");
+		assertThat(sink.scan(Scannable.Attr.TERMINATED)).isTrue();
+	}
+
+	@Test
+	void rejectedSubscribeCallbackNull() {
+		SinkOneMulticast<String> sink = new SinkOneMulticast<>();
+
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+			sink.subscribe((Subscriber<String>) null);
+		});
+	}
+
+	@Test
+	void successDoOnSuccess() {
+		SinkOneMulticast<String> sink = new SinkOneMulticast<>();
+		AtomicReference<String> ref = new AtomicReference<>();
+
+		sink.doOnSuccess(ref::set).subscribe();
+		EmitResult emitResult = sink.tryEmitValue("test");
+
+		assertThat(emitResult).isEqualTo(EmitResult.OK);
+
+		assertThat(ref.get()).isEqualToIgnoringCase("test");
+		assertThat(sink.scan(Scannable.Attr.ERROR)).isNull();
+		assertThat(sink.scan(Scannable.Attr.TERMINATED)).isTrue();
+	}
+
+	@Test
+	void doubleFulfill() {
+		SinkOneMulticast<String> sink = new SinkOneMulticast<>();
+
+		StepVerifier.create(sink)
+			.then(() -> {
+				sink.emitValue("test1", Sinks.EmitFailureHandler.FAIL_FAST);
+				sink.emitValue("test2", Sinks.EmitFailureHandler.FAIL_FAST);
+			})
+			.expectNext("test1")
+			.expectComplete()
+			.verifyThenAssertThat()
+			.hasDroppedExactly("test2");
+	}
+
+	@Test
+	void nullFulfill() {
+		SinkOneMulticast<String> sink = new SinkOneMulticast<>();
+
+		EmitResult emitResult = sink.tryEmitValue(null);
+
+		assertThat(emitResult).isEqualTo(EmitResult.OK);
+
+		assertThat(sink.scan(Scannable.Attr.ERROR)).isNull();
+		assertThat(sink.scan(Scannable.Attr.TERMINATED)).isTrue();
+	}
+
+	@Test
+	void doubleError() {
+		TestLogger testLogger = new TestLogger();
+		LoggerUtils.enableCaptureWith(testLogger);
+		try {
+			SinkOneMulticast<String> sink = new SinkOneMulticast<>();
+
+			sink.emitError(new Exception("test"), Sinks.EmitFailureHandler.FAIL_FAST);
+			sink.emitError(new Exception("test2"), Sinks.EmitFailureHandler.FAIL_FAST);
+			Assertions.assertThat(testLogger.getErrContent())
+				.contains("Operator called default onErrorDropped")
+				.contains("test2");
+		}
+		finally {
+			LoggerUtils.disableCapture();
+		}
+	}
+
+	@Test
+	void doubleSignal() {
+		TestLogger testLogger = new TestLogger();
+		LoggerUtils.enableCaptureWith(testLogger);
+		try {
+			SinkOneMulticast<String> sink = new SinkOneMulticast<>();
+
+			sink.emitValue("test", Sinks.EmitFailureHandler.FAIL_FAST);
+			sink.emitError(new Exception("test2"), Sinks.EmitFailureHandler.FAIL_FAST);
+
+			Assertions.assertThat(testLogger.getErrContent())
+				.contains("Operator called default onErrorDropped")
+				.contains("test2");
+		}
+		finally {
+			LoggerUtils.disableCapture();
+		}
+	}
+
+	@Test
+	void blockNegativeIsImmediateTimeout() {
+		long start = System.nanoTime();
+		SinkOneMulticast<Object> sink = new SinkOneMulticast<>();
+
+		assertThatExceptionOfType(IllegalStateException.class)
+			.isThrownBy(() -> sink.block(Duration.ofNanos(-1)))
+			.withMessage("Timeout on blocking read for 0 NANOSECONDS");
+
+		assertThat(Duration.ofNanos(System.nanoTime() - start))
+			.isLessThan(Duration.ofMillis(500));
+	}
+
+	@Test
+	void blockZeroIsImmediateTimeout() {
+		long start = System.nanoTime();
+		SinkOneMulticast<Object> sink = new SinkOneMulticast<>();
+
+		assertThatExceptionOfType(IllegalStateException.class)
+			.isThrownBy(() -> sink.block(Duration.ZERO))
+			.withMessage("Timeout on blocking read for 1 NANOSECONDS");
+
+		assertThat(Duration.ofNanos(System.nanoTime() - start))
+			.isLessThan(Duration.ofMillis(500));
+	}
+
+	@Test
+	@Timeout(5)
+	void blockNegativeWithWarmedUpSink() {
+		SinkOneMulticast<String> sink = new SinkOneMulticast<>();
+		sink.tryEmitValue("test").orThrow();
+
+		assertThat(sink.block(Duration.ofMillis(-1))).isEqualTo("test");
+	}
+
+	@Test
+	@Timeout(5)
+	void blockZeroWithWarmedUpSink() {
+		SinkOneMulticast<String> sink = new SinkOneMulticast<>();
+		sink.tryEmitValue("test").orThrow();
+
+		assertThat(sink.block(Duration.ofMillis(0))).isEqualTo("test");
+	}
+
+	@Test
+	void scanSink() {
+		SinkOneMulticast<String> test = new SinkOneMulticast<>();
+
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
+		assertThat(test.scan(Scannable.Attr.ERROR)).isNull();
+		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
+
+		test.tryEmitEmpty().orThrow();
+		assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
+		assertThat(test.scan(Scannable.Attr.ERROR)).isNull();
+	}
+
+	@Test
+	void scanEmittedError() {
+		SinkOneMulticast<Integer> sinkTerminated = new SinkOneMulticast<>();
+
+		assertThat(sinkTerminated.scan(Scannable.Attr.TERMINATED)).as("not yet terminated").isFalse();
+
+		sinkTerminated.tryEmitError(new IllegalStateException("boom")).orThrow();
+
+		assertThat(sinkTerminated.scan(Scannable.Attr.TERMINATED)).as("terminated with error").isTrue();
+		assertThat(sinkTerminated.scan(Scannable.Attr.ERROR)).as("error").hasMessage("boom");
+	}
+
+	@Test
+	void inners() {
+		SinkOneMulticast<Integer> sink = new SinkOneMulticast<>();
+		CoreSubscriber<Integer> notScannable = new BaseSubscriber<Integer>() {};
+		InnerConsumer<Integer> scannable = new LambdaSubscriber<>(null, null, null, null);
+
+		assertThat(sink.inners()).as("before subscriptions").isEmpty();
+
+		sink.subscribe(notScannable);
+		sink.subscribe(scannable);
+
+		assertThat(sink.inners())
+			.asList()
+			.as("after subscriptions")
+			.hasSize(2)
+			.extracting(l -> (Object) ((SinkOneMulticast.Inner<?>) l).actual())
+			.containsExactly(notScannable, scannable);
+	}
+
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkOneMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkOneMulticastTest.java
@@ -246,7 +246,7 @@ class SinkOneMulticastTest {
 
 		assertThatExceptionOfType(IllegalStateException.class)
 			.isThrownBy(() -> sink.block(Duration.ZERO))
-			.withMessage("Timeout on blocking read for 1 NANOSECONDS");
+			.withMessage("Timeout on blocking read for 0 NANOSECONDS");
 
 		assertThat(Duration.ofNanos(System.nanoTime() - start))
 			.isLessThan(Duration.ofMillis(500));

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -2330,17 +2330,6 @@ public class StepVerifierTests {
 
 	@Test
 	public void verifyDrainOnRequestInCaseOfFusion() {
-		Sinks.One<Integer> processor = Sinks.one();
-		StepVerifier.create(processor.asMono(), 0)
-				.expectFusion(Fuseable.ANY)
-				.then(() -> processor.emitValue(1, FAIL_FAST))
-				.thenRequest(1)
-				.expectNext(1)
-				.verifyComplete();
-	}
-
-	@Test
-	public void verifyDrainOnRequestInCaseOfFusion2() {
 		ArrayList<Long> requests = new ArrayList<>();
 		Sinks.Many<Integer> processor = Sinks.many().unicast().onBackpressureBuffer();
 		StepVerifier.create(processor.asFlux().doOnRequest(requests::add), 0)


### PR DESCRIPTION
 - Ensure `mono.share().subscribe()` returns a dedicated `Disposable`
 - Old behavior of returning the underlying `NextProcessor` (which can then be
   terminated) is still reachable through `mono.toProcessor()` (deprecated)
 - Ensure cancelling `mono.share()` subscribers behaves like a reference counted
   multicast, ie the same as `Flux#share`: upstream is cancelled and next incoming
   subscriber will trigger an upstream re-subscription
 - Ensure this doesn't impact `Sinks.one()` by splitting out the implementation
 into `SinkOneMulticast`
 - copy relevant tests in `NextProcessorTest` for `SinkOneMulticastTest`

Fixes #2680.
