### PR TITLE
Rework Processor-with-upstream case to be backward compatible

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -166,8 +166,7 @@ task japicmp(type: JapicmpTask) {
 		'reactor.core.publisher.Sinks$EmitFailureHandler#busyLooping(java.time.Duration)',
 		'reactor.core.publisher.FluxSink#contextView()',
 		'reactor.core.publisher.MonoSink#contextView()',
-		'reactor.core.publisher.SynchronousSink#contextView()',
-		'reactor.core.publisher.Sinks#unsafe()'
+		'reactor.core.publisher.SynchronousSink#contextView()'
 	]
 }
 

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -29,7 +29,6 @@ import org.reactivestreams.Subscription;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
-import reactor.core.Disposables;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
@@ -59,8 +58,7 @@ import static reactor.core.publisher.FluxPublish.PublishSubscriber.TERMINATED;
  * @deprecated To be removed in 3.5. Prefer clear cut usage of {@link Sinks} through
  * variations of {@link Sinks.MulticastSpec#onBackpressureBuffer() Sinks.many().multicast().onBackpressureBuffer()}.
  * If you really need the subscribe-to-upstream functionality of a {@link org.reactivestreams.Processor}, switch
- * to {@link Sinks.ManyWithUpstream} with {@link Sinks#unsafe()} variants of
- * {@link Sinks.MulticastUnsafeSpec#onBackpressureBuffer() Sinks.unsafe().many().multicast().onBackpressureBuffer()}.
+ * to {@link Sinks.ManyWithUpstream} with {@link Sinks#unsafe()} variants of {@link Sinks.RootSpec#manyWithUpstream() Sinks.unsafe().manyWithUpstream()}.
  * <p/>This processor was blocking in {@link EmitterProcessor#onNext(Object)}. This behaviour can be implemented with the {@link Sinks} API by calling
  * {@link Sinks.Many#tryEmitNext(Object)} and retrying, e.g.:
  * <pre>{@code while (sink.tryEmitNext(v).hasFailed()) {

--- a/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
@@ -30,7 +30,7 @@ import reactor.util.concurrent.Queues;
 
 final class SinksSpecs {
 
-	static final Sinks.UnsafeSpec  UNSAFE_ROOT_SPEC = new UnsafeSpecImpl();
+	static final Sinks.RootSpec  UNSAFE_ROOT_SPEC = new UnsafeSpecImpl();
 	static final DefaultSinksSpecs DEFAULT_SINKS    = new DefaultSinksSpecs();
 
 	abstract static class AbstractSerializedSink {
@@ -64,7 +64,7 @@ final class SinksSpecs {
 
 
 	static final class UnsafeSpecImpl
-		implements Sinks.UnsafeSpec, Sinks.ManyUnsafeSpec, Sinks.MulticastUnsafeSpec, Sinks.MulticastReplaySpec {
+		implements Sinks.RootSpec, Sinks.ManySpec, Sinks.ManyWithUpstreamUnsafeSpec, Sinks.MulticastSpec, Sinks.MulticastReplaySpec {
 
 		final Sinks.UnicastSpec unicastSpec;
 
@@ -83,7 +83,7 @@ final class SinksSpecs {
 		}
 
 		@Override
-		public Sinks.ManyUnsafeSpec many() {
+		public Sinks.ManySpec many() {
 			return this;
 		}
 
@@ -93,28 +93,33 @@ final class SinksSpecs {
 		}
 
 		@Override
+		public Sinks.MulticastSpec multicast() {
+			return this;
+		}
+
+		@Override
 		public Sinks.MulticastReplaySpec replay() {
 			return this;
 		}
 
 		@Override
-		public <T> Sinks.ManyWithUpstream<T> onBackpressureBuffer() {
+		public Sinks.ManyWithUpstreamUnsafeSpec manyWithUpstream() {
+			return this;
+		}
+
+		@Override
+		public <T> Sinks.Many<T> onBackpressureBuffer() {
 			return new EmitterProcessor<>(true, Queues.SMALL_BUFFER_SIZE);
 		}
 
 		@Override
-		public <T> Sinks.ManyWithUpstream<T> onBackpressureBuffer(int bufferSize) {
+		public <T> Sinks.Many<T> onBackpressureBuffer(int bufferSize) {
 			return new EmitterProcessor<>(true, bufferSize);
 		}
 
 		@Override
-		public <T> Sinks.ManyWithUpstream<T> onBackpressureBuffer(int bufferSize, boolean autoCancel) {
+		public <T> Sinks.Many<T> onBackpressureBuffer(int bufferSize, boolean autoCancel) {
 			return new EmitterProcessor<>(autoCancel, bufferSize);
-		}
-
-		@Override
-		public Sinks.MulticastUnsafeSpec multicast() {
-			return this;
 		}
 
 		@Override
@@ -170,6 +175,16 @@ final class SinksSpecs {
 		@Override
 		public <T> Many<T> limit(int historySize, Duration maxAge, Scheduler scheduler) {
 			return ReplayProcessor.createSizeAndTimeout(historySize, maxAge, scheduler);
+		}
+
+		@Override
+		public <T> Sinks.ManyWithUpstream<T> multicastOnBackpressureBuffer() {
+			return new EmitterProcessor<>(true, Queues.SMALL_BUFFER_SIZE);
+		}
+
+		@Override
+		public <T> Sinks.ManyWithUpstream<T> multicastOnBackpressureBuffer(int bufferSize, boolean autoCancel) {
+			return new EmitterProcessor<>(autoCancel, bufferSize);
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/EmitterProcessorTest.java
@@ -23,12 +23,10 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
-import org.assertj.core.data.Percentage;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -48,7 +46,6 @@ import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.test.subscriber.TestSubscriber;
-import reactor.test.util.RaceTestUtils;
 import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
@@ -70,8 +67,8 @@ public class EmitterProcessorTest {
 	AutoDisposingExtension afterTest = new AutoDisposingExtension();
 
 	@Test
-	void smokeTestManySubscriber() {
-		final Sinks.ManyWithUpstream<Integer> adapter = Sinks.unsafe().many().multicast().onBackpressureBuffer();
+	void smokeTestManyWithUpstream() {
+		final Sinks.ManyWithUpstream<Integer> adapter = Sinks.unsafe().manyWithUpstream().multicastOnBackpressureBuffer();
 		final TestSubscriber<Integer> testSubscriber1 = TestSubscriber.create();
 		final TestSubscriber<Integer> testSubscriber2 = TestSubscriber.create();
 		final Flux<Integer> upstream = Flux.range(1, 10);
@@ -102,7 +99,7 @@ public class EmitterProcessorTest {
 
 	@Test
 	void smokeTestSubscribeAndDispose() {
-		final Sinks.ManyWithUpstream<Integer> adapter = Sinks.unsafe().many().multicast().onBackpressureBuffer();
+		final Sinks.ManyWithUpstream<Integer> adapter = Sinks.unsafe().manyWithUpstream().multicastOnBackpressureBuffer();
 		final TestSubscriber<Integer> testSubscriber1 = TestSubscriber.create();
 		final TestSubscriber<Integer> testSubscriber2 = TestSubscriber.create();
 		final Flux<Integer> upstream = Flux.never();
@@ -130,7 +127,7 @@ public class EmitterProcessorTest {
 
 	@Test
 	void subscribeToUpstreamTwiceSkipsSecondSubscription() {
-		final Sinks.ManyWithUpstream<Integer> adapter = Sinks.unsafe().many().multicast().onBackpressureBuffer(123);
+		final Sinks.ManyWithUpstream<Integer> adapter = Sinks.unsafe().manyWithUpstream().multicastOnBackpressureBuffer(123, true);
 		final TestPublisher<Integer> upstream1 = TestPublisher.create();
 		final TestPublisher<Integer> upstream2 = TestPublisher.create();
 


### PR DESCRIPTION
This commit reworks #3042 and reverts the changes to RootSpec returning
methods. These changes were binary incompatible with the previous
release of reactor, despite an API-compatible change.

What is reverted:
 - the `UnsafeRootSpec` and intermediate specs are removed
 - `Sinks.unsafe()` is back to returning `RootSpec`

What is kept:
 - `RootSpec` is dedicated to `Sinks.unsafe()`
 - `Sinks.manyWithUpstream` interface is still introduced

What is modified:
 - `RootSpec` receives an additional `manyWithUpstream()` method which
 is the one exposing `Sinks.manyWithUpstream` implementations
