### PR TITLE
Have `FluxOnBackpressureBufferStrategy` reject sizes <= 0

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
@@ -48,6 +48,10 @@ final class FluxOnBackpressureBufferStrategy<O> extends InternalFluxOperator<O, 
 			@Nullable Consumer<? super O> onBufferOverflow,
 			BufferOverflowStrategy bufferOverflowStrategy) {
 		super(source);
+		if (bufferSize < 1) {
+			throw new IllegalArgumentException("Buffer Size must be strictly positive");
+		}
+
 		this.bufferSize = bufferSize;
 		this.onBufferOverflow = onBufferOverflow;
 		this.bufferOverflowStrategy = bufferOverflowStrategy;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
@@ -466,21 +466,21 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 
 	@ParameterizedTest
 	@ValueSource(ints = {-1, 0})
-	public void fluxOnBackpressureBufferStrategyRequiresPositiveMaxSize(int maxSize) {
+	void fluxOnBackpressureBufferStrategyRequiresPositiveMaxSize(int maxSize) {
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> Flux.just("foo").onBackpressureBuffer(maxSize, v -> {}, ERROR))
 				.withMessage("Buffer Size must be strictly positive");
 	}
 
 	@Test
-	public void fluxOnBackpressureBufferStrategyRequiresCallback() {
+	void fluxOnBackpressureBufferStrategyRequiresCallback() {
 		assertThatNullPointerException()
 				.isThrownBy(() -> Flux.just("foo").onBackpressureBuffer(1, null, ERROR))
 				.withMessage("onBufferOverflow");
 	}
 
 	@Test
-	public void fluxOnBackpressureBufferStrategyRequiresStrategy() {
+	void fluxOnBackpressureBufferStrategyRequiresStrategy() {
 		assertThatNullPointerException()
 				.isThrownBy(() -> Flux.just("foo").onBackpressureBuffer(1, v -> {}, null))
 				.withMessage("bufferOverflowStrategy");

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
@@ -25,6 +25,8 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
@@ -462,30 +464,26 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 		assertThat(hookCapturedError).as("unexpected hookCapturedError").isNull();
 	}
 
+	@ParameterizedTest
+	@ValueSource(ints = {-1, 0})
+	public void fluxOnBackpressureBufferStrategyRequiresPositiveMaxSize(int maxSize) {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> Flux.just("foo").onBackpressureBuffer(maxSize, v -> {}, ERROR))
+				.withMessage("Buffer Size must be strictly positive");
+	}
+
 	@Test
 	public void fluxOnBackpressureBufferStrategyRequiresCallback() {
-		try {
-			Flux.just("foo").onBackpressureBuffer(1,
-					null,
-					ERROR);
-			fail("expected NullPointerException");
-		}
-		catch (NullPointerException e) {
-			assertThat(e).hasMessage("onBufferOverflow");
-		}
+		assertThatNullPointerException()
+				.isThrownBy(() -> Flux.just("foo").onBackpressureBuffer(1, null, ERROR))
+				.withMessage("onBufferOverflow");
 	}
 
 	@Test
 	public void fluxOnBackpressureBufferStrategyRequiresStrategy() {
-		try {
-			Flux.just("foo").onBackpressureBuffer(1,
-					v -> { },
-					null);
-			fail("expected NullPointerException");
-		}
-		catch (NullPointerException e) {
-			assertThat(e).hasMessage("bufferOverflowStrategy");
-		}
+		assertThatNullPointerException()
+				.isThrownBy(() -> Flux.just("foo").onBackpressureBuffer(1, v -> {}, null))
+				.withMessage("bufferOverflowStrategy");
 	}
 
 	@Test


### PR DESCRIPTION
I realized that there is no check for buffer size in `Flux#onBackpressureBuffer(int, BufferOverflowStrategy)` and `Flux#onBackpressureBuffer(int, Consumer, BufferOverflowStrategy)` unlike other `#onBackpressureBuffer` methods.

It's possible to get `OutOfMemoryError` by setting it to `-1` due to

https://github.com/reactor/reactor-core/blob/f9dd07c691e6a2a5149bccaf4e9a211cb80f8cce/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java#L153