### PR TITLE
Fix Mono.flatMapIterable javadoc: no prefetch parameter

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -3145,8 +3145,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 
 	/**
 	 * Transform the item emitted by this {@link Mono} into {@link Iterable}, then forward
-	 * its elements into the returned {@link Flux}. The prefetch argument allows to
-	 * give an arbitrary prefetch size to the inner {@link Iterable}.
+	 * its elements into the returned {@link Flux}.
 	 * The {@link Iterable#iterator()} method will be called at least once and at most twice.
 	 *
 	 * <p>


### PR DESCRIPTION
`Mono.flatMapIterable` does not actually accept a `prefetch` argument.

It appears that this doc was copied from `Flux.flatMapIterable` (which does accept a `prefetch` argument).