### PR TITLE
fix #2839: Fix bug which results in sending non-positive requests upstream

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
@@ -320,6 +320,9 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 		}
 
 		final void requestMore(long n) {
+			if (n < 1L) {
+				return;
+			}
 			Subscription s = this.subscription;
 			if (s != null) {
 				Operators.addCap(OUTSTANDING, this, n);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -107,6 +108,39 @@ public class FluxBufferTimeoutTest {
 						            .hasMessage("Could not emit buffer due to lack of requests")
 						            .isInstanceOf(IllegalStateException.class)
 		            );
+	}
+
+	Flux<List<Integer>> scenario_bufferWithTimeoutAvoidingNegativeRequests() {
+		return Flux.range(1, 3)
+		           .delayElements(Duration.ofMillis(100))
+		           .doOnRequest(amount -> bubbledAssert(() -> assertThat(amount).isPositive()))
+		           .bufferTimeout(5, Duration.ofMillis(100));
+	}
+
+	private static void bubbledAssert(Callable<?> assertion) {
+		try {
+			assertion.call();
+		}
+		catch (Throwable e) {
+			throw Exceptions.bubble(e);
+		}
+	}
+
+	@Test
+	public void bufferWithTimeoutAvoidingNegativeRequests() {
+		StepVerifier.withVirtualTime(this::scenario_bufferWithTimeoutAvoidingNegativeRequests,
+				0)
+		            .expectSubscription()
+		            .expectNoEvent(Duration.ofMillis(100))
+		            .thenRequest(2)
+		            .expectNoEvent(Duration.ofMillis(100))
+		            .assertNext(s -> assertThat(s).containsExactly(1))
+		            .expectNoEvent(Duration.ofMillis(100))
+		            .assertNext(s -> assertThat(s).containsExactly(2))
+		            .thenRequest(1) // This should not cause a negative upstream request
+		            .expectNoEvent(Duration.ofMillis(100))
+		            .thenCancel()
+		            .verify();
 	}
 
 	@Test


### PR DESCRIPTION
It is currently possible for negative/zero requests to be sent upstream.

A unit test has been added to replicate that scenario.