### PR TITLE
Tune test performanceOfContinuouslyCancellingGroup

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
@@ -74,7 +74,7 @@ public class FluxGroupByTest extends
 
 		latch.await();
 		assertThat(upstream).as("upstream and downstream consistent").hasValue(downstream.get());
-		assertThat(downstream).as("order of magnitude").hasValueGreaterThan(9_999);
+		assertThat(downstream).as("order of magnitude").hasValueGreaterThan(30_000);
 	}
 
 	@Override


### PR DESCRIPTION
This commit tunes the magnitude configuration in the FluxGroupByTest
performanceOfContinuouslyCancellingGroups test.

Previously it was downsized a bit too low to 10K, but 100K was causing
flakyness. 30K seems to be a good middle ground.

Fixes #2740.
