### PR TITLE
Introduce an alternative to Processor-with-upstream case

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -166,7 +166,8 @@ task japicmp(type: JapicmpTask) {
 		'reactor.core.publisher.Sinks$EmitFailureHandler#busyLooping(java.time.Duration)',
 		'reactor.core.publisher.FluxSink#contextView()',
 		'reactor.core.publisher.MonoSink#contextView()',
-		'reactor.core.publisher.SynchronousSink#contextView()'
+		'reactor.core.publisher.SynchronousSink#contextView()',
+		'reactor.core.publisher.Sinks#unsafe()'
 	]
 }
 

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -235,7 +235,7 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements In
 			upstream.subscribe(this);
 			return ed;
 		}
-		return Disposables.disposed();
+		throw new IllegalStateException("A Sinks.ManyWithUpstream must be subscribed to a source only once");
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -56,8 +56,8 @@ import static reactor.core.publisher.FluxPublish.PublishSubscriber.TERMINATED;
  * @deprecated To be removed in 3.5. Prefer clear cut usage of {@link Sinks} through
  * variations of {@link Sinks.MulticastSpec#onBackpressureBuffer() Sinks.many().multicast().onBackpressureBuffer()}.
  * If you really need the subscribe-to-upstream functionality of a {@link org.reactivestreams.Processor}, switch
- * to {@link reactor.core.publisher.Sinks.ManyUpstreamAdapter} with variants of
- * {@link Sinks.ManyUpstreamSpec#onBackpressureBuffer() Sinks.unsafe().manyToUpstream().onBackpressureBuffer()}.
+ * to {@link reactor.core.publisher.Sinks.ManySubscriber} with {@link Sinks#unsafe()} variants of
+ * {@link Sinks.MulticastUnsafeSpec#onBackpressureBuffer() Sinks.unsafe().many().multicast().onBackpressureBuffer()}.
  * <p/>This processor was blocking in {@link EmitterProcessor#onNext(Object)}. This behaviour can be implemented with the {@link Sinks} API by calling
  * {@link Sinks.Many#tryEmitNext(Object)} and retrying, e.g.:
  * <pre>{@code while (sink.tryEmitNext(v).hasFailed()) {
@@ -67,7 +67,7 @@ import static reactor.core.publisher.FluxPublish.PublishSubscriber.TERMINATED;
  */
 @Deprecated
 public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements InternalManySink<T>,
-	Sinks.ManyUpstreamAdapter<T> {
+	Sinks.ManySubscriber<T> {
 
 	@SuppressWarnings("rawtypes")
 	static final FluxPublish.PubSubInner[] EMPTY = new FluxPublish.PublishInner[0];
@@ -196,6 +196,10 @@ public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements In
 		return Operators.multiSubscribersContext(subscribers);
 	}
 
+	@Override
+	public CoreSubscriber<T> asSubscriber() {
+		return this;
+	}
 	@Override
 	public void subscribeTo(Publisher<? extends T> upstream) {
 		upstream.subscribe(this);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ import static reactor.core.publisher.Sinks.Many;
  * @param <IN> the input value type
  * @param <OUT> the output value type
  * @deprecated Processors will be removed in 3.5. Prefer using {@link Sinks.Many} instead,
- *  * or see https://github.com/reactor/reactor-core/issues/2431 for alternatives
+ * or see https://github.com/reactor/reactor-core/issues/2431 for alternatives
  */
 @Deprecated
 public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -956,22 +956,6 @@ public final class Sinks {
 	public interface ManyWithUpstream<T> extends Many<T> {
 
 		/**
-		 * View this {@link Sinks.Many} as a {@link CoreSubscriber}, allowing to subscribe it to
-		 * an upstream {@link Publisher}.
-		 * <p>
-		 * Note that when this is done, one MUST stop using emit/tryEmit APIs and should refrain
-		 * from directly calling {@link Subscriber} methods, reserving signal creation to be the sole
-		 * responsibility of the upstream {@link Publisher}.
-		 * <p>
-		 * Note that there is no direct way of detaching such a {@link Subscriber} from its
-		 * upstream. For this, prefer using {@link #subscribeTo(Publisher)}.
-		 *
-		 * @return the {@link Sinks.ManyWithUpstream} viewed as a {@link CoreSubscriber}
-		 * @see #subscribeTo(Publisher)
-		 */
-		CoreSubscriber<T> asSubscriber();
-
-		/**
 		 * Explicitly subscribe this {@link Sinks.Many} to an upstream {@link Publisher} without
 		 * exposing it as a {@link Subscriber} at all.
 		 * <p>
@@ -985,8 +969,6 @@ public final class Sinks {
 		 * <p>
 		 * The returned {@link Disposable} is an instance that is already {@link Disposable#isDisposed() disposed} when this method has been
 		 * previously called, as a {@link Subscriber} cannot be subscribed to more than one {@link Publisher}.
-		 * Note that subscriptions using the {@link #asSubscriber()} API cannot be reliably detected that way,
-		 * and might substitute with the currently attempted subscription with regard to the {@link Disposable} target.
 		 */
 		Disposable subscribeTo(Publisher<? extends T> upstream);
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -390,6 +390,11 @@ public final class Sinks {
 		MulticastReplaySpec replay();
 	}
 
+	/**
+	 * Provides multicast : 1 sink, N {@link Subscriber}.
+	 * <p>
+	 * This {@link MulticastSpec} provides {@link Sinks#unsafe() unsafe} flavors, including some {@link ManyWithUpstream} implementations.
+	 */
 	public interface MulticastUnsafeSpec extends  MulticastSpec {
 
 		@Override
@@ -402,6 +407,11 @@ public final class Sinks {
 		<T> ManyWithUpstream<T> onBackpressureBuffer(int bufferSize, boolean autoCancel);
 	}
 
+	/**
+	 *  Provides {@link Sinks.Many} specs for sinks which can emit multiple elements.
+	 *  <p>
+	 *  This {@link ManySpec} provides {@link Sinks#unsafe() unsafe} flavors, including some {@link ManyWithUpstream} implementations.
+	 */
 	public interface ManyUnsafeSpec extends ManySpec {
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -981,7 +981,12 @@ public final class Sinks {
 		 * The returned {@link Disposable} provides a way of both unsubscribing from the upstream
 		 * and terminating the sink: currently registered subscribers downstream receive an {@link Subscriber#onError(Throwable) onError}
 		 * signal with a {@link java.util.concurrent.CancellationException} and further attempts at subscribing
-		 * to the sink will trigger a similar signal..
+		 * to the sink will trigger a similar signal.
+		 * <p>
+		 * The returned {@link Disposable} is an instance that is already {@link Disposable#isDisposed() disposed} when this method has been
+		 * previously called, as a {@link Subscriber} cannot be subscribed to more than one {@link Publisher}.
+		 * Note that subscriptions using the {@link #asSubscriber()} API cannot be reliably detected that way,
+		 * and might substitute with the currently attempted subscription with regard to the {@link Disposable} target.
 		 */
 		Disposable subscribeTo(Publisher<? extends T> upstream);
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -105,7 +105,7 @@ public final class Sinks {
 	 *
 	 * @return {@link RootSpec}
 	 */
-	public static UnsafeRootSpec unsafe() {
+	public static RootSpec unsafe() {
 		return SinksSpecs.UNSAFE_ROOT_SPEC;
 	}
 
@@ -296,7 +296,7 @@ public final class Sinks {
 	 * An abstraction adjacent to {@link Processor} that combines downstream usage as a {@link Flux}
 	 * (see {@link #asFlux()}) and upstream usage as a {@link CoreSubscriber} (via {@link #subscribeTo(Publisher)}).
 	 * Implementations have similar characteristics to a {@link Sinks.Many}, but are instantiated via
-	 * {@link Sinks#unsafe()}.{@link UnsafeRootSpec#manyToUpstream() manyToUpstream()}.
+	 * {@link Sinks#unsafe()}.{@link RootSpec#manyToUpstream() manyToUpstream()}.
 	 *
 	 * @apiNote The {@link Subscriber} is intentionally not exposed, unlike in {@link FluxProcessor} where the API required external
 	 * synchronization to abide to the Reactive Streams spec, a requirement that was generally overlooked.
@@ -333,7 +333,7 @@ public final class Sinks {
 		/**
 		 * A {@link ManyUpstreamAdapter} with characteristics matching the
 		 * {@link MulticastSpec#onBackpressureBuffer()} (as instantiated via
-		 * Sinks.{@link Sinks#unsafe() unsafe()}.{@link UnsafeRootSpec#many() many()}.{@link ManySpec#multicast() multicast()}).
+		 * Sinks.{@link Sinks#unsafe() unsafe()}.{@link RootSpec#many() many()}.{@link ManySpec#multicast() multicast()}).
 		 *
 		 * @return the {@link ManyUpstreamAdapter}
 		 * @see reactor.core.publisher.EmitterProcessor
@@ -343,7 +343,7 @@ public final class Sinks {
 		/**
 		 * A {@link Processor} with characteristics matching the
 		 * {@link MulticastSpec#onBackpressureBuffer(int)} (as instantiated via
-		 * Sinks.{@link Sinks#unsafe() unsafe()}.{@link UnsafeRootSpec#many() many()}.{@link ManySpec#multicast() multicast()}).
+		 * Sinks.{@link Sinks#unsafe() unsafe()}.{@link RootSpec#many() many()}.{@link ManySpec#multicast() multicast()}).
 		 *
 		 * @param bufferSize the maximum queue size
 		 * @return the {@link ManyUpstreamAdapter}
@@ -354,7 +354,7 @@ public final class Sinks {
 		/**
 		 * A {@link Processor} with characteristics matching the
 		 * {@link MulticastSpec#onBackpressureBuffer(int, boolean)} (as instantiated via
-		 * Sinks.{@link Sinks#unsafe() unsafe()}.{@link UnsafeRootSpec#many() many()}.{@link ManySpec#multicast() multicast()}).
+		 * Sinks.{@link Sinks#unsafe() unsafe()}.{@link RootSpec#many() many()}.{@link ManySpec#multicast() multicast()}).
 		 *
 		 * @param bufferSize the maximum queue size
 		 * @param autoCancel should the sink fully shutdowns (not publishing anymore) when the last subscriber cancels
@@ -367,26 +367,9 @@ public final class Sinks {
 
 	/**
 	 * Provides a choice of {@link Sinks.One}/{@link Sinks.Empty} factories and
-	 * {@link Sinks.ManySpec further specs} for {@link Sinks.Many} without thread-safety
-	 * and synchronization. Also includes a {@link #manyToUpstream()} set of {@link Processor}-like
-	 * factories.
-	 */
-	public interface UnsafeRootSpec extends RootSpec {
-
-		/**
-		 * Provides {@link ManyUpstreamAdapter} implementations that have characteristics similar to
-		 * relevant {@link Sinks.Many} but should be used exclusively as a bridge between an upstream
-		 * {@link Publisher} and (possibly several) downstream {@link Subscriber}(s).
-		 *
-		 * @apiNote The {@link Subscriber} is intentionally not exposed, unlike in {@link FluxProcessor} where the API required external
-		 * synchronization to abide to the Reactive Streams spec, a requirement that was generally overlooked.
-		 */
-		ManyUpstreamSpec manyToUpstream();
-	}
-
-	/**
-	 * Provides a choice of {@link Sinks.One}/{@link Sinks.Empty} factories and
 	 * {@link Sinks.ManySpec further specs} for {@link Sinks.Many}.
+	 * Also includes a {@link #manyToUpstream()} set of {@link Processor}-like
+	 * factories.
 	 */
 	public interface RootSpec {
 
@@ -421,6 +404,16 @@ public final class Sinks {
 		 * @return {@link ManySpec}
 		 */
 		ManySpec many();
+
+		/**
+		 * Provides {@link ManyUpstreamAdapter} implementations that have characteristics similar to
+		 * relevant {@link Sinks.Many} but should be used exclusively as a bridge between an upstream
+		 * {@link Publisher} and (possibly several) downstream {@link Subscriber}(s).
+		 *
+		 * @apiNote The {@link Subscriber} is intentionally not exposed, unlike in {@link FluxProcessor} where the API required external
+		 * synchronization to abide to the Reactive Streams spec, a requirement that was generally overlooked.
+		 */
+		ManyUpstreamSpec manyToUpstream();
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -965,10 +965,10 @@ public final class Sinks {
 		 * The returned {@link Disposable} provides a way of both unsubscribing from the upstream
 		 * and terminating the sink: currently registered subscribers downstream receive an {@link Subscriber#onError(Throwable) onError}
 		 * signal with a {@link java.util.concurrent.CancellationException} and further attempts at subscribing
-		 * to the sink will trigger a similar signal.
+		 * to the sink will trigger a similar signal immediately (in which case the returned {@link Disposable} might be no-op).
 		 * <p>
-		 * The returned {@link Disposable} is an instance that is already {@link Disposable#isDisposed() disposed} when this method has been
-		 * previously called, as a {@link Subscriber} cannot be subscribed to more than one {@link Publisher}.
+		 * Any attempt at subscribing the same {@link ManyWithUpstream} multiple times throws an {@link IllegalStateException}
+		 * indicating that the subscription must be unique.
 		 */
 		Disposable subscribeTo(Publisher<? extends T> upstream);
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -337,10 +337,10 @@ public final class Sinks {
 	 * of the Reactive Streams specification in order to be correctly used.
 	 * <p>
 	 * Some flavors of {@link Sinks.Many} are {@link ManyWithUpstream} which additionally
-	 * support being turned into a {@link CoreSubscriber} and  attached to an upstream {@link Publisher}.
-	 * Please note that when this is done, one MUST stop using emit/tryEmit APIs and should refrain
-	 * from directly calling {@link Subscriber} methods, reserving signal creation to be the sole
-	 * responsibility of the upstream {@link Publisher}. The list of such flavors is as follows:
+	 * support being subscribed to an upstream {@link Publisher}, at most once.
+	 * Please note that when this is done, one MUST stop using emit/tryEmit APIs, reserving signal
+	 * creation to be the sole responsibility of the upstream {@link Publisher}.
+	 * The list of such flavors is as follows:
 	 * <ul>
 	 *     <li>
 	 *         {@link #many()}.{@link ManyUnsafeSpec#multicast() multicast()}.{@link MulticastUnsafeSpec#onBackpressureBuffer() onBackpressureBuffer()}
@@ -358,7 +358,7 @@ public final class Sinks {
 		/**
 		 * {@inheritDoc}
 		 * <p>
-		 * Some flavors return a {@link ManyWithUpstream}, allowing usage similar to a {@link org.reactivestreams.Processor} with an upstream {@link Publisher}.
+		 * Some flavors return a {@link ManyWithUpstream}, supporting being subscribed to an upstream {@link Publisher}.
 		 */
 		@Override
 		ManyUnsafeSpec many();
@@ -947,9 +947,8 @@ public final class Sinks {
 	}
 
 	/**
-	 * A {@link Sinks.Many} which additionally allows being used as a {@link CoreSubscriber}
-	 * and  attached to an upstream {@link Publisher}, which is an advanced pattern requiring
-	 * external synchronization. See {@link #subscribeTo(Publisher)}} for more details.
+	 * A {@link Sinks.Many} which additionally allows being subscribed to an upstream {@link Publisher},
+	 * which is an advanced pattern requiring external synchronization. See {@link #subscribeTo(Publisher)}} for more details.
 	 *
 	 * @param <T> the type of data emitted by the sink
 	 */

--- a/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
@@ -30,7 +30,7 @@ import reactor.util.annotation.Nullable;
 
 final class SinksSpecs {
 
-	static final Sinks.UnsafeRootSpec UNSAFE_ROOT_SPEC  = new RootSpecImpl(false);
+	static final Sinks.RootSpec UNSAFE_ROOT_SPEC  = new RootSpecImpl(false);
 	static final Sinks.RootSpec DEFAULT_ROOT_SPEC = new RootSpecImpl(true);
 
 	abstract static class AbstractSerializedSink {
@@ -62,7 +62,7 @@ final class SinksSpecs {
 		}
 	}
 
-	static final class RootSpecImpl implements Sinks.UnsafeRootSpec,
+	static final class RootSpecImpl implements Sinks.RootSpec,
 	                                     Sinks.ManySpec,
 	                                     Sinks.MulticastSpec,
 	                                     Sinks.MulticastReplaySpec {

--- a/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
@@ -98,17 +98,17 @@ final class SinksSpecs {
 		}
 
 		@Override
-		public <T> Sinks.ManySubscriber<T> onBackpressureBuffer() {
+		public <T> Sinks.ManyWithUpstream<T> onBackpressureBuffer() {
 			return new EmitterProcessor<>(true, Queues.SMALL_BUFFER_SIZE);
 		}
 
 		@Override
-		public <T> Sinks.ManySubscriber<T> onBackpressureBuffer(int bufferSize) {
+		public <T> Sinks.ManyWithUpstream<T> onBackpressureBuffer(int bufferSize) {
 			return new EmitterProcessor<>(true, bufferSize);
 		}
 
 		@Override
-		public <T> Sinks.ManySubscriber<T> onBackpressureBuffer(int bufferSize, boolean autoCancel) {
+		public <T> Sinks.ManyWithUpstream<T> onBackpressureBuffer(int bufferSize, boolean autoCancel) {
 			return new EmitterProcessor<>(autoCancel, bufferSize);
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
@@ -26,12 +26,12 @@ import reactor.core.publisher.Sinks.Empty;
 import reactor.core.publisher.Sinks.Many;
 import reactor.core.publisher.Sinks.One;
 import reactor.core.scheduler.Scheduler;
-import reactor.util.annotation.Nullable;
+import reactor.util.concurrent.Queues;
 
 final class SinksSpecs {
 
-	static final Sinks.RootSpec UNSAFE_ROOT_SPEC  = new RootSpecImpl(false);
-	static final Sinks.RootSpec DEFAULT_ROOT_SPEC = new RootSpecImpl(true);
+	static final Sinks.UnsafeSpec  UNSAFE_ROOT_SPEC = new UnsafeSpecImpl();
+	static final DefaultSinksSpecs DEFAULT_SINKS    = new DefaultSinksSpecs();
 
 	abstract static class AbstractSerializedSink {
 
@@ -62,71 +62,149 @@ final class SinksSpecs {
 		}
 	}
 
-	static final class RootSpecImpl implements Sinks.RootSpec,
-	                                     Sinks.ManySpec,
-	                                     Sinks.MulticastSpec,
-	                                     Sinks.MulticastReplaySpec {
 
-		final boolean serialized;
-		final Sinks.UnicastSpec      unicastSpec; //needed because UnicastSpec method names overlap with MulticastSpec
-		@Nullable
-		final Sinks.ManyUpstreamSpec manyUpstreamSpec; //needed because ProcessorSpec method names overlap with MulticastSpec
+	static final class UnsafeSpecImpl
+		implements Sinks.UnsafeSpec, Sinks.ManyUnsafeSpec, Sinks.MulticastUnsafeSpec, Sinks.MulticastReplaySpec {
 
-		RootSpecImpl(boolean serialized) {
-			this.serialized = serialized;
-			//there will only be as many instances of UnicastSpecImpl as there are RootSpecImpl instances (2)
-			this.unicastSpec = new UnicastSpecImpl(serialized);
-			//there will only be as many instances of UnicastSpecImpl as there are RootSpecImpl instances with serialized==false (1)
-			if (!serialized) {
-				this.manyUpstreamSpec = new ManyUpstreamSpecImpl();
-			}
-			else {
-				this.manyUpstreamSpec = null;
-			}
-		}
+		final Sinks.UnicastSpec unicastSpec;
 
-		<T, EMPTY extends Empty<T> & ContextHolder> Empty<T> wrapEmpty(EMPTY original) {
-			if (serialized) {
-				return new SinkEmptySerialized<>(original, original);
-			}
-			return original;
-		}
-
-		<T, ONE extends One<T> & ContextHolder> One<T> wrapOne(ONE original) {
-			if (serialized) {
-				return new SinkOneSerialized<>(original, original);
-			}
-			return original;
-		}
-
-		<T, MANY extends Many<T> & ContextHolder> Many<T> wrapMany(MANY original) {
-			if (serialized) {
-				return new SinkManySerialized<>(original, original);
-			}
-			return original;
-		}
-
-		@Override
-		public Sinks.ManySpec many() {
-			return this;
+		UnsafeSpecImpl() {
+			this.unicastSpec = new UnicastSpecImpl(false);
 		}
 
 		@Override
 		public <T> Empty<T> empty() {
-			return wrapEmpty(new SinkEmptyMulticast<>());
+			return new SinkEmptyMulticast<>();
 		}
 
 		@Override
 		public <T> One<T> one() {
-			return wrapOne(new SinkOneMulticast<>());
+			return new SinkOneMulticast<>();
 		}
 
 		@Override
-		public Sinks.ManyUpstreamSpec manyToUpstream() {
-			if (manyUpstreamSpec == null) {
-				throw new IllegalStateException("manyToUpstream() should not be reachable on serialized RootSpecImpl");
-			}
-			return this.manyUpstreamSpec;
+		public Sinks.ManyUnsafeSpec many() {
+			return this;
+		}
+
+		@Override
+		public Sinks.UnicastSpec unicast() {
+			return this.unicastSpec;
+		}
+
+		@Override
+		public Sinks.MulticastReplaySpec replay() {
+			return this;
+		}
+
+		@Override
+		public <T> Sinks.ManySubscriber<T> onBackpressureBuffer() {
+			return new EmitterProcessor<>(true, Queues.SMALL_BUFFER_SIZE);
+		}
+
+		@Override
+		public <T> Sinks.ManySubscriber<T> onBackpressureBuffer(int bufferSize) {
+			return new EmitterProcessor<>(true, bufferSize);
+		}
+
+		@Override
+		public <T> Sinks.ManySubscriber<T> onBackpressureBuffer(int bufferSize, boolean autoCancel) {
+			return new EmitterProcessor<>(autoCancel, bufferSize);
+		}
+
+		@Override
+		public Sinks.MulticastUnsafeSpec multicast() {
+			return this;
+		}
+
+		@Override
+		public <T> Many<T> directAllOrNothing() {
+			return new SinkManyBestEffort<>(true);
+		}
+
+		@Override
+		public <T> Many<T> directBestEffort() {
+			return new SinkManyBestEffort<>(false);
+		}
+
+		@Override
+		public <T> Many<T> all() {
+			return ReplayProcessor.create();
+		}
+
+		@Override
+		public <T> Many<T> all(int batchSize) {
+			return ReplayProcessor.create(batchSize);
+		}
+
+		@Override
+		public <T> Many<T> latest() {
+			return ReplayProcessor.cacheLast();
+		}
+
+		@Override
+		public <T> Many<T> latestOrDefault(T value) {
+			return ReplayProcessor.cacheLastOrDefault(value);
+		}
+
+		@Override
+		public <T> Many<T> limit(int historySize) {
+			return ReplayProcessor.create(historySize);
+		}
+
+		@Override
+		public <T> Many<T> limit(Duration maxAge) {
+			return ReplayProcessor.createTimeout(maxAge);
+		}
+
+		@Override
+		public <T> Many<T> limit(Duration maxAge, Scheduler scheduler) {
+			return ReplayProcessor.createTimeout(maxAge, scheduler);
+		}
+
+		@Override
+		public <T> Many<T> limit(int historySize, Duration maxAge) {
+			return ReplayProcessor.createSizeAndTimeout(historySize, maxAge);
+		}
+
+		@Override
+		public <T> Many<T> limit(int historySize, Duration maxAge, Scheduler scheduler) {
+			return ReplayProcessor.createSizeAndTimeout(historySize, maxAge, scheduler);
+		}
+	}
+
+	//Note: RootSpec is now reserved for Sinks.unsafe()
+	static final class DefaultSinksSpecs implements Sinks.ManySpec, Sinks.MulticastSpec, Sinks.MulticastReplaySpec {
+
+		final Sinks.UnicastSpec unicastSpec; //needed because UnicastSpec method names overlap with MulticastSpec
+
+		DefaultSinksSpecs() {
+			//there will only one instance of serialized UnicastSpecImpl as there is only one instance of  SafeRootSpecImpl
+			this.unicastSpec = new UnicastSpecImpl(true);
+		}
+
+		<T, EMPTY extends Empty<T> & ContextHolder> Empty<T> wrapEmpty(EMPTY original) {
+			return new SinkEmptySerialized<>(original, original);
+		}
+
+		<T, ONE extends One<T> & ContextHolder> One<T> wrapOne(ONE original) {
+			return new SinkOneSerialized<>(original, original);
+		}
+
+		<T, MANY extends Many<T> & ContextHolder> Many<T> wrapMany(MANY original) {
+			return new SinkManySerialized<>(original, original);
+		}
+
+		Sinks.ManySpec many() {
+			return this;
+		}
+
+		<T> Empty<T> empty() {
+			return wrapEmpty(new SinkEmptyMulticast<>());
+		}
+
+		<T> One<T> one() {
+			return wrapOne(new SinkOneMulticast<>());
 		}
 
 		@Override
@@ -293,29 +371,4 @@ final class SinksSpecs {
 			return wrapMany(original);
 		}
 	}
-
-	static final class ManyUpstreamSpecImpl implements Sinks.ManyUpstreamSpec {
-
-		@Override
-		public <T> Sinks.ManyUpstreamAdapter<T> onBackpressureBuffer() {
-			@SuppressWarnings("deprecation")
-			Sinks.ManyUpstreamAdapter<T> processor = EmitterProcessor.create();
-			return processor;
-		}
-
-		@Override
-		public <T> Sinks.ManyUpstreamAdapter<T> onBackpressureBuffer(int bufferSize) {
-			@SuppressWarnings("deprecation")
-			Sinks.ManyUpstreamAdapter<T> processor = EmitterProcessor.create(bufferSize);
-			return processor;
-		}
-
-		@Override
-		public <T> Sinks.ManyUpstreamAdapter<T> onBackpressureBuffer(int bufferSize, boolean autoCancel) {
-			@SuppressWarnings("deprecation")
-			Sinks.ManyUpstreamAdapter<T> processor = EmitterProcessor.create(bufferSize, autoCancel);
-			return processor;
-		}
-	}
 }
-

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -135,10 +135,10 @@ public class EmitterProcessorTest {
 		final TestPublisher<Integer> upstream2 = TestPublisher.create();
 
 		Disposable sub1 = adapter.subscribeTo(upstream1);
-		Disposable sub2 = adapter.subscribeTo(upstream2);
+
+		assertThatIllegalStateException().isThrownBy(() -> adapter.subscribeTo(upstream2));
 
 		assertThat(sub1.isDisposed()).as("first subscription active").isFalse();
-		assertThat(sub2.isDisposed()).as("second subscription cancelled").isTrue();
 
 		upstream1.assertMinRequested(123);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -65,8 +65,8 @@ public class EmitterProcessorTest {
 	AutoDisposingExtension afterTest = new AutoDisposingExtension();
 
 	@Test
-	void smokeTestManyUpstreamAdapter() throws InterruptedException {
-		final Sinks.ManyUpstreamAdapter<Integer> adapter = Sinks.unsafe().manyToUpstream().onBackpressureBuffer();
+	void smokeTestManySubscriber() {
+		final Sinks.ManySubscriber<Integer> adapter = Sinks.unsafe().many().multicast().onBackpressureBuffer();
 		final TestSubscriber<Integer> testSubscriber1 = TestSubscriber.create();
 		final TestSubscriber<Integer> testSubscriber2 = TestSubscriber.create();
 		final Flux<Integer> upstream = Flux.range(1, 10);

--- a/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
@@ -73,6 +73,15 @@ class SinksTest {
 		assertThat(Sinks.unsafe().empty()).isNotInstanceOf(SinksSpecs.AbstractSerializedSink.class);
 	}
 
+	@Test
+	void manyAdapterNotAvailableOnRootSpec() {
+		SinksSpecs.RootSpecImpl serializedRootSpec = new SinksSpecs.RootSpecImpl(true);
+
+		assertThat(serializedRootSpec.manyUpstreamSpec).as("manyUpstreamSpec").isNull();
+		assertThatIllegalStateException().isThrownBy(serializedRootSpec::manyToUpstream)
+			.withMessage("manyToUpstream() should not be reachable on serialized RootSpecImpl");
+	}
+
 
 	@Nested
 	class Multicast {

--- a/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
+
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.StepVerifierOptions;
@@ -72,16 +73,6 @@ class SinksTest {
 	void unsafeEmptyIsNotSerialized() {
 		assertThat(Sinks.unsafe().empty()).isNotInstanceOf(SinksSpecs.AbstractSerializedSink.class);
 	}
-
-	@Test
-	void manyAdapterNotAvailableOnRootSpec() {
-		SinksSpecs.RootSpecImpl serializedRootSpec = new SinksSpecs.RootSpecImpl(true);
-
-		assertThat(serializedRootSpec.manyUpstreamSpec).as("manyUpstreamSpec").isNull();
-		assertThatIllegalStateException().isThrownBy(serializedRootSpec::manyToUpstream)
-			.withMessage("manyToUpstream() should not be reachable on serialized RootSpecImpl");
-	}
-
 
 	@Nested
 	class Multicast {

--- a/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
-
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.StepVerifierOptions;
@@ -73,6 +72,7 @@ class SinksTest {
 	void unsafeEmptyIsNotSerialized() {
 		assertThat(Sinks.unsafe().empty()).isNotInstanceOf(SinksSpecs.AbstractSerializedSink.class);
 	}
+
 
 	@Nested
 	class Multicast {


### PR DESCRIPTION
This introduces a migration path for a subset of Processors (namely the
`EmitterProcessor`) before they get removed from the public API in 3.5.0.

The `ManyUpstreamAdapter` is a Processor-adjactent API that doesn't expose
the `CoreSubscriber` API but rather separates concerns:
 - use of the `Publisher` aspect via `asFlux()` (similar to `Sinks.Many`)
 - subscription to an upstream via `subscribeTo(Publisher)`

This way, the underlying `CoreSubscriber` nature is never revealed to the user
which avoids the trouble with non-serialized access.

Emitter-like variants are exposed via `Sinks.unsafe().manyToUpstream()`
as `.onBackpressureBuffer(...)` variants mirroring the ones in `MulticastSpec`.

### questions
 - [x] should equivalents of `ReplayProcessor` also be added? (IIRC it also kind
  of supports the "subscribe-to-upstream-and-respect-downstream-backpressure"
  use case) => for now, focusing on EmitterProcessor
 - [ ] can this be introduced in 3.5.0 directly instead? 