### PR TITLE
[agent] Avoid instrumenting methods with unwrappable returnType

### DIFF
--- a/reactor-tools/src/main/java/reactor/tools/agent/CallSiteInfoAddingMethodVisitor.java
+++ b/reactor-tools/src/main/java/reactor/tools/agent/CallSiteInfoAddingMethodVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-tools/src/main/java/reactor/tools/agent/CallSiteInfoAddingMethodVisitor.java
+++ b/reactor-tools/src/main/java/reactor/tools/agent/CallSiteInfoAddingMethodVisitor.java
@@ -16,12 +16,12 @@
 
 package reactor.tools.agent;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import net.bytebuddy.jar.asm.Label;
 import net.bytebuddy.jar.asm.MethodVisitor;
 import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.jar.asm.Type;
-
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Adds callSite info to every operator call (except "checkpoint").
@@ -41,6 +41,12 @@ class CallSiteInfoAddingMethodVisitor extends MethodVisitor {
 
     static final String ADD_CALLSITE_INFO_METHOD = "(Lorg/reactivestreams/Publisher;Ljava/lang/String;)Lorg/reactivestreams/Publisher;";
 
+    /**
+     * Determine if a class (in the {@code com/package/ClassName} format) can be considered a CorePublisher.
+     *
+     * @param className the class name in the {@code com/package/ClassName} format
+     * @return true if it is exactly one of the CorePublisher interfaces (except ConnectableFlux), false otherwise
+     */
     static boolean isCorePublisher(String className) {
         switch (className) {
             case "reactor/core/publisher/Flux":
@@ -51,6 +57,18 @@ class CallSiteInfoAddingMethodVisitor extends MethodVisitor {
             default:
                 return false;
         }
+    }
+
+    /**
+     * Determine if a class (in the {@code com/package/ClassName} format) is compatible with lift or equivalent
+     * wrapping done by Hooks. The return type of visited methods should be checked with this in order to
+     * verify their result can be wrapped with debug traceback.
+     *
+     * @param className the class name in the {@code com/package/ClassName} format
+     * @return true if it can be wrapped with debug traceback while maintaining the same type, false otherwise
+     */
+    static boolean isLiftCompatiblePublisher(String className) {
+        return isCorePublisher(className) || "reactor/core/publisher/ConnectableFlux".equals(className);
     }
 
     final String currentMethod;
@@ -91,7 +109,8 @@ class CallSiteInfoAddingMethodVisitor extends MethodVisitor {
                 return;
             }
             String returnType = Type.getReturnType(descriptor).getInternalName();
-            if (!returnType.startsWith("reactor/core/publisher/")) {
+            //Note this is the default path. If the return type is not lift-compatible (eg. MonoProcessor) then we shouldn't instrument it / wrap it
+            if (!isLiftCompatiblePublisher(returnType)) {
                 return;
             }
 

--- a/reactor-tools/src/main/java/reactor/tools/agent/ReturnHandlingMethodVisitor.java
+++ b/reactor-tools/src/main/java/reactor/tools/agent/ReturnHandlingMethodVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-tools/src/main/java/reactor/tools/agent/ReturnHandlingMethodVisitor.java
+++ b/reactor-tools/src/main/java/reactor/tools/agent/ReturnHandlingMethodVisitor.java
@@ -16,12 +16,12 @@
 
 package reactor.tools.agent;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import net.bytebuddy.jar.asm.Label;
 import net.bytebuddy.jar.asm.MethodVisitor;
 import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.jar.asm.Type;
-
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Checkpoints every method returning Mono/Flux/ParallelFlux,
@@ -84,6 +84,8 @@ class ReturnHandlingMethodVisitor extends MethodVisitor {
 
         if (!checkpointed && CallSiteInfoAddingMethodVisitor.isCorePublisher(owner)) {
             String returnType = Type.getReturnType(descriptor).getInternalName();
+            //note that ReactorDebugClassVisitor doesn't apply this visitor on return types other than Flux/Mono/ParallelFlux
+            //so the return type should always be lift-compatible
             if (returnType.startsWith("reactor/core/publisher/")) {
                 checkpointed = true;
             }

--- a/reactor-tools/src/test/java/reactor/tools/agent/ReactorDebugAgentTest.java
+++ b/reactor-tools/src/test/java/reactor/tools/agent/ReactorDebugAgentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-tools/src/test/java/reactor/tools/agent/ReactorDebugAgentTest.java
+++ b/reactor-tools/src/test/java/reactor/tools/agent/ReactorDebugAgentTest.java
@@ -16,19 +16,21 @@
 
 package reactor.tools.agent;
 
-import net.sf.cglib.proxy.Enhancer;
-import net.sf.cglib.proxy.NoOp;
-import org.junit.jupiter.api.Test;
-import reactor.core.CoreSubscriber;
-import reactor.core.Scannable;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Iterator;
 import java.util.function.Function;
 import java.util.stream.Stream;
+
+import net.sf.cglib.proxy.Enhancer;
+import net.sf.cglib.proxy.NoOp;
+import org.junit.jupiter.api.Test;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Scannable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoProcessor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -82,6 +84,16 @@ public class ReactorDebugAgentTest {
 
 		assertThat(Scannable.from(flux).stepName())
 				.startsWith("GroupedFlux.map ⇢ at reactor.tools.agent.ReactorDebugAgentTest.shouldWorkWithGroupedFlux(ReactorDebugAgentTest.java:" + (baseline + 1));
+	}
+
+	@Test
+	@Deprecated
+	void shouldIgnoreMonoProcessor() {
+		Mono<Integer> mono = Mono.just(1);
+		MonoProcessor<Integer> monoProcessor = mono.toProcessor();
+		assertThat(Scannable.from(monoProcessor).stepName())
+			.doesNotContain(" ⇢ at")
+			.isEqualTo("nextProcessor");
 	}
 
 	@Test


### PR DESCRIPTION
This commit adds a check to instrumentation of methods that return a
publisher type that cannot be wrapped while maintaining a compatible
type.

One such incompatibility occurs in `Mono#toProcessor()`. It was
instrumented because `MonoProcessor` is a `Mono` technically, which
led to a `MonoAssembly` wrapping type. But that is not compatible with
the exposed return type (`MonoProcessor`).

Fixes #2970.
