### PR TITLE
ConcatArray: avoid next subscription if cancelled

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/FluxConcatArrayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxConcatArrayTest.java
@@ -17,6 +17,7 @@
 package reactor.core.publisher;
 
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
@@ -257,6 +258,28 @@ public class FluxConcatArrayTest {
 		)
 		            .expectNext(1, 2, 3, 4)
 		            .verifyErrorMessage("test");
+	}
+
+	@Test
+	void stopSubscribingAdditionalSourcesWhenDownstreamCancelled() {
+		Flux.concat(Mono.fromSupplier(() -> 5), Mono.error(IllegalStateException::new))
+			.next()
+			.as(StepVerifier::create)
+			.expectNext(5)
+			.expectComplete()
+			.verifyThenAssertThat()
+			.hasNotDroppedErrors();
+	}
+
+	@Test
+	void stopSubscribingAdditionalSourcesWhenDownstreamCancelled_delayError() {
+		Flux.concatDelayError(Mono.fromSupplier(() -> 5), Mono.error(IllegalStateException::new))
+			.next()
+			.as(StepVerifier::create)
+			.expectNext(5)
+			.expectComplete()
+			.verifyThenAssertThat()
+			.hasNotDroppedErrors();
 	}
 
 	@Test


### PR DESCRIPTION
This commit prevents FluxConcatArray from unnecessarily subscribing to
the next concatenated `Publisher` if the whole concat has been
cancelled.

Furthermore, it rework the delayError version a bit to better track
cancellation via a dedicated boolean, as `ERROR` field is also used
to track completion.

Fixes #2778.
