### PR TITLE
Add logging convenience methods, polish a few messages

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
@@ -282,7 +282,7 @@ final class FluxMetrics<T> extends InternalFluxOperator<T, T> {
 			}
 		}
 		else {
-			log.warn("Attempting to activate metrics but the upstream is not Scannable. " + "You might want to use `name()` (and optionally `tags()`) right before `metrics()`");
+			log.warn("Attempting to activate metrics but the upstream is not Scannable. You might want to use `name()` (and optionally `tags()`) right before `metrics()`");
 			return REACTOR_DEFAULT_NAME;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
@@ -91,7 +91,9 @@ final class MonoCacheInvalidateWhen<T> extends InternalMonoOperator<T, T> {
 				this.invalidateHandler.accept(value);
 			}
 			catch (Throwable invalidateHandlerError) {
-				LOGGER.warn("InvalidateHandler failed on invalidated value " + value, invalidateHandlerError);
+				LOGGER.warnOrDebug(
+					isVerbose -> isVerbose ? "Failed to apply invalidate handler on value " + value : "Failed to apply invalidate handler",
+					invalidateHandlerError);
 			}
 		}
 	}
@@ -371,7 +373,7 @@ final class MonoCacheInvalidateWhen<T> extends InternalMonoOperator<T, T> {
 
 		@Override
 		public void onError(Throwable t) {
-			LOGGER.warn("Invalidation triggered by onError(" + t + ")");
+			LOGGER.debug("Invalidation triggered by onError(" + t + ")");
 			main.invalidate();
 		}
 

--- a/reactor-core/src/main/java/reactor/util/Logger.java
+++ b/reactor-core/src/main/java/reactor/util/Logger.java
@@ -16,10 +16,29 @@
 
 package reactor.util;
 
+import java.util.function.Supplier;
+
 /**
  * Logger interface designed for internal Reactor usage.
  */
 public interface Logger {
+
+	/**
+	 * A kind of {@link java.util.function.Predicate} and {@link Supplier} mix, provides two
+	 * variants of a message {@link String} depending on the level of detail desired.
+	 */
+	@FunctionalInterface
+	interface ChoiceOfMessageSupplier {
+
+		/**
+		 * Provide two possible versions of a message {@link String}, depending on the
+		 * level of detail desired.
+		 *
+		 * @param isVerbose {@code true} for higher level of detail, {@code false} for lower level of detail
+		 * @return the message {@link String} according to the passed level of detail
+		 */
+		String get(boolean isVerbose);
+	}
 
 	/**
 	 * Return the name of this <code>Logger</code> instance.
@@ -142,6 +161,50 @@ public interface Logger {
 	void info(String msg, Throwable t);
 
 	/**
+	 * Convenience method to log a message that is different according to the log level.
+	 * In priority, DEBUG level is used if {@link #isDebugEnabled()}.
+	 * Otherwise, INFO level is used (unless {@link #isInfoEnabled()} is false).
+	 * <p>
+	 * This can be used to log different level of details according to the active
+	 * log level.
+	 *
+	 * @param messageSupplier the {@link ChoiceOfMessageSupplier} invoked in priority
+	 * with {@code true} for the DEBUG level message, or {@code false} for INFO level
+	 * @see #info(String)
+	 */
+	default void infoOrDebug(ChoiceOfMessageSupplier messageSupplier) {
+		if (isDebugEnabled()) {
+			debug(messageSupplier.get(true));
+		}
+		else if (isInfoEnabled()) {
+			info(messageSupplier.get(false));
+		}
+	}
+
+	/**
+	 * Convenience method to log an exception (throwable), with an accompanying
+	 * message that is different according to the log level.
+	 * In priority, DEBUG level is used if {@link #isDebugEnabled()}.
+	 * Otherwise, INFO level is used (unless {@link #isInfoEnabled()} is false).
+	 * <p>
+	 * This can be used to log different level of details according to the active
+	 * log level.
+	 *
+	 * @param messageSupplier the {@link ChoiceOfMessageSupplier} invoked in priority
+	 * with {@code true} for the DEBUG level message, or {@code false} for INFO level
+	 * @param cause the {@link Throwable} the original exception to be logged
+	 * @see #info(String, Throwable)
+	 */
+	default void infoOrDebug(ChoiceOfMessageSupplier messageSupplier, Throwable cause) {
+		if (isDebugEnabled()) {
+			debug(messageSupplier.get(true), cause);
+		}
+		else if (isInfoEnabled()) {
+			info(messageSupplier.get(false), cause);
+		}
+	}
+
+	/**
 	 * Is the logger instance enabled for the WARN level?
 	 *
 	 * @return True if this Logger is enabled for the WARN level,
@@ -180,6 +243,50 @@ public interface Logger {
 	void warn(String msg, Throwable t);
 
 	/**
+	 * Convenience method to log a message that is different according to the log level.
+	 * In priority, DEBUG level is used if {@link #isDebugEnabled()}.
+	 * Otherwise, WARN level is used (unless {@link #isWarnEnabled()} is false).
+	 * <p>
+	 * This can be used to log different level of details according to the active
+	 * log level.
+	 *
+	 * @param messageSupplier the {@link ChoiceOfMessageSupplier} invoked in priority
+	 * with {@code true} for the DEBUG level message, or {@code false} for WARN level
+	 * @see #warn(String)
+	 */
+	default void warnOrDebug(ChoiceOfMessageSupplier messageSupplier) {
+		if (isDebugEnabled()) {
+			debug(messageSupplier.get(true));
+		}
+		else if (isWarnEnabled()) {
+			warn(messageSupplier.get(false));
+		}
+	}
+
+	/**
+	 * Convenience method to log an exception (throwable), with an accompanying
+	 * message that is different according to the log level.
+	 * In priority, DEBUG level is used if {@link #isDebugEnabled()}.
+	 * Otherwise, WARN level is used (unless {@link #isWarnEnabled()} is false).
+	 * <p>
+	 * This can be used to log different level of details according to the active
+	 * log level.
+	 *
+	 * @param messageSupplier the {@link ChoiceOfMessageSupplier} invoked in priority
+	 * with {@code true} for the DEBUG level message, or {@code false} for WARN level
+	 * @param cause the {@link Throwable} the original exception to be logged
+	 * @see #warn(String, Throwable)
+	 */
+	default void warnOrDebug(ChoiceOfMessageSupplier messageSupplier, Throwable cause) {
+		if (isDebugEnabled()) {
+			debug(messageSupplier.get(true), cause);
+		}
+		else if (isWarnEnabled()) {
+			warn(messageSupplier.get(false), cause);
+		}
+	}
+
+	/**
 	 * Is the logger instance enabled for the ERROR level?
 	 *
 	 * @return True if this Logger is enabled for the ERROR level,
@@ -216,5 +323,49 @@ public interface Logger {
 	 * @param t   the exception (throwable) to log
 	 */
 	void error(String msg, Throwable t);
+
+	/**
+	 * Convenience method to log a message that is different according to the log level.
+	 * In priority, DEBUG level is used if {@link #isDebugEnabled()}.
+	 * Otherwise, ERROR level is used (unless {@link #isErrorEnabled()} is false).
+	 * <p>
+	 * This can be used to log different level of details according to the active
+	 * log level.
+	 *
+	 * @param messageSupplier the {@link ChoiceOfMessageSupplier} invoked in priority
+	 * with {@code true} for the DEBUG level message, or {@code false} for ERROR level
+	 * @see #error(String)
+	 */
+	default void errorOrDebug(ChoiceOfMessageSupplier messageSupplier) {
+		if (isDebugEnabled()) {
+			debug(messageSupplier.get(true));
+		}
+		else if (isErrorEnabled()) {
+			error(messageSupplier.get(false));
+		}
+	}
+
+	/**
+	 * Convenience method to log an exception (throwable), with an accompanying
+	 * message that is different according to the log level.
+	 * In priority, DEBUG level is used if {@link #isDebugEnabled()}.
+	 * Otherwise, ERROR level is used (unless {@link #isErrorEnabled()} is false).
+	 * <p>
+	 * This can be used to log different level of details according to the active
+	 * log level.
+	 *
+	 * @param messageSupplier the {@link ChoiceOfMessageSupplier} invoked in priority
+	 * with {@code true} for the DEBUG level message, or {@code false} for ERROR level
+	 * @param cause the {@link Throwable} the original exception to be logged
+	 * @see #error(String, Throwable)
+	 */
+	default void errorOrDebug(ChoiceOfMessageSupplier messageSupplier, Throwable cause) {
+		if (isDebugEnabled()) {
+			debug(messageSupplier.get(true), cause);
+		}
+		else if (isErrorEnabled()) {
+			error(messageSupplier.get(false), cause);
+		}
+	}
 
 }

--- a/reactor-core/src/test/java/reactor/util/LoggerTest.java
+++ b/reactor-core/src/test/java/reactor/util/LoggerTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Simon Baslé
+ */
+class LoggerTest {
+
+	private Logger mockVerbose() {
+		Logger mockLogger = Mockito.mock(Logger.class);
+
+		when(mockLogger.isInfoEnabled()).thenReturn(true);
+		when(mockLogger.isWarnEnabled()).thenReturn(true);
+		when(mockLogger.isErrorEnabled()).thenReturn(true);
+		when(mockLogger.isDebugEnabled()).thenReturn(true);
+
+		doCallRealMethod().when(mockLogger).infoOrDebug(any());
+		doCallRealMethod().when(mockLogger).infoOrDebug(any(), any());
+		doCallRealMethod().when(mockLogger).warnOrDebug(any());
+		doCallRealMethod().when(mockLogger).warnOrDebug(any(), any());
+		doCallRealMethod().when(mockLogger).errorOrDebug(any());
+		doCallRealMethod().when(mockLogger).errorOrDebug(any(), any());
+
+		return mockLogger;
+	}
+
+	private Logger mockTerse() {
+		Logger mockLogger = Mockito.mock(Logger.class);
+
+		when(mockLogger.isInfoEnabled()).thenReturn(true);
+		when(mockLogger.isWarnEnabled()).thenReturn(true);
+		when(mockLogger.isErrorEnabled()).thenReturn(true);
+		when(mockLogger.isDebugEnabled()).thenReturn(false);
+
+		doCallRealMethod().when(mockLogger).infoOrDebug(any());
+		doCallRealMethod().when(mockLogger).infoOrDebug(any(), any());
+		doCallRealMethod().when(mockLogger).warnOrDebug(any());
+		doCallRealMethod().when(mockLogger).warnOrDebug(any(), any());
+		doCallRealMethod().when(mockLogger).errorOrDebug(any());
+		doCallRealMethod().when(mockLogger).errorOrDebug(any(), any());
+
+		return mockLogger;
+	}
+
+	private Logger mockSilent() {
+		Logger mockLogger = Mockito.mock(Logger.class);
+
+		when(mockLogger.isInfoEnabled()).thenReturn(false);
+		when(mockLogger.isWarnEnabled()).thenReturn(false);
+		when(mockLogger.isErrorEnabled()).thenReturn(false);
+		when(mockLogger.isDebugEnabled()).thenReturn(false);
+
+		doCallRealMethod().when(mockLogger).infoOrDebug(any());
+		doCallRealMethod().when(mockLogger).infoOrDebug(any(), any());
+		doCallRealMethod().when(mockLogger).warnOrDebug(any());
+		doCallRealMethod().when(mockLogger).warnOrDebug(any(), any());
+		doCallRealMethod().when(mockLogger).errorOrDebug(any());
+		doCallRealMethod().when(mockLogger).errorOrDebug(any(), any());
+
+		return mockLogger;
+	}
+
+	private void verifyIsXxxEnabledXxxOrDebugAndNoMore(Logger mockLogger) {
+		Mockito.verify(mockLogger, atMostOnce()).isDebugEnabled();
+		Mockito.verify(mockLogger, atMostOnce()).isInfoEnabled();
+		Mockito.verify(mockLogger, atMostOnce()).isWarnEnabled();
+		Mockito.verify(mockLogger, atMostOnce()).isErrorEnabled();
+
+		Mockito.verify(mockLogger, atMostOnce()).infoOrDebug(any());
+		Mockito.verify(mockLogger, atMostOnce()).infoOrDebug(any(), any());
+
+		Mockito.verify(mockLogger, atMostOnce()).warnOrDebug(any());
+		Mockito.verify(mockLogger, atMostOnce()).warnOrDebug(any(), any());
+
+		Mockito.verify(mockLogger, atMostOnce()).errorOrDebug(any());
+		Mockito.verify(mockLogger, atMostOnce()).errorOrDebug(any(), any());
+
+		Mockito.verifyNoMoreInteractions(mockLogger);
+	}
+
+	@Test
+	void infoOrDebug_debugEnabled() {
+		Logger mockLogger = mockVerbose();
+
+		mockLogger.infoOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE");
+		Mockito.verify(mockLogger).debug("VERBOSE");
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+	@Test
+	void infoOrDebug_infoEnabled() {
+		Logger mockLogger = mockTerse();
+
+		mockLogger.infoOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE");
+		Mockito.verify(mockLogger).info("TERSE");
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+	@Test
+	void infoOrDebug_noneEnabled() {
+		Logger mockLogger = mockSilent();
+
+		mockLogger.infoOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE");
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+	@Test
+	void infoOrDebugCause_debugEnabled() {
+		Throwable cause = new IllegalStateException("expected");
+		Logger mockLogger = mockVerbose();
+
+		mockLogger.infoOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE", cause);
+		Mockito.verify(mockLogger).debug("VERBOSE", cause);
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+	@Test
+	void infoOrDebugCause_infoEnabled() {
+		Throwable cause = new IllegalStateException("expected");
+		Logger mockLogger = mockTerse();
+
+		mockLogger.infoOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE", cause);
+		Mockito.verify(mockLogger).info("TERSE", cause);
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+	@Test
+	void infoOrDebugCause_noneEnabled() {
+		Throwable cause = new IllegalStateException("expected");
+		Logger mockLogger = mockSilent();
+
+		mockLogger.infoOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE", cause);
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+	@Test
+	void warnOrDebug_debugEnabled() {
+		Logger mockLogger = mockVerbose();
+
+		mockLogger.warnOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE");
+		Mockito.verify(mockLogger).debug("VERBOSE");
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+	@Test
+	void warnOrDebug_infoEnabled() {
+		Logger mockLogger = mockTerse();
+
+		mockLogger.warnOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE");
+		Mockito.verify(mockLogger).warn("TERSE");
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+	@Test
+	void warnOrDebug_noneEnabled() {
+		Logger mockLogger = mockSilent();
+
+		mockLogger.warnOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE");
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+	@Test
+	void warnOrDebugCause_debugEnabled() {
+		Throwable cause = new IllegalStateException("expected");
+		Logger mockLogger = mockVerbose();
+
+		mockLogger.warnOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE", cause);
+		Mockito.verify(mockLogger).debug("VERBOSE", cause);
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+	@Test
+	void warnOrDebugCause_infoEnabled() {
+		Throwable cause = new IllegalStateException("expected");
+		Logger mockLogger = mockTerse();
+
+		mockLogger.warnOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE", cause);
+		Mockito.verify(mockLogger).warn("TERSE", cause);
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+	@Test
+	void warnOrDebugCause_noneEnabled() {
+		Throwable cause = new IllegalStateException("expected");
+		Logger mockLogger = mockSilent();
+
+		mockLogger.warnOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE", cause);
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+	@Test
+	void errorOrDebug_debugEnabled() {
+		Logger mockLogger = mockVerbose();
+
+		mockLogger.errorOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE");
+		Mockito.verify(mockLogger).debug("VERBOSE");
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+	@Test
+	void errorOrDebug_infoEnabled() {
+		Logger mockLogger = mockTerse();
+
+		mockLogger.errorOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE");
+		Mockito.verify(mockLogger).error("TERSE");
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+	@Test
+	void errorOrDebug_noneEnabled() {
+		Logger mockLogger = mockSilent();
+
+		mockLogger.errorOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE");
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+	@Test
+	void errorOrDebugCause_debugEnabled() {
+		Throwable cause = new IllegalStateException("expected");
+		Logger mockLogger = mockVerbose();
+
+		mockLogger.errorOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE", cause);
+		Mockito.verify(mockLogger).debug("VERBOSE", cause);
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+	@Test
+	void errorOrDebugCause_infoEnabled() {
+		Throwable cause = new IllegalStateException("expected");
+		Logger mockLogger = mockTerse();
+
+		mockLogger.errorOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE", cause);
+		Mockito.verify(mockLogger).error("TERSE", cause);
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+	@Test
+	void errorOrDebugCause_noneEnabled() {
+		Throwable cause = new IllegalStateException("expected");
+		Logger mockLogger = mockSilent();
+
+		mockLogger.errorOrDebug(isVerbose -> isVerbose ? "VERBOSE" : "TERSE", cause);
+
+		verifyIsXxxEnabledXxxOrDebugAndNoMore(mockLogger);
+	}
+
+}


### PR DESCRIPTION

## Add convenience [info|warn|error]OrDebug to Logger

This is a convenience method to chose between two versions of a message, according to the enabled logging levels.
If debug is enabled, a more verbose message is expected and logged.
If not, there's a fallback to a less verbose message (depending on the flavor: info, warn or error).

## Polish a few logging statements

Change the logging level of a couple of log statements.
Use the new convenience method in a case where the input value (onNext) is directly logged.
