### PR TITLE
Add default contextView() implem to [Flux|Mono|Synchronous]Sink

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -184,7 +184,10 @@ task japicmp(type: JapicmpTask) {
 		'reactor.core.scheduler.Schedulers#newElastic(java.lang.String, int)',
 		'reactor.core.scheduler.Schedulers#newElastic(java.lang.String, int, boolean)',
 		'reactor.core.scheduler.Schedulers#newElastic(int, java.util.concurrent.ThreadFactory)',
-		'reactor.core.scheduler.Schedulers$Factory#newElastic(int, java.util.concurrent.ThreadFactory)'
+		'reactor.core.scheduler.Schedulers$Factory#newElastic(int, java.util.concurrent.ThreadFactory)',
+		'reactor.core.publisher.FluxSink#contextView()',
+		'reactor.core.publisher.MonoSink#contextView()',
+		'reactor.core.publisher.SynchronousSink#contextView()'
 	]
 }
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSink.java
@@ -83,7 +83,9 @@ public interface FluxSink<T> {
 	 *
 	 * @return the current subscriber {@link ContextView}.
 	 */
-	ContextView contextView();
+	default ContextView contextView() {
+		return currentContext();
+	}
 
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSink.java
@@ -83,7 +83,9 @@ public interface MonoSink<T> {
 	 *
 	 * @return the current subscriber {@link ContextView}.
 	 */
-	ContextView contextView();
+	default ContextView contextView() {
+		return this.currentContext();
+	}
 
 	/**
 	 * Attaches a {@link LongConsumer} to this {@link MonoSink} that will be notified of

--- a/reactor-core/src/main/java/reactor/core/publisher/SynchronousSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SynchronousSink.java
@@ -65,7 +65,9 @@ public interface SynchronousSink<T> {
 	 *
 	 * @return the current subscriber {@link ContextView}.
 	 */
-	ContextView contextView();
+	default ContextView contextView() {
+		return currentContext();
+	}
 
 	/**
 	 * @param e the exception to signal, not null

--- a/reactor-core/src/test/java/reactor/core/ContextBestPracticesArchTest.java
+++ b/reactor-core/src/test/java/reactor/core/ContextBestPracticesArchTest.java
@@ -27,10 +27,15 @@ import com.tngtech.archunit.lang.SimpleConditionEvent;
 
 import org.junit.jupiter.api.Test;
 
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.MonoSink;
+import reactor.core.publisher.SynchronousSink;
+
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CurrentContextArchTest {
+class ContextBestPracticesArchTest {
 
 	static JavaClasses CORE_SUBSCRIBER_CLASSES = new ClassFileImporter()
 			.withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
@@ -50,7 +55,7 @@ public class CurrentContextArchTest {
 	}
 
 	@Test
-	public void corePublishersShouldNotUseDefaultCurrentContext() {
+	void corePublishersShouldNotUseDefaultCurrentContext() {
 		classes()
 				.that().implement(CoreSubscriber.class)
 				.and().doNotHaveModifier(JavaModifier.ABSTRACT)
@@ -78,7 +83,7 @@ public class CurrentContextArchTest {
 	@Test
 	// This is ok as this class tests the deprecated FluxProcessor. Will be removed with it in 3.5.
 	@SuppressWarnings("deprecation")
-	public void fluxProcessorsShouldNotUseDefaultCurrentContext() {
+	void fluxProcessorsShouldNotUseDefaultCurrentContext() {
 		classes()
 				.that().areAssignableTo(reactor.core.publisher.FluxProcessor.class)
 				.and().doNotHaveModifier(JavaModifier.ABSTRACT)
@@ -104,5 +109,36 @@ public class CurrentContextArchTest {
 					}
 				})
 				.check(FLUXPROCESSOR_CLASSES);
+	}
+
+	@Test
+	void oldSinksShouldNotUseDefaultCurrentContext() {
+		classes()
+			.that().implement(SynchronousSink.class)
+			.or().implement(FluxSink.class)
+			.or().implement(MonoSink.class)
+			.and().doNotHaveModifier(JavaModifier.ABSTRACT)
+			.should(new ArchCondition<JavaClass>("not use the default contextView()") {
+				@Override
+				public void check(JavaClass item, ConditionEvents events) {
+					boolean overridesMethod = item
+						.getAllMethods()
+						.stream()
+						.filter(it -> "contextView".equals(it.getName()))
+						.filter(it -> it.getRawParameterTypes().isEmpty())
+						.anyMatch(it -> !it.getOwner().isEquivalentTo(SynchronousSink.class)
+							&& !it.getOwner().isEquivalentTo(FluxSink.class)
+							&& !it.getOwner().isEquivalentTo(MonoSink.class)
+						);
+
+					if (!overridesMethod) {
+						events.add(SimpleConditionEvent.violated(
+							item,
+							item.getFullName() + item.getSourceCodeLocation() + ": contextView() is not overridden"
+						));
+					}
+				}
+			})
+			.check(CORE_SUBSCRIBER_CLASSES);
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/ContextBestPracticesArchTest.java
+++ b/reactor-core/src/test/java/reactor/core/ContextBestPracticesArchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This commit adds a default implementation to the contextView() method added
in 3.5.0-M1 to the FluxSink, MonoSink and SynchronousSink classes.