### PR TITLE
Refguide debugging.adoc uses traceback terminology consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ However it should work fine with Android SDK 21 (Android 5.0) and above. See the
 in the reference guide.
 
 ## Trouble importing the project in IDE?
-Since the introduction of Java 9 stubs in order to optimize the performance of debug backtraces, one can sometimes
+Since the introduction of Java 9 stubs in order to optimize the performance of debug tracebacks, one can sometimes
 encounter cryptic messages from the build system when importing or re-importing the project in their IDE.
 
 For example: 

--- a/docs/asciidoc/debugging.adoc
+++ b/docs/asciidoc/debugging.adoc
@@ -398,7 +398,7 @@ The description could be a static identifier or user-readable description or a w
 correlation ID (for instance, coming from a header in the case of an HTTP request).
 
 NOTE: When both global debugging and local `checkpoint()` are enabled, checkpointed
-tracebacks  are appended as suppressed error output after the observing operator
+tracebacks are appended as suppressed error output after the observing operator
 graph and following the same declarative order.
 
 [[reactor-tools-debug]]

--- a/docs/asciidoc/debugging.adoc
+++ b/docs/asciidoc/debugging.adoc
@@ -388,7 +388,7 @@ following example:
 Assembly trace from producer [reactor.core.publisher.ParallelSource], described as [descriptionCorrelation1234] : <1>
 	reactor.core.publisher.ParallelFlux.checkpoint(ParallelFlux.java:215)
 	reactor.core.publisher.FluxOnAssemblyTest.parallelFluxCheckpointDescriptionAndForceStack(FluxOnAssemblyTest.java:225)
-Error has been observed by the following operator(s):
+Error has been observed at the following site(s):
 	|_	ParallelFlux.checkpoint ⇢ reactor.core.publisher.FluxOnAssemblyTest.parallelFluxCheckpointDescriptionAndForceStack(FluxOnAssemblyTest.java:225)
 ----
 <1> `descriptionCorrelation1234` is the description provided in the `checkpoint`.

--- a/docs/asciidoc/debugging.adoc
+++ b/docs/asciidoc/debugging.adoc
@@ -135,7 +135,8 @@ start of your application.
 Later on, if an exception occurs, the failing operator is able to refer to that capture
 and to rework the stack trace, appending additional information.
 
-TIP: We call this captured assembly information a *traceback*.
+TIP: We call this captured assembly information (and additional information added to the
+exceptions by Reactor in general) a *traceback*.
 
 In the next section, we see how the stack trace differs and how to interpret
 that new information.
@@ -218,7 +219,7 @@ that line, we find out he meant to use the less restrictive `take(1)` instead.
 
 We have solved our problem.
 
-Now consider the following line in the stack trace:
+Now consider the following section in the stack trace:
 
 ====
 [source]
@@ -227,7 +228,7 @@ Error has been observed at the following site(s):
 ----
 ====
 
-That second part of the debug stack trace was not necessarily interesting in
+That second part of the traceback was not necessarily interesting in
 this particular example, because the error was actually happening in the last
 operator in the chain (the one closest to `subscribe`). Considering another
 example might make it more clear:
@@ -397,7 +398,7 @@ The description could be a static identifier or user-readable description or a w
 correlation ID (for instance, coming from a header in the case of an HTTP request).
 
 NOTE: When both global debugging and local `checkpoint()` are enabled, checkpointed
-snapshot stacks are appended as suppressed error output after the observing operator
+tracebacks  are appended as suppressed error output after the observing operator
 graph and following the same declarative order.
 
 [[reactor-tools-debug]]

--- a/docs/asciidoc/debugging.adoc
+++ b/docs/asciidoc/debugging.adoc
@@ -363,19 +363,6 @@ to the assembly traceback. This way, the stack trace is omitted and you rely on 
 description to identify the assembly site. `checkpoint(String)` imposes less processing
 cost than a regular `checkpoint`.
 
-//snippets are in FluxOnAssemblyTest
-`checkpoint(String)` includes "`light`" in its output (which can be handy when
-searching), as shown in the following example:
-
-====
-[source]
-----
-...
-	Suppressed: The stacktrace has been enhanced by Reactor, refer to additional information below:
-Assembly site of producer [reactor.core.publisher.ParallelSource] is identified by light checkpoint [light checkpoint identifier].
-----
-====
-
 Last but not least, if you want to add a more generic description to the checkpoint but
 still rely on the stack trace mechanism to identify the assembly site, you can force that
 behavior by using the `checkpoint("description", true)` version. We are now back to the
@@ -397,9 +384,10 @@ Error has been observed at the following site(s):
 The description could be a static identifier or user-readable description or a wider
 correlation ID (for instance, coming from a header in the case of an HTTP request).
 
-NOTE: When both global debugging and local `checkpoint()` are enabled, checkpointed
-tracebacks are appended as suppressed error output after the observing operator
-graph and following the same declarative order.
+NOTE: When global debugging is enabled in conjunction with checkpoints, the global debugging
+traceback style is applied and checkpoints are only reflected in the
+"Error has been observed..." section.
+As a result, the name of heavy checkpoints is not visible in this case.
 
 [[reactor-tools-debug]]
 == Production-ready Global Debugging

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -3339,7 +3339,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * creation.
 	 * <p>
 	 * It should be placed towards the end of the reactive chain, as errors
-	 * triggered downstream of it cannot be observed and augmented with the backtrace.
+	 * triggered downstream of it cannot be observed and augmented with the traceback.
 	 * <p>
 	 * The traceback is attached to the error as a {@link Throwable#getSuppressed() suppressed exception}.
 	 * As such, if the error is a {@link Exceptions#isMultiple(Throwable) composite one}, the traceback

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
@@ -691,14 +691,14 @@ class FluxOnAssemblyTest {
 
 		String debugStack = sw.toString();
 
-		Iterator<String> lines = seekToBacktrace(debugStack);
+		Iterator<String> lines = seekToTraceback(debugStack);
 
 		assertThat(lines.next())
-				.as("first backtrace line")
+				.as("first traceback line")
 				.contains("Flux.single ⇢ at reactor.core.publisher.FluxOnAssemblyTest.stackAndLightCheckpoint(FluxOnAssemblyTest.java:");
 
 		assertThat(lines.next())
-				.as("second backtrace line")
+				.as("second traceback line")
 				.endsWith("checkpoint ⇢ single");
 	}
 
@@ -719,14 +719,14 @@ class FluxOnAssemblyTest {
 
 		String debugStack = sw.toString();
 
-		Iterator<String> lines = seekToBacktrace(debugStack);
+		Iterator<String> lines = seekToTraceback(debugStack);
 
 		assertThat(lines.next())
-				.as("first backtrace line")
+				.as("first traceback line")
 				.endsWith("checkpoint ⇢ after1");
 
 		assertThat(lines.next())
-				.as("second backtrace line")
+				.as("second traceback line")
 				.endsWith("checkpoint ⇢ after2");
 	}
 
@@ -776,7 +776,7 @@ class FluxOnAssemblyTest {
 		objectOutputStream.writeObject(sharedError);
 	}
 
-	private Iterator<String> seekToBacktrace(String debugStack) {
+	private Iterator<String> seekToTraceback(String debugStack) {
 		Iterator<String> lines = seekToSupressedAssembly(debugStack);
 		while (lines.hasNext()) {
 			String line = lines.next();


### PR DESCRIPTION
Notably:

﻿- Consistently use traceback terminology, not backtrace
- show that original stack trace is now moved at the end
- use traceback term a bit more to clarify what we mean by that
- Use 'at the following site(s)' phrasing
- polish refguide section a bit more and align with work already done in 3.4.x

Forward-merge will need to be carefully done to accommodate similar changes
done in 3.4.x, and notably around `Original Stack Trace` wording and the multiple
roots representation.