### PR TITLE
Fix DoOnEach ASYNC fusion triggering onNext signal twice

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDoOnEachTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDoOnEachTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,25 @@ import static org.junit.jupiter.api.Named.named;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class FluxDoOnEachTest {
+
+
+	// see https://github.com/reactor/reactor-core/issues/3044
+	@Test
+	void doOnEachAsyncFusionDoesntTriggerOnNextTwice() {
+		List<String> signals = new ArrayList<>();
+		StepVerifier.create(Flux.just("a", "b", "c")
+				.collectList()
+				.doOnEach(sig -> signals.add(sig.toString()))
+			)
+			.expectFusion(Fuseable.ASYNC)
+			.expectNext(Arrays.asList("a", "b", "c"))
+			.verifyComplete();
+
+		assertThat(signals).containsExactly(
+			"doOnEach_onNext([a, b, c])",
+			"onComplete()"
+		);
+	}
 
 	@Test
 	public void nullSource() {

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ public class MonoSubscriberTest {
 
 		ds.clear();
 
-		assertThat(ds.state).isEqualTo(MonoSubscriber.FUSED_CONSUMED);
+		assertThat(ds.state).isEqualTo(MonoSubscriber.FUSED_ASYNC_CONSUMED);
 		assertThat(ds.value).isNull();
 	}
 


### PR DESCRIPTION
This commit fixes the DoOnEachFuseableSubscriber to interpret any
upstream onNext as a fusion trigger in ASYNC mode (onNext(null)).

Furthermore, this commit fixes the Operators.MonoSubscriber handling of
FUSED case. Since that abstract operator only supports ASYNC fusion,
the FUSED_* states are renamed FUSED_ASYNC_*. In the drain loop, even in
FUSED case the operator emits t downstream where it should emit null
technically (again, because FUSED == ASYNC). This error is also fixed.

Fixes #3044.
