### PR TITLE
Renovate group patched libs only, separate all plugin updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,28 +23,17 @@
       ]
     },
     {
-      "matchPackagePatterns": [ "*" ],
-      "matchUpdateTypes": [ "minor", "patch" ],
-      "groupName": "all non-major library dependencies",
-      "groupSlug": "libs-minor-patch"
+      "matchUpdateTypes": [ "patch" ],
+      "groupName": "library dependencies with new patch",
+      "groupSlug": "libs-patch"
     },
     {
       "matchDepTypes": [ "plugin" ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "all non-major plugins",
-      "groupSlug": "plugins-minor-patch"
+      "groupName": null
     },
     {
       "matchPackagePatterns": [ ".*jfrog.*" ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "all non-major plugins",
-      "groupSlug": "plugins-minor-patch"
+      "groupName": "jfrog plugins"
     },
     {
       "matchManagers": ["gradle-wrapper"],


### PR DESCRIPTION
Since there doesn't seem to be a reverse to `matchDepTypes`,
nor a depType that maps to a simple dependency, we configure
Renovate to group on `patch` level only by default then in a
separate rule for `plugin`, we force to ungroup by using the
`groupName: null` trick.

Technically, it could be beneficial to further separate prod
dependencies, but that should do as a minimum grouping.