### PR TITLE
Prevent FluxBufferTimeout requests < 0 when enough outstanding

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
@@ -320,6 +320,9 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 		}
 
 		final void requestMore(long n) {
+			if (n < 1L) {
+				return;
+			}
 			Subscription s = this.subscription;
 			if (s != null) {
 				Operators.addCap(OUTSTANDING, this, n);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
@@ -314,15 +314,14 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 				}
 				else {
 					long requestLimit = Operators.multiplyCap(requested, batchSize);
-					requestMore(requestLimit - outstanding);
+					if (requestLimit > outstanding) {
+						requestMore(requestLimit - outstanding);
+					}
 				}
 			}
 		}
 
 		final void requestMore(long n) {
-			if (n < 1L) {
-				return;
-			}
 			Subscription s = this.subscription;
 			if (s != null) {
 				Operators.addCap(OUTSTANDING, this, n);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -107,6 +109,31 @@ public class FluxBufferTimeoutTest {
 						            .hasMessage("Could not emit buffer due to lack of requests")
 						            .isInstanceOf(IllegalStateException.class)
 		            );
+	}
+
+	@Test
+	void bufferWithTimeoutAvoidingNegativeRequests() {
+		final List<Long> requestPattern = new CopyOnWriteArrayList<>();
+
+		StepVerifier.withVirtualTime(() ->
+					Flux.range(1, 3)
+						.delayElements(Duration.ofMillis(100))
+						.doOnRequest(requestPattern::add)
+						.bufferTimeout(5, Duration.ofMillis(100)),
+				0)
+			.expectSubscription()
+			.expectNoEvent(Duration.ofMillis(100))
+			.thenRequest(2)
+			.expectNoEvent(Duration.ofMillis(100))
+			.assertNext(s -> assertThat(s).containsExactly(1))
+			.expectNoEvent(Duration.ofMillis(100))
+			.assertNext(s -> assertThat(s).containsExactly(2))
+			.thenRequest(1) // This should not cause a negative upstream request
+			.expectNoEvent(Duration.ofMillis(100))
+			.thenCancel()
+			.verify();
+
+		assertThat(requestPattern).allSatisfy(r -> assertThat(r).isPositive());
 	}
 
 	@Test


### PR DESCRIPTION
This commit puts a simple guard against negative request in the
BufferTimeoutSubscriber#requestMore method in order to cover cases
where discrepancies are introduced by the timeouts.

Request accounting is not perfect when both a size and a duration can
be specified, given that requests upstream are multiplicated in order
to get a chance at filling buffers.

Hence, this change puts a simple guard which ignores negative requests.

Fixes #2839.
