### PR TITLE
Use ben-manes.versions plugin to find potential upgrades

### DIFF
--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -1,8 +1,5 @@
 name: check-versions
 on:
-  push:
-    branches:
-      - refreshVersionCatalog
   workflow_dispatch:
   schedule:
     - cron: 0 15 * * 4
@@ -13,7 +10,9 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        targetBranch: [ "3.4.x", "main"]
+        # TODO: uncomment the below line once the gradle plugin is added to the build on each of these branches
+        # targetBranch: [ "3.4.x", "main"]
+        targetBranch: [ "refreshVersionCatalog" ]
     steps:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # tag=v2
         with:

--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -1,5 +1,8 @@
 name: check-versions
 on:
+  push:
+    branches:
+      - refreshVersionCatalog
   workflow_dispatch:
   schedule:
     - cron: 0 15 * * 4

--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -1,0 +1,25 @@
+name: check-versions
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 15 * * 4
+permissions: read-all
+jobs:
+  checkVersion:
+    name: Check dependency upgrades
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        targetBranch: [ "3.4.x", "main"]
+    steps:
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # tag=v2
+        with:
+          ref: ${{ matrix.targetBranch }}
+      - name: setup java
+        uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # renovate: tag=v2
+        with:
+          distribution: 'temurin'
+          java-version: 8
+      - name: dependency updates for ${{ matrix.targetBranch }}
+        id: dependencyUpdate
+        run: ./gradlew dependencyUpdates # this should detect GHA and add to summary

--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -1,5 +1,8 @@
 name: check-versions
 on:
+  push: # TODO remove once tested
+    branches:
+      - refreshVersionCatalog
   workflow_dispatch:
   schedule:
     - cron: 0 15 * * 4

--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,14 @@ tasks.named("dependencyUpdates").configure {
 			writer.write ':white_check_mark: All dependencies up to date'
 		}
 		println writer.toString()
+
+		//detect GitHub Actions workflow summary file and append our markdown summary to it
+		def summaryFile = "$System.env.GITHUB_STEP_SUMMARY"
+		def file = new File(summaryFile)
+		if (!updatable.isEmpty() && !summaryFile.isEmpty() && file.exists() && file.canWrite()) {
+			println "GitHub Action workflow summary detected, adding to summary"
+			file.withWriter('utf-8') { wrt -> wrt.write(writer.toString()) }
+		}
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ plugins {
 	alias(libs.plugins.nohttp)
 	alias(libs.plugins.jcstress) apply false
 	alias(libs.plugins.spotless)
+	// for discovery of new versions
+	alias(libs.plugins.versions)
 }
 
 apply plugin: "io.reactor.gradle.detect-ci"
@@ -129,6 +131,45 @@ spotless {
 			'reactor-core/src/main/java/reactor/util/annotation/NonNullApi.java',
 			'reactor-core/src/main/java/reactor/util/annotation/Nullable.java'
 		licenseHeaderFile('codequality/spotless/licenseSlashstarStyle.txt')
+	}
+}
+
+// https://github.com/ben-manes/gradle-versions-plugin
+def isNonStable = { String version ->
+	def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
+	def regex = /^[0-9,.v-]+(-r)?$/
+	return !stableKeyword && !(version ==~ regex)
+}
+tasks.named("dependencyUpdates").configure {
+	rejectVersionIf {
+		def artifact = "" + it.candidate
+		def isMicrometer = artifact.startsWith("io.micrometer")
+		def isJsr166 = artifact.startsWith("io.projectreactor:jsr166")
+		def isJsr305 = artifact.startsWith("com.google.code.findbugs:jsr305")
+
+		return isNonStable(it.candidate.version)
+			|| isMicrometer //TODO allow upgrades in the future on main ?
+			|| isJsr166
+			|| (isJsr305 && !artifact.endsWith("3.0.1"))
+	}
+
+	outputFormatter = { result ->
+		def updatable = result.outdated.dependencies
+		//go with console summary by default
+		def writer = new StringWriter()
+		if (!updatable.isEmpty()) {
+			writer.write '## Summary of available dependencies\n'
+			updatable
+				.sort { it.name }
+				.each { dependency ->
+				def newVersion = dependency.available.release ?: dependency.available.milestone
+				writer.write " - **$dependency.name** `$newVersion` (from v$dependency.version => `$dependency.group:$dependency.name:$newVersion`)\n"
+			}
+		}
+		else {
+			writer.write ':white_check_mark: All dependencies up to date'
+		}
+		println writer.toString()
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -146,11 +146,13 @@ tasks.named("dependencyUpdates").configure {
 		def isMicrometer = artifact.startsWith("io.micrometer")
 		def isJsr166 = artifact.startsWith("io.projectreactor:jsr166")
 		def isJsr305 = artifact.startsWith("com.google.code.findbugs:jsr305")
+		def isKotlin = artifact.startsWith("org.jetbrains.kotlin")
 
 		return isNonStable(it.candidate.version)
 			|| isMicrometer //TODO allow upgrades in the future on main ?
 			|| isJsr166
 			|| (isJsr305 && !artifact.endsWith("3.0.1"))
+			|| (isKotlin && !artifact.contains(":1.5."))
 	}
 
 	outputFormatter = { result ->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,3 +51,4 @@ nohttp = { id = "io.spring.nohttp", version = "0.0.10" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
 spotless = { id = "com.diffplug.spotless", version = "6.7.0" }
 testsets = { id = "org.unbroken-dome.test-sets", version = "4.0.0" }
+versions = "com.github.ben-manes.versions:0.42.0"


### PR DESCRIPTION
This PR explores using a Gradle plugin to detect new dependency versions.
The goal is to evaluate this approach compared to dependabot (which cannot currently work on libs.versions.toml) and renovate (which cannot currently work on 3.4.x without giving extensive write permissions to the app, the readonly variant can only work with the default repo branch).

The idea would be to get a recurring (eg. weekly) report of dependencies. Up to the team to perform the upgrade (in a single PR or several ones) and test it.

- Use ben-manes.versions plugin to find potential upgrades
- detect GHA and append version report to job summary

TODO:
 - [x] Add a cron GHA workflow that runs the plugin task on both `3.4.x` and `main`
 - [x] test the output of job summary