### PR TITLE
Use Named.of to describe parameterized tests input

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCacheTimeTest.java
@@ -24,9 +24,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.reactivestreams.Subscription;
 
@@ -34,6 +34,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Schedulers;
+import reactor.test.ParameterizedTestWithName;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.MonoOperatorTest;
 import reactor.test.publisher.TestPublisher;
@@ -43,6 +44,8 @@ import reactor.util.context.ContextView;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 
@@ -937,24 +940,24 @@ public class MonoCacheTimeTest extends MonoOperatorTest<String, String> {
 		assertThat(subCount.get()).isEqualTo(2);
 	}
 
-	@ParameterizedTest(name = "{displayName} [for null case #{index}]")
+	@ParameterizedTestWithName
 	@MethodSource("nullInvocations")
-	public void nullArgumentsToCacheOperatorsAreImmediatelyRejected(ThrowableAssert.ThrowingCallable nullInvocation) { //TODO replace with Named.of in JUnit 5.8+
-		assertThatExceptionOfType(NullPointerException.class).isThrownBy(nullInvocation);
+	void nullArgumentsToCacheOperatorsAreImmediatelyRejected(ThrowingCallable type) {
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(type);
 	}
 
-	private static Stream<ThrowableAssert.ThrowingCallable> nullInvocations() {
+	private static Stream<Arguments> nullInvocations() {
 		return Stream.of(
-			() -> Mono.empty().cache(null),
-			() -> Mono.empty().cache(null, Schedulers.parallel()),
-			() -> Mono.empty().cache(Duration.ZERO, null),
-			() -> Mono.empty().cache(null, e -> Duration.ZERO, () -> Duration.ZERO),
-			() -> Mono.empty().cache(v -> Duration.ZERO, null, () -> Duration.ZERO),
-			() -> Mono.empty().cache(v -> Duration.ZERO, e -> Duration.ZERO, null),
-			() -> Mono.empty().cache(null, e -> Duration.ZERO, () -> Duration.ZERO, Schedulers.parallel()),
-			() -> Mono.empty().cache(v -> Duration.ZERO, null, () -> Duration.ZERO, Schedulers.parallel()),
-			() -> Mono.empty().cache(v -> Duration.ZERO, e -> Duration.ZERO, null, Schedulers.parallel()),
-			() -> Mono.empty().cache(v -> Duration.ZERO, e -> Duration.ZERO, () -> Duration.ZERO, null)
+			arguments(named("cache(null)", (ThrowingCallable) () -> Mono.empty().cache(null))),
+			arguments(named("cache(null,parallel)", (ThrowingCallable) () -> Mono.empty().cache(null, Schedulers.parallel()))),
+			arguments(named("cache(ZERO,null)", (ThrowingCallable) () -> Mono.empty().cache(Duration.ZERO, null))),
+			arguments(named("cache(null,e->ZERO,()->ZERO)", (ThrowingCallable) () -> Mono.empty().cache(null, e -> Duration.ZERO, () -> Duration.ZERO))),
+			arguments(named("cache(v->ZERO,null,()->ZERO)", (ThrowingCallable) () -> Mono.empty().cache(v -> Duration.ZERO, null, () -> Duration.ZERO))),
+			arguments(named("cache(v->ZERO,e->ZERO,null)", (ThrowingCallable) () -> Mono.empty().cache(v -> Duration.ZERO, e -> Duration.ZERO, null))),
+			arguments(named("cache(null,e->ZERO,()->ZERO,parallel)", (ThrowingCallable) () -> Mono.empty().cache(null, e -> Duration.ZERO, () -> Duration.ZERO, Schedulers.parallel()))),
+			arguments(named("cache(v->ZERO,null,()->ZERO,parallel)", (ThrowingCallable) () -> Mono.empty().cache(v -> Duration.ZERO, null, () -> Duration.ZERO, Schedulers.parallel()))),
+			arguments(named("cache(v->ZERO,e->ZERO,null,parallel)", (ThrowingCallable) () -> Mono.empty().cache(v -> Duration.ZERO, e -> Duration.ZERO, null, Schedulers.parallel()))),
+			arguments(named("cache(v->ZERO,e->ZERO,()->ZERO,null)", (ThrowingCallable) () ->  Mono.empty().cache(v -> Duration.ZERO, e -> Duration.ZERO, () -> Duration.ZERO, null)))
 		);
 	}
 }

--- a/reactor-core/src/test/java/reactor/util/concurrent/QueuesTest.java
+++ b/reactor-core/src/test/java/reactor/util/concurrent/QueuesTest.java
@@ -29,13 +29,15 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import reactor.core.publisher.Hooks;
+import reactor.test.ParameterizedTestWithName;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class QueuesTest {
 
@@ -157,12 +159,12 @@ public class QueuesTest {
 		assertThat(emptyQueue.toArray(new Integer[0])).as("toArray(empty)").isEmpty();
 	}
 
-	@ParameterizedTest(name = "{displayName} [{index}] {0}")
+	@ParameterizedTestWithName
 	@MethodSource("queues")
-	public void testWrapping(String name, Supplier<Queue<Object>> queueSupplier) { //TODO replace with Named.of in JUnit 5.8+
-		assertThat(queueSupplier.get()).as("no wrapper").hasSize(0);
+	void testWrapping(Supplier<Queue<Object>> queue) {
+		assertThat(queue.get()).as("no wrapper").hasSize(0);
 
-		Hooks.addQueueWrapper("test", queue -> {
+		Hooks.addQueueWrapper("test", q -> {
 			return new AbstractQueue<Object>() {
 
 				@Override
@@ -192,22 +194,22 @@ public class QueuesTest {
 			};
 		});
 
-		assertThat(queueSupplier.get()).as("with wrapper").hasSize(42);
+		assertThat(queue.get()).as("with wrapper").hasSize(42);
 
 		Hooks.removeQueueWrapper("test");
 
-		assertThat(queueSupplier.get()).as("wrapper removed").hasSize(0);
+		assertThat(queue.get()).as("wrapper removed").hasSize(0);
 	}
 
 	private static Stream<Arguments> queues() {
 		return Stream.of(
-				Arguments.of("one", Queues.one()),
-				Arguments.of("small", Queues.small()),
-				Arguments.of("xs", Queues.xs()),
-				Arguments.of("unbounded", Queues.unbounded()),
-				Arguments.of("unbounded(42)", Queues.unbounded(42)),
-				Arguments.of("unboundedMultiproducer", Queues.unboundedMultiproducer()),
-				Arguments.of("get(9000)", Queues.get(9000))
+			arguments(named("one", Queues.one())),
+			arguments(named("small", Queues.small())),
+			arguments(named("xs", Queues.xs())),
+			arguments(named("unbounded", Queues.unbounded())),
+			arguments(named("unbounded(42)", Queues.unbounded(42))),
+			arguments(named("unboundedMultiproducer", Queues.unboundedMultiproducer())),
+			arguments(named("get(9000)", Queues.get(9000)))
 		);
 	}
 


### PR DESCRIPTION
This commit replaces various patterns introduced to pass arguments to
parameterized tests with a meaningful description of some sort (eg. a
`String type` extra parameter, or Object[][] arrangements).

The Arguments and Named classes can be leveraged to provide a meaningful
description to a parameter other than its toString, while using the
`{argumentsWithNames}` placeholder in the test description itself.

Fixes #2788.
