### PR TITLE
[doc]Correct flux subscribe example in faq

### DIFF
--- a/docs/asciidoc/faq.adoc
+++ b/docs/asciidoc/faq.adoc
@@ -81,10 +81,9 @@ The following sample is even better (because it is simpler):
 ====
 [source,java]
 ----
-Flux<String> secrets = Flux
-  .just("something", "chain")
-  .map(secret -> secret.replaceAll(".", "*"))
-  .subscribe(next -> System.out.println("Received: " + next));
+Flux.just("something", "chain")
+    .map(secret -> secret.replaceAll(".", "*"))
+    .subscribe(next -> System.out.println("Received: " + next));
 ----
 ====
 


### PR DESCRIPTION
Fix: subscribe() return type is Disposable, so remove incorrect return varibale (Flux<String> secrets) here.