### PR TITLE
Clarify ContextN.putAll(Map) intended internal use in javadoc

### DIFF
--- a/reactor-core/src/main/java/reactor/util/context/ContextN.java
+++ b/reactor-core/src/main/java/reactor/util/context/ContextN.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The Javadoc clarifies expectations for internal usage of package private
`ContextN.putAll(Map)` method that is inheritted from `Map` interface
in terms of `null` keys and values.