### PR TITLE
Upgrade download, gradle enterprise, spotless, byteBuddy

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ artifactory = { id = "com.jfrog.artifactory", version = "4.28.2" }
 asciidoctor-convert = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor" }
 asciidoctor-pdf = { id = "org.asciidoctor.jvm.pdf", version.ref = "asciidoctor" }
 bnd = { id = "biz.aQute.bnd.builder", version = "6.2.0" }
-download = { id = "de.undercouch.download", version = "5.0.5" }
+download = { id = "de.undercouch.download", version = "5.1.0" }
 japicmp = { id = "me.champeau.gradle.japicmp", version = "0.4.0" }
 jcstress = { id = "io.github.reyerizo.gradle.jcstress", version = "0.8.13" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,5 +49,5 @@ jcstress = { id = "io.github.reyerizo.gradle.jcstress", version = "0.8.13" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 nohttp = { id = "io.spring.nohttp", version = "0.0.10" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
-spotless = { id = "com.diffplug.spotless", version = "6.5.1" }
+spotless = { id = "com.diffplug.spotless", version = "6.5.2" }
 testsets = { id = "org.unbroken-dome.test-sets", version = "4.0.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ baselinePerfExtra = "3.4.8"
 
 # Other shared versions
 asciidoctor = "3.3.2"
-bytebuddy = "1.12.9"
+bytebuddy = "1.12.10"
 jmh = "1.35"
 junit = "5.8.2"
 kotlin = "1.5.32"
@@ -43,11 +43,11 @@ artifactory = { id = "com.jfrog.artifactory", version = "4.28.2" }
 asciidoctor-convert = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor" }
 asciidoctor-pdf = { id = "org.asciidoctor.jvm.pdf", version.ref = "asciidoctor" }
 bnd = { id = "biz.aQute.bnd.builder", version = "6.2.0" }
-download = { id = "de.undercouch.download", version = "5.0.4" }
+download = { id = "de.undercouch.download", version = "5.0.5" }
 japicmp = { id = "me.champeau.gradle.japicmp", version = "0.4.0" }
 jcstress = { id = "io.github.reyerizo.gradle.jcstress", version = "0.8.13" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 nohttp = { id = "io.spring.nohttp", version = "0.0.10" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
-spotless = { id = "com.diffplug.spotless", version = "6.5.0" }
+spotless = { id = "com.diffplug.spotless", version = "6.5.1" }
 testsets = { id = "org.unbroken-dome.test-sets", version = "4.0.0" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 plugins {
-	id "com.gradle.enterprise" version "3.9"
+	id "com.gradle.enterprise" version "3.10"
 }
 
 rootProject.name = 'reactor'


### PR DESCRIPTION
This commit upgrades the following dependencies:
 - plugin download to v5.0.5 (supersedes and fixes #3018)
 - plugin gradleEnterprise to v3.10 (supersedes and fixes #3023)
 - plugin spotless to v6.5.1 (supersedes and fixes #3032)
 - dependency byteBuddy to v1.12.10 (supersedes and fixes #3033)
