### PR TITLE
Fix cancel too synchronized in MonoCollect[List]

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollect.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import org.reactivestreams.Subscription;
+
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.util.annotation.Nullable;
@@ -175,19 +176,19 @@ final class MonoCollect<T, R> extends MonoFromFluxOperator<T, R>
 		public void cancel() {
 			int state;
 			R c;
-			synchronized (this) {
-				state = STATE.getAndSet(this, CANCELLED);
-				if (state != CANCELLED) {
-					s.cancel();
-				}
-				if (state <= HAS_REQUEST_NO_VALUE) {
+			state = STATE.getAndSet(this, CANCELLED);
+			if (state != CANCELLED) {
+				s.cancel();
+			}
+			if (state <= HAS_REQUEST_NO_VALUE) {
+				synchronized (this) {
 					c = container;
 					this.value = null;
 					container = null;
 				}
-				else {
-					c = null;
-				}
+			}
+			else {
+				c = null;
 			}
 			if (c != null) {
 				discard(c);

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
@@ -138,11 +138,11 @@ final class MonoCollectList<T> extends MonoFromFluxOperator<T, List<T>> implemen
 		public void cancel() {
 			int state;
 			List<T> l;
+			state = STATE.getAndSet(this, CANCELLED);
+			if (state != CANCELLED) {
+				s.cancel();
+			}
 			synchronized (this) {
-				state = STATE.getAndSet(this, CANCELLED);
-				if (state != CANCELLED) {
-					s.cancel();
-				}
 				if (state <= HAS_REQUEST_NO_VALUE) {
 					l = list;
 					this.value = null;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.reactivestreams.Subscription;
+
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.util.annotation.Nullable;
@@ -142,15 +143,15 @@ final class MonoCollectList<T> extends MonoFromFluxOperator<T, List<T>> implemen
 			if (state != CANCELLED) {
 				s.cancel();
 			}
-			synchronized (this) {
-				if (state <= HAS_REQUEST_NO_VALUE) {
+			if (state <= HAS_REQUEST_NO_VALUE) {
+				synchronized (this) {
 					l = list;
 					this.value = null;
 					list = null;
 				}
-				else {
-					l = null;
-				}
+			}
+			else {
+				l = null;
 			}
 			if (l != null) {
 				discard(l);

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
@@ -140,18 +140,18 @@ final class MonoCollectList<T> extends MonoFromFluxOperator<T, List<T>> implemen
 			int state;
 			List<T> l;
 			state = STATE.getAndSet(this, CANCELLED);
-			if (state != CANCELLED) {
-				s.cancel();
-			}
-			if (state <= HAS_REQUEST_NO_VALUE) {
-				synchronized (this) {
+			synchronized (this) {
+				if (state <= HAS_REQUEST_NO_VALUE) {
 					l = list;
 					this.value = null;
 					list = null;
 				}
+				else {
+					l = null;
+				}
 			}
-			else {
-				l = null;
+			if (state != CANCELLED) {
+				s.cancel();
 			}
 			if (l != null) {
 				discard(l);

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
@@ -140,6 +140,9 @@ final class MonoCollectList<T> extends MonoFromFluxOperator<T, List<T>> implemen
 			int state;
 			List<T> l;
 			state = STATE.getAndSet(this, CANCELLED);
+			if (state != CANCELLED) {
+				s.cancel();
+			}
 			synchronized (this) {
 				if (state <= HAS_REQUEST_NO_VALUE) {
 					l = list;
@@ -149,9 +152,6 @@ final class MonoCollectList<T> extends MonoFromFluxOperator<T, List<T>> implemen
 				else {
 					l = null;
 				}
-			}
-			if (state != CANCELLED) {
-				s.cancel();
 			}
 			if (l != null) {
 				discard(l);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import java.util.function.Function;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Subscription;
 
 import reactor.core.CoreSubscriber;
@@ -322,6 +323,7 @@ class MonoCollectListTest {
 	// https://github.com/reactor/reactor-core/issues/3052
 	@Test
 	@Tag("slow")
+	@Timeout(30)
 	void deadlockCancelOnNext() throws InterruptedException {
 		for (int i = 0; i < 100_000; i++) {
 			CoreSubscriber<? super List<Integer>> testSubscriber = TestSubscriber.create();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
@@ -323,9 +323,9 @@ class MonoCollectListTest {
 	// https://github.com/reactor/reactor-core/issues/3052
 	@Test
 	@Tag("slow")
-	@Timeout(30)
+	@Timeout(100)
 	void deadlockCancelOnNext() throws InterruptedException {
-		for (int i = 0; i < 100_000; i++) {
+		for (int i = 0; i < 1_000; i++) {
 			CoreSubscriber<? super List<Integer>> testSubscriber = TestSubscriber.create();
 			MonoCollectList.MonoCollectListSubscriber<Integer> subscriber = new MonoCollectListSubscriber<>(testSubscriber);
 			CountDownLatch latch = new CountDownLatch(2);

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCollectListTest.java
@@ -323,7 +323,7 @@ class MonoCollectListTest {
 	// https://github.com/reactor/reactor-core/issues/3052
 	@Test
 	@Tag("slow")
-	@Timeout(100)
+	@Timeout(30)
 	void deadlockCancelOnNext() throws InterruptedException {
 		for (int i = 0; i < 1_000; i++) {
 			CoreSubscriber<? super List<Integer>> testSubscriber = TestSubscriber.create();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCollectTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCollectTest.java
@@ -407,7 +407,7 @@ public class MonoCollectTest {
 	@Tag("slow")
 	@Timeout(30)
 	void deadlockCancelOnNext() throws InterruptedException {
-		for (int i = 0; i < 100_000; i++) {
+		for (int i = 0; i < 1_000; i++) {
 			CoreSubscriber<? super List<Integer>> testSubscriber = TestSubscriber.create();
 			MonoCollect.CollectSubscriber<Integer, ArrayList<Integer>> subscriber = new MonoCollect.CollectSubscriber<>(testSubscriber, ArrayList::add, new ArrayList<>());
 			CountDownLatch latch = new CountDownLatch(2);


### PR DESCRIPTION
This commit reduces the length of the critical section in MonoCollectList and
MonoCollect cancel() method that is synchronized.
In particular, it removes upstream.cancel() from said critical section.

This will prevent a deadlock in case the upstream operator protects a resource
using synchronization in both its cancel() method and in any other method that
calls the collect subscriber downstream (typically onNext()).

By making the critical section shorter, we ensure that the relevant fields are
read / written to / nulled out correctly while avoiding synchronization on the
calls to the upstream / downstream, hence restoring progress.

Fixes #3052.