### PR TITLE
Update ByteBuddy to v1.12.9

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ baselinePerfExtra = "3.4.7"
 
 # Other shared versions
 asciidoctor = "3.3.2"
-bytebuddy = "1.12.8"
+bytebuddy = "1.12.9"
 jmh = "1.35"
 junit = "5.8.2"
 kotlin = "1.5.32"


### PR DESCRIPTION
Supersedes and closes #3003.
