### PR TITLE
Polish parameterized tests for better display names

### DIFF
--- a/buildSrc/src/main/java/io/reactor/gradle/JavaConventions.java
+++ b/buildSrc/src/main/java/io/reactor/gradle/JavaConventions.java
@@ -74,7 +74,7 @@ public class JavaConventions implements Plugin<Project> {
 
 		if (JavaVersion.current().isJava8Compatible()) {
 			project.getTasks().withType(JavaCompile.class, t -> {
-				if (t.getName().equalsIgnoreCase("testcompile")) {
+				if (t.getName().endsWith("TestJava")) {
 					List<String> args = new ArrayList<>(t.getOptions().getCompilerArgs());
 					args.add("-parameters");
 					t.getOptions().setCompilerArgs(args);

--- a/reactor-core/src/test/java/reactor/core/publisher/ContextLossDetectionTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ContextLossDetectionTest.java
@@ -26,7 +26,6 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -34,6 +33,7 @@ import org.reactivestreams.Subscription;
 
 import reactor.core.CorePublisher;
 import reactor.core.CoreSubscriber;
+import reactor.test.ParameterizedTestWithName;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 import reactor.util.context.ContextView;
@@ -106,7 +106,7 @@ public class ContextLossDetectionTest {
 		Hooks.disableContextLossTracking();
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sources")
 	public void transformDeferredDetectsContextLoss(ContextTestCase fn) {
 		LossyTransformer transformer = new LossyTransformer(fn + "'s badTransformer",
@@ -118,7 +118,7 @@ public class ContextLossDetectionTest {
 				.withMessage("Context loss after applying " + fn + "'s badTransformer");
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sources")
 	public void transformDeferredDetectsContextLossWithEmptyContext(ContextTestCase fn) {
 		LossyTransformer transformer = new LossyTransformer(fn + "'s badTransformer",
@@ -130,7 +130,7 @@ public class ContextLossDetectionTest {
 				.withMessage("Context loss after applying " + fn + "'s badTransformer");
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sources")
 	public void transformDeferredDetectsContextLossWithDefaultContext(ContextTestCase fn) {
 		LossyTransformer transformer = new LossyTransformer(fn + "'s badTransformer", true);
@@ -141,7 +141,7 @@ public class ContextLossDetectionTest {
 				.withMessage("Context loss after applying " + fn + "'s badTransformer");
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sources")
 	public void transformDeferredDetectsContextLossWithRSSubscriber(ContextTestCase fn) {
 		LossyTransformer transformer = new LossyTransformer(fn + "'s badTransformer", false);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCreateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCreateTest.java
@@ -28,10 +28,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
@@ -41,6 +41,7 @@ import reactor.core.publisher.FluxCreate.SerializedFluxSink;
 import reactor.core.publisher.FluxSink.OverflowStrategy;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
+import reactor.test.ParameterizedTestWithName;
 import reactor.test.StepVerifier;
 import reactor.test.StepVerifier.Step;
 import reactor.test.subscriber.AssertSubscriber;
@@ -1491,7 +1492,7 @@ class FluxCreateTest {
 		assertThat(failed).as("failed").isZero();
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@EnumSource(OverflowStrategy.class)
 	void secondOnCancelHandlerIsDisposedImmediately(OverflowStrategy overflowStrategy) {
 		AtomicInteger firstDisposed = new AtomicInteger();
@@ -1504,7 +1505,7 @@ class FluxCreateTest {
 		assertThat(secondDisposed).as("second handler for %s", overflowStrategy).hasValue(1);
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@EnumSource(OverflowStrategy.class)
 	void secondOnDisposeHandlerIsDisposedImmediately(OverflowStrategy overflowStrategy) {
 		AtomicInteger firstDisposed = new AtomicInteger();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDoOnEachTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDoOnEachTest.java
@@ -26,9 +26,9 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.reactivestreams.Subscription;
+
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
@@ -38,14 +38,13 @@ import reactor.core.publisher.FluxDoOnEach.DoOnEachConditionalSubscriber;
 import reactor.core.publisher.FluxDoOnEach.DoOnEachFuseableConditionalSubscriber;
 import reactor.core.publisher.FluxPeekFuseableTest.AssertQueueSubscription;
 import reactor.core.scheduler.Schedulers;
+import reactor.test.ParameterizedTestWithName;
 import reactor.test.StepVerifier;
 import reactor.test.StepVerifierOptions;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.context.Context;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 public class FluxDoOnEachTest {
 
@@ -97,7 +96,7 @@ public class FluxDoOnEachTest {
 		};
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sources12Complete")
 	public void normal(Flux<Integer> source) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
@@ -295,7 +294,7 @@ public class FluxDoOnEachTest {
 		assertThat(onComplete).isFalse();
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sourcesError")
 	public void error(Flux<Integer> source) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
@@ -328,7 +327,7 @@ public class FluxDoOnEachTest {
 		assertThat(state.intValue()).isZero();
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sourcesEmpty")
 	public void empty(Flux<Integer> source) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
@@ -360,7 +359,7 @@ public class FluxDoOnEachTest {
 		assertThat(state.intValue()).isEqualTo(0);
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sourcesNever")
 	public void never(Flux<Integer> source) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
@@ -392,7 +391,7 @@ public class FluxDoOnEachTest {
 		assertThat(state.intValue()).isEqualTo(0);
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sources12Complete")
 	public void nextCallbackError(Flux<Integer> source) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
@@ -415,7 +414,7 @@ public class FluxDoOnEachTest {
 		assertThat(state.intValue()).isEqualTo(1);
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sources12Complete")
 	public void nextCallbackBubbleError(Flux<Integer> source) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
@@ -442,7 +441,7 @@ public class FluxDoOnEachTest {
 		}
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sources12Complete")
 	public void completeCallbackError(Flux<Integer> source) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
@@ -471,7 +470,7 @@ public class FluxDoOnEachTest {
 		                        .isTrue();
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sourcesError")
 	public void errorCallbackError(Flux<Integer> source) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnBackpressureBufferStrategyTest.java
@@ -25,18 +25,17 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.reactivestreams.Subscription;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
+import reactor.test.ParameterizedTestWithName;
 import reactor.test.StepVerifier;
 import reactor.test.StepVerifierOptions;
 import reactor.test.publisher.TestPublisher;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.*;
 import static reactor.core.publisher.BufferOverflowStrategy.*;
 import static reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST;
@@ -466,7 +465,7 @@ public class FluxOnBackpressureBufferStrategyTest implements Consumer<String>,
 		assertThat(hookCapturedError).as("unexpected hookCapturedError").isNull();
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@ValueSource(ints = {-1, 0})
 	void fluxOnBackpressureBufferStrategyRequiresPositiveMaxSize(int maxSize) {
 		assertThatIllegalArgumentException()

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxStreamTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxStreamTest.java
@@ -32,13 +32,13 @@ import java.util.stream.StreamSupport;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
+import reactor.test.ParameterizedTestWithName;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
@@ -488,7 +488,7 @@ public class FluxStreamTest {
 	}
 
 	//see https://github.com/reactor/reactor-core/issues/2761
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@ValueSource(booleans = { false, true })
 	void fromStreamWithFailingIteratorNextInFusion(boolean conditionalSubscriber) throws InterruptedException {
 		CountDownLatch thrown = new CountDownLatch(1);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
@@ -18,19 +18,21 @@ package reactor.core.publisher;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.reactivestreams.Subscription;
+
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
+import reactor.test.ParameterizedTestWithName;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.concurrent.Queues;
@@ -41,9 +43,8 @@ import static reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST;
 @SuppressWarnings("deprecation")
 public class FluxSwitchMapTest {
 
-	@ParameterizedTest
-	@ValueSource(ints = {0}) // TODO: add for prefetch one
-	@Timeout(120_000)
+	@Test // TODO: add parameterized version, cover prefetch one
+	@Timeout(value = 2, unit = TimeUnit.MINUTES)
 	@Tag("slow")
 	// test for issue https://github.com/reactor/reactor-core/issues/2554
 	public void test2596() {
@@ -91,7 +92,7 @@ public class FluxSwitchMapTest {
 		}
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@ValueSource(ints = {0, 32})
 	public void noswitch(int prefetch) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
@@ -166,7 +167,7 @@ public class FluxSwitchMapTest {
 
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@ValueSource(ints = {0, 32})
 	public void doswitch(int prefetch) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
@@ -218,7 +219,7 @@ public class FluxSwitchMapTest {
 		            .verifyComplete();
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@ValueSource(ints = {0, 32})
 	public void mainCompletesBefore(int prefetch) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
@@ -248,7 +249,7 @@ public class FluxSwitchMapTest {
 
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@ValueSource(ints = {0, 32})
 	public void mainError(int prefetch) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
@@ -274,7 +275,7 @@ public class FluxSwitchMapTest {
 		  .assertNotComplete();
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@ValueSource(ints = {0, 32})
 	public void innerError(int prefetch) {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
@@ -302,7 +303,7 @@ public class FluxSwitchMapTest {
 		assertThat(sp2.currentSubscriberCount()).as("sp2 has subscriber").isZero();
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@ValueSource(ints = {0, 32})
 	public void mapperThrows(int prefetch) {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
@@ -323,7 +324,7 @@ public class FluxSwitchMapTest {
 		  .assertNotComplete();
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@ValueSource(ints = {0, 32})
 	public void mapperReturnsNull(int prefetch) {
 		AssertSubscriber<Object> ts = AssertSubscriber.create();
@@ -341,7 +342,7 @@ public class FluxSwitchMapTest {
 		  .assertNotComplete();
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@ValueSource(ints = {0, 32})
 	public void switchOnNextDynamically(int prefetch) {
 		StepVerifier.create(Flux.just(1, 2, 3)
@@ -350,7 +351,7 @@ public class FluxSwitchMapTest {
 		            .verifyComplete();
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@ValueSource(ints = {0, 32})
 	public void switchOnNextDynamicallyOnNext(int prefetch) {
 		Sinks.Many<Flux<Integer>> up = Sinks.many().unicast().onBackpressureBuffer();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxUsingWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxUsingWhenTest.java
@@ -25,12 +25,8 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 import java.util.logging.Level;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
@@ -42,6 +38,7 @@ import reactor.core.Fuseable;
 import reactor.core.Scannable.Attr;
 import reactor.core.publisher.FluxUsingWhen.ResourceSubscriber;
 import reactor.core.publisher.FluxUsingWhen.UsingWhenSubscriber;
+import reactor.test.ParameterizedTestWithName;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.PublisherProbe;
 import reactor.test.publisher.TestPublisher;
@@ -374,7 +371,7 @@ public class FluxUsingWhenTest {
 		testResource.rollbackProbe.assertWasSubscribed();
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sources01")
 	public void cancelWithHandler(Flux<String> source) {
 		TestResource testResource = new TestResource();
@@ -395,7 +392,7 @@ public class FluxUsingWhenTest {
 		testResource.cancelProbe.assertWasSubscribed();
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sources01")
 	public void cancelWithHandlerFailure(Flux<String> source) {
 		TestResource testResource = new TestResource();
@@ -429,7 +426,7 @@ public class FluxUsingWhenTest {
 				.contains("java.lang.IllegalStateException: cancel error");
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sources01")
 	public void cancelWithHandlerGenerationFailureLogs(Flux<String> source) throws InterruptedException {
 		TestLogger tl = new TestLogger();
@@ -460,7 +457,7 @@ public class FluxUsingWhenTest {
 				.contains("java.lang.NullPointerException");
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sources01")
 	@Deprecated
 	public void cancelWithoutHandlerAppliesCommit(Flux<String> source) {
@@ -485,7 +482,7 @@ public class FluxUsingWhenTest {
 		testResource.rollbackProbe.assertWasNotSubscribed();
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sources01")
 	@Deprecated
 	public void cancelDefaultHandlerFailure(Flux<String> source) {
@@ -525,7 +522,7 @@ public class FluxUsingWhenTest {
 				.contains("java.lang.IllegalStateException: commit error");
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sourcesFullTransaction")
 	public void apiCommit(Flux<String> fullTransaction) {
 		final AtomicReference<TestResource> ref = new AtomicReference<>();
@@ -553,7 +550,7 @@ public class FluxUsingWhenTest {
 				.matches(tr -> !tr.rollbackProbe.wasSubscribed(), "no rollback");
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sourcesFullTransaction")
 	public void apiCommitFailure(Flux<String> fullTransaction) {
 		final AtomicReference<TestResource> ref = new AtomicReference<>();
@@ -582,7 +579,7 @@ public class FluxUsingWhenTest {
 				.matches(tr -> !tr.rollbackProbe.wasSubscribed(), "no rollback");
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sourcesFullTransaction")
 	public void commitGeneratingNull(Flux<String> fullTransaction) {
 		final AtomicReference<TestResource> ref = new AtomicReference<>();
@@ -612,7 +609,7 @@ public class FluxUsingWhenTest {
 				.matches(tr -> !tr.rollbackProbe.wasSubscribed(), "no rollback");
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sourcesTransactionError")
 	public void apiRollback(Flux<String> transactionWithError) {
 		final AtomicReference<TestResource> ref = new AtomicReference<>();
@@ -640,7 +637,7 @@ public class FluxUsingWhenTest {
 				.matches(tr -> tr.rollbackProbe.wasSubscribed(), "rollback method used");
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sourcesTransactionError")
 	public void apiRollbackFailure(Flux<String> transactionWithError) {
 		final AtomicReference<TestResource> ref = new AtomicReference<>();
@@ -668,7 +665,7 @@ public class FluxUsingWhenTest {
 				.matches(tr -> tr.rollbackProbe.wasSubscribed(), "rollback method used");
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sourcesTransactionError")
 	public void apiRollbackGeneratingNull(Flux<String> transactionWithError) {
 		final AtomicReference<TestResource> ref = new AtomicReference<>();
@@ -696,7 +693,7 @@ public class FluxUsingWhenTest {
 				.matches(tr -> !tr.rollbackProbe.wasSubscribed(), "rollback method short-circuited");
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sourcesFullTransaction")
 	public void apiCancel(Flux<String> transactionWithError) {
 		final AtomicReference<TestResource> ref = new AtomicReference<>();
@@ -720,7 +717,7 @@ public class FluxUsingWhenTest {
 				.matches(tr -> tr.cancelProbe.wasSubscribed(), "cancel method used");
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sourcesFullTransaction")
 	public void apiCancelFailure(Flux<String> transaction) {
 		TestLogger testLogger = new TestLogger();
@@ -759,7 +756,7 @@ public class FluxUsingWhenTest {
 		}
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sourcesFullTransaction")
 	public void apiCancelGeneratingNullLogs(Flux<String> transactionWithError) {
 		TestLogger testLogger = new TestLogger();
@@ -862,7 +859,7 @@ public class FluxUsingWhenTest {
 		assertThat(test).isNotInstanceOf(Fuseable.QueueSubscription.class);
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sourcesContext")
 	public void contextPropagationOnCommit(Mono<String> source) {
 		AtomicReference<String> probeContextValue = new AtomicReference<>();
@@ -903,7 +900,7 @@ public class FluxUsingWhenTest {
 		assertThat(resourceContextValue).hasValue("contextual");
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sourcesContextError")
 	public void contextPropagationOnRollback(Mono<String> source) {
 		AtomicReference<String> probeContextValue = new AtomicReference<>();
@@ -943,7 +940,7 @@ public class FluxUsingWhenTest {
 		assertThat(resourceContextValue).hasValue("contextual");
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sources01")
 	public void contextPropagationOnCancel(Flux<String> source) {
 		TestResource testResource = new TestResource();
@@ -973,7 +970,7 @@ public class FluxUsingWhenTest {
 		assertThat(errorRef).hasValue(null);
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("sources01")
 	public void contextPropagationOnCancelWithNoHandler(Flux<String> source) {
 		TestResource testResource = new TestResource();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -25,16 +25,16 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.reactivestreams.Subscription;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
-import reactor.test.util.LoggerUtils;
+import reactor.test.ParameterizedTestWithName;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.test.util.LoggerUtils;
 import reactor.test.util.TestLogger;
 import reactor.util.concurrent.Queues;
 import reactor.util.function.Tuple2;
@@ -44,7 +44,6 @@ import reactor.util.function.Tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.fail;
 import static reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST;
 
 public class FluxZipTest extends FluxOperatorTest<String, String> {
@@ -67,7 +66,7 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 		);
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@CsvSource({
 			"false, false, first",
 			"true, false, first",
@@ -80,7 +79,7 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 		StepVerifier.create(first.zipWith(second)).verifyErrorMessage(expectedMessage);
 	}
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@CsvSource({
 			"false, false, first",
 			"true, false, first",

--- a/reactor-core/src/test/java/reactor/core/publisher/InternalManySinkTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/InternalManySinkTest.java
@@ -20,12 +20,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+
 import reactor.core.Exceptions;
-import reactor.core.publisher.Sinks.EmitResult;
 import reactor.core.publisher.Sinks.EmissionException;
 import reactor.core.publisher.Sinks.EmitFailureHandler;
+import reactor.core.publisher.Sinks.EmitResult;
+import reactor.test.ParameterizedTestWithName;
 import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,7 +35,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 class InternalManySinkTest {
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@EnumSource(value = Sinks.EmitResult.class)
 	void shouldDelegateToHandler(Sinks.EmitResult emitResult) {
 		assumeThat(emitResult.isFailure()).isTrue();

--- a/reactor-core/src/test/java/reactor/core/publisher/InternalOneSinkTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/InternalOneSinkTest.java
@@ -20,12 +20,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+
 import reactor.core.Exceptions;
-import reactor.core.publisher.Sinks.EmitResult;
 import reactor.core.publisher.Sinks.EmissionException;
 import reactor.core.publisher.Sinks.EmitFailureHandler;
+import reactor.core.publisher.Sinks.EmitResult;
+import reactor.test.ParameterizedTestWithName;
 import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,7 +35,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 class InternalOneSinkTest {
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@EnumSource(value = Sinks.EmitResult.class)
 	void shouldDelegateToHandler(EmitResult emitResult) {
 		assumeThat(emitResult.isFailure()).isTrue();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
@@ -22,15 +22,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.Test;
-
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.reactivestreams.Subscription;
+
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Scannable;
@@ -938,9 +937,9 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 		assertThat(subCount.get()).isEqualTo(2);
 	}
 
-	@ParameterizedTest
+	@ParameterizedTest(name = "{displayName} [for null case #{index}]")
 	@MethodSource("nullInvocations")
-	public void nullArgumentsToCacheOperatorsAreImmediatelyRejected(ThrowableAssert.ThrowingCallable nullInvocation) {
+	public void nullArgumentsToCacheOperatorsAreImmediatelyRejected(ThrowableAssert.ThrowingCallable nullInvocation) { //TODO replace with Named.of in JUnit 5.8+
 		assertThatExceptionOfType(NullPointerException.class).isThrownBy(nullInvocation);
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
@@ -137,7 +137,7 @@ public class OnDiscardShouldNotLeakTest {
 	}
 
 	@DisplayName("Multiple Subscribers racing Cancel/OnNext/Request")
-	@ParameterizedTest(name="{index} {displayName} [{argumentsWithNames}]")
+	@ParameterizedTest(name="{displayName} [{index}] for {2} (conditional={0}, fused={1})")
 	@MethodSource("data")
 	public void ensureMultipleSubscribersSupportWithNoLeaksWhenRacingCancelAndOnNextAndRequest(boolean conditional, boolean fused, DiscardScenario discardScenario) {
 		installScheduler(discardScenario.description, discardScenario.numberOfSubscriptions + 2 /* Cancel, request*/);
@@ -190,7 +190,7 @@ public class OnDiscardShouldNotLeakTest {
 	}
 
 	@DisplayName("Multiple Subscribers with populated queue racing Cancel/OnNext/Request")
-	@ParameterizedTest(name="{index} {displayName} [{argumentsWithNames}]")
+	@ParameterizedTest(name="{displayName} [{index}] for {2} (conditional={0}, fused={1})")
 	@MethodSource("data")
 	public void ensureMultipleSubscribersSupportWithNoLeaksWhenPopulatedQueueRacingCancelAndOnNextAndRequest(boolean conditional, boolean fused, DiscardScenario discardScenario) {
 		Assumptions.assumeThat(discardScenario.numberOfSubscriptions).isGreaterThan(1);
@@ -248,7 +248,7 @@ public class OnDiscardShouldNotLeakTest {
 	}
 
 	@DisplayName("Populated queue racing Cancel/OnNext")
-	@ParameterizedTest(name="{index} {displayName} [{argumentsWithNames}]")
+	@ParameterizedTest(name="{displayName} [{index}] for {2} (conditional={0}, fused={1})")
 	@MethodSource("data")
 	public void ensureNoLeaksPopulatedQueueAndRacingCancelAndOnNext(boolean conditional, boolean fused, DiscardScenario discardScenario) {
 		Assumptions.assumeThat(discardScenario.numberOfSubscriptions).isOne();
@@ -303,7 +303,7 @@ public class OnDiscardShouldNotLeakTest {
 	}
 
 	@DisplayName("Populated queue racing Cancel/OnComplete")
-	@ParameterizedTest(name="{index} {displayName} [{argumentsWithNames}]")
+	@ParameterizedTest(name="{displayName} [{index}] for {2} (conditional={0}, fused={1})")
 	@MethodSource("data")
 	public void ensureNoLeaksPopulatedQueueAndRacingCancelAndOnComplete(boolean conditional, boolean fused, DiscardScenario discardScenario) {
 		Assumptions.assumeThat(discardScenario.numberOfSubscriptions).isOne();
@@ -355,7 +355,7 @@ public class OnDiscardShouldNotLeakTest {
 	}
 
 	@DisplayName("Populated queue racing Cancel/OnError")
-	@ParameterizedTest(name="{index} {displayName} [{argumentsWithNames}]")
+	@ParameterizedTest(name="{displayName} [{index}] for {2} (conditional={0}, fused={1})")
 	@MethodSource("data")
 	public void ensureNoLeaksPopulatedQueueAndRacingCancelAndOnError(boolean conditional, boolean fused, DiscardScenario discardScenario) {
 		Assumptions.assumeThat(discardScenario.numberOfSubscriptions).isOne();
@@ -411,7 +411,7 @@ public class OnDiscardShouldNotLeakTest {
 	}
 
 	@DisplayName("Populated queue racing Cancel/overflow Error")
-	@ParameterizedTest(name="{index} {displayName} [{argumentsWithNames}]")
+	@ParameterizedTest(name="{displayName} [{index}] for {2} (conditional={0}, fused={1})")
 	@MethodSource("data")
 	public void ensureNoLeaksPopulatedQueueAndRacingCancelAndOverflowError(boolean conditional, boolean fused, DiscardScenario discardScenario) {
 		Assumptions.assumeThat(discardScenario.numberOfSubscriptions).isOne();
@@ -473,7 +473,7 @@ public class OnDiscardShouldNotLeakTest {
 	}
 
 	@DisplayName("Populated queue racing Cancel/Request")
-	@ParameterizedTest(name="{index} {displayName} [{argumentsWithNames}]")
+	@ParameterizedTest(name="{displayName} [{index}] for {2} (conditional={0}, fused={1})")
 	@MethodSource("data")
 	public void ensureNoLeaksPopulatedQueueAndRacingCancelAndRequest(boolean conditional, boolean fused, DiscardScenario discardScenario) {
 		Assumptions.assumeThat(discardScenario.numberOfSubscriptions).isOne();

--- a/reactor-core/src/test/java/reactor/test/ParameterizedTestWithName.java
+++ b/reactor-core/src/test/java/reactor/test/ParameterizedTestWithName.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.params.ParameterizedTest;
+
+/**
+ * Meta-annotation that provides a better default for {@link ParameterizedTest} name.
+ */
+@ParameterizedTest(name="{displayName} [{index}] {argumentsWithNames}")
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ParameterizedTestWithName {
+
+}

--- a/reactor-core/src/test/java/reactor/test/TestBestPracticesArchTest.java
+++ b/reactor-core/src/test/java/reactor/test/TestBestPracticesArchTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.test;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaAnnotation;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+/**
+ * @author Simon Baslé
+ */
+public class TestBestPracticesArchTest {
+
+	static JavaClasses TEST_CLASSES = new ClassFileImporter()
+		.withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_JARS)
+		.withImportOption(location -> !ImportOption.Predefined.DO_NOT_INCLUDE_TESTS.includes(location))
+		.importPackages("reactor");
+
+	@Test
+	void parameterizedTestsIncludeDisplayNameInPattern() {
+		DescribedPredicate<JavaAnnotation> parameterizedTestWithDisplayName =
+			DescribedPredicate.describe("ParameterizedTest with {displayName}, or perhaps consider @ParameterizedTestWithName instead",
+				javaAnnotation -> {
+					if (!javaAnnotation.getRawType().isAssignableFrom(ParameterizedTest.class)) {
+						return false;
+					}
+					return javaAnnotation.get("name")
+						.transform(String::valueOf)
+						.or("NOPE")
+						.contains(ParameterizedTest.DISPLAY_NAME_PLACEHOLDER);
+				});
+
+		methods()
+			.that().areAnnotatedWith(ParameterizedTest.class)
+			.should().beAnnotatedWith(parameterizedTestWithDisplayName)
+			.check(TEST_CLASSES);
+	}
+}

--- a/reactor-core/src/test/java/reactor/util/concurrent/QueuesTest.java
+++ b/reactor-core/src/test/java/reactor/util/concurrent/QueuesTest.java
@@ -16,7 +16,13 @@
 
 package reactor.util.concurrent;
 
-import java.util.*;
+import java.util.AbstractQueue;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.PriorityQueue;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Supplier;
@@ -26,11 +32,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
 import reactor.core.publisher.Hooks;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.*;
 
 public class QueuesTest {
 
@@ -152,9 +157,9 @@ public class QueuesTest {
 		assertThat(emptyQueue.toArray(new Integer[0])).as("toArray(empty)").isEmpty();
 	}
 
-	@ParameterizedTest(name = "[{index}] {0}")
+	@ParameterizedTest(name = "{displayName} [{index}] {0}")
 	@MethodSource("queues")
-	public void testWrapping(String name, Supplier<Queue<Object>> queueSupplier) {
+	public void testWrapping(String name, Supplier<Queue<Object>> queueSupplier) { //TODO replace with Named.of in JUnit 5.8+
 		assertThat(queueSupplier.get()).as("no wrapper").hasSize(0);
 
 		Hooks.addQueueWrapper("test", queue -> {

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/scheduler/SchedulersMetricsTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/scheduler/SchedulersMetricsTest.java
@@ -40,9 +40,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import reactor.test.AutoDisposingExtension;
+import reactor.test.ParameterizedTestWithName;
 import reactor.util.Metrics;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
 import static org.awaitility.Awaitility.await;
 import static reactor.core.scheduler.SchedulerMetricDecorator.TAG_SCHEDULER_ID;
 
@@ -220,9 +222,9 @@ public class SchedulersMetricsTest {
 		};
 	}
 
-	@ParameterizedTest
+	@ParameterizedTest(name="{displayName} [{index}] for {1}")
 	@MethodSource("metricsSchedulers")
-    public void shouldReportExecutorMetrics(Supplier<Scheduler> schedulerSupplier, String type) {
+    public void shouldReportExecutorMetrics(Supplier<Scheduler> schedulerSupplier, String type) { //TODO replace with Named.of in JUnit 5.8+
 		Scheduler scheduler = afterTest.autoDispose(schedulerSupplier.get());
 		final int taskCount = 3;
 
@@ -245,7 +247,7 @@ public class SchedulersMetricsTest {
 		});
     }
 
-	@ParameterizedTest
+	@ParameterizedTestWithName
 	@MethodSource("metricsSchedulers")
 	@Timeout(10)
 	public void shouldReportExecutionTimes(Supplier<Scheduler> schedulerSupplier, String type) {


### PR DESCRIPTION
All parameterized tests should include the `{displayName}` placeholder.

Some parameterizedTests with arguments that don't have a great toString
have been changed to explicitly refer to relevant parameters only.

Others have been changed to new meta-annotation
ParameterizedTestWithName, which defines a better default name.

Also, the buildSrc compilation configuration has been fixed to ensure
that the -parameters compiler argument is set for all java test tasks
(this doesn't include JMH and stress tests, but that should be ok for
now).

Fixes #2606.
