### PR TITLE
[reactor-test] Add StepVerifier option to use ConditionalSubscriber

### DIFF
--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -87,7 +87,7 @@ task japicmp(type: JapicmpTask) {
 	includeSynthetic = true
 
 	// TODO after a .0 release, remove the reactor-test exclusions below if any
-	methodExcludes = [ "reactor.test.StepVerifier.Step#enableConditionalSupport(java.util.function.Predicate)" ]
+	methodExcludes = [ "reactor.test.StepVerifier.FirstStep#enableConditionalSupport(java.util.function.Predicate)" ]
 }
 
 tasks.withType(Test).all {

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -87,7 +87,9 @@ task japicmp(type: JapicmpTask) {
 	includeSynthetic = true
 
 	// TODO after a .0 release, remove the reactor-test exclusions below if any
-	methodExcludes = [ "reactor.test.StepVerifier.FirstStep#enableConditionalSupport(java.util.function.Predicate)" ]
+	methodExcludes = [
+		'reactor.test.StepVerifier$FirstStep#enableConditionalSupport(java.util.function.Predicate)'
+	]
 }
 
 tasks.withType(Test).all {

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -87,7 +87,7 @@ task japicmp(type: JapicmpTask) {
 	includeSynthetic = true
 
 	// TODO after a .0 release, remove the reactor-test exclusions below if any
-	methodExcludes = [ ]
+	methodExcludes = [ "reactor.test.StepVerifier.Step#enableConditionalSupport(java.util.function.Predicate)" ]
 }
 
 tasks.withType(Test).all {

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -653,21 +653,6 @@ public interface StepVerifier {
 		Step<T> as(String description);
 
 		/**
-		 * Provide a {@link Predicate} that will turn this StepVerifier's subscribers into
-		 * {@link reactor.core.Fuseable.ConditionalSubscriber} and drive the {@link reactor.core.Fuseable.ConditionalSubscriber#tryOnNext(Object)}
-		 * behavior of these subscribers. Set to {@code null} to deactivate (the default).
-		 *
-		 * @param tryOnNextPredicate the {@link Predicate} to use for conditional tryOnNext path
-		 * @return the verifier for final {@link #verify()} call
-		 */
-		default Step<T> enableConditionalSupport(@Nullable Predicate<? super T> tryOnNextPredicate) {
-			if (tryOnNextPredicate != null) {
-				throw new UnsupportedOperationException("This implementation of StepVerifier doesn't support ConditionalSubscriber mode");
-			}
-			return this;
-		}
-
-		/**
 		 * Expect an element and consume with the given consumer.Any {@code
 		 * AssertionError}s thrown by the consumer will be rethrown during {@linkplain
 		 * #verify() verification}.
@@ -994,6 +979,21 @@ public interface StepVerifier {
 	 * @param <T> the type of values that the subscriber contains
 	 */
 	interface FirstStep<T> extends Step<T> {
+
+		/**
+		 * Provide a {@link Predicate} that will turn this StepVerifier's subscribers into
+		 * {@link reactor.core.Fuseable.ConditionalSubscriber} and drive the {@link reactor.core.Fuseable.ConditionalSubscriber#tryOnNext(Object)}
+		 * behavior of these subscribers. Set to {@code null} to deactivate (the default).
+		 *
+		 * @param tryOnNextPredicate the {@link Predicate} to use for conditional tryOnNext path
+		 * @return the verifier for final {@link #verify()} call
+		 */
+		default FirstStep<T> enableConditionalSupport(@Nullable Predicate<? super T> tryOnNextPredicate) {
+			if (tryOnNextPredicate != null) {
+				throw new UnsupportedOperationException("This implementation of StepVerifier doesn't support ConditionalSubscriber mode");
+			}
+			return this;
+		}
 
 		/**
 		 * Expect the source {@link Publisher} to run with Reactor Fusion flow

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -653,6 +653,21 @@ public interface StepVerifier {
 		Step<T> as(String description);
 
 		/**
+		 * Provide a {@link Predicate} that will turn this StepVerifier's subscribers into
+		 * {@link reactor.core.Fuseable.ConditionalSubscriber} and drive the {@link reactor.core.Fuseable.ConditionalSubscriber#tryOnNext(Object)}
+		 * behavior of these subscribers. Set to {@code null} to deactivate (the default).
+		 *
+		 * @param tryOnNextPredicate the {@link Predicate} to use for conditional tryOnNext path
+		 * @return the verifier for final {@link #verify()} call
+		 */
+		default Step<T> enableConditionalSupport(@Nullable Predicate<? super T> tryOnNextPredicate) {
+			if (tryOnNextPredicate != null) {
+				throw new UnsupportedOperationException("This implementation of StepVerifier doesn't support ConditionalSubscriber mode");
+			}
+			return this;
+		}
+
+		/**
 		 * Expect an element and consume with the given consumer.Any {@code
 		 * AssertionError}s thrown by the consumer will be rethrown during {@linkplain
 		 * #verify() verification}.

--- a/reactor-test/src/test/java/reactor/test/DefaultStepVerifierBuilderTests.java
+++ b/reactor-test/src/test/java/reactor/test/DefaultStepVerifierBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,10 @@ import java.util.Queue;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+
+import reactor.core.Fuseable;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;
 import reactor.test.DefaultStepVerifierBuilder.DefaultVerifySubscriber;
 import reactor.test.DefaultStepVerifierBuilder.DescriptionEvent;
@@ -201,5 +204,31 @@ public class DefaultStepVerifierBuilderTests {
 		assertThat(queue).hasSize(3)
 		                 .extracting(Event::getDescription)
 		                 .containsExactly("A", "foo", "baz");
+	}
+
+	@Test
+	void enableConditionalSupportProducesAConditionalSubscriber() {
+		DefaultStepVerifierBuilder<Object> builder = new DefaultStepVerifierBuilder<>(StepVerifierOptions.create(), Mono::empty);
+
+		assertThat(builder.build().toSubscriber())
+			.as("without enableConditionalSupport")
+			.isNotInstanceOf(Fuseable.ConditionalSubscriber.class);
+
+		assertThat(builder.enableConditionalSupport(i -> true).build().toSubscriber())
+			.as("with enableConditionalSupport")
+			.isInstanceOf(Fuseable.ConditionalSubscriber.class);
+	}
+
+	@Test
+	void enableConditionalSupportProducesAConditionalSubscriberAndSubscribes() {
+		DefaultStepVerifierBuilder<Object> builder = new DefaultStepVerifierBuilder<>(StepVerifierOptions.create(), Mono::empty);
+
+		assertThat(builder.build().toVerifierAndSubscribe())
+			.as("without enableConditionalSupport")
+			.isNotInstanceOf(Fuseable.ConditionalSubscriber.class);
+
+		assertThat(builder.enableConditionalSupport(i -> true).build().toVerifierAndSubscribe())
+			.as("with enableConditionalSupport")
+			.isInstanceOf(Fuseable.ConditionalSubscriber.class);
 	}
 }


### PR DESCRIPTION
This commit adds a new feature to StepVerifier that enforces the use
of a ConditionalSubscriber as the verifier's Subscriber.

It is activated by calling `enableConditionalSupport` at any `Step`
(similar to the `as` naming method). Note that the reason the feature is
added to the `Step` API is that it is the only part that is typed with
`<T>` (which is desirable for the `Predicate` to be typed).

This feature only guarantees that the StepVerifier will use a subscriber
that implements ConditionalSubscriber when it subscribes to the source.
Note that this doesn't guarantee the Publisher under test is itself
going to produce ConditionalSubscribers, and even if it does, this
doesn't guarantee that at runtime the `tryOnNext` path will be used.
All of this depends on the source and the publisher chain under test.
