### PR TITLE
Scannable.tags() rework, add tagsDeduplicated()

### DIFF
--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerListenerConfigurationTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerListenerConfigurationTest.java
@@ -228,6 +228,25 @@ class MicrometerListenerConfigurationTest {
 	}
 
 	@Test
+	void resolveTags_multipleScatteredTagsSetAboveWithDeduplication() {
+		Tags defaultTags = Tags.of("common1", "commonValue1");
+		Flux<Integer> flux = Flux.just(1)
+			.tag("k1", "v1")
+			.tag("k2", "oldV2")
+			.filter(i -> i % 2 == 0)
+			.tag("k2", "v2")
+			.map(i -> i + 10);
+
+		Tags resolvedTags = MicrometerListenerConfiguration.resolveTags(flux, defaultTags);
+
+		assertThat(resolvedTags.stream().map(Object::toString)).containsExactly(
+			"tag(common1=commonValue1)",
+			"tag(k1=v1)",
+			"tag(k2=v2)"
+		);
+	}
+
+	@Test
 	void resolveTags_notScannable() {
 		Tags defaultTags = Tags.of("common1", "commonValue1");
 		Publisher<Object> publisher = Operators::complete;

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -187,7 +187,8 @@ task japicmp(type: JapicmpTask) {
 		'reactor.core.scheduler.Schedulers$Factory#newElastic(int, java.util.concurrent.ThreadFactory)',
 		'reactor.core.publisher.FluxSink#contextView()',
 		'reactor.core.publisher.MonoSink#contextView()',
-		'reactor.core.publisher.SynchronousSink#contextView()'
+		'reactor.core.publisher.SynchronousSink#contextView()',
+		'reactor.core.Scannable#tagsDeduplicated()'
 	]
 }
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxName.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxName.java
@@ -17,14 +17,9 @@
 package reactor.core.publisher;
 
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
@@ -47,18 +42,18 @@ final class FluxName<T> extends InternalFluxOperator<T, T> {
 
 	final String name;
 
-	final List<Tuple2<String, String>> tagsWithDuplication;
+	final List<Tuple2<String, String>> tagsWithDuplicates;
 
 	static <T> Flux<T> createOrAppend(Flux<T> source, String name) {
 		Objects.requireNonNull(name, "name");
 
 		if (source instanceof FluxName) {
 			FluxName<T> s = (FluxName<T>) source;
-			return new FluxName<>(s.source, name, s.tagsWithDuplication);
+			return new FluxName<>(s.source, name, s.tagsWithDuplicates);
 		}
 		if (source instanceof FluxNameFuseable) {
 			FluxNameFuseable<T> s = (FluxNameFuseable<T>) source;
-			return new FluxNameFuseable<>(s.source, name, s.tags);
+			return new FluxNameFuseable<>(s.source, name, s.tagsWithDuplicates);
 		}
 		if (source instanceof Fuseable) {
 			return new FluxNameFuseable<>(source, name, null);
@@ -75,8 +70,8 @@ final class FluxName<T> extends InternalFluxOperator<T, T> {
 		if (source instanceof FluxName) {
 			FluxName<T> s = (FluxName<T>) source;
 			List<Tuple2<String, String>> tags;
-			if(s.tagsWithDuplication != null) {
-				tags = new LinkedList<>(s.tagsWithDuplication);
+			if(s.tagsWithDuplicates != null) {
+				tags = new LinkedList<>(s.tagsWithDuplicates);
 				tags.add(newTag);
 			}
 			else {
@@ -87,18 +82,18 @@ final class FluxName<T> extends InternalFluxOperator<T, T> {
 
 		if (source instanceof FluxNameFuseable) {
 			FluxNameFuseable<T> s = (FluxNameFuseable<T>) source;
-			Set<Tuple2<String, String>> tags;
-			if (s.tags != null) {
-				tags = new LinkedHashSet<>(s.tags);
+			List<Tuple2<String, String>> tags;
+			if (s.tagsWithDuplicates != null) {
+				tags = new LinkedList<>(s.tagsWithDuplicates);
 				tags.add(newTag);
 			}
 			else {
-				tags = Collections.singleton(newTag);
+				tags = Collections.singletonList(newTag);
 			}
 			return new FluxNameFuseable<>(s.source, s.name, tags);
 		}
 		if (source instanceof Fuseable) {
-			return new FluxNameFuseable<>(source, null, Collections.singleton(newTag)); //FIXME
+			return new FluxNameFuseable<>(source, null, Collections.singletonList(newTag));
 		}
 		return new FluxName<>(source, null, Collections.singletonList(newTag));
 	}
@@ -108,7 +103,7 @@ final class FluxName<T> extends InternalFluxOperator<T, T> {
 			@Nullable List<Tuple2<String, String>> tags) {
 		super(source);
 		this.name = name;
-		this.tagsWithDuplication = tags;
+		this.tagsWithDuplicates = tags;
 	}
 
 	@Override
@@ -123,8 +118,8 @@ final class FluxName<T> extends InternalFluxOperator<T, T> {
 			return name;
 		}
 
-		if (key == Attr.TAGS && tagsWithDuplication != null) {
-			return tagsWithDuplication.stream();
+		if (key == Attr.TAGS && tagsWithDuplicates != null) {
+			return tagsWithDuplicates.stream();
 		}
 
 		if (key == RUN_STYLE) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxNameFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxNameFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxNameFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxNameFuseable.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import java.util.Set;
+import java.util.List;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
@@ -24,7 +24,6 @@ import reactor.util.annotation.Nullable;
 import reactor.util.function.Tuple2;
 
 import static reactor.core.Scannable.Attr.RUN_STYLE;
-import static reactor.core.Scannable.Attr.RunStyle.SYNC;
 
 /**
  * An operator that just bears a name or a set of tags, which can be retrieved via the
@@ -38,14 +37,14 @@ final class FluxNameFuseable<T> extends InternalFluxOperator<T, T> implements Fu
 
 	final String name;
 
-	final Set<Tuple2<String, String>> tags;
+	final List<Tuple2<String, String>> tagsWithDuplicates;
 
 	FluxNameFuseable(Flux<? extends T> source,
 			@Nullable String name,
-			@Nullable Set<Tuple2<String, String>> tags) {
+			@Nullable List<Tuple2<String, String>> tags) {
 		super(source);
 		this.name = name;
-		this.tags = tags;
+		this.tagsWithDuplicates = tags;
 	}
 
 	@Override
@@ -60,8 +59,8 @@ final class FluxNameFuseable<T> extends InternalFluxOperator<T, T> implements Fu
 			return name;
 		}
 
-		if (key == Attr.TAGS && tags != null) {
-			return tags.stream();
+		if (key == Attr.TAGS && tagsWithDuplicates != null) {
+			return tagsWithDuplicates.stream();
 		}
 
 		if (key == RUN_STYLE) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoName.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoName.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoName.java
@@ -17,9 +17,9 @@
 package reactor.core.publisher;
 
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
@@ -38,7 +38,7 @@ final class MonoName<T> extends InternalMonoOperator<T, T> {
 
 	final String name;
 
-	final Set<Tuple2<String, String>> tags;
+	final List<Tuple2<String, String>> tagsWithDuplicates;
 
 	@SuppressWarnings("unchecked")
 	static <T> Mono<T> createOrAppend(Mono<T> source, String name) {
@@ -46,11 +46,11 @@ final class MonoName<T> extends InternalMonoOperator<T, T> {
 
 		if (source instanceof MonoName) {
 			MonoName<T> s = (MonoName<T>) source;
-			return new MonoName<>(s.source, name, s.tags);
+			return new MonoName<>(s.source, name, s.tagsWithDuplicates);
 		}
 		if (source instanceof MonoNameFuseable) {
 			MonoNameFuseable<T> s = (MonoNameFuseable<T>) source;
-			return new MonoNameFuseable<>(s.source, name, s.tags);
+			return new MonoNameFuseable<>(s.source, name, s.tagsWithDuplicates);
 		}
 		if (source instanceof Fuseable) {
 			return new MonoNameFuseable<>(source, name, null);
@@ -58,41 +58,48 @@ final class MonoName<T> extends InternalMonoOperator<T, T> {
 		return new MonoName<>(source, name, null);
 	}
 
-	@SuppressWarnings("unchecked")
 	static <T> Mono<T> createOrAppend(Mono<T> source, String tagName, String tagValue) {
 		Objects.requireNonNull(tagName, "tagName");
 		Objects.requireNonNull(tagValue, "tagValue");
 
-		Set<Tuple2<String, String>> tags = Collections.singleton(Tuples.of(tagName, tagValue));
+		Tuple2<String, String> newTag = Tuples.of(tagName, tagValue);
 
 		if (source instanceof MonoName) {
 			MonoName<T> s = (MonoName<T>) source;
-			if(s.tags != null) {
-				tags = new HashSet<>(tags);
-				tags.addAll(s.tags);
+			List<Tuple2<String, String>> tags;
+			if(s.tagsWithDuplicates != null) {
+				tags = new LinkedList<>(s.tagsWithDuplicates);
+				tags.add(newTag);
+			}
+			else {
+				tags = Collections.singletonList(newTag);
 			}
 			return new MonoName<>(s.source, s.name, tags);
 		}
 		if (source instanceof MonoNameFuseable) {
 			MonoNameFuseable<T> s = (MonoNameFuseable<T>) source;
-			if (s.tags != null) {
-				tags = new HashSet<>(tags);
-				tags.addAll(s.tags);
+			List<Tuple2<String, String>> tags;
+			if (s.tagsWithDuplicates != null) {
+				tags = new LinkedList<>(s.tagsWithDuplicates);
+				tags.add(newTag);
+			}
+			else {
+				tags = Collections.singletonList(newTag);
 			}
 			return new MonoNameFuseable<>(s.source, s.name, tags);
 		}
 		if (source instanceof Fuseable) {
-			return new MonoNameFuseable<>(source, null, tags);
+			return new MonoNameFuseable<>(source, null, Collections.singletonList(newTag));
 		}
-		return new MonoName<>(source, null, tags);
+		return new MonoName<>(source, null, Collections.singletonList(newTag));
 	}
 
 	MonoName(Mono<? extends T> source,
 			@Nullable String name,
-			@Nullable Set<Tuple2<String, String>> tags) {
+			@Nullable List<Tuple2<String, String>> tags) {
 		super(source);
 		this.name = name;
-		this.tags = tags;
+		this.tagsWithDuplicates = tags;
 	}
 
 	@Override
@@ -107,8 +114,8 @@ final class MonoName<T> extends InternalMonoOperator<T, T> {
 			return name;
 		}
 
-		if (key == Attr.TAGS && tags != null) {
-			return tags.stream();
+		if (key == Attr.TAGS && tagsWithDuplicates != null) {
+			return tagsWithDuplicates.stream();
 		}
 
 		if (key == Attr.RUN_STYLE) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoNameFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoNameFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoNameFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoNameFuseable.java
@@ -16,7 +16,7 @@
 
 package reactor.core.publisher;
 
-import java.util.Set;
+import java.util.List;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
@@ -24,7 +24,6 @@ import reactor.util.annotation.Nullable;
 import reactor.util.function.Tuple2;
 
 import static reactor.core.Scannable.Attr.RUN_STYLE;
-import static reactor.core.Scannable.Attr.RunStyle.SYNC;
 
 /**
  * An operator that just bears a name or a set of tags, which can be retrieved via the
@@ -37,14 +36,14 @@ final class MonoNameFuseable<T> extends InternalMonoOperator<T, T> implements Fu
 
 	final String name;
 
-	final Set<Tuple2<String, String>> tags;
+	final List<Tuple2<String, String>> tagsWithDuplicates;
 
 	MonoNameFuseable(Mono<? extends T> source,
 			@Nullable String name,
-			@Nullable Set<Tuple2<String, String>> tags) {
+			@Nullable List<Tuple2<String, String>> tags) {
 		super(source);
 		this.name = name;
-		this.tags = tags;
+		this.tagsWithDuplicates = tags;
 	}
 
 	@Override
@@ -59,8 +58,8 @@ final class MonoNameFuseable<T> extends InternalMonoOperator<T, T> implements Fu
 			return name;
 		}
 
-		if (key == Attr.TAGS && tags != null) {
-			return tags.stream();
+		if (key == Attr.TAGS && tagsWithDuplicates != null) {
+			return tagsWithDuplicates.stream();
 		}
 
 		if (key == RUN_STYLE) {

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxName.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxName.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFluxName.java
@@ -17,9 +17,9 @@
 package reactor.core.publisher;
 
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
@@ -42,7 +42,7 @@ final class ParallelFluxName<T> extends ParallelFlux<T> implements Scannable{
 
 	final String name;
 
-	final Set<Tuple2<String, String>> tags;
+	final List<Tuple2<String, String>> tagsWithDuplicates;
 
 	@SuppressWarnings("unchecked")
 	static <T> ParallelFlux<T> createOrAppend(ParallelFlux<T> source, String name) {
@@ -50,7 +50,7 @@ final class ParallelFluxName<T> extends ParallelFlux<T> implements Scannable{
 
 		if (source instanceof ParallelFluxName) {
 			ParallelFluxName<T> s = (ParallelFluxName<T>) source;
-			return new ParallelFluxName<>(s.source, name, s.tags);
+			return new ParallelFluxName<>(s.source, name, s.tagsWithDuplicates);
 		}
 		return new ParallelFluxName<>(source, name, null);
 	}
@@ -60,25 +60,29 @@ final class ParallelFluxName<T> extends ParallelFlux<T> implements Scannable{
 		Objects.requireNonNull(tagName, "tagName");
 		Objects.requireNonNull(tagValue, "tagValue");
 
-		Set<Tuple2<String, String>> tags = Collections.singleton(Tuples.of(tagName, tagValue));
+		Tuple2<String, String> newTag = Tuples.of(tagName, tagValue);
 
 		if (source instanceof ParallelFluxName) {
 			ParallelFluxName<T> s = (ParallelFluxName<T>) source;
-			if(s.tags != null) {
-				tags = new HashSet<>(tags);
-				tags.addAll(s.tags);
+			List<Tuple2<String, String>> tags;
+			if(s.tagsWithDuplicates != null) {
+				tags = new LinkedList<>(s.tagsWithDuplicates);
+				tags.add(newTag);
+			}
+			else {
+				tags = Collections.singletonList(newTag);
 			}
 			return new ParallelFluxName<>(s.source, s.name, tags);
 		}
-		return new ParallelFluxName<>(source, null, tags);
+		return new ParallelFluxName<>(source, null, Collections.singletonList(newTag));
 	}
 
 	ParallelFluxName(ParallelFlux<T> source,
 			@Nullable String name,
-			@Nullable Set<Tuple2<String, String>> tags) {
+			@Nullable List<Tuple2<String, String>> tags) {
 		this.source = source;
 		this.name = name;
-		this.tags = tags;
+		this.tagsWithDuplicates = tags;
 	}
 
 	@Override
@@ -98,8 +102,8 @@ final class ParallelFluxName<T> extends ParallelFlux<T> implements Scannable{
 			return name;
 		}
 
-		if (key == Attr.TAGS && tags != null) {
-			return tags.stream();
+		if (key == Attr.TAGS && tagsWithDuplicates != null) {
+			return tagsWithDuplicates.stream();
 		}
 
 		if (key == Attr.PARENT) return source;

--- a/reactor-core/src/test/java/reactor/core/ScannableTest.java
+++ b/reactor-core/src/test/java/reactor/core/ScannableTest.java
@@ -17,9 +17,11 @@
 package reactor.core;
 
 import java.time.Duration;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -476,61 +478,42 @@ public class ScannableTest {
 	}
 
 	@Test
-	void tagsWhenAKeyIsDefinedInMultipleParents() {
+	void tagsIncludesDuplicatesAndReverseDeclarationOrder() {
 		Flux<Integer> f = Flux.just(1, 2, 3)
-			.tag("key1", "earlyValue1")
 			.tag("key2", "earlyValue2")
+			.tag("key1", "earlyValue1")
 			.tag("key1", "earlyOverwriteValue1")
-			.filter(i -> true)
+			.filter(i -> true) //this separates two macro-fused tag stages
 			.tag("key1", "lateValue1")
 			.tag("key2", "lateValue2")
 			.tag("key1", "lateOverwriteValue1");
 
-		assertThat(Scannable.from(f).tags().map(t2 -> t2.getT1() + "=" + t2.getT2()))
-			.containsExactlyInAnyOrder("key1=lateOverwriteValue1", "key2=lateValue2");
-	}
-
-	@Test
-	void tagsWithDuplicatesWhenAKeyIsDefinedInMultipleParents() {
-		Flux<Integer> f = Flux.just(1, 2, 3)
-			.tag("key1", "earlyValue1")
-			.tag("key2", "earlyValue2")
-			.tag("key1", "earlyOverwriteValue1")
-			.filter(i -> true)
-			.tag("key1", "lateValue1")
-			.tag("key2", "lateValue2")
-			.tag("key1", "lateOverwriteValue1");
-
-		assertThat(Scannable.from(f).tags(true).map(t2 -> t2.getT1() + "=" + t2.getT2()))
-			.containsExactly( //note: the order between key1 and key2 for each "source" is set-dependent
-				"key2=lateValue2",
-				"key1=lateValue1",
-				"key1=lateOverwriteValue1",
-				"key2=earlyValue2",
-				"key1=earlyValue1",
-				"key1=earlyOverwriteValue1"
+		assertThat(Scannable.from(f).tags())
+			.containsExactly(
+				Tuples.of("key2", "earlyValue2"),
+				Tuples.of("key1", "earlyValue1"),
+				Tuples.of("key1", "earlyOverwriteValue1"),
+				Tuples.of("key1", "lateValue1"),
+				Tuples.of("key2", "lateValue2"),
+				Tuples.of("key1", "lateOverwriteValue1")
 			);
 	}
 
 	@Test
-	void tagsWithDuplicatesReversedWhenAKeyIsDefinedInMultipleParents() {
+	void tagsDeduplicatedUsesLatestValueButOriginalKeyOrder() {
 		Flux<Integer> f = Flux.just(1, 2, 3)
-			.tag("key1", "earlyValue1")
 			.tag("key2", "earlyValue2")
+			.tag("key1", "earlyValue1")
 			.tag("key1", "earlyOverwriteValue1")
-			.filter(i -> true)
+			.filter(i -> true) //this separates two macro-fused tag stages
 			.tag("key1", "lateValue1")
 			.tag("key2", "lateValue2")
 			.tag("key1", "lateOverwriteValue1");
 
-		assertThat(Scannable.from(f).tags(true, true).map(t2 -> t2.getT1() + "=" + t2.getT2()))
-			.containsExactly( //note: the order between key1 and key2 for each "source" is set-dependent
-				"key1=earlyOverwriteValue1",
-				"key2=earlyValue2",
-				"key1=earlyValue1", //TODO that one would disappear with a change from Set to Map
-				"key1=lateValue1",
-				"key2=lateValue2",
-				"key1=lateOverwriteValue1"
+		assertThat(Scannable.from(f).tagsDeduplicated())
+			.containsExactly(
+				new AbstractMap.SimpleImmutableEntry<>("key2", "lateValue2"),
+				new AbstractMap.SimpleImmutableEntry<>("key1", "lateOverwriteValue1")
 			);
 	}
 
@@ -674,7 +657,7 @@ public class ScannableTest {
 		assertThat(Scannable.from(flux).steps())
 				.containsExactly(
 						"source(FluxJust)",
-						"Flux.checkpoint ⇢ at reactor.core.ScannableTest.operatorChainWithCheckpoint(ScannableTest.java:612)",
+						"Flux.checkpoint ⇢ at reactor.core.ScannableTest.operatorChainWithCheckpoint(ScannableTest.java:667)",
 						"map"
 				);
 	}

--- a/reactor-core/src/test/java/reactor/core/ScannableTest.java
+++ b/reactor-core/src/test/java/reactor/core/ScannableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -657,7 +657,7 @@ public class ScannableTest {
 		assertThat(Scannable.from(flux).steps())
 				.containsExactly(
 						"source(FluxJust)",
-						"Flux.checkpoint ⇢ at reactor.core.ScannableTest.operatorChainWithCheckpoint(ScannableTest.java:667)",
+						"Flux.checkpoint ⇢ at reactor.core.ScannableTest.operatorChainWithCheckpoint(ScannableTest.java:654)",
 						"map"
 				);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxNameFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxNameFuseableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxNameFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxNameFuseableTest.java
@@ -16,7 +16,9 @@
 
 package reactor.core.publisher;
 
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -33,9 +35,7 @@ public class FluxNameFuseableTest {
 	public void scanOperator() throws Exception {
 		Tuple2<String, String> tag1 = Tuples.of("foo", "oof");
 		Tuple2<String, String> tag2 = Tuples.of("bar", "rab");
-		Set<Tuple2<String, String>> tags = new HashSet<>();
-		tags.add(tag1);
-		tags.add(tag2);
+		List<Tuple2<String, String>> tags = Arrays.asList(tag1, tag2);
 
 		Flux<Integer> source = Flux.range(1, 4).map(i -> i);
 		FluxNameFuseable<Integer> test = new FluxNameFuseable<>(source, "foo", tags);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package reactor.core.publisher;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -33,7 +33,7 @@ public class FluxNameTest {
 	public void scanOperator() throws Exception {
 		Tuple2<String, String> tag1 = Tuples.of("foo", "oof");
 		Tuple2<String, String> tag2 = Tuples.of("bar", "rab");
-		Set<Tuple2<String, String>> tags = new HashSet<>();
+		List<Tuple2<String, String>> tags = new ArrayList<>();
 		tags.add(tag1);
 		tags.add(tag2);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxNameTest.java
@@ -17,6 +17,7 @@
 package reactor.core.publisher;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -33,9 +34,7 @@ public class FluxNameTest {
 	public void scanOperator() throws Exception {
 		Tuple2<String, String> tag1 = Tuples.of("foo", "oof");
 		Tuple2<String, String> tag2 = Tuples.of("bar", "rab");
-		List<Tuple2<String, String>> tags = new ArrayList<>();
-		tags.add(tag1);
-		tags.add(tag2);
+		List<Tuple2<String, String>> tags = Arrays.asList(tag1, tag2);
 
 		Flux<Integer> source = Flux.range(1, 4).map(i -> i);
 		FluxName<Integer> test = new FluxName<>(source, "foo", tags);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNameFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNameFuseableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNameFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNameFuseableTest.java
@@ -16,7 +16,9 @@
 
 package reactor.core.publisher;
 
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -33,9 +35,7 @@ public class MonoNameFuseableTest {
 	public void scanOperator() throws Exception {
 		Tuple2<String, String> tag1 = Tuples.of("foo", "oof");
 		Tuple2<String, String> tag2 = Tuples.of("bar", "rab");
-		Set<Tuple2<String, String>> tags = new HashSet<>();
-		tags.add(tag1);
-		tags.add(tag2);
+		List<Tuple2<String, String>> tags = Arrays.asList(tag1, tag2);
 
 		Mono<Integer> source = Mono.just(1).map(i -> i);
 		MonoNameFuseable<Integer> test = new MonoNameFuseable<>(source, "foo", tags);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoNameTest.java
@@ -16,7 +16,9 @@
 
 package reactor.core.publisher;
 
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -33,9 +35,7 @@ public class MonoNameTest {
 	public void scanOperator() throws Exception {
 		Tuple2<String, String> tag1 = Tuples.of("foo", "oof");
 		Tuple2<String, String> tag2 = Tuples.of("bar", "rab");
-		Set<Tuple2<String, String>> tags = new HashSet<>();
-		tags.add(tag1);
-		tags.add(tag2);
+		List<Tuple2<String, String>> tags = Arrays.asList(tag1, tag2);
 
 		Mono<Integer> source = Mono.just(1).map(i -> i);
 		MonoName<Integer> test = new MonoName<>(source, "foo", tags);

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxNameTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelFluxNameTest.java
@@ -16,7 +16,9 @@
 
 package reactor.core.publisher;
 
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -43,9 +45,7 @@ public class ParallelFluxNameTest {
 	public void scanOperator() throws Exception {
 		Tuple2<String, String> tag1 = Tuples.of("foo", "oof");
 		Tuple2<String, String> tag2 = Tuples.of("bar", "rab");
-		Set<Tuple2<String, String>> tags = new HashSet<>();
-		tags.add(tag1);
-		tags.add(tag2);
+		List<Tuple2<String, String>> tags = Arrays.asList(tag1, tag2);
 
 		ParallelFlux<Integer> source = Flux.range(1, 4).parallel(3);
 		ParallelFluxName<Integer> test = new ParallelFluxName<>(source, "foo", tags);


### PR DESCRIPTION
- change behavior of tags() method, offer alternative with duplicates
- tags() with duplicates starting from parent, tagsDeduplicated()
- switch to List in FluxFuseable/Mono/MonoFuseable/ParallelName
- tests use tagsWithDuplicates/List
- Use tagsDeduplicated() in observability module
- polish: license headers, test line shift

Fixes #2542.