### PR TITLE
[reactor-test] Fix consumeWhile+expectRecorded* skipping signal

### DIFF
--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -1414,13 +1414,19 @@ final class DefaultStepVerifierBuilder<T>
 					//possibly re-evaluate the current onNext
 					event = this.script.peek();
 				}
-				if (event instanceof SignalCountEvent) {
-					if (onSignalCount(actualSignal, (SignalCountEvent<T>) event)) {
+
+				if (event instanceof CollectEvent) {
+					if (onCollect(actualSignal)) {
 						return;
 					}
+					else if (((CollectEvent<?>) event).supplier == null) {
+						//possibly re-evaluate the current onNext
+						event = this.script.peek();
+					}
 				}
-				else if (event instanceof CollectEvent) {
-					if (onCollect(actualSignal)) {
+
+				if (event instanceof SignalCountEvent) {
+					if (onSignalCount(actualSignal, (SignalCountEvent<T>) event)) {
 						return;
 					}
 				}

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -2423,4 +2423,125 @@ public class StepVerifierTests {
 				.as("copy didn't influence original")
 				.isNull();
 	}
+
+	@Test
+	void collectMultipleTimes_detectsUnexpectedTermination() {
+		Flux<Integer> sourceFlux = Flux.range(1, 11);
+
+		StepVerifier stepVerifier = StepVerifier.create(sourceFlux)
+			.recordWith(ArrayList::new)
+			.expectNextCount(5)
+			.consumeRecordedWith(elements -> assertThat(elements).containsExactly(1, 2, 3, 4, 5))
+			.recordWith(ArrayList::new)
+			.expectNext(6)
+			.expectNext(7, 8, 9, 10)
+			.consumeRecordedWith(elements -> assertThat(elements).containsExactly(6, 7, 8, 9, 10))
+			.expectNext(11)
+			.expectErrorMessage("expected error");
+
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(stepVerifier::verify)
+			.withMessage("expectation \"expectErrorMessage\" failed (expected: onError(\"expected error\"); actual: onComplete())");
+	}
+
+	@Test
+	void collectMultipleTimes_detectsUnexpectedCollectedElement1() {
+		Flux<Integer> sourceFlux = Flux.range(1, 10);
+
+		StepVerifier stepVerifier = StepVerifier.create(sourceFlux)
+			.recordWith(ArrayList::new)
+			.expectNextCount(5)
+			.consumeRecordedWith(elements -> assertThat(elements).containsExactly(1, 5))
+			.recordWith(ArrayList::new)
+			.expectNext(6, 7, 8, 9, 10)
+			.consumeRecordedWith(elements -> assertThat(elements).containsExactly(6, 7, 8, 9, 10))
+			.expectComplete();
+
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(stepVerifier::verify)
+			.withMessage("\n" +
+				"Expecting:\n" +
+				"  [1, 2, 3, 4, 5]\n" +
+				"to contain exactly (and in same order):\n" +
+				"  [1, 5]\n" +
+				"but some elements were not expected:\n" +
+				"  [2, 3, 4]\n");
+	}
+
+	@Test
+	void collectMultipleTimes_detectsUnexpectedCollectedElement2() {
+		Flux<Integer> sourceFlux = Flux.range(1, 10);
+
+		StepVerifier stepVerifier = StepVerifier.create(sourceFlux)
+			.recordWith(ArrayList::new)
+			.expectNextCount(5)
+			.consumeRecordedWith(elements -> assertThat(elements).containsExactly(1, 2, 3, 4, 5))
+			.recordWith(ArrayList::new)
+			.expectNext(6, 7, 8, 9, 10)
+			.consumeRecordedWith(elements -> assertThat(elements).containsExactly(6, 10))
+			.expectComplete();
+
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(stepVerifier::verify)
+			.withMessage("\n" +
+				"Expecting:\n" +
+				"  [6, 7, 8, 9, 10]\n" +
+				"to contain exactly (and in same order):\n" +
+				"  [6, 10]\n" +
+				"but some elements were not expected:\n" +
+				"  [7, 8, 9]\n");
+	}
+
+	@Test
+	void collectAfterFirst_reportsAssertionFailure() {
+		Flux<Integer> sourceFlux = Flux.range(1, 10);
+
+		StepVerifier stepVerifier = StepVerifier.create(sourceFlux)
+			.expectNext(1)
+			.recordWith(ArrayList::new)
+			.thenConsumeWhile(x -> true)
+			.consumeRecordedWith(elements -> assertThat(elements).containsExactly(2, 3, 4, 5, 6, 7, 8, 9))
+			.expectComplete();
+
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(stepVerifier::verify)
+			.withMessage("\n" +
+				"Expecting:\n" +
+				"  [2, 3, 4, 5, 6, 7, 8, 9, 10]\n" +
+				"to contain exactly (and in same order):\n" +
+				"  [2, 3, 4, 5, 6, 7, 8, 9]\n" +
+				"but some elements were not expected:\n" +
+				"  [10]\n");
+	}
+
+	@Test
+	void collectEmptyAndNoopConsumeWhile_detectsMissingNext() {
+		Flux<Object> emptyFlux = Flux.empty();
+
+		final StepVerifier stepVerifier = StepVerifier.create(emptyFlux)
+			.recordWith(ArrayList::new)
+			.thenConsumeWhile(x -> true)
+			.consumeRecordedWith(elements -> assertThat(elements).isEmpty())
+			.expectNext("foo")
+			.expectComplete();
+
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(stepVerifier::verify)
+			.withMessage("expectation \"expectNext(foo)\" failed (expected: onNext(foo); actual: onComplete())");
+	}
+
+	@Test
+	void collectEmptyAndNoopConsumeWhile_detectsWrongTermination() {
+		Flux<Object> errorFlux = Flux.error(new RuntimeException("oh no"));
+
+		final StepVerifier stepVerifier = StepVerifier.create(errorFlux)
+			.recordWith(ArrayList::new)
+			.thenConsumeWhile(x -> true)
+			.consumeRecordedWith(elements -> assertThat(elements).isEmpty())
+			.expectComplete();
+
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(stepVerifier::verify)
+			.withMessage("expectation \"expectComplete\" failed (expected: onComplete(); actual: onError(java.lang.RuntimeException: oh no))");
+	}
 }


### PR DESCRIPTION
This commit prevents the case where combining `thenConsumeWhile` and
`expectRecordedMatches` steps would lead to a non-matching signal
being skipped.

Rather, this reorders the logic so that the testing `CollectEvent` will
allow peeking for the next `SignalEvent` and run that expectation on the
current signal, which wasn't processed by `consumeWhile`.

A non-matching signal is either the first `onNext` that doesn't match
the consumeWhile predicate, or a onComplete/onError signal (which are
never considered by consumeWhile).

Fixes #2760.
