### PR TITLE
Make context-propagation-api dependency optional + documentation

### DIFF
--- a/docs/asciidoc/advancedFeatures.adoc
+++ b/docs/asciidoc/advancedFeatures.adoc
@@ -839,7 +839,16 @@ its `ContextView`:
 
 TIP: In order to read from the `Context` without misleading users into thinking one can write to it
 while data is running through the pipeline, only the `ContextView` is exposed by the operators above.
+In case one needs to use one of the remaining APIs that still require a `Context`, one can use `Context.of(contextView)` for conversion.
 
+[[context.propagation]]
+=== Micrometer Context-Propagation Support
+Since 3.5.0, Reactor-Core embeds basic support for the `io.micrometer:context-propagation-api` SPI.
+This library is intended as a mean to easily adapt between various implementations of the concept of a Context, of which
+`ContextView`/`Context` is an example, and between `ThreadLocal` variables as well.
+
+`ReactorContextAccessor` is one implementation of this SPI that is loaded via `ServiceLoader`. No user action is required,
+other than depending on reactor-core and `context-propagation-api` (the class is public but shouldn't generally be accessed by user code).
 
 === Simple `Context` Examples
 

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -74,9 +74,6 @@ dependencies {
 	}
 	tckTestImplementation libs.testNg
 
-	// context-propagation-api
-	implementation libs.micrometer.contextPropagationApi
-
 	// JSR-305 annotations
 	compileOnly libs.jsr305
 	testCompileOnly libs.jsr305
@@ -89,6 +86,9 @@ dependencies {
 	compileOnly platform(libs.micrometer.bom)
 	compileOnly libs.micrometer.commons
 	compileOnly libs.micrometer.core
+
+	// Optional context-propagation-api
+	compileOnly libs.micrometer.contextPropagationApi
 
 	// Optional BlockHound support
 	compileOnly libs.blockhound

--- a/reactor-core/src/main/java/reactor/util/context/ReactorContextAccessor.java
+++ b/reactor-core/src/main/java/reactor/util/context/ReactorContextAccessor.java
@@ -22,8 +22,11 @@ import java.util.function.Predicate;
 import io.micrometer.context.ContextAccessor;
 
 /**
- * {@code ContextAccessor} to enable reading values from a Reactor
+ * A {@code ContextAccessor} to enable reading values from a Reactor
  * {@link ContextView} and writing values to {@link Context}.
+ * <p>
+ * Please note that this public class implements the {@code libs.micrometer.contextPropagationApi}
+ * SPI library, which is an optional dependency.
  *
  * @author Rossen Stoyanchev
  * @since 3.5.0


### PR DESCRIPTION
Polishing of #3098 :
 - make dependency optional
 - mention the optional SPI in the accessor's javadoc