### PR TITLE
Backport: contextView() implem of [Flux|Mono|Synchronous]Sink

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -162,7 +162,12 @@ task japicmp(type: JapicmpTask) {
 	// TODO after a .0 release, bump the gradle.properties baseline
 	// TODO after a .0 release, remove the reactor-core exclusions below if any
 	classExcludes = [ ]
-	methodExcludes = [ 'reactor.core.publisher.Sinks$EmitFailureHandler#busyLooping(java.time.Duration)' ]
+	methodExcludes = [
+		'reactor.core.publisher.Sinks$EmitFailureHandler#busyLooping(java.time.Duration)',
+		'reactor.core.publisher.FluxSink#contextView()',
+		'reactor.core.publisher.MonoSink#contextView()',
+		'reactor.core.publisher.SynchronousSink#contextView()'
+	]
 }
 
 gradle.taskGraph.afterTask { task, state ->

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSink.java
@@ -83,7 +83,9 @@ public interface FluxSink<T> {
 	 *
 	 * @return the current subscriber {@link ContextView}.
 	 */
-	ContextView contextView();
+	default ContextView contextView() {
+		return currentContext();
+	}
 
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSink.java
@@ -83,7 +83,9 @@ public interface MonoSink<T> {
 	 *
 	 * @return the current subscriber {@link ContextView}.
 	 */
-	ContextView contextView();
+	default ContextView contextView() {
+		return this.currentContext();
+	}
 
 	/**
 	 * Attaches a {@link LongConsumer} to this {@link MonoSink} that will be notified of

--- a/reactor-core/src/main/java/reactor/core/publisher/SynchronousSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SynchronousSink.java
@@ -65,7 +65,9 @@ public interface SynchronousSink<T> {
 	 *
 	 * @return the current subscriber {@link ContextView}.
 	 */
-	ContextView contextView();
+	default ContextView contextView() {
+		return currentContext();
+	}
 
 	/**
 	 * @param e the exception to signal, not null


### PR DESCRIPTION
This commit backports #3021, a default implementation of the
`contextView()` method of the FluxSink, MonoSink and SynchronousSink
"old sinks" classes.

The backport is necessary because the new method was not added only in
3.5.0-M1 as initially stated, but in 3.4.17 as well.

Backport of commit 6eecf859e.
See #2971, #2974 and #3021.
