### PR TITLE
[agent] Bump OpCode to ASM9 for compatibility with newer JDKs

### DIFF
--- a/reactor-tools/src/main/java/reactor/tools/agent/CallSiteInfoAddingMethodVisitor.java
+++ b/reactor-tools/src/main/java/reactor/tools/agent/CallSiteInfoAddingMethodVisitor.java
@@ -70,7 +70,7 @@ class CallSiteInfoAddingMethodVisitor extends MethodVisitor {
             String currentSource,
             AtomicBoolean changed
     ) {
-        super(Opcodes.ASM7, visitor);
+        super(Opcodes.ASM9, visitor);
         this.currentMethod = currentMethod;
         this.currentClassName = currentClassName;
         this.currentSource = currentSource;

--- a/reactor-tools/src/main/java/reactor/tools/agent/ReactorDebugClassVisitor.java
+++ b/reactor-tools/src/main/java/reactor/tools/agent/ReactorDebugClassVisitor.java
@@ -32,7 +32,7 @@ class ReactorDebugClassVisitor extends ClassVisitor {
 	private String currentSource;
 
 	ReactorDebugClassVisitor(ClassVisitor classVisitor, AtomicBoolean changed) {
-		super(Opcodes.ASM7, classVisitor);
+		super(Opcodes.ASM9, classVisitor);
 		this.changed = changed;
 	}
 

--- a/reactor-tools/src/main/java/reactor/tools/agent/ReturnHandlingMethodVisitor.java
+++ b/reactor-tools/src/main/java/reactor/tools/agent/ReturnHandlingMethodVisitor.java
@@ -64,7 +64,7 @@ class ReturnHandlingMethodVisitor extends MethodVisitor {
             String currentSource,
             AtomicBoolean changed
     ) {
-        super(Opcodes.ASM7, visitor);
+        super(Opcodes.ASM9, visitor);
         this.changed = changed;
         this.currentClassName = currentClassName;
         this.currentMethod = currentMethod;


### PR DESCRIPTION
This is so ByteBuddy doesn't trip on eg. records, even though the
reactor-tool agent visitors don't act on these for now.

Fixes #2821.
