### PR TITLE
Introducing Context::putAllMap

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -163,7 +163,8 @@ task japicmp(type: JapicmpTask) {
 	// TODO after a .0 release, remove the reactor-core exclusions below if any
 	classExcludes = [ ]
 	methodExcludes = [
-			'reactor.util.context.ContextView#forEach(java.util.function.BiConsumer)'
+			'reactor.util.context.ContextView#forEach(java.util.function.BiConsumer)',
+			'reactor.util.context.Context#putAllMap(java.util.Map)'
 	]
 }
 

--- a/reactor-core/src/main/java/reactor/util/context/Context.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,7 @@
 
 package reactor.util.context;
 
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 import reactor.util.annotation.Nullable;
 
@@ -281,6 +278,20 @@ public interface Context extends ContextView {
 			return Context.of((Map<?, ?>) newContext);
 		}
 		return newContext;
+	}
+
+	default Context putAllMap(Map<?, ?> from) {
+		if (from.isEmpty()) {
+			return this;
+		}
+
+		ContextN combined = new ContextN(this.size() + from.size());
+		this.forEach(combined);
+		from.forEach(combined);
+		if (combined.size() <= 5) {
+			return Context.of((Map<?, ?>) combined);
+		}
+		return combined;
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/util/context/Context.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context.java
@@ -280,6 +280,14 @@ public interface Context extends ContextView {
 		return newContext;
 	}
 
+	/**
+	 * Create a new {@link Context} by merging the content of this context and a given
+	 * {@link Map}. If the {@link Map} is empty, the same {@link Context} instance
+	 * is returned.
+	 *
+	 * @param from the {@link Map} from which to include entries in the resulting {@link Context}.
+	 * @return a new {@link Context} with a merge of the entries from this context and the given {@link Map}.
+	 */
 	default Context putAllMap(Map<?, ?> from) {
 		if (from.isEmpty()) {
 			return this;

--- a/reactor-core/src/main/java/reactor/util/context/ContextN.java
+++ b/reactor-core/src/main/java/reactor/util/context/ContextN.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -181,6 +181,17 @@ final class ContextN extends LinkedHashMap<Object, Object>
 			other.stream().sequential().forEach(newContext);
 		}
 
+		return newContext;
+	}
+
+	@Override
+	public Context putAllMap(Map<?, ?> from) {
+		if (from.isEmpty()) {
+			return this;
+		}
+
+		ContextN newContext = new ContextN(this);
+		from.forEach(newContext);
 		return newContext;
 	}
 

--- a/reactor-core/src/test/java/reactor/util/context/Context0Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context0Test.java
@@ -16,13 +16,13 @@
 
 package reactor.util.context;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.function.BiConsumer;
-
-import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -179,5 +179,35 @@ public class Context0Test {
 		assertThat(ctx)
 				.containsEntry(1, "SHOULD NOT BE REPLACED")
 				.hasSize(1);
+	}
+
+	@Test
+	void putAllMap() {
+		Map<Object, Object> map = new HashMap<>();
+		map.put("A", 1);
+		map.put("B", 2);
+		map.put("C", 3);
+		Context put = c.putAllMap(map);
+
+		assertThat(put).isInstanceOf(Context3.class)
+				.hasToString("Context3{A=1, B=2, C=3}");
+	}
+
+	@Test
+	void putAllMapEmpty() {
+		Context put = c.putAllMap(Collections.emptyMap());
+		assertThat(put).isSameAs(c);
+	}
+
+	@Test
+	void putAllMapNullKey() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> c.putAllMap(Collections.singletonMap(null, "oops")));
+	}
+
+	@Test
+	void putAllMapNullValue() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> c.putAllMap(Collections.singletonMap("A", null)));
 	}
 }

--- a/reactor-core/src/test/java/reactor/util/context/Context1Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context1Test.java
@@ -16,15 +16,11 @@
 
 package reactor.util.context;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Objects;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
-
-import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -245,4 +241,44 @@ public class Context1Test {
 				.hasSize(2);
 	}
 
+	@Test
+	void putAllMap() {
+		Map<Object, Object> map = new HashMap<>();
+		map.put("A", 1);
+		map.put("B", 2);
+		map.put("C", 3);
+		Context put = c.putAllMap(map);
+
+		assertThat(put).isInstanceOf(Context4.class)
+				.hasToString("Context4{1=A, A=1, B=2, C=3}");
+	}
+
+	@Test
+	void putAllMapEmpty() {
+		Context put = c.putAllMap(Collections.emptyMap());
+		assertThat(put).isSameAs(c);
+	}
+
+	@Test
+	void putAllMapNullKey() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> c.putAllMap(Collections.singletonMap(null, "oops")));
+	}
+
+	@Test
+	void putAllMapNullValue() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> c.putAllMap(Collections.singletonMap("A", null)));
+	}
+
+	@Test
+	void putAllMapReplaces() {
+		Map<Object, Object> map = new HashMap<>();
+		map.put(c.key, "replaced");
+		map.put("A", 1);
+		Context put = c.putAllMap(map);
+
+		assertThat(put).isInstanceOf(Context2.class)
+				.hasToString("Context2{1=replaced, A=1}");
+	}
 }

--- a/reactor-core/src/test/java/reactor/util/context/Context2Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context2Test.java
@@ -16,14 +16,14 @@
 
 package reactor.util.context;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
-
-import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -260,4 +260,44 @@ public class Context2Test {
 				.hasSize(3);
 	}
 
+	@Test
+	void putAllMap() {
+		Map<Object, Object> map = new HashMap<>();
+		map.put("A", 1);
+		map.put("B", 2);
+		map.put("C", 3);
+		Context put = c.putAllMap(map);
+
+		assertThat(put).isInstanceOf(Context5.class)
+				.hasToString("Context5{1=A, 2=B, A=1, B=2, C=3}");
+	}
+
+	@Test
+	void putAllMapEmpty() {
+		Context put = c.putAllMap(Collections.emptyMap());
+		assertThat(put).isSameAs(c);
+	}
+
+	@Test
+	void putAllMapNullKey() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> c.putAllMap(Collections.singletonMap(null, "oops")));
+	}
+
+	@Test
+	void putAllMapNullValue() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> c.putAllMap(Collections.singletonMap("A", null)));
+	}
+
+	@Test
+	void putAllMapReplaces() {
+		Map<Object, Object> map = new HashMap<>();
+		map.put(c.key1, "replaced");
+		map.put("A", 1);
+		Context put = c.putAllMap(map);
+
+		assertThat(put).isInstanceOf(Context3.class)
+				.hasToString("Context3{1=replaced, 2=B, A=1}");
+	}
 }

--- a/reactor-core/src/test/java/reactor/util/context/Context3Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context3Test.java
@@ -16,14 +16,14 @@
 
 package reactor.util.context;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
-
-import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -287,5 +287,46 @@ public class Context3Test {
 				.containsEntry(3, "REPLACED3")
 				.containsEntry("extra", "value")
 				.hasSize(4);
+	}
+
+	@Test
+	void putAllMap() {
+		Map<Object, Object> map = new HashMap<>();
+		map.put("A", 1);
+		map.put("B", 2);
+		map.put("C", 3);
+		Context put = c.putAllMap(map);
+
+		assertThat(put).isInstanceOf(ContextN.class)
+				.hasToString("ContextN{1=A, 2=B, 3=C, A=1, B=2, C=3}");
+	}
+
+	@Test
+	void putAllMapEmpty() {
+		Context put = c.putAllMap(Collections.emptyMap());
+		assertThat(put).isSameAs(c);
+	}
+
+	@Test
+	void putAllMapNullKey() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> c.putAllMap(Collections.singletonMap(null, "oops")));
+	}
+
+	@Test
+	void putAllMapNullValue() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> c.putAllMap(Collections.singletonMap("A", null)));
+	}
+
+	@Test
+	void putAllMapReplaces() {
+		Map<Object, Object> map = new HashMap<>();
+		map.put(c.key1, "replaced");
+		map.put("A", 1);
+		Context put = c.putAllMap(map);
+
+		assertThat(put).isInstanceOf(Context4.class)
+				.hasToString("Context4{1=replaced, 2=B, 3=C, A=1}");
 	}
 }

--- a/reactor-core/src/test/java/reactor/util/context/Context4Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context4Test.java
@@ -16,6 +16,8 @@
 
 package reactor.util.context;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -23,10 +25,7 @@ import java.util.NoSuchElementException;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.*;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static reactor.util.context.ContextTest.key;
 import static reactor.util.context.ContextTest.keyValue;
 
@@ -450,4 +449,44 @@ public class Context4Test {
 				.hasSize(5);
 	}
 
+	@Test
+	void putAllMap() {
+		Map<Object, Object> map = new HashMap<>();
+		map.put("A", 1);
+		map.put("B", 2);
+		map.put("C", 3);
+		Context put = c.putAllMap(map);
+
+		assertThat(put).isInstanceOf(ContextN.class)
+				.hasToString("ContextN{1=A, 2=B, 3=C, 4=D, A=1, B=2, C=3}");
+	}
+
+	@Test
+	void putAllMapEmpty() {
+		Context put = c.putAllMap(Collections.emptyMap());
+		assertThat(put).isSameAs(c);
+	}
+
+	@Test
+	void putAllMapNullKey() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> c.putAllMap(Collections.singletonMap(null, "oops")));
+	}
+
+	@Test
+	void putAllMapNullValue() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> c.putAllMap(Collections.singletonMap("A", null)));
+	}
+
+	@Test
+	void putAllMapReplaces() {
+		Map<Object, Object> map = new HashMap<>();
+		map.put(c.key1, "replaced");
+		map.put("A", 1);
+		Context put = c.putAllMap(map);
+
+		assertThat(put).isInstanceOf(Context5.class)
+				.hasToString("Context5{1=replaced, 2=B, 3=C, 4=D, A=1}");
+	}
 }

--- a/reactor-core/src/test/java/reactor/util/context/Context5Test.java
+++ b/reactor-core/src/test/java/reactor/util/context/Context5Test.java
@@ -16,15 +16,11 @@
 
 package reactor.util.context;
 
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.NoSuchElementException;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
-
-import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -351,5 +347,46 @@ public class Context5Test {
 				.containsEntry(5, "REPLACED5")
 				.containsEntry("extra", "value")
 				.hasSize(6);
+	}
+
+	@Test
+	void putAllMap() {
+		Map<Object, Object> map = new HashMap<>();
+		map.put("A", 1);
+		map.put("B", 2);
+		map.put("C", 3);
+		Context put = c.putAllMap(map);
+
+		assertThat(put).isInstanceOf(ContextN.class)
+				.hasToString("ContextN{1=A, 2=B, 3=C, 4=D, 5=E, A=1, B=2, C=3}");
+	}
+
+	@Test
+	void putAllMapEmpty() {
+		Context put = c.putAllMap(Collections.emptyMap());
+		assertThat(put).isSameAs(c);
+	}
+
+	@Test
+	void putAllMapNullKey() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> c.putAllMap(Collections.singletonMap(null, "oops")));
+	}
+
+	@Test
+	void putAllMapNullValue() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> c.putAllMap(Collections.singletonMap("A", null)));
+	}
+
+	@Test
+	void putAllMapReplaces() {
+		Map<Object, Object> map = new HashMap<>();
+		map.put(c.key1, "replaced");
+		map.put("A", 1);
+		Context put = c.putAllMap(map);
+
+		assertThat(put).isInstanceOf(ContextN.class)
+				.hasToString("ContextN{1=replaced, 2=B, 3=C, 4=D, 5=E, A=1}");
 	}
 }

--- a/reactor-core/src/test/java/reactor/util/context/ContextNTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextNTest.java
@@ -16,16 +16,12 @@
 
 package reactor.util.context;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.function.BiConsumer;
-import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.*;
 import static reactor.util.context.ContextTest.*;
@@ -459,4 +455,44 @@ public class ContextNTest {
 		assertThat(contextN).containsEntry("A", -1);
 	}
 
+	@Test
+	void putAllMap() {
+		Map<Object, Object> map = new HashMap<>();
+		map.put("A", 1);
+		map.put("B", 2);
+		map.put("C", 3);
+		Context put = c.putAllMap(map);
+
+		assertThat(put).isInstanceOf(ContextN.class)
+				.hasToString("ContextN{1=A, 2=B, 3=C, 4=D, 5=E, 6=F, A=1, B=2, C=3}");
+	}
+
+	@Test
+	void putAllMapEmpty() {
+		Context put = c.putAllMap(Collections.emptyMap());
+		assertThat(put).isSameAs(c);
+	}
+
+	@Test
+	void putAllMapNullKey() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> c.putAllMap(Collections.singletonMap(null, "oops")));
+	}
+
+	@Test
+	void putAllMapNullValue() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> c.putAllMap(Collections.singletonMap("A", null)));
+	}
+
+	@Test
+	void putAllMapReplaces() {
+		Map<Object, Object> map = new HashMap<>();
+		map.put(1, "replaced");
+		map.put("A", 1);
+		Context put = c.putAllMap(map);
+
+		assertThat(put).isInstanceOf(ContextN.class)
+				.hasToString("ContextN{1=replaced, 2=B, 3=C, 4=D, 5=E, 6=F, A=1}");
+	}
 }

--- a/reactor-core/src/test/java/reactor/util/context/ContextTest.java
+++ b/reactor-core/src/test/java/reactor/util/context/ContextTest.java
@@ -16,16 +16,13 @@
 
 package reactor.util.context;
 
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.NoSuchElementException;
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import org.assertj.core.api.Condition;
-import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -432,6 +429,42 @@ class ContextTest {
 	}
 
 	@Test
+	void defaultPutAllMap() {
+		Map<Object, Object> leftMap = new HashMap<>();
+		leftMap.put(1, "A");
+		leftMap.put(10, "A10");
+		leftMap.put(11, "A11");
+		leftMap.put(12, "A12");
+		leftMap.put(13, "A13");
+		Map<Object, Object> rightMap = new HashMap<>();
+		rightMap.put(2, "B");
+		rightMap.put(3, "C");
+		rightMap.put(4, "D");
+		rightMap.put(5, "E");
+
+		ForeignContext left = new ForeignContext(leftMap);
+		Context combined = left.putAllMap(rightMap);
+		assertThat(left.stream()
+				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
+				.containsExactlyInAnyOrderEntriesOf(leftMap);
+
+		assertThat(combined).isNotSameAs(left);
+		Map<Object, Object> combinedMap = combined.stream()
+				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+		assertThat(combinedMap)
+				.containsEntry(1, "A")
+				.containsEntry(2, "B")
+				.containsEntry(3, "C")
+				.containsEntry(4, "D")
+				.containsEntry(5, "E")
+				.containsEntry(10, "A10")
+				.containsEntry(11, "A11")
+				.containsEntry(12, "A12")
+				.containsEntry(13, "A13");
+	}
+
+	@Test
 	void defaultPutAllOtherIsAbstractContext() {
 		Map<Object, Object> leftMap = new HashMap<>();
 		leftMap.put(1, "A");
@@ -512,6 +545,22 @@ class ContextTest {
 	}
 
 	@Test
+	void defaultPutAllMapForeignSmallSize() {
+		Context initial = new ForeignContext(1, "A");
+		Map<?, ?> other = Collections.singletonMap(2, "B");
+
+		Context result = initial.putAllMap(other);
+
+		assertThat(result).isInstanceOf(Context2.class);
+		Context2 context2 = (Context2) result;
+
+		assertThat(context2.key1).as("key1").isEqualTo(1);
+		assertThat(context2.value1).as("value1").isEqualTo("A");
+		assertThat(context2.key2).as("key2").isEqualTo(2);
+		assertThat(context2.value2).as("value2").isEqualTo("B");
+	}
+
+	@Test
 	void putAllForeignMiddleSize() {
 		ForeignContext initial = new ForeignContext(1, "value1")
 				.directPut(2, "value2")
@@ -528,6 +577,30 @@ class ContextTest {
 		assertThat(resultN)
 				.containsKeys(1, 2, 3, 4, 5)
 				.containsValues("replaced", "value2", "value3", "value4", "value5");
+	}
+
+	@Test
+	void putAllMapForeignMediumSize() {
+		ForeignContext initial = new ForeignContext(1, "value1")
+				.directPut(2, "value2")
+				.directPut(3, "value3")
+				.directPut(4, "value4");
+		Map<Object, Object> other = new HashMap<>();
+		other.put(1, "replaced");
+		other.put(5, "value5");
+		other.put(6, "value6");
+
+		Context result = initial.putAllMap(other);
+
+		assertThat(result).isInstanceOf(ContextN.class);
+		ContextN contextN = (ContextN) result;
+
+		assertThat(contextN).containsEntry(1, "replaced");
+		assertThat(contextN).containsEntry(2, "value2");
+		assertThat(contextN).containsEntry(3, "value3");
+		assertThat(contextN).containsEntry(4, "value4");
+		assertThat(contextN).containsEntry(5, "value5");
+		assertThat(contextN).containsEntry(6, "value6");
 	}
 
 	@Test


### PR DESCRIPTION
New method for easier write capability to `Context` when the user
is interacting with a generic `Map` instead of a `Context` and wants
all values to be added without creating an additional `ContextView` holder.

Resolves #3080