### PR TITLE
Bump ByteBuddy to 1.11.16, use TestKit in agent integration test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ ext {
 	archUnitVersion = '0.21.0'
 
 	// For reactor-tools
-	byteBuddyVersion = '1.10.9' //sync with plugin version above //TODO bump to 1.11.16 with breaking changes
+	byteBuddyVersion = '1.11.16' //dependency, but plugin usage is now in a mock build done via TestKit
 	cgLibVersion = '3.3.0'
 
 	// JMH

--- a/reactor-tools/build.gradle
+++ b/reactor-tools/build.gradle
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-plugins {
-    id 'net.bytebuddy.byte-buddy-gradle-plugin' version "$byteBuddyVersion" apply false
-}
+import org.apache.tools.ant.filters.ReplaceTokens
 
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'org.unbroken-dome.test-sets'
@@ -53,6 +51,11 @@ dependencies {
     testImplementation "cglib:cglib:$cgLibVersion"
 
     jarFileTestImplementation "org.assertj:assertj-core:$assertJVersion"
+
+    buildPluginTestImplementation gradleTestKit()
+    buildPluginTestImplementation platform("org.junit:junit-bom:${jUnitPlatformVersion}")
+    buildPluginTestImplementation "org.junit.jupiter:junit-jupiter-api"
+    buildPluginTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }
 
 test {
@@ -157,18 +160,32 @@ javaAgentTest {
 }
 project.tasks.check.dependsOn(javaAgentTest)
 
-// See https://github.com/raphw/byte-buddy/issues/833
-compileBuildPluginTestJava.doLast(
-        new net.bytebuddy.build.gradle.TransformationAction(
-                project,
-                new net.bytebuddy.build.gradle.ByteBuddyExtension(project).tap {
-                    transformation {
-                        plugin = "reactor.tools.agent.ReactorDebugByteBuddyPlugin"
-                    }
-                },
-                compileBuildPluginTestJava
-        )
-)
+project.tasks.buildPluginTest.mustRunAfter(shadowJar)
+project.tasks.buildPluginTest.dependsOn(shadowJar)
+
+task generateMockGradle(type: Copy) {
+    def coreJar = rootProject.findProject("reactor-core").buildDir.toString() + "/libs/reactor-core-" + version + ".jar"
+    def agentJar = buildDir.toString() + "/libs/reactor-tools-" + version + "-original.jar"
+    def mockGradleDir = buildDir.toString() + "/mock-gradle"
+
+    from "$projectDir/src/buildPluginTest/resources/mock-gradle"
+    into "$mockGradleDir"
+    filter(ReplaceTokens, tokens: [
+      CORE: coreJar,
+      AGENT: agentJar,
+      REACTIVE_STREAMS_VERSION: rootProject.ext.reactiveStreamsVersion,
+      JUNIT_BOM_VERSION: rootProject.ext.jUnitPlatformVersion,
+      BYTE_BUDDY_VERSION: rootProject.ext.byteBuddyVersion
+    ])
+}
+
+buildPluginTest {
+    def mockGradleDir = "$buildDir/mock-gradle"
+    println "will run mock gradle build from $mockGradleDir"
+    systemProperty "mock-gradle-dir", mockGradleDir
+}
+
+project.tasks.buildPluginTest.dependsOn(generateMockGradle)
 project.tasks.check.dependsOn(buildPluginTest)
 
 tasks.withType(Test).all {

--- a/reactor-tools/src/buildPluginTest/java/reactor/tools/agent/ApplyingByteBuddyPluginGradleTest.java
+++ b/reactor-tools/src/buildPluginTest/java/reactor/tools/agent/ApplyingByteBuddyPluginGradleTest.java
@@ -43,12 +43,15 @@ class ApplyingByteBuddyPluginGradleTest {
 	}
 
 	@Test
-	void testHelloWorldTask() {
+	void applyingByteBuddyPluginDuringGradleBuild() {
 		BuildResult result = GradleRunner.create()
 			.withProjectDir(testProjectDir)
 			.withDebug(true)
 			.withArguments("test", "--info", "--stacktrace")
 			.build();
+
+		//the test task in reactor-tools/src/buildPluginTest/resources/mock-gradle/src/test/java/demo/SomeClassTest.java
+		//checks that applying the reactor-tool ByteBuddy plugin in Gradle instruments prod code but not test code.
 
 		assertTrue(result.getOutput().contains("test"));
 		final BuildTask task = result.task(":test");

--- a/reactor-tools/src/buildPluginTest/java/reactor/tools/agent/ApplyingByteBuddyPluginGradleTest.java
+++ b/reactor-tools/src/buildPluginTest/java/reactor/tools/agent/ApplyingByteBuddyPluginGradleTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.tools.agent;
+
+import java.io.File;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Simon Baslé
+ */
+class ApplyingByteBuddyPluginGradleTest {
+
+	static File testProjectDir;
+
+	@BeforeEach
+	void setup() {
+		String testProjectPath = System.getProperty("mock-gradle-dir");
+		assertNotNull(testProjectPath, "Cannot find testProjectPath, set or verify -Dmock-gradle-dir");
+		testProjectDir = new File(testProjectPath);
+		assertTrue(testProjectDir.exists() && testProjectDir.isDirectory(), "testProjectDir not created correctly");
+	}
+
+	@Test
+	void testHelloWorldTask() {
+		BuildResult result = GradleRunner.create()
+			.withProjectDir(testProjectDir)
+			.withDebug(true)
+			.withArguments("test", "--info", "--stacktrace")
+			.build();
+
+		assertTrue(result.getOutput().contains("test"));
+		final BuildTask task = result.task(":test");
+		assertNotNull(task);
+		assertEquals(TaskOutcome.SUCCESS, task.getOutcome());
+	}
+}

--- a/reactor-tools/src/buildPluginTest/resources/mock-gradle/build.gradle
+++ b/reactor-tools/src/buildPluginTest/resources/mock-gradle/build.gradle
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+buildscript {
+	repositories {
+		mavenCentral()
+	}
+	dependencies {
+		//the plugin feature only works with the -original jar !!
+		//otherwise implemented Plugin interface is the shaded one
+		classpath files("@AGENT@")
+	}
+}
+
+plugins {
+	id "net.bytebuddy.byte-buddy-gradle-plugin" version "@BYTE_BUDDY_VERSION@"
+	id 'java'
+}
+
+repositories {
+	mavenCentral()
+}
+
+ext {
+	//smoke test to fail the mock gradle if it is wrongly configured with the shaded jar rather than the original
+	if (!"@AGENT@".endsWith("-original.jar")) {
+		throw new GradleException("The build file must be configured with reactor-tools' -original.jar version !!")
+	}
+}
+
+dependencies {
+	implementation "org.reactivestreams:reactive-streams:@REACTIVE_STREAMS_VERSION@"
+	implementation files("@CORE@")
+
+	testImplementation platform("org.junit:junit-bom:@JUNIT_BOM_VERSION@")
+	testImplementation "org.junit.jupiter:junit-jupiter-api"
+	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
+
+	testImplementation "org.assertj:assertj-core:3.20.2"
+}
+
+test {
+	useJUnitPlatform()
+}
+
+byteBuddy {
+	transformation {
+		plugin = reactor.tools.agent.ReactorDebugByteBuddyPlugin.class
+	}
+}

--- a/reactor-tools/src/buildPluginTest/resources/mock-gradle/settings.gradle
+++ b/reactor-tools/src/buildPluginTest/resources/mock-gradle/settings.gradle
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+rootProject.name = 'bytebuddy-and-reactoragent'

--- a/reactor-tools/src/buildPluginTest/resources/mock-gradle/src/main/java/demo/SomeClass.java
+++ b/reactor-tools/src/buildPluginTest/resources/mock-gradle/src/main/java/demo/SomeClass.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package demo;
+
+import reactor.core.publisher.Flux;
+
+public class SomeClass {
+
+	public Flux<Integer> obtainFlux() {
+		return Flux.just(1);
+	}
+
+}


### PR DESCRIPTION
This commit bumps Byte-Buddy to 1.11.16, which makes the ad-hoc groovy
integration testing of the Byte Buddy gradle plugin feature non
functional due to breaking changes.

After much trial-and-error, the best way to fix that integration test
I found was to completely separate the test, as a inlined project in
resources. The entire project can then be copied in the `buildDir` and
executed using Gradle TestKit.

In order to get access to the snapshot of code under test, some token
replacement is used with the `files(@TOKEN@)` type of dependency.

This allowed to resurface the importance of using the `reactor-tools`
`-original.jar` version, as otherwise the ByteBuddy gradle plugin
will refuse to use the reactor Plugin (which implements the shaded
interface).

See https://github.com/raphw/byte-buddy/issues/833 for the original
issue that lead to the previous code.
