### PR TITLE
Fix subscribers being retained by SinkOneMulticast

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/SinkOneMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkOneMulticast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,6 +124,11 @@ final class SinkOneMulticast<O> extends SinkEmptyMulticast<O> implements Interna
 		NextInner(CoreSubscriber<? super T> actual, SinkOneMulticast<T> parent) {
 			super(actual);
 			this.parent = parent;
+		}
+
+		@Override
+		protected void doOnCancel() {
+			parent.remove(this);
 		}
 
 		@Override


### PR DESCRIPTION
This commit fixes a leak where subscribers are retained by SinkOneMulticast
despite cancellation. The `NextInner` didn't remove itself from its parent on
cancellation.

Fixes #3001.﻿