### PR TITLE
Mono.create sink now discards if emitting after cancel

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
@@ -140,7 +140,12 @@ final class MonoCreate<T> extends Mono<T> implements SourceProducer<T> {
 				success();
 				return;
 			}
-			if (isDisposed()) {
+			Disposable d = this.disposable;
+			if (d == CANCELLED) {
+				Operators.onDiscard(value, actual.currentContext());
+				return;
+			}
+			else if (d == TERMINATED) {
 				Operators.onNextDropped(value, actual.currentContext());
 				return;
 			}


### PR DESCRIPTION
Currently, contrary to flavours of sinks in `Flux.create`, when emitting
a value in the Mono.create sink there is no distinction between the
cancelled and terminated states. Any of these states leads to the value
being dropped (Hooks.onNextDropped).

This commit changes that and distinguish between terminated downstream
(onNextDropped) and cancelled (Operators.onDiscard).

Fixes #2765.
