### PR TITLE
[build] Have jcstress part of slowerChecks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
       id: checks
       uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7 # renovate: tag=v2
       with:
-        arguments: check -Pjunit-tags=!slow
+        arguments: check -Pjunit-tags=!slow -x jcstress
 
   slowerChecks:
     # similar limitations as in prepare, but we parallelize slower tests here
@@ -51,7 +51,7 @@ jobs:
         id: slowerTests
         uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7 # renovate: tag=v2
         with:
-          arguments: test -Pjunit-tags=slow
+          arguments: reactor-core:test -Pjunit-tags=slow jcstress
 
   #deploy the snapshot artifacts to Artifactory
   deploySnapshot:


### PR DESCRIPTION
This commit makes jcstress tests part of the slowerChecks job
in the publish.yml workflow.

Latest runs of this workflow show 24min for prepare and 14min
for slowerChecks, so this should bring better equilibrium.

Additionally, we ensure that only reactor-core:test are run
(the only one with a "slow" tag), as the previous command
was running _all_ tests and only filtering the core ones.

Fixes #2805.
