### PR TITLE
Fix Module was compiled with an incompatible version of Kotlin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -257,12 +257,20 @@ configure(subprojects) { p ->
 		if (p.plugins.hasPlugin("kotlin")) {
 			println "Applying Kotlin conventions to ${p.name}"
 			compileKotlin {
-				kotlinOptions.jvmTarget = "1.8"
-				kotlinOptions.freeCompilerArgs = ["-Xjsr305=strict"]
+				kotlinOptions {
+					jvmTarget = "1.8"
+					freeCompilerArgs = ["-Xjsr305=strict"]
+					languageVersion = "1.3" //TODO kotlin languageVersion 1.3 is now deprecated
+					apiVersion = "1.3"
+				}
 			}
 			compileTestKotlin {
-				kotlinOptions.jvmTarget = "1.8"
-				kotlinOptions.freeCompilerArgs = ["-Xjsr305=strict"]
+				kotlinOptions {
+					jvmTarget = "1.8"
+					freeCompilerArgs = ["-Xjsr305=strict"]
+					languageVersion = "1.3" //TODO kotlin languageVersion 1.3 is now deprecated
+					apiVersion = "1.3"
+				}
 			}
 		}
 	}


### PR DESCRIPTION
While upgrading to Gradle 7.2, the version of the Kotlin gradle plugin
was also upgraded to 1.5.31 to ensure plugin compatibility.

What was overlooked is that this means an upgrade of the Kotlin language
level, which is undesirable in a patch release.

This is made visible in donwstream projects still relying on Kotlin 1.3
with the following message for instance:

```
Module was compiled with an incompatible version of Kotlin.
The binary version of its metadata is 1.5.1, expected version is 1.1.16.
```

This commit fixes the situation by enforcing Kotlin version 1.3 for both
`apiVersion` and `languageVersion`. It results in metadata at version
1.1.18, but local tests show that it should this time be compatible with
expected version 1.1.16.

Fixes #2793.
