### PR TITLE
Make OnAssemblyException serializable again

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnAssembly.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnAssembly.java
@@ -16,6 +16,7 @@
 
 package reactor.core.publisher;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -257,7 +258,8 @@ final class FluxOnAssembly<T> extends InternalFluxOperator<T, T> implements Fuse
 		}
 	}
 
-	static final class ObservedAtInformationNode {
+	static final class ObservedAtInformationNode implements Serializable {
+		private static final long serialVersionUID = 1L;
 
 		final int id;
 		final String operator;


### PR DESCRIPTION
Since the introduction of FluxOnAssembly.ObservedAtInformationNode exceptions thrown in a Flux chain are no longer serializable. To fix this the FluxOnAssembly.ObservedAtInformationNode now implements the Serializable interface.

Fixes #2831.