### PR TITLE
Micrometer module: add observation(), deprecate global registry

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ micrometer-commons = { module = "io.micrometer:micrometer-commons" }
 micrometer-core = { module = "io.micrometer:micrometer-core" }
 micrometer-contextPropagationApi = "io.micrometer:context-propagation-api:1.0.0-SNAPSHOT"
 micrometer-observation-test = { module = "io.micrometer:micrometer-observation-test" }
+micrometer-tracing-test = "io.micrometer:micrometer-tracing-integration-test:1.0.0-SNAPSHOT"
 micrometer-test = { module = "io.micrometer:micrometer-test" }
 mockito = "org.mockito:mockito-core:4.6.1"
 reactiveStreams = { module = "org.reactivestreams:reactive-streams", version.ref = "reactiveStreams" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,8 @@ micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micro
 micrometer-commons = { module = "io.micrometer:micrometer-commons" }
 micrometer-core = { module = "io.micrometer:micrometer-core" }
 micrometer-contextPropagationApi = "io.micrometer:context-propagation-api:1.0.0-SNAPSHOT"
+micrometer-observation-test = { module = "io.micrometer:micrometer-observation-test" }
+micrometer-test = { module = "io.micrometer:micrometer-test" }
 mockito = "org.mockito:mockito-core:4.6.1"
 reactiveStreams = { module = "org.reactivestreams:reactive-streams", version.ref = "reactiveStreams" }
 reactiveStreams-tck = { module = "org.reactivestreams:reactive-streams-tck", version.ref = "reactiveStreams" }

--- a/reactor-core-micrometer/build.gradle
+++ b/reactor-core-micrometer/build.gradle
@@ -58,6 +58,7 @@ dependencies {
 	testImplementation libs.micrometer.core
 	testImplementation libs.micrometer.test
 	testImplementation libs.micrometer.observation.test
+	testImplementation libs.micrometer.tracing.test
 
 	testImplementation(project(":reactor-test")) {
 		exclude module: 'reactor-core'

--- a/reactor-core-micrometer/build.gradle
+++ b/reactor-core-micrometer/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 
 	implementation platform(libs.micrometer.bom)
 	api libs.micrometer.core
+	implementation libs.micrometer.contextPropagationApi
 
 	testImplementation platform(libs.junit.bom)
 	testImplementation "org.junit.jupiter:junit-jupiter-api"
@@ -55,6 +56,8 @@ dependencies {
 
 	testImplementation platform(libs.micrometer.bom)
 	testImplementation libs.micrometer.core
+	testImplementation libs.micrometer.test
+	testImplementation libs.micrometer.observation.test
 
 	testImplementation(project(":reactor-test")) {
 		exclude module: 'reactor-core'

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/Micrometer.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/Micrometer.java
@@ -44,25 +44,32 @@ public final class Micrometer {
 	public static final String DEFAULT_METER_PREFIX = "reactor";
 
 	/**
-	 * Set the registry to use in reactor for metrics related purposes.
+	 * Set the registry to use in reactor-core-micrometer for metrics related purposes.
 	 * @return the previously configured registry.
+	 * @deprecated in M4, will be removed in M5 / RC1. prefer your own singleton and explicitly
+	 * passing the registry to {@link #metrics(MeterRegistry, Clock)}
 	 */
-	public static MeterRegistry useMeterRegistry(MeterRegistry newRegistry) {
+	@Deprecated
+	public static MeterRegistry useRegistry(MeterRegistry newRegistry) {
 		MeterRegistry previous = registry;
 		registry = newRegistry;
 		return previous;
 	}
 
 	/**
-	 * Get the registry used in reactor for metrics related purposes.
+	 * Get the registry used in reactor-core-micrometer for metrics related purposes.
+	 *
+	 * @deprecated in M4, will be removed in M5 / RC1. prefer your own singleton and explicitly
+	 * passing the registry to {@link #metrics(MeterRegistry, Clock)}
 	 */
-	public static MeterRegistry getMeterRegistry() {
+	@Deprecated
+	public static MeterRegistry getRegistry() {
 		return registry;
 	}
 
 	/**
 	 * A {@link SignalListener} factory that will ultimately produce Micrometer metrics
-	 * to the configured default {@link #getMeterRegistry() registry}.
+	 * to the configured default {@link #getRegistry() registry}.
 	 * To be used with either the {@link reactor.core.publisher.Flux#tap(SignalListenerFactory)} or
 	 * {@link reactor.core.publisher.Mono#tap(SignalListenerFactory)} operator.
 	 * <p>
@@ -147,7 +154,7 @@ public final class Micrometer {
 	 * Set-up a decorator that will instrument any {@link ExecutorService} that backs a reactor-core {@link Scheduler}
 	 * (or scheduler implementations which use {@link Schedulers#decorateExecutorService(Scheduler, ScheduledExecutorService)}).
 	 * <p>
-	 * The {@link MeterRegistry} to use can be configured via {@link #useMeterRegistry(MeterRegistry)}
+	 * The {@link MeterRegistry} to use can be configured via {@link #useRegistry(MeterRegistry)}
 	 * prior to using this method, the default being {@link io.micrometer.core.instrument.Metrics#globalRegistry}.
 	 *
 	 * @implNote Note that this is added as a decorator via Schedulers when enabling metrics for schedulers,
@@ -155,7 +162,7 @@ public final class Micrometer {
 	 */
 	public static void enableSchedulersMetricsDecorator() {
 		Schedulers.addExecutorServiceDecorator(SCHEDULERS_DECORATOR_KEY,
-			new MicrometerSchedulerMetricsDecorator(getMeterRegistry()));
+			new MicrometerSchedulerMetricsDecorator(getRegistry()));
 	}
 
 	/**

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/Micrometer.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/Micrometer.java
@@ -43,7 +43,7 @@ public final class Micrometer {
 	 * Set the registry to use in reactor for metrics related purposes.
 	 * @return the previously configured registry.
 	 */
-	public static MeterRegistry useRegistry(MeterRegistry newRegistry) {
+	public static MeterRegistry useMeterRegistry(MeterRegistry newRegistry) {
 		MeterRegistry previous = registry;
 		registry = newRegistry;
 		return previous;
@@ -52,13 +52,13 @@ public final class Micrometer {
 	/**
 	 * Get the registry used in reactor for metrics related purposes.
 	 */
-	public static MeterRegistry getRegistry() {
+	public static MeterRegistry getMeterRegistry() {
 		return registry;
 	}
 
 	/**
 	 * A {@link SignalListener} factory that will ultimately produce Micrometer metrics
-	 * to the configured default {@link #getRegistry() registry}.
+	 * to the configured default {@link #getMeterRegistry() registry}.
 	 * To be used with either the {@link reactor.core.publisher.Flux#tap(SignalListenerFactory)} or
 	 * {@link reactor.core.publisher.Mono#tap(SignalListenerFactory)} operator.
 	 * <p>
@@ -74,7 +74,7 @@ public final class Micrometer {
 	 * @return a {@link SignalListenerFactory} to record metrics
 	 */
 	public static <T> SignalListenerFactory<T, ?> metrics() {
-		return new MicrometerListenerFactory<>();
+		return new MicrometerMeterListenerFactory<>();
 	}
 
 	/**
@@ -95,7 +95,7 @@ public final class Micrometer {
 	 * @return a {@link SignalListenerFactory} to record metrics
 	 */
 	public static <T> SignalListenerFactory<T, ?> metrics(MeterRegistry registry, Clock clock) {
-		return new MicrometerListenerFactory<T>() {
+		return new MicrometerMeterListenerFactory<T>() {
 			@Override
 			protected Clock useClock() {
 				return clock;
@@ -112,7 +112,7 @@ public final class Micrometer {
 	 * Set-up a decorator that will instrument any {@link ExecutorService} that backs a reactor-core {@link Scheduler}
 	 * (or scheduler implementations which use {@link Schedulers#decorateExecutorService(Scheduler, ScheduledExecutorService)}).
 	 * <p>
-	 * The {@link MeterRegistry} to use can be configured via {@link #useRegistry(MeterRegistry)}
+	 * The {@link MeterRegistry} to use can be configured via {@link #useMeterRegistry(MeterRegistry)}
 	 * prior to using this method, the default being {@link io.micrometer.core.instrument.Metrics#globalRegistry}.
 	 *
 	 * @implNote Note that this is added as a decorator via Schedulers when enabling metrics for schedulers,
@@ -120,7 +120,7 @@ public final class Micrometer {
 	 */
 	public static void enableSchedulersMetricsDecorator() {
 		Schedulers.addExecutorServiceDecorator(SCHEDULERS_DECORATOR_KEY,
-			new MicrometerSchedulerMetricsDecorator(getRegistry()));
+			new MicrometerSchedulerMetricsDecorator(getMeterRegistry()));
 	}
 
 	/**

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/Micrometer.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/Micrometer.java
@@ -83,7 +83,9 @@ public final class Micrometer {
 	 *
 	 * @param <T> the type of onNext in the target publisher
 	 * @return a {@link SignalListenerFactory} to record metrics
+	 * @deprecated in M4, will be removed in M5 / RC1. prefer explicitly passing a registry via {@link #metrics(MeterRegistry, Clock)}
 	 */
+	@Deprecated
 	public static <T> SignalListenerFactory<T, ?> metrics() {
 		return new MicrometerMeterListenerFactory<>();
 	}

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/Micrometer.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/Micrometer.java
@@ -25,13 +25,12 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.observation.Observation;
-import io.micrometer.observation.Observation.Scope;
 import io.micrometer.observation.ObservationRegistry;
 
 import reactor.core.observability.SignalListener;
+import reactor.core.observability.SignalListenerFactory;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
-import reactor.core.observability.SignalListenerFactory;
 
 public final class Micrometer {
 

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListener.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListener.java
@@ -35,11 +35,11 @@ import reactor.core.observability.SignalListener;
  *
  * @author Simon Baslé
  */
-final class MicrometerListener<T> implements SignalListener<T> {
+final class MicrometerMeterListener<T> implements SignalListener<T> {
 
-	final MicrometerListenerConfiguration configuration;
+	final MicrometerMeterListenerConfiguration configuration;
 	@Nullable
-	final DistributionSummary             requestedCounter;
+	final DistributionSummary                  requestedCounter;
 	@Nullable
 	final Timer                           onNextIntervalTimer;
 
@@ -47,7 +47,7 @@ final class MicrometerListener<T> implements SignalListener<T> {
 	long         lastNextEventNanos = -1L;
 	boolean      valued;
 
-	MicrometerListener(MicrometerListenerConfiguration configuration) {
+	MicrometerMeterListener(MicrometerMeterListenerConfiguration configuration) {
 		this.configuration = configuration;
 
 		this.valued = false;

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListener.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListener.java
@@ -215,10 +215,16 @@ final class MicrometerMeterListener<T> implements SignalListener<T> {
 	static final Tags   DEFAULT_TAGS_MONO = Tags.of("type", "Mono");
 
 	// === Operator ===
-	static final Tag  TAG_ON_ERROR    = Tag.of("status", "error");
-	static final Tags TAG_ON_COMPLETE = Tags.of("status", "completed", TAG_KEY_EXCEPTION, "");
-	static final Tags TAG_ON_COMPLETE_EMPTY = Tags.of("status", "completedEmpty", TAG_KEY_EXCEPTION, "");
-	static final Tags TAG_CANCEL            = Tags.of("status", "cancelled", TAG_KEY_EXCEPTION, "");
+	static final String TAG_KEY_STATUS = "status";
+	static final String TAG_STATUS_CANCELLED = "cancelled";
+	static final String TAG_STATUS_COMPLETED = "completed";
+	static final String TAG_STATUS_COMPLETED_EMPTY = "completedEmpty";
+	static final String TAG_STATUS_ERROR = "error";
+
+	static final Tag  TAG_ON_ERROR    = Tag.of(TAG_KEY_STATUS, TAG_STATUS_ERROR);
+	static final Tags TAG_ON_COMPLETE = Tags.of(TAG_KEY_STATUS, TAG_STATUS_COMPLETED, TAG_KEY_EXCEPTION, "");
+	static final Tags TAG_ON_COMPLETE_EMPTY = Tags.of(TAG_KEY_STATUS, TAG_STATUS_COMPLETED_EMPTY, TAG_KEY_EXCEPTION, "");
+	static final Tags TAG_CANCEL            = Tags.of(TAG_KEY_STATUS, TAG_STATUS_CANCELLED, TAG_KEY_EXCEPTION, "");
 
 	/*
 	 * This method calls the registry, which can be costly. However the cancel signal is only expected

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListener.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListener.java
@@ -25,10 +25,10 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 
+import reactor.core.observability.SignalListener;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.SignalType;
 import reactor.util.annotation.Nullable;
-import reactor.core.observability.SignalListener;
 
 /**
  * A {@link SignalListener} that activates metrics gathering using Micrometer 1.x.

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListenerConfiguration.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListenerConfiguration.java
@@ -16,10 +16,7 @@
 
 package reactor.core.observability.micrometer;
 
-import java.util.LinkedList;
 import java.util.List;
-import java.util.function.BiFunction;
-import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
 
 import io.micrometer.core.instrument.Clock;
@@ -33,32 +30,31 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.Logger;
 import reactor.util.Loggers;
-import reactor.util.function.Tuple2;
 
 /**
- * A companion configuration object for {@link MicrometerListener} that serves as the state created by
- * {@link MicrometerListenerFactory}.
+ * A companion configuration object for {@link MicrometerMeterListener} that serves as the state created by
+ * {@link MicrometerMeterListenerFactory}.
  *
  * @author Simon Baslé
  */
-final class MicrometerListenerConfiguration {
+final class MicrometerMeterListenerConfiguration {
 
-	private static final Logger LOGGER = Loggers.getLogger(MicrometerListenerConfiguration.class);
+	private static final Logger LOGGER = Loggers.getLogger(MicrometerMeterListenerConfiguration.class);
 
-	static MicrometerListenerConfiguration fromFlux(Flux<?> source, MeterRegistry meterRegistry, Clock clock) {
-		Tags defaultTags = MicrometerListener.DEFAULT_TAGS_FLUX;
+	static MicrometerMeterListenerConfiguration fromFlux(Flux<?> source, MeterRegistry meterRegistry, Clock clock) {
+		Tags defaultTags = MicrometerMeterListener.DEFAULT_TAGS_FLUX;
 		final String name = resolveName(source, LOGGER);
 		final Tags tags = resolveTags(source, defaultTags);
 
-		return new MicrometerListenerConfiguration(name, tags, meterRegistry, clock, false);
+		return new MicrometerMeterListenerConfiguration(name, tags, meterRegistry, clock, false);
 	}
 
-	static MicrometerListenerConfiguration fromMono(Mono<?> source, MeterRegistry meterRegistry, Clock clock) {
-		Tags defaultTags = MicrometerListener.DEFAULT_TAGS_MONO;
+	static MicrometerMeterListenerConfiguration fromMono(Mono<?> source, MeterRegistry meterRegistry, Clock clock) {
+		Tags defaultTags = MicrometerMeterListener.DEFAULT_TAGS_MONO;
 		final String name = resolveName(source, LOGGER);
 		final Tags tags = resolveTags(source, defaultTags);
 
-		return new MicrometerListenerConfiguration(name, tags, meterRegistry, clock, true);
+		return new MicrometerMeterListenerConfiguration(name, tags, meterRegistry, clock, true);
 	}
 
 	/**
@@ -116,8 +112,8 @@ final class MicrometerListenerConfiguration {
 	// separator is the dot, not camelCase...
 	final MeterRegistry registry;
 
-	MicrometerListenerConfiguration(String sequenceName, Tags tags, MeterRegistry registryCandidate, Clock clock,
-									boolean isMono) {
+	MicrometerMeterListenerConfiguration(String sequenceName, Tags tags, MeterRegistry registryCandidate, Clock clock,
+										 boolean isMono) {
 		this.clock = clock;
 		this.commonTags = tags;
 		this.isMono = isMono;

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListenerFactory.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListenerFactory.java
@@ -20,11 +20,11 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.reactivestreams.Publisher;
 
+import reactor.core.observability.SignalListener;
+import reactor.core.observability.SignalListenerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.context.ContextView;
-import reactor.core.observability.SignalListener;
-import reactor.core.observability.SignalListenerFactory;
 
 /**
  * A {@link SignalListenerFactory} for {@link MicrometerMeterListener}.

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListenerFactory.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListenerFactory.java
@@ -27,36 +27,36 @@ import reactor.core.observability.SignalListener;
 import reactor.core.observability.SignalListenerFactory;
 
 /**
- * A {@link SignalListenerFactory} for {@link MicrometerListener}.
+ * A {@link SignalListenerFactory} for {@link MicrometerMeterListener}.
  *
  * @author Simon Baslé
  */
-class MicrometerListenerFactory<T> implements SignalListenerFactory<T, MicrometerListenerConfiguration> {
+class MicrometerMeterListenerFactory<T> implements SignalListenerFactory<T, MicrometerMeterListenerConfiguration> {
 
 	protected Clock useClock() {
 		return Clock.SYSTEM;
 	}
 
 	protected MeterRegistry useRegistry() {
-		return Micrometer.getRegistry();
+		return Micrometer.getMeterRegistry();
 	}
 
 	@Override
-	public MicrometerListenerConfiguration initializePublisherState(Publisher<? extends T> source) {
+	public MicrometerMeterListenerConfiguration initializePublisherState(Publisher<? extends T> source) {
 		if (source instanceof Mono) {
-			return MicrometerListenerConfiguration.fromMono((Mono<?>) source, useRegistry(), useClock());
+			return MicrometerMeterListenerConfiguration.fromMono((Mono<?>) source, useRegistry(), useClock());
 		}
 		else if (source instanceof Flux) {
-			return MicrometerListenerConfiguration.fromFlux((Flux<?>) source, useRegistry(), useClock());
+			return MicrometerMeterListenerConfiguration.fromFlux((Flux<?>) source, useRegistry(), useClock());
 		}
 		else {
-			throw new IllegalArgumentException("MicrometerListenerFactory must only be used via the tap operator / with a Flux or Mono");
+			throw new IllegalArgumentException("MicrometerMeterListenerFactory must only be used via the tap operator / with a Flux or Mono");
 		}
 	}
 
 	@Override
 	public SignalListener<T> createListener(Publisher<? extends T> source, ContextView listenerContext,
-											MicrometerListenerConfiguration publisherContext) {
-		return new MicrometerListener<>(publisherContext);
+											MicrometerMeterListenerConfiguration publisherContext) {
+		return new MicrometerMeterListener<>(publisherContext);
 	}
 }

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListenerFactory.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListenerFactory.java
@@ -38,7 +38,7 @@ class MicrometerMeterListenerFactory<T> implements SignalListenerFactory<T, Micr
 	}
 
 	protected MeterRegistry useRegistry() {
-		return Micrometer.getMeterRegistry();
+		return Micrometer.getRegistry();
 	}
 
 	@Override

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerObservationListener.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerObservationListener.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.observability.micrometer;
+
+import io.micrometer.observation.Observation;
+
+import reactor.core.observability.SignalListener;
+import reactor.core.publisher.SignalType;
+import reactor.util.annotation.Nullable;
+
+/**
+ * A {@link SignalListener} that makes timings using the {@link io.micrometer.observation.Observation} API from Micrometer 1.10.
+ * <p>
+ * This is a transposition of {@link MicrometerMeterListener}, but only retains the timers.
+ *
+ * @author Simon Baslé
+ */
+final class MicrometerObservationListener<T> implements SignalListener<T> {
+
+	static final String OBSERVATION_FLOW = ".observation.flow";
+	static final String OBSERVATION_VALUES = ".observation.values";
+
+
+	final MicrometerObservationListenerConfiguration configuration;
+	@Nullable
+	final Observation                                signalIntervalObservation;
+	final Observation                                subscribeToTerminalObservation;
+
+	/**
+	 * Scope is first opened in onSubscribe.
+	 * It is then closed and opened in each onNext.
+	 * Finally, last Scope is closed in either of the terminal states (cancelled, completed, error).
+	 */
+	@Nullable
+	Observation.Scope onNextScope;
+
+	boolean valued;
+
+	MicrometerObservationListener(MicrometerObservationListenerConfiguration configuration) {
+		this.configuration = configuration;
+
+		this.valued = false;
+		if (configuration.isMono) {
+			//for Mono we don't record signalInterval (since there is at most 1 onNext, it's the same as subscribeToTerminalObservation).
+			//Note that we still need a mean to distinguish between empty Mono and valued Mono for recordOnCompleteEmpty
+			signalIntervalObservation = null;
+			onNextScope = Observation.Scope.NOOP;
+		}
+		else {
+			this.signalIntervalObservation = Observation.createNotStarted(
+				configuration.sequenceName + OBSERVATION_VALUES,
+				configuration.registry
+			).lowCardinalityKeyValues(configuration.commonKeyValues);
+		}
+
+		subscribeToTerminalObservation = Observation.createNotStarted(
+			configuration.sequenceName + OBSERVATION_FLOW,
+			configuration.registry
+		).lowCardinalityKeyValues(configuration.commonKeyValues);
+	}
+
+	@Override
+	public void doOnCancel() {
+		//Due to dealing with scopes, we have to stop the current scope.
+		//Note this could skew the onNext counter off by one if the Observation is a facade over metrics.
+		if (this.onNextScope != null) {
+			this.onNextScope.close();
+		}
+
+		Observation observation = subscribeToTerminalObservation
+			.lowCardinalityKeyValue(MicrometerMeterListener.TAG_KEY_STATUS, MicrometerMeterListener.TAG_STATUS_CANCELLED)
+			.highCardinalityKeyValue(MicrometerMeterListener.TAG_KEY_EXCEPTION, "");
+
+		observation.stop();
+	}
+
+	@Override
+	public void doOnComplete() {
+		//Due to dealing with scopes, we have to stop the current scope.
+		//Note this could skew the onNext counter off by one if the Observation is a facade over metrics.
+		if (this.onNextScope != null) {
+			this.onNextScope.close();
+		}
+
+		// We differentiate between empty completion and value completion via tags.
+		String status = null;
+		if (!valued) {
+			status = MicrometerMeterListener.TAG_STATUS_COMPLETED_EMPTY;
+		}
+		else if (!configuration.isMono) {
+			status = MicrometerMeterListener.TAG_STATUS_COMPLETED;
+		}
+
+		// if status == null, recording with OnComplete tag is done directly in onNext for the Mono(valued) case
+		if (status != null) {
+			Observation completeObservation = subscribeToTerminalObservation
+				.lowCardinalityKeyValue(MicrometerMeterListener.TAG_KEY_STATUS, status)
+				.highCardinalityKeyValue(MicrometerMeterListener.TAG_KEY_EXCEPTION, "");
+
+			completeObservation.stop();
+		}
+	}
+
+	@Override
+	public void doOnError(Throwable e) {
+		//Due to dealing with scopes, we have to stop the current scope.
+		//Note this could skew the onNext counter off by one if the Observation is a facade over metrics.
+		if (this.onNextScope != null) {
+			this.onNextScope.close();
+		}
+
+		Observation errorObservation = subscribeToTerminalObservation
+			.lowCardinalityKeyValue(MicrometerMeterListener.TAG_KEY_STATUS, MicrometerMeterListener.TAG_STATUS_ERROR)
+			.highCardinalityKeyValue(MicrometerMeterListener.TAG_KEY_EXCEPTION, e.getClass().getName());
+
+		errorObservation.stop();
+	}
+
+	@Override
+	public void doOnNext(T t) {
+		valued = true;
+		if (signalIntervalObservation == null || onNextScope == null) { //NB: interval observation is only null if isMono
+			//record valued completion directly
+			Observation completeObservation = subscribeToTerminalObservation
+				.lowCardinalityKeyValue(MicrometerMeterListener.TAG_KEY_STATUS, MicrometerMeterListener.TAG_STATUS_COMPLETED)
+				.highCardinalityKeyValue(MicrometerMeterListener.TAG_KEY_EXCEPTION, "");
+
+			completeObservation.stop();
+			return;
+		}
+		//record the delay since previous onNext/onSubscribe. This also records the count.
+		this.onNextScope.close();
+		this.onNextScope = this.signalIntervalObservation.openScope();
+	}
+
+	@Override
+	public void doOnSubscription() {
+		this.subscribeToTerminalObservation.start();
+		if (this.signalIntervalObservation != null) {
+			this.onNextScope = this.signalIntervalObservation.openScope();
+		}
+	}
+
+	//unused hooks
+
+	@Override
+	public void doOnMalformedOnComplete() {
+		//NO-OP
+	}
+
+	@Override
+	public void doOnMalformedOnError(Throwable e) {
+		// NO-OP
+	}
+
+	@Override
+	public void doOnMalformedOnNext(T value) {
+		// NO-OP
+	}
+
+	@Override
+	public void doOnRequest(long l) {
+		// NO-OP
+	}
+
+	@Override
+	public void doFirst() {
+		// NO-OP
+	}
+
+	@Override
+	public void doOnFusion(int negotiatedFusion) {
+		// NO-OP
+	}
+
+	@Override
+	public void doFinally(SignalType terminationType) {
+		// NO-OP
+	}
+
+	@Override
+	public void doAfterComplete() {
+		// NO-OP
+	}
+
+	@Override
+	public void doAfterError(Throwable error) {
+		// NO-OP
+	}
+
+	@Override
+	public void handleListenerError(Throwable listenerError) {
+		// NO-OP
+	}
+
+}

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerObservationListener.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerObservationListener.java
@@ -151,6 +151,7 @@ final class MicrometerObservationListener<T> implements SignalListener<T> {
 	public void doOnSubscription() {
 		this.subscribeToTerminalObservation.start();
 		if (this.signalIntervalObservation != null) {
+			this.signalIntervalObservation.start();
 			this.onNextScope = this.signalIntervalObservation.openScope();
 		}
 	}

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerObservationListenerConfiguration.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerObservationListenerConfiguration.java
@@ -21,7 +21,6 @@ import java.util.stream.Collectors;
 
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
-import io.micrometer.core.instrument.Clock;
 import io.micrometer.observation.ObservationRegistry;
 import org.reactivestreams.Publisher;
 

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerObservationListenerConfiguration.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerObservationListenerConfiguration.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.observability.micrometer;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.observation.ObservationRegistry;
+import org.reactivestreams.Publisher;
+
+import reactor.core.Scannable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+/**
+ * A companion configuration object for {@link MicrometerObservationListener} that serves as the state created by
+ * {@link MicrometerObservationListenerFactory}.
+ *
+ * @author Simon Baslé
+ */
+final class MicrometerObservationListenerConfiguration {
+
+	static final KeyValues DEFAULT_KV_FLUX = KeyValues.of("type", "Flux");
+	static final KeyValues DEFAULT_KV_MONO = KeyValues.of("type", "Mono");
+
+	private static final Logger LOGGER = Loggers.getLogger(MicrometerObservationListenerConfiguration.class);
+
+	static MicrometerObservationListenerConfiguration fromFlux(Flux<?> source, ObservationRegistry observationRegistry) {
+		KeyValues defaultKeyValues = DEFAULT_KV_FLUX;
+		final String name = MicrometerMeterListenerConfiguration.resolveName(source, LOGGER);
+		final KeyValues keyValues = resolveKeyValues(source, defaultKeyValues);
+
+		return new MicrometerObservationListenerConfiguration(name, keyValues, observationRegistry, false);
+	}
+
+	static MicrometerObservationListenerConfiguration fromMono(Mono<?> source, ObservationRegistry observationRegistry) {
+		KeyValues defaultKeyValues = DEFAULT_KV_MONO;
+		final String name = MicrometerMeterListenerConfiguration.resolveName(source, LOGGER);
+		final KeyValues keyValues = resolveKeyValues(source, defaultKeyValues);
+
+		return new MicrometerObservationListenerConfiguration(name, keyValues, observationRegistry, true);
+	}
+
+	/**
+	 * Extract the "tags" from the upstream as {@link KeyValues}.
+	 *
+	 * @param source the upstream
+	 *
+	 * @return a {@link KeyValues} collection
+	 */
+	static KeyValues resolveKeyValues(Publisher<?> source, KeyValues tags) {
+		Scannable scannable = Scannable.from(source);
+
+		if (scannable.isScanAvailable()) {
+			List<KeyValue> discoveredTags = scannable.tagsDeduplicated()
+				.entrySet().stream()
+				.map(e -> KeyValue.of(e.getKey(), e.getValue()))
+				.collect(Collectors.toList());
+			return tags.and(discoveredTags);
+		}
+
+		return tags;
+	}
+
+	final KeyValues commonKeyValues;
+	final boolean   isMono;
+	final String  sequenceName;
+
+	final ObservationRegistry registry;
+
+	MicrometerObservationListenerConfiguration(String sequenceName, KeyValues commonKeyValues,
+											   ObservationRegistry registryCandidate,
+											   boolean isMono) {
+		this.commonKeyValues = commonKeyValues;
+		this.isMono = isMono;
+		this.sequenceName = sequenceName;
+		this.registry = registryCandidate;
+	}
+}

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerObservationListenerFactory.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerObservationListenerFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.observability.micrometer;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import org.reactivestreams.Publisher;
+
+import reactor.core.observability.SignalListener;
+import reactor.core.observability.SignalListenerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.util.context.ContextView;
+
+/**
+ * A {@link SignalListenerFactory} for {@link MicrometerObservationListener}.
+ *
+ * @author Simon Baslé
+ */
+class MicrometerObservationListenerFactory<T> implements SignalListenerFactory<T, MicrometerObservationListenerConfiguration> {
+
+	final ObservationRegistry registry;
+
+	public MicrometerObservationListenerFactory(ObservationRegistry registry) {
+		this.registry = registry;
+	}
+
+	@Override
+	public MicrometerObservationListenerConfiguration initializePublisherState(Publisher<? extends T> source) {
+		if (source instanceof Mono) {
+			return MicrometerObservationListenerConfiguration.fromMono((Mono<?>) source, this.registry);
+		}
+		else if (source instanceof Flux) {
+			return MicrometerObservationListenerConfiguration.fromFlux((Flux<?>) source, this.registry);
+		}
+		else {
+			throw new IllegalArgumentException("MicrometerObservationListenerFactory must only be used via the tap operator / with a Flux or Mono");
+		}
+	}
+
+	@Override
+	public SignalListener<T> createListener(Publisher<? extends T> source, ContextView listenerContext,
+											MicrometerObservationListenerConfiguration publisherContext) {
+		return new MicrometerObservationListener<>(publisherContext);
+	}
+}

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerObservationListenerFactory.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerObservationListenerFactory.java
@@ -16,8 +16,6 @@
 
 package reactor.core.observability.micrometer;
 
-import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 import org.reactivestreams.Publisher;
 

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerObservationListenerFactory.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerObservationListenerFactory.java
@@ -56,6 +56,6 @@ class MicrometerObservationListenerFactory<T> implements SignalListenerFactory<T
 	@Override
 	public SignalListener<T> createListener(Publisher<? extends T> source, ContextView listenerContext,
 											MicrometerObservationListenerConfiguration publisherContext) {
-		return new MicrometerObservationListener<>(publisherContext);
+		return new MicrometerObservationListener<>(listenerContext, publisherContext);
 	}
 }

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerMeterListenerConfigurationTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerMeterListenerConfigurationTest.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Simon Baslé
  */
-class MicrometerListenerConfigurationTest {
+class MicrometerMeterListenerConfigurationTest {
 
 	@ParameterizedTestWithName
 	@CsvSource(value = {
@@ -58,7 +58,7 @@ class MicrometerListenerConfigurationTest {
 			flux = flux.tag("tag", tag);
 		}
 
-	MicrometerListenerConfiguration configuration = MicrometerListenerConfiguration.fromFlux(flux, expectedRegistry, expectedClock);
+	MicrometerMeterListenerConfiguration configuration = MicrometerMeterListenerConfiguration.fromFlux(flux, expectedRegistry, expectedClock);
 
 		assertThat(configuration.clock).as("clock").isSameAs(expectedClock);
 		assertThat(configuration.registry).as("registry").isSameAs(expectedRegistry);
@@ -100,7 +100,7 @@ class MicrometerListenerConfigurationTest {
 			mono = mono.tag("tag", tag);
 		}
 
-		MicrometerListenerConfiguration configuration = MicrometerListenerConfiguration.fromMono(mono, expectedRegistry, expectedClock);
+		MicrometerMeterListenerConfiguration configuration = MicrometerMeterListenerConfiguration.fromMono(mono, expectedRegistry, expectedClock);
 
 		assertThat(configuration.clock).as("clock").isSameAs(expectedClock);
 		assertThat(configuration.registry).as("registry").isSameAs(expectedRegistry);
@@ -127,7 +127,7 @@ class MicrometerListenerConfigurationTest {
 		TestLogger logger = new TestLogger(false);
 		Flux<Integer> flux = Flux.just(1);
 
-		String resolvedName = MicrometerListenerConfiguration.resolveName(flux, logger);
+		String resolvedName = MicrometerMeterListenerConfiguration.resolveName(flux, logger);
 
 		assertThat(resolvedName).isEqualTo(Micrometer.DEFAULT_METER_PREFIX);
 		assertThat(logger.getOutContent() + logger.getErrContent()).as("logs").isEmpty();
@@ -138,7 +138,7 @@ class MicrometerListenerConfigurationTest {
 		TestLogger logger = new TestLogger(false);
 		Flux<Integer> flux = Flux.just(1).name("someName");
 
-		String resolvedName = MicrometerListenerConfiguration.resolveName(flux, logger);
+		String resolvedName = MicrometerMeterListenerConfiguration.resolveName(flux, logger);
 
 		assertThat(resolvedName).isEqualTo("someName");
 		assertThat(logger.getOutContent() + logger.getErrContent()).as("logs").isEmpty();
@@ -149,7 +149,7 @@ class MicrometerListenerConfigurationTest {
 		TestLogger logger = new TestLogger(false);
 		Flux<Integer> flux = Flux.just(1).name("someName").filter(i -> i % 2 == 0).map(i -> i + 10);
 
-		String resolvedName = MicrometerListenerConfiguration.resolveName(flux, logger);
+		String resolvedName = MicrometerMeterListenerConfiguration.resolveName(flux, logger);
 
 		assertThat(resolvedName).isEqualTo("someName");
 		assertThat(logger.getOutContent() + logger.getErrContent()).as("logs").isEmpty();
@@ -160,7 +160,7 @@ class MicrometerListenerConfigurationTest {
 		TestLogger testLogger = new TestLogger(false);
 		Publisher<Object> publisher = Operators::complete;
 
-		String resolvedName = MicrometerListenerConfiguration.resolveName(publisher, testLogger);
+		String resolvedName = MicrometerMeterListenerConfiguration.resolveName(publisher, testLogger);
 
 		assertThat(resolvedName).as("resolved name").isEqualTo(Micrometer.DEFAULT_METER_PREFIX);
 		assertThat(testLogger.getErrContent()).contains("Attempting to activate metrics but the upstream is not Scannable. You might want to use `name()` (and optionally `tags()`) right before this listener");
@@ -171,7 +171,7 @@ class MicrometerListenerConfigurationTest {
 		Tags defaultTags = Tags.of("common1", "commonValue1");
 		Flux<Integer> flux = Flux.just(1);
 
-		Tags resolvedTags = MicrometerListenerConfiguration.resolveTags(flux, defaultTags);
+		Tags resolvedTags = MicrometerMeterListenerConfiguration.resolveTags(flux, defaultTags);
 
 		assertThat(resolvedTags.stream().map(Object::toString))
 			.containsExactly("tag(common1=commonValue1)");
@@ -184,7 +184,7 @@ class MicrometerListenerConfigurationTest {
 			.just(1)
 			.tag("k1", "v1");
 
-		Tags resolvedTags = MicrometerListenerConfiguration.resolveTags(flux, defaultTags);
+		Tags resolvedTags = MicrometerMeterListenerConfiguration.resolveTags(flux, defaultTags);
 
 		assertThat(resolvedTags.stream().map(Object::toString)).containsExactlyInAnyOrder(
 			"tag(common1=commonValue1)",
@@ -201,7 +201,7 @@ class MicrometerListenerConfigurationTest {
 			.filter(i -> i % 2 == 0)
 			.map(i -> i + 10);
 
-		Tags resolvedTags = MicrometerListenerConfiguration.resolveTags(flux, defaultTags);
+		Tags resolvedTags = MicrometerMeterListenerConfiguration.resolveTags(flux, defaultTags);
 
 		assertThat(resolvedTags.stream().map(Object::toString)).containsExactlyInAnyOrder(
 			"tag(common1=commonValue1)",
@@ -218,7 +218,7 @@ class MicrometerListenerConfigurationTest {
 			.tag("k2", "v2")
 			.map(i -> i + 10);
 
-		Tags resolvedTags = MicrometerListenerConfiguration.resolveTags(flux, defaultTags);
+		Tags resolvedTags = MicrometerMeterListenerConfiguration.resolveTags(flux, defaultTags);
 
 		assertThat(resolvedTags.stream().map(Object::toString)).containsExactlyInAnyOrder(
 			"tag(common1=commonValue1)",
@@ -237,7 +237,7 @@ class MicrometerListenerConfigurationTest {
 			.tag("k2", "v2")
 			.map(i -> i + 10);
 
-		Tags resolvedTags = MicrometerListenerConfiguration.resolveTags(flux, defaultTags);
+		Tags resolvedTags = MicrometerMeterListenerConfiguration.resolveTags(flux, defaultTags);
 
 		assertThat(resolvedTags.stream().map(Object::toString)).containsExactly(
 			"tag(common1=commonValue1)",
@@ -251,7 +251,7 @@ class MicrometerListenerConfigurationTest {
 		Tags defaultTags = Tags.of("common1", "commonValue1");
 		Publisher<Object> publisher = Operators::complete;
 
-		Tags resolvedTags = MicrometerListenerConfiguration.resolveTags(publisher, defaultTags);
+		Tags resolvedTags = MicrometerMeterListenerConfiguration.resolveTags(publisher, defaultTags);
 
 		assertThat(resolvedTags.stream().map(Object::toString)).containsExactly("tag(common1=commonValue1)");
 	}

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerMeterListenerFactoryTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerMeterListenerFactoryTest.java
@@ -46,15 +46,15 @@ class MicrometerMeterListenerFactoryTest {
 	@Test
 	void useRegistryDefaultsToCommonRegistry() {
 		SimpleMeterRegistry commonRegistry = new SimpleMeterRegistry();
-		MeterRegistry defaultCommon = Micrometer.useRegistry(commonRegistry);
+		MeterRegistry defaultCommon = Micrometer.useMeterRegistry(commonRegistry);
 		try {
 			MicrometerMeterListenerFactory<?> factory = new MicrometerMeterListenerFactory<>();
 
-			assertThat(factory.useRegistry()).isSameAs(Micrometer.getRegistry())
+			assertThat(factory.useRegistry()).isSameAs(Micrometer.getMeterRegistry())
 				.isSameAs(commonRegistry);
 		}
 		finally {
-			Micrometer.useRegistry(defaultCommon);
+			Micrometer.useMeterRegistry(defaultCommon);
 		}
 	}
 

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerMeterListenerFactoryTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerMeterListenerFactoryTest.java
@@ -22,11 +22,11 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 
+import reactor.core.observability.SignalListener;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;
 import reactor.util.context.Context;
-import reactor.core.observability.SignalListener;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerMeterListenerFactoryTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerMeterListenerFactoryTest.java
@@ -34,11 +34,11 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 /**
  * @author Simon Baslé
  */
-class MicrometerListenerFactoryTest {
+class MicrometerMeterListenerFactoryTest {
 
 	@Test
 	void useClockDefaultsToSystemClock() {
-		MicrometerListenerFactory<?> factory = new MicrometerListenerFactory<>();
+		MicrometerMeterListenerFactory<?> factory = new MicrometerMeterListenerFactory<>();
 
 		assertThat(factory.useClock()).isSameAs(Clock.SYSTEM);
 	}
@@ -48,7 +48,7 @@ class MicrometerListenerFactoryTest {
 		SimpleMeterRegistry commonRegistry = new SimpleMeterRegistry();
 		MeterRegistry defaultCommon = Micrometer.useRegistry(commonRegistry);
 		try {
-			MicrometerListenerFactory<?> factory = new MicrometerListenerFactory<>();
+			MicrometerMeterListenerFactory<?> factory = new MicrometerMeterListenerFactory<>();
 
 			assertThat(factory.useRegistry()).isSameAs(Micrometer.getRegistry())
 				.isSameAs(commonRegistry);
@@ -60,7 +60,7 @@ class MicrometerListenerFactoryTest {
 
 	@Test
 	void configurationFromMono() {
-		MicrometerListenerConfiguration configuration = CUSTOM_FACTORY.initializePublisherState(Mono.just(1));
+		MicrometerMeterListenerConfiguration configuration = CUSTOM_FACTORY.initializePublisherState(Mono.just(1));
 
 		assertThat(configuration.registry).as("registry").isSameAs(CUSTOM_REGISTRY);
 		assertThat(configuration.clock).as("clock").isSameAs(CUSTOM_CLOCK);
@@ -70,7 +70,7 @@ class MicrometerListenerFactoryTest {
 
 	@Test
 	void configurationFromFlux() {
-		MicrometerListenerConfiguration configuration = CUSTOM_FACTORY.initializePublisherState(Flux.just(1, 2));
+		MicrometerMeterListenerConfiguration configuration = CUSTOM_FACTORY.initializePublisherState(Flux.just(1, 2));
 
 		assertThat(configuration.registry).as("registry").isSameAs(CUSTOM_REGISTRY);
 		assertThat(configuration.clock).as("clock").isSameAs(CUSTOM_CLOCK);
@@ -82,17 +82,17 @@ class MicrometerListenerFactoryTest {
 	void configurationFromGenericPublisherIsRejected() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> CUSTOM_FACTORY.initializePublisherState(Operators::complete))
-			.withMessage("MicrometerListenerFactory must only be used via the tap operator / with a Flux or Mono");
+			.withMessage("MicrometerMeterListenerFactory must only be used via the tap operator / with a Flux or Mono");
 	}
 
 	@Test
 	void createListenerOfTypeMicrometer() {
 		Publisher<Integer> source = Mono.just(1);
-		MicrometerListenerConfiguration conf = CUSTOM_FACTORY.initializePublisherState(source);
+		MicrometerMeterListenerConfiguration conf = CUSTOM_FACTORY.initializePublisherState(source);
 		SignalListener<?> signalListener = CUSTOM_FACTORY.createListener(source, Context.empty(), conf);
 
-		assertThat(signalListener).isInstanceOf(MicrometerListener.class);
-		assertThat(((MicrometerListener<?>) signalListener).configuration).as("configuration").isSameAs(conf);
+		assertThat(signalListener).isInstanceOf(MicrometerMeterListener.class);
+		assertThat(((MicrometerMeterListener<?>) signalListener).configuration).as("configuration").isSameAs(conf);
 	}
 
 	protected static final Clock CUSTOM_CLOCK = new Clock() {
@@ -106,8 +106,9 @@ class MicrometerListenerFactoryTest {
 			return 0;
 		}
 	};
-	protected static final SimpleMeterRegistry CUSTOM_REGISTRY = new SimpleMeterRegistry();
-	protected static final MicrometerListenerFactory<Object> CUSTOM_FACTORY = new MicrometerListenerFactory<Object>() {
+	protected static final SimpleMeterRegistry                    CUSTOM_REGISTRY = new SimpleMeterRegistry();
+	protected static final MicrometerMeterListenerFactory<Object>
+																  CUSTOM_FACTORY  = new MicrometerMeterListenerFactory<Object>() {
 		@Override
 		protected Clock useClock() {
 			return CUSTOM_CLOCK;

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerMeterListenerFactoryTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerMeterListenerFactoryTest.java
@@ -46,15 +46,15 @@ class MicrometerMeterListenerFactoryTest {
 	@Test
 	void useRegistryDefaultsToCommonRegistry() {
 		SimpleMeterRegistry commonRegistry = new SimpleMeterRegistry();
-		MeterRegistry defaultCommon = Micrometer.useMeterRegistry(commonRegistry);
+		MeterRegistry defaultCommon = Micrometer.useRegistry(commonRegistry);
 		try {
 			MicrometerMeterListenerFactory<?> factory = new MicrometerMeterListenerFactory<>();
 
-			assertThat(factory.useRegistry()).isSameAs(Micrometer.getMeterRegistry())
+			assertThat(factory.useRegistry()).isSameAs(Micrometer.getRegistry())
 				.isSameAs(commonRegistry);
 		}
 		finally {
-			Micrometer.useMeterRegistry(defaultCommon);
+			Micrometer.useRegistry(defaultCommon);
 		}
 	}
 

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerMeterListenerTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerMeterListenerTest.java
@@ -33,12 +33,12 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 /**
  * @author Simon Baslé
  */
-class MicrometerListenerTest {
+class MicrometerMeterListenerTest {
 
 	SimpleMeterRegistry registry;
 	AtomicLong virtualClockTime;
-	Clock virtualClock;
-	MicrometerListenerConfiguration configuration;
+	Clock                                virtualClock;
+	MicrometerMeterListenerConfiguration configuration;
 
 	@BeforeEach
 	void initRegistry() {
@@ -55,7 +55,7 @@ class MicrometerListenerTest {
 				return virtualClockTime.get();
 			}
 		};
-		configuration = new MicrometerListenerConfiguration(
+		configuration = new MicrometerMeterListenerConfiguration(
 			"testName",
 			Tags.of("testTag1", "testTagValue1","testTag2", "testTagValue2"),
 			registry,
@@ -65,14 +65,14 @@ class MicrometerListenerTest {
 
 	@Test
 	void initialStateFluxWithDefaultName() {
-		configuration = new MicrometerListenerConfiguration(
+		configuration = new MicrometerMeterListenerConfiguration(
 			Micrometer.DEFAULT_METER_PREFIX,
 			Tags.of("testTag1", "testTagValue1","testTag2", "testTagValue2"),
 			registry,
 			virtualClock,
 			false);
 
-		MicrometerListener<Integer> listener = new MicrometerListener<>(configuration);
+		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 
 		assertThat(listener.valued).as("valued").isFalse();
 		assertThat(listener.requestedCounter).as("requestedCounter disabled").isNull();
@@ -91,14 +91,14 @@ class MicrometerListenerTest {
 
 	@Test
 	void initialStateFluxWithCustomName() {
-		configuration = new MicrometerListenerConfiguration(
+		configuration = new MicrometerMeterListenerConfiguration(
 			"testName",
 			Tags.of("testTag1", "testTagValue1","testTag2", "testTagValue2"),
 			registry,
 			virtualClock,
 			false);
 
-		MicrometerListener<Integer> listener = new MicrometerListener<>(configuration);
+		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 
 		assertThat(listener.valued).as("valued").isFalse();
 		assertThat(listener.requestedCounter).as("requestedCounter").isNotNull();
@@ -122,14 +122,14 @@ class MicrometerListenerTest {
 
 	@Test
 	void initialStateMono() {
-		configuration = new MicrometerListenerConfiguration(
+		configuration = new MicrometerMeterListenerConfiguration(
 			Micrometer.DEFAULT_METER_PREFIX,
 			Tags.of("testTag1", "testTagValue1","testTag2", "testTagValue2"),
 			registry,
 			virtualClock,
 			true);
 
-		MicrometerListener<Integer> listener = new MicrometerListener<>(configuration);
+		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 
 		assertThat(listener.valued).as("valued").isFalse();
 		assertThat(listener.requestedCounter).as("requestedCounter disabled").isNull();
@@ -142,7 +142,7 @@ class MicrometerListenerTest {
 
 	@Test
 	void timerSampleInitializedInSubscription() {
-		MicrometerListener<Integer> listener = new MicrometerListener<>(configuration);
+		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 
 		assertThat(listener.subscribeToTerminateSample)
 			.as("subscribeToTerminateSample pre subscription")
@@ -166,7 +166,7 @@ class MicrometerListenerTest {
 		assertThat(registry.getMeters())
 			.as("meters post subscription")
 			.hasSize(3);
-		assertThat(registry.find("testName" + MicrometerListener.METER_SUBSCRIBED).counter())
+		assertThat(registry.find("testName" + MicrometerMeterListener.METER_SUBSCRIBED).counter())
 			.as("meter .subscribed")
 			.isNotNull()
 			.satisfies(meter -> assertThat(meter.count()).isEqualTo(1d));
@@ -174,14 +174,14 @@ class MicrometerListenerTest {
 
 	@Test
 	void doOnCancelTimesFlowDurationMeter() {
-		MicrometerListener<Integer> listener = new MicrometerListener<>(configuration);
+		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 		listener.doOnSubscription();
 		assertThat(registry.getMeters()).hasSize(3);
 
 		virtualClockTime.set(100);
 		listener.doOnCancel();
 
-		Timer timer = registry.find("testName" + MicrometerListener.METER_FLOW_DURATION)
+		Timer timer = registry.find("testName" + MicrometerMeterListener.METER_FLOW_DURATION)
 			.timer();
 
 		assertThat(registry.getMeters()).hasSize(4);
@@ -195,14 +195,14 @@ class MicrometerListenerTest {
 
 	@Test
 	void doOnCompleteTimesFlowDurationMeter_completeEmpty() {
-		MicrometerListener<Integer> listener = new MicrometerListener<>(configuration);
+		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 		listener.doOnSubscription();
 		assertThat(registry.getMeters()).hasSize(3);
 
 		virtualClockTime.set(100);
 		listener.doOnComplete();
 
-		Timer timer = registry.find("testName" + MicrometerListener.METER_FLOW_DURATION)
+		Timer timer = registry.find("testName" + MicrometerMeterListener.METER_FLOW_DURATION)
 			.timer();
 
 		assertThat(registry.getMeters()).hasSize(4);
@@ -216,7 +216,7 @@ class MicrometerListenerTest {
 
 	@Test
 	void doOnCompleteTimesFlowDurationMeter_completeValued() {
-		MicrometerListener<Integer> listener = new MicrometerListener<>(configuration);
+		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 		listener.doOnSubscription();
 		assertThat(registry.getMeters()).hasSize(3);
 
@@ -224,7 +224,7 @@ class MicrometerListenerTest {
 		listener.valued = true;
 		listener.doOnComplete();
 
-		Timer timer = registry.find("testName" + MicrometerListener.METER_FLOW_DURATION)
+		Timer timer = registry.find("testName" + MicrometerMeterListener.METER_FLOW_DURATION)
 			.timer();
 
 		assertThat(registry.getMeters()).hasSize(4);
@@ -238,14 +238,14 @@ class MicrometerListenerTest {
 
 	@Test
 	void doOnErrorTimesFlowDurationMeter() {
-		MicrometerListener<Integer> listener = new MicrometerListener<>(configuration);
+		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 		listener.doOnSubscription();
 		assertThat(registry.getMeters()).hasSize(3);
 
 		virtualClockTime.set(100);
 		listener.doOnError(new IllegalStateException("expected"));
 
-		Timer timer = registry.find("testName" + MicrometerListener.METER_FLOW_DURATION)
+		Timer timer = registry.find("testName" + MicrometerMeterListener.METER_FLOW_DURATION)
 			.timer();
 
 		assertThat(registry.getMeters()).hasSize(4);
@@ -259,7 +259,7 @@ class MicrometerListenerTest {
 
 	@Test
 	void doOnNextRecordsInterval() {
-		MicrometerListener<Integer> listener = new MicrometerListener<>(configuration);
+		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 		listener.doOnSubscription();
 
 		virtualClockTime.set(100);
@@ -268,7 +268,7 @@ class MicrometerListenerTest {
 		assertThat(listener.valued).as("valued").isTrue();
 		assertThat(listener.lastNextEventNanos).as("lastEventNanos recorded").isEqualTo(100);
 
-		assertThat(registry.find("testName" + MicrometerListener.METER_FLOW_DURATION).meters())
+		assertThat(registry.find("testName" + MicrometerMeterListener.METER_FLOW_DURATION).meters())
 			.as("no flow.duration meter yet")
 			.isEmpty();
 
@@ -283,9 +283,9 @@ class MicrometerListenerTest {
 
 	@Test
 	void doOnNextRecordsInterval_defaultName() {
-		configuration = new MicrometerListenerConfiguration(Micrometer.DEFAULT_METER_PREFIX, Tags.empty(),
+		configuration = new MicrometerMeterListenerConfiguration(Micrometer.DEFAULT_METER_PREFIX, Tags.empty(),
 			registry, virtualClock, false);
-		MicrometerListener<Integer> listener = new MicrometerListener<>(configuration);
+		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 		listener.doOnSubscription();
 
 		virtualClockTime.set(100);
@@ -294,7 +294,7 @@ class MicrometerListenerTest {
 		assertThat(listener.valued).as("valued").isTrue();
 		assertThat(listener.lastNextEventNanos).as("lastEventNanos recorded").isEqualTo(100);
 
-		assertThat(registry.find(Micrometer.DEFAULT_METER_PREFIX + MicrometerListener.METER_FLOW_DURATION).meters())
+		assertThat(registry.find(Micrometer.DEFAULT_METER_PREFIX + MicrometerMeterListener.METER_FLOW_DURATION).meters())
 			.as("no flow.duration meter yet")
 			.isEmpty();
 
@@ -308,9 +308,9 @@ class MicrometerListenerTest {
 
 	@Test
 	void doOnNext_monoRecordsCompletionOnly() {
-		configuration = new MicrometerListenerConfiguration("testName", Tags.empty(),
+		configuration = new MicrometerMeterListenerConfiguration("testName", Tags.empty(),
 			registry, virtualClock, true);
-		MicrometerListener<Integer> listener = new MicrometerListener<>(configuration);
+		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 
 		listener.doOnSubscription();
 
@@ -320,7 +320,7 @@ class MicrometerListenerTest {
 		assertThat(listener.valued).as("valued").isTrue();
 		assertThat(listener.lastNextEventNanos).as("no lastEventNanos recorded").isZero();
 
-		Timer timer = registry.find("testName" + MicrometerListener.METER_FLOW_DURATION)
+		Timer timer = registry.find("testName" + MicrometerMeterListener.METER_FLOW_DURATION)
 			.timer();
 
 		assertThat(timer.getId().toString())
@@ -333,7 +333,7 @@ class MicrometerListenerTest {
 
 	@Test
 	void doOnNextMultipleRecords() {
-		MicrometerListener<Integer> listener = new MicrometerListener<>(configuration);
+		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 		listener.doOnSubscription();
 
 		virtualClockTime.set(100);
@@ -354,7 +354,7 @@ class MicrometerListenerTest {
 
 	@Test
 	void doOnRequestRecordsTotalDemand() {
-		MicrometerListener<Integer> listener = new MicrometerListener<>(configuration);
+		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 		listener.doOnRequest(100L);
 
 		assertThat(listener.requestedCounter.count()).as("1 request calls").isEqualTo(1);
@@ -369,30 +369,30 @@ class MicrometerListenerTest {
 
 	@Test
 	void doOnRequestMonoIgnoresRequest() {
-		configuration = new MicrometerListenerConfiguration("testName", Tags.empty(), registry, virtualClock, true);
-		MicrometerListener<Integer> listener = new MicrometerListener<>(configuration);
+		configuration = new MicrometerMeterListenerConfiguration("testName", Tags.empty(), registry, virtualClock, true);
+		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 		assertThatCode(() -> listener.doOnRequest(100L)).doesNotThrowAnyException();
 		assertThat(listener.requestedCounter).isNull();
 	}
 
 	@Test
 	void doOnRequestDefaultNameIgnoresRequest() {
-		configuration = new MicrometerListenerConfiguration(Micrometer.DEFAULT_METER_PREFIX, Tags.empty(), registry, virtualClock, false);
-		MicrometerListener<Integer> listener = new MicrometerListener<>(configuration);
+		configuration = new MicrometerMeterListenerConfiguration(Micrometer.DEFAULT_METER_PREFIX, Tags.empty(), registry, virtualClock, false);
+		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 		assertThatCode(() -> listener.doOnRequest(100L)).doesNotThrowAnyException();
 		assertThat(listener.requestedCounter).isNull();
 	}
 
 	@Test
 	void malformedCounterCapturesNextCompleteError() {
-		MicrometerListener<Integer> listener = new MicrometerListener<>(configuration);
+		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 
-		Counter malformedCounter = registry.find("testName" + MicrometerListener.METER_MALFORMED).counter();
+		Counter malformedCounter = registry.find("testName" + MicrometerMeterListener.METER_MALFORMED).counter();
 		assertThat(malformedCounter).as("counter not registered").isNull();
 
 		listener.doOnMalformedOnNext(123);
 
-		malformedCounter = registry.find("testName" + MicrometerListener.METER_MALFORMED).counter();
+		malformedCounter = registry.find("testName" + MicrometerMeterListener.METER_MALFORMED).counter();
 		assertThat(malformedCounter).as("lazy counter registration").isNotNull();
 		assertThat(malformedCounter.count()).as("onNext malformed").isOne();
 

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationIntegrationTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationIntegrationTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.observability.micrometer;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.test.SampleTestRunner;
+import io.micrometer.tracing.test.simple.SpansAssert;
+import org.junit.jupiter.api.Tag;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static reactor.core.observability.micrometer.MicrometerMeterListener.TAG_KEY_STATUS;
+import static reactor.core.observability.micrometer.MicrometerMeterListener.TAG_STATUS_ERROR;
+
+/**
+ * @author Simon Baslé
+ */
+@Tag("slow")
+public class MicrometerObservationIntegrationTest extends SampleTestRunner {
+
+	MicrometerObservationIntegrationTest() {
+		super(SampleTestRunner.SampleRunnerConfig.builder()
+			.build());
+	}
+
+	@Override
+	public SampleTestRunnerConsumer yourCode() throws Exception {
+		final Scheduler delayScheduler = Schedulers.newSingle("test");
+		final IllegalStateException EXCEPTION = new IllegalStateException("expected error");
+		return (bb, meterRegistry) -> {
+			Span beforeStart = bb.getTracer().currentSpan();
+
+			Function<Integer, Mono<String>> querySimulator = id ->
+				Mono.delay(Duration.ofMillis(500), delayScheduler)
+					.tag("endpoint", "simulated/" + id)
+					.map(ignored -> "query for id " + id)
+					.doOnNext(v -> {
+						if (id == 2L) throw EXCEPTION;
+					})
+					//FIXME enforce providing a name via String or ObservationConvention
+					//FIXME Micrometer taps should ignore name()
+					.name("query" + id)
+					.tap(Micrometer.observation(getObservationRegistry()));
+
+			Flux.range(0, 100)
+				.name("testFlux")
+				.tag("interval", "500ms")
+				.take(3)
+				.tag("size", "3")
+				.concatMap(querySimulator)
+				.tap(Micrometer.observation(getObservationRegistry()))
+				.onErrorReturn("ended with error") // prevent error throwing. the tap should still get notified
+				.blockLast();
+
+			SpansAssert spansAssert = SpansAssert.assertThat(bb.getFinishedSpans());
+			SpansAssert.SpansAssertReturningAssert assertThatMain = spansAssert.assertThatASpanWithNameEqualTo("test-flux");
+			SpansAssert.SpansAssertReturningAssert assertThatQuery2 = spansAssert.assertThatASpanWithNameEqualTo("query2");
+
+			spansAssert.hasSize(4);
+
+			assertThatMain
+				//FIXME reactor-defined tags should have a reactor. prefix
+				//FIXME reactor-defined Tags and KeyValues should be Documented
+				.hasTag(TAG_KEY_STATUS, TAG_STATUS_ERROR)
+				.hasTag("type", "Flux")
+				.hasTag("interval", "500ms")
+				.hasTag("size", "3")
+				//TODO propose new duration assertion? span's timestamps should return Instant, not long. OTel is using nanos, Brave is storing long microsecond
+//				.satisfies(span -> assertThat(Duration.ofNanos(span.getEndTimestamp() - span.getStartTimestamp()))
+//					.as("duration")
+//					.isGreaterThanOrEqualTo(Duration.ofMillis(1500))
+//				)
+				//OTEL doesn't really capture the exception type, only the message
+				.thenThrowable().hasMessage(EXCEPTION.getMessage());
+
+			//query2 span
+			assertThatQuery2
+				.hasTag("endpoint", "simulated/2")
+				.thenThrowable().hasMessage(EXCEPTION.getMessage());
+
+			//quick assert query0 and query1
+			spansAssert
+				.thenASpanWithNameEqualTo("query0")
+				.doesNotHaveEventWithNameEqualTo("exception")
+				.hasTag("endpoint", "simulated/0")
+				.backToSpans()
+				.hasASpanWithName("query1");
+
+			assertThat(bb.getTracer().currentSpan())
+				.as("no leftover span in main thread")
+				.isNotSameAs(beforeStart) //something happened
+				.isEqualTo(beforeStart); //original span was restored
+
+			//finally, assert that the delay thread was not polluted either
+			CountDownLatch latch = new CountDownLatch(1);
+			delayScheduler.schedule(() -> {
+				try {
+					assertThat(bb.getTracer().currentSpan())
+						.as("no leftover span in delay thread")
+						.isNull();
+				}
+				finally {
+					latch.countDown();
+				}
+			});
+			latch.await(10, TimeUnit.SECONDS);
+		};
+	}
+}

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerConfigurationTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerConfigurationTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.observability.micrometer;
+
+import io.micrometer.common.KeyValues;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Operators;
+import reactor.test.ParameterizedTestWithName;
+import reactor.util.annotation.Nullable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Simon Baslé
+ */
+class MicrometerObservationListenerConfigurationTest {
+
+	@ParameterizedTestWithName
+	@CsvSource(value = {
+		",",
+		"someName,",
+		",someTag",
+		"someName,someTag"
+	})
+	void fromFlux(@Nullable String name, @Nullable String tag) {
+		ObservationRegistry expectedRegistry = ObservationRegistry.create();
+
+		Flux<Integer> flux = Flux.just(1, 2, 3);
+
+		if (name != null) {
+			flux = flux.name(name);
+		}
+		if (tag != null) {
+			flux = flux.tag("tag", tag);
+		}
+
+	MicrometerObservationListenerConfiguration configuration = MicrometerObservationListenerConfiguration.fromFlux(flux, expectedRegistry);
+
+		assertThat(configuration.registry).as("registry").isSameAs(expectedRegistry);
+		assertThat(configuration.isMono).as("isMono").isFalse();
+
+		assertThat(configuration.sequenceName)
+			.as("sequenceName")
+			.isEqualTo(name == null ? Micrometer.DEFAULT_METER_PREFIX : name);
+
+		if (tag == null) {
+			assertThat(configuration.commonKeyValues.stream().map(t -> t.getKey() + "=" + t.getValue()))
+				.as("commonKeyValues without additional KeyValue")
+				.containsExactly("type=Flux");
+		}
+		else {
+			assertThat(configuration.commonKeyValues.stream().map(t -> t.getKey() + "=" + t.getValue()))
+				.as("commonKeyValues")
+				.containsExactlyInAnyOrder("type=Flux", "tag="+tag);
+		}
+	}
+
+	@ParameterizedTestWithName
+	@CsvSource(value = {
+		",",
+		"someName,",
+		",someTag",
+		"someName,someTag"
+	})
+	void fromMono(@Nullable String name, @Nullable String tag) {
+		ObservationRegistry expectedRegistry = ObservationRegistry.create();
+
+		Mono<Integer> mono = Mono.just(1);
+
+		if (name != null) {
+			mono = mono.name(name);
+		}
+		if (tag != null) {
+			mono = mono.tag("tag", tag);
+		}
+
+		MicrometerObservationListenerConfiguration configuration = MicrometerObservationListenerConfiguration.fromMono(mono, expectedRegistry);
+
+		assertThat(configuration.registry).as("registry").isSameAs(expectedRegistry);
+		assertThat(configuration.isMono).as("isMono").isTrue();
+
+		assertThat(configuration.sequenceName)
+			.as("sequenceName")
+			.isEqualTo(name == null ? Micrometer.DEFAULT_METER_PREFIX : name);
+
+		if (tag == null) {
+			assertThat(configuration.commonKeyValues.stream().map(t -> t.getKey() + "=" + t.getValue()))
+				.as("commonKeyValues without additional KeyValue")
+				.containsExactly("type=Mono");
+		}
+		else {
+			assertThat(configuration.commonKeyValues.stream().map(t -> t.getKey() + "=" + t.getValue()))
+				.as("commonKeyValues")
+				.containsExactlyInAnyOrder("type=Mono", "tag="+tag);
+		}
+	}
+
+	// == NB: this configuration reuses the MicrometerObservationListenerConfiguration#resolveName method, not tested here
+
+	@Test
+	void resolveKeyValues_notSet() {
+		KeyValues defaultKeyValues = KeyValues.of("common1", "commonValue1");
+		Flux<Integer> flux = Flux.just(1);
+
+		KeyValues resolvedKeyValues = MicrometerObservationListenerConfiguration.resolveKeyValues(flux, defaultKeyValues);
+
+		assertThat(resolvedKeyValues.stream().map(Object::toString))
+			.containsExactly("tag(common1=commonValue1)");
+	}
+
+	@Test
+	void resolveKeyValues_setRightAbove() {
+		KeyValues defaultKeyValues = KeyValues.of("common1", "commonValue1");
+		Flux<Integer> flux = Flux
+			.just(1)
+			.tag("k1", "v1");
+
+		KeyValues resolvedKeyValues = MicrometerObservationListenerConfiguration.resolveKeyValues(flux, defaultKeyValues);
+
+		assertThat(resolvedKeyValues.stream().map(Object::toString)).containsExactlyInAnyOrder(
+			"tag(common1=commonValue1)",
+			"tag(k1=v1)"
+		);
+	}
+
+	@Test
+	void resolveKeyValues_setHigherAbove() {
+		KeyValues defaultKeyValues = KeyValues.of("common1", "commonValue1");
+		Flux<Integer> flux = Flux
+			.just(1)
+			.tag("k1", "v1")
+			.filter(i -> i % 2 == 0)
+			.map(i -> i + 10);
+
+		KeyValues resolvedKeyValues = MicrometerObservationListenerConfiguration.resolveKeyValues(flux, defaultKeyValues);
+
+		assertThat(resolvedKeyValues.stream().map(Object::toString)).containsExactlyInAnyOrder(
+			"tag(common1=commonValue1)",
+			"tag(k1=v1)"
+		);
+	}
+
+	@Test
+	void resolveKeyValues_multipleScatteredKeyValuesSetAbove() {
+		KeyValues defaultKeyValues = KeyValues.of("common1", "commonValue1");
+		Flux<Integer> flux = Flux.just(1)
+			.tag("k1", "v1")
+			.filter(i -> i % 2 == 0)
+			.tag("k2", "v2")
+			.map(i -> i + 10);
+
+		KeyValues resolvedKeyValues = MicrometerObservationListenerConfiguration.resolveKeyValues(flux, defaultKeyValues);
+
+		assertThat(resolvedKeyValues.stream().map(Object::toString)).containsExactlyInAnyOrder(
+			"tag(common1=commonValue1)",
+			"tag(k1=v1)",
+			"tag(k2=v2)"
+		);
+	}
+
+	@Test
+	void resolveKeyValues_multipleScatteredKeyValuesSetAboveWithDeduplication() {
+		KeyValues defaultKeyValues = KeyValues.of("common1", "commonValue1");
+		Flux<Integer> flux = Flux.just(1)
+			.tag("k1", "v1")
+			.tag("k2", "oldV2")
+			.filter(i -> i % 2 == 0)
+			.tag("k2", "v2")
+			.map(i -> i + 10);
+
+		KeyValues resolvedKeyValues = MicrometerObservationListenerConfiguration.resolveKeyValues(flux, defaultKeyValues);
+
+		assertThat(resolvedKeyValues.stream().map(Object::toString)).containsExactly(
+			"tag(common1=commonValue1)",
+			"tag(k1=v1)",
+			"tag(k2=v2)"
+		);
+	}
+
+	@Test
+	void resolveKeyValues_notScannable() {
+		KeyValues defaultKeyValues = KeyValues.of("common1", "commonValue1");
+		Publisher<Object> publisher = Operators::complete;
+
+		KeyValues resolvedKeyValues = MicrometerObservationListenerConfiguration.resolveKeyValues(publisher, defaultKeyValues);
+
+		assertThat(resolvedKeyValues.stream().map(Object::toString)).containsExactly("tag(common1=commonValue1)");
+	}
+}

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerFactoryTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerFactoryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.observability.micrometer;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+
+import reactor.core.observability.SignalListener;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Operators;
+import reactor.util.context.Context;
+import reactor.util.context.ContextView;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * @author Simon Baslé
+ */
+class MicrometerObservationListenerFactoryTest {
+
+	protected static final ObservationRegistry CUSTOM_REGISTRY = ObservationRegistry.create();
+
+	protected static final MicrometerObservationListenerFactory<Object> CUSTOM_FACTORY =
+		new MicrometerObservationListenerFactory<>(CUSTOM_REGISTRY);
+
+	@Test
+	void configurationFromMono() {
+		MicrometerObservationListenerConfiguration configuration = CUSTOM_FACTORY.initializePublisherState(Mono.just(1));
+
+		assertThat(configuration.registry).as("registry").isSameAs(CUSTOM_REGISTRY);
+		assertThat(configuration.isMono).as("isMono").isTrue();
+		assertThat(configuration.commonKeyValues).map(Object::toString).containsExactly("tag(type=Mono)");
+	}
+
+	@Test
+	void configurationFromFlux() {
+		MicrometerObservationListenerConfiguration configuration = CUSTOM_FACTORY.initializePublisherState(Flux.just(1, 2));
+
+		assertThat(configuration.registry).as("registry").isSameAs(CUSTOM_REGISTRY);
+		assertThat(configuration.isMono).as("isMono").isFalse();
+		assertThat(configuration.commonKeyValues).map(Object::toString).containsExactly("tag(type=Flux)");
+	}
+
+	@Test
+	void configurationFromGenericPublisherIsRejected() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> CUSTOM_FACTORY.initializePublisherState(Operators::complete))
+			.withMessage("MicrometerObservationListenerFactory must only be used via the tap operator / with a Flux or Mono");
+	}
+
+	@Test
+	void createListenerOfTypeMicrometer() {
+		Publisher<Integer> source = Mono.just(1);
+		ContextView expectedContext = Context.of(1, "A");
+		MicrometerObservationListenerConfiguration conf = CUSTOM_FACTORY.initializePublisherState(source);
+		SignalListener<?> signalListener = CUSTOM_FACTORY.createListener(source, expectedContext, conf);
+
+		assertThat(signalListener).isInstanceOf(MicrometerObservationListener.class);
+		MicrometerObservationListener<?> observationListener = (MicrometerObservationListener<?>) signalListener;
+
+		assertThat(observationListener.configuration).as("configuration").isSameAs(conf);
+		assertThat(observationListener.context).as("context").isSameAs(expectedContext);
+	}
+
+}

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerFactoryTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerFactoryTest.java
@@ -76,7 +76,7 @@ class MicrometerObservationListenerFactoryTest {
 		MicrometerObservationListener<?> observationListener = (MicrometerObservationListener<?>) signalListener;
 
 		assertThat(observationListener.configuration).as("configuration").isSameAs(conf);
-		assertThat(observationListener.context).as("context").isSameAs(expectedContext);
+		assertThat(observationListener.originalContext).as("context").isSameAs(expectedContext);
 	}
 
 }

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerTest.java
@@ -83,7 +83,7 @@ class MicrometerObservationListenerTest {
 			.isNotNull();
 		assertThat(registry).as("before start").doesNotHaveAnyObservation();
 
-		listener.doOnSubscription(); // forces observation start
+		listener.doFirst(); // forces observation start
 
 		assertThat(registry)
 			.hasSingleObservationThat()
@@ -112,7 +112,7 @@ class MicrometerObservationListenerTest {
 			.isNotNull();
 		assertThat(registry).as("no observation started").doesNotHaveAnyObservation();
 
-		listener.doOnSubscription(); // forces observation start
+		listener.doFirst(); // forces observation start
 
 		assertThat(registry)
 			.hasSingleObservationThat()
@@ -141,7 +141,7 @@ class MicrometerObservationListenerTest {
 			.isNotNull();
 		assertThat(registry).as("no observation started").doesNotHaveAnyObservation();
 
-		listener.doOnSubscription(); // forces observation start
+		listener.doFirst(); // forces observation start
 
 		assertThat(registry)
 			.hasSingleObservationThat()
@@ -213,7 +213,7 @@ class MicrometerObservationListenerTest {
 
 		MicrometerObservationListener<Integer> listener = new MicrometerObservationListener<>(subscriberContext, configuration);
 
-		listener.doOnSubscription(); // forces observation start
+		listener.doFirst(); // forces observation start
 		listener.doOnCancel(); // stops via cancellation
 
 		assertThat(registry)
@@ -237,7 +237,7 @@ class MicrometerObservationListenerTest {
 
 		MicrometerObservationListener<Integer> listener = new MicrometerObservationListener<>(subscriberContext, configuration);
 
-		listener.doOnSubscription(); // forces observation start
+		listener.doFirst(); // forces observation start
 		listener.doOnComplete(); // stops via completion (empty)
 
 		assertThat(registry)
@@ -261,7 +261,7 @@ class MicrometerObservationListenerTest {
 
 		MicrometerObservationListener<Integer> listener = new MicrometerObservationListener<>(subscriberContext, configuration);
 
-		listener.doOnSubscription(); // forces observation start
+		listener.doFirst(); // forces observation start
 		listener.doOnNext(1);
 		listener.doOnComplete(); // stops via completion
 
@@ -289,7 +289,7 @@ class MicrometerObservationListenerTest {
 		//we use a test-oriented constructor to force the onNext completion case to have a different tag value
 		MicrometerObservationListener<Integer> listener = new MicrometerObservationListener<>(subscriberContext, configuration, expectedStatus);
 
-		listener.doOnSubscription(); // forces observation start
+		listener.doFirst(); // forces observation start
 		listener.doOnNext(1); // emulates onNext, should stop observation
 
 		assertThat(registry)
@@ -320,7 +320,7 @@ class MicrometerObservationListenerTest {
 
 		MicrometerObservationListener<Integer> listener = new MicrometerObservationListener<>(subscriberContext, configuration);
 
-		listener.doOnSubscription(); // forces observation start
+		listener.doFirst(); // forces observation start
 		listener.doOnComplete(); // stops via completion (empty)
 
 		assertThat(registry)
@@ -344,7 +344,7 @@ class MicrometerObservationListenerTest {
 
 		MicrometerObservationListener<Integer> listener = new MicrometerObservationListener<>(subscriberContext, configuration);
 
-		listener.doOnSubscription(); // forces observation start
+		listener.doFirst(); // forces observation start
 		listener.doOnError(exception); // stops via onError
 
 		assertThat(registry)

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerTest.java
@@ -16,18 +16,11 @@
 
 package reactor.core.observability.micrometer;
 
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.Timer;
-import io.micrometer.observation.Observation;
 import io.micrometer.observation.tck.TestObservationRegistry;
-import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +31,6 @@ import reactor.util.context.ContextView;
 
 import static io.micrometer.observation.tck.TestObservationRegistryAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * @author Simon Baslé

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerTest.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.observability.micrometer;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.util.context.Context;
+import reactor.util.context.ContextView;
+
+import static io.micrometer.observation.tck.TestObservationRegistryAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * @author Simon Baslé
+ */
+class MicrometerObservationListenerTest {
+
+	TestObservationRegistry                    registry;
+	AtomicLong                                 virtualClockTime;
+	Clock                                      virtualClock;
+	MicrometerObservationListenerConfiguration configuration;
+	ContextView                                subscriberContext;
+
+	@BeforeEach
+	void initRegistry() {
+		registry = TestObservationRegistry.create();
+		virtualClockTime = new AtomicLong();
+		virtualClock = new Clock() {
+			@Override
+			public long wallTime() {
+				return virtualClockTime.get();
+			}
+
+			@Override
+			public long monotonicTime() {
+				return virtualClockTime.get();
+			}
+		};
+		configuration = new MicrometerObservationListenerConfiguration(
+			"testName",
+			KeyValues.of("testTag1", "testTagValue1","testTag2", "testTagValue2"),
+			registry,
+			false);
+		subscriberContext = Context.of("contextKey", "contextValue");
+	}
+
+	@Test
+	void whenStartedFluxWithDefaultName() {
+		configuration = new MicrometerObservationListenerConfiguration(
+			Micrometer.DEFAULT_METER_PREFIX,
+			//note: "type" key is added by MicrometerObservationListenerConfiguration#fromFlux (which is tested separately)
+			KeyValues.of("testTag1", "testTagValue1","testTag2", "testTagValue2"),
+			registry,
+			false);
+
+		MicrometerObservationListener<Integer> listener = new MicrometerObservationListener<>(subscriberContext, configuration);
+
+		assertThat(listener.valued).as("valued").isFalse();
+		assertThat(listener.subscribeToTerminalObservation)
+			.as("subscribeToTerminalObservation field")
+			.isNotNull();
+		assertThat(registry).as("before start").doesNotHaveAnyObservation();
+
+		listener.doOnSubscription(); // forces observation start
+
+		assertThat(registry)
+			.hasSingleObservationThat()
+			.hasNameEqualTo("reactor.observation.flow")
+			.as("subscribeToTerminalObservation")
+			.hasBeenStarted()
+			.isNotStopped()
+			.hasLowCardinalityKeyValue("testTag1", "testTagValue1")
+			.hasLowCardinalityKeyValue("testTag2", "testTagValue2");
+	}
+
+	@Test
+	void whenStartedFluxWithCustomName() {
+		configuration = new MicrometerObservationListenerConfiguration(
+			"testName",
+			//note: "type" key is added by MicrometerObservationListenerConfiguration#fromFlux (which is tested separately)
+			KeyValues.of("testTag1", "testTagValue1","testTag2", "testTagValue2"),
+			registry,
+			false);
+
+		MicrometerObservationListener<Integer> listener = new MicrometerObservationListener<>(subscriberContext, configuration);
+
+		assertThat(listener.valued).as("valued").isFalse();
+		assertThat(listener.subscribeToTerminalObservation)
+			.as("subscribeToTerminalObservation field")
+			.isNotNull();
+		assertThat(registry).as("no observation started").doesNotHaveAnyObservation();
+
+		listener.doOnSubscription(); // forces observation start
+
+		assertThat(registry)
+			.hasSingleObservationThat()
+			.hasNameEqualTo("testName.observation.flow")
+			.as("subscribeToTerminalObservation")
+			.hasBeenStarted()
+			.isNotStopped()
+			.hasLowCardinalityKeyValue("testTag1", "testTagValue1")
+			.hasLowCardinalityKeyValue("testTag2", "testTagValue2");
+	}
+
+	@Test
+	void whenStartedMono() {
+		configuration = new MicrometerObservationListenerConfiguration(
+			Micrometer.DEFAULT_METER_PREFIX,
+			//note: "type" key is added by MicrometerObservationListenerConfiguration#fromMono (which is tested separately)
+			KeyValues.of("testTag1", "testTagValue1","testTag2", "testTagValue2"),
+			registry,
+			true);
+
+		MicrometerObservationListener<Integer> listener = new MicrometerObservationListener<>(subscriberContext, configuration);
+
+		assertThat(listener.valued).as("valued").isFalse();
+		assertThat(listener.subscribeToTerminalObservation)
+			.as("subscribeToTerminalObservation field")
+			.isNotNull();
+		assertThat(registry).as("no observation started").doesNotHaveAnyObservation();
+
+		listener.doOnSubscription(); // forces observation start
+
+		assertThat(registry)
+			.hasSingleObservationThat()
+			.hasNameEqualTo("reactor.observation.flow")
+			.as("subscribeToTerminalObservation")
+			.hasBeenStarted()
+			.isNotStopped()
+			.hasLowCardinalityKeyValue("testTag1", "testTagValue1")
+			.hasLowCardinalityKeyValue("testTag2", "testTagValue2");
+	}
+
+	@Test
+	void tapFromFluxWithTags() {
+		Flux<Integer> flux = Flux.just(1)
+			.name("testFlux")
+			.tag("testTag1", "testTagValue1")
+			.tag("testTag2", "testTagValue2")
+			.tap(new MicrometerObservationListenerFactory<>(registry));
+
+		assertThat(registry).as("before subscription").doesNotHaveAnyObservation();
+
+		flux.blockLast();
+
+		assertThat(registry)
+			.hasSingleObservationThat()
+			.hasNameEqualTo("testFlux.observation.flow")
+			.as("subscribeToTerminalObservation")
+			.hasBeenStarted()
+			.hasBeenStopped()
+			.hasLowCardinalityKeyValue("testTag1", "testTagValue1")
+			.hasLowCardinalityKeyValue("testTag2", "testTagValue2")
+			.hasLowCardinalityKeyValue("type", "Flux")
+			.hasLowCardinalityKeyValue("status", "completed")
+			.doesNotHaveHighCardinalityKeyValueWithKey(MicrometerMeterListener.TAG_KEY_EXCEPTION)
+			.doesNotHaveLowCardinalityKeyValueWithKey(MicrometerMeterListener.TAG_KEY_EXCEPTION);
+	}
+
+	@Test
+	void tapFromMonoWithTags() {
+		Mono<Integer> mono = Mono.just(1)
+			.name("testMono")
+			.tag("testTag1", "testTagValue1")
+			.tag("testTag2", "testTagValue2")
+			.tap(new MicrometerObservationListenerFactory<>(registry));
+
+		assertThat(registry).as("before subscription").doesNotHaveAnyObservation();
+
+		mono.block();
+
+		assertThat(registry)
+			.hasSingleObservationThat()
+			.hasNameEqualTo("testMono.observation.flow")
+			.as("subscribeToTerminalObservation")
+			.hasBeenStarted()
+			.hasBeenStopped()
+			.hasLowCardinalityKeyValue("testTag1", "testTagValue1")
+			.hasLowCardinalityKeyValue("testTag2", "testTagValue2")
+			.hasLowCardinalityKeyValue("type", "Mono")
+			.hasLowCardinalityKeyValue("status", "completed")
+			.doesNotHaveHighCardinalityKeyValueWithKey(MicrometerMeterListener.TAG_KEY_EXCEPTION)
+			.doesNotHaveLowCardinalityKeyValueWithKey(MicrometerMeterListener.TAG_KEY_EXCEPTION);
+	}
+
+	@Test
+	void observationStoppedByCancellation() {
+		configuration = new MicrometerObservationListenerConfiguration(
+			"flux",
+			KeyValues.of("forcedType", "Flux"),
+			registry,
+			false);
+
+		MicrometerObservationListener<Integer> listener = new MicrometerObservationListener<>(subscriberContext, configuration);
+
+		listener.doOnSubscription(); // forces observation start
+		listener.doOnCancel(); // stops via cancellation
+
+		assertThat(registry)
+			.hasSingleObservationThat()
+			.hasNameEqualTo("flux.observation.flow")
+			.hasBeenStarted()
+			.hasBeenStopped()
+			.hasLowCardinalityKeyValue("forcedType", "Flux")
+			.doesNotHaveLowCardinalityKeyValueWithKey("exception")
+			.doesNotHaveHighCardinalityKeyValueWithKey("exception")
+			.hasLowCardinalityKeyValue("status", "cancelled");
+	}
+
+	@Test
+	void observationStoppedByCompleteEmpty() {
+		configuration = new MicrometerObservationListenerConfiguration(
+			"emptyFlux",
+			KeyValues.of("forcedType", "Flux"),
+			registry,
+			false);
+
+		MicrometerObservationListener<Integer> listener = new MicrometerObservationListener<>(subscriberContext, configuration);
+
+		listener.doOnSubscription(); // forces observation start
+		listener.doOnComplete(); // stops via completion (empty)
+
+		assertThat(registry)
+			.hasSingleObservationThat()
+			.hasNameEqualTo("emptyFlux.observation.flow")
+			.hasBeenStarted()
+			.hasBeenStopped()
+			.hasLowCardinalityKeyValue("forcedType", "Flux")
+			.doesNotHaveLowCardinalityKeyValueWithKey("exception")
+			.doesNotHaveHighCardinalityKeyValueWithKey("exception")
+			.hasLowCardinalityKeyValue("status", "completedEmpty");
+	}
+
+	@Test
+	void observationStoppedByCompleteWithValues() {
+		configuration = new MicrometerObservationListenerConfiguration(
+			"flux",
+			KeyValues.of("forcedType", "Flux"),
+			registry,
+			false);
+
+		MicrometerObservationListener<Integer> listener = new MicrometerObservationListener<>(subscriberContext, configuration);
+
+		listener.doOnSubscription(); // forces observation start
+		listener.doOnNext(1);
+		listener.doOnComplete(); // stops via completion
+
+		assertThat(registry)
+			.hasSingleObservationThat()
+			.hasNameEqualTo("flux.observation.flow")
+			.hasBeenStarted()
+			.hasBeenStopped()
+			.hasLowCardinalityKeyValue("forcedType", "Flux")
+			.doesNotHaveLowCardinalityKeyValueWithKey("exception")
+			.doesNotHaveHighCardinalityKeyValueWithKey("exception")
+			.hasLowCardinalityKeyValue("status", "completed");
+	}
+
+	@Test
+	void observationMonoStoppedByOnNext() {
+		configuration = new MicrometerObservationListenerConfiguration(
+			"valuedMono",
+			KeyValues.of("forcedType", "Mono"),
+			registry,
+			true);
+
+		final String expectedStatus = "completedOnNext";
+
+		//we use a test-oriented constructor to force the onNext completion case to have a different tag value
+		MicrometerObservationListener<Integer> listener = new MicrometerObservationListener<>(subscriberContext, configuration, expectedStatus);
+
+		listener.doOnSubscription(); // forces observation start
+		listener.doOnNext(1); // emulates onNext, should stop observation
+
+		assertThat(registry)
+			.hasSingleObservationThat()
+			.hasNameEqualTo("valuedMono.observation.flow")
+			.hasBeenStarted()
+			.hasBeenStopped()
+			.hasLowCardinalityKeyValue("forcedType", "Mono")
+			.hasLowCardinalityKeyValue("status", expectedStatus);
+
+		listener.doOnComplete();
+
+		//if the test in doOnComplete was bugged, the status key would be associated with "completed" now
+		assertThat(registry)
+			.hasSingleObservationThat()
+			.as("post-doOnComplete")
+			.hasLowCardinalityKeyValue("status", expectedStatus);
+	}
+
+	@Test
+	void observationEmptyMonoStoppedByOnComplete() {
+		configuration = new MicrometerObservationListenerConfiguration(
+			"emptyMono",
+			KeyValues.of("forcedType", "Mono"),
+			registry,
+			true);
+
+		MicrometerObservationListener<Integer> listener = new MicrometerObservationListener<>(subscriberContext, configuration);
+
+		listener.doOnSubscription(); // forces observation start
+		listener.doOnComplete(); // stops via completion (empty)
+
+		assertThat(registry)
+			.hasSingleObservationThat()
+			.hasNameEqualTo("emptyMono.observation.flow")
+			.hasBeenStarted()
+			.hasBeenStopped()
+			.hasLowCardinalityKeyValue("forcedType", "Mono")
+			.hasLowCardinalityKeyValue("status", "completedEmpty");
+	}
+
+	@Test
+	void observationStoppedByError() {
+		configuration = new MicrometerObservationListenerConfiguration(
+			"errorFlux",
+			KeyValues.of("forcedType", "Flux"),
+			registry,
+			false);
+		IllegalStateException exception = new IllegalStateException("observationStoppedByError");
+
+		MicrometerObservationListener<Integer> listener = new MicrometerObservationListener<>(subscriberContext, configuration);
+
+		listener.doOnSubscription(); // forces observation start
+		listener.doOnError(exception); // stops via onError
+
+		assertThat(registry)
+			.hasSingleObservationThat()
+			.hasNameEqualTo("errorFlux.observation.flow")
+			.hasBeenStarted()
+			.hasBeenStopped()
+			//TODO integrated assertion to assert the error content?
+			.satisfies(ctx -> assertThat(ctx.getError()).as("Observation#error()").hasValue(exception))
+			.hasLowCardinalityKeyValue("forcedType", "Flux")
+			//TODO better way to assert the keyspace is limited to a list?
+			.doesNotHaveLowCardinalityKeyValueWithKey("exception")
+			.doesNotHaveHighCardinalityKeyValueWithKey("exception")
+			.hasLowCardinalityKeyValue("status", "error");
+	}
+}

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerTest.java
@@ -175,8 +175,7 @@ class MicrometerObservationListenerTest {
 			.hasLowCardinalityKeyValue("testTag2", "testTagValue2")
 			.hasLowCardinalityKeyValue("type", "Flux")
 			.hasLowCardinalityKeyValue("status", "completed")
-			.doesNotHaveHighCardinalityKeyValueWithKey(MicrometerMeterListener.TAG_KEY_EXCEPTION)
-			.doesNotHaveLowCardinalityKeyValueWithKey(MicrometerMeterListener.TAG_KEY_EXCEPTION);
+			.hasKeyValuesCount(4);
 	}
 
 	@Test
@@ -201,8 +200,7 @@ class MicrometerObservationListenerTest {
 			.hasLowCardinalityKeyValue("testTag2", "testTagValue2")
 			.hasLowCardinalityKeyValue("type", "Mono")
 			.hasLowCardinalityKeyValue("status", "completed")
-			.doesNotHaveHighCardinalityKeyValueWithKey(MicrometerMeterListener.TAG_KEY_EXCEPTION)
-			.doesNotHaveLowCardinalityKeyValueWithKey(MicrometerMeterListener.TAG_KEY_EXCEPTION);
+			.hasKeyValuesCount(4);
 	}
 
 	@Test
@@ -224,9 +222,9 @@ class MicrometerObservationListenerTest {
 			.hasBeenStarted()
 			.hasBeenStopped()
 			.hasLowCardinalityKeyValue("forcedType", "Flux")
-			.doesNotHaveLowCardinalityKeyValueWithKey("exception")
-			.doesNotHaveHighCardinalityKeyValueWithKey("exception")
-			.hasLowCardinalityKeyValue("status", "cancelled");
+			.hasLowCardinalityKeyValue("status", "cancelled")
+			.hasKeyValuesCount(2)
+			.doesNotHaveError();
 	}
 
 	@Test
@@ -248,9 +246,9 @@ class MicrometerObservationListenerTest {
 			.hasBeenStarted()
 			.hasBeenStopped()
 			.hasLowCardinalityKeyValue("forcedType", "Flux")
-			.doesNotHaveLowCardinalityKeyValueWithKey("exception")
-			.doesNotHaveHighCardinalityKeyValueWithKey("exception")
-			.hasLowCardinalityKeyValue("status", "completedEmpty");
+			.hasLowCardinalityKeyValue("status", "completedEmpty")
+			.hasKeyValuesCount(2)
+			.doesNotHaveError();
 	}
 
 	@Test
@@ -273,9 +271,9 @@ class MicrometerObservationListenerTest {
 			.hasBeenStarted()
 			.hasBeenStopped()
 			.hasLowCardinalityKeyValue("forcedType", "Flux")
-			.doesNotHaveLowCardinalityKeyValueWithKey("exception")
-			.doesNotHaveHighCardinalityKeyValueWithKey("exception")
-			.hasLowCardinalityKeyValue("status", "completed");
+			.hasLowCardinalityKeyValue("status", "completed")
+			.hasKeyValuesCount(2)
+			.doesNotHaveError();
 	}
 
 	@Test
@@ -300,7 +298,8 @@ class MicrometerObservationListenerTest {
 			.hasBeenStarted()
 			.hasBeenStopped()
 			.hasLowCardinalityKeyValue("forcedType", "Mono")
-			.hasLowCardinalityKeyValue("status", expectedStatus);
+			.hasLowCardinalityKeyValue("status", expectedStatus)
+			.doesNotHaveError();
 
 		listener.doOnComplete();
 
@@ -330,7 +329,8 @@ class MicrometerObservationListenerTest {
 			.hasBeenStarted()
 			.hasBeenStopped()
 			.hasLowCardinalityKeyValue("forcedType", "Mono")
-			.hasLowCardinalityKeyValue("status", "completedEmpty");
+			.hasLowCardinalityKeyValue("status", "completedEmpty")
+			.doesNotHaveError();
 	}
 
 	@Test
@@ -352,12 +352,9 @@ class MicrometerObservationListenerTest {
 			.hasNameEqualTo("errorFlux.observation.flow")
 			.hasBeenStarted()
 			.hasBeenStopped()
-			//TODO integrated assertion to assert the error content?
-			.satisfies(ctx -> assertThat(ctx.getError()).as("Observation#error()").hasValue(exception))
+			.hasOnlyKeys("forcedType", "status")
 			.hasLowCardinalityKeyValue("forcedType", "Flux")
-			//TODO better way to assert the keyspace is limited to a list?
-			.doesNotHaveLowCardinalityKeyValueWithKey("exception")
-			.doesNotHaveHighCardinalityKeyValueWithKey("exception")
-			.hasLowCardinalityKeyValue("status", "error");
+			.hasLowCardinalityKeyValue("status", "error")
+			.hasError(exception);
 	}
 }

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerTest.java
@@ -64,7 +64,7 @@ class MicrometerTest {
 	void metricsUsesCommonRegistry() {
 		SimpleMeterRegistry customCommonRegistry = new SimpleMeterRegistry();
 		Micrometer.useRegistry(customCommonRegistry);
-		MicrometerListenerFactory<?> factory = (MicrometerListenerFactory<?>) Micrometer.metrics();
+		MicrometerMeterListenerFactory<?> factory = (MicrometerMeterListenerFactory<?>) Micrometer.metrics();
 
 		assertThat(factory.useClock()).as("clock").isSameAs(Clock.SYSTEM);
 		assertThat(factory.useRegistry()).as("registry").isSameAs(customCommonRegistry);
@@ -87,7 +87,7 @@ class MicrometerTest {
 			}
 		};
 
-		MicrometerListenerFactory<?> factory = (MicrometerListenerFactory<?>) Micrometer.metrics(customLocalRegistry, customLocalClock);
+		MicrometerMeterListenerFactory<?> factory = (MicrometerMeterListenerFactory<?>) Micrometer.metrics(customLocalRegistry, customLocalClock);
 
 		assertThat(factory.useClock()).as("clock").isSameAs(customLocalClock).isNotSameAs(Clock.SYSTEM);
 		assertThat(factory.useRegistry()).as("registry").isSameAs(customLocalRegistry).isNotSameAs(customCommonRegistry);

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerTest.java
@@ -35,35 +35,35 @@ class MicrometerTest {
 
 	@BeforeEach
 	void init() {
-		defaultRegistry = Micrometer.getMeterRegistry();
+		defaultRegistry = Micrometer.getRegistry();
 	}
 
 	@AfterEach
 	void restore() {
-		Micrometer.useMeterRegistry(defaultRegistry);
+		Micrometer.useRegistry(defaultRegistry);
 	}
 
 	@Test
 	void defaultRegistryCanBeChanged() {
-		MeterRegistry registry = Micrometer.getMeterRegistry();
+		MeterRegistry registry = Micrometer.getRegistry();
 		try {
 			assertThat(registry).as("default common registry").isEqualTo(Metrics.globalRegistry);
 
 			MeterRegistry replacement = new SimpleMeterRegistry();
-			MeterRegistry old = Micrometer.useMeterRegistry(replacement);
+			MeterRegistry old = Micrometer.useRegistry(replacement);
 
 			assertThat(old).as("useRegistry return value").isSameAs(registry);
-			assertThat(Micrometer.getMeterRegistry()).as("getRegistry post useRegistry").isSameAs(replacement);
+			assertThat(Micrometer.getRegistry()).as("getRegistry post useRegistry").isSameAs(replacement);
 		}
 		finally {
-			Micrometer.useMeterRegistry(registry);
+			Micrometer.useRegistry(registry);
 		}
 	}
 
 	@Test
 	void metricsUsesCommonRegistry() {
 		SimpleMeterRegistry customCommonRegistry = new SimpleMeterRegistry();
-		Micrometer.useMeterRegistry(customCommonRegistry);
+		Micrometer.useRegistry(customCommonRegistry);
 		MicrometerMeterListenerFactory<?> factory = (MicrometerMeterListenerFactory<?>) Micrometer.metrics();
 
 		assertThat(factory.useClock()).as("clock").isSameAs(Clock.SYSTEM);
@@ -73,7 +73,7 @@ class MicrometerTest {
 	@Test
 	void metricsUsesSpecifiedClockAndRegistry() {
 		SimpleMeterRegistry customCommonRegistry = new SimpleMeterRegistry();
-		Micrometer.useMeterRegistry(customCommonRegistry);
+		Micrometer.useRegistry(customCommonRegistry);
 		SimpleMeterRegistry customLocalRegistry = new SimpleMeterRegistry();
 		Clock customLocalClock = new Clock() {
 			@Override

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerTest.java
@@ -35,35 +35,35 @@ class MicrometerTest {
 
 	@BeforeEach
 	void init() {
-		defaultRegistry = Micrometer.getRegistry();
+		defaultRegistry = Micrometer.getMeterRegistry();
 	}
 
 	@AfterEach
 	void restore() {
-		Micrometer.useRegistry(defaultRegistry);
+		Micrometer.useMeterRegistry(defaultRegistry);
 	}
 
 	@Test
 	void defaultRegistryCanBeChanged() {
-		MeterRegistry registry = Micrometer.getRegistry();
+		MeterRegistry registry = Micrometer.getMeterRegistry();
 		try {
 			assertThat(registry).as("default common registry").isEqualTo(Metrics.globalRegistry);
 
 			MeterRegistry replacement = new SimpleMeterRegistry();
-			MeterRegistry old = Micrometer.useRegistry(replacement);
+			MeterRegistry old = Micrometer.useMeterRegistry(replacement);
 
 			assertThat(old).as("useRegistry return value").isSameAs(registry);
-			assertThat(Micrometer.getRegistry()).as("getRegistry post useRegistry").isSameAs(replacement);
+			assertThat(Micrometer.getMeterRegistry()).as("getRegistry post useRegistry").isSameAs(replacement);
 		}
 		finally {
-			Micrometer.useRegistry(registry);
+			Micrometer.useMeterRegistry(registry);
 		}
 	}
 
 	@Test
 	void metricsUsesCommonRegistry() {
 		SimpleMeterRegistry customCommonRegistry = new SimpleMeterRegistry();
-		Micrometer.useRegistry(customCommonRegistry);
+		Micrometer.useMeterRegistry(customCommonRegistry);
 		MicrometerMeterListenerFactory<?> factory = (MicrometerMeterListenerFactory<?>) Micrometer.metrics();
 
 		assertThat(factory.useClock()).as("clock").isSameAs(Clock.SYSTEM);
@@ -73,7 +73,7 @@ class MicrometerTest {
 	@Test
 	void metricsUsesSpecifiedClockAndRegistry() {
 		SimpleMeterRegistry customCommonRegistry = new SimpleMeterRegistry();
-		Micrometer.useRegistry(customCommonRegistry);
+		Micrometer.useMeterRegistry(customCommonRegistry);
 		SimpleMeterRegistry customLocalRegistry = new SimpleMeterRegistry();
 		Clock customLocalClock = new Clock() {
 			@Override

--- a/reactor-core/src/main/java/reactor/core/observability/SignalListener.java
+++ b/reactor-core/src/main/java/reactor/core/observability/SignalListener.java
@@ -200,4 +200,18 @@ public interface SignalListener<T> {
 	 * @param listenerError the exception thrown from a {@link SignalListener} handler method
 	 */
 	void handleListenerError(Throwable listenerError);
+
+	/**
+	 * In some cases, the tap operation should alter the {@link Context} exposed by the operator in order to store additional
+	 * data. This method is invoked when the tap subscriber is created, which is between the invocation of {@link #doFirst()}
+	 * and the invocation of {@link #doOnSubscription()}. Generally, only addition of new keys should be performed on
+	 * the downstream original {@link Context}. Extra care should be exercised if any pre-existing key is to be removed
+	 * or replaced.
+	 *
+	 * @param originalContext the original downstream operator's {@link Context}
+	 * @return the {@link Context} to use and expose upstream
+	 */
+	default Context addToContext(Context originalContext) {
+		return originalContext;
+	}
 }


### PR DESCRIPTION
This PR modifies the new reactor-core-micrometer module to add support for
Observation in addition to `Micrometer#metrics()`.

`Micrometer#observation(ObservationRegistry)` allows to set up a `tap` with
two observations: subscription-to-completion and onNext events. These are
simplifications of the equivalent `MicrometerMeterListener` Timers.

## :warning: `warn/deprecation` Compared to `M3`

The `Micrometer#observation` enforces to pass in an `ObservationRegistry` since there is no global default.
But for `metrics()` there is still a `MeterRegistry` setting exposed, with a too generic name.
We're deprecating this global field in favor of using explicit passing of `MeterRegistry` to `metrics()` since we're now in a context where that library is readily available to the user. `Micrometer#metrics()` is also deprecated.