### PR TITLE
Change behavior of switchOnNext/switchMap default 0 prefetch

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This commit changes the no-parameter variant of Flux switchMap and
switchOnNext operators to default to a behavior of prefetch = 0.

This was documented in 3.4.x when the parameterized variant was
deprecated. Note that the prefetch > 0 implementation is slated for
complete removal in 3.6.0.

Old prefetch behavior could be emulated with `limitRate` on inners.

Fixes #2607.