### PR TITLE
Have concatMap default to 0 prefetch behavior

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDelayUntilTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDelayUntilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -210,7 +210,7 @@ public class FluxDelayUntilTest {
 	@Test
 	public void isAlias() {
 		assertThat(Flux.range(1, 10).delayUntil(a -> Mono.empty()))
-				.isInstanceOf(FluxConcatMap.class);
+				.isInstanceOf(FluxConcatMapNoPrefetch.class);
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxIntervalTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxIntervalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
 import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -186,15 +187,19 @@ public class FluxIntervalTest {
     }
 
 
-    @Test
-	public void tickOverflow() {
-		StepVerifier.withVirtualTime(() ->
-				Flux.interval(Duration.ofMillis(50))
-				    .delayUntil(i -> Mono.delay(Duration.ofMillis(250))))
-		            .thenAwait(Duration.ofMinutes(1))
-		            .expectNextCount(6)
-		            .verifyErrorMessage("Could not emit tick 32 due to lack of requests (interval doesn't support small downstream requests that replenish slower than the ticks)");
-    }
+	@Test
+	void tickOverflow() {
+		StepVerifier.withVirtualTime(() -> Flux.interval(Duration.ofMillis(50)), 0)
+			.expectSubscription()
+			.thenRequest(10)
+			.thenAwait(Duration.ofMillis(550))
+			.expectNextCount(10)
+			.expectErrorSatisfies(e -> assertThat(e)
+				.matches(Exceptions::isOverflow)
+				.hasMessage("Could not emit tick 10 due to lack of requests (interval doesn't support small downstream requests that replenish slower than the ticks)")
+			)
+			.verify(Duration.ofSeconds(1));
+	}
 
     @Test
 	public void shouldBeAbleToScheduleIntervalsWithLowGranularity() {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowWhenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -306,7 +306,7 @@ public class FluxWindowWhenTest {
 		return Flux.just(1, 2, 3, 4, 5, 6, 7, 8)
 		           .delayElements(Duration.ofMillis(99))
 		           .window(Duration.ofMillis(300), Duration.ofMillis(200))
-		           .concatMap(Flux::buffer);
+		           .concatMap(Flux::buffer, 1);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -81,6 +81,7 @@ import reactor.util.function.Tuples;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
+import static reactor.core.Exceptions.unwrapMultipleExcludingTracebacks;
 import static reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST;
 
 public class FluxTests extends AbstractReactorTest {
@@ -177,14 +178,12 @@ public class FluxTests extends AbstractReactorTest {
 
 		Flux<Integer> source = Flux.range(0, 5);
 
-		Flux<String> concatMap = source.concatMapDelayError(mapFunction)
-		                               .doOnError(t -> concatSuppressed.addAll(
-		                               		Arrays.asList(t.getSuppressed())))
+		Flux<String> concatMap = source.concatMapDelayError(mapFunction, 32)
+		                               .doOnError(t -> concatSuppressed.addAll(unwrapMultipleExcludingTracebacks(t)))
 		                               .materialize()
 		                               .map(Object::toString);
 		Flux<String> flatMap = source.flatMapDelayError(mapFunction, 2, 32)
-		                             .doOnError(t -> flatSuppressed.addAll(
-		                             		Arrays.asList(t.getSuppressed())))
+		                             .doOnError(t -> flatSuppressed.addAll(unwrapMultipleExcludingTracebacks(t)))
 		                             .materialize()
 		                             .map(Object::toString);
 


### PR DESCRIPTION
This commit changes the no-parameter variant of concatMap to avoid use
of prefetch (similar to calling `concatMap(function, 0)`).

concatMapDelayError is also similarly changed. The variants that take
a prefetch parameter are kept.

Fixes #2599.
