### PR TITLE
Use Gradle's VersionCatalog for dependencies + update plugin"

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -12,17 +12,17 @@ configurations {
 
 dependencies {
   // Use the baseline to avoid using new APIs in the benchmarks
-  compileOnly "io.projectreactor:reactor-core:${perfBaselineVersion}"
+  compileOnly libs.reactor.perfBaseline.core
   compileOnly libs.jsr305
 
   implementation libs.jmh.core
-  implementation libs.jmh.reactorExtra, {
+  implementation libs.reactor.perfBaseline.extra, {
     exclude group: 'io.projectreactor', module: 'reactor-core'
   }
   annotationProcessor libs.jmh.annotations.processor
 
   current project(':reactor-core')
-  baseline "io.projectreactor:reactor-core:${perfBaselineVersion}", {
+  baseline libs.reactor.perfBaseline.core, {
     changing = true
   }
 }

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -13,13 +13,13 @@ configurations {
 dependencies {
   // Use the baseline to avoid using new APIs in the benchmarks
   compileOnly "io.projectreactor:reactor-core:${perfBaselineVersion}"
-  compileOnly "com.google.code.findbugs:jsr305:${findbugsVersion}"
+  compileOnly libs.jsr305
 
-  implementation "org.openjdk.jmh:jmh-core:${jmhVersion}"
-  implementation "io.projectreactor.addons:reactor-extra:3.3.3.RELEASE", {
+  implementation libs.jmh.core
+  implementation libs.jmh.reactorExtra, {
     exclude group: 'io.projectreactor', module: 'reactor-core'
   }
-  annotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:${jmhVersion}"
+  annotationProcessor libs.jmh.annotations.processor
 
   current project(':reactor-core')
   baseline "io.projectreactor:reactor-core:${perfBaselineVersion}", {

--- a/build.gradle
+++ b/build.gradle
@@ -18,32 +18,28 @@ import org.gradle.util.VersionNumber
 import java.text.SimpleDateFormat
 
 buildscript {
-	// we define kotlin version for benefit of both core and test (see kotlin-gradle-plugin below)
-	ext.kotlinVersion = '1.5.31'
 	repositories {
 		mavenCentral()
 		maven { url "https://repo.spring.io/plugins-release" }
-	}
-	dependencies {
-		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
-		classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.24.18" //applied in individual submodules
 	}
 }
 
 
 plugins {
-	id "com.github.johnrengelman.shadow" version "7.0.0"
-	id 'org.asciidoctor.jvm.convert' version '3.3.2' apply false
-	id 'org.asciidoctor.jvm.pdf' version '3.3.2' apply false
-	id "me.champeau.gradle.japicmp" version "0.3.0"
-	id "de.undercouch.download" version "4.1.2"
-	id "org.unbroken-dome.test-sets" version "4.0.0" apply false
+	alias(libs.plugins.kotlin)
+	alias(libs.plugins.artifactory)
+	alias(libs.plugins.shadow)
+	alias(libs.plugins.asciidoctor.convert) apply false
+	alias(libs.plugins.asciidoctor.pdf) apply false
+	alias(libs.plugins.japicmp)
+	alias(libs.plugins.download)
+	alias(libs.plugins.testsets)
 	// note: build scan plugin now must be applied in settings.gradle
 	// plugin portal is now outdated due to bintray sunset, at least for artifactory gradle plugin
-	id 'biz.aQute.bnd.builder' version '5.3.0' apply false
-	id 'io.spring.nohttp' version '0.0.9'
-	id "io.github.reyerizo.gradle.jcstress" version "0.8.11" apply false
-	id "com.diffplug.spotless" version "5.15.0"
+	alias(libs.plugins.bnd) apply false
+	alias(libs.plugins.nohttp)
+	alias(libs.plugins.jcstress) apply false
+	alias(libs.plugins.spotless)
 }
 
 apply plugin: "io.reactor.gradle.detect-ci"
@@ -80,40 +76,9 @@ ext {
 	}
 
 	/*
-	 * Note that some versions can be bumped by a script.
-	 * These are found in `gradle.properties`...
-	 *
-	 * Versions not necessarily bumped by a script (testing, etc...) below:
+	 * Note that all dependencies and their versions are now defined in
+	 * ./gradle/libs.versions.toml
 	 */
-	// Misc not often upgraded
-	jsr166BackportVersion = '1.0.0.RELEASE'
-	// Used as a way to get jsr305 annotations.
-	// 3.0.1 is the last version that has the 'annotations' jar needed on the compile classpath
-	findbugsVersion = '3.0.1'
-
-	// Blockhound
-	blockhoundVersion = '1.0.6.RELEASE'
-
-	// Logging
-	slf4jVersion = '1.7.32'
-	logbackVersion = '1.2.5'
-
-	// Testing
-	jUnitPlatformVersion = '5.8.0' //needs to be manually synchronized in buildSrc
-	assertJVersion = '3.21.0' //needs to be manually synchronized in buildSrc
-	mockitoVersion = '3.12.4'
-	awaitilityVersion = '4.1.0'
-	throwingFunctionVersion = '1.5.1'
-	javaObjectLayoutVersion = '0.16'
-	testNgVersion = '7.4.0'
-	archUnitVersion = '0.21.0'
-
-	// For reactor-tools
-	byteBuddyVersion = '1.11.19' //dependency, but plugin usage is now in a mock build done via TestKit
-	cgLibVersion = '3.3.0'
-
-	// JMH
-	jmhVersion = '1.33'
 }
 
 // only publish scan if a specific gradle entreprise server is passed

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,54 @@ repositories { //needed at root for asciidoctor and nohttp-checkstyle
 	mavenCentral()
 }
 
+tasks.named("dependencyUpdates").configure {
+	def within = { String desc, String version, String constraint ->
+		if (!version.startWith(constraint)) {
+			reject("$desc must be kept on ${constraint}.x")
+		}
+	}
+	def strictly = { String desc, String version, String exactVersion ->
+		if (version != exactVersion) {
+			reject("$desc must be on ${exactVersion}")
+		}
+	}
+
+	checkConstraints = true
+	revision = "release"
+	resolutionStrategy {
+		componentSelection {
+			all {
+				if (it.candidate.module == "reactor-extra") {
+					within("JMH Reactor-Extra", it.candidate.version, libs.versions.allConstraints.jmhReactorExtra.get())
+				}
+				else if (it.candidate.module == "jsr305") {
+					// 3.0.1 is the last version that has the 'annotations' jar needed on the compile classpath
+					strictly("JSR 305", it.candidate.version, libs.versions.allConstraints.jsr305.get())
+				}
+				else if (it.candidate.module.contains("kotlin")) {
+					within("Kotlin", it.candidate.version, libs.versions.allConstraints.kotlin.get())
+				}
+				else if (it.candidate.module == "logback-classic") {
+					within("Logback", it.candidate.version, libs.versions.allConstraints.logback.get())
+				}
+				else if (it.candidate.module == "micrometer-core") {
+					// we want to be backward compatible with 1.3.0 all the way
+					strictly("Micrometer", it.candidate.version, libs.versions.allConstraints.micrometer.get())
+				}
+				else if (it.candidate.module == "slf4j-api") {
+					within("Slf4J", it.candidate.version, libs.versions.allConstraints.slf4j.get())
+				}
+			}
+		}
+	}
+}
+
+versionCatalogUpdate {
+	sortByKey = true
+	addDependencies = false
+	keepUnused = true
+}
+
 ext {
 	jdk = JavaVersion.current().majorVersion
 	jdkJavadoc = "https://docs.oracle.com/javase/$jdk/docs/api/"

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ buildscript {
 
 
 plugins {
+	id "com.github.ben-manes.versions" version "0.39.0"
+	id "nl.littlerobots.version-catalog-update" version "0.2.1"
 	alias(libs.plugins.kotlin)
 	alias(libs.plugins.artifactory)
 	alias(libs.plugins.shadow)

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent
 import org.gradle.util.VersionNumber
 import java.text.SimpleDateFormat
 
@@ -52,25 +53,25 @@ repositories { //needed at root for asciidoctor and nohttp-checkstyle
 	mavenCentral()
 }
 
-tasks.named("dependencyUpdates").configure {
-	def within = { com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent version, String constraint ->
-		if (!version.candidate.version.startsWith(constraint)) {
-			def reason = "$version.candidate.displayName is not in the required ${constraint}.x line"
-			version.reject(reason)
-		}
+// a utility function to reject candidate upgrades based on startsWith
+def within = { ComponentSelectionWithCurrent version, String constraint ->
+	if (!version.candidate.version.startsWith(constraint)) {
+		def reason = "$version.candidate.displayName is not in the required ${constraint}.x line"
+		version.reject(reason)
 	}
-	def strictly = { com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent version,
-									 String constraint, String reasonComplement ->
-		if (version.candidate.version != constraint) {
-			def reason = "$version.candidate.displayName rejected: must be kept on $constraint, $reasonComplement"
-			println reason
-			version.reject(reason)
-		}
+}
+// a utility function to reject candidate upgrades that are not strictly equal to expected version
+def strictly = { ComponentSelectionWithCurrent version, String constraint, String reasonComplement ->
+	if (version.candidate.version != constraint) {
+		def reason = "$version.candidate.displayName rejected: must be kept on $constraint, $reasonComplement"
+		version.reject(reason)
 	}
+}
 
-	checkConstraints = true
-	revision = "release"
-	resolutionStrategy {
+tasks.named("dependencyUpdates").configure {
+	checkConstraints = true // check dependency constraints and platforms
+	revision = "release" // disallow milestones
+	resolutionStrategy { // further avoid undesirable versions
 		componentSelection {
 			all {
 				if (candidate.module == "jsr305") {
@@ -94,7 +95,7 @@ tasks.named("dependencyUpdates").configure {
 }
 
 versionCatalogUpdate {
-	sortByKey = false
+	sortByKey = false //we put some constraints and baselines at the beginning
 	addDependencies = false
 	keepUnused = true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -53,14 +53,18 @@ repositories { //needed at root for asciidoctor and nohttp-checkstyle
 }
 
 tasks.named("dependencyUpdates").configure {
-	def within = { String desc, String version, String constraint ->
-		if (!version.startWith(constraint)) {
-			reject("$desc must be kept on ${constraint}.x")
+	def within = { com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent version, String constraint ->
+		if (!version.candidate.version.startsWith(constraint)) {
+			def reason = "$version.candidate.displayName is not in the required ${constraint}.x line"
+			version.reject(reason)
 		}
 	}
-	def strictly = { String desc, String version, String exactVersion ->
-		if (version != exactVersion) {
-			reject("$desc must be on ${exactVersion}")
+	def strictly = { com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent version,
+									 String constraint, String reasonComplement ->
+		if (version.candidate.version != constraint) {
+			def reason = "$version.candidate.displayName rejected: must be kept on $constraint, $reasonComplement"
+			println reason
+			version.reject(reason)
 		}
 	}
 
@@ -69,25 +73,20 @@ tasks.named("dependencyUpdates").configure {
 	resolutionStrategy {
 		componentSelection {
 			all {
-				if (it.candidate.module == "reactor-extra") {
-					within("JMH Reactor-Extra", it.candidate.version, libs.versions.allConstraints.jmhReactorExtra.get())
+				if (candidate.module == "jsr305") {
+					strictly(it, libs.versions.allConstraints.jsr305.get(), "which is the last one with 'annotations' jar on compile classpath")
 				}
-				else if (it.candidate.module == "jsr305") {
-					// 3.0.1 is the last version that has the 'annotations' jar needed on the compile classpath
-					strictly("JSR 305", it.candidate.version, libs.versions.allConstraints.jsr305.get())
+				else if (candidate.module == "micrometer-core") {
+					strictly(it, libs.versions.allConstraints.micrometer.get(), "since we want to be backward compatible with 1.3.x all the way")
 				}
-				else if (it.candidate.module.contains("kotlin")) {
-					within("Kotlin", it.candidate.version, libs.versions.allConstraints.kotlin.get())
+				else if (candidate.module.contains("kotlin")) {
+					within(it, libs.versions.allConstraints.kotlin.get())
 				}
-				else if (it.candidate.module == "logback-classic") {
-					within("Logback", it.candidate.version, libs.versions.allConstraints.logback.get())
+				else if (candidate.module == "logback-classic") {
+					within(it, libs.versions.allConstraints.logback.get())
 				}
-				else if (it.candidate.module == "micrometer-core") {
-					// we want to be backward compatible with 1.3.0 all the way
-					strictly("Micrometer", it.candidate.version, libs.versions.allConstraints.micrometer.get())
-				}
-				else if (it.candidate.module == "slf4j-api") {
-					within("Slf4J", it.candidate.version, libs.versions.allConstraints.slf4j.get())
+				else if (candidate.module == "slf4j-api") {
+					within(it, libs.versions.allConstraints.slf4j.get())
 				}
 			}
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -74,19 +74,19 @@ tasks.named("dependencyUpdates").configure {
 		componentSelection {
 			all {
 				if (candidate.module == "jsr305") {
-					strictly(it, libs.versions.allConstraints.jsr305.get(), "which is the last one with 'annotations' jar on compile classpath")
+					strictly(it, libs.versions.constraints.jsr305.get(), "which is the last one with 'annotations' jar on compile classpath")
 				}
 				else if (candidate.module == "micrometer-core") {
-					strictly(it, libs.versions.allConstraints.micrometer.get(), "since we want to be backward compatible with 1.3.x all the way")
+					strictly(it, libs.versions.constraints.micrometer.get(), "since we want to be backward compatible with 1.3.x all the way")
 				}
 				else if (candidate.module.contains("kotlin")) {
-					within(it, libs.versions.allConstraints.kotlin.get())
+					within(it, libs.versions.constraints.kotlin.get())
 				}
 				else if (candidate.module == "logback-classic") {
-					within(it, libs.versions.allConstraints.logback.get())
+					within(it, libs.versions.constraints.logback.get())
 				}
 				else if (candidate.module == "slf4j-api") {
-					within(it, libs.versions.allConstraints.slf4j.get())
+					within(it, libs.versions.constraints.slf4j.get())
 				}
 			}
 		}
@@ -94,7 +94,7 @@ tasks.named("dependencyUpdates").configure {
 }
 
 versionCatalogUpdate {
-	sortByKey = true
+	sortByKey = false
 	addDependencies = false
 	keepUnused = true
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -24,8 +24,8 @@ repositories {
 }
 
 dependencies {
-	testImplementation("org.assertj:assertj-core:3.21.0")
-	testImplementation platform("org.junit:junit-bom:5.8.0")
+	testImplementation libs.assertj
+	testImplementation platform(libs.junit.bom)
 	testImplementation "org.junit.jupiter:junit-jupiter-api"
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins {
-	id "com.gradle.enterprise" version "3.6.1"
-}
 
-rootProject.name = 'reactor'
-
-include 'benchmarks', 'reactor-core', 'reactor-test', 'reactor-tools'
-
-//libs catalog is declared in ./gradle/libs.versions.toml
-//TODO remove once Version Catalogs are stabilized. It is also activated in buildSrc
 enableFeaturePreview("VERSION_CATALOGS")
+
+//import the catalog from main project
+dependencyResolutionManagement {
+	versionCatalogs {
+		libs {
+			from(files("../gradle/libs.versions.toml"))
+		}
+	}
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
 version=3.4.14-SNAPSHOT
 bomVersion=2020.0.14
-perfBaselineVersion=3.4.13

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,4 @@
-micrometerVersion=1.3.0
 version=3.4.14-SNAPSHOT
-reactiveStreamsVersion=1.0.3
 compatibleVersion=3.4.13
 bomVersion=2020.0.14
 perfBaselineVersion=3.4.13

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 version=3.4.14-SNAPSHOT
-compatibleVersion=3.4.13
 bomVersion=2020.0.14
 perfBaselineVersion=3.4.13

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,54 @@
+[versions]
+asciidoctor = "3.3.2"
+assertj = "3.21.0"
+# plugin usage is now in a mock build done via TestKit
+bytebuddy = "1.11.19"
+jmh = "1.33"
+jmhReactorExtra = { strictly = "[3.3, 3.4[", prefer = "3.3.3.RELEASE" }
+# 3.0.1 is the last version that has the 'annotations' jar needed on the compile classpath
+jsr305 = { strictly = "3.0.1" }
+junit = "5.8.0"
+kotlin = { strictly = "[1.5, 1.6[", prefer = "1.5.31" }
+logback = { strictly = "[1.2.5, 1.3[", prefer = "1.2.5" }
+micrometer = { strictly = "[1.3, 1.4[", prefer = "1.3.0" }
+reactiveStreams = "1.0.3"
+slf4j = { strictly = "[1.7, 2.0[", prefer = "1.7.32" }
+
+[libraries]
+archUnit = "com.tngtech.archunit:archunit:0.21.0"
+assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+awaitility = "org.awaitility:awaitility:4.1.0"
+blockhound = "io.projectreactor.tools:blockhound:1.0.6.RELEASE"
+byteBuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "bytebuddy" }
+byteBuddy-api = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
+cglib = "cglib:cglib:3.3.0"
+javaObjectLayout = "org.openjdk.jol:jol-core:0.16"
+jmh-annotations-processor = { module = "org.openjdk.jmh:jmh-generator-annprocess", version.ref = "jmh" }
+jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
+jmh-reactorExtra = { module = "io.projectreactor.addons:reactor-extra", version.ref = "jmhReactorExtra" }
+jsr166backport = "io.projectreactor:jsr166:1.0.0.RELEASE"
+jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+micrometer = { module = "io.micrometer:micrometer-core", version.ref = "micrometer"}
+mockito = "org.mockito:mockito-core:3.12.4"
+reactiveStreams = { module = "org.reactivestreams:reactive-streams", version.ref = "reactiveStreams" }
+reactiveStreams-tck = { module = "org.reactivestreams:reactive-streams-tck", version.ref = "reactiveStreams" }
+slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+testNg = "org.testng:testng:7.4.0"
+throwingFunction = "com.pivovarit:throwing-function:1.5.1"
+
+[plugins]
+artifactory = "com.jfrog.artifactory:4.24.18"
+asciidoctor-convert = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor" }
+asciidoctor-pdf = { id = "org.asciidoctor.jvm.pdf", version.ref = "asciidoctor" }
+bnd = "biz.aQute.bnd.builder:5.3.0"
+download = "de.undercouch.download:4.1.2"
+japicmp = "me.champeau.gradle.japicmp:0.3.0"
+jcstress = "io.github.reyerizo.gradle.jcstress:0.8.11"
+kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+nohttp = "io.spring.nohttp:0.0.9"
+shadow = "com.github.johnrengelman.shadow:7.1.1"
+spotless = "com.diffplug.spotless:5.15.0"
+testsets = "org.unbroken-dome.test-sets:4.0.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,22 @@
 [versions]
+allConstraints-jmhReactorExtra = "3.3"
+allConstraints-jsr305 = "3.0.1"
+allConstraints-kotlin = "1.6"
+allConstraints-logback = "1.2"
+allConstraints-micrometer = "1.3.0"
+allConstraints-slf4j = "1.7"
 asciidoctor = "3.3.2"
 assertj = "3.21.0"
-# plugin usage is now in a mock build done via TestKit
 bytebuddy = "1.11.19"
 jmh = "1.33"
-jmhReactorExtra = { strictly = "[3.3, 3.4[", prefer = "3.3.3.RELEASE" }
-# 3.0.1 is the last version that has the 'annotations' jar needed on the compile classpath
-jsr305 = { strictly = "3.0.1" }
+jmhReactorExtra = "3.3.3.RELEASE"
+jsr305 = "3.0.1"
 junit = "5.8.0"
-kotlin = { strictly = "[1.5, 1.6[", prefer = "1.5.31" }
-logback = { strictly = "[1.2.5, 1.3[", prefer = "1.2.5" }
-micrometer = { strictly = "[1.3, 1.4[", prefer = "1.3.0" }
+kotlin = "1.5.31"
+logback = "1.2.5"
+micrometer = "1.3.0"
 reactiveStreams = "1.0.3"
-slf4j = { strictly = "[1.7, 2.0[", prefer = "1.7.32" }
+slf4j = "1.7.32"
 
 [libraries]
 archUnit = "com.tngtech.archunit:archunit:0.21.0"
@@ -31,7 +35,7 @@ jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
-micrometer = { module = "io.micrometer:micrometer-core", version.ref = "micrometer"}
+micrometer = { module = "io.micrometer:micrometer-core", version.ref = "micrometer" }
 mockito = "org.mockito:mockito-core:3.12.4"
 reactiveStreams = { module = "org.reactivestreams:reactive-streams", version.ref = "reactiveStreams" }
 reactiveStreams-tck = { module = "org.reactivestreams:reactive-streams-tck", version.ref = "reactiveStreams" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,21 @@
 [versions]
-allConstraints-jmhReactorExtra = "3.3"
-allConstraints-jsr305 = "3.0.1"
-allConstraints-kotlin = "1.6"
-allConstraints-logback = "1.2"
-allConstraints-micrometer = "1.3.0"
-allConstraints-slf4j = "1.7"
+# Baselines, should be updated on every release
+baseline-core-api = "3.4.13"
+baseline-core-perf = "3.4.13"
+baseline-extra-perf = "3.3.8.RELEASE"
+
+# Constraints to avoid too eager upgrades, used in versions plugin configuration
+constraints-jsr305 = "3.0.1"
+constraints-kotlin = "1.6"
+constraints-logback = "1.2"
+constraints-micrometer = "1.3.0"
+constraints-slf4j = "1.7"
+
+# Actual versions
 asciidoctor = "3.3.2"
 assertj = "3.21.0"
 bytebuddy = "1.11.19"
 jmh = "1.33"
-jmhReactorExtra = "3.3.3.RELEASE"
 jsr305 = "3.0.1"
 junit = "5.8.0"
 kotlin = "1.5.31"
@@ -29,7 +35,6 @@ cglib = "cglib:cglib:3.3.0"
 javaObjectLayout = "org.openjdk.jol:jol-core:0.16"
 jmh-annotations-processor = { module = "org.openjdk.jmh:jmh-generator-annprocess", version.ref = "jmh" }
 jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
-jmh-reactorExtra = { module = "io.projectreactor.addons:reactor-extra", version.ref = "jmhReactorExtra" }
 jsr166backport = "io.projectreactor:jsr166:1.0.0.RELEASE"
 jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
@@ -39,6 +44,8 @@ micrometer = { module = "io.micrometer:micrometer-core", version.ref = "micromet
 mockito = "org.mockito:mockito-core:3.12.4"
 reactiveStreams = { module = "org.reactivestreams:reactive-streams", version.ref = "reactiveStreams" }
 reactiveStreams-tck = { module = "org.reactivestreams:reactive-streams-tck", version.ref = "reactiveStreams" }
+reactor-perfBaseline-core = { module = "io.projectreactor:reactor-core", version.ref = "baseline.core.perf" }
+reactor-perfBaseline-extra = { module = "io.projectreactor.addons:reactor-extra", version.ref = "baseline.extra.perf" }
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 testNg = "org.testng:testng:7.4.0"
 throwingFunction = "com.pivovarit:throwing-function:1.5.1"

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -57,64 +57,63 @@ configurations {
 
 dependencies {
 	// Reactive Streams
-	api "org.reactivestreams:reactive-streams:${reactiveStreamsVersion}"
-	tckTestImplementation ("org.reactivestreams:reactive-streams-tck:${reactiveStreamsVersion}") {
+	api libs.reactiveStreams
+	tckTestImplementation (libs.reactiveStreams.tck) {
 		// without this exclusion, testng brings an old version of junit which *embeds* an old version of hamcrest
 		// which gets picked up first and that we don't want. TCK runs fine w/o (old) junit 4.
 		exclude group: 'junit', module: 'junit'
 	}
+	tckTestImplementation libs.testNg
 
 	// JSR-305 annotations
-	compileOnly "com.google.code.findbugs:jsr305:$findbugsVersion"
-	testCompileOnly "com.google.code.findbugs:jsr305:$findbugsVersion"
+	compileOnly libs.jsr305
+	testCompileOnly libs.jsr305
 
 	// Optional Logging Operator
-	compileOnly "org.slf4j:slf4j-api:$slf4jVersion"
-	testCompileOnly "org.slf4j:slf4j-api:$slf4jVersion"
+	compileOnly libs.slf4j
+	testCompileOnly libs.slf4j
 
 	// Optional Metrics
-	compileOnly "io.micrometer:micrometer-core:$micrometerVersion"
+	compileOnly libs.micrometer
 
 	// Not putting kotlin-stdlib as implementation to not force it as a transitive lib
-	compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}"
-	testImplementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}"
+	compileOnly libs.kotlin.stdlib
+	testImplementation libs.kotlin.stdlib
 
 	// Optional BlockHound support
-	compileOnly "io.projectreactor.tools:blockhound:$blockhoundVersion"
+	compileOnly libs.blockhound
 	// Also make BlockHound visible in the CP of dedicated testset
-	blockHoundTestImplementation "io.projectreactor.tools:blockhound:$blockhoundVersion"
+	blockHoundTestImplementation libs.blockhound
 
 	// Optional JDK 9 Converter
-	jsr166backport "io.projectreactor:jsr166:$jsr166BackportVersion"
+	jsr166backport libs.jsr166backport
 
-	testImplementation platform("org.junit:junit-bom:${jUnitPlatformVersion}")
+	// Testing
+	testImplementation platform(libs.junit.bom)
 	testImplementation "org.junit.jupiter:junit-jupiter-api"
 	testImplementation "org.junit.platform:junit-platform-launcher"
 	testImplementation "org.junit.jupiter:junit-jupiter-params"
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
-
-	testImplementation "ch.qos.logback:logback-classic:$logbackVersion" //need to access API to decrease some tests verbosity
-	// Testing
 	testImplementation(project(":reactor-test")) {
 		exclude module: 'reactor-core'
 	}
-
-	testImplementation "org.assertj:assertj-core:$assertJVersion"
-	testImplementation "org.mockito:mockito-core:$mockitoVersion"
-	testImplementation "org.openjdk.jol:jol-core:$javaObjectLayoutVersion"
-	testImplementation "org.awaitility:awaitility:$awaitilityVersion"
-	testImplementation "com.pivovarit:throwing-function:$throwingFunctionVersion"
-	testImplementation "com.tngtech.archunit:archunit:$archUnitVersion"
+	testImplementation libs.logback //need to access API to decrease some tests verbosity
+	testImplementation libs.assertj
+	testImplementation libs.mockito
+	testImplementation libs.javaObjectLayout
+	testImplementation libs.awaitility
+	testImplementation libs.throwingFunction
+	testImplementation libs.archUnit
 
 	// withMicrometerTest is a test-set that validates what happens when micrometer *IS*
 	// on the classpath. Needs sourceSets.test.output because tests there use helpers like AutoDisposingRule etc.
-	withMicrometerTestImplementation "io.micrometer:micrometer-core:$micrometerVersion"
+	withMicrometerTestImplementation libs.micrometer
 	withMicrometerTestImplementation sourceSets.test.output
 
-  	jcstressImplementation(project(":reactor-test")) {
-	  exclude module: 'reactor-core'
+	jcstressImplementation(project(":reactor-test")) {
+		exclude module: 'reactor-core'
 	}
-  	jcstressImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+	jcstressImplementation libs.logback
 
 }
 

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -121,8 +121,8 @@ task downloadBaseline(type: Download) {
 	onlyIfNewer true
 	compress true
 
-	src "${repositories.mavenCentral().url}io/projectreactor/reactor-core/$compatibleVersion/reactor-core-${compatibleVersion}.jar"
-	dest "${buildDir}/baselineLibs/reactor-core-${compatibleVersion}.jar"
+	src "${repositories.mavenCentral().url}io/projectreactor/reactor-core/${libs.versions.baseline.core.api.get()}/reactor-core-${libs.versions.baseline.core.api.get()}.jar"
+	dest "${buildDir}/baselineLibs/reactor-core-${libs.versions.baseline.core.api.get()}.jar"
 }
 
 task japicmp(type: JapicmpTask) {
@@ -130,16 +130,16 @@ task japicmp(type: JapicmpTask) {
 		println "Offline: skipping downloading of baseline and JAPICMP"
 	  	enabled = false
 	}
-	else if ("$compatibleVersion" == "SKIP") {
+	else if ("${libs.versions.baseline.core.api.get()}" == "SKIP") {
 		println "SKIP: Instructed to skip the baseline comparison"
 	  	enabled = false
 	}
 	else {
-		println "Will download and perform baseline comparison with ${compatibleVersion}"
+		println "Will download and perform baseline comparison with ${libs.versions.baseline.core.api.get()}"
 	  	dependsOn(downloadBaseline)
 	}
 
-	oldClasspath = files("${buildDir}/baselineLibs/reactor-core-${compatibleVersion}.jar")
+	oldClasspath = files("${buildDir}/baselineLibs/reactor-core-${libs.versions.baseline.core.api.get()}.jar")
 	newClasspath = files(jar.archiveFile)
 	onlyBinaryIncompatibleModified = false
 	failOnModification = false

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -57,8 +57,8 @@ task downloadBaseline(type: Download) {
 	onlyIfNewer true
 	compress true
 
-	src "${repositories.mavenCentral().url}io/projectreactor/reactor-test/$compatibleVersion/reactor-test-${compatibleVersion}.jar"
-	dest "${buildDir}/baselineLibs/reactor-test-${compatibleVersion}.jar"
+	src "${repositories.mavenCentral().url}io/projectreactor/reactor-test/${libs.versions.baseline.core.api.get()}/reactor-test-${libs.versions.baseline.core.api.get()}.jar"
+	dest "${buildDir}/baselineLibs/reactor-test-${libs.versions.baseline.core.api.get()}.jar"
 
 	finalizedBy { japicmp }
 }
@@ -68,16 +68,16 @@ task japicmp(type: JapicmpTask) {
 		println "Offline: skipping downloading of baseline and JAPICMP"
 	  	enabled = false
 	}
-	else if ("$compatibleVersion" == "SKIP") {
+	else if ("${libs.versions.baseline.core.api.get()}" == "SKIP") {
 		println "SKIP: Instructed to skip the baseline comparison"
 	  	enabled = false
 	}
 	else {
-		println "Will download and perform baseline comparison with ${compatibleVersion}"
+		println "Will download and perform baseline comparison with ${libs.versions.baseline.core.api.get()}"
 	  	dependsOn(downloadBaseline)
 	}
 
-	oldClasspath = files("${buildDir}/baselineLibs/reactor-test-${compatibleVersion}.jar")
+	oldClasspath = files("${buildDir}/baselineLibs/reactor-test-${libs.versions.baseline.core.api.get()}.jar")
 	newClasspath = files(jar.archiveFile)
 	onlyBinaryIncompatibleModified = true
 	failOnModification = true

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -38,19 +38,19 @@ ext {
 
 dependencies {
 	api project(":reactor-core")
-	compileOnly "com.google.code.findbugs:jsr305:${findbugsVersion}"
+	compileOnly libs.jsr305
 
 	// Not putting kotlin-stdlib as implementation to not force it as a transitive lib
-	compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}"
-	testImplementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}"
+	compileOnly libs.kotlin.stdlib
+	testImplementation libs.kotlin.stdlib
 
-	testImplementation platform("org.junit:junit-bom:${jUnitPlatformVersion}")
+	testImplementation platform(libs.junit.bom)
 	testImplementation "org.junit.jupiter:junit-jupiter-api"
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
-	testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
+	testRuntimeOnly libs.logback
 
-	testImplementation "org.assertj:assertj-core:$assertJVersion"
-	testImplementation "org.mockito:mockito-core:$mockitoVersion"
+	testImplementation libs.assertj
+	testImplementation libs.mockito
 }
 
 task downloadBaseline(type: Download) {

--- a/reactor-tools/build.gradle
+++ b/reactor-tools/build.gradle
@@ -35,28 +35,28 @@ configurations {
 dependencies {
     api project(":reactor-core")
 
-    compileOnly "com.google.code.findbugs:jsr305:${findbugsVersion}"
-    compileOnly "com.google.code.findbugs:annotations:${findbugsVersion}"
+    compileOnly libs.jsr305
+    compileOnly libs.jsr305
 
-    shaded "net.bytebuddy:byte-buddy-agent:$byteBuddyVersion"
-    shaded "net.bytebuddy:byte-buddy:$byteBuddyVersion"
+    shaded libs.byteBuddy.api
+    shaded libs.byteBuddy.agent
     for (dependency in project.configurations.shaded.dependencies) {
         compileOnly(dependency)
         testRuntimeOnly(dependency)
         javaAgentTestRuntimeOnly(dependency)
     }
 
-    testImplementation platform("org.junit:junit-bom:${jUnitPlatformVersion}")
+    testImplementation platform(libs.junit.bom)
     testImplementation "org.junit.jupiter:junit-jupiter-api"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 
-    testImplementation "org.assertj:assertj-core:$assertJVersion"
-    testImplementation "cglib:cglib:$cgLibVersion"
+    testImplementation libs.assertj
+    testImplementation libs.cglib
 
-    jarFileTestImplementation "org.assertj:assertj-core:$assertJVersion"
+    jarFileTestImplementation libs.assertj
 
     buildPluginTestImplementation gradleTestKit()
-    buildPluginTestImplementation platform("org.junit:junit-bom:${jUnitPlatformVersion}")
+    buildPluginTestImplementation platform(libs.junit.bom)
     buildPluginTestImplementation "org.junit.jupiter:junit-jupiter-api"
     buildPluginTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }
@@ -176,9 +176,9 @@ task generateMockGradle(type: Copy) {
     filter(ReplaceTokens, tokens: [
       CORE: coreJar,
       AGENT: agentJar,
-      REACTIVE_STREAMS_VERSION: rootProject.ext.reactiveStreamsVersion,
-      JUNIT_BOM_VERSION: rootProject.ext.jUnitPlatformVersion,
-      BYTE_BUDDY_VERSION: rootProject.ext.byteBuddyVersion
+      REACTIVE_STREAMS_VERSION: libs.versions.reactiveStreams.get(),
+      JUNIT_BOM_VERSION: libs.versions.junit.get(),
+      BYTE_BUDDY_VERSION: libs.versions.bytebuddy.get()
     ])
 }
 


### PR DESCRIPTION
This PR enables the usage of Gradle 7 Version Catalog.

The TOML file is used, and we also introduce two gradle plugins that can help
with semi-automatic upgrades: littlerobots/version-catalog-update-plugin and
ben-manes/gradle-versions-plugin.

The versions contain:
 - a set of `baseline` versions (replaces equivalents in gradle.properties)
 - a set of `constraints` versions used in the above plugin configuration in
 order to avoid being offered upgrades in which we're not interested
 - direct versions which are used in several places

The remaining versions are directly defined inline in the libraries and plugins
sections. This aligns best with what the update plugin will produce.

Note that the update plugin will remove comments and could rewrite entries that
can be simplified. It shouldn't reorder entries though, per configuration.

﻿- Create version catalog and switch all builds to use it
- Add acceptable "lines" constraints as special versions
- Add version catalog updater plugin
- Limit which versions to consider, using allConstraints entries
- Rework within/strictly, stop constraining extra
- rework and reorder constraints, prepare baselines
- use libs.reactor.perfBaseline in benchmarks build
- replace compatibleVersion from properties with libs.versions
- remove perfBaselineVersion from properties
- polish the versions plugin configuration + comments
