### PR TITLE
Use `@NonNull` annotation, not JetBrain's NotNull

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
@@ -28,11 +28,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
-import org.jetbrains.annotations.NotNull;
-
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
+import reactor.util.annotation.NonNull;
 import reactor.util.annotation.Nullable;
 
 /**
@@ -131,7 +130,7 @@ final class DelegateServiceScheduler implements Scheduler, Scannable {
 			exec.shutdown();
 		}
 
-		@NotNull
+		@NonNull
 		@Override
 		public List<Runnable> shutdownNow() {
 			return exec.shutdownNow();
@@ -148,95 +147,95 @@ final class DelegateServiceScheduler implements Scheduler, Scannable {
 		}
 
 		@Override
-		public boolean awaitTermination(long timeout, @NotNull TimeUnit unit)
+		public boolean awaitTermination(long timeout, @NonNull TimeUnit unit)
 				throws InterruptedException {
 			return exec.awaitTermination(timeout, unit);
 		}
 
-		@NotNull
+		@NonNull
 		@Override
-		public <T> Future<T> submit(@NotNull Callable<T> task) {
+		public <T> Future<T> submit(@NonNull Callable<T> task) {
 			return exec.submit(task);
 		}
 
-		@NotNull
+		@NonNull
 		@Override
-		public <T> Future<T> submit(@NotNull Runnable task, T result) {
+		public <T> Future<T> submit(@NonNull Runnable task, T result) {
 			return exec.submit(task, result);
 		}
 
-		@NotNull
+		@NonNull
 		@Override
-		public Future<?> submit(@NotNull Runnable task) {
+		public Future<?> submit(@NonNull Runnable task) {
 			return exec.submit(task);
 		}
 
-		@NotNull
+		@NonNull
 		@Override
-		public <T> List<Future<T>> invokeAll(@NotNull Collection<? extends Callable<T>> tasks)
+		public <T> List<Future<T>> invokeAll(@NonNull Collection<? extends Callable<T>> tasks)
 				throws InterruptedException {
 			return exec.invokeAll(tasks);
 		}
 
-		@NotNull
+		@NonNull
 		@Override
-		public <T> List<Future<T>> invokeAll(@NotNull Collection<? extends Callable<T>> tasks,
+		public <T> List<Future<T>> invokeAll(@NonNull Collection<? extends Callable<T>> tasks,
 				long timeout,
-				@NotNull TimeUnit unit) throws InterruptedException {
+				@NonNull TimeUnit unit) throws InterruptedException {
 			return exec.invokeAll(tasks, timeout, unit);
 		}
 
-		@NotNull
+		@NonNull
 		@Override
-		public <T> T invokeAny(@NotNull Collection<? extends Callable<T>> tasks)
+		public <T> T invokeAny(@NonNull Collection<? extends Callable<T>> tasks)
 				throws InterruptedException, ExecutionException {
 			return exec.invokeAny(tasks);
 		}
 
 		@Override
-		public <T> T invokeAny(@NotNull Collection<? extends Callable<T>> tasks,
+		public <T> T invokeAny(@NonNull Collection<? extends Callable<T>> tasks,
 				long timeout,
-				@NotNull TimeUnit unit)
+				@NonNull TimeUnit unit)
 				throws InterruptedException, ExecutionException, TimeoutException {
 			return exec.invokeAny(tasks, timeout, unit);
 		}
 
 		@Override
-		public void execute(@NotNull Runnable command) {
+		public void execute(@NonNull Runnable command) {
 			exec.execute(command);
 		}
 
-		@NotNull
+		@NonNull
 		@Override
-		public ScheduledFuture<?> schedule(@NotNull Runnable command,
+		public ScheduledFuture<?> schedule(@NonNull Runnable command,
 				long delay,
-				@NotNull TimeUnit unit) {
+				@NonNull TimeUnit unit) {
 			throw Exceptions.failWithRejectedNotTimeCapable();
 		}
 
-		@NotNull
+		@NonNull
 		@Override
-		public <V> ScheduledFuture<V> schedule(@NotNull Callable<V> callable,
+		public <V> ScheduledFuture<V> schedule(@NonNull Callable<V> callable,
 				long delay,
-				@NotNull TimeUnit unit) {
+				@NonNull TimeUnit unit) {
 			throw Exceptions.failWithRejectedNotTimeCapable();
 		}
 
-		@NotNull
+		@NonNull
 		@Override
-		public ScheduledFuture<?> scheduleAtFixedRate(@NotNull Runnable command,
+		public ScheduledFuture<?> scheduleAtFixedRate(@NonNull Runnable command,
 				long initialDelay,
 				long period,
-				@NotNull TimeUnit unit) {
+				@NonNull TimeUnit unit) {
 			throw Exceptions.failWithRejectedNotTimeCapable();
 		}
 
-		@NotNull
+		@NonNull
 		@Override
-		public ScheduledFuture<?> scheduleWithFixedDelay(@NotNull Runnable command,
+		public ScheduledFuture<?> scheduleWithFixedDelay(@NonNull Runnable command,
 				long initialDelay,
 				long delay,
-				@NotNull TimeUnit unit) {
+				@NonNull TimeUnit unit) {
 			throw Exceptions.failWithRejectedNotTimeCapable();
 		}
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/ReactorThreadFactory.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ReactorThreadFactory.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
-import org.jetbrains.annotations.NotNull;
+import reactor.util.annotation.NonNull;
 import reactor.util.annotation.Nullable;
 
 /**
@@ -55,7 +55,7 @@ class ReactorThreadFactory implements ThreadFactory,
 	}
 
 	@Override
-	public final Thread newThread(@NotNull Runnable runnable) {
+	public final Thread newThread(@NonNull Runnable runnable) {
 		String newThreadName = name + "-" + counterReference.incrementAndGet();
 		Thread t = rejectBlocking
 				? new NonBlockingThread(runnable, newThreadName)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxIterableTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
@@ -43,6 +42,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.MockUtils;
 import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.util.annotation.NonNull;
 import reactor.util.context.Context;
 import reactor.util.function.Tuples;
 
@@ -266,7 +266,7 @@ public class FluxIterableTest {
 				this.seed = seed;
 			}
 
-			@NotNull
+			@NonNull
 			@Override
 			public Iterator<Integer> iterator() {
 				return new Iterator<Integer>() {

--- a/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTest.java
@@ -26,10 +26,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
+import reactor.util.annotation.NonNull;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -141,7 +141,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerTest {
 				shutdown = true;
 			}
 
-			@NotNull
+			@NonNull
 			@Override
 			public List<Runnable> shutdownNow() {
 				return Collections.emptyList();
@@ -158,13 +158,13 @@ public class ExecutorSchedulerTest extends AbstractSchedulerTest {
 			}
 
 			@Override
-			public boolean awaitTermination(long timeout, @NotNull TimeUnit unit)
+			public boolean awaitTermination(long timeout, @NonNull TimeUnit unit)
 					throws InterruptedException {
 				return false;
 			}
 
 			@Override
-			public void execute(@NotNull Runnable command) {
+			public void execute(@NonNull Runnable command) {
 				if (count.incrementAndGet() % 2 == 0)
 					throw boom;
 			}
@@ -199,7 +199,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerTest {
 				shutdown = true;
 			}
 
-			@NotNull
+			@NonNull
 			@Override
 			public List<Runnable> shutdownNow() {
 				return Collections.emptyList();
@@ -216,13 +216,13 @@ public class ExecutorSchedulerTest extends AbstractSchedulerTest {
 			}
 
 			@Override
-			public boolean awaitTermination(long timeout, @NotNull TimeUnit unit)
+			public boolean awaitTermination(long timeout, @NonNull TimeUnit unit)
 					throws InterruptedException {
 				return false;
 			}
 
 			@Override
-			public void execute(@NotNull Runnable command) {
+			public void execute(@NonNull Runnable command) {
 				if (shutdown) throw boom;
 				shutdown = true;
 			}
@@ -248,7 +248,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerTest {
 	static final class ScannableExecutor implements Executor, Scannable {
 
 		@Override
-		public void execute(@NotNull Runnable command) {
+		public void execute(@NonNull Runnable command) {
 			command.run();
 		}
 
@@ -268,7 +268,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerTest {
 
 	static final class PlainExecutor implements Executor {
 		@Override
-		public void execute(@NotNull Runnable command) {
+		public void execute(@NonNull Runnable command) {
 			command.run();
 		}
 


### PR DESCRIPTION
This commit fixes accidental usage of JetBrain's `@NotNull` annotation,
which is likely only possible because we still have Kotlin plugin (and
this annotation has class retention only).

Fixes #2806.
