### PR TITLE
Automatically draft release notes on maintenance branches push

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,19 +1,21 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
+change-template: '- $TITLE'
+filter-by-commitish: true
 template: |
   # :checklist: TODO below
    - [ ] Replace release train references
    - [ ] Replace older maintenance train references
    - [ ] Ensure changes from other maintenance release are indeed grouped and extra-indented
-  
+
   ${{ github.event.repository.name }} `$RESOLVED_VERSION` is part of **`2020.0.{SR}` Release Train (`Europium` SR{SR})**.
-  
+
   This release contains {SHORT DESCRIPTION OF THE CONTENTS}.
-  
+
   All changes from [`{OLDER_TRAIN}`](https://github.com/${{ github.repository }}/releases/tag/v{OLDER_TRAIN}) are also included and these are listed below with an additional level of indentation.
-  
+
   $CHANGES
-  
+
   ## :+1: Thanks to all contributors who participated to this release
   $CONTRIBUTORS
 categories:
@@ -34,13 +36,9 @@ categories:
       - 'type/documentation'
   - title: ':up: Dependency Upgrades'
     label: 'type/dependency-upgrade'
-change-template: '- $TITLE'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+
 exclude-contributors:
   - 'simonbasle'
   - 'OlegDokuka'
   - 'violetagg'
   - 'pderop'
-  # - 'garyrussel'
-  # - 'acogoluegnes'
-filter-by-commitish: true

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,21 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-filter-by-commitish: true
+template: |
+  # :checklist: TODO below
+   - [ ] Replace release train references
+   - [ ] Replace older maintenance train references
+   - [ ] Ensure changes from other maintenance release are indeed grouped and extra-indented
+  
+  ${{ github.event.repository.name }} `$RESOLVED_VERSION` is part of **`2020.0.{SR}` Release Train (`Europium` SR{SR})**.
+  
+  This release contains {SHORT DESCRIPTION OF THE CONTENTS}.
+  
+  All changes from [`{OLDER_TRAIN}`](https://github.com/${{ github.repository }}/releases/tag/v{OLDER_TRAIN}) are also included and these are listed below with an additional level of indentation.
+  
+  $CHANGES
+  
+  ## :+1: Thanks to all contributors who participated to this release
+  $CONTRIBUTORS
 categories:
   - title: ':warning: Update considerations and deprecations'
     labels:
@@ -28,19 +43,4 @@ exclude-contributors:
   - 'pderop'
   # - 'garyrussel'
   # - 'acogoluegnes'
-template: |
-  # :checklist: TODO below
-   - [ ] Replace release train references
-   - [ ] Replace older maintenance train references
-   - [ ] Ensure changes from other maintenance release are indeed grouped and extra-indented
-  
-  ${{ github.event.repository.name }} `$RESOLVED_VERSION` is part of **`2020.0.{SR}` Release Train (`Europium` SR{SR})**.
-  
-  This release contains {SHORT DESCRIPTION OF THE CONTENTS}.
-  
-  All changes from [`{OLDER_TRAIN}`](https://github.com/${{ github.repository }}/releases/tag/v{OLDER_TRAIN}) are also included and these are listed below with an additional level of indentation.
-  
-  $CHANGES
-  
-  ## :+1: Thanks to all contributors who participated to this release
-  $CONTRIBUTORS
+filter-by-commitish: true

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,23 +1,5 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-change-template: '- $TITLE'
-filter-by-commitish: true
-template: |
-  # :checklist: TODO below
-   - [ ] Replace release train references
-   - [ ] Replace older maintenance train references
-   - [ ] Ensure changes from other maintenance release are indeed grouped and extra-indented
-
-  ${{ github.event.repository.name }} `$RESOLVED_VERSION` is part of **`2020.0.{SR}` Release Train (`Europium` SR{SR})**.
-
-  This release contains {SHORT DESCRIPTION OF THE CONTENTS}.
-
-  All changes from [`{OLDER_TRAIN}`](https://github.com/${{ github.repository }}/releases/tag/v{OLDER_TRAIN}) are also included and these are listed below with an additional level of indentation.
-
-  $CHANGES
-
-  ## :+1: Thanks to all contributors who participated to this release
-  $CONTRIBUTORS
 categories:
   - title: ':warning: Update considerations and deprecations'
     labels:
@@ -36,9 +18,28 @@ categories:
       - 'type/documentation'
   - title: ':up: Dependency Upgrades'
     label: 'type/dependency-upgrade'
-
+change-template: '- $TITLE'
 exclude-contributors:
   - 'simonbasle'
   - 'OlegDokuka'
   - 'violetagg'
   - 'pderop'
+  - 'garyrussel'
+  - 'acogoluegnes'
+filter-by-commitish: true
+template: |
+  # :checklist: TODO below
+   - [ ] Replace release train references
+   - [ ] Replace older maintenance train references
+   - [ ] Ensure changes from other maintenance release are indeed grouped and extra-indented
+
+  ${{ github.event.repository.name }} `$RESOLVED_VERSION` is part of **`2020.0.{SR}` Release Train (`Europium` SR{SR})**.
+
+  This release contains {SHORT DESCRIPTION OF THE CONTENTS}.
+
+  All changes from [`{OLDER_TRAIN}`](https://github.com/${{ github.repository }}/releases/tag/v{OLDER_TRAIN}) are also included and these are listed below with an additional level of indentation.
+
+  $CHANGES
+
+  ## :+1: Thanks to all contributors who participated to this release
+  $CONTRIBUTORS

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,46 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+filter-by-commitish: true
+categories:
+  - title: ':warning: Update considerations and deprecations'
+    labels:
+      - 'warn/api-change'
+      - 'warn/behavior-change'
+      - 'warn/blocker'
+      - 'warn/deprecation'
+      - 'warn/regression'
+  - title: ':sparkles: New features and improvements'
+    label: 'type/enhancement'
+  - title: ':lady_beetle: Bug fixes'
+    label: 'type/bug'
+  - title: ':book: Documentation, Tests and Build'
+    labels:
+      - 'type/chores'
+      - 'type/documentation'
+  - title: ':up: Dependency Upgrades'
+    label: 'type/dependency-upgrade'
+change-template: '- $TITLE'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+exclude-contributors:
+  - 'simonbasle'
+  - 'OlegDokuka'
+  - 'violetagg'
+  - 'pderop'
+  # - 'garyrussel'
+  # - 'acogoluegnes'
+template: |
+  # :checklist: TODO below
+   - [ ] Replace release train references
+   - [ ] Replace older maintenance train references
+   - [ ] Ensure changes from other maintenance release are indeed grouped and extra-indented
+  
+  ${{ github.event.repository.name }} `$RESOLVED_VERSION` is part of **`2020.0.{SR}` Release Train (`Europium` SR{SR})**.
+  
+  This release contains {SHORT DESCRIPTION OF THE CONTENTS}.
+  
+  All changes from [`{OLDER_TRAIN}`](https://github.com/${{ github.repository }}/releases/tag/v{OLDER_TRAIN}) are also included and these are listed below with an additional level of indentation.
+  
+  $CHANGES
+  
+  ## :+1: Thanks to all contributors who participated to this release
+  $CONTRIBUTORS

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,21 +51,6 @@ jobs:
         with:
           arguments: test -Pjunit-tags=slow
 
-  #draft release notes only if this is a snapshot commit (ie. a merge of a PR)
-  releaseDrafter:
-    name: releaserDrafter
-    runs-on: ubuntu-20.04
-    needs: [ prepare ]
-    if: needs.prepare.outputs.versionType == 'SNAPSHOT'
-    steps:
-      # Renovate Bot should suggest updates to the action
-      - uses: release-drafter/release-drafter@v5.15.0
-        with:
-          disable-autolabeler: true
-          commitish: ${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   #deploy the snapshot artifacts to Artifactory
   deploySnapshot:
     name: deploySnapshot

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,21 @@ jobs:
         with:
           arguments: test -Pjunit-tags=slow
 
+  #draft release notes only if this is a snapshot commit (ie. a merge of a PR)
+  releaseDrafter:
+    name: releaserDrafter
+    runs-on: ubuntu-20.04
+    needs: [ prepare ]
+    if: needs.prepare.outputs.versionType == 'SNAPSHOT'
+    steps:
+      # Renovate Bot should suggest updates to the action
+      - uses: release-drafter/release-drafter@v5.15.0
+        with:
+          disable-autolabeler: true
+          commitish: ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   #deploy the snapshot artifacts to Artifactory
   deploySnapshot:
     name: deploySnapshot

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -31,7 +31,7 @@ jobs:
         uses: release-drafter/release-drafter@v5.15.0
         id: notes
         #draft release notes only if this is a snapshot commit (ie. a merge of a PR)
-        if: needs.prepare.outputs.versionType == 'SNAPSHOT'
+        if: steps.version.outputs.versionType == 'SNAPSHOT'
         with:
           disable-autolabeler: true
           commitish: "main" #${{ github.ref_name }} # temporarily test the release note

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,6 @@ on:
     branches: # For branches, better to list them explicitly than regexp include
       - main
       - 3.3.x
-      - releaseDrafting
 jobs:
   releaseDraft:
     # Notes on prepare: this job has no access to secrets, only github token. As a result, all non-core actions are centralized here
@@ -34,6 +33,6 @@ jobs:
         if: steps.version.outputs.versionType == 'SNAPSHOT'
         with:
           disable-autolabeler: true
-          commitish: "main" #${{ github.ref_name }} # temporarily test the release note
+          commitish: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,8 +6,7 @@ on:
       - 3.3.x
 jobs:
   releaseDraft:
-    # Notes on prepare: this job has no access to secrets, only github token. As a result, all non-core actions are centralized here
-    # This includes the tagging and drafting of release notes. Still, when possible we favor plain run of gradle tasks
+    # Note this job has no access to secrets, only github token. When possible we favor plain run of gradle tasks.
     name: release-draft
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,38 @@
+name: Release Notes Drafter
+on:
+  push:
+    branches: # For branches, better to list them explicitly than regexp include
+      - main
+      - 3.3.x
+jobs:
+  releaseDraft:
+    # Notes on prepare: this job has no access to secrets, only github token. As a result, all non-core actions are centralized here
+    # This includes the tagging and drafting of release notes. Still, when possible we favor plain run of gradle tasks
+    name: release-draft
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 8
+      - name: interpret version
+        id: version
+        #we only run the qualifyVersionGha task so that no other console printing can hijack this step's output
+        #output:
+        #  versionType: ${{ steps.version.outputs.versionType }}
+        #  fullVersion: ${{ steps.version.outputs.fullVersion }}
+        #fails if versionType is BAD, which interrupts the workflow
+        run: ./gradlew qualifyVersionGha
+      - name: compile release notes
+        # Renovate Bot should suggest updates to the action
+        uses: release-drafter/release-drafter@v5.15.0
+        id: notes
+        #draft release notes only if this is a snapshot commit (ie. a merge of a PR)
+        if: needs.prepare.outputs.versionType == 'SNAPSHOT'
+        with:
+          disable-autolabeler: true
+          commitish: ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,6 +4,7 @@ on:
     branches: # For branches, better to list them explicitly than regexp include
       - main
       - 3.3.x
+      - releaseDrafting
 jobs:
   releaseDraft:
     # Notes on prepare: this job has no access to secrets, only github token. As a result, all non-core actions are centralized here
@@ -33,6 +34,6 @@ jobs:
         if: needs.prepare.outputs.versionType == 'SNAPSHOT'
         with:
           disable-autolabeler: true
-          commitish: ${{ github.ref_name }}
+          commitish: "main" #${{ github.ref_name }} # temporarily test the release note
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -61,6 +61,7 @@ task qualifyVersionGha() {
 			println "::error ::Unable to parse $version to a VersionNumber with recognizable qualifier"
 			throw new TaskExecutionException(tasks.getByName("qualifyVersionGha"), new IllegalArgumentException("Unable to parse $version to a VersionNumber with recognizable qualifier"))
 		}
+		println "Recognized $version as $versionType"
 	}
 }
 


### PR DESCRIPTION
This commit introduces Release-Drafter in the publish.yml workflow,
for pushes categorized as "SNAPSHOT" (ie corresponding to the merging of
a PR).

The use of `filter-by-commitish` in the config and `commitish` (set to
the target branch) in the action config should ensure that drafts are
created for both the `main` branch and older maintenance branches.

Fixes #1445.
