### PR TITLE
Use gradle-build-action for invoking Gradle on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,10 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    - uses: eskatos/gradle-command-action@v1
+    - uses: gradle/gradle-build-action@v2
       name: gradle
       with:
         arguments: :reactor-core:test --no-daemon -Pjunit-tags=!slow
-        wrapper-cache-enabled: true
-        dependencies-cache-enabled: true
-        configuration-cache-enabled: true
   core-slow:
     name: core slower tests
     runs-on: ubuntu-latest
@@ -30,13 +27,10 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    - uses: eskatos/gradle-command-action@v1
+    - uses: gradle/gradle-build-action@v2
       name: gradle
       with:
         arguments: :reactor-core:test --no-daemon -Pjunit-tags=slow
-        wrapper-cache-enabled: true
-        dependencies-cache-enabled: true
-        configuration-cache-enabled: true
   other:
     name: other tests
     runs-on: ubuntu-latest
@@ -47,17 +41,11 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    - uses: eskatos/gradle-command-action@v1
+    - uses: gradle/gradle-build-action@v2
       name: license header
       with:
         arguments: spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
-        wrapper-cache-enabled: true
-        dependencies-cache-enabled: true
-        configuration-cache-enabled: true
-    - uses: eskatos/gradle-command-action@v1
+    - uses: gradle/gradle-build-action@v2
       name: other tests
       with:
         arguments: check -x :reactor-core:test --no-daemon
-        wrapper-cache-enabled: true
-        dependencies-cache-enabled: true
-        configuration-cache-enabled: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,13 +23,17 @@ jobs:
         java-version: 8
     - name: interpret version
       id: version
+      uses: gradle/gradle-build-action@v2
       #we only run the qualifyVersionGha task so that no other console printing can hijack this step's output
       #output: versionType, fullVersion
       #fails if versionType is BAD, which interrupts the workflow
-      run: ./gradlew qualifyVersionGha
+      with:
+        arguments: qualifyVersionGha
     - name: run checks
       id: checks
-      run: ./gradlew check
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: check
 
   #deploy the snapshot artifacts to Artifactory
   deploySnapshot:
@@ -47,8 +51,13 @@ jobs:
       env:
         ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ARTIFACTORY_SNAPSHOT_USERNAME}}
         ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ARTIFACTORY_PASSWORD}}
-      run: |
-          ./gradlew assemble artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io -Partifactory_publish_repoKey=libs-snapshot-local
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: |
+          assemble 
+          artifactoryPublish 
+          -Partifactory_publish_contextUrl=https://repo.spring.io 
+          -Partifactory_publish_repoKey=libs-snapshot-local
 
   #sign the milestone artifacts and deploy them to Artifactory
   deployMilestone:
@@ -68,8 +77,14 @@ jobs:
         ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ARTIFACTORY_PASSWORD}}
         ORG_GRADLE_PROJECT_signingKey: ${{secrets.SIGNING_KEY}}
         ORG_GRADLE_PROJECT_signingPassword: ${{secrets.SIGNING_PASSPHRASE}}
-      run: |
-          ./gradlew assemble sign artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io -Partifactory_publish_repoKey=libs-milestone-local
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: |
+          assemble 
+          sign 
+          artifactoryPublish 
+          -Partifactory_publish_contextUrl=https://repo.spring.io 
+          -Partifactory_publish_repoKey=libs-milestone-local
     - name: tag
       run: |
         git config --local user.name 'reactorbot'
@@ -97,8 +112,15 @@ jobs:
         ORG_GRADLE_PROJECT_signingPassword: ${{secrets.SIGNING_PASSPHRASE}}
         ORG_GRADLE_PROJECT_sonatypeUsername: ${{secrets.SONATYPE_USERNAME}}
         ORG_GRADLE_PROJECT_sonatypePassword: ${{secrets.SONATYPE_PASSWORD}}
-      run: |
-          ./gradlew assemble sign artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io  -Partifactory_publish_repoKey=libs-release-local publishMavenJavaPublicationToSonatypeRepository
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: |
+          assemble 
+          sign 
+          artifactoryPublish 
+          -Partifactory_publish_contextUrl=https://repo.spring.io  
+          -Partifactory_publish_repoKey=libs-release-local 
+          publishMavenJavaPublicationToSonatypeRepository
     - name: tag
       run: |
         git config --local user.name 'reactorbot'


### PR DESCRIPTION
The `gradle/gradle-build-action` replaces `eskatos/gradle-command-action`, and `v2` brings a number of improvements around caching and usability.