### PR TITLE
Add logging in Exceptions.throwIf[Jvm]Fatal, add isFatal methods

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Exceptions.java
+++ b/reactor-core/src/main/java/reactor/core/Exceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/Exceptions.java
+++ b/reactor-core/src/main/java/reactor/core/Exceptions.java
@@ -25,6 +25,8 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import reactor.core.publisher.Flux;
+import reactor.util.Logger;
+import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
 import reactor.util.retry.Retry;
 
@@ -35,6 +37,8 @@ import reactor.util.retry.Retry;
  * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
  */
 public abstract class Exceptions {
+
+	private static final Logger LOGGER = Loggers.getLogger(Exceptions.class);
 
 	/**
 	 * A common error message used when a reactive streams source doesn't seem to respect
@@ -413,6 +417,70 @@ public abstract class Exceptions {
 	}
 
 	/**
+	 * Check if a {@link Throwable} is considered by Reactor as Jvm Fatal and would be thrown
+	 * by both {@link #throwIfFatal(Throwable)} and {@link #throwIfJvmFatal(Throwable)}.
+	 * This is a subset of {@link #isFatal(Throwable)}, namely:
+	 * <ul>
+	 *     <li>{@link VirtualMachineError}</li>
+	 *     <li>{@link ThreadDeath}</li>
+	 *     <li>{@link LinkageError}</li>
+	 * </ul>
+	 * <p>
+	 * Unless wrapped explicitly, such exceptions would always be thrown by operators instead of
+	 * propagation through onError, potentially interrupting progress of Flux/Mono sequences.
+	 * When they occur, the JVM itself is assumed to be in an unrecoverable state, and so is Reactor.
+	 *
+	 * @see #throwIfFatal(Throwable)
+	 * @see #throwIfJvmFatal(Throwable)
+	 * @see #isFatal(Throwable)
+	 * @param t the {@link Throwable} to check
+	 * @return true if the throwable is considered Jvm Fatal
+	 */
+	public static boolean isJvmFatal(@Nullable Throwable t) {
+		if (t instanceof VirtualMachineError ||
+			t instanceof ThreadDeath ||
+			t instanceof LinkageError) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Check if a {@link Throwable} is considered by Reactor as Fatal and would be thrown by
+	 * {@link #throwIfFatal(Throwable)}.
+	 * <ul>
+	 * 	<li>{@code BubblingException} (as detectable by {@link #isBubbling(Throwable)})</li>
+	 * 	<li>{@code ErrorCallbackNotImplemented} (as detectable by {@link #isErrorCallbackNotImplemented(Throwable)})</li>
+	 * 	<li> {@link #isJvmFatal(Throwable) Jvm Fatal exceptions}
+	 * 	  <ul>
+	 * 		<li>{@link VirtualMachineError}</li>
+	 * 		<li>{@link ThreadDeath}</li>
+	 * 		<li>{@link LinkageError}</li>
+	 * 	  </ul>
+	 * 	</li>
+	 * </ul>
+	 * <p>
+	 * Unless wrapped explicitly, such exceptions would always be thrown by operators instead of
+	 * propagation through onError, potentially interrupting progress of Flux/Mono sequences.
+	 * When they occur, the assumption is that Reactor is in an unrecoverable state (notably
+	 * because the JVM itself might be in an unrecoverable state).
+	 *
+	 * @see #throwIfFatal(Throwable)
+	 * @see #isJvmFatal(Throwable)
+	 * @param t the {@link Throwable} to check
+	 * @return true if the throwable is considered fatal
+	 */
+	public static boolean isFatal(@Nullable Throwable t) {
+		if (t instanceof BubblingException || t instanceof ErrorCallbackNotImplemented) {
+			return true;
+		}
+		if (isJvmFatal(t)) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
 	 * Throws a particular {@code Throwable} only if it belongs to a set of "fatal" error
 	 * varieties. These varieties are as follows: <ul>
 	 *     <li>{@code BubblingException} (as detectable by {@link #isBubbling(Throwable)})</li>
@@ -422,13 +490,16 @@ public abstract class Exceptions {
 	 * @param t the exception to evaluate
 	 */
 	public static void throwIfFatal(@Nullable Throwable t) {
-		if (t instanceof BubblingException) {
-			throw (BubblingException) t;
+		if (t == null) {
+			return;
 		}
-		if (t instanceof ErrorCallbackNotImplemented) {
-			throw (ErrorCallbackNotImplemented) t;
-		}
+		//we give throwIfJvmFatal an opportunity to detect, log and throw first
 		throwIfJvmFatal(t);
+		if (isFatal(t)) {
+			LOGGER.warn("throwIfFatal detected a fatal exception, throwing", t);
+			assert t instanceof RuntimeException;
+			throw (RuntimeException) t;
+		}
 	}
 
 	/**
@@ -440,14 +511,13 @@ public abstract class Exceptions {
 	 * @param t the exception to evaluate
 	 */
 	public static void throwIfJvmFatal(@Nullable Throwable t) {
-		if (t instanceof VirtualMachineError) {
-			throw (VirtualMachineError) t;
+		if (t == null) {
+			return;
 		}
-		if (t instanceof ThreadDeath) {
-			throw (ThreadDeath) t;
-		}
-		if (t instanceof LinkageError) {
-			throw (LinkageError) t;
+		if (isJvmFatal(t)) {
+			LOGGER.warn("throwIfJvmFatal detected a fatal exception, throwing", t);
+			assert t instanceof Error;
+			throw (Error) t;
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/Exceptions.java
+++ b/reactor-core/src/main/java/reactor/core/Exceptions.java
@@ -492,11 +492,11 @@ public abstract class Exceptions {
 			return;
 		}
 		if (isFatalButNotJvmFatal(t)) {
-			LOGGER.warn("throwIfFatal detected a fatal exception, throwing", t);
+			LOGGER.warn("throwIfFatal detected a fatal exception, which is thrown and logged below:", t);
 			throw (RuntimeException) t;
 		}
 		if (isJvmFatal(t)) {
-			LOGGER.warn("throwIfFatal detected a jvm fatal exception, throwing", t);
+			LOGGER.warn("throwIfFatal detected a jvm fatal exception, which is thrown and logged below:", t);
 			throw (Error) t;
 		}
 	}
@@ -514,7 +514,7 @@ public abstract class Exceptions {
 			return;
 		}
 		if (isJvmFatal(t)) {
-			LOGGER.warn("throwIfJvmFatal detected a fatal exception, throwing", t);
+			LOGGER.warn("throwIfJvmFatal detected a jvm fatal exception, which is thrown and logged below:", t);
 			assert t instanceof Error;
 			throw (Error) t;
 		}

--- a/reactor-core/src/test/java/reactor/core/ExceptionsTest.java
+++ b/reactor-core/src/test/java/reactor/core/ExceptionsTest.java
@@ -27,7 +27,6 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-import reactor.TestLoggerExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.util.LoggerUtils;
 import reactor.test.util.RaceTestUtils;

--- a/reactor-core/src/test/java/reactor/core/ExceptionsTest.java
+++ b/reactor-core/src/test/java/reactor/core/ExceptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/ExceptionsTest.java
+++ b/reactor-core/src/test/java/reactor/core/ExceptionsTest.java
@@ -24,11 +24,9 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import reactor.core.publisher.Mono;
-import reactor.test.util.LoggerUtils;
 import reactor.test.util.RaceTestUtils;
 import reactor.test.util.TestLogger;
 import reactor.util.annotation.Nullable;
@@ -238,16 +236,9 @@ public class ExceptionsTest {
 			.isTrue();
 	}
 
-	@AfterEach
-	void disableCapture() {
-		LoggerUtils.disableCapture();
-	}
-
 	@Test
-	void throwIfFatalThrowsAndLogsBubbling() {
-		TestLogger testLogger = new TestLogger(false);
-		LoggerUtils.enableCaptureWith(testLogger);
-
+	@TestLoggerExtension.Redirect
+	void throwIfFatalThrowsAndLogsBubbling(TestLogger testLogger) {
 		BubblingException expected = new BubblingException("expected to be logged");
 
 		assertThatExceptionOfType(BubblingException.class)
@@ -259,10 +250,8 @@ public class ExceptionsTest {
 	}
 
 	@Test
-	void throwIfFatalThrowsAndLogsErrorCallbackNotImplemented() {
-		TestLogger testLogger = new TestLogger(false);
-		LoggerUtils.enableCaptureWith(testLogger);
-
+	@TestLoggerExtension.Redirect
+	void throwIfFatalThrowsAndLogsErrorCallbackNotImplemented(TestLogger testLogger) {
 		ErrorCallbackNotImplemented expected = new ErrorCallbackNotImplemented(new IllegalStateException("expected to be logged"));
 
 		assertThatExceptionOfType(ErrorCallbackNotImplemented.class)
@@ -275,10 +264,8 @@ public class ExceptionsTest {
 	}
 
 	@Test
-	void throwIfFatalWithJvmFatalErrorsDoesThrowAndLog() {
-		TestLogger testLogger = new TestLogger(false);
-		LoggerUtils.enableCaptureWith(testLogger);
-
+	@TestLoggerExtension.Redirect
+	void throwIfFatalWithJvmFatalErrorsDoesThrowAndLog(TestLogger testLogger) {
 		SoftAssertions.assertSoftly(softly -> {
 			softly.assertThatExceptionOfType(VirtualMachineError.class)
 				.as("VirtualMachineError")
@@ -303,10 +290,8 @@ public class ExceptionsTest {
 	}
 
 	@Test
-	void throwIfJvmFatalDoesThrowAndLog() {
-		TestLogger testLogger = new TestLogger(false);
-		LoggerUtils.enableCaptureWith(testLogger);
-
+	@TestLoggerExtension.Redirect
+	void throwIfJvmFatalDoesThrowAndLog(TestLogger testLogger) {
 		assertThatExceptionOfType(VirtualMachineError.class)
 				.as("VirtualMachineError")
 				.isThrownBy(() -> Exceptions.throwIfJvmFatal(JVM_FATAL_VIRTUAL_MACHINE_ERROR))
@@ -329,10 +314,8 @@ public class ExceptionsTest {
 	};
 
 	@Test
-	void throwIfJvmFatalDoesntThrowNorLogsOnSimplyFatalExceptions() {
-		TestLogger testLogger = new TestLogger(false);
-		LoggerUtils.enableCaptureWith(testLogger);
-
+	@TestLoggerExtension.Redirect
+	void throwIfJvmFatalDoesntThrowNorLogsOnSimplyFatalExceptions(TestLogger testLogger) {
 		SoftAssertions.assertSoftly(softly -> {
 			softly.assertThatCode(() -> Exceptions.throwIfJvmFatal(new BubblingException("not thrown")))
 				.doesNotThrowAnyException();

--- a/reactor-core/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
@@ -209,9 +209,9 @@ public class LambdaMonoSubscriberTest {
 		TestSubscription testSubscription = new TestSubscription();
 		tested.onSubscribe(testSubscription);
 
-		//the error is expected to be thrown as it is fatal, so it doesn't go through onErrorDropped
+		//the error is expected to be thrown as it is fatal, so it doesn't go through onErrorDropped. However, throwIfJvmFatal now logs it.
 		assertThatExceptionOfType(OutOfMemoryError.class).isThrownBy(() -> tested.onNext("foo"));
-		Assertions.assertThat(testLogger.getErrContent()).isEmpty();
+		Assertions.assertThat(testLogger.getErrContent()).startsWith("[ WARN] throwIfFatal detected a jvm fatal exception, which is thrown and logged below: - java.lang.OutOfMemoryError");
 
 		assertThat(testSubscription.isCancelled).as("subscription isCancelled")
 			.isFalse();


### PR DESCRIPTION
This commit improves the discoverability of exceptions that are "fatal"
to Reactor by:
 - adding `Exceptions.isFatal` and `Exceptions.isJvmFatal` methods
 - adding logging to `Exceptions.throwIfFatal` and
 `Exceptions.throwIfJvmFatal` just before a fatal exception is thrown

This should at least help pinpointing such occurrences from the logs,
in cases where the thrown exception bubble all the way up the stack of
a thread with no uncaughtExceptionHandler for example.

Fixes #3111.
