### PR TITLE
[build] Action updates: fix pinning

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,8 +7,7 @@
     ":label(type/dependency-upgrade)",
     ":reviewer(reactor/core-team)",
     ":timezone(Europe/Paris)",
-    "schedule:nonOfficeHours",
-    "helper:pinGitHubActionDigests"
+    "schedule:nonOfficeHours"
   ],
   "prBodyNotes": [
     "Renovate has been configured to skip the CLA:",
@@ -42,8 +41,9 @@
       "schedule": ["before 3am on Monday"]
     },
     {
-      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["action"],
       "groupName": "Github Workflows",
+      "pinDigests": true,
       "schedule": ["before 3am on Monday"]
     },
     {


### PR DESCRIPTION
This commit fixes the Renovate configuration for actions in order to use
SHA pinning. The config block is derived from the existing helper
(helpers:pinGithubActionDigests) but since we're configuring more stuff
like grouping and schedule, this commit uses an explicit approach.

It also changes the use of matchManagers to matchDepTypes (inspired by
the helper again).

Fixes #2900.
