### PR TITLE
April round of upgrades superseding Renovate PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
-      - uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7 # renovate: tag=v2
+      - uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee # tag=v2
         name: spotless (license header)
         if: always()
         with:
           arguments: spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
-      - uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7 # renovate: tag=v2
+      - uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee # tag=v2
         name: api compatibility
         if: always()
         with:
@@ -46,7 +46,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 8
-    - uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7 # renovate: tag=v2
+    - uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee # tag=v2
       name: gradle
       with:
         arguments: :reactor-core:test --no-daemon -Pjunit-tags=!slow
@@ -60,7 +60,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 8
-    - uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7 # renovate: tag=v2
+    - uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee # tag=v2
       name: gradle
       with:
         arguments: :reactor-core:test --no-daemon -Pjunit-tags=slow
@@ -74,7 +74,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 8
-    - uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7 # renovate: tag=v2
+    - uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee # tag=v2
       name: other tests
       with:
         arguments: check -x :reactor-core:test -x spotlessCheck --no-daemon

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       run: ./gradlew qualifyVersionGha
     - name: run checks
       id: checks
-      uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7 # renovate: tag=v2
+      uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee # tag=v2
       with:
         arguments: check -Pjunit-tags=!slow -x jcstress
 
@@ -49,7 +49,7 @@ jobs:
           java-version: 8
       - name: run slower tests
         id: slowerTests
-        uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7 # renovate: tag=v2
+        uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee # tag=v2
         with:
           arguments: reactor-core:test -Pjunit-tags=slow jcstress
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,12 +2,12 @@
 # Baselines, should be updated on every release
 baseline-core-api = "3.4.16"
 baselinePerfCore = "3.4.16"
-baselinePerfExtra = "3.4.6"
+baselinePerfExtra = "3.4.7"
 
 # Other shared versions
 asciidoctor = "3.3.2"
 bytebuddy = "1.12.8"
-jmh = "1.34"
+jmh = "1.35"
 junit = "5.8.2"
 kotlin = "1.5.32"
 reactiveStreams = "1.0.3"
@@ -39,15 +39,15 @@ testNg = "org.testng:testng:7.5"
 throwingFunction = "com.pivovarit:throwing-function:1.5.1"
 
 [plugins]
-artifactory = { id = "com.jfrog.artifactory", version = "4.27.1" }
+artifactory = { id = "com.jfrog.artifactory", version = "4.28.1" }
 asciidoctor-convert = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor" }
 asciidoctor-pdf = { id = "org.asciidoctor.jvm.pdf", version.ref = "asciidoctor" }
 bnd = { id = "biz.aQute.bnd.builder", version = "6.2.0" }
-download = { id = "de.undercouch.download", version = "5.0.2" }
+download = { id = "de.undercouch.download", version = "5.0.4" }
 japicmp = { id = "me.champeau.gradle.japicmp", version = "0.4.0" }
 jcstress = { id = "io.github.reyerizo.gradle.jcstress", version = "0.8.13" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 nohttp = { id = "io.spring.nohttp", version = "0.0.10" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
-spotless = { id = "com.diffplug.spotless", version = "6.3.0" }
+spotless = { id = "com.diffplug.spotless", version = "6.4.1" }
 testsets = { id = "org.unbroken-dome.test-sets", version = "4.0.0" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 plugins {
-	id "com.gradle.enterprise" version "3.8.1"
+	id "com.gradle.enterprise" version "3.9"
 }
 
 rootProject.name = 'reactor'


### PR DESCRIPTION
This PR supersedes several Renovate PRs, as these are either targeting the main
branch or tried to target `3.4.x` but embark all commits from `main`...

 ﻿- Update several test / plugin dependencies in 3.4.x
 - Update Gradle to v7.4.2
 - Upgrade gradle-build-action to v2.1.5

Commits have been reworded to reflect the PR number.
To be merged with rebase, as each individual commit references the superseded
PR or PRs.