### PR TITLE
[build] Hardening of GitHub actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,8 @@
     ":label(type/dependency-upgrade)",
     ":reviewer(reactor/core-team)",
     ":timezone(Europe/Paris)",
-    "schedule:nonOfficeHours"
+    "schedule:nonOfficeHours",
+    "helper:pinGitHubActionDigests"
   ],
   "prBodyNotes": [
     "Renovate has been configured to skip the CLA:",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,12 @@
 name: CI
 on:
   pull_request: {}
+permissions: read-all
 jobs:
   core-fast:
     name: core fast tests
     runs-on: ubuntu-latest
     steps:
-    # the skip-duplicate-actions step actually applies to the whole workflow
-    - uses: fkirc/skip-duplicate-actions@master
-      name: cancel previous runs
-      with:
-        github_token: ${{ github.token }}
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v2
       with:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,6 +1,6 @@
 name: "Gradle Wrapper"
 on: [push, pull_request]
-
+permissions: read-all
 jobs:
   validation:
     name: "validation"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
     branches: # For branches, better to list them explicitly than regexp include
       - main
       - 3.3.x
+permissions: read-all
 jobs:
   # General job notes: we DON'T want to cancel any previous runs, especially in the case of a "back to snapshots" build right after a release push
   # We specify the ubuntu version to minimize the chances we have to deal with a migration during a release
@@ -92,12 +93,6 @@ jobs:
         ORG_GRADLE_PROJECT_signingPassword: ${{secrets.SIGNING_PASSPHRASE}}
       run: |
           ./gradlew assemble sign artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io -Partifactory_publish_repoKey=libs-milestone-local
-    - name: tag
-      run: |
-        git config --local user.name 'reactorbot'
-        git config --local user.email '32325210+reactorbot@users.noreply.github.com'
-        git tag -m "Release milestone ${{ needs.prepare.outputs.fullVersion }}" v${{ needs.prepare.outputs.fullVersion }} ${{ github.sha }}
-        git push --tags
 
   #sign the release artifacts and deploy them to Artifactory
   deployRelease:
@@ -122,12 +117,36 @@ jobs:
         ORG_GRADLE_PROJECT_sonatypePassword: ${{secrets.SONATYPE_PASSWORD}}
       run: |
           ./gradlew assemble sign artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io  -Partifactory_publish_repoKey=libs-release-local publishMavenJavaPublicationToSonatypeRepository
-    - name: tag
-      run: |
-        git config --local user.name 'reactorbot'
-        git config --local user.email '32325210+reactorbot@users.noreply.github.com'
-        git tag -m "Release version ${{ needs.prepare.outputs.fullVersion }}" v${{ needs.prepare.outputs.fullVersion }} ${{ github.sha }}
-        git push --tags
+
+  tagMilestone:
+    name: Tag milestone
+    needs: [ prepare, deployMilestone ]
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
+      - name: tag
+        run: |
+          git config --local user.name 'reactorbot'
+          git config --local user.email '32325210+reactorbot@users.noreply.github.com'
+          git tag -m "Release milestone ${{ needs.prepare.outputs.fullVersion }}" v${{ needs.prepare.outputs.fullVersion }} ${{ github.sha }}
+          git push --tags
+
+  tagRelease:
+    name: Tag release
+    needs: [ prepare, deployRelease ]
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
+      - name: tag
+        run: |
+          git config --local user.name 'reactorbot'
+          git config --local user.email '32325210+reactorbot@users.noreply.github.com'
+          git tag -m "Release version ${{ needs.prepare.outputs.fullVersion }}" v${{ needs.prepare.outputs.fullVersion }} ${{ github.sha }}
+          git push --tags
 
 # For Gradle configuration of signing, see https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
 # publishMavenJavaPublicationToSonatypeRepository only sends to a staging repository


### PR DESCRIPTION

This commit makes several modifications to our workflows to make them
more secure:

- explicitly have GITHUB_TOKEN read-only by default
- remove a not-that-useful step which requires a write token
- split tagging steps in their own jobs, limiting the scope of needed
write permission to these short-lived jobs
- modify Renovate config so that it will pin github actions to a SHA
