### PR TITLE
Switch to Micrometer 2 (snapshots) and adapt where needed

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -60,7 +60,7 @@
       "matchPackageNames": ["io.micrometer:micrometer-core"],
       "groupName": "Micrometer 1.3.0",
       "groupSlug": "micrometer",
-      "allowedVersions": "=1.3.0"
+      "enabled": false
     }
   ]
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ asciidoctor = "3.3.2"
 bytebuddy = "1.12.8"
 jmh = "1.35"
 junit = "5.8.2"
+micrometer = "2.0.0-SNAPSHOT"
 reactiveStreams = "1.0.3"
 
 [libraries]
@@ -26,7 +27,10 @@ jsr166backport = "io.projectreactor:jsr166:1.0.0.RELEASE"
 jsr305 = "com.google.code.findbugs:jsr305:3.0.1"
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 logback = "ch.qos.logback:logback-classic:1.2.11"
-micrometer = "io.micrometer:micrometer-core:1.3.0"
+micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometer" }
+micrometer-binders = { module = "io.micrometer:micrometer-binders" }
+micrometer-commons = { module = "io.micrometer:micrometer-commons" }
+micrometer-core = { module = "io.micrometer:micrometer-core" }
 mockito = "org.mockito:mockito-core:4.4.0"
 reactiveStreams = { module = "org.reactivestreams:reactive-streams", version.ref = "reactiveStreams" }
 reactiveStreams-tck = { module = "org.reactivestreams:reactive-streams-tck", version.ref = "reactiveStreams" }

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -83,7 +83,10 @@ dependencies {
 	testCompileOnly libs.slf4j
 
 	// Optional Metrics
-	compileOnly libs.micrometer
+	compileOnly platform(libs.micrometer.bom)
+	compileOnly libs.micrometer.commons
+	compileOnly libs.micrometer.core
+	compileOnly libs.micrometer.binders
 
 	// Optional BlockHound support
 	compileOnly libs.blockhound
@@ -112,7 +115,10 @@ dependencies {
 
 	// withMicrometerTest is a test-set that validates what happens when micrometer *IS*
 	// on the classpath. Needs sourceSets.test.output because tests there use helpers like AutoDisposingRule etc.
-	withMicrometerTestImplementation libs.micrometer
+	withMicrometerTestImplementation platform(libs.micrometer.bom)
+	withMicrometerTestImplementation libs.micrometer.binders
+	withMicrometerTestImplementation libs.micrometer.commons
+	withMicrometerTestImplementation libs.micrometer.core
 	withMicrometerTestImplementation sourceSets.test.output
 
 	jcstressImplementation(project(":reactor-test")) {

--- a/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SchedulerMetricDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,9 +24,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
+import io.micrometer.binder.jvm.ExecutorServiceMetrics;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.search.Search;
 
 import reactor.core.Disposable;
@@ -73,7 +73,7 @@ final class SchedulerMetricDecorator
 				executorDifferentiator.computeIfAbsent(scheduler, key -> new AtomicInteger(0))
 				                      .getAndIncrement();
 
-		Tags tags = Tags.of(TAG_SCHEDULER_ID, schedulerId);
+		Tag[] tags = new Tag[] { Tag.of(TAG_SCHEDULER_ID, schedulerId) };
 
 		/*
 		Design note: we assume that a given Scheduler won't apply the decorator twice to the


### PR DESCRIPTION

 - use the micrometer 2.0 SNAPSHOT bom
 - configure Renovate to entirely ignore micrometer
 - add micrometer-binders dependency (ExecutorService instrumentation has moved)
 - add micrometer-commons dependency in preparation of Tag(s) moving there
 - adapt SchedulerMetricsDecorator to these elements

Note that `Metrics` considers that Micrometer is active by mere detection of the
`MeterRegistry`, which might not be sufficient for schedulers notably now.