### PR TITLE
Improve traceback rendering of checkpoints

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableFluxOnAssembly.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableFluxOnAssembly.java
@@ -69,7 +69,7 @@ final class ConnectableFluxOnAssembly<T> extends InternalConnectableFluxOperator
 	public Object scanUnsafe(Attr key) {
 		if (key == Attr.PREFETCH) return getPrefetch();
 		if (key == Attr.PARENT) return source;
-		if (key == Attr.ACTUAL_METADATA) return !stacktrace.checkpointed;
+		if (key == Attr.ACTUAL_METADATA) return !stacktrace.isCheckpoint;
 		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
 
 		return null;

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -57,7 +57,8 @@ import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
-import reactor.core.publisher.FluxOnAssembly.AssemblyLightSnapshot;
+import reactor.core.publisher.FluxOnAssembly.CheckpointHeavySnapshot;
+import reactor.core.publisher.FluxOnAssembly.CheckpointLightSnapshot;
 import reactor.core.publisher.FluxOnAssembly.AssemblySnapshot;
 import reactor.core.publisher.FluxSink.OverflowStrategy;
 import reactor.core.scheduler.Scheduler;
@@ -3410,10 +3411,10 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	public final Flux<T> checkpoint(@Nullable String description, boolean forceStackTrace) {
 		final AssemblySnapshot stacktrace;
 		if (!forceStackTrace) {
-			stacktrace = new AssemblyLightSnapshot(description);
+			stacktrace = new CheckpointLightSnapshot(description);
 		}
 		else {
-			stacktrace = new AssemblySnapshot(description, Traces.callSiteSupplierFactory.get());
+			stacktrace = new CheckpointHeavySnapshot(description, Traces.callSiteSupplierFactory.get());
 		}
 
 		return new FluxOnAssembly<>(this, stacktrace);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCallableOnAssembly.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCallableOnAssembly.java
@@ -58,7 +58,7 @@ final class FluxCallableOnAssembly<T> extends InternalFluxOperator<T, T>
 
 	@Override
 	public Object scanUnsafe(Attr key) {
-		if (key == Attr.ACTUAL_METADATA) return !stacktrace.checkpointed;
+		if (key == Attr.ACTUAL_METADATA) return !stacktrace.isCheckpoint;
 		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
 
 		return super.scanUnsafe(key);

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -52,7 +52,8 @@ import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
-import reactor.core.publisher.FluxOnAssembly.AssemblyLightSnapshot;
+import reactor.core.publisher.FluxOnAssembly.CheckpointHeavySnapshot;
+import reactor.core.publisher.FluxOnAssembly.CheckpointLightSnapshot;
 import reactor.core.publisher.FluxOnAssembly.AssemblySnapshot;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Scheduler.Worker;
@@ -2235,10 +2236,10 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	public final Mono<T> checkpoint(@Nullable String description, boolean forceStackTrace) {
 		final AssemblySnapshot stacktrace;
 		if (!forceStackTrace) {
-			stacktrace = new AssemblyLightSnapshot(description);
+			stacktrace = new CheckpointLightSnapshot(description);
 		}
 		else {
-			stacktrace = new AssemblySnapshot(description, Traces.callSiteSupplierFactory.get());
+			stacktrace = new CheckpointHeavySnapshot(description, Traces.callSiteSupplierFactory.get());
 		}
 
 		return new MonoOnAssembly<>(this, stacktrace);

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCallableOnAssembly.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCallableOnAssembly.java
@@ -93,7 +93,7 @@ final class MonoCallableOnAssembly<T> extends InternalMonoOperator<T, T>
 
 	@Override
 	public Object scanUnsafe(Attr key) {
-		if (key == Attr.ACTUAL_METADATA) return !stacktrace.checkpointed;
+		if (key == Attr.ACTUAL_METADATA) return !stacktrace.isCheckpoint;
 		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
 
 		return super.scanUnsafe(key);

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoOnAssembly.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoOnAssembly.java
@@ -62,7 +62,7 @@ final class MonoOnAssembly<T> extends InternalMonoOperator<T, T> implements Fuse
 
 	@Override
 	public Object scanUnsafe(Attr key) {
-		if (key == Attr.ACTUAL_METADATA) return !stacktrace.checkpointed;
+		if (key == Attr.ACTUAL_METADATA) return !stacktrace.isCheckpoint;
 		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
 
 		return super.scanUnsafe(key);

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -42,7 +42,8 @@ import reactor.core.Disposables;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.core.publisher.FluxConcatMap.ErrorMode;
-import reactor.core.publisher.FluxOnAssembly.AssemblyLightSnapshot;
+import reactor.core.publisher.FluxOnAssembly.CheckpointHeavySnapshot;
+import reactor.core.publisher.FluxOnAssembly.CheckpointLightSnapshot;
 import reactor.core.publisher.FluxOnAssembly.AssemblySnapshot;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -175,7 +176,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 * @return the assembly tracing {@link ParallelFlux}
 	 */
 	public final ParallelFlux<T> checkpoint() {
-		AssemblySnapshot stacktrace = new AssemblySnapshot(null, Traces.callSiteSupplierFactory.get());
+		AssemblySnapshot stacktrace = new CheckpointHeavySnapshot(null, Traces.callSiteSupplierFactory.get());
 		return new ParallelFluxOnAssembly<>(this, stacktrace);
 	}
 
@@ -201,7 +202,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 * @return the assembly marked {@link ParallelFlux}
 	 */
 	public final ParallelFlux<T> checkpoint(String description) {
-		return new ParallelFluxOnAssembly<>(this, new AssemblyLightSnapshot(description));
+		return new ParallelFluxOnAssembly<>(this, new CheckpointLightSnapshot(description));
 	}
 
 	/**
@@ -238,10 +239,10 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	public final ParallelFlux<T> checkpoint(String description, boolean forceStackTrace) {
 		final AssemblySnapshot stacktrace;
 		if (!forceStackTrace) {
-			stacktrace = new AssemblyLightSnapshot(description);
+			stacktrace = new CheckpointLightSnapshot(description);
 		}
 		else {
-			stacktrace = new AssemblySnapshot(description, Traces.callSiteSupplierFactory.get());
+			stacktrace = new CheckpointHeavySnapshot(description, Traces.callSiteSupplierFactory.get());
 		}
 
 		return new ParallelFluxOnAssembly<>(this, stacktrace);

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxOnAssembly.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxOnAssembly.java
@@ -20,7 +20,6 @@ package reactor.core.publisher;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
-import reactor.core.publisher.FluxOnAssembly.AssemblyLightSnapshot;
 import reactor.core.publisher.FluxOnAssembly.AssemblySnapshot;
 import reactor.util.annotation.Nullable;
 
@@ -96,7 +95,7 @@ final class ParallelFluxOnAssembly<T> extends ParallelFlux<T>
 	public Object scanUnsafe(Attr key) {
 		if (key == Attr.PARENT) return source;
 		if (key == Attr.PREFETCH) return getPrefetch();
-		if (key == Attr.ACTUAL_METADATA) return !stacktrace.checkpointed;
+		if (key == Attr.ACTUAL_METADATA) return !stacktrace.isCheckpoint;
 		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
 
 		return null;


### PR DESCRIPTION
This commit improves the rendering of checkpoints in tracebacks.
Notably, it harmonizes all three variants:
 - `checkpoint()` is rendered as "checkpoint() -> at ..."
 - `checkpoint(String)` is rendered as "checkpoint -> foo"
 - `checkpoint(String, true)` is rendered as "checkpoint(foo) -> at ..."

Additionally, this commit ensures that the representation is similar for
Flux, Mono and ParallelFlux. It adds tests that validate both with and
without `onOperatorDebug()`.

Finally, this commit removes the "checkpoint" nature of tracebacks that
are added by the reactor-tool agent (via `MethodReturnSnapshot`).

Fixes #2819.
