### PR TITLE
June dependency upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
-      - uses: gradle/gradle-build-action@fec4a42eb0c83154e5c9590748ba8337949c5701 # tag=v2
+      - uses: gradle/gradle-build-action@e88ed3e650b26bd116cfee53cf198c1f6856682d # tag=v2
         name: spotless (license header)
         if: always()
         with:
           arguments: spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
-      - uses: gradle/gradle-build-action@fec4a42eb0c83154e5c9590748ba8337949c5701 # tag=v2
+      - uses: gradle/gradle-build-action@e88ed3e650b26bd116cfee53cf198c1f6856682d # tag=v2
         name: api compatibility
         if: always()
         with:
@@ -46,7 +46,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 8
-    - uses: gradle/gradle-build-action@fec4a42eb0c83154e5c9590748ba8337949c5701 # tag=v2
+    - uses: gradle/gradle-build-action@e88ed3e650b26bd116cfee53cf198c1f6856682d # tag=v2
       name: gradle
       with:
         arguments: :reactor-core:test --no-daemon -Pjunit-tags=!slow
@@ -60,7 +60,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 8
-    - uses: gradle/gradle-build-action@fec4a42eb0c83154e5c9590748ba8337949c5701 # tag=v2
+    - uses: gradle/gradle-build-action@e88ed3e650b26bd116cfee53cf198c1f6856682d # tag=v2
       name: gradle
       with:
         arguments: :reactor-core:test --no-daemon -Pjunit-tags=slow
@@ -74,7 +74,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 8
-    - uses: gradle/gradle-build-action@fec4a42eb0c83154e5c9590748ba8337949c5701 # tag=v2
+    - uses: gradle/gradle-build-action@e88ed3e650b26bd116cfee53cf198c1f6856682d # tag=v2
       name: other tests
       with:
         arguments: check -x :reactor-core:test -x spotlessCheck --no-daemon

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       run: ./gradlew qualifyVersionGha
     - name: run checks
       id: checks
-      uses: gradle/gradle-build-action@fec4a42eb0c83154e5c9590748ba8337949c5701 # tag=v2
+      uses: gradle/gradle-build-action@e88ed3e650b26bd116cfee53cf198c1f6856682d # tag=v2
       with:
         arguments: check -Pjunit-tags=!slow -x jcstress
 
@@ -49,7 +49,7 @@ jobs:
           java-version: 8
       - name: run slower tests
         id: slowerTests
-        uses: gradle/gradle-build-action@fec4a42eb0c83154e5c9590748ba8337949c5701 # tag=v2
+        uses: gradle/gradle-build-action@e88ed3e650b26bd116cfee53cf198c1f6856682d # tag=v2
         with:
           arguments: reactor-core:test -Pjunit-tags=slow jcstress
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,5 +49,5 @@ jcstress = { id = "io.github.reyerizo.gradle.jcstress", version = "0.8.13" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 nohttp = { id = "io.spring.nohttp", version = "0.0.10" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
-spotless = { id = "com.diffplug.spotless", version = "6.5.2" }
+spotless = { id = "com.diffplug.spotless", version = "6.7.0" }
 testsets = { id = "org.unbroken-dome.test-sets", version = "4.0.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ testNg = "org.testng:testng:7.5"
 throwingFunction = "com.pivovarit:throwing-function:1.5.1"
 
 [plugins]
-artifactory = { id = "com.jfrog.artifactory", version = "4.28.2" }
+artifactory = { id = "com.jfrog.artifactory", version = "4.28.3" }
 asciidoctor-convert = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor" }
 asciidoctor-pdf = { id = "org.asciidoctor.jvm.pdf", version.ref = "asciidoctor" }
 bnd = { id = "biz.aQute.bnd.builder", version = "6.3.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ reactiveStreams = "1.0.3"
 
 [libraries]
 archUnit = "com.tngtech.archunit:archunit:0.23.1"
-assertj = "org.assertj:assertj-core:3.22.0"
+assertj = "org.assertj:assertj-core:3.23.1"
 awaitility = "org.awaitility:awaitility:4.2.0"
 blockhound = "io.projectreactor.tools:blockhound:1.0.6.RELEASE"
 byteBuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "bytebuddy" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,7 @@ throwingFunction = "com.pivovarit:throwing-function:1.5.1"
 artifactory = { id = "com.jfrog.artifactory", version = "4.28.2" }
 asciidoctor-convert = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor" }
 asciidoctor-pdf = { id = "org.asciidoctor.jvm.pdf", version.ref = "asciidoctor" }
-bnd = { id = "biz.aQute.bnd.builder", version = "6.2.0" }
+bnd = { id = "biz.aQute.bnd.builder", version = "6.3.0" }
 download = { id = "de.undercouch.download", version = "5.1.0" }
 japicmp = { id = "me.champeau.gradle.japicmp", version = "0.4.0" }
 jcstress = { id = "io.github.reyerizo.gradle.jcstress", version = "0.8.13" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 logback = "ch.qos.logback:logback-classic:1.2.11"
 micrometer = "io.micrometer:micrometer-core:1.3.0"
-mockito = "org.mockito:mockito-core:4.5.1"
+mockito = "org.mockito:mockito-core:4.6.1"
 reactiveStreams = { module = "org.reactivestreams:reactive-streams", version.ref = "reactiveStreams" }
 reactiveStreams-tck = { module = "org.reactivestreams:reactive-streams-tck", version.ref = "reactiveStreams" }
 reactor-perfBaseline-core = { module = "io.projectreactor:reactor-core", version.ref = "baselinePerfCore" }

--- a/reactor-core/src/test/java/reactor/core/QueueSubscriptionTest.java
+++ b/reactor-core/src/test/java/reactor/core/QueueSubscriptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/QueueSubscriptionTest.java
+++ b/reactor-core/src/test/java/reactor/core/QueueSubscriptionTest.java
@@ -81,9 +81,9 @@ class QueueSubscriptionTest {
 				})
 		.withMessage("\n" +
 			"Expecting actual:\n" +
-			"  \"foo\"\n" +
-			"and actual:\n" +
 			"  ThisIsNotAQueue\n" +
+			"and:\n" +
+			"  \"foo\"\n" +
 			"to refer to the same object");
 	}
 

--- a/reactor-tools/src/buildPluginTest/resources/mock-gradle/build.gradle
+++ b/reactor-tools/src/buildPluginTest/resources/mock-gradle/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 	testImplementation "org.junit.jupiter:junit-jupiter-api"
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 
-	testImplementation "org.assertj:assertj-core:3.22.0"
+	testImplementation "org.assertj:assertj-core:3.23.1"
 }
 
 test {

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 plugins {
-	id "com.gradle.enterprise" version "3.10"
+	id "com.gradle.enterprise" version "3.10.1"
 }
 
 rootProject.name = 'reactor'


### PR DESCRIPTION
This is a 3.4.x combination of dependency upgrades originally flagged by Renovate in the main branch

-  Update dependency org.assertj:assertj-core to v3.23.1, supersedes and closes #3058
-  Update gradle/gradle-build-action v2 digest, supersedes and closes #3050
-  Update plugin spotless to v6.7.0, supersedes and closes #3040
-  Update dependency org.mockito:mockito-core to v4.6.1, supersedes and closes #3056
-  Update plugin bnd to v6.3.0, supersedes and closes #3061
-  Update plugin com.gradle.enterprise to v3.10.1, supersedes and closes #3048
-  Update plugin artifactory to v4.28.3, supersedes and closes #3041
