### PR TITLE
UsingWhen leak / fails to cancel when early cancel race

### DIFF
--- a/reactor-core/src/jcstress/java/reactor/core/publisher/MonoUsingWhenStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/MonoUsingWhenStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/MonoUsingWhenStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/MonoUsingWhenStressTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.concurrent.atomic.AtomicIntegerArray;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.LLLLL_Result;
+
+import static org.openjdk.jcstress.annotations.Expect.*;
+
+public abstract class MonoUsingWhenStressTest {
+
+	//SENT, DERIVED, CLOSED, CANCELLED, VALUE OBSERVED
+	@JCStressTest
+	@Outcome(id = {"OK, 1, 1, 0, 100"}, expect = FORBIDDEN, desc = "generated, derived, closed but no emit observed")
+	@Outcome(id = {"OK, 0, 4040, 0, 0"}, expect = FORBIDDEN, desc = "generated, but otherwise unprocessed")
+	@Outcome(id = {"OK, 1, 1, 0, 101"}, expect = ACCEPTABLE, desc = "generated, derived, closed after emitted")
+	@Outcome(id = {"OK, 1, 0, 1, 0"}, expect = ACCEPTABLE, desc = "generated, derived, cancelled before emit observed")
+	@Outcome(id = {"CANCELLED, 0, 0, 0, 0"}, expect = ACCEPTABLE, desc = "cancelled before generation")
+	@Outcome(id = {"CANCELLED, 0, 1, 0, 0"}, expect = ACCEPTABLE_INTERESTING, desc = "cancelled before generation, but closed")
+	@State
+	public static class CancelCloseToResourceEmission {
+
+		final AtomicIntegerArray producedAndTerminatedOrCleaned = new AtomicIntegerArray(3);
+		Sinks.One<AtomicIntegerArray> resourceSink = Sinks.one();
+
+		final Mono<Long> mono = Mono.usingWhen(
+			resourceSink.asMono(),
+			it -> {
+				it.incrementAndGet(0);
+				return Mono.never();
+			},
+			it -> Mono.fromRunnable(() -> it.incrementAndGet(1)),
+			(it, error) -> Mono.fromRunnable(() -> it.incrementAndGet(1)),
+			it -> Mono.fromRunnable(() -> it.incrementAndGet(2))
+		);
+
+		final StressSubscriber<Long> valueSubscriber = new StressSubscriber<>(100);
+
+		{
+			mono.subscribe(valueSubscriber);
+		}
+
+		@Actor
+		public void emit(LLLLL_Result result) {
+			result.r1 = resourceSink.tryEmitValue(producedAndTerminatedOrCleaned);
+		}
+
+		@Actor
+		public void cancel() {
+			valueSubscriber.cancel();
+		}
+
+		@Actor
+		public void waitForTermination() {
+			long deadline = System.currentTimeMillis() + 500;
+			while (true) {
+				if (System.currentTimeMillis() > deadline) {
+					producedAndTerminatedOrCleaned.addAndGet(1, 4040);
+					return;
+				}
+				if (producedAndTerminatedOrCleaned.get(1) != 0 ||
+					producedAndTerminatedOrCleaned.get(2) != 0) {
+					return;
+				}
+				try {
+					Thread.sleep(50);
+				}
+				catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+			}
+		}
+
+		@Arbiter
+		public void arbiter(LLLLL_Result result) {
+			result.r2 = producedAndTerminatedOrCleaned.get(0);
+			result.r3 = producedAndTerminatedOrCleaned.get(1);
+			result.r4 = producedAndTerminatedOrCleaned.get(2);
+			result.r5 = valueSubscriber.onNextCalls.get() +
+				valueSubscriber.onErrorCalls.get() * 100 +
+				valueSubscriber.onCompleteCalls.get() * 1000;
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxUsingWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxUsingWhen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxUsingWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxUsingWhen.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable.ConditionalSubscriber;
@@ -249,9 +250,10 @@ final class FluxUsingWhen<T, S> extends Flux<T> implements SourceProducer<T> {
 			}
 			else {
 				super.terminate();
-				if (closureSubscriber != null) {
-					closureSubscriber.cancel();
-				}
+			}
+
+			if (closureSubscriber != null) {
+				closureSubscriber.cancel();
 			}
 		}
 
@@ -419,7 +421,9 @@ final class FluxUsingWhen<T, S> extends Flux<T> implements SourceProducer<T> {
 					actual.onSubscribe(this);
 				}
 				else {
-					arbiter.set(s);
+					if (!arbiter.set(s)) {
+						cancel();
+					}
 				}
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoUsingWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoUsingWhen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoUsingWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoUsingWhen.java
@@ -24,9 +24,9 @@ import java.util.function.Function;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
-import reactor.core.Fuseable.ConditionalSubscriber;
 import reactor.core.publisher.FluxUsingWhen.UsingWhenSubscriber;
 import reactor.core.publisher.Operators.DeferredSubscription;
 import reactor.util.annotation.Nullable;
@@ -235,9 +235,10 @@ final class MonoUsingWhen<T, S> extends Mono<T> implements SourceProducer<T> {
 			}
 			else {
 				super.terminate();
-				if (closureSubscriber != null) {
-					closureSubscriber.cancel();
-				}
+			}
+
+			if (closureSubscriber != null) {
+				closureSubscriber.cancel();
 			}
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoUsingWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoUsingWhenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoUsingWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoUsingWhenTest.java
@@ -17,17 +17,21 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Scannable.Attr;
 import reactor.core.publisher.MonoUsingWhen.ResourceSubscriber;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.util.context.Context;
@@ -36,6 +40,54 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 public class MonoUsingWhenTest {
+
+	@Test
+	void reproducer() throws InterruptedException {
+
+		Random random = new Random();
+		Releaseable releaseable = new Releaseable();
+
+		for (int i = 0; i < 100; i++) {
+			System.out.println(i);
+			runTest(random, releaseable);
+		}
+	}
+
+	private void runTest(Random random, Releaseable releaseable) throws InterruptedException {
+		Mono<Long> mono = Mono.usingWhen(Mono.fromSupplier(() -> releaseable)
+		                                     .delayElement(Duration.ofMillis(50)).doOnNext(Releaseable::allocate),
+				it -> Mono.delay(Duration.ofMillis(50), Schedulers.boundedElastic()),
+				Releaseable::release);
+
+		CompletableFuture<Long> future = mono.toFuture();
+
+		Thread.sleep(random.nextInt(200));
+		future.cancel(true);
+
+		Awaitility.await().atMost(Duration.ofSeconds(10)).until(releaseable::isReleased);
+	}
+
+	static class Releaseable {
+
+		private final AtomicBoolean released = new AtomicBoolean(true);
+
+		private final Mono<Void> releaser = Mono.fromRunnable(() -> this.released.set(true));
+
+		void allocate() {
+			System.out.println("alloc");
+			released.set(false);
+		}
+
+		boolean isReleased() {
+			return released.get();
+		}
+
+		Mono<Void> release() {
+			System.out.println("release");
+			return releaser;
+		}
+
+	}
 
 	@Test
 	public void nullResourcePublisherRejected() {


### PR DESCRIPTION
This commit adds a stress test and fixes some race conditions in
early cancel cases:

 - check return value of `set(Subscription)` to detect an early cancel in
 `UsingWhenSubscriber` (the closure subscriber) `onSubscribe` => ensures
 its `cancel()` method (which triggers cancel handler) is invoked if false
 - always check `closureSubscriber` is not null when cancelling the
coordinator `ResourceSubscriber` (again, if it is set we ensure that closure
subscriber `UsingWhenSubscriber#cancel` is invoked, triggering handler)

Fixes #2836.