### PR TITLE
Update gradle/gradle-build-action to v2.1.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
-      - uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee # tag=v2
+      - uses: gradle/gradle-build-action@fec4a42eb0c83154e5c9590748ba8337949c5701 # tag=v2
         name: spotless (license header)
         if: always()
         with:
           arguments: spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
-      - uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee # tag=v2
+      - uses: gradle/gradle-build-action@fec4a42eb0c83154e5c9590748ba8337949c5701 # tag=v2
         name: api compatibility
         if: always()
         with:
@@ -46,7 +46,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 8
-    - uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee # tag=v2
+    - uses: gradle/gradle-build-action@fec4a42eb0c83154e5c9590748ba8337949c5701 # tag=v2
       name: gradle
       with:
         arguments: :reactor-core:test --no-daemon -Pjunit-tags=!slow
@@ -60,7 +60,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 8
-    - uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee # tag=v2
+    - uses: gradle/gradle-build-action@fec4a42eb0c83154e5c9590748ba8337949c5701 # tag=v2
       name: gradle
       with:
         arguments: :reactor-core:test --no-daemon -Pjunit-tags=slow
@@ -74,7 +74,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 8
-    - uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee # tag=v2
+    - uses: gradle/gradle-build-action@fec4a42eb0c83154e5c9590748ba8337949c5701 # tag=v2
       name: other tests
       with:
         arguments: check -x :reactor-core:test -x spotlessCheck --no-daemon

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       run: ./gradlew qualifyVersionGha
     - name: run checks
       id: checks
-      uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee # tag=v2
+      uses: gradle/gradle-build-action@fec4a42eb0c83154e5c9590748ba8337949c5701 # tag=v2
       with:
         arguments: check -Pjunit-tags=!slow -x jcstress
 
@@ -49,7 +49,7 @@ jobs:
           java-version: 8
       - name: run slower tests
         id: slowerTests
-        uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee # tag=v2
+        uses: gradle/gradle-build-action@fec4a42eb0c83154e5c9590748ba8337949c5701 # tag=v2
         with:
           arguments: reactor-core:test -Pjunit-tags=slow jcstress
 


### PR DESCRIPTION
Unlike stated in commit 95f1046a1 / PR #2992, the previous hash used
was for version 2.1.4.

This commit actually upgrades the action to the latest version, which
is v2.1.5 (and commit has `fec4a42`).

Supersedes and closes #2993. (Renovate currently cannot target 3.4.x)
