### PR TITLE
Enable Renovate bot with custom configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,42 @@
+
+{
+  "extends": [
+    "config:base",
+    ":semanticPrefixChore",
+    ":prHourlyLimit4",
+    ":automergeDisabled",
+    "group:allNonMajor",
+    ":label(type/dependency-upgrade)",
+    ":reviewer(reactor/core-team)",
+    ":timezone(Europe/Paris)",
+    "schedule:nonOfficeHours"
+  ],
+  "prBodyNotes": [
+    "Renovate has been configured to skip the CLA:",
+    "@pivotal-cla This is an Obvious Fix"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["com.google.code.findbugs:jsr305"],
+      "groupName": "JSR305 with annotations jar",
+      "groupSlug": "jsr305",
+      "allowedVersions": "=3.0.1"
+    },
+    {
+      "matchPackageNames": ["io.micrometer:micrometer-core"],
+      "groupName": "Micrometer 1.3.0",
+      "groupSlug": "micrometer",
+      "allowedVersions": "=1.3.0"
+    },
+    {
+      "matchManagers": ["gradle-wrapper"],
+      "groupName": "Gradle",
+      "schedule": ["before 3am on Monday"]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "Github Workflows",
+      "schedule": ["before 3am on Monday"]
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,9 @@
-
 {
   "extends": [
     "config:base",
     ":semanticPrefixChore",
     ":prHourlyLimit4",
     ":automergeDisabled",
-    "group:allNonMajor",
     ":label(type/dependency-upgrade)",
     ":reviewer(reactor/core-team)",
     ":timezone(Europe/Paris)",
@@ -17,16 +15,36 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": ["com.google.code.findbugs:jsr305"],
-      "groupName": "JSR305 with annotations jar",
-      "groupSlug": "jsr305",
-      "allowedVersions": "=3.0.1"
+      "matchDatasources": ["maven"],
+      "registryUrls": [
+        "https://repo.maven.apache.org/maven2",
+        "https://oss.sonatype.org/content/repositories/releases/",
+        "https://plugins.gradle.org/m2/"
+      ]
     },
     {
-      "matchPackageNames": ["io.micrometer:micrometer-core"],
-      "groupName": "Micrometer 1.3.0",
-      "groupSlug": "micrometer",
-      "allowedVersions": "=1.3.0"
+      "matchPackagePatterns": [ "*" ],
+      "matchUpdateTypes": [ "minor", "patch" ],
+      "groupName": "all non-major library dependencies",
+      "groupSlug": "libs-minor-patch"
+    },
+    {
+      "matchDepTypes": [ "plugin" ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "all non-major plugins",
+      "groupSlug": "plugins-minor-patch"
+    },
+    {
+      "matchPackagePatterns": [ ".*jfrog.*" ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "all non-major plugins",
+      "groupSlug": "plugins-minor-patch"
     },
     {
       "matchManagers": ["gradle-wrapper"],
@@ -37,6 +55,22 @@
       "matchManagers": ["github-actions"],
       "groupName": "Github Workflows",
       "schedule": ["before 3am on Monday"]
+    },
+    {
+      "matchPackageNames": [ "io.projectreactor:jsr166" ],
+      "enabled": "false"
+    },
+    {
+      "matchPackageNames": ["com.google.code.findbugs:jsr305"],
+      "groupName": "JSR305 with annotations jar",
+      "groupSlug": "jsr305",
+      "allowedVersions": "=3.0.1"
+    },
+    {
+      "matchPackageNames": ["io.micrometer:micrometer-core"],
+      "groupName": "Micrometer 1.3.0",
+      "groupSlug": "micrometer",
+      "allowedVersions": "=1.3.0"
     }
   ]
 }


### PR DESCRIPTION
This commit adds renovate configuration with customizations:

 - group all non-major updates together, scheduled every day
 - set aside minor updates to gradle (gradle-wrapper)
 - set aside minor updates to github actions used in workflows
 - limit upgrades for jsr305 and micrometer
 - set reviewers, labels, etc...
 - ensure no automerging
 - mark renovates PRs as obvious fixes for CLA

It was validated in #2855 but couldn't be merged because of
the CLA (configuration is not considered an obvious fix).