### PR TITLE
Introducing JCStress tests for concurrent queues

### DIFF
--- a/reactor-core/src/jcstress/java/reactor/util/concurrent/MpscLinkedQueueStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/util/concurrent/MpscLinkedQueueStressTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.concurrent;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.Expect;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.LLLLL_Result;
+import org.openjdk.jcstress.infra.results.LLLL_Result;
+import org.openjdk.jcstress.infra.results.LLL_Result;
+
+public abstract class MpscLinkedQueueStressTest {
+
+	@JCStressTest
+	@Outcome(id = {"3, v1, v2, v3"}, expect = Expect.ACCEPTABLE, desc = "Pair, then single")
+	@Outcome(id = {"3, v3, v1, v2"}, expect = Expect.ACCEPTABLE, desc = "Single, then pair")
+	@State
+	public static class BiPredicateAndOfferStressTest {
+
+		final MpscLinkedQueue<String> queue = new MpscLinkedQueue<>();
+
+		@Actor
+		public void offerPair() {
+			queue.test("v1", "v2");
+		}
+
+		@Actor
+		public void offerSingle() {
+			queue.offer("v3");
+		}
+
+		@Arbiter
+		public void arbiter(LLLL_Result r) {
+			r.r1 = queue.size();
+			r.r2 = queue.poll();
+			r.r3 = queue.poll();
+			r.r4 = queue.poll();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"4, a1, a2, b1, b2"}, expect = Expect.ACCEPTABLE, desc = "Pair A, then pair B")
+	@Outcome(id = {"4, b1, b2, a1, a2"}, expect = Expect.ACCEPTABLE, desc = "Pair B, then pair A")
+	@State
+	public static class BiPredicateTwoActorsStressTest {
+
+		final MpscLinkedQueue<String> queue = new MpscLinkedQueue<>();
+
+		@Actor
+		public void offerPairA() {
+			queue.test("a1", "a2");
+		}
+
+		@Actor
+		public void offerPairB() {
+			queue.test("b1", "b2");
+		}
+
+		@Arbiter
+		public void arbiter(LLLLL_Result r) {
+			r.r1 = queue.size();
+			r.r2 = queue.poll();
+			r.r3 = queue.poll();
+			r.r4 = queue.poll();
+			r.r5 = queue.poll();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"0, v1, v2"}, expect = Expect.ACCEPTABLE, desc = "Value consumed")
+	@Outcome(id = {"2, v1, v2"}, expect = Expect.ACCEPTABLE, desc = "Value not consumed")
+	@State
+	public static class BiPredicateAndPollStressTest {
+
+		final MpscLinkedQueue<String> queue = new MpscLinkedQueue<>();
+
+		@Actor
+		public void offerPair() {
+			queue.test("v1", "v2");
+		}
+
+		@Actor
+		public void pollPair(LLL_Result r) {
+			String v = queue.poll();
+			if (null != v) {
+				r.r2 = v;
+				r.r3 = queue.poll();
+			}
+		}
+
+		@Arbiter
+		public void arbiter(LLL_Result r) {
+			int size = queue.size();
+			r.r1 = size;
+			if (size != 0) {
+				r.r2 = queue.poll();
+				r.r3 = queue.poll();
+			}
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"4, a1, a2, b1, b2"}, expect = Expect.ACCEPTABLE,
+			desc = "Consumed empty queue, pair A, then pair B present")
+	@Outcome(id = {"4, b1, b2, a1, a2"}, expect = Expect.ACCEPTABLE,
+			desc = "Consumed empty queue, pair B, then pair A present")
+	@Outcome(id = {"2, a1, a2, b1, b2"}, expect = Expect.ACCEPTABLE,
+			desc = "Consumed pair A, then pair B left")
+	@Outcome(id = {"2, b1, b2, a1, a2"}, expect = Expect.ACCEPTABLE,
+			desc = "Consumed pair B, then pair A left")
+	@State
+	public static class BiPredicateTwoProducersOneConsumerStressTest {
+
+		final MpscLinkedQueue<String> queue = new MpscLinkedQueue<>();
+
+		@Actor
+		public void offerPairA() {
+			queue.test("a1", "a2");
+		}
+
+		@Actor
+		public void offerPairB() {
+			queue.test("b1", "b2");
+		}
+
+		@Actor
+		public void pollPair(LLLLL_Result r) {
+			String item = queue.poll();
+
+			if (null != item) {
+				r.r2 = item;
+				r.r3 = queue.poll();
+			}
+		}
+
+		@Arbiter
+		public void arbiter(LLLLL_Result r) {
+			r.r1 = queue.size();
+			if (queue.size() > 2) {
+				r.r2 = queue.poll();
+				r.r3 = queue.poll();
+			}
+			r.r4 = queue.poll();
+			r.r5 = queue.poll();
+		}
+	}
+}

--- a/reactor-core/src/jcstress/java/reactor/util/concurrent/SpscArrayQueueStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/util/concurrent/SpscArrayQueueStressTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.concurrent;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.Expect;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.LLLLLL_Result;
+
+public abstract class SpscArrayQueueStressTest {
+
+	@JCStressTest
+	@Outcome(id = {"5, 1, 2, 3, 4, 5"}, expect = Expect.ACCEPTABLE, desc = "None consumed, all in order")
+	@Outcome(id = {"4, 1, 2, 3, 4, 5"}, expect = Expect.ACCEPTABLE, desc = "1 consumed, all in order")
+	@Outcome(id = {"3, 1, 2, 3, 4, 5"}, expect = Expect.ACCEPTABLE, desc = "2 consumed, all in order")
+	@Outcome(id = {"2, 1, 2, 3, 4, 5"}, expect = Expect.ACCEPTABLE, desc = "3 consumed, all in order")
+	@Outcome(id = {"1, 1, 2, 3, 4, 5"}, expect = Expect.ACCEPTABLE, desc = "4 consumed, all in order")
+	@Outcome(id = {"0, 1, 2, 3, 4, 5"}, expect = Expect.ACCEPTABLE, desc = "All consumed, all in order")
+	@State
+	public static class OfferAndPollStressTest {
+
+		final SpscArrayQueue<Integer> queue = new SpscArrayQueue<>(8);
+
+		@Actor
+		public void offer() {
+			queue.offer(1);
+			queue.offer(2);
+			queue.offer(3);
+			queue.offer(4);
+			queue.offer(5);
+		}
+
+		@Actor
+		public void poll(LLLLLL_Result r) {
+			int elementNum = 0;
+			for (int i = 0; i < 5; i++) {
+				Integer e = queue.poll();
+				if (e != null) {
+					switch (++elementNum) {
+						case 1:
+							r.r2 = e;
+							break;
+						case 2:
+							r.r3 = e;
+							break;
+						case 3:
+							r.r4 = e;
+							break;
+						case 4:
+							r.r5 = e;
+							break;
+						case 5:
+							r.r6 = e;
+							break;
+					}
+				}
+			}
+		}
+
+		@Arbiter
+		public void arbiter(LLLLLL_Result r) {
+			int size = queue.size();
+			r.r1 = size;
+
+			int elementNum = 5 - size;
+			for (int i = 0; i < size; i++) {
+				Integer e = queue.poll();
+				switch (++elementNum) {
+					case 1:
+						r.r2 = e;
+						break;
+					case 2:
+						r.r3 = e;
+						break;
+					case 3:
+						r.r4 = e;
+						break;
+					case 4:
+						r.r5 = e;
+						break;
+					case 5:
+						r.r6 = e;
+						break;
+					default:
+						break;
+				}
+			}
+		}
+	}
+
+}

--- a/reactor-core/src/jcstress/java/reactor/util/concurrent/SpscLinkedArrayQueueStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/util/concurrent/SpscLinkedArrayQueueStressTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.concurrent;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.Expect;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.LLLLLL_Result;
+import org.openjdk.jcstress.infra.results.LLL_Result;
+
+public abstract class SpscLinkedArrayQueueStressTest {
+
+	// We initialize the queue to the minimum link size which is 8 and our tests must
+	// cover adding more elements than the underlying array can initially contain to
+	// evaluate concurrency at the growth boundary.
+	private static final int LINK_SIZE = 8;
+
+	@JCStressTest
+	@Outcome(id = {"2, v1, v2"}, expect = Expect.ACCEPTABLE, desc = "Pair not consumed")
+	@Outcome(id = {"0, v1, v2"}, expect = Expect.ACCEPTABLE, desc = "Pair consumed")
+	@State
+	public static class BiPredicateAndPollStressTest {
+
+		final SpscLinkedArrayQueue<String> queue = new SpscLinkedArrayQueue<>(LINK_SIZE);
+
+		@Actor
+		public void offerPair() {
+			queue.test("v1", "v2");
+		}
+
+		@Actor
+		public void pollPair(LLL_Result r) {
+			String v = queue.poll();
+			r.r2 = v;
+			if (v != null) {
+				r.r3 = queue.poll();
+			}
+		}
+
+		@Arbiter
+		public void arbiter(LLL_Result r) {
+			int size = queue.size();
+			r.r1 = size;
+			if (size > 0) {
+				r.r2 = queue.poll();
+				r.r3 = queue.poll();
+			}
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"0, a1, a2, a3, a4, a5, a6, a7, a8, b1, b2"},
+			expect = Expect.ACCEPTABLE, desc = "5 pairs consumed")
+	@Outcome(id = {"2, a1, a2, a3, a4, a5, a6, a7, a8, b1, b2"},
+			expect = Expect.ACCEPTABLE, desc = "4 pairs consumed")
+	@Outcome(id = {"4, a1, a2, a3, a4, a5, a6, a7, a8, b1, b2"},
+			expect = Expect.ACCEPTABLE, desc = "3 pairs consumed")
+	@Outcome(id = {"6, a1, a2, a3, a4, a5, a6, a7, a8, b1, b2"},
+			expect = Expect.ACCEPTABLE, desc = "2 pairs consumed")
+	@Outcome(id = {"8, a1, a2, a3, a4, a5, a6, a7, a8, b1, b2"},
+			expect = Expect.ACCEPTABLE, desc = "1 pair consumed")
+	@Outcome(id = {"10, a1, a2, a3, a4, a5, a6, a7, a8, b1, b2"},
+			expect = Expect.ACCEPTABLE, desc = "0 pairs consumed")
+	@State
+	public static class BiPredicateAndPollAtGrowthBoundaryStressTest {
+
+		final SpscLinkedArrayQueue<String> queue = new SpscLinkedArrayQueue<>(8);
+
+		{
+			queue.test("p1", "p2");
+			queue.test("p3", "p4");
+		}
+
+		@Actor
+		public void offerPairs() {
+			queue.test("a1", "a2");
+			queue.test("a3", "a4");
+			queue.test("a5", "a6");
+			queue.test("a7", "a8");
+			queue.test("b1", "b2");
+		}
+
+		@Actor
+		public void pollPairs(LLLLLL_Result r) {
+			// Consume prefix.
+			queue.poll();
+			queue.poll();
+			queue.poll();
+			queue.poll();
+
+			String v;
+
+			v = queue.poll();
+			if (v != null) {
+				r.r2 = v + ", " + queue.poll();
+			}
+			else {
+				return;
+			}
+
+			v = queue.poll();
+			if (v != null) {
+				r.r3 = v + ", " + queue.poll();
+			}
+			else {
+				return;
+			}
+
+			v = queue.poll();
+			if (v != null) {
+				r.r4 = v + ", " + queue.poll();
+			}
+			else {
+				return;
+			}
+
+			v = queue.poll();
+			if (v != null) {
+				r.r5 = v + ", " + queue.poll();
+			}
+			else {
+				return;
+			}
+
+			v = queue.poll();
+			if (v != null) {
+				r.r6 = v + ", " + queue.poll();
+			}
+		}
+
+		@Arbiter
+		public void arbiter(LLLLLL_Result r) {
+			int size = queue.size();
+
+			r.r1 = size;
+			switch (size) {
+				case 10:
+					r.r2 = queue.poll() + ", " + queue.poll();
+					// fall through to consume the rest
+				case 8:
+					r.r3 = queue.poll() + ", " + queue.poll();
+					// fall through to consume the rest
+				case 6:
+					r.r4 = queue.poll() + ", " + queue.poll();
+					// fall through to consume the rest
+				case 4:
+					r.r5 = queue.poll() + ", " + queue.poll();
+					// fall through to consume the rest
+				case 2:
+					r.r6 = queue.poll() + ", " + queue.poll();
+			}
+		}
+	}
+}


### PR DESCRIPTION
Concurrent queues from `reactor.util.concurrent` package are now
exercised against the contractual obligations in their respective
scenarios (multiple-producer-single-consumer and
single-producer-single-consumer).