### PR TITLE
Increase landscape width of refguide content for readability

### DIFF
--- a/docs/asciidoc/stylesheets/reactor.css
+++ b/docs/asciidoc/stylesheets/reactor.css
@@ -822,7 +822,7 @@ p a > code:hover {
     margin-right: auto;
     margin-top: 0;
     margin-bottom: 0;
-    max-width: 62.5em;
+    max-width: max(80em, 60%);
     *zoom: 1;
     position: relative;
     padding-left: 4em;


### PR DESCRIPTION
Refs #2784

I attempted to increase width of refguide content for readability as below. Could you review this, please?

**For landscape**

At first,
we cannot set `max-width` to `60%` because width may be smaller than `62.5em`, e.g., FHD (1920x1080) window's width is (`1920px` - `20em (padding for header)`) * `60%` = `60em` < `62.5em`.

In FHD window, ideally,
`1920px` * `60%` + `8em (div's padding)` = `80em` is a required width for readability.

For more wide window,
the constant will be smaller than `60%` of the window's width.

Thus, `max-width` is desirable to be maximum of `80em` and `60%` of a window.

**For portrait (phone)**

The changes for landscape doesn't affect for portrait because it changes `max-width` to be increase.

\---

So, I set `max-width` to `max(80em, 60%)`.

Note: `max()` is supported by most popular browsers exclude Internet Explorer.
https://developer.mozilla.org/en-US/docs/Web/CSS/max

---

Current: [html.tar.gz](https://github.com/reactor/reactor-core/files/8455899/html.tar.gz)
Modified: [html.tar.gz](https://github.com/reactor/reactor-core/files/8455900/html.tar.gz)
