### PR TITLE
Fix Mono.then not cancelling between Callable sources

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoIgnoreThen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoIgnoreThen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -219,6 +219,10 @@ final class MonoIgnoreThen<T> extends Mono<T> implements Scannable {
                 if (i == a.length) {
                     Mono<T> m = this.lastMono;
                     if (m instanceof Callable) {
+                        if (isCancelled(this.state)) {
+                            //NB: in the non-callable case, this is handled by activeSubscription.cancel()
+                            return;
+                        }
                         T v;
                         try {
                             v = ((Callable<T>)m).call();
@@ -240,6 +244,10 @@ final class MonoIgnoreThen<T> extends Mono<T> implements Scannable {
                     final Publisher<?> m = a[i];
 
                     if (m instanceof Callable) {
+                        if (isCancelled(this.state)) {
+                            //NB: in the non-callable case, this is handled by activeSubscription.cancel()
+                            return;
+                        }
                         try {
                             Operators.onDiscard(((Callable<?>) m).call(), currentContext());
                         }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreThenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoIgnoreThenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,12 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
@@ -30,10 +36,87 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
+import reactor.util.Logger;
+import reactor.util.Loggers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class MonoIgnoreThenTest {
+
+	private static final Logger LOGGER = Loggers.getLogger(MonoIgnoreThenTest.class);
+
+	@Test
+	void multipleThenChainedCancelInTheMiddle() throws InterruptedException {
+		List<Integer> startedSteps = new CopyOnWriteArrayList<>();
+		List<Integer> completedSteps = new CopyOnWriteArrayList<>();
+		List<Integer> cancelledSteps = new CopyOnWriteArrayList<>();
+
+		Mono<?> run1 = Mono.fromRunnable(() -> multipleThenStep(1, startedSteps, completedSteps, cancelledSteps)).subscribeOn(Schedulers.boundedElastic());
+		Mono<?> run2 = Mono.fromRunnable(() -> multipleThenStep(2, startedSteps, completedSteps, cancelledSteps)).subscribeOn(Schedulers.boundedElastic());
+		Mono<?> run3 = Mono.fromRunnable(() -> multipleThenStep(3, startedSteps, completedSteps, cancelledSteps)).subscribeOn(Schedulers.boundedElastic());
+
+		assertThat(Arrays.asList(run1, run2, run3)).as("smoke test: no callables").noneMatch(m -> m instanceof Callable);
+
+		assertThatExceptionOfType(RuntimeException.class).isThrownBy(() ->
+				run1.then(run2)
+					.then(run3)
+					.timeout(Duration.ofMillis(750))
+					.block())
+			.withCauseExactlyInstanceOf(TimeoutException.class);
+
+		//we give 1.5s total in case run3 incorrectly starts or run2 incorrectly completes
+		Thread.sleep(750);
+		//we verify that run3 didn't even start
+		assertThat(startedSteps).as("started steps").containsExactly(1, 2);
+		//in this configuration the sleep is interrupted so run2 "done" should not happen
+		assertThat(completedSteps).as("done steps").containsExactly(1);
+		assertThat(cancelledSteps).as("interruptions").containsExactly(2);
+	}
+
+	@Test
+	void multipleThenChainedCancelInTheMiddle_withCallables() throws InterruptedException {
+		List<Integer> startedSteps = new CopyOnWriteArrayList<>();
+		List<Integer> completedSteps = new CopyOnWriteArrayList<>();
+		List<Integer> cancelledSteps = new CopyOnWriteArrayList<>();
+
+		Mono<?> run1 = Mono.fromRunnable(() -> multipleThenStep(1, startedSteps, completedSteps, cancelledSteps));
+		Mono<?> run2 = Mono.fromRunnable(() -> multipleThenStep(2, startedSteps, completedSteps, cancelledSteps));
+		Mono<?> run3 = Mono.fromRunnable(() -> multipleThenStep(3, startedSteps, completedSteps, cancelledSteps));
+
+		assertThat(Arrays.asList(run1, run2, run3)).as("smoke test: all callables").allMatch(m -> m instanceof Callable);
+
+		assertThatExceptionOfType(RuntimeException.class).isThrownBy(() ->
+				run1.then(run2)
+					.then(run3)
+				.timeout(Duration.ofMillis(750))
+				.block())
+				.withCauseExactlyInstanceOf(TimeoutException.class);
+
+		//we give 1.5s total in case run3 incorrectly starts
+		Thread.sleep(750);
+		//we verify that run3 didn't even start
+		assertThat(startedSteps).as("started steps").containsExactly(1, 2);
+		//unfortunately in this configuration the sleep cannot really be interrupted so the "done" will still happen
+		assertThat(completedSteps).as("done steps").containsExactly(1, 2);
+		assertThat(cancelledSteps).as("no interruptions").isEmpty();
+	}
+
+	private void multipleThenStep(int i, Collection<Integer> startedSteps, Collection<Integer> completedSteps, Collection<Integer> cancelledSteps) {
+		startedSteps.add(i);
+		try {
+			LOGGER.debug("Running stage {}", i);
+			//this sleep is problematic usually, but done here on purpose in order to have a Callable Mono
+			// that induces a sufficient delay for timeout to trigger
+			Thread.sleep(500);
+			LOGGER.debug("Running stage {} done", i);
+			completedSteps.add(i);
+		} catch (InterruptedException e) {
+			cancelledSteps.add(i);
+			LOGGER.debug("Stage {} has been interrupted / cancelled", i);
+		}
+	}
+
 
 	@Nested
 	class ThenIgnoreVariant {


### PR DESCRIPTION
This commit adds a check of cancellation between two subsequent chained
Monos, in the case these Monos are `Callable`.

Without it, the cancellation would be kind of ignored and all subsequent
Callable Monos would still get invoked.

Fixes #2933.
