### PR TITLE
fix #2839 Buffer when downstream not ready

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
@@ -192,7 +192,7 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 
 		void flushCallback(@Nullable T ev) { //TODO investigate ev not used
 			synchronized (this) {
-				C v = values;
+				final C v = values;
 				if (v != null && !v.isEmpty()) {
 					long r = requested;
 					if (r != 0L) {


### PR DESCRIPTION
When downstream requests have been exhausted but items have been
buffered the current behaviour is to raise an error, this change instead
will leave the buffer in place in that circumstance and flush it at the
point of the next request. Complete signals that arrive while there is a
buffer waiting are now delayed until it is flushed.

Also fixed is the potential for negative request amounts being sent
upstream which is a trivial change to just not send those.