### PR TITLE
Add context-propagation-api dependency + ReactorContextAccessor

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,8 @@ asciidoctor = "3.3.2"
 bytebuddy = "1.12.10"
 jmh = "1.35"
 junit = "5.8.2"
-micrometer = "1.10.0-M1"
+#note that context-propagation-api has a different version directly set in libraries
+micrometer = "1.10.0-SNAPSHOT"
 reactiveStreams = "1.0.4"
 
 [libraries]
@@ -30,6 +31,7 @@ logback = "ch.qos.logback:logback-classic:1.2.11"
 micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometer" }
 micrometer-commons = { module = "io.micrometer:micrometer-commons" }
 micrometer-core = { module = "io.micrometer:micrometer-core" }
+micrometer-contextPropagationApi = "io.micrometer:context-propagation-api:1.0.0-SNAPSHOT"
 mockito = "org.mockito:mockito-core:4.6.1"
 reactiveStreams = { module = "org.reactivestreams:reactive-streams", version.ref = "reactiveStreams" }
 reactiveStreams-tck = { module = "org.reactivestreams:reactive-streams-tck", version.ref = "reactiveStreams" }

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -74,6 +74,9 @@ dependencies {
 	}
 	tckTestImplementation libs.testNg
 
+	// context-propagation-api
+	implementation libs.micrometer.contextPropagationApi
+
 	// JSR-305 annotations
 	compileOnly libs.jsr305
 	testCompileOnly libs.jsr305

--- a/reactor-core/src/main/java/reactor/util/context/ReactorContextAccessor.java
+++ b/reactor-core/src/main/java/reactor/util/context/ReactorContextAccessor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.context;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+import io.micrometer.context.ContextAccessor;
+
+/**
+ * {@code ContextAccessor} to enable reading values from a Reactor
+ * {@link ContextView} and writing values to {@link Context}.
+ *
+ * @author Rossen Stoyanchev
+ * @since 3.5.0
+ */
+public final class ReactorContextAccessor implements ContextAccessor<ContextView, Context> {
+
+	@Override
+	public boolean canReadFrom(Class<?> contextType) {
+		return ContextView.class.isAssignableFrom(contextType);
+	}
+
+	@Override
+	public void readValues(ContextView source, Predicate<Object> keyPredicate, Map<Object, Object> target) {
+		source.stream()
+			.filter(entry -> keyPredicate.test(entry.getKey()))
+			.forEach(entry -> target.put(entry.getKey(), entry.getValue()));
+	}
+
+	@Override
+	public boolean canWriteTo(Class<?> contextType) {
+		return Context.class.isAssignableFrom(contextType);
+	}
+
+	@Override
+	public Context writeValues(Map<Object, Object> source, Context target) {
+		return target.putAll(Context.of(source).readOnly());
+	}
+
+}

--- a/reactor-core/src/main/resources/META-INF/services/io.micrometer.context.ContextAccessor
+++ b/reactor-core/src/main/resources/META-INF/services/io.micrometer.context.ContextAccessor
@@ -1,0 +1,1 @@
+reactor.util.context.ReactorContextAccessor


### PR DESCRIPTION
This PR:

 - adds a dependency to `micrometer:context-propagation-api`
 - switches the micrometer BOM to the snapshot version (for compatibility with
   the above new dependency)
 - adds a `ReactorContextAccessor` implementation of `ContextAccessor` to be
 picked up by ServiceLoader mechanism (META-INF/services/ file also included)

Once this is merged the equivalent classes in context-propagation-api can be
removed ASAP, which would remove the cyclic dependency with Reactor that is
presently introduced.