### PR TITLE
Reintroduction of Processors as deprecated

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/DelegateProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DelegateProcessor.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Scannable;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+
+/**
+ * @author Stephane Maldini
+ */
+@Deprecated
+final class DelegateProcessor<IN, OUT> extends FluxProcessor<IN, OUT> {
+
+	final Publisher<OUT> downstream;
+	final Subscriber<IN> upstream;
+
+	DelegateProcessor(Publisher<OUT> downstream,
+			Subscriber<IN> upstream) {
+		this.downstream = Objects.requireNonNull(downstream, "Downstream must not be null");
+		this.upstream = Objects.requireNonNull(upstream, "Upstream must not be null");
+	}
+
+	@Override
+	public Context currentContext() {
+		if(upstream instanceof CoreSubscriber){
+			return ((CoreSubscriber<?>)upstream).currentContext();
+		}
+		return Context.empty();
+	}
+
+	@Override
+	public void onComplete() {
+		upstream.onComplete();
+	}
+
+	@Override
+	public void onError(Throwable t) {
+		upstream.onError(t);
+	}
+
+	@Override
+	public void onNext(IN in) {
+		upstream.onNext(in);
+	}
+
+	@Override
+	public void onSubscribe(Subscription s) {
+		upstream.onSubscribe(s);
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super OUT> actual) {
+		Objects.requireNonNull(actual, "subscribe");
+		downstream.subscribe(actual);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean isSerialized() {
+		return upstream instanceof SerializedSubscriber ||
+				(upstream instanceof FluxProcessor &&
+						((FluxProcessor<?, ?>)upstream).isSerialized());
+	}
+
+	@Override
+	public Stream<? extends Scannable> inners() {
+		//noinspection ConstantConditions
+		return Scannable.from(upstream)
+		                .inners();
+	}
+
+	@Override
+	public int getBufferSize() {
+		//noinspection ConstantConditions
+		return Scannable.from(upstream)
+		                .scanOrDefault(Attr.CAPACITY, super.getBufferSize());
+	}
+
+	@Override
+	@Nullable
+	public Throwable getError() {
+		//noinspection ConstantConditions
+		return Scannable.from(upstream)
+		                .scanOrDefault(Attr.ERROR, super.getError());
+	}
+
+	@Override
+	public boolean isTerminated() {
+		//noinspection ConstantConditions
+		return Scannable.from(upstream)
+		                .scanOrDefault(Attr.TERMINATED, super.isTerminated());
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PARENT) {
+			return downstream;
+		}
+		//noinspection ConstantConditions
+		return Scannable.from(upstream)
+		                .scanUnsafe(key);
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectInnerContainer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectInnerContainer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+/**
+ * A package-private interface allowing to mutualize logic between {@link DirectProcessor}
+ * and {@link SinkManyBestEffort}.
+ *
+ * @author Simon Baslé
+ * @deprecated remove again once DirectProcessor is removed
+ */
+@Deprecated
+interface DirectInnerContainer<T> {
+
+	/**
+	 * Add a new {@link SinkManyBestEffort.DirectInner} to this publisher.
+	 *
+	 * @param s the new {@link SinkManyBestEffort.DirectInner} to add
+	 *
+	 * @return {@code true} if the inner could be added, {@code false} if the publisher cannot accept new subscribers
+	 */
+	boolean add(SinkManyBestEffort.DirectInner<T> s);
+
+	/**
+	 * Remove an {@link SinkManyBestEffort.DirectInner} from this publisher. Does nothing if the inner is not currently managed
+	 * by the publisher.
+	 *
+	 * @param s the  {@link SinkManyBestEffort.DirectInner} to remove
+	 */
+	void remove(SinkManyBestEffort.DirectInner<T> s);
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/DirectProcessor.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.stream.Stream;
+
+import org.reactivestreams.Subscription;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
+import reactor.core.Scannable;
+import reactor.core.publisher.SinkManyBestEffort.DirectInner;
+import reactor.core.publisher.Sinks.EmitResult;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+
+/**
+ * Dispatches onNext, onError and onComplete signals to zero-to-many Subscribers.
+ * Please note, that along with multiple consumers, current implementation of
+ * DirectProcessor supports multiple producers. However, all producers must produce
+ * messages on the same Thread, otherwise
+ * <a href="https://www.reactive-streams.org/">Reactive Streams Spec</a> contract is
+ * violated.
+ * <p>
+ *      <img width="640" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.2.0.M2/src/docs/marble/directprocessornormal.png" alt="">
+ * </p>
+ *
+ * </br>
+ * </br>
+ *
+ * <p>
+ *     <b>Note: </b> DirectProcessor does not coordinate backpressure between its
+ *     Subscribers and the upstream, but consumes its upstream in an
+ *     unbounded manner.
+ *     In the case where a downstream Subscriber is not ready to receive items (hasn't
+ *     requested yet or enough), it will be terminated with an
+ *     <i>{@link IllegalStateException}</i>.
+ *     Hence in terms of interaction model, DirectProcessor only supports PUSH from the
+ *     source through the processor to the Subscribers.
+ *
+ *     <p>
+ *        <img width="640" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.2.0.M2/src/docs/marble/directprocessorerror.png" alt="">
+ *     </p>
+ * </p>
+ *
+ * </br>
+ * </br>
+ *
+ * <p>
+ *      <b>Note: </b> If there are no Subscribers, upstream items are dropped and only
+ *      the terminal events are retained. A terminated DirectProcessor will emit the
+ *      terminal signal to late subscribers.
+ *
+ *      <p>
+ *         <img width="640" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.2.0.M2/src/docs/marble/directprocessorterminal.png" alt="">
+ *      </p>
+ * </p>
+ *
+ * </br>
+ * </br>
+ *
+ * <p>
+ *      <b>Note: </b> The implementation ignores Subscriptions set via onSubscribe.
+ * </p>
+ *
+ * @param <T> the input and output value type
+ * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks}. Closest sink
+ * is {@link Sinks.MulticastSpec#directBestEffort() Sinks.many().multicast().directBestEffort()},
+ * except it doesn't terminate overflowing downstreams.
+ */
+@Deprecated
+public final class DirectProcessor<T> extends FluxProcessor<T, T>
+	implements DirectInnerContainer<T> {
+
+	/**
+	 * Create a new {@link DirectProcessor}
+	 *
+	 * @param <E> Type of processed signals
+	 *
+	 * @return a fresh processor
+	 * @deprecated To be removed in 3.5. Closest sink is {@link Sinks.MulticastSpec#directBestEffort() Sinks.many().multicast().directBestEffort()},
+	 * except it doesn't terminate overflowing downstreams.
+	 */
+	@Deprecated
+	public static <E> DirectProcessor<E> create() {
+		return new DirectProcessor<>();
+	}
+
+	@SuppressWarnings("unchecked")
+	private volatile     DirectInner<T>[]                                           subscribers = SinkManyBestEffort.EMPTY;
+	@SuppressWarnings("rawtypes")
+	private static final AtomicReferenceFieldUpdater<DirectProcessor, DirectInner[]>SUBSCRIBERS =
+		AtomicReferenceFieldUpdater.newUpdater(DirectProcessor.class, DirectInner[].class, "subscribers");
+
+	Throwable error;
+
+	DirectProcessor() {
+	}
+
+	@Override
+	public int getPrefetch() {
+		return Integer.MAX_VALUE;
+	}
+
+	@Override
+	public Context currentContext() {
+		return Operators.multiSubscribersContext(subscribers);
+	}
+
+	@Override
+	public void onSubscribe(Subscription s) {
+		Objects.requireNonNull(s, "s");
+		if (subscribers != SinkManyBestEffort.TERMINATED) {
+			s.request(Long.MAX_VALUE);
+		}
+		else {
+			s.cancel();
+		}
+	}
+
+	@Override
+	public void onComplete() {
+		//no particular error condition handling for onComplete
+		@SuppressWarnings("unused") Sinks.EmitResult emitResult = tryEmitComplete();
+	}
+
+	private void emitComplete() {
+		//no particular error condition handling for onComplete
+		@SuppressWarnings("unused") EmitResult emitResult = tryEmitComplete();
+	}
+
+	private EmitResult tryEmitComplete() {
+		@SuppressWarnings("unchecked")
+		DirectInner<T>[] inners = SUBSCRIBERS.getAndSet(this, SinkManyBestEffort.TERMINATED);
+
+		if (inners == SinkManyBestEffort.TERMINATED) {
+			return EmitResult.FAIL_TERMINATED;
+		}
+
+		for (DirectInner<?> s : inners) {
+			s.emitComplete();
+		}
+		return EmitResult.OK;
+	}
+
+	@Override
+	public void onError(Throwable throwable) {
+		emitError(throwable);
+	}
+
+	private void emitError(Throwable error) {
+		Sinks.EmitResult result = tryEmitError(error);
+		if (result == EmitResult.FAIL_TERMINATED) {
+			Operators.onErrorDroppedMulticast(error, subscribers);
+		}
+	}
+
+	private Sinks.EmitResult tryEmitError(Throwable t) {
+		Objects.requireNonNull(t, "t");
+
+		@SuppressWarnings("unchecked")
+		DirectInner<T>[] inners = SUBSCRIBERS.getAndSet(this, SinkManyBestEffort.TERMINATED);
+
+		if (inners == SinkManyBestEffort.TERMINATED) {
+			return EmitResult.FAIL_TERMINATED;
+		}
+
+		error = t;
+		for (DirectInner<?> s : inners) {
+			s.emitError(t);
+		}
+		return Sinks.EmitResult.OK;
+	}
+
+	private void emitNext(T value) {
+		switch (tryEmitNext(value)) {
+			case FAIL_ZERO_SUBSCRIBER:
+				//we want to "discard" without rendering the sink terminated.
+				// effectively NO-OP cause there's no subscriber, so no context :(
+				break;
+			case FAIL_OVERFLOW:
+				Operators.onDiscard(value, currentContext());
+				//the emitError will onErrorDropped if already terminated
+				emitError(Exceptions.failWithOverflow("Backpressure overflow during Sinks.Many#emitNext"));
+				break;
+			case FAIL_CANCELLED:
+				Operators.onDiscard(value, currentContext());
+				break;
+			case FAIL_TERMINATED:
+				Operators.onNextDroppedMulticast(value, subscribers);
+				break;
+			case OK:
+				break;
+			default:
+				throw new IllegalStateException("unexpected return code");
+		}
+	}
+
+	@Override
+	public void onNext(T t) {
+		emitNext(t);
+	}
+
+	private EmitResult tryEmitNext(T t) {
+		Objects.requireNonNull(t, "t");
+
+		DirectInner<T>[] inners = subscribers;
+
+		if (inners == SinkManyBestEffort.TERMINATED) {
+			return EmitResult.FAIL_TERMINATED;
+		}
+		if (inners == SinkManyBestEffort.EMPTY) {
+			return Sinks.EmitResult.FAIL_ZERO_SUBSCRIBER;
+		}
+
+		for (DirectInner<T> s : inners) {
+			s.directEmitNext(t);
+		}
+		return Sinks.EmitResult.OK;
+	}
+
+	@Override
+	protected boolean isIdentityProcessor() {
+		return true;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super T> actual) {
+		Objects.requireNonNull(actual, "subscribe");
+
+		DirectInner<T> p = new DirectInner<>(actual, this);
+		actual.onSubscribe(p);
+
+		if (add(p)) {
+			if (p.isCancelled()) {
+				remove(p);
+			}
+		}
+		else {
+			Throwable e = error;
+			if (e != null) {
+				actual.onError(e);
+			}
+			else {
+				actual.onComplete();
+			}
+		}
+	}
+
+	@Override
+	public Stream<? extends Scannable> inners() {
+		return Stream.of(subscribers);
+	}
+
+	@Override
+	public boolean isTerminated() {
+		return SinkManyBestEffort.TERMINATED == subscribers;
+	}
+
+	@Override
+	public long downstreamCount() {
+		return subscribers.length;
+	}
+
+	@Override
+	public boolean add(DirectInner<T> s) {
+		DirectInner<T>[] a = subscribers;
+		if (a == SinkManyBestEffort.TERMINATED) {
+			return false;
+		}
+
+		synchronized (this) {
+			a = subscribers;
+			if (a == SinkManyBestEffort.TERMINATED) {
+				return false;
+			}
+			int len = a.length;
+
+			@SuppressWarnings("unchecked") DirectInner<T>[] b = new DirectInner[len + 1];
+			System.arraycopy(a, 0, b, 0, len);
+			b[len] = s;
+
+			subscribers = b;
+
+			return true;
+		}
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public void remove(DirectInner<T> s) {
+		DirectInner<T>[] a = subscribers;
+		if (a == SinkManyBestEffort.TERMINATED || a == SinkManyBestEffort.EMPTY) {
+			return;
+		}
+
+		synchronized (this) {
+			a = subscribers;
+			if (a == SinkManyBestEffort.TERMINATED || a == SinkManyBestEffort.EMPTY) {
+				return;
+			}
+			int len = a.length;
+
+			int j = -1;
+
+			for (int i = 0; i < len; i++) {
+				if (a[i] == s) {
+					j = i;
+					break;
+				}
+			}
+			if (j < 0) {
+				return;
+			}
+			if (len == 1) {
+				subscribers = SinkManyBestEffort.EMPTY;
+				return;
+			}
+
+			DirectInner<T>[] b = new DirectInner[len - 1];
+			System.arraycopy(a, 0, b, 0, j);
+			System.arraycopy(a, j + 1, b, j, len - j - 1);
+
+			subscribers = b;
+		}
+	}
+
+	@Override
+	public boolean hasDownstreams() {
+		DirectInner<T>[] s = subscribers;
+		return s != SinkManyBestEffort.EMPTY && s != SinkManyBestEffort.TERMINATED;
+	}
+
+	@Override
+	@Nullable
+	public Throwable getError() {
+		if (subscribers == SinkManyBestEffort.TERMINATED) {
+			return error;
+		}
+		return null;
+	}
+
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/EmitterProcessor.java
@@ -1,0 +1,723 @@
+/*
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.stream.Stream;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+import reactor.core.Exceptions;
+import reactor.core.Fuseable;
+import reactor.core.Scannable;
+import reactor.core.publisher.Sinks.EmitResult;
+import reactor.util.annotation.Nullable;
+import reactor.util.concurrent.Queues;
+import reactor.util.context.Context;
+
+import static reactor.core.publisher.FluxPublish.PublishSubscriber.TERMINATED;
+
+/**
+ * An implementation of a message-passing Processor implementing
+ * publish-subscribe with synchronous (thread-stealing and happen-before interactions)
+ * drain loops.
+ * <p>
+ * The default {@link #create} factories will only produce the new elements observed in
+ * the parent sequence after a given {@link Subscriber} is subscribed.
+ * <p>
+ * <p>
+ * <img width="640" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/emitter.png"
+ * alt="">
+ * <p>
+ *
+ * @param <T> the input and output value type
+ *
+ * @author Stephane Maldini
+ * @deprecated To be removed in 3.5. Prefer clear cut usage of {@link Sinks} through
+ * variations of {@link Sinks.MulticastSpec#onBackpressureBuffer() Sinks.many().multicast().onBackpressureBuffer()}.
+ * If you really need the subscribe-to-upstream functionality of a {@link org.reactivestreams.Processor}, switch
+ * to {@link Sinks.ManyWithUpstream} with {@link Sinks#unsafe()} variants of {@link Sinks.RootSpec#manyWithUpstream() Sinks.unsafe().manyWithUpstream()}.
+ * <p/>This processor was blocking in {@link EmitterProcessor#onNext(Object)}. This behaviour can be implemented with the {@link Sinks} API by calling
+ * {@link Sinks.Many#tryEmitNext(Object)} and retrying, e.g.:
+ * <pre>{@code while (sink.tryEmitNext(v).hasFailed()) {
+ *     LockSupport.parkNanos(10);
+ * }
+ * }</pre>
+ */
+@Deprecated
+public final class EmitterProcessor<T> extends FluxProcessor<T, T> implements InternalManySink<T>,
+	Sinks.ManyWithUpstream<T> {
+
+	@SuppressWarnings("rawtypes")
+	static final FluxPublish.PubSubInner[] EMPTY = new FluxPublish.PublishInner[0];
+
+	/**
+	 * Create a new {@link EmitterProcessor} using {@link Queues#SMALL_BUFFER_SIZE}
+	 * backlog size and auto-cancel.
+	 *
+	 * @param <E> Type of processed signals
+	 *
+	 * @return a fresh processor
+	 * @deprecated use {@link Sinks.MulticastSpec#onBackpressureBuffer() Sinks.many().multicast().onBackpressureBuffer()}
+	 * (or the unsafe variant if you're sure about external synchronization). To be removed in 3.5.
+	 */
+	@Deprecated
+	public static <E> EmitterProcessor<E> create() {
+		return create(Queues.SMALL_BUFFER_SIZE, true);
+	}
+
+	/**
+	 * Create a new {@link EmitterProcessor} using {@link Queues#SMALL_BUFFER_SIZE}
+	 * backlog size and the provided auto-cancel.
+	 *
+	 * @param <E> Type of processed signals
+	 * @param autoCancel automatically cancel
+	 *
+	 * @return a fresh processor
+	 * @deprecated use {@link Sinks.MulticastSpec#onBackpressureBuffer(int, boolean) Sinks.many().multicast().onBackpressureBuffer(bufferSize, boolean)}
+	 * using the old default of {@link Queues#SMALL_BUFFER_SIZE} for the {@code bufferSize}
+	 * (or the unsafe variant if you're sure about external synchronization). To be removed in 3.5.
+	 */
+	@Deprecated
+	public static <E> EmitterProcessor<E> create(boolean autoCancel) {
+		return create(Queues.SMALL_BUFFER_SIZE, autoCancel);
+	}
+
+	/**
+	 * Create a new {@link EmitterProcessor} using the provided backlog size, with auto-cancel.
+	 *
+	 * @param <E> Type of processed signals
+	 * @param bufferSize the internal buffer size to hold signals
+	 *
+	 * @return a fresh processor
+	 * @deprecated use {@link Sinks.MulticastSpec#onBackpressureBuffer(int) Sinks.many().multicast().onBackpressureBuffer(bufferSize)}
+	 * (or the unsafe variant if you're sure about external synchronization). To be removed in 3.5.
+	 */
+	@Deprecated
+	public static <E> EmitterProcessor<E> create(int bufferSize) {
+		return create(bufferSize, true);
+	}
+
+	/**
+	 * Create a new {@link EmitterProcessor} using the provided backlog size and auto-cancellation.
+	 *
+	 * @param <E> Type of processed signals
+	 * @param bufferSize the internal buffer size to hold signals
+	 * @param autoCancel automatically cancel
+	 *
+	 * @return a fresh processor
+	 * @deprecated use {@link Sinks.MulticastSpec#onBackpressureBuffer(int, boolean) Sinks.many().multicast().onBackpressureBuffer(bufferSize, autoCancel)}
+	 * (or the unsafe variant if you're sure about external synchronization). To be removed in 3.5.
+	 */
+	@Deprecated
+	public static <E> EmitterProcessor<E> create(int bufferSize, boolean autoCancel) {
+		return new EmitterProcessor<>(autoCancel, bufferSize);
+	}
+
+	final int prefetch;
+
+	final boolean autoCancel;
+
+	volatile Subscription s;
+	@SuppressWarnings("rawtypes")
+	static final AtomicReferenceFieldUpdater<EmitterProcessor, Subscription> S =
+			AtomicReferenceFieldUpdater.newUpdater(EmitterProcessor.class,
+					Subscription.class,
+					"s");
+
+	volatile FluxPublish.PubSubInner<T>[] subscribers;
+
+	@SuppressWarnings("rawtypes")
+	static final AtomicReferenceFieldUpdater<EmitterProcessor, FluxPublish.PubSubInner[]>
+			SUBSCRIBERS = AtomicReferenceFieldUpdater.newUpdater(EmitterProcessor.class,
+			FluxPublish.PubSubInner[].class,
+			"subscribers");
+
+	volatile EmitterDisposable upstreamDisposable;
+	@SuppressWarnings("rawtypes")
+	static final AtomicReferenceFieldUpdater<EmitterProcessor, EmitterDisposable> UPSTREAM_DISPOSABLE =
+			AtomicReferenceFieldUpdater.newUpdater(EmitterProcessor.class, EmitterDisposable.class, "upstreamDisposable");
+
+
+	@SuppressWarnings("unused")
+	volatile int wip;
+
+	@SuppressWarnings("rawtypes")
+	static final AtomicIntegerFieldUpdater<EmitterProcessor> WIP =
+			AtomicIntegerFieldUpdater.newUpdater(EmitterProcessor.class, "wip");
+
+	volatile Queue<T> queue;
+
+	int sourceMode;
+
+	volatile boolean done;
+
+	volatile Throwable error;
+
+	@SuppressWarnings("rawtypes")
+	static final AtomicReferenceFieldUpdater<EmitterProcessor, Throwable> ERROR =
+			AtomicReferenceFieldUpdater.newUpdater(EmitterProcessor.class,
+					Throwable.class,
+					"error");
+
+	EmitterProcessor(boolean autoCancel, int prefetch) {
+		if (prefetch < 1) {
+			throw new IllegalArgumentException("bufferSize must be strictly positive, " + "was: " + prefetch);
+		}
+		this.autoCancel = autoCancel;
+		this.prefetch = prefetch;
+		//doesn't use INIT/CANCELLED distinction, contrary to FluxPublish)
+		//see remove()
+		SUBSCRIBERS.lazySet(this, EMPTY);
+	}
+
+	@Override
+	public Stream<? extends Scannable> inners() {
+		return Stream.of(subscribers);
+	}
+
+	@Override
+	public Context currentContext() {
+		return Operators.multiSubscribersContext(subscribers);
+	}
+
+
+	private boolean isDetached() {
+		return s == Operators.cancelledSubscription() && done && error instanceof CancellationException;
+	}
+
+	private boolean detach() {
+		if (Operators.terminate(S, this)) {
+			done = true;
+			CancellationException detachException = new CancellationException("the ManyWithUpstream sink had a Subscription to an upstream which has been manually cancelled");
+			if (ERROR.compareAndSet(EmitterProcessor.this, null, detachException)) {
+				Queue<T> q = queue;
+				if (q != null) {
+					q.clear();
+				}
+				for (FluxPublish.PubSubInner<T> inner : terminate()) {
+					inner.actual.onError(detachException);
+				}
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public Disposable subscribeTo(Publisher<? extends T> upstream) {
+		EmitterDisposable ed = new EmitterDisposable(this);
+		if (UPSTREAM_DISPOSABLE.compareAndSet(this, null, ed)) {
+			upstream.subscribe(this);
+			return ed;
+		}
+		throw new IllegalStateException("A Sinks.ManyWithUpstream must be subscribed to a source only once");
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super T> actual) {
+		Objects.requireNonNull(actual, "subscribe");
+		EmitterInner<T> inner = new EmitterInner<>(actual, this);
+		actual.onSubscribe(inner);
+
+		if (inner.isCancelled()) {
+			return;
+		}
+
+		if (add(inner)) {
+			if (inner.isCancelled()) {
+				remove(inner);
+			}
+			drain();
+		}
+		else {
+			Throwable e = error;
+			if (e != null) {
+				inner.actual.onError(e);
+			}
+			else {
+				inner.actual.onComplete();
+			}
+		}
+	}
+
+	@Override
+	public void onComplete() {
+		//no particular error condition handling for onComplete
+		@SuppressWarnings("unused") EmitResult emitResult = tryEmitComplete();
+	}
+
+	@Override
+	public EmitResult tryEmitComplete() {
+		if (done) {
+			return EmitResult.FAIL_TERMINATED;
+		}
+		done = true;
+		drain();
+		return EmitResult.OK;
+	}
+
+	@Override
+	public void onError(Throwable throwable) {
+		emitError(throwable, Sinks.EmitFailureHandler.FAIL_FAST);
+	}
+
+	@Override
+	public EmitResult tryEmitError(Throwable t) {
+		Objects.requireNonNull(t, "onError");
+		if (done) {
+			return EmitResult.FAIL_TERMINATED;
+		}
+		if (Exceptions.addThrowable(ERROR, this, t)) {
+			done = true;
+			drain();
+			return EmitResult.OK;
+		}
+		else {
+			return EmitResult.FAIL_TERMINATED;
+		}
+	}
+
+	@Override
+	public void onNext(T t) {
+		if (sourceMode == Fuseable.ASYNC) {
+			drain();
+			return;
+		}
+		emitNext(t, Sinks.EmitFailureHandler.FAIL_FAST);
+	}
+
+	@Override
+	public EmitResult tryEmitNext(T t) {
+		if (done) {
+			return EmitResult.FAIL_TERMINATED;
+		}
+
+		Objects.requireNonNull(t, "onNext");
+
+		Queue<T> q = queue;
+
+		if (q == null) {
+			if (Operators.setOnce(S, this, Operators.emptySubscription())) {
+				q = Queues.<T>get(prefetch).get();
+				queue = q;
+			}
+			else {
+				for (; ; ) {
+					if (isCancelled()) {
+						return EmitResult.FAIL_CANCELLED;
+					}
+					q = queue;
+					if (q != null) {
+						break;
+					}
+				}
+			}
+		}
+
+		if (!q.offer(t)) {
+			return subscribers == EMPTY ? EmitResult.FAIL_ZERO_SUBSCRIBER : EmitResult.FAIL_OVERFLOW;
+		}
+		drain();
+		return EmitResult.OK;
+	}
+
+	@Override
+	public int currentSubscriberCount() {
+		return subscribers.length;
+	}
+
+	@Override
+	public Flux<T> asFlux() {
+		return this;
+	}
+
+	@Override
+	protected boolean isIdentityProcessor() {
+		return true;
+	}
+
+	/**
+	 * Return the number of parked elements in the emitter backlog.
+	 *
+	 * @return the number of parked elements in the emitter backlog.
+	 */
+	public int getPending() {
+		Queue<T> q = queue;
+		return q != null ? q.size() : 0;
+	}
+
+	@Override
+	public boolean isDisposed() {
+		return isTerminated() || isCancelled();
+	}
+
+	@Override
+	public void onSubscribe(final Subscription s) {
+		//since the CoreSubscriber nature isn't exposed to the user, the only path to onSubscribe is
+		//already guarded by UPSTREAM_DISPOSABLE. just in case the publisher misbehaves we still use setOnce
+		if (Operators.setOnce(S, this, s)) {
+			if (s instanceof Fuseable.QueueSubscription) {
+				@SuppressWarnings("unchecked") Fuseable.QueueSubscription<T> f =
+						(Fuseable.QueueSubscription<T>) s;
+
+				int m = f.requestFusion(Fuseable.ANY);
+				if (m == Fuseable.SYNC) {
+					sourceMode = m;
+					queue = f;
+					drain();
+					return;
+				}
+				else if (m == Fuseable.ASYNC) {
+					sourceMode = m;
+					queue = f;
+					s.request(Operators.unboundedOrPrefetch(prefetch));
+					return;
+				}
+			}
+
+			queue = Queues.<T>get(prefetch).get();
+
+			s.request(Operators.unboundedOrPrefetch(prefetch));
+		}
+	}
+
+	@Override
+	@Nullable
+	public Throwable getError() {
+		return error;
+	}
+
+	/**
+	 * @return true if all subscribers have actually been cancelled and the processor auto shut down
+	 */
+	public boolean isCancelled() {
+		return Operators.cancelledSubscription() == s;
+	}
+
+	@Override
+	final public int getBufferSize() {
+		return prefetch;
+	}
+
+	@Override
+	public boolean isTerminated() {
+		return done && getPending() == 0;
+	}
+
+	@Override
+	public int getPrefetch() {
+		return prefetch;
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PARENT) return s;
+		if (key == Attr.BUFFERED) return getPending();
+		if (key == Attr.CANCELLED) return isCancelled();
+		if (key == Attr.PREFETCH) return getPrefetch();
+
+		return super.scanUnsafe(key);
+	}
+
+	final void drain() {
+		if (WIP.getAndIncrement(this) != 0) {
+			return;
+		}
+
+		int missed = 1;
+
+		for (; ; ) {
+
+			boolean d = done;
+
+			Queue<T> q = queue;
+
+			boolean empty = q == null || q.isEmpty();
+
+			if (checkTerminated(d, empty)) {
+				return;
+			}
+
+			FluxPublish.PubSubInner<T>[] a = subscribers;
+
+			if (a != EMPTY && !empty) {
+				long maxRequested = Long.MAX_VALUE;
+
+				int len = a.length;
+				int cancel = 0;
+
+				for (FluxPublish.PubSubInner<T> inner : a) {
+					long r = inner.requested;
+					if (r >= 0L) {
+						maxRequested = Math.min(maxRequested, r);
+					}
+					else { //Long.MIN == PublishInner.CANCEL_REQUEST
+						cancel++;
+					}
+				}
+
+				if (len == cancel) {
+					T v;
+
+					try {
+						v = q.poll();
+					}
+					catch (Throwable ex) {
+						Exceptions.addThrowable(ERROR,
+								this, Operators.onOperatorError(s, ex, currentContext()));
+						d = true;
+						v = null;
+					}
+					if (checkTerminated(d, v == null)) {
+						return;
+					}
+					if (sourceMode != Fuseable.SYNC) {
+						s.request(1);
+					}
+					continue;
+				}
+
+				int e = 0;
+
+				while (e < maxRequested && cancel != Integer.MIN_VALUE) {
+					d = done;
+					T v;
+
+					try {
+						v = q.poll();
+					}
+					catch (Throwable ex) {
+						Exceptions.addThrowable(ERROR,
+								this, Operators.onOperatorError(s, ex, currentContext()));
+						d = true;
+						v = null;
+					}
+
+					empty = v == null;
+
+					if (checkTerminated(d, empty)) {
+						return;
+					}
+
+					if (empty) {
+						//async mode only needs to break but SYNC mode needs to perform terminal cleanup here...
+						if (sourceMode == Fuseable.SYNC) {
+							//the q is empty
+							done = true;
+							checkTerminated(true, true);
+						}
+						break;
+					}
+
+					for (FluxPublish.PubSubInner<T> inner : a) {
+						inner.actual.onNext(v);
+						if (Operators.producedCancellable(FluxPublish
+										.PublishInner.REQUESTED, inner,
+								1) == Long.MIN_VALUE) {
+							cancel = Integer.MIN_VALUE;
+						}
+					}
+
+					e++;
+				}
+
+				if (e != 0 && sourceMode != Fuseable.SYNC) {
+					s.request(e);
+				}
+
+				if (maxRequested != 0L && !empty) {
+					continue;
+				}
+			}
+			else if ( sourceMode == Fuseable.SYNC ) {
+				done = true;
+				if (checkTerminated(true, empty)) { //empty can be true if no subscriber
+					break;
+				}
+			}
+
+			missed = WIP.addAndGet(this, -missed);
+			if (missed == 0) {
+				break;
+			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	FluxPublish.PubSubInner<T>[] terminate() {
+		return SUBSCRIBERS.getAndSet(this, TERMINATED);
+	}
+
+	boolean checkTerminated(boolean d, boolean empty) {
+		if (s == Operators.cancelledSubscription()) {
+			if (autoCancel) {
+				terminate();
+				Queue<T> q = queue;
+				if (q != null) {
+					q.clear();
+				}
+			}
+			return true;
+		}
+		if (d) {
+			Throwable e = error;
+			if (e != null && e != Exceptions.TERMINATED) {
+				Queue<T> q = queue;
+				if (q != null) {
+					q.clear();
+				}
+				for (FluxPublish.PubSubInner<T> inner : terminate()) {
+					inner.actual.onError(e);
+				}
+				return true;
+			}
+			else if (empty) {
+				for (FluxPublish.PubSubInner<T> inner : terminate()) {
+					inner.actual.onComplete();
+				}
+				return true;
+			}
+		}
+		return false;
+	}
+
+	final boolean add(EmitterInner<T> inner) {
+		for (; ; ) {
+			FluxPublish.PubSubInner<T>[] a = subscribers;
+			if (a == TERMINATED) {
+				return false;
+			}
+			int n = a.length;
+			FluxPublish.PubSubInner<?>[] b = new FluxPublish.PubSubInner[n + 1];
+			System.arraycopy(a, 0, b, 0, n);
+			b[n] = inner;
+			if (SUBSCRIBERS.compareAndSet(this, a, b)) {
+				return true;
+			}
+		}
+	}
+
+	final void remove(FluxPublish.PubSubInner<T> inner) {
+		for (; ; ) {
+			FluxPublish.PubSubInner<T>[] a = subscribers;
+			if (a == TERMINATED || a == EMPTY) {
+				return;
+			}
+			int n = a.length;
+			int j = -1;
+			for (int i = 0; i < n; i++) {
+				if (a[i] == inner) {
+					j = i;
+					break;
+				}
+			}
+
+			if (j < 0) {
+				return;
+			}
+
+			FluxPublish.PubSubInner<?>[] b;
+			if (n == 1) {
+				b = EMPTY;
+			}
+			else {
+				b = new FluxPublish.PubSubInner<?>[n - 1];
+				System.arraycopy(a, 0, b, 0, j);
+				System.arraycopy(a, j + 1, b, j, n - j - 1);
+			}
+			if (SUBSCRIBERS.compareAndSet(this, a, b)) {
+				//contrary to FluxPublish, there is a possibility of auto-cancel, which
+				//happens when the removed inner makes the subscribers array EMPTY
+				if (autoCancel && b == EMPTY && Operators.terminate(S, this)) {
+					if (WIP.getAndIncrement(this) != 0) {
+						return;
+					}
+					terminate();
+					Queue<T> q = queue;
+					if (q != null) {
+						q.clear();
+					}
+				}
+				return;
+			}
+		}
+	}
+
+	@Override
+	public long downstreamCount() {
+		return subscribers.length;
+	}
+
+	static final class EmitterInner<T> extends FluxPublish.PubSubInner<T> {
+
+		final EmitterProcessor<T> parent;
+
+		EmitterInner(CoreSubscriber<? super T> actual, EmitterProcessor<T> parent) {
+			super(actual);
+			this.parent = parent;
+		}
+
+		@Override
+		void drainParent() {
+			parent.drain();
+		}
+
+		@Override
+		void removeAndDrainParent() {
+			parent.remove(this);
+			parent.drain();
+		}
+	}
+
+	static final class EmitterDisposable implements Disposable {
+
+		@Nullable
+		EmitterProcessor<?> target;
+
+		public EmitterDisposable(EmitterProcessor<?> emitterProcessor) {
+			this.target = emitterProcessor;
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return target == null || target.isDetached();
+		}
+
+		@Override
+		public void dispose() {
+			EmitterProcessor<?> t = target;
+			if (t == null) {
+				return;
+			}
+			if (t.detach() || t.isDetached()) {
+				target = null;
+			}
+		}
+	}
+
+
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxProcessor.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Objects;
+import java.util.concurrent.CancellationException;
+import java.util.stream.Stream;
+
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+import reactor.core.Scannable;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+
+import static reactor.core.publisher.Sinks.Many;
+
+/**
+ * A base processor that exposes {@link Flux} API for {@link Processor}.
+ *
+ * Implementors include {@link UnicastProcessor}, {@link EmitterProcessor}, {@link ReplayProcessor}.
+ *
+ * @author Stephane Maldini
+ *
+ * @param <IN> the input value type
+ * @param <OUT> the output value type
+ * @deprecated Processors will be removed in 3.5. Prefer using {@link Many} instead,
+ * or see https://github.com/reactor/reactor-core/issues/2431 for alternatives
+ */
+@Deprecated
+public abstract class FluxProcessor<IN, OUT> extends Flux<OUT>
+		implements Processor<IN, OUT>, CoreSubscriber<IN>, Scannable, Disposable, ContextHolder {
+
+	/**
+	 * Build a {@link FluxProcessor} whose data are emitted by the most recent emitted {@link Publisher}.
+	 * The {@link Flux} will complete once both the publishers source and the last switched to {@link Publisher} have
+	 * completed.
+	 *
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/switchonnext.png" alt="">
+	 *
+	 * @param <T> the produced type
+	 * @return a {@link FluxProcessor} accepting publishers and producing T
+	 * @deprecated should use {@link Sinks}, {@link Many#asFlux()} and {@link Flux#switchOnNext(Publisher)}. To be removed in 3.5.0.
+	 */
+	@Deprecated
+	public static <T> FluxProcessor<Publisher<? extends T>, T> switchOnNext() {
+		UnicastProcessor<Publisher<? extends T>> emitter = UnicastProcessor.create();
+		FluxProcessor<Publisher<? extends T>, T> p = FluxProcessor.wrap(emitter, switchOnNext(emitter));
+		return p;
+	}
+	/**
+	 * Transform a receiving {@link Subscriber} and a producing {@link Publisher} in a logical {@link FluxProcessor}.
+	 * The link between the passed upstream and returned downstream will not be created automatically, e.g. not
+	 * subscribed together. A {@link Processor} might choose to have orthogonal sequence input and output.
+	 *
+	 * @param <IN> the receiving type
+	 * @param <OUT> the producing type
+	 *
+	 * @param upstream the upstream subscriber
+	 * @param downstream the downstream publisher
+	 * @return a new blackboxed {@link FluxProcessor}
+	 */
+	public static <IN, OUT> FluxProcessor<IN, OUT> wrap(final Subscriber<IN> upstream, final Publisher<OUT> downstream) {
+		return new DelegateProcessor<>(downstream, upstream);
+	}
+
+	@Override
+	public void dispose() {
+		onError(new CancellationException("Disposed"));
+	}
+
+	/**
+	 * Return the number of active {@link Subscriber} or {@literal -1} if untracked.
+	 *
+	 * @return the number of active {@link Subscriber} or {@literal -1} if untracked
+	 */
+	public long downstreamCount(){
+		return inners().count();
+	}
+
+	/**
+	 * Return the processor buffer capacity if any or {@link Integer#MAX_VALUE}
+	 *
+	 * @return processor buffer capacity if any or {@link Integer#MAX_VALUE}
+	 */
+	public int getBufferSize() {
+		return Integer.MAX_VALUE;
+	}
+
+	/**
+	 * Current error if any, default to null
+	 *
+	 * @return Current error if any, default to null
+	 */
+	@Nullable
+	public Throwable getError() {
+		return null;
+	}
+
+	/**
+	 * Return true if any {@link Subscriber} is actively subscribed
+	 *
+	 * @return true if any {@link Subscriber} is actively subscribed
+	 */
+	public boolean hasDownstreams() {
+		return downstreamCount() != 0L;
+	}
+
+	/**
+	 * Return true if terminated with onComplete
+	 *
+	 * @return true if terminated with onComplete
+	 */
+	public final boolean hasCompleted() {
+		return isTerminated() && getError() == null;
+	}
+
+	/**
+	 * Return true if terminated with onError
+	 *
+	 * @return true if terminated with onError
+	 */
+	public final boolean hasError() {
+		return isTerminated() && getError() != null;
+	}
+
+	@Override
+	public Stream<? extends Scannable> inners() {
+		return Stream.empty();
+	}
+
+	/**
+	 * Has this upstream finished or "completed" / "failed" ?
+	 *
+	 * @return has this upstream finished or "completed" / "failed" ?
+	 */
+	public boolean isTerminated() {
+		return false;
+	}
+
+	/**
+	 * Return true if this {@link FluxProcessor} supports multithread producing
+	 *
+	 * @return true if this {@link FluxProcessor} supports multithread producing
+	 */
+	public boolean isSerialized() {
+		return false;
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.TERMINATED) return isTerminated();
+		if (key == Attr.ERROR) return getError();
+		if (key == Attr.CAPACITY) return getBufferSize();
+
+		return null;
+	}
+
+	@Override
+	public Context currentContext() {
+		return Context.empty();
+	}
+
+	/**
+	 * Create a {@link FluxProcessor} that safely gates multi-threaded producer
+	 * {@link Subscriber#onNext(Object)}.
+	 *
+	 * <p><strong>Discard Support:</strong> The resulting processor discards elements received from the source
+	 * {@link Publisher} (if any) when it cancels subscription to said source.
+	 *
+	 * @return a serializing {@link FluxProcessor}
+	 */
+	public final FluxProcessor<IN, OUT> serialize() {
+		return new DelegateProcessor<>(this, Operators.serialize(this));
+	}
+
+	/**
+	 * Create a {@link FluxSink} that safely gates multi-threaded producer
+	 * {@link Subscriber#onNext(Object)}. This processor will be subscribed to 
+	 * that {@link FluxSink}, and any previous subscribers will be unsubscribed.
+	 *
+	 * <p> The returned {@link FluxSink} will not apply any
+	 * {@link FluxSink.OverflowStrategy} and overflowing {@link FluxSink#next(Object)}
+	 * will behave in two possible ways depending on the Processor:
+	 * <ul>
+	 * <li> an unbounded processor will handle the overflow itself by dropping or
+	 * buffering </li>
+	 * <li> a bounded processor will block/spin</li>
+	 * </ul>
+	 *
+	 * @return a serializing {@link FluxSink}
+	 * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks}
+	 * through the {@link Sinks#many()} spec.
+	 */
+	@Deprecated
+	public final FluxSink<IN> sink() {
+		return sink(FluxSink.OverflowStrategy.IGNORE);
+	}
+
+	/**
+	 * Create a {@link FluxSink} that safely gates multi-threaded producer
+	 * {@link Subscriber#onNext(Object)}.  This processor will be subscribed to 
+	 * that {@link FluxSink}, and any previous subscribers will be unsubscribed.
+	 *
+	 * <p> The returned {@link FluxSink} will not apply any
+	 * {@link FluxSink.OverflowStrategy} and overflowing {@link FluxSink#next(Object)}
+	 * will behave in two possible ways depending on the Processor:
+	 * <ul>
+	 * <li> an unbounded processor will handle the overflow itself by dropping or
+	 * buffering </li>
+	 * <li> a bounded processor will block/spin on IGNORE strategy, or apply the
+	 * strategy behavior</li>
+	 * </ul>
+	 *
+	 * @param strategy the overflow strategy, see {@link FluxSink.OverflowStrategy}
+	 * for the
+	 * available strategies
+	 * @return a serializing {@link FluxSink}
+	 * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks}
+	 * through the {@link Sinks#many()} spec.
+	 */
+	@Deprecated
+	public final FluxSink<IN> sink(FluxSink.OverflowStrategy strategy) {
+		Objects.requireNonNull(strategy, "strategy");
+		if (getBufferSize() == Integer.MAX_VALUE){
+			strategy = FluxSink.OverflowStrategy.IGNORE;
+		}
+
+		FluxCreate.BaseSink<IN> s = FluxCreate.createSink(this, strategy);
+		onSubscribe(s);
+
+		if(s.isCancelled() ||
+				(isSerialized() && getBufferSize() == Integer.MAX_VALUE)){
+			return s;
+		}
+		if (serializeAlways())
+			return new FluxCreate.SerializedFluxSink<>(s);
+		else
+			return new FluxCreate.SerializeOnRequestSink<>(s);
+	}
+
+	/**
+	 * Returns serialization strategy. If true, {@link FluxProcessor#sink()} will always
+	 * be serialized. Otherwise sink is serialized only if {@link FluxSink#onRequest(java.util.function.LongConsumer)}
+	 * is invoked.
+	 * @return true to serialize any sink, false to delay serialization till onRequest
+	 */
+	protected boolean serializeAlways() {
+		return true;
+	}
+
+	/**
+	 * Return true if {@code FluxProcessor<T, T>}
+	 *
+	 * @return true if {@code FluxProcessor<T, T>}
+	 */
+	protected boolean isIdentityProcessor() {
+		return false;
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoProcessor.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.util.concurrent.CancellationException;
+import java.util.stream.Stream;
+
+import org.reactivestreams.Processor;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+import reactor.core.Scannable;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+
+/**
+ * A {@code MonoProcessor} is a {@link Processor} that is also a {@link Mono}.
+ *
+ * <p>
+ * <img width="640" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/monoprocessor.png" alt="">
+ *
+ * <p>
+ * Implementations might implements stateful semantics, allowing multiple subscriptions.
+ * Once a {@link MonoProcessor} has been resolved, implementations may also replay cached signals to newer subscribers.
+ * <p>
+ * Despite having default implementations, most methods should be reimplemented with meaningful semantics relevant to
+ * concrete child classes.
+ *
+ * @param <O> the type of the value that will be made available
+ *
+ * @author Stephane Maldini
+ * @deprecated Processors will be removed in 3.5. Prefer using {@link Sinks.One} or {@link Sinks.Empty} instead,
+ * or see https://github.com/reactor/reactor-core/issues/2431 for alternatives
+ */
+@Deprecated
+public abstract class MonoProcessor<O> extends Mono<O>
+		implements Processor<O, O>, CoreSubscriber<O>, Disposable,
+		           Subscription,
+		           Scannable {
+
+	/**
+	 * Create a {@link MonoProcessor} that will eagerly request 1 on {@link #onSubscribe(Subscription)}, cache and emit
+	 * the eventual result for 1 or N subscribers.
+	 *
+	 * @param <T> type of the expected value
+	 *
+	 * @return A {@link MonoProcessor}.
+	 * @deprecated Use {@link Sinks#one()}, to be removed in 3.5
+	 */
+	@Deprecated
+	public static <T> MonoProcessor<T> create() {
+		return new NextProcessor<>(null);
+	}
+
+	/**
+	 * @deprecated the {@link MonoProcessor} will cease to implement {@link Subscription} in 3.5
+	 */
+	@Override
+	@Deprecated
+	public void cancel() {
+	}
+
+	/**
+	 * Indicates whether this {@code MonoProcessor} has been interrupted via cancellation.
+	 *
+	 * @return {@code true} if this {@code MonoProcessor} is cancelled, {@code false}
+	 * otherwise.
+	 * @deprecated the {@link MonoProcessor} will cease to implement {@link Subscription} and this method will be removed in 3.5
+	 */
+	@Deprecated
+	public boolean isCancelled() {
+		return false;
+	}
+
+	/**
+	 * @param n the request amount
+	 * @deprecated the {@link MonoProcessor} will cease to implement {@link Subscription} in 3.5
+	 */
+	@Override
+	@Deprecated
+	public void request(long n) {
+		Operators.validate(n);
+	}
+
+	@Override
+	public void dispose() {
+		onError(new CancellationException("Disposed"));
+	}
+
+	/**
+	 * Block the calling thread indefinitely, waiting for the completion of this {@code MonoProcessor}. If the
+	 * {@link MonoProcessor} is completed with an error a RuntimeException that wraps the error is thrown.
+	 *
+	 * @return the value of this {@code MonoProcessor}
+	 */
+	@Override
+	@Nullable
+	public O block() {
+		return block(null);
+	}
+
+	/**
+	 * Block the calling thread for the specified time, waiting for the completion of this {@code MonoProcessor}. If the
+	 * {@link MonoProcessor} is completed with an error a RuntimeException that wraps the error is thrown.
+	 *
+	 * @param timeout the timeout value as a {@link Duration}
+	 *
+	 * @return the value of this {@code MonoProcessor} or {@code null} if the timeout is reached and the {@code MonoProcessor} has
+	 * not completed
+	 */
+	@Override
+	@Nullable
+	public O block(@Nullable Duration timeout) {
+		return peek();
+	}
+
+	/**
+	 * Return the produced {@link Throwable} error if any or null
+	 *
+	 * @return the produced {@link Throwable} error if any or null
+	 */
+	@Nullable
+	public Throwable getError() {
+		return null;
+	}
+
+	/**
+	 * Indicates whether this {@code MonoProcessor} has been completed with an error.
+	 *
+	 * @return {@code true} if this {@code MonoProcessor} was completed with an error, {@code false} otherwise.
+	 */
+	public final boolean isError() {
+		return getError() != null;
+	}
+
+	/**
+	 * Indicates whether this {@code MonoProcessor} has been successfully completed a value.
+	 *
+	 * @return {@code true} if this {@code MonoProcessor} is successful, {@code false} otherwise.
+	 */
+	public final boolean isSuccess() {
+		return isTerminated() && !isError();
+	}
+
+	/**
+	 * Indicates whether this {@code MonoProcessor} has been terminated by the
+	 * source producer with a success or an error.
+	 *
+	 * @return {@code true} if this {@code MonoProcessor} is successful, {@code false} otherwise.
+	 */
+	public boolean isTerminated() {
+		return false;
+	}
+
+	@Override
+	public boolean isDisposed() {
+		return isTerminated() || isCancelled();
+	}
+
+	/**
+	 * Returns the value that completed this {@link MonoProcessor}. Returns {@code null} if the {@link MonoProcessor} has not been completed. If the
+	 * {@link MonoProcessor} is completed with an error a RuntimeException that wraps the error is thrown.
+	 *
+	 * @return the value that completed the {@link MonoProcessor}, or {@code null} if it has not been completed
+	 *
+	 * @throws RuntimeException if the {@link MonoProcessor} was completed with an error
+	 * @deprecated this method is discouraged, consider peeking into a MonoProcessor by {@link Mono#toFuture() turning it into a CompletableFuture}
+	 */
+	@Nullable
+	@Deprecated
+	public O peek() {
+		return null;
+	}
+
+	@Override
+	public Context currentContext() {
+		InnerProducer<?>[] innerProducersArray =
+				inners().filter(InnerProducer.class::isInstance)
+				        .map(InnerProducer.class::cast)
+				        .toArray(InnerProducer[]::new);
+
+		return Operators.multiSubscribersContext(innerProducersArray);
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		//touch guard
+		boolean t = isTerminated();
+
+		if (key == Attr.TERMINATED) return t;
+		if (key == Attr.ERROR) return getError();
+		if (key == Attr.PREFETCH) return Integer.MAX_VALUE;
+		if (key == Attr.CANCELLED) return isCancelled();
+		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+
+		return null;
+	}
+
+	/**
+	 * Return the number of active {@link Subscriber} or {@literal -1} if untracked.
+	 *
+	 * @return the number of active {@link Subscriber} or {@literal -1} if untracked
+	 */
+	public long downstreamCount() {
+		return inners().count();
+	}
+
+	/**
+	 * Return true if any {@link Subscriber} is actively subscribed
+	 *
+	 * @return true if any {@link Subscriber} is actively subscribed
+	 */
+	public final boolean hasDownstreams() {
+		return downstreamCount() != 0;
+	}
+
+	@Override
+	public Stream<? extends Scannable> inners() {
+		return Stream.empty();
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
@@ -36,7 +36,9 @@ import reactor.core.publisher.Sinks.EmitResult;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
-class NextProcessor<O> extends Mono<O> implements CoreSubscriber<O>, reactor.core.Disposable, Scannable {
+// NextProcessor extends a deprecated class but is itself not deprecated and is here to stay, hence the following line is ok.
+@SuppressWarnings("deprecation")
+class NextProcessor<O> extends MonoProcessor<O> implements CoreSubscriber<O>, reactor.core.Disposable, Scannable {
 
 	/**
 	 * This boolean indicates a usage as `Mono#share()` where, for alignment with Flux#share(), the removal of all
@@ -63,23 +65,24 @@ class NextProcessor<O> extends Mono<O> implements CoreSubscriber<O>, reactor.cor
 		return isTerminated();
 	}
 
-	/**
-	 * Indicates whether this {@link NextProcessor} has been completed with an error.
-	 *
-	 * @return {@code true} if this {@link NextProcessor} was completed with an error, {@code false} otherwise.
-	 */
-	public final boolean isError() {
-		return getError() != null;
-	}
-
-	/**
-	 * Indicates whether this {@link NextProcessor} has been successfully completed a value.
-	 *
-	 * @return {@code true} if this {@link NextProcessor} is successful, {@code false} otherwise.
-	 */
-	public final boolean isSuccess() {
-		return isTerminated() && !isError();
-	}
+	//TODO reintroduce the boolean getters below once MonoProcessor is removed again
+//	/**
+//	 * Indicates whether this {@link NextProcessor} has been completed with an error.
+//	 *
+//	 * @return {@code true} if this {@link NextProcessor} was completed with an error, {@code false} otherwise.
+//	 */
+//	public final boolean isError() {
+//		return getError() != null;
+//	}
+//
+//	/**
+//	 * Indicates whether this {@link NextProcessor} has been successfully completed a value.
+//	 *
+//	 * @return {@code true} if this {@link NextProcessor} is successful, {@code false} otherwise.
+//	 */
+//	public final boolean isSuccess() {
+//		return isTerminated() && !isError();
+//	}
 
 	@SuppressWarnings("rawtypes")
 	static final AtomicReferenceFieldUpdater<NextProcessor, NextInner[]> SUBSCRIBERS =
@@ -127,7 +130,8 @@ class NextProcessor<O> extends Mono<O> implements CoreSubscriber<O>, reactor.cor
 	 * @throws RuntimeException if the {@link NextProcessor} was completed with an error
 	 */
 	@Nullable
-	O peek() {
+	@Override
+	public O peek() {
 		if (!isTerminated()) {
 			return null;
 		}
@@ -380,10 +384,11 @@ class NextProcessor<O> extends Mono<O> implements CoreSubscriber<O>, reactor.cor
 	}
 
 	/**
-		 * Return the number of active {@link Subscriber} or {@literal -1} if untracked.
-		 *
-		 * @return the number of active {@link Subscriber} or {@literal -1} if untracked
-		 */
+	 * Return the number of active {@link Subscriber} or {@literal -1} if untracked.
+	 *
+	 * @return the number of active {@link Subscriber} or {@literal -1} if untracked
+	 */
+	@Override
 	public long downstreamCount() {
 		return subscribers.length;
 	}
@@ -414,6 +419,13 @@ class NextProcessor<O> extends Mono<O> implements CoreSubscriber<O>, reactor.cor
 		}
 	}
 
+	@Override
+	// This method is inherited from a deprecated class and will be removed in 3.5.
+	@SuppressWarnings("deprecation")
+	public void cancel() {
+		doCancel();
+	}
+
 	void doCancel() { //TODO compare with the cancellation in remove(), do we need both approaches?
 		if (isTerminated()) {
 			return;
@@ -437,22 +449,31 @@ class NextProcessor<O> extends Mono<O> implements CoreSubscriber<O>, reactor.cor
 		}
 	}
 
+	@Override
+	// This method is inherited from a deprecated class and will be removed in 3.5.
+	@SuppressWarnings("deprecation")
+	public boolean isCancelled() {
+		return subscription == Operators.cancelledSubscription() && !isTerminated();
+	}
+
 	/**
-		 * Indicates whether this {@link NextProcessor} has been terminated by the
-		 * source producer with a success or an error.
-		 *
-		 * @return {@code true} if this {@link NextProcessor} is successful, {@code false} otherwise.
-		 */
+	 * Indicates whether this {@link NextProcessor} has been terminated by the
+	 * source producer with a success or an error.
+	 *
+	 * @return {@code true} if this {@link NextProcessor} is successful, {@code false} otherwise.
+	 */
+	@Override
 	public boolean isTerminated() {
 		return subscribers == TERMINATED;
 	}
 
 	/**
-		 * Return the produced {@link Throwable} error if any or null
-		 *
-		 * @return the produced {@link Throwable} error if any or null
-		 */
+	 * Return the produced {@link Throwable} error if any or null
+	 *
+	 * @return the produced {@link Throwable} error if any or null
+	 */
 	@Nullable
+	@Override
 	public Throwable getError() {
 		return error;
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -1,0 +1,686 @@
+/*
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.stream.Stream;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
+import reactor.core.Scannable;
+import reactor.core.publisher.Sinks.EmitResult;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.annotation.Nullable;
+import reactor.util.concurrent.Queues;
+import reactor.util.context.Context;
+
+import static reactor.core.publisher.FluxReplay.ReplaySubscriber.EMPTY;
+import static reactor.core.publisher.FluxReplay.ReplaySubscriber.TERMINATED;
+
+/**
+ * Replays all or the last N items to Subscribers.
+ * <p>
+ * <img width="640" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/emitterreplay.png"
+ * alt="">
+ * <p>
+ *
+ * @param <T> the value type
+ * @deprecated To be removed in 3.5, prefer clear cut usage of {@link Sinks} through
+ * variations under {@link Sinks.MulticastReplaySpec Sinks.many().replay()}.
+ */
+@Deprecated
+public final class ReplayProcessor<T> extends FluxProcessor<T, T>
+		implements Fuseable, InternalManySink<T> {
+
+	/**
+	 * Create a {@link ReplayProcessor} that caches the last element it has pushed,
+	 * replaying it to late subscribers. This is a buffer-based ReplayProcessor with
+	 * a history size of 1.
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/replaylast.png"
+	 * alt="">
+	 *
+	 * @param <T> the type of the pushed elements
+	 *
+	 * @return a new {@link ReplayProcessor} that replays its last pushed element to each new
+	 * {@link Subscriber}
+	 * @deprecated use {@link Sinks.MulticastReplaySpec#latest() Sinks.many().replay().latest()}
+	 * (or the unsafe variant if you're sure about external synchronization). To be removed in 3.5.
+	 */
+	@Deprecated
+	public static <T> ReplayProcessor<T> cacheLast() {
+		return cacheLastOrDefault(null);
+	}
+
+	/**
+	 * Create a {@link ReplayProcessor} that caches the last element it has pushed,
+	 * replaying it to late subscribers. If a {@link Subscriber} comes in <b>before</b>
+	 * any value has been pushed, then the {@code defaultValue} is emitted instead. 
+	 * This is a buffer-based ReplayProcessor with a history size of 1.
+	 * <p>
+	 * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/replaylastd.png"
+	 * alt="">
+	 *
+	 * @param value a default value to start the sequence with in case nothing has been
+	 * cached yet.
+	 * @param <T> the type of the pushed elements
+	 *
+	 * @return a new {@link ReplayProcessor} that replays its last pushed element to each new
+	 * {@link Subscriber}, or a default one if nothing was pushed yet
+	 * @deprecated use {@link Sinks.MulticastReplaySpec#latestOrDefault(Object) Sinks.many().replay().latestOrDefault(value)}
+	 * (or the unsafe variant if you're sure about external synchronization). To be removed in 3.5.
+	 */
+	@Deprecated
+	public static <T> ReplayProcessor<T> cacheLastOrDefault(@Nullable T value) {
+		ReplayProcessor<T> b = create(1);
+		if (value != null) {
+			b.onNext(value);
+		}
+		return b;
+	}
+
+	/**
+	 * Create a new {@link ReplayProcessor} that replays an unbounded number of elements,
+	 * using a default internal {@link Queues#SMALL_BUFFER_SIZE Queue}.
+	 * 
+	 * @param <E> the type of the pushed elements
+	 *
+	 * @return a new {@link ReplayProcessor} that replays the whole history to each new
+	 * {@link Subscriber}.
+	 * @deprecated use {@link Sinks.MulticastReplaySpec#all() Sinks.many().replay().all()}
+	 * (or the unsafe variant if you're sure about external synchronization). To be removed in 3.5.
+	 */
+	@Deprecated
+	public static <E> ReplayProcessor<E> create() {
+		return create(Queues.SMALL_BUFFER_SIZE, true);
+	}
+
+	/**
+	 * Create a new {@link ReplayProcessor} that replays up to {@code historySize}
+	 * elements.
+	 *
+	 * @param historySize the backlog size, ie. maximum items retained for replay.
+	 * @param <E> the type of the pushed elements
+	 *
+	 * @return a new {@link ReplayProcessor} that replays a limited history to each new
+	 * {@link Subscriber}.
+	 * @deprecated use {@link Sinks.MulticastReplaySpec#limit(int) Sinks.many().replay().limit(historySize)}
+	 * (or the unsafe variant if you're sure about external synchronization). To be removed in 3.5.
+	 */
+	@Deprecated
+	public static <E> ReplayProcessor<E> create(int historySize) {
+		return create(historySize, false);
+	}
+
+	/**
+	 * Create a new {@link ReplayProcessor} that either replay all the elements or a
+	 * limited amount of elements depending on the {@code unbounded} parameter.
+	 *
+	 * @param historySize maximum items retained if bounded, or initial link size if unbounded
+	 * @param unbounded true if "unlimited" data store must be supplied
+	 * @param <E> the type of the pushed elements
+	 *
+	 * @return a new {@link ReplayProcessor} that replays the whole history to each new
+	 * {@link Subscriber} if configured as unbounded, a limited history otherwise.
+	 * @deprecated use {@link Sinks.MulticastReplaySpec#limit(int) Sinks.many().replay().limit(historySize)}
+	 * for bounded cases ({@code unbounded == false}) or {@link Sinks.MulticastReplaySpec#all(int) Sinks.many().replay().all(bufferSize)}
+	 * otherwise (or the unsafe variant if you're sure about external synchronization). To be removed in 3.5.
+	 */
+	@Deprecated
+	public static <E> ReplayProcessor<E> create(int historySize, boolean unbounded) {
+		FluxReplay.ReplayBuffer<E> buffer;
+		if (unbounded) {
+			buffer = new FluxReplay.UnboundedReplayBuffer<>(historySize);
+		}
+		else {
+			buffer = new FluxReplay.SizeBoundReplayBuffer<>(historySize);
+		}
+		return new ReplayProcessor<>(buffer);
+	}
+
+	/**
+	 * Creates a time-bounded replay processor.
+	 * <p>
+	 * In this setting, the {@code ReplayProcessor} internally tags each observed item
+	 * with a timestamp value supplied by the {@link Schedulers#parallel()} and keeps only
+	 * those whose age is less than the supplied time value converted to milliseconds. For
+	 * example, an item arrives at T=0 and the max age is set to 5; at T&gt;=5 this first
+	 * item is then evicted by any subsequent item or termination signal, leaving the
+	 * buffer empty.
+	 * <p>
+	 * Once the processor is terminated, subscribers subscribing to it will receive items
+	 * that remained in the buffer after the terminal signal, regardless of their age.
+	 * <p>
+	 * If an subscriber subscribes while the {@code ReplayProcessor} is active, it will
+	 * observe only those items from within the buffer that have an age less than the
+	 * specified time, and each item observed thereafter, even if the buffer evicts items
+	 * due to the time constraint in the mean time. In other words, once an subscriber
+	 * subscribes, it observes items without gaps in the sequence except for any outdated
+	 * items at the beginning of the sequence.
+	 * <p>
+	 *
+	 * @param <T> the type of items observed and emitted by the Processor
+	 * @param maxAge the maximum age of the contained items
+	 *
+	 * @return a new {@link ReplayProcessor} that replays elements based on their age.
+	 * @deprecated use {@link Sinks.MulticastReplaySpec#limit(Duration) Sinks.many().replay().limit(maxAge)}
+	 * (or the unsafe variant if you're sure about external synchronization). To be removed in 3.5.
+	 */
+	@Deprecated
+	public static <T> ReplayProcessor<T> createTimeout(Duration maxAge) {
+		return createTimeout(maxAge, Schedulers.parallel());
+	}
+
+	/**
+	 * Creates a time-bounded replay processor.
+	 * <p>
+	 * In this setting, the {@code ReplayProcessor} internally tags each observed item
+	 * with a timestamp value supplied by the {@link Scheduler} and keeps only
+	 * those whose age is less than the supplied time value converted to milliseconds. For
+	 * example, an item arrives at T=0 and the max age is set to 5; at T&gt;=5 this first
+	 * item is then evicted by any subsequent item or termination signal, leaving the
+	 * buffer empty.
+	 * <p>
+	 * Once the processor is terminated, subscribers subscribing to it will receive items
+	 * that remained in the buffer after the terminal signal, regardless of their age.
+	 * <p>
+	 * If an subscriber subscribes while the {@code ReplayProcessor} is active, it will
+	 * observe only those items from within the buffer that have an age less than the
+	 * specified time, and each item observed thereafter, even if the buffer evicts items
+	 * due to the time constraint in the mean time. In other words, once an subscriber
+	 * subscribes, it observes items without gaps in the sequence except for any outdated
+	 * items at the beginning of the sequence.
+	 * <p>
+	 *
+	 * @param <T> the type of items observed and emitted by the Processor
+	 * @param maxAge the maximum age of the contained items
+	 *
+	 * @return a new {@link ReplayProcessor} that replays elements based on their age.
+	 * @deprecated use {@link Sinks.MulticastReplaySpec#limit(Duration, Scheduler) Sinks.many().replay().limit(maxAge, scheduler)}
+	 * (or the unsafe variant if you're sure about external synchronization). To be removed in 3.5.
+	 */
+	@Deprecated
+	public static <T> ReplayProcessor<T> createTimeout(Duration maxAge, Scheduler scheduler) {
+		return createSizeAndTimeout(Integer.MAX_VALUE, maxAge, scheduler);
+	}
+
+	/**
+	 * Creates a time- and size-bounded replay processor.
+	 * <p>
+	 * In this setting, the {@code ReplayProcessor} internally tags each received item
+	 * with a timestamp value supplied by the {@link Schedulers#parallel()} and holds at
+	 * most
+	 * {@code size} items in its internal buffer. It evicts items from the start of the
+	 * buffer if their age becomes less-than or equal to the supplied age in milliseconds
+	 * or the buffer reaches its {@code size} limit.
+	 * <p>
+	 * When subscribers subscribe to a terminated {@code ReplayProcessor}, they observe
+	 * the items that remained in the buffer after the terminal signal, regardless of
+	 * their age, but at most {@code size} items.
+	 * <p>
+	 * If an subscriber subscribes while the {@code ReplayProcessor} is active, it will
+	 * observe only those items from within the buffer that have age less than the
+	 * specified time and each subsequent item, even if the buffer evicts items due to the
+	 * time constraint in the mean time. In other words, once an subscriber subscribes, it
+	 * observes items without gaps in the sequence except for the outdated items at the
+	 * beginning of the sequence.
+	 * <p>
+	 *
+	 * @param <T> the type of items observed and emitted by the Processor
+	 * @param maxAge the maximum age of the contained items
+	 * @param size the maximum number of buffered items
+	 *
+	 * @return a new {@link ReplayProcessor} that replay up to {@code size} elements, but
+	 * will evict them from its history based on their age.
+	 * @deprecated use {@link Sinks.MulticastReplaySpec#limit(int, Duration) Sinks.many().replay().limit(size, maxAge)}
+	 * (or the unsafe variant if you're sure about external synchronization). To be removed in 3.5.
+	 */
+	@Deprecated
+	public static <T> ReplayProcessor<T> createSizeAndTimeout(int size, Duration maxAge) {
+		return createSizeAndTimeout(size, maxAge, Schedulers.parallel());
+	}
+
+	/**
+	 * Creates a time- and size-bounded replay processor.
+	 * <p>
+	 * In this setting, the {@code ReplayProcessor} internally tags each received item
+	 * with a timestamp value supplied by the {@link Scheduler} and holds at most
+	 * {@code size} items in its internal buffer. It evicts items from the start of the
+	 * buffer if their age becomes less-than or equal to the supplied age in milliseconds
+	 * or the buffer reaches its {@code size} limit.
+	 * <p>
+	 * When subscribers subscribe to a terminated {@code ReplayProcessor}, they observe
+	 * the items that remained in the buffer after the terminal signal, regardless of
+	 * their age, but at most {@code size} items.
+	 * <p>
+	 * If an subscriber subscribes while the {@code ReplayProcessor} is active, it will
+	 * observe only those items from within the buffer that have age less than the
+	 * specified time and each subsequent item, even if the buffer evicts items due to the
+	 * time constraint in the mean time. In other words, once an subscriber subscribes, it
+	 * observes items without gaps in the sequence except for the outdated items at the
+	 * beginning of the sequence.
+	 * <p>
+	 *
+	 * @param <T> the type of items observed and emitted by the Processor
+	 * @param maxAge the maximum age of the contained items in milliseconds
+	 * @param size the maximum number of buffered items
+	 * @param scheduler the {@link Scheduler} that provides the current time
+	 *
+	 * @return a new {@link ReplayProcessor} that replay up to {@code size} elements, but
+	 * will evict them from its history based on their age.
+	 * @deprecated use {@link Sinks.MulticastReplaySpec#limit(int, Duration, Scheduler) Sinks.many().replay().limit(size, maxAge, scheduler)}
+	 * (or the unsafe variant if you're sure about external synchronization). To be removed in 3.5.
+	 */
+	@Deprecated
+	public static <T> ReplayProcessor<T> createSizeAndTimeout(int size,
+			Duration maxAge,
+			Scheduler scheduler) {
+		Objects.requireNonNull(scheduler, "scheduler is null");
+		if (size <= 0) {
+			throw new IllegalArgumentException("size > 0 required but it was " + size);
+		}
+		return new ReplayProcessor<>(new FluxReplay.SizeAndTimeBoundReplayBuffer<>(size,
+				maxAge.toNanos(),
+				scheduler));
+	}
+
+	final FluxReplay.ReplayBuffer<T> buffer;
+
+	Subscription subscription;
+
+	volatile FluxReplay.ReplaySubscription<T>[] subscribers;
+	@SuppressWarnings("rawtypes")
+	static final AtomicReferenceFieldUpdater<ReplayProcessor, FluxReplay.ReplaySubscription[]>
+			SUBSCRIBERS = AtomicReferenceFieldUpdater.newUpdater(ReplayProcessor.class,
+			FluxReplay.ReplaySubscription[].class,
+			"subscribers");
+
+	ReplayProcessor(FluxReplay.ReplayBuffer<T> buffer) {
+		this.buffer = buffer;
+		SUBSCRIBERS.lazySet(this, EMPTY);
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super T> actual) {
+		Objects.requireNonNull(actual, "subscribe");
+		FluxReplay.ReplaySubscription<T> rs = new ReplayInner<>(actual, this);
+		actual.onSubscribe(rs);
+
+		if (add(rs)) {
+			if (rs.isCancelled()) {
+				remove(rs);
+				return;
+			}
+		}
+		buffer.replay(rs);
+	}
+
+	@Override
+	@Nullable
+	public Throwable getError() {
+		return buffer.getError();
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PARENT){
+			return subscription;
+		}
+		if (key == Attr.CAPACITY) return buffer.capacity();
+
+		return super.scanUnsafe(key);
+	}
+
+	@Override
+	public Stream<? extends Scannable> inners() {
+		return Stream.of(subscribers);
+	}
+
+	@Override
+	public long downstreamCount() {
+		return subscribers.length;
+	}
+
+	@Override
+	public boolean isTerminated() {
+		return buffer.isDone();
+	}
+
+	boolean add(FluxReplay.ReplaySubscription<T> rs) {
+		for (; ; ) {
+			FluxReplay.ReplaySubscription<T>[] a = subscribers;
+			if (a == TERMINATED) {
+				return false;
+			}
+			int n = a.length;
+
+			@SuppressWarnings("unchecked") FluxReplay.ReplaySubscription<T>[] b =
+					new ReplayInner[n + 1];
+			System.arraycopy(a, 0, b, 0, n);
+			b[n] = rs;
+			if (SUBSCRIBERS.compareAndSet(this, a, b)) {
+				return true;
+			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	void remove(FluxReplay.ReplaySubscription<T> rs) {
+		outer:
+		for (; ; ) {
+			FluxReplay.ReplaySubscription<T>[] a = subscribers;
+			if (a == TERMINATED || a == EMPTY) {
+				return;
+			}
+			int n = a.length;
+
+			for (int i = 0; i < n; i++) {
+				if (a[i] == rs) {
+					FluxReplay.ReplaySubscription<T>[] b;
+
+					if (n == 1) {
+						b = EMPTY;
+					}
+					else {
+						b = new ReplayInner[n - 1];
+						System.arraycopy(a, 0, b, 0, i);
+						System.arraycopy(a, i + 1, b, i, n - i - 1);
+					}
+
+					if (SUBSCRIBERS.compareAndSet(this, a, b)) {
+						return;
+					}
+
+					continue outer;
+				}
+			}
+
+			break;
+		}
+	}
+
+	@Override
+	public void onSubscribe(Subscription s) {
+		if (buffer.isDone()) {
+			s.cancel();
+		}
+		else if (Operators.validate(subscription, s)) {
+			subscription = s;
+			s.request(Long.MAX_VALUE);
+		}
+	}
+
+	@Override
+	public Context currentContext() {
+		return Operators.multiSubscribersContext(subscribers);
+	}
+
+	@Override
+	public int getPrefetch() {
+		return Integer.MAX_VALUE;
+	}
+
+	@Override
+	public void onComplete() {
+		//no particular error condition handling for onComplete
+		@SuppressWarnings("unused") EmitResult emitResult = tryEmitComplete();
+	}
+
+	@Override
+	public EmitResult tryEmitComplete() {
+		FluxReplay.ReplayBuffer<T> b = buffer;
+		if (b.isDone()) {
+			return EmitResult.FAIL_TERMINATED;
+		}
+
+		b.onComplete();
+
+		@SuppressWarnings("unchecked") FluxReplay.ReplaySubscription<T>[] a =
+				SUBSCRIBERS.getAndSet(this, TERMINATED);
+
+		for (FluxReplay.ReplaySubscription<T> rs : a) {
+			b.replay(rs);
+		}
+		return EmitResult.OK;
+	}
+
+	@Override
+	public void onError(Throwable throwable) {
+		emitError(throwable, Sinks.EmitFailureHandler.FAIL_FAST);
+	}
+
+	@Override
+	public EmitResult tryEmitError(Throwable t) {
+		FluxReplay.ReplayBuffer<T> b = buffer;
+		if (b.isDone()) {
+			return EmitResult.FAIL_TERMINATED;
+		}
+
+		b.onError(t);
+
+		@SuppressWarnings("unchecked") FluxReplay.ReplaySubscription<T>[] a =
+					SUBSCRIBERS.getAndSet(this, TERMINATED);
+
+		for (FluxReplay.ReplaySubscription<T> rs : a) {
+			b.replay(rs);
+		}
+		return EmitResult.OK;
+	}
+
+	@Override
+	public void onNext(T t) {
+		emitNext(t, Sinks.EmitFailureHandler.FAIL_FAST);
+	}
+
+	@Override
+	public EmitResult tryEmitNext(T t) {
+		FluxReplay.ReplayBuffer<T> b = buffer;
+		if (b.isDone()) {
+			return EmitResult.FAIL_TERMINATED;
+		}
+
+		//note: ReplayProcessor can so far ALWAYS buffer the element, no FAIL_ZERO_SUBSCRIBER here
+		b.add(t);
+		for (FluxReplay.ReplaySubscription<T> rs : subscribers) {
+			b.replay(rs);
+		}
+		return EmitResult.OK;
+	}
+
+	@Override
+	public int currentSubscriberCount() {
+		return subscribers.length;
+	}
+
+	@Override
+	public Flux<T> asFlux() {
+		return this;
+	}
+
+	@Override
+	protected boolean isIdentityProcessor() {
+		return true;
+	}
+
+	static final class ReplayInner<T>
+			implements FluxReplay.ReplaySubscription<T> {
+
+		final CoreSubscriber<? super T> actual;
+
+		final ReplayProcessor<T> parent;
+
+		final FluxReplay.ReplayBuffer<T> buffer;
+
+		int index;
+
+		int tailIndex;
+
+		Object node;
+
+		volatile int wip;
+		@SuppressWarnings("rawtypes")
+		static final AtomicIntegerFieldUpdater<ReplayInner> WIP =
+				AtomicIntegerFieldUpdater.newUpdater(ReplayInner.class,
+						"wip");
+
+		volatile long requested;
+		@SuppressWarnings("rawtypes")
+		static final AtomicLongFieldUpdater<ReplayInner> REQUESTED =
+				AtomicLongFieldUpdater.newUpdater(ReplayInner.class,
+						"requested");
+
+		int fusionMode;
+
+		ReplayInner(CoreSubscriber<? super T> actual,
+				ReplayProcessor<T> parent) {
+			this.actual = actual;
+			this.parent = parent;
+			this.buffer = parent.buffer;
+		}
+
+		@Override
+		public long requested() {
+			return requested;
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return requested == Long.MIN_VALUE;
+		}
+
+		@Override
+		public CoreSubscriber<? super T> actual() {
+			return actual;
+		}
+
+		@Override
+		public int requestFusion(int requestedMode) {
+			if ((requestedMode & ASYNC) != 0) {
+				fusionMode = ASYNC;
+				return ASYNC;
+			}
+			return NONE;
+		}
+
+		@Override
+		@Nullable
+		public T poll() {
+			return buffer.poll(this);
+		}
+
+		@Override
+		public void clear() {
+			buffer.clear(this);
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return buffer.isEmpty(this);
+		}
+
+		@Override
+		public int size() {
+			return buffer.size(this);
+		}
+
+		@Override
+		public void request(long n) {
+			if (Operators.validate(n)) {
+				if (fusionMode() == NONE) {
+					Operators.addCapCancellable(REQUESTED, this, n);
+				}
+				buffer.replay(this);
+			}
+		}
+
+		@Override
+		public void requestMore(int index) {
+			this.index = index;
+		}
+
+		@Override
+		public void cancel() {
+			if (REQUESTED.getAndSet(this, Long.MIN_VALUE) != Long.MIN_VALUE) {
+				parent.remove(this);
+
+				if (enter()) {
+					node = null;
+				}
+			}
+		}
+
+		@Override
+		public void node(@Nullable Object node) {
+			this.node = node;
+		}
+
+		@Override
+		public int fusionMode() {
+			return fusionMode;
+		}
+
+		@Override
+		@Nullable
+		public Object node() {
+			return node;
+		}
+
+		@Override
+		public int index() {
+			return index;
+		}
+
+		@Override
+		public void index(int index) {
+			this.index = index;
+		}
+
+		@Override
+		public int tailIndex() {
+			return tailIndex;
+		}
+
+		@Override
+		public void tailIndex(int tailIndex) {
+			this.tailIndex = tailIndex;
+		}
+
+		@Override
+		public boolean enter() {
+			return WIP.getAndIncrement(this) == 0;
+		}
+
+		@Override
+		public int leave(int missed) {
+			return WIP.addAndGet(this, -missed);
+		}
+
+		@Override
+		public void produced(long n) {
+			REQUESTED.addAndGet(this, -n);
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
@@ -33,7 +33,7 @@ import reactor.util.context.Context;
  * @author Simon Baslé
  */
 final class SinkManyBestEffort<T> extends Flux<T>
-		implements InternalManySink<T>, Scannable {
+		implements InternalManySink<T>, Scannable, DirectInnerContainer<T> {
 
 	static final DirectInner[] EMPTY      = new DirectInner[0];
 	static final DirectInner[] TERMINATED = new DirectInner[0];
@@ -221,7 +221,7 @@ final class SinkManyBestEffort<T> extends Flux<T>
 	 *
 	 * @return {@code true} if the inner could be added, {@code false} if the publisher cannot accept new subscribers
 	 */
-	boolean add(DirectInner<T> s) {
+	public boolean add(DirectInner<T> s) {
 		DirectInner<T>[] a = subscribers;
 		if (a == TERMINATED) {
 			return false;
@@ -252,7 +252,7 @@ final class SinkManyBestEffort<T> extends Flux<T>
 	 * @param s the  {@link SinkManyBestEffort.DirectInner} to remove
 	 */
 	@SuppressWarnings("unchecked")
-	void remove(DirectInner<T> s) {
+	public void remove(DirectInner<T> s) {
 		DirectInner<T>[] a = subscribers;
 		if (a == TERMINATED || a == EMPTY) {
 			return;
@@ -295,14 +295,14 @@ final class SinkManyBestEffort<T> extends Flux<T>
 	static class DirectInner<T> extends AtomicBoolean implements InnerProducer<T> {
 
 		final CoreSubscriber<? super T> actual;
-		final SinkManyBestEffort<T>   parent;
+		final DirectInnerContainer<T>   parent;
 
 		volatile     long                                requested;
 		@SuppressWarnings("rawtypes")
 		static final AtomicLongFieldUpdater<DirectInner> REQUESTED = AtomicLongFieldUpdater.newUpdater(
 				DirectInner.class, "requested");
 
-		DirectInner(CoreSubscriber<? super T> actual, SinkManyBestEffort<T> parent) {
+		DirectInner(CoreSubscriber<? super T> actual, DirectInnerContainer<T> parent) {
 			this.actual = actual;
 			this.parent = parent;
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -1,0 +1,652 @@
+/*
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.reactivestreams.Subscription;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+import reactor.core.Exceptions;
+import reactor.core.Fuseable;
+import reactor.core.Scannable;
+import reactor.core.publisher.Sinks.EmitResult;
+import reactor.util.annotation.Nullable;
+import reactor.util.concurrent.Queues;
+import reactor.util.context.Context;
+
+/**
+ * A Processor implementation that takes a custom queue and allows
+ * only a single subscriber. UnicastProcessor allows multiplexing of the events which
+ * means that it supports multiple producers and only one consumer.
+ * However, it should be noticed that multi-producer case is only valid if appropriate
+ * Queue
+ * is provided. Otherwise, it could break
+ * <a href="https://www.reactive-streams.org/">Reactive Streams Spec</a> if Publishers
+ * publish on different threads.
+ *
+ * <p>
+ *      <img width="640" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.2.0.M2/src/docs/marble/unicastprocessornormal.png" alt="">
+ * </p>
+ *
+ * </br>
+ * </br>
+ *
+ * <p>
+ *      <b>Note: </b> UnicastProcessor does not respect the actual subscriber's
+ *      demand as it is described in
+ *      <a href="https://www.reactive-streams.org/">Reactive Streams Spec</a>. However,
+ *      UnicastProcessor embraces configurable Queue internally which allows enabling
+ *      backpressure support and preventing of consumer's overwhelming.
+ *
+ *      Hence, interaction model between producers and UnicastProcessor will be PUSH
+ *      only. In opposite, interaction model between UnicastProcessor and consumer will be
+ *      PUSH-PULL as defined in
+ *      <a href="https://www.reactive-streams.org/">Reactive Streams Spec</a>.
+ *
+ *      In the case when upstream's signals overflow the bound of internal Queue,
+ *      UnicastProcessor will fail with signaling onError(
+ *      {@literal reactor.core.Exceptions.OverflowException}).
+ *
+ *      <p>
+ *         <img width="640" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.2.0.M2/src/docs/marble/unicastprocessoroverflow.png" alt="">
+ *      </p>
+ * </p>
+ *
+ * </br>
+ * </br>
+ *
+ * <p>
+ *      <b>Note: </b> The implementation keeps the order of signals. That means that in
+ *      case of terminal signal (completion or error signals) it will be postponed
+ *      until all of the previous signals has been consumed.
+ *      <p>
+ *         <img width="640" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.2.0.M2/src/docs/marble/unicastprocessorterminal.png" alt="">
+ *      </p>
+ * </p>
+ *
+ * @param <T> the input and output type
+ * @deprecated to be removed in 3.5, prefer clear cut usage of {@link Sinks} through
+ * variations under {@link Sinks.UnicastSpec Sinks.many().unicast()}.
+ */
+@Deprecated
+public final class UnicastProcessor<T> extends FluxProcessor<T, T>
+		implements Fuseable.QueueSubscription<T>, Fuseable, InnerOperator<T, T>,
+		           InternalManySink<T> {
+
+	/**
+	 * Create a new {@link UnicastProcessor} that will buffer on an internal queue in an
+	 * unbounded fashion.
+	 *
+	 * @param <E> the relayed type
+	 * @return a unicast {@link FluxProcessor}
+	 * @deprecated use {@link Sinks.UnicastSpec#onBackpressureBuffer() Sinks.many().unicast().onBackpressureBuffer()}
+	 * (or the unsafe variant if you're sure about external synchronization). To be removed in 3.5.
+	 */
+	@Deprecated
+	public static <E> UnicastProcessor<E> create() {
+		return new UnicastProcessor<>(Queues.<E>unbounded().get());
+	}
+
+	/**
+	 * Create a new {@link UnicastProcessor} that will buffer on a provided queue in an
+	 * unbounded fashion.
+	 *
+	 * @param queue the buffering queue
+	 * @param <E> the relayed type
+	 * @return a unicast {@link FluxProcessor}
+	 * @deprecated use {@link Sinks.UnicastSpec#onBackpressureBuffer(Queue) Sinks.many().unicast().onBackpressureBuffer(queue)}
+	 * (or the unsafe variant if you're sure about external synchronization). To be removed in 3.5.
+	 */
+	@Deprecated
+	public static <E> UnicastProcessor<E> create(Queue<E> queue) {
+		return new UnicastProcessor<>(Hooks.wrapQueue(queue));
+	}
+
+	/**
+	 * Create a new {@link UnicastProcessor} that will buffer on a provided queue in an
+	 * unbounded fashion.
+	 *
+	 * @param queue the buffering queue
+	 * @param endcallback called on any terminal signal
+	 * @param <E> the relayed type
+	 * @return a unicast {@link FluxProcessor}
+	 * @deprecated use {@link Sinks.UnicastSpec#onBackpressureBuffer(Queue, Disposable)  Sinks.many().unicast().onBackpressureBuffer(queue, endCallback)}
+	 * (or the unsafe variant if you're sure about external synchronization). To be removed in 3.5.
+	 */
+	@Deprecated
+	public static <E> UnicastProcessor<E> create(Queue<E> queue, Disposable endcallback) {
+		return new UnicastProcessor<>(Hooks.wrapQueue(queue), endcallback);
+	}
+
+	/**
+	 * Create a new {@link UnicastProcessor} that will buffer on a provided queue in an
+	 * unbounded fashion.
+	 *
+	 * @param queue the buffering queue
+	 * @param endcallback called on any terminal signal
+	 * @param onOverflow called when queue.offer return false and unicastProcessor is
+	 * about to emit onError.
+	 * @param <E> the relayed type
+	 *
+	 * @return a unicast {@link FluxProcessor}
+	 * @deprecated use {@link Sinks.UnicastSpec#onBackpressureBuffer(Queue, Disposable)  Sinks.many().unicast().onBackpressureBuffer(queue, endCallback)}
+	 * (or the unsafe variant if you're sure about external synchronization). The {@code onOverflow} callback is not
+	 * supported anymore. To be removed in 3.5.
+	 */
+	@Deprecated
+	public static <E> UnicastProcessor<E> create(Queue<E> queue,
+			Consumer<? super E> onOverflow,
+			Disposable endcallback) {
+		return new UnicastProcessor<>(Hooks.wrapQueue(queue), onOverflow, endcallback);
+	}
+
+	final Queue<T>            queue;
+	final Consumer<? super T> onOverflow;
+
+	volatile Disposable onTerminate;
+	@SuppressWarnings("rawtypes")
+	static final AtomicReferenceFieldUpdater<UnicastProcessor, Disposable> ON_TERMINATE =
+			AtomicReferenceFieldUpdater.newUpdater(UnicastProcessor.class, Disposable.class, "onTerminate");
+
+	volatile boolean done;
+	Throwable error;
+
+	boolean hasDownstream; //important to not loose the downstream too early and miss discard hook, while having relevant hasDownstreams()
+	volatile CoreSubscriber<? super T> actual;
+
+	volatile boolean cancelled;
+
+	volatile int once;
+	@SuppressWarnings("rawtypes")
+	static final AtomicIntegerFieldUpdater<UnicastProcessor> ONCE =
+			AtomicIntegerFieldUpdater.newUpdater(UnicastProcessor.class, "once");
+
+	volatile int wip;
+	@SuppressWarnings("rawtypes")
+	static final AtomicIntegerFieldUpdater<UnicastProcessor> WIP =
+			AtomicIntegerFieldUpdater.newUpdater(UnicastProcessor.class, "wip");
+
+	volatile int discardGuard;
+	@SuppressWarnings("rawtypes")
+	static final AtomicIntegerFieldUpdater<UnicastProcessor> DISCARD_GUARD =
+			AtomicIntegerFieldUpdater.newUpdater(UnicastProcessor.class, "discardGuard");
+
+	volatile long requested;
+	@SuppressWarnings("rawtypes")
+	static final AtomicLongFieldUpdater<UnicastProcessor> REQUESTED =
+			AtomicLongFieldUpdater.newUpdater(UnicastProcessor.class, "requested");
+
+	boolean outputFused;
+
+	public UnicastProcessor(Queue<T> queue) {
+		this.queue = Objects.requireNonNull(queue, "queue");
+		this.onTerminate = null;
+		this.onOverflow = null;
+	}
+
+	public UnicastProcessor(Queue<T> queue, Disposable onTerminate) {
+		this.queue = Objects.requireNonNull(queue, "queue");
+		this.onTerminate = Objects.requireNonNull(onTerminate, "onTerminate");
+		this.onOverflow = null;
+	}
+
+	@Deprecated
+	public UnicastProcessor(Queue<T> queue,
+			Consumer<? super T> onOverflow,
+			Disposable onTerminate) {
+		this.queue = Objects.requireNonNull(queue, "queue");
+		this.onOverflow = Objects.requireNonNull(onOverflow, "onOverflow");
+		this.onTerminate = Objects.requireNonNull(onTerminate, "onTerminate");
+	}
+
+	@Override
+	public int getBufferSize() {
+		return Queues.capacity(this.queue);
+	}
+
+	@Override
+	public Stream<Scannable> inners() {
+		return hasDownstream ? Stream.of(Scannable.from(actual)) : Stream.empty();
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (Attr.ACTUAL == key) return actual();
+		if (Attr.BUFFERED == key) return queue.size();
+		if (Attr.PREFETCH == key) return Integer.MAX_VALUE;
+		if (Attr.CANCELLED == key) return cancelled;
+
+		//TERMINATED and ERROR covered in super
+		return super.scanUnsafe(key);
+	}
+
+	@Override
+	public void onComplete() {
+		//no particular error condition handling for onComplete
+		@SuppressWarnings("unused") EmitResult emitResult = tryEmitComplete();
+	}
+
+	@Override
+	public EmitResult tryEmitComplete() {
+		if (done) {
+			return EmitResult.FAIL_TERMINATED;
+		}
+		if (cancelled) {
+			return EmitResult.FAIL_CANCELLED;
+		}
+
+		done = true;
+
+		doTerminate();
+
+		drain(null);
+		return EmitResult.OK;
+	}
+
+	@Override
+	public void onError(Throwable throwable) {
+		emitError(throwable, Sinks.EmitFailureHandler.FAIL_FAST);
+	}
+
+	@Override
+	public EmitResult tryEmitError(Throwable t) {
+		if (done) {
+			return EmitResult.FAIL_TERMINATED;
+		}
+		if (cancelled) {
+			return EmitResult.FAIL_CANCELLED;
+		}
+
+		error = t;
+		done = true;
+
+		doTerminate();
+
+		drain(null);
+		return EmitResult.OK;
+	}
+
+	@Override
+	public void onNext(T t) {
+		emitNext(t, Sinks.EmitFailureHandler.FAIL_FAST);
+	}
+
+	@Override
+	public void emitNext(T value, Sinks.EmitFailureHandler failureHandler) {
+		if (onOverflow == null) {
+			InternalManySink.super.emitNext(value, failureHandler);
+			return;
+		}
+
+		// TODO consider deprecating onOverflow and suggesting using a strategy instead
+		InternalManySink.super.emitNext(
+				value, (signalType, emission) -> {
+					boolean shouldRetry = failureHandler.onEmitFailure(SignalType.ON_NEXT, emission);
+					if (!shouldRetry) {
+						switch (emission) {
+							case FAIL_ZERO_SUBSCRIBER:
+							case FAIL_OVERFLOW:
+								try {
+									onOverflow.accept(value);
+								}
+								catch (Throwable e) {
+									Exceptions.throwIfFatal(e);
+									emitError(e, Sinks.EmitFailureHandler.FAIL_FAST);
+								}
+								break;
+						}
+					}
+					return shouldRetry;
+				}
+		);
+	}
+
+	@Override
+	public EmitResult tryEmitNext(T t) {
+		if (done) {
+			return EmitResult.FAIL_TERMINATED;
+		}
+		if (cancelled) {
+			return EmitResult.FAIL_CANCELLED;
+		}
+
+		if (!queue.offer(t)) {
+			return (once > 0) ? EmitResult.FAIL_OVERFLOW : EmitResult.FAIL_ZERO_SUBSCRIBER;
+		}
+		drain(t);
+		return EmitResult.OK;
+	}
+
+	@Override
+	public int currentSubscriberCount() {
+		return hasDownstream ? 1 : 0;
+	}
+
+	@Override
+	public Flux<T> asFlux() {
+		return this;
+	}
+
+	@Override
+	protected boolean isIdentityProcessor() {
+		return true;
+	}
+
+	void doTerminate() {
+		Disposable r = onTerminate;
+		if (r != null && ON_TERMINATE.compareAndSet(this, r, null)) {
+			r.dispose();
+		}
+	}
+
+	void drainRegular(CoreSubscriber<? super T> a) {
+		int missed = 1;
+
+		final Queue<T> q = queue;
+
+		for (;;) {
+
+			long r = requested;
+			long e = 0L;
+
+			while (r != e) {
+				boolean d = done;
+
+				T t = q.poll();
+				boolean empty = t == null;
+
+				if (checkTerminated(d, empty, a, q, t)) {
+					return;
+				}
+
+				if (empty) {
+					break;
+				}
+
+				a.onNext(t);
+
+				e++;
+			}
+
+			if (r == e) {
+				if (checkTerminated(done, q.isEmpty(), a, q, null)) {
+					return;
+				}
+			}
+
+			if (e != 0 && r != Long.MAX_VALUE) {
+				REQUESTED.addAndGet(this, -e);
+			}
+
+			missed = WIP.addAndGet(this, -missed);
+			if (missed == 0) {
+				break;
+			}
+		}
+	}
+
+	void drainFused(CoreSubscriber<? super T> a) {
+		int missed = 1;
+
+		for (;;) {
+
+			if (cancelled) {
+				// We are the holder of the queue, but we still have to perform discarding under the guarded block
+				// to prevent any racing done by downstream
+				this.clear();
+				hasDownstream = false;
+				return;
+			}
+
+			boolean d = done;
+
+			a.onNext(null);
+
+			if (d) {
+				hasDownstream = false;
+
+				Throwable ex = error;
+				if (ex != null) {
+					a.onError(ex);
+				} else {
+					a.onComplete();
+				}
+				return;
+			}
+
+			missed = WIP.addAndGet(this, -missed);
+			if (missed == 0) {
+				break;
+			}
+		}
+	}
+
+	void drain(@Nullable T dataSignalOfferedBeforeDrain) {
+		if (WIP.getAndIncrement(this) != 0) {
+			if (dataSignalOfferedBeforeDrain != null) {
+				if (cancelled) {
+					Operators.onDiscard(dataSignalOfferedBeforeDrain,
+							actual.currentContext());
+				}
+				else if (done) {
+					Operators.onNextDropped(dataSignalOfferedBeforeDrain,
+							currentContext());
+				}
+			}
+			return;
+		}
+
+		int missed = 1;
+
+		for (;;) {
+			CoreSubscriber<? super T> a = actual;
+			if (a != null) {
+
+				if (outputFused) {
+					drainFused(a);
+				} else {
+					drainRegular(a);
+				}
+				return;
+			}
+
+			missed = WIP.addAndGet(this, -missed);
+			if (missed == 0) {
+				break;
+			}
+		}
+	}
+
+	boolean checkTerminated(boolean d, boolean empty, CoreSubscriber<? super T> a, Queue<T> q, @Nullable T t) {
+		if (cancelled) {
+			Operators.onDiscard(t, a.currentContext());
+			Operators.onDiscardQueueWithClear(q, a.currentContext(), null);
+			hasDownstream = false;
+			return true;
+		}
+		if (d && empty) {
+			Throwable e = error;
+			hasDownstream = false;
+			if (e != null) {
+				a.onError(e);
+			} else {
+				a.onComplete();
+			}
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
+	public void onSubscribe(Subscription s) {
+		if (done || cancelled) {
+			s.cancel();
+		} else {
+			s.request(Long.MAX_VALUE);
+		}
+	}
+
+	@Override
+	public int getPrefetch() {
+		return Integer.MAX_VALUE;
+	}
+
+	@Override
+	public Context currentContext() {
+		CoreSubscriber<? super T> actual = this.actual;
+		return actual != null ? actual.currentContext() : Context.empty();
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super T> actual) {
+		Objects.requireNonNull(actual, "subscribe");
+		if (once == 0 && ONCE.compareAndSet(this, 0, 1)) {
+
+			this.hasDownstream = true;
+			actual.onSubscribe(this);
+			this.actual = actual;
+			if (cancelled) {
+				this.hasDownstream = false;
+			} else {
+				drain(null);
+			}
+		} else {
+			Operators.error(actual, new IllegalStateException("UnicastProcessor " +
+					"allows only a single Subscriber"));
+		}
+	}
+
+	@Override
+	public void request(long n) {
+		if (Operators.validate(n)) {
+			Operators.addCap(REQUESTED, this, n);
+			drain(null);
+		}
+	}
+
+	@Override
+	public void cancel() {
+		if (cancelled) {
+			return;
+		}
+		cancelled = true;
+
+		doTerminate();
+
+		if (WIP.getAndIncrement(this) == 0) {
+			if (!outputFused) {
+				// discard MUST be happening only and only if there is no racing on elements consumption
+				// which is guaranteed by the WIP guard here in case non-fused output
+				Operators.onDiscardQueueWithClear(queue, currentContext(), null);
+			}
+			hasDownstream = false;
+		}
+	}
+
+	@Override
+	@Nullable
+	public T poll() {
+		return queue.poll();
+	}
+
+	@Override
+	public int size() {
+		return queue.size();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return queue.isEmpty();
+	}
+
+	@Override
+	public void clear() {
+		// use guard on the queue instance as the best way to ensure there is no racing on draining
+		// the call to this method must be done only during the ASYNC fusion so all the callers will be waiting
+		// this should not be performance costly with the assumption the cancel is rare operation
+		if (DISCARD_GUARD.getAndIncrement(this) != 0) {
+			return;
+		}
+
+		int missed = 1;
+
+		for (;;) {
+			Operators.onDiscardQueueWithClear(queue, currentContext(), null);
+
+			int dg = discardGuard;
+			if (missed == dg) {
+				missed = DISCARD_GUARD.addAndGet(this, -missed);
+				if (missed == 0) {
+					break;
+				}
+			}
+			else {
+				missed = dg;
+			}
+		}
+	}
+
+	@Override
+	public int requestFusion(int requestedMode) {
+		if ((requestedMode & Fuseable.ASYNC) != 0) {
+			outputFused = true;
+			return Fuseable.ASYNC;
+		}
+		return Fuseable.NONE;
+	}
+
+	@Override
+	public boolean isDisposed() {
+		return cancelled || done;
+	}
+
+	@Override
+	public boolean isTerminated() {
+		return done;
+	}
+
+	@Override
+	@Nullable
+	public Throwable getError() {
+		return error;
+	}
+
+	@Override
+	public CoreSubscriber<? super T> actual() {
+		return actual;
+	}
+
+	@Override
+	public long downstreamCount() {
+		return hasDownstreams() ? 1L : 0L;
+	}
+
+	@Override
+	public boolean hasDownstreams() {
+		return hasDownstream;
+	}
+
+}


### PR DESCRIPTION
This partially reverts #3051, by reintroducing Flux and Mono
Processor implementation as they were in 3.4.x (still deprecated).

This was done by copying the classes and making a few small adaptations
to DirectProcessor and SinkManyBestEffort (reintroducing the interface
DirectInnerContainer, as a package-private mean of mutualizing the
DirectInner code).

This soft-revert doesn't reintroduce tests, Flux-level APIs or changes
in the documentation / reference guide.
