### PR TITLE
Reference Traces callsite suppliers by class.getName()

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Traces.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Traces.java
@@ -52,9 +52,9 @@ final class Traces {
 
 	static {
 		String[] strategyClasses = {
-				Traces.class.getName() + "$StackWalkerCallSiteSupplierFactory",
-				Traces.class.getName() + "$SharedSecretsCallSiteSupplierFactory",
-				Traces.class.getName() + "$ExceptionCallSiteSupplierFactory",
+			StackWalkerCallSiteSupplierFactory.class.getName(),
+			SharedSecretsCallSiteSupplierFactory.class.getName(),
+			ExceptionCallSiteSupplierFactory.class.getName()
 		};
 		// find one available call-site supplier w.r.t. the jdk version to provide
 		// linkage-compatibility between jdk 8 and 9+

--- a/reactor-core/src/main/java/reactor/core/publisher/Traces.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Traces.java
@@ -51,18 +51,17 @@ final class Traces {
 	static Supplier<Supplier<String>> callSiteSupplierFactory;
 
 	static {
-		String[] strategyClasses = {
-			StackWalkerCallSiteSupplierFactory.class.getName(),
-			SharedSecretsCallSiteSupplierFactory.class.getName(),
-			ExceptionCallSiteSupplierFactory.class.getName()
+		Class<?>[] strategyClasses = {
+			StackWalkerCallSiteSupplierFactory.class,
+			SharedSecretsCallSiteSupplierFactory.class,
+			ExceptionCallSiteSupplierFactory.class
 		};
 		// find one available call-site supplier w.r.t. the jdk version to provide
 		// linkage-compatibility between jdk 8 and 9+
 		callSiteSupplierFactory = Stream
 				.of(strategyClasses)
-				.flatMap(className -> {
+				.flatMap(clazz -> {
 					try {
-						Class<?> clazz = Class.forName(className);
 						@SuppressWarnings("unchecked")
 						Supplier<Supplier<String>> function = (Supplier) clazz.getDeclaredConstructor()
 						                                                      .newInstance();

--- a/reactor-core/src/test/java/reactor/core/publisher/TracesTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/TracesTest.java
@@ -23,6 +23,36 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TracesTest {
 
 	@Test
+	void assertCallSiteSupplierPerJavaVersion() {
+		final String version = System.getProperty("java.specification.version");
+		if (version.startsWith("1.")) {
+			if (version.equals("1.8")) {
+				assertThat(Traces.callSiteSupplierFactory.getClass().getSimpleName())
+					.as("callsite supplier on Java " + version)
+					.isEqualTo("SharedSecretsCallSiteSupplierFactory");
+			}
+			else {
+				assertThat(Traces.callSiteSupplierFactory.getClass().getSimpleName())
+					.as("callsite supplier on Java " + version)
+					.isEqualTo("ExceptionCallSiteSupplierFactory");
+			}
+		}
+		else {
+			int javaVersion = Integer.parseInt(version);
+			if (javaVersion >= 9) {
+				assertThat(Traces.callSiteSupplierFactory.getClass().getSimpleName())
+					.as("callsite supplier on Java " + version)
+					.isEqualTo("StackWalkerCallSiteSupplierFactory");
+			}
+			else {
+				assertThat(Traces.callSiteSupplierFactory.getClass().getSimpleName())
+					.as("callsite supplier on Java " + version)
+					.isEqualTo("ExceptionCallSiteSupplierFactory");
+			}
+		}
+	}
+
+	@Test
 	public void extractOperatorLine_reactor() {
 		String stack = "\treactor.core.publisher.Flux.filter(Flux.java:4209)\n" +
 				"\treactor.core.ScannableTest.operatorChainWithDebugMode(ScannableTest.java:542)\n";


### PR DESCRIPTION
This should allow GraalVM to detect the classes and make them available
at runtime.

Fixes #2796.
