### PR TITLE
Improve LoggerUtils support and add TestLoggerExtension

### DIFF
--- a/reactor-core/src/test/java/reactor/core/TestLoggerExtension.java
+++ b/reactor-core/src/test/java/reactor/core/TestLoggerExtension.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import reactor.test.util.LoggerUtils;
+import reactor.test.util.TestLogger;
+import reactor.util.Logger;
+import reactor.util.annotation.Nullable;
+
+/**
+ * A JUnit5 extension that installs a {@link TestLogger} as the capturing instance via {@link LoggerUtils#enableCaptureWith(Logger)},
+ * {@link LoggerUtils#disableCapture() disable capture} at the end of the test and injects the {@link TestLogger}
+ * into the test case (by implementing {@link ParameterResolver}).
+ *
+ * @author Simon Baslé
+ */
+public class TestLoggerExtension implements ParameterResolver, AfterEachCallback, BeforeEachCallback {
+
+	/**
+	 * Set up a default {@link TestLoggerExtension}, unless further tuned by {@link WithThreadName}
+	 * and/or @{@link Redirect} annotations.
+	 * By default loggers will route the log messages to both the original logger and the injected
+	 * {@link TestLogger} (without a thread name).
+	 *
+	 * @see WithThreadName
+	 * @see Redirect
+	 */
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.TYPE, ElementType.METHOD })
+	@ExtendWith(TestLoggerExtension.class)
+	public @interface Capture { }
+
+	/**
+	 * Set up a {@link TestLoggerExtension} where injected {@link TestLogger} includes the thread names.
+	 * If used in isolation, routes log messages to both original logger and injected {@link TestLogger}.
+	 * If used along {@link Redirect}, only influences the thread name aspect.
+	 */
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.TYPE, ElementType.METHOD })
+	@ExtendWith(TestLoggerExtension.class)
+	public @interface WithThreadName { }
+
+	/**
+	 * Set up a {@link TestLoggerExtension} that routes log messages only to the injected {@link TestLogger},
+	 * suppressing the logs from the original logger.
+	 * Unless {@link WithThreadName} is also used, the {@link TestLogger} doesn't include thread names in messages.
+	 *
+	 * @see WithThreadName
+	 */
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.TYPE, ElementType.METHOD })
+	@ExtendWith(TestLoggerExtension.class)
+	public @interface Redirect { }
+
+	TestLogger logger;
+
+	@Override
+	public void beforeEach(ExtensionContext context) throws Exception {
+		if (context.getElement().isPresent()) {
+			boolean withThreadName = context.getElement().get().isAnnotationPresent(WithThreadName.class);
+			boolean suppressOriginal = context.getElement().get().isAnnotationPresent(Redirect.class);
+			this.logger = new TestLogger(withThreadName);
+			LoggerUtils.enableCaptureWith(logger, !suppressOriginal);
+		}
+	}
+
+	@Override
+	public void afterEach(ExtensionContext context) throws Exception {
+		LoggerUtils.disableCapture();
+	}
+
+	@Override
+	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+		throws ParameterResolutionException {
+		return parameterContext.getParameter().getType() == TestLogger.class;
+	}
+
+	@Override
+	@Nullable
+	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+		throws ParameterResolutionException {
+		if (parameterContext.getParameter().getType() == TestLogger.class) {
+			return this.logger;
+		}
+		return null;
+	}
+}

--- a/reactor-core/src/test/java/reactor/core/TestLoggerExtension.java
+++ b/reactor-core/src/test/java/reactor/core/TestLoggerExtension.java
@@ -44,12 +44,10 @@ import reactor.util.annotation.Nullable;
 public class TestLoggerExtension implements ParameterResolver, AfterEachCallback, BeforeEachCallback {
 
 	/**
-	 * Set up a default {@link TestLoggerExtension}, unless further tuned by {@link WithThreadName}
-	 * and/or @{@link Redirect} annotations.
+	 * Set up a default {@link TestLoggerExtension}, unless @{@link Redirect} annotation is also present.
 	 * By default loggers will route the log messages to both the original logger and the injected
-	 * {@link TestLogger} (without a thread name).
+	 * {@link TestLogger}, and in the latter there won't be automatic inclusion of thread names.
 	 *
-	 * @see WithThreadName
 	 * @see Redirect
 	 */
 	@Retention(RetentionPolicy.RUNTIME)
@@ -58,21 +56,8 @@ public class TestLoggerExtension implements ParameterResolver, AfterEachCallback
 	public @interface Capture { }
 
 	/**
-	 * Set up a {@link TestLoggerExtension} where injected {@link TestLogger} includes the thread names.
-	 * If used in isolation, routes log messages to both original logger and injected {@link TestLogger}.
-	 * If used along {@link Redirect}, only influences the thread name aspect.
-	 */
-	@Retention(RetentionPolicy.RUNTIME)
-	@Target({ ElementType.TYPE, ElementType.METHOD })
-	@ExtendWith(TestLoggerExtension.class)
-	public @interface WithThreadName { }
-
-	/**
 	 * Set up a {@link TestLoggerExtension} that routes log messages only to the injected {@link TestLogger},
-	 * suppressing the logs from the original logger.
-	 * Unless {@link WithThreadName} is also used, the {@link TestLogger} doesn't include thread names in messages.
-	 *
-	 * @see WithThreadName
+	 * suppressing the logs from the original logger. Messages don't include thread names.
 	 */
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.TYPE, ElementType.METHOD })
@@ -84,9 +69,8 @@ public class TestLoggerExtension implements ParameterResolver, AfterEachCallback
 	@Override
 	public void beforeEach(ExtensionContext context) throws Exception {
 		if (context.getElement().isPresent()) {
-			boolean withThreadName = context.getElement().get().isAnnotationPresent(WithThreadName.class);
 			boolean suppressOriginal = context.getElement().get().isAnnotationPresent(Redirect.class);
-			this.logger = new TestLogger(withThreadName);
+			this.logger = new TestLogger(false);
 			LoggerUtils.enableCaptureWith(logger, !suppressOriginal);
 		}
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/BaseSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BaseSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/BaseSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BaseSubscriberTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 
 import reactor.core.Disposable;
+import reactor.core.TestLoggerExtension;
 import reactor.test.util.LoggerUtils;
 import reactor.test.util.TestLogger;
 
@@ -82,30 +83,23 @@ public class BaseSubscriberTest {
 	}
 
 	@Test
-	public void onErrorCallbackNotImplemented() {
-		TestLogger testLogger = new TestLogger();
-		LoggerUtils.enableCaptureWith(testLogger);
-		try {
-			Flux<String> flux = Flux.error(new IllegalStateException());
+	@TestLoggerExtension.Redirect
+	void onErrorCallbackNotImplemented(TestLogger testLogger) {
+		Flux<String> flux = Flux.error(new IllegalStateException());
 
-			flux.subscribe(new BaseSubscriber<String>() {
-				@Override
-				protected void hookOnSubscribe(Subscription subscription) {
-					request(1);
-				}
+		flux.subscribe(new BaseSubscriber<String>() {
+			@Override
+			protected void hookOnSubscribe(Subscription subscription) {
+				request(1);
+			}
 
-				@Override
-				protected void hookOnNext(String value) {
-					//NO-OP
-				}
-			});
-			Assertions.assertThat(testLogger.getErrContent())
-			          .contains("Operator called default onErrorDropped")
-			          .contains("reactor.core.Exceptions$ErrorCallbackNotImplemented: java.lang.IllegalStateException");
-		}
-		finally {
-			LoggerUtils.disableCapture();
-		}
+			@Override
+			protected void hookOnNext(String value) {
+				//NO-OP
+			}
+		});
+		Assertions.assertThat(testLogger.getErrContent())
+			.startsWith("[ERROR] Operator called default onErrorDropped - reactor.core.Exceptions$ErrorCallbackNotImplemented: java.lang.IllegalStateException");
 	}
 
 	@Test
@@ -277,41 +271,33 @@ public class BaseSubscriberTest {
 	}
 
 	@Test
-	public void finallyExecutesWhenHookOnErrorFails() {
-		TestLogger testLogger = new TestLogger();
-		LoggerUtils.enableCaptureWith(testLogger);
-		try {
-			RuntimeException error = new IllegalArgumentException("hookOnError");
-			AtomicReference<SignalType> checkFinally = new AtomicReference<>();
+	@TestLoggerExtension.Redirect
+	void finallyExecutesWhenHookOnErrorFails(TestLogger testLogger) {
+		RuntimeException error = new IllegalArgumentException("hookOnError");
+		AtomicReference<SignalType> checkFinally = new AtomicReference<>();
 
-			Flux.<String>error(new IllegalStateException("someError")).subscribe(new BaseSubscriber<String>() {
-				@Override
-				protected void hookOnSubscribe(Subscription subscription) {
-					requestUnbounded();
-				}
+		Flux.<String>error(new IllegalStateException("someError")).subscribe(new BaseSubscriber<String>() {
+			@Override
+			protected void hookOnSubscribe(Subscription subscription) {
+				requestUnbounded();
+			}
 
-				@Override
-				protected void hookOnNext(String value) {
-				}
+			@Override
+			protected void hookOnNext(String value) {
+			}
 
-				@Override
-				protected void hookOnError(Throwable throwable) {
-					throw error;
-				}
+			@Override
+			protected void hookOnError(Throwable throwable) {
+				throw error;
+			}
 
-				@Override
-				protected void hookFinally(SignalType type) {
-					checkFinally.set(type);
-				}
-			});
-			Assertions.assertThat(testLogger.getErrContent())
-			          .contains("Operator called default onErrorDropped")
-			          .contains(error.getMessage());
-			assertThat(checkFinally).hasValue(SignalType.ON_ERROR);
-		}
-		finally {
-			LoggerUtils.disableCapture();
-		}
+			@Override
+			protected void hookFinally(SignalType type) {
+				checkFinally.set(type);
+			}
+		});
+		Assertions.assertThat(testLogger.getErrContent())
+			.startsWith("[ERROR] Operator called default onErrorDropped - java.lang.IllegalArgumentException: hookOnError");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxDoFinallyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxDoFinallyTest.java
@@ -30,6 +30,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Scannable;
+import reactor.core.TestLoggerExtension;
 import reactor.test.StepVerifier;
 import reactor.test.util.LoggerUtils;
 import reactor.test.util.TestLogger;
@@ -353,28 +354,22 @@ public class FluxDoFinallyTest implements Consumer<SignalType> {
 	}
 
 	@Test
+	@TestLoggerExtension.Redirect
 	//see https://github.com/reactor/reactor-core/issues/951
-	public void gh951_withoutDoOnError() {
-		TestLogger testLogger = new TestLogger();
-		LoggerUtils.enableCaptureWith(testLogger);
-		try {
-			List<String> events = new ArrayList<>();
+	void gh951_withoutDoOnError(TestLogger testLogger) {
+		List<String> events = new ArrayList<>();
 
-			Mono.just(true)
-			    .map(this::throwError)
-			    .doFinally(any -> events.add("doFinally " + any.toString()))
-			    .subscribe();
+		Mono.just(true)
+			.map(this::throwError)
+			.doFinally(any -> events.add("doFinally " + any.toString()))
+			.subscribe();
 
-			Assertions.assertThat(events)
-			          .as("withoutDoOnError")
-			          .containsExactly("doFinally onError");
-			Assertions.assertThat(testLogger.getErrContent())
-			          .contains("Operator called default onErrorDropped")
-			          .contains("reactor.core.Exceptions$ErrorCallbackNotImplemented: java.lang.IllegalStateException: boom");
-		}
-		finally {
-			LoggerUtils.disableCapture();
-		}
+		Assertions.assertThat(events)
+			.as("withoutDoOnError")
+			.containsExactly("doFinally onError");
+		Assertions.assertThat(testLogger.getErrContent())
+			.contains("Operator called default onErrorDropped")
+			.contains("reactor.core.Exceptions$ErrorCallbackNotImplemented: java.lang.IllegalStateException: boom");
 	}
 
 	private Boolean throwError(Boolean x) {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekTest.java
@@ -31,6 +31,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
+import reactor.core.TestLoggerExtension;
 import reactor.test.util.LoggerUtils;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.FluxOperatorTest;
@@ -494,39 +495,34 @@ public class FluxPeekTest extends FluxOperatorTest<String, String> {
 	}
 
 	@Test
-	public void afterTerminateCallbackErrorDoesNotInvokeOnError() {
-		TestLogger testLogger = new TestLogger();
-		LoggerUtils.enableCaptureWith(testLogger);
-		try {
-			IllegalStateException e = new IllegalStateException("test");
-			AtomicReference<Throwable> errorCallbackCapture = new AtomicReference<>();
+	@TestLoggerExtension.Redirect
+	void afterTerminateCallbackErrorDoesNotInvokeOnError(TestLogger testLogger) {
+		IllegalStateException e = new IllegalStateException("test");
+		AtomicReference<Throwable> errorCallbackCapture = new AtomicReference<>();
 
-			FluxPeek<String> flux = new FluxPeek<>(Flux.empty(),
-					null,
-					null,
-					errorCallbackCapture::set,
-					null,
-					() -> {
-						throw e;
-					},
-					null,
-					null);
+		FluxPeek<String> flux = new FluxPeek<>(Flux.empty(),
+			null,
+			null,
+			errorCallbackCapture::set,
+			null,
+			() -> {
+				throw e;
+			},
+			null,
+			null);
 
-			AssertSubscriber<String> ts = AssertSubscriber.create();
+		AssertSubscriber<String> ts = AssertSubscriber.create();
 
-			flux.subscribe(ts);
+		flux.subscribe(ts);
 
-			ts.assertNoValues();
-			ts.assertComplete();
+		ts.assertNoValues();
+		ts.assertComplete();
 
-			assertThat(errorCallbackCapture.get()).isNull();
+		assertThat(errorCallbackCapture.get()).isNull();
 
-			assertThat(testLogger.getErrContent())
-					.contains("Operator called default onErrorDropped")
-					.contains(e.toString());
-		} finally {
-			LoggerUtils.disableCapture();
-		}
+		assertThat(testLogger.getErrContent())
+			.contains("Operator called default onErrorDropped")
+			.contains(e.toString());
 	}
 
 	@Test
@@ -573,68 +569,57 @@ public class FluxPeekTest extends FluxOperatorTest<String, String> {
 	}
 
 	@Test
-	public void afterTerminateCallbackErrorAndErrorCallbackError() {
-		TestLogger testLogger = new TestLogger();
-		LoggerUtils.enableCaptureWith(testLogger);
-		try {
-			IllegalStateException error1 = new IllegalStateException("afterTerminate");
-			IllegalArgumentException error2 = new IllegalArgumentException("error");
+	@TestLoggerExtension.Redirect
+	void afterTerminateCallbackErrorAndErrorCallbackError(TestLogger testLogger) {
+		IllegalStateException error1 = new IllegalStateException("afterTerminate");
+		IllegalArgumentException error2 = new IllegalArgumentException("error");
 
-			FluxPeek<String> flux = new FluxPeek<>(Flux.empty(), null, null, e -> {
-				throw error2;
-			}, null, () -> {
-				throw error1;
-			}, null, null);
+		FluxPeek<String> flux = new FluxPeek<>(Flux.empty(), null, null, e -> {
+			throw error2;
+		}, null, () -> {
+			throw error1;
+		}, null, null);
 
-			AssertSubscriber<String> ts = AssertSubscriber.create();
+		AssertSubscriber<String> ts = AssertSubscriber.create();
 
-			flux.subscribe(ts);
-			assertThat(testLogger.getErrContent())
-					.contains("Operator called default onErrorDropped")
-					.contains(error1.getMessage());
-			assertThat(error2.getSuppressed()).hasSize(0);
-			//error2 is never thrown
-			ts.assertNoValues();
-			ts.assertComplete();
-		}
-		finally {
-			LoggerUtils.disableCapture();
-		}
+		flux.subscribe(ts);
+		assertThat(testLogger.getErrContent())
+			.contains("Operator called default onErrorDropped")
+			.contains(error1.getMessage());
+		assertThat(error2.getSuppressed()).hasSize(0);
+		//error2 is never thrown
+		ts.assertNoValues();
+		ts.assertComplete();
 	}
 
 	@Test
-	public void afterTerminateCallbackErrorAndErrorCallbackError2() {
-		TestLogger testLogger = new TestLogger();
-		LoggerUtils.enableCaptureWith(testLogger);
-		try {
-			IllegalStateException afterTerminate = new IllegalStateException("afterTerminate");
-			IllegalArgumentException error = new IllegalArgumentException("error");
-			NullPointerException ex = new NullPointerException();
+	@TestLoggerExtension.Redirect
+	void afterTerminateCallbackErrorAndErrorCallbackError2(TestLogger testLogger) {
+		IllegalStateException afterTerminate = new IllegalStateException("afterTerminate");
+		IllegalArgumentException error = new IllegalArgumentException("error");
+		NullPointerException ex = new NullPointerException();
 
-			FluxPeek<String> flux = new FluxPeek<>(Flux.error(ex), null, null, e -> {
-				throw error;
-			}, null, () -> {
-				throw afterTerminate;
-			}, null, null);
+		FluxPeek<String> flux = new FluxPeek<>(Flux.error(ex), null, null, e -> {
+			throw error;
+		}, null, () -> {
+			throw afterTerminate;
+		}, null, null);
 
-			AssertSubscriber<String> ts = AssertSubscriber.create();
+		AssertSubscriber<String> ts = AssertSubscriber.create();
 
-			flux.subscribe(ts);
-			assertThat(testLogger.getErrContent())
-					.contains("Operator called default onErrorDropped")
-					.contains(afterTerminate.getMessage());
-			//afterTerminate suppressed error which itself suppressed original err
-			assertThat(afterTerminate.getSuppressed()).hasSize(1);
-			assertThat(afterTerminate).hasSuppressedException(error);
+		flux.subscribe(ts);
+		assertThat(testLogger.getErrContent())
+			.contains("Operator called default onErrorDropped")
+			.contains(afterTerminate.getMessage());
+		//afterTerminate suppressed error which itself suppressed original err
+		assertThat(afterTerminate.getSuppressed()).hasSize(1);
+		assertThat(afterTerminate).hasSuppressedException(error);
 
-			assertThat(error.getSuppressed()).hasSize(1);
-			assertThat(error).hasSuppressedException(ex);
-			ts.assertNoValues();
-			//the subscriber still sees the 'error' message since actual.onError is called before the afterTerminate callback
-			ts.assertErrorMessage("error");
-		}  finally {
-			LoggerUtils.disableCapture();
-		}
+		assertThat(error.getSuppressed()).hasSize(1);
+		assertThat(error).hasSuppressedException(ex);
+		ts.assertNoValues();
+		//the subscriber still sees the 'error' message since actual.onError is called before the afterTerminate callback
+		ts.assertErrorMessage("error");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxUsingWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxUsingWhenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxZipTest.java
@@ -731,27 +731,22 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 	}
 
 	@Test //FIXME use Violation.NO_CLEANUP_ON_TERMINATE
-	public void failDoubleError3() {
-		TestLogger testLogger = new TestLogger();
-		LoggerUtils.enableCaptureWith(testLogger);
-		try {
-			StepVerifier.create(Flux.zip(obj -> 0,
-					Flux.just(1)
-					    .hide(),
-					Flux.never(),
-					s -> {
-						s.onSubscribe(Operators.emptySubscription());
-						s.onError(new Exception("test"));
-						s.onError(new Exception("test2"));
-					}))
-			            .verifyErrorMessage("test");
+	@TestLoggerExtension.Redirect
+	void failDoubleError3(TestLogger testLogger) {
+		StepVerifier.create(Flux.zip(obj -> 0,
+				Flux.just(1)
+					.hide(),
+				Flux.never(),
+				s -> {
+					s.onSubscribe(Operators.emptySubscription());
+					s.onError(new Exception("test"));
+					s.onError(new Exception("test2"));
+				}))
+					.verifyErrorMessage("test");
 
-			Assertions.assertThat(testLogger.getErrContent())
-			          .contains("Operator called default onErrorDropped")
-			          .contains("test2");
-		} finally {
-			LoggerUtils.disableCapture();
-		}
+		Assertions.assertThat(testLogger.getErrContent())
+				  .contains("Operator called default onErrorDropped")
+				  .contains("test2");
 	}
 
 	@Test //FIXME use Violation.NO_CLEANUP_ON_TERMINATE
@@ -767,27 +762,22 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 	}
 
 	@Test //FIXME use Violation.NO_CLEANUP_ON_TERMINATE
-	public void failDoubleErrorHide() {
-		TestLogger testLogger = new TestLogger();
-		LoggerUtils.enableCaptureWith(testLogger);
-		try {
-			StepVerifier.create(Flux.zip(obj -> 0,
-					Flux.just(1)
-					    .hide(),
-					Flux.never(),
-					s -> {
-						s.onSubscribe(Operators.emptySubscription());
-						s.onError(new Exception("test"));
-						s.onError(new Exception("test2"));
-					}))
-			            .verifyErrorMessage("test");
+	@TestLoggerExtension.Redirect
+	void failDoubleErrorHide(TestLogger testLogger) {
+		StepVerifier.create(Flux.zip(obj -> 0,
+				Flux.just(1)
+					.hide(),
+				Flux.never(),
+				s -> {
+					s.onSubscribe(Operators.emptySubscription());
+					s.onError(new Exception("test"));
+					s.onError(new Exception("test2"));
+				}))
+					.verifyErrorMessage("test");
 
-			Assertions.assertThat(testLogger.getErrContent())
-			          .contains("Operator called default onErrorDropped")
-			          .contains("test2");
-		} finally {
-			LoggerUtils.disableCapture();
-		}
+		Assertions.assertThat(testLogger.getErrContent())
+				  .contains("Operator called default onErrorDropped")
+				  .contains("test2");
 	}
 
 	@Test
@@ -806,27 +796,22 @@ public class FluxZipTest extends FluxOperatorTest<String, String> {
 	}
 
 	@Test //FIXME use Violation.NO_CLEANUP_ON_TERMINATE
-	public void failDoubleError2() {
-		TestLogger testLogger = new TestLogger();
-		LoggerUtils.enableCaptureWith(testLogger);
-		try {
-			StepVerifier.create(Flux.zip(obj -> 0,
-					Flux.just(1)
-					    .hide(),
-					Flux.never(),
-					s -> {
-						s.onSubscribe(Operators.emptySubscription());
-						s.onError(new Exception("test"));
-						s.onError(new Exception("test2"));
-					}))
-			            .verifyErrorMessage("test");
+	@TestLoggerExtension.Redirect
+	void failDoubleError2(TestLogger testLogger) {
+		StepVerifier.create(Flux.zip(obj -> 0,
+				Flux.just(1)
+					.hide(),
+				Flux.never(),
+				s -> {
+					s.onSubscribe(Operators.emptySubscription());
+					s.onError(new Exception("test"));
+					s.onError(new Exception("test2"));
+				}))
+					.verifyErrorMessage("test");
 
-			Assertions.assertThat(testLogger.getErrContent())
-			          .contains("Operator called default onErrorDropped")
-			          .contains("test2");
-		} finally {
-			LoggerUtils.disableCapture();
-		}
+		Assertions.assertThat(testLogger.getErrContent())
+				  .contains("Operator called default onErrorDropped")
+				  .contains("test2");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/LambdaMonoSubscriberTest.java
@@ -195,7 +195,7 @@ public class LambdaMonoSubscriberTest {
 			.contains("IllegalArgumentException");
 
 		assertThat(testSubscription.isCancelled).as("subscription isCancelled")
-			.isFalse();
+			.isTrue();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTest.java
@@ -24,6 +24,7 @@ import org.assertj.core.api.Assertions;
 import org.reactivestreams.Subscription;
 
 import reactor.core.Scannable;
+import reactor.core.TestLoggerExtension;
 import reactor.test.util.LoggerUtils;
 import reactor.test.StepVerifier;
 import reactor.test.util.TestLogger;
@@ -165,22 +166,16 @@ public class MonoPeekTest {
 	}
 
 	@Test
-	public void testErrorWithDoOnSuccess() {
-		TestLogger testLogger = new TestLogger();
-		LoggerUtils.enableCaptureWith(testLogger);
-		try {
-			Mono.error(new NullPointerException("boom"))
-			    .doOnSuccess(aValue -> {
-			    })
-			    .subscribe();
+	@TestLoggerExtension.Redirect
+	void testErrorWithDoOnSuccess(TestLogger testLogger) {
+		Mono.error(new NullPointerException("boom"))
+			.doOnSuccess(aValue -> {
+			})
+			.subscribe();
 
-			Assertions.assertThat(testLogger.getErrContent())
-			          .contains("Operator called default onErrorDropped")
-			          .contains("reactor.core.Exceptions$ErrorCallbackNotImplemented: java.lang.NullPointerException: boom");
-		}
-		finally {
-			LoggerUtils.disableCapture();
-		}
+		Assertions.assertThat(testLogger.getErrContent())
+			.contains("Operator called default onErrorDropped")
+			.contains("reactor.core.Exceptions$ErrorCallbackNotImplemented: java.lang.NullPointerException: boom");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/NextProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/NextProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/NextProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/NextProcessorTest.java
@@ -34,6 +34,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Scannable;
+import reactor.core.TestLoggerExtension;
 import reactor.test.util.LoggerUtils;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
@@ -476,40 +477,28 @@ class NextProcessorTest {
 	}
 
 	@Test
-	void doubleError() {
-		TestLogger testLogger = new TestLogger();
-		LoggerUtils.enableCaptureWith(testLogger);
-		try {
-			NextProcessor<String> mp = new NextProcessor<>(null);
+	@TestLoggerExtension.Redirect
+	void doubleError(TestLogger testLogger) {
+		NextProcessor<String> mp = new NextProcessor<>(null);
 
-			mp.onError(new Exception("test"));
-			mp.onError(new Exception("test2"));
-			Assertions.assertThat(testLogger.getErrContent())
-			          .contains("Operator called default onErrorDropped")
-			          .contains("test2");
-		}
-		finally {
-			LoggerUtils.disableCapture();
-		}
+		mp.onError(new Exception("test"));
+		mp.onError(new Exception("test2"));
+		Assertions.assertThat(testLogger.getErrContent())
+			.contains("Operator called default onErrorDropped")
+			.contains("test2");
 	}
 
 	@Test
-	void doubleSignal() {
-		TestLogger testLogger = new TestLogger();
-		LoggerUtils.enableCaptureWith(testLogger);
-		try {
-			NextProcessor<String> mp = new NextProcessor<>(null);
+	@TestLoggerExtension.Redirect
+	void doubleSignal(TestLogger testLogger) {
+		NextProcessor<String> mp = new NextProcessor<>(null);
 
-			mp.onNext("test");
-			mp.onError(new Exception("test2"));
+		mp.onNext("test");
+		mp.onError(new Exception("test2"));
 
-			Assertions.assertThat(testLogger.getErrContent())
-			          .contains("Operator called default onErrorDropped")
+		Assertions.assertThat(testLogger.getErrContent())
+			.contains("Operator called default onErrorDropped")
 			          .contains("test2");
-		}
-		finally {
-			LoggerUtils.disableCapture();
-		}
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
@@ -45,6 +45,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
+import reactor.core.TestLoggerExtension;
 import reactor.core.publisher.Operators.CancelledSubscription;
 import reactor.core.publisher.Operators.DeferredSubscription;
 import reactor.core.publisher.Operators.EmptySubscription;
@@ -977,20 +978,14 @@ public class OperatorsTest {
 	}
 
 	@Test
-	public void onDiscardCallbackErrorsLog() {
+	@TestLoggerExtension.Redirect
+	void onDiscardCallbackErrorsLog(TestLogger testLogger) {
 		Context context = Operators.enableOnDiscard(Context.empty(), t -> {
 			throw new RuntimeException("Boom");
 		});
 
-		TestLogger testLogger = new TestLogger();
-		LoggerUtils.enableCaptureWith(testLogger);
-		try {
-			Operators.onDiscard("Foo", context);
-			assertThat(testLogger.getErrContent()).contains("Error in discard hook - java.lang.RuntimeException: Boom");
-		}
-		finally {
-			LoggerUtils.disableCapture();
-		}
+		Operators.onDiscard("Foo", context);
+		assertThat(testLogger.getErrContent()).contains("Error in discard hook - java.lang.RuntimeException: Boom");
 	}
 	
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkOneMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkOneMulticastTest.java
@@ -28,6 +28,7 @@ import org.reactivestreams.Subscriber;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Scannable;
+import reactor.core.TestLoggerExtension;
 import reactor.core.publisher.Sinks.EmitResult;
 import reactor.test.StepVerifier;
 import reactor.test.util.LoggerUtils;
@@ -210,40 +211,28 @@ class SinkOneMulticastTest {
 	}
 
 	@Test
-	void doubleError() {
-		TestLogger testLogger = new TestLogger();
-		LoggerUtils.enableCaptureWith(testLogger);
-		try {
-			SinkOneMulticast<String> sink = new SinkOneMulticast<>();
+	@TestLoggerExtension.Redirect
+	void doubleError(TestLogger testLogger) {
+		SinkOneMulticast<String> sink = new SinkOneMulticast<>();
 
-			sink.emitError(new Exception("test"), Sinks.EmitFailureHandler.FAIL_FAST);
-			sink.emitError(new Exception("test2"), Sinks.EmitFailureHandler.FAIL_FAST);
-			Assertions.assertThat(testLogger.getErrContent())
-				.contains("Operator called default onErrorDropped")
-				.contains("test2");
-		}
-		finally {
-			LoggerUtils.disableCapture();
-		}
+		sink.emitError(new Exception("test"), Sinks.EmitFailureHandler.FAIL_FAST);
+		sink.emitError(new Exception("test2"), Sinks.EmitFailureHandler.FAIL_FAST);
+		Assertions.assertThat(testLogger.getErrContent())
+			.contains("Operator called default onErrorDropped")
+			.contains("test2");
 	}
 
 	@Test
-	void doubleSignal() {
-		TestLogger testLogger = new TestLogger();
-		LoggerUtils.enableCaptureWith(testLogger);
-		try {
-			SinkOneMulticast<String> sink = new SinkOneMulticast<>();
+	@TestLoggerExtension.Redirect
+	void doubleSignal(TestLogger testLogger) {
+		SinkOneMulticast<String> sink = new SinkOneMulticast<>();
 
-			sink.emitValue("test", Sinks.EmitFailureHandler.FAIL_FAST);
-			sink.emitError(new Exception("test2"), Sinks.EmitFailureHandler.FAIL_FAST);
+		sink.emitValue("test", Sinks.EmitFailureHandler.FAIL_FAST);
+		sink.emitError(new Exception("test2"), Sinks.EmitFailureHandler.FAIL_FAST);
 
-			Assertions.assertThat(testLogger.getErrContent())
-				.contains("Operator called default onErrorDropped")
-				.contains("test2");
-		}
-		finally {
-			LoggerUtils.disableCapture();
-		}
+		Assertions.assertThat(testLogger.getErrContent())
+			.contains("Operator called default onErrorDropped")
+			.contains("test2");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/scenarios/FluxTests.java
@@ -59,6 +59,7 @@ import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
+import reactor.core.TestLoggerExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
@@ -1195,25 +1196,20 @@ public class FluxTests extends AbstractReactorTest {
 		latch.await(30, TimeUnit.SECONDS);
 		assertThat(latch.getCount()).as("dispatch count").isEqualTo(0L);
 	}
+
 	@Test
-	public void unimplementedErrorCallback() {
-		TestLogger testLogger = new TestLogger();
-		LoggerUtils.enableCaptureWith(testLogger);
-		try {
-			Flux.error(new Exception("forced1"))
-			    .log("error")
-			    .subscribe();
+	@TestLoggerExtension.Capture
+	public void unimplementedErrorCallback(TestLogger testLogger) {
+		Flux.error(new Exception("forced1"))
+			.log("error")
+			.subscribe();
 
-			Flux.error(new Exception("forced2"))
-			    .subscribe();
+		Flux.error(new Exception("forced2"))
+			.subscribe();
 
-			assertThat(testLogger.getErrContent())
-			          .contains("Operator called default onErrorDropped")
-			          .contains("reactor.core.Exceptions$ErrorCallbackNotImplemented: java.lang.Exception: forced2");
-		}
-		finally {
-			LoggerUtils.disableCapture();
-		}
+		assertThat(testLogger.getErrContent())
+			.contains("Operator called default onErrorDropped")
+			.contains("reactor.core.Exceptions$ErrorCallbackNotImplemented: java.lang.Exception: forced2");
 	}
 
 	@Test
@@ -1446,9 +1442,8 @@ public class FluxTests extends AbstractReactorTest {
 	}
 
 	@Test
-	public void testThrowWithoutOnErrorShowsUpInSchedulerHandler() {
-		TestLogger testLogger = new TestLogger();
-		LoggerUtils.enableCaptureWith(testLogger);
+	@TestLoggerExtension.Capture
+	void testThrowWithoutOnErrorShowsUpInSchedulerHandler(TestLogger testLogger) {
 		AtomicReference<String> failure = new AtomicReference<>(null);
 		AtomicBoolean handled = new AtomicBoolean(false);
 
@@ -1488,7 +1483,6 @@ public class FluxTests extends AbstractReactorTest {
 			fail(e.toString());
 		}
 		finally {
-			LoggerUtils.disableCapture();
 			Thread.setDefaultUncaughtExceptionHandler(null);
 			Schedulers.resetOnHandleError();
 			Schedulers.resetOnScheduleHook("test");

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,9 +46,10 @@ dependencies {
 
 	testImplementation platform(libs.junit.bom)
 	testImplementation "org.junit.jupiter:junit-jupiter-api"
+	testImplementation "org.junit.jupiter:junit-jupiter-params"
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
-	testRuntimeOnly libs.logback
 
+	testRuntimeOnly libs.logback
 	testImplementation libs.assertj
 	testImplementation libs.mockito
 }

--- a/reactor-test/src/main/java/reactor/test/util/LoggerUtils.java
+++ b/reactor-test/src/main/java/reactor/test/util/LoggerUtils.java
@@ -35,6 +35,7 @@ public final class LoggerUtils {
 
 	@Nullable
 	private static Logger testLogger;
+	private static boolean redirectToOriginal = true;
 
 	private LoggerUtils() {
 	}
@@ -80,6 +81,20 @@ public final class LoggerUtils {
 		if (LoggerUtils.testLogger != null) {
 			throw new IllegalStateException("A logger was already set, maybe from a previous run. Don't forget to call disableCapture()");
 		}
+		LoggerUtils.redirectToOriginal = true;
+		LoggerUtils.testLogger = testLogger;
+	}
+
+	/**
+	 * Set the logger used for capturing.
+	 *
+	 * @throws IllegalStateException if a previous logger has been set but not cleared via {@link #disableCapture()}
+	 */
+	public static void enableCaptureWith(Logger testLogger, boolean redirectToOriginal) {
+		if (LoggerUtils.testLogger != null) {
+			throw new IllegalStateException("A logger was already set, maybe from a previous run. Don't forget to call disableCapture()");
+		}
+		LoggerUtils.redirectToOriginal = redirectToOriginal;
 		LoggerUtils.testLogger = testLogger;
 	}
 
@@ -87,6 +102,7 @@ public final class LoggerUtils {
 	 * Disable capturing, forgetting about the logger set via {@link #enableCaptureWith(Logger)}.
 	 */
 	public static void disableCapture() {
+		LoggerUtils.redirectToOriginal = true;
 		LoggerUtils.testLogger = null;
 	}
 
@@ -158,7 +174,9 @@ public final class LoggerUtils {
 			if (logger != null) {
 				logger.trace(msg);
 			}
-			delegate.trace(msg);
+			if (LoggerUtils.redirectToOriginal) {
+				delegate.trace(msg);
+			}
 		}
 
 		@Override
@@ -167,7 +185,9 @@ public final class LoggerUtils {
 			if (logger != null) {
 				logger.trace(format, arguments);
 			}
-			delegate.trace(format, arguments);
+			if (LoggerUtils.redirectToOriginal) {
+				delegate.trace(format, arguments);
+			}
 		}
 
 		@Override
@@ -176,7 +196,9 @@ public final class LoggerUtils {
 			if (logger != null) {
 				logger.trace(msg, t);
 			}
-			delegate.trace(msg, t);
+			if (LoggerUtils.redirectToOriginal) {
+				delegate.trace(msg, t);
+			}
 		}
 
 		@Override
@@ -191,7 +213,9 @@ public final class LoggerUtils {
 			if (logger != null) {
 				logger.debug(msg);
 			}
-			delegate.debug(msg);
+			if (LoggerUtils.redirectToOriginal) {
+				delegate.debug(msg);
+			}
 		}
 
 		@Override
@@ -200,7 +224,9 @@ public final class LoggerUtils {
 			if (logger != null) {
 				logger.debug(format, arguments);
 			}
-			delegate.debug(format, arguments);
+			if (LoggerUtils.redirectToOriginal) {
+				delegate.debug(format, arguments);
+			}
 		}
 
 		@Override
@@ -209,7 +235,9 @@ public final class LoggerUtils {
 			if (logger != null) {
 				logger.debug(msg, t);
 			}
-			delegate.debug(msg, t);
+			if (LoggerUtils.redirectToOriginal) {
+				delegate.debug(msg, t);
+			}
 		}
 
 		@Override
@@ -224,7 +252,9 @@ public final class LoggerUtils {
 			if (logger != null) {
 				logger.info(msg);
 			}
-			delegate.info(msg);
+			if (LoggerUtils.redirectToOriginal) {
+				delegate.info(msg);
+			}
 		}
 
 		@Override
@@ -233,7 +263,9 @@ public final class LoggerUtils {
 			if (logger != null) {
 				logger.info(format, arguments);
 			}
-			delegate.info(format, arguments);
+			if (LoggerUtils.redirectToOriginal) {
+				delegate.info(format, arguments);
+			}
 		}
 
 		@Override
@@ -242,7 +274,9 @@ public final class LoggerUtils {
 			if (logger != null) {
 				logger.info(msg, t);
 			}
-			delegate.info(msg, t);
+			if (LoggerUtils.redirectToOriginal) {
+				delegate.info(msg, t);
+			}
 		}
 
 		@Override
@@ -257,7 +291,9 @@ public final class LoggerUtils {
 			if (logger != null) {
 				logger.warn(msg);
 			}
-			delegate.warn(msg);
+			if (LoggerUtils.redirectToOriginal) {
+				delegate.warn(msg);
+			}
 		}
 
 		@Override
@@ -266,7 +302,9 @@ public final class LoggerUtils {
 			if (logger != null) {
 				logger.warn(format, arguments);
 			}
-			delegate.warn(format, arguments);
+			if (LoggerUtils.redirectToOriginal) {
+				delegate.warn(format, arguments);
+			}
 		}
 
 		@Override
@@ -275,7 +313,9 @@ public final class LoggerUtils {
 			if (logger != null) {
 				logger.warn(msg, t);
 			}
-			delegate.warn(msg, t);
+			if (LoggerUtils.redirectToOriginal) {
+				delegate.warn(msg, t);
+			}
 		}
 
 		@Override
@@ -290,7 +330,9 @@ public final class LoggerUtils {
 			if (logger != null) {
 				logger.error(msg);
 			}
-			delegate.error(msg);
+			if (LoggerUtils.redirectToOriginal) {
+				delegate.error(msg);
+			}
 		}
 
 		@Override
@@ -299,7 +341,9 @@ public final class LoggerUtils {
 			if (logger != null) {
 				logger.error(format, arguments);
 			}
-			delegate.error(format, arguments);
+			if (LoggerUtils.redirectToOriginal) {
+				delegate.error(format, arguments);
+			}
 		}
 
 		@Override
@@ -308,7 +352,9 @@ public final class LoggerUtils {
 			if (logger != null) {
 				logger.error(msg, t);
 			}
-			delegate.error(msg, t);
+			if (LoggerUtils.redirectToOriginal) {
+				delegate.error(msg, t);
+			}
 		}
 	}
 }

--- a/reactor-test/src/main/java/reactor/test/util/LoggerUtils.java
+++ b/reactor-test/src/main/java/reactor/test/util/LoggerUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-test/src/test/java/reactor/test/util/LoggerUtilsTest.java
+++ b/reactor-test/src/test/java/reactor/test/util/LoggerUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,44 +18,90 @@ package reactor.test.util;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import reactor.core.Disposable;
+import reactor.core.Exceptions;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 
 import static org.assertj.core.api.Assertions.*;
 
+@Isolated
 class LoggerUtilsTest {
 
-	@Test
-	void installsFactory() {
-		Disposable disposable = LoggerUtils.useCurrentLoggersWithCapture();
-		TestLogger testLogger = new TestLogger();
-		try {
-			Logger frameworkLogger = Loggers.getLogger("category"); // simulates an early creation of a logger
+	/**
+	 * Disposable added to this list will be disposed at end of test, ignoring exceptions
+	 */
+	static final List<Disposable> SAFE_DISPOSE = new ArrayList<>();
 
-			LoggerUtils.enableCaptureWith(testLogger);
-			frameworkLogger.debug("Look ma!, I'm debugging!");
-			assertThat(testLogger.getOutContent()).contains("Look ma!, I'm debugging!");
-			LoggerUtils.disableCapture();
-			frameworkLogger.debug("This won't be captured");
-			assertThat(testLogger.getOutContent()).doesNotContain("This won't be captured");
-		} finally {
-			disposable.dispose();
+	static Disposable disposeAfterTest(Disposable d) {
+		SAFE_DISPOSE.add(d);
+		return d;
+	}
 
-			// The following tests that once disposed, capturing is no longer in effect
-			LoggerUtils.enableCaptureWith(testLogger);
-			Logger otherLogger = Loggers.getLogger("another");
-			otherLogger.debug("This won't be captured either");
-			assertThat(testLogger.getOutContent()).doesNotContain("This won't be captured either");
+	@AfterEach
+	void safelyDispose() {
+		for (Disposable disposable : SAFE_DISPOSE) {
+			try {
+				disposable.dispose();
+			}
+			catch (Exception e) {
+				//NO-OP
+			}
 		}
+		SAFE_DISPOSE.clear();
 	}
 
 	@Test
-	void disposeOnlyUninstallsItself() {
-		Disposable disposable = LoggerUtils.useCurrentLoggersWithCapture();
+	void installsFactory() {
+		Disposable disposable = disposeAfterTest(LoggerUtils.useCurrentLoggersWithCapture());
+		TestLogger testLogger = new TestLogger();
+		Logger frameworkLogger = Loggers.getLogger("category"); // simulates an early creation of a logger
+
+		LoggerUtils.enableCaptureWith(testLogger);
+		frameworkLogger.debug("Look ma!, I'm debugging!");
+		assertThat(testLogger.getOutContent()).contains("Look ma!, I'm debugging!");
+
+		LoggerUtils.disableCapture();
+		frameworkLogger.debug("This won't be captured");
+		assertThat(testLogger.getOutContent()).doesNotContain("This won't be captured");
+
+		LoggerUtils.enableCaptureWith(testLogger);
+		frameworkLogger.debug("I've reactivated redirection");
+		assertThat(testLogger.getOutContent()).contains("I've reactivated redirection");
+
+		disposable.dispose();
+
+		// The following tests that once disposed, capturing is no longer in effect
+		Logger otherLogger = Loggers.getLogger("another");
+		otherLogger.debug("This won't be captured either");
+		assertThat(testLogger.getOutContent()).doesNotContain("This won't be captured either");
+	}
+
+	@Test
+	void disposeUninstallsFromLoggersAndLoggerUtils() {
+		Disposable d = disposeAfterTest(LoggerUtils.useCurrentLoggersWithCapture());
+
+		assertThat(Loggers.getLogger("foo")).as("when factory installed").isInstanceOf(LoggerUtils.DivertingLogger.class);
+		assertThat(LoggerUtils.currentCapturingFactory).as("when currentCapturingFactory").isSameAs(d);
+
+		d.dispose();
+
+		assertThat(Loggers.getLogger("foo")).as("after uninstall").isNotInstanceOf(LoggerUtils.DivertingLogger.class);
+		assertThat(LoggerUtils.currentCapturingFactory).as("not currentCapturingFactory").isNull();
+	}
+
+	@Test
+	void disposeOnlyUninstallsItselfFromLoggersFactory() {
+		Disposable disposable = disposeAfterTest(LoggerUtils.useCurrentLoggersWithCapture());
 		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> {
 			Loggers.resetLoggerFactory(); // Overwrites our custom logger
 			disposable.dispose();
@@ -68,7 +114,7 @@ class LoggerUtilsTest {
 		final int LOOPS = 2000;
 		List<Disposable> disposables = new ArrayList<>(LOOPS);
 		for (int i = 0; i < LOOPS; i++) {
-			disposables.add(LoggerUtils.useCurrentLoggersWithCapture());
+			disposables.add(disposeAfterTest(LoggerUtils.useCurrentLoggersWithCapture()));
 		}
 
 		final Logger test = Loggers.getLogger("test");
@@ -78,4 +124,221 @@ class LoggerUtilsTest {
 		assertThatCode(() -> test.error("expected error message")).doesNotThrowAnyException();
 	}
 
+	@Test
+	void enableCaptureWithThrowsIfNotCapturing() {
+		assertThatIllegalStateException()
+			.isThrownBy(() -> LoggerUtils.enableCaptureWith(new TestLogger()))
+			.withMessage("LoggerUtils#useCurrentLoggerWithCapture() hasn't been called");
+	}
+
+	@Test
+	void enableCaptureWithNoRedirectThrowsIfNotCapturing() {
+		assertThatIllegalStateException()
+			.isThrownBy(() -> LoggerUtils.enableCaptureWith(new TestLogger(), false))
+			.withMessage("LoggerUtils#useCurrentLoggerWithCapture() hasn't been called");
+	}
+
+	@Test
+	void enableCaptureWithThrowsIfPreviouslyEnabledCapture() {
+		disposeAfterTest(LoggerUtils.useCurrentLoggersWithCapture());
+
+		assertThatCode(() -> LoggerUtils.enableCaptureWith(new TestLogger()))
+			.as("first enableCapture")
+			.doesNotThrowAnyException();
+
+		assertThatIllegalStateException()
+			.as("redundant enableCapture")
+			.isThrownBy(() -> LoggerUtils.enableCaptureWith(new TestLogger()))
+			.withMessage("A logger was already set, maybe from a previous run. Don't forget to call disableCapture()");
+	}
+
+	@Test
+	void enableCaptureWithNoRedirectThrowsIfPreviouslyEnabledCapture() {
+		disposeAfterTest(LoggerUtils.useCurrentLoggersWithCapture());
+
+		assertThatCode(() -> LoggerUtils.enableCaptureWith(new TestLogger()))
+			.as("first enableCapture")
+			.doesNotThrowAnyException();
+
+		assertThatIllegalStateException()
+			.as("redundant enableCapture")
+			.isThrownBy(() -> LoggerUtils.enableCaptureWith(new TestLogger(), false))
+			.withMessage("A logger was already set, maybe from a previous run. Don't forget to call disableCapture()");
+	}
+
+	@Nested
+	class DivertingLoggerTest {
+
+		private final TestLogger INACTIVE_TEST_LOGGER = new TestLogger(false) {
+			@Override
+			public boolean isInfoEnabled() {
+				return false;
+			}
+
+			@Override
+			public boolean isTraceEnabled() {
+				return false;
+			}
+
+			@Override
+			public boolean isDebugEnabled() {
+				return false;
+			}
+
+			@Override
+			public boolean isWarnEnabled() {
+				return false;
+			}
+
+			@Override
+			public boolean isErrorEnabled() {
+				return false;
+			}
+		};
+
+		@ParameterizedTest
+		@ValueSource(booleans = { true, false })
+		void allLogMethods(boolean redirect) {
+			final TestLogger underlyingTestLogger = new TestLogger(false);
+			Function<String, Logger> fakeFactory = s -> {
+				throw new UnsupportedOperationException("test shouldn't trigger the original factory");
+			};
+			final TestLogger capturingTestLogger = new TestLogger(false);
+			LoggerUtils.CapturingFactory capturingFactory = new LoggerUtils.CapturingFactory(fakeFactory);
+			LoggerUtils.DivertingLogger divertingLogger = new LoggerUtils.DivertingLogger(underlyingTestLogger, capturingFactory);
+
+			//optionally activate the redirection to our capturingTestLogger, with suppression of original logs
+			capturingFactory.enableRedirection(capturingTestLogger, redirect);
+
+			divertingLogger.info("info1");
+			divertingLogger.info("info{}", 2);
+			divertingLogger.info("info3", Exceptions.TERMINATED); //TERMINATED has no stacktrace
+
+			divertingLogger.warn("warn1");
+			divertingLogger.warn("warn{}", 2);
+			divertingLogger.warn("warn3", Exceptions.TERMINATED); //TERMINATED has no stacktrace
+
+			divertingLogger.error("error1");
+			divertingLogger.error("error{}", 2);
+			divertingLogger.error("error3", Exceptions.TERMINATED); //TERMINATED has no stacktrace
+
+			divertingLogger.debug("debug1");
+			divertingLogger.debug("debug{}", 2);
+			divertingLogger.debug("debug3", Exceptions.TERMINATED); //TERMINATED has no stacktrace
+
+			divertingLogger.trace("trace1");
+			divertingLogger.trace("trace{}", 2);
+			divertingLogger.trace("trace3", Exceptions.TERMINATED); //TERMINATED has no stacktrace
+
+			String[] expectedOut = new String[] {
+				"[ INFO] info1",
+				"[ INFO] info2",
+				"[ INFO] info3 - reactor.core.Exceptions$StaticThrowable: Operator has been terminated",
+				"[DEBUG] debug1",
+				"[DEBUG] debug2",
+				"[DEBUG] debug3 - reactor.core.Exceptions$StaticThrowable: Operator has been terminated",
+				"[TRACE] trace1",
+				"[TRACE] trace2",
+				"[TRACE] trace3 - reactor.core.Exceptions$StaticThrowable: Operator has been terminated"
+			};
+
+			String[] expectedErrInAnyOrder = new String[] {
+				"[ WARN] warn1",
+				"[ WARN] warn2",
+				"[ WARN] warn3 - reactor.core.Exceptions$StaticThrowable: Operator has been terminated",
+				"[ERROR] error1",
+				"[ERROR] error2",
+				"[ERROR] error3 - reactor.core.Exceptions$StaticThrowable: Operator has been terminated",
+				//all logging methods with Throwable also print the stacktrace to err logger
+				"reactor.core.Exceptions$StaticThrowable: Operator has been terminated",
+				"reactor.core.Exceptions$StaticThrowable: Operator has been terminated",
+				"reactor.core.Exceptions$StaticThrowable: Operator has been terminated",
+				"reactor.core.Exceptions$StaticThrowable: Operator has been terminated",
+				"reactor.core.Exceptions$StaticThrowable: Operator has been terminated"
+			};
+
+			assertThat(capturingTestLogger.getOutContent().split(System.lineSeparator()))
+				.as("captured out")
+				.containsExactly(expectedOut);
+
+			assertThat(capturingTestLogger.getErrContent().split(System.lineSeparator()))
+				.as("captured err")
+				.containsExactlyInAnyOrder(expectedErrInAnyOrder);
+
+			if (redirect) {
+				assertThat(underlyingTestLogger.getOutContent().split(System.lineSeparator()))
+					.as("redirected to original out")
+					.containsExactly(expectedOut);
+				assertThat(underlyingTestLogger.getErrContent().split(System.lineSeparator()))
+					.as("redirected to original err")
+					.containsExactlyInAnyOrder(expectedErrInAnyOrder);
+			}
+			else {
+				assertThat(underlyingTestLogger.getErrContent()).as("suppressed original err").isEmpty();
+				assertThat(underlyingTestLogger.getOutContent()).as("suppressed original out").isEmpty();
+			}
+		}
+
+		@Test
+		void categoriesAreActiveIfActiveInOriginal() {
+			TestLogger original = new TestLogger(false);
+			TestLogger redirect = INACTIVE_TEST_LOGGER;
+			LoggerUtils.CapturingFactory capturingFactory = new LoggerUtils.CapturingFactory(s -> original);
+			capturingFactory.enableRedirection(redirect, true);
+
+			LoggerUtils.DivertingLogger divertingLogger = new LoggerUtils.DivertingLogger(original, capturingFactory);
+			
+			assertThat(divertingLogger.isInfoEnabled()).as("isInfoEnabled").isTrue();
+			assertThat(divertingLogger.isWarnEnabled()).as("isWarnEnabled").isTrue();
+			assertThat(divertingLogger.isErrorEnabled()).as("isErrorEnabled").isTrue();
+			assertThat(divertingLogger.isDebugEnabled()).as("isDebugEnabled").isTrue();
+			assertThat(divertingLogger.isTraceEnabled()).as("isTraceEnabled").isTrue();
+		}
+
+		@Test
+		void categoriesAreActiveIfActiveInRedirect() {
+			TestLogger original = INACTIVE_TEST_LOGGER;
+			TestLogger redirect = new TestLogger(false);
+			LoggerUtils.CapturingFactory capturingFactory = new LoggerUtils.CapturingFactory(s -> original);
+			capturingFactory.enableRedirection(redirect, true);
+
+			LoggerUtils.DivertingLogger divertingLogger = new LoggerUtils.DivertingLogger(original, capturingFactory);
+
+			assertThat(divertingLogger.isInfoEnabled()).as("isInfoEnabled").isTrue();
+			assertThat(divertingLogger.isWarnEnabled()).as("isWarnEnabled").isTrue();
+			assertThat(divertingLogger.isErrorEnabled()).as("isErrorEnabled").isTrue();
+			assertThat(divertingLogger.isDebugEnabled()).as("isDebugEnabled").isTrue();
+			assertThat(divertingLogger.isTraceEnabled()).as("isTraceEnabled").isTrue();
+		}
+
+		@Test
+		void categoriesAreInactiveIfInactiveInOriginalAndNoRedirect() {
+			TestLogger original = INACTIVE_TEST_LOGGER;
+			LoggerUtils.CapturingFactory capturingFactory = new LoggerUtils.CapturingFactory(s -> original);
+
+			LoggerUtils.DivertingLogger divertingLogger = new LoggerUtils.DivertingLogger(original, capturingFactory);
+
+			assertThat(divertingLogger.isInfoEnabled()).as("isInfoEnabled").isFalse();
+			assertThat(divertingLogger.isWarnEnabled()).as("isWarnEnabled").isFalse();
+			assertThat(divertingLogger.isErrorEnabled()).as("isErrorEnabled").isFalse();
+			assertThat(divertingLogger.isDebugEnabled()).as("isDebugEnabled").isFalse();
+			assertThat(divertingLogger.isTraceEnabled()).as("isTraceEnabled").isFalse();
+		}
+
+		@Test
+		void categoriesAreInactiveIfInactiveInOriginalAndRedirect() {
+			TestLogger original = INACTIVE_TEST_LOGGER;
+			TestLogger redirect = INACTIVE_TEST_LOGGER;
+			LoggerUtils.CapturingFactory capturingFactory = new LoggerUtils.CapturingFactory(s -> original);
+			capturingFactory.enableRedirection(redirect, true);
+
+			LoggerUtils.DivertingLogger divertingLogger = new LoggerUtils.DivertingLogger(original, capturingFactory);
+
+			assertThat(divertingLogger.isInfoEnabled()).as("isInfoEnabled").isFalse();
+			assertThat(divertingLogger.isWarnEnabled()).as("isWarnEnabled").isFalse();
+			assertThat(divertingLogger.isErrorEnabled()).as("isErrorEnabled").isFalse();
+			assertThat(divertingLogger.isDebugEnabled()).as("isDebugEnabled").isFalse();
+			assertThat(divertingLogger.isTraceEnabled()).as("isTraceEnabled").isFalse();
+		}
+	}
 }

--- a/reactor-test/src/test/java/reactor/test/util/TestLoggerTest.java
+++ b/reactor-test/src/test/java/reactor/test/util/TestLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,18 @@ package reactor.test.util;
 
 import org.junit.jupiter.api.Test;
 
+import reactor.core.Exceptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class TestLoggerTest {
+class TestLoggerTest {
 
 	@Test
 	void returnMessageWithoutThreadNameWhenLogCurrentThreadNameIsFalse() {
 		TestLogger testLogger = new TestLogger(false);
 
+		assertThat(testLogger.isLogCurrentThreadName()).as("isLogCurrentThreadName").isFalse();
 		assertEquals("[ERROR] TestMessage\n", testLogger.logContent("ERROR",
 				"TestMessage"));
 	}
@@ -34,7 +38,145 @@ public class TestLoggerTest {
 	void returnMessageWithoutThreadNameWhenLogCurrentThreadNameIsTrue() {
 		TestLogger testLogger = new TestLogger(true);
 
+		assertThat(testLogger.isLogCurrentThreadName()).as("isLogCurrentThreadName").isTrue();
 		assertEquals(String.format("[ERROR] (%s) TestMessage\n", Thread.currentThread().getName()),
 				testLogger.logContent("ERROR", "TestMessage"));
+	}
+
+	@Test
+	void getName() {
+		assertThat(new TestLogger().getName()).isEqualTo("TestLogger");
+	}
+
+	@Test
+	void resetContents() {
+		final TestLogger testLogger = new TestLogger(false);
+		testLogger.info("info");
+		testLogger.error("error");
+
+		assertThat(testLogger.getOutContent())
+			.as("out before reset")
+			.isEqualToIgnoringNewLines("[ INFO] info");
+		assertThat(testLogger.getErrContent())
+			.as("err before reset")
+			.isEqualToIgnoringNewLines("[ERROR] error");
+
+		testLogger.reset();
+
+		assertThat(testLogger.getOutContent())
+			.as("after reset")
+			.isEqualTo(testLogger.getErrContent())
+			.isEmpty();
+	}
+
+	@Test
+	void allModesAreConsideredEnabled() {
+		TestLogger testLogger = new TestLogger();
+
+		assertThat(testLogger.isInfoEnabled()).as("isInfoEnabled").isTrue();
+		assertThat(testLogger.isDebugEnabled()).as("isDebugEnabled").isTrue();
+		assertThat(testLogger.isTraceEnabled()).as("isTraceEnabled").isTrue();
+		assertThat(testLogger.isWarnEnabled()).as("isWarnEnabled").isTrue();
+		assertThat(testLogger.isErrorEnabled()).as("isErrorEnabled").isTrue();
+	}
+
+	@Test
+	void infoNoThrowableLogsToOutContent() {
+		TestLogger testLogger = new TestLogger(false);
+		testLogger.info("msg1");
+		testLogger.info("msg{}", 2);
+
+		assertThat(testLogger.getOutContent()).as("out")
+			.isEqualToIgnoringNewLines("[ INFO] msg1[ INFO] msg2");
+		assertThat(testLogger.getErrContent()).as("err").isEmpty();
+	}
+
+	@Test
+	void infoThrowableLogsToOutContentPrintStackTraceToErrContent() {
+		TestLogger testLogger = new TestLogger(false);
+		testLogger.info("msg", Exceptions.TERMINATED);
+
+		assertThat(testLogger.getOutContent()).as("out")
+			.isEqualToIgnoringNewLines("[ INFO] msg - reactor.core.Exceptions$StaticThrowable: Operator has been terminated");
+		assertThat(testLogger.getErrContent()).as("err")
+			.isEqualToIgnoringNewLines("reactor.core.Exceptions$StaticThrowable: Operator has been terminated");
+	}
+
+	@Test
+	void debugNoThrowableLogsToOutContent() {
+		TestLogger testLogger = new TestLogger(false);
+		testLogger.debug("msg1");
+		testLogger.debug("msg{}", 2);
+
+		assertThat(testLogger.getOutContent()).as("out")
+			.isEqualToIgnoringNewLines("[DEBUG] msg1[DEBUG] msg2");
+		assertThat(testLogger.getErrContent()).as("err").isEmpty();
+	}
+
+	@Test
+	void debugThrowableLogsToOutContentPrintStackTraceToErrContent() {
+		TestLogger testLogger = new TestLogger(false);
+		testLogger.debug("msg", Exceptions.TERMINATED);
+
+		assertThat(testLogger.getOutContent()).as("out")
+			.isEqualToIgnoringNewLines("[DEBUG] msg - reactor.core.Exceptions$StaticThrowable: Operator has been terminated");
+		assertThat(testLogger.getErrContent()).as("err")
+			.isEqualToIgnoringNewLines("reactor.core.Exceptions$StaticThrowable: Operator has been terminated");
+	}
+
+	@Test
+	void traceNoThrowableLogsToOutContent() {
+		TestLogger testLogger = new TestLogger(false);
+		testLogger.trace("msg1");
+		testLogger.trace("msg{}", 2);
+
+		assertThat(testLogger.getOutContent()).as("out")
+			.isEqualToIgnoringNewLines("[TRACE] msg1[TRACE] msg2");
+		assertThat(testLogger.getErrContent()).as("err").isEmpty();
+	}
+
+	@Test
+	void traceThrowableLogsToOutContentPrintStackTraceToErrContent() {
+		TestLogger testLogger = new TestLogger(false);
+		testLogger.trace("msg", Exceptions.TERMINATED);
+
+		assertThat(testLogger.getOutContent()).as("out")
+			.isEqualToIgnoringNewLines("[TRACE] msg - reactor.core.Exceptions$StaticThrowable: Operator has been terminated");
+		assertThat(testLogger.getErrContent()).as("err")
+			.isEqualToIgnoringNewLines("reactor.core.Exceptions$StaticThrowable: Operator has been terminated");
+	}
+
+	@Test
+	void warnLogsAndPrintsThrowableStackTraceToErrContent() {
+		TestLogger testLogger = new TestLogger(false);
+		testLogger.warn("msg1");
+		testLogger.warn("msg{}", 2);
+		testLogger.warn("msg", Exceptions.TERMINATED);
+
+		assertThat(testLogger.getOutContent()).as("out").isEmpty();
+		assertThat(testLogger.getErrContent().split(System.lineSeparator()))
+			.as("err")
+			.containsExactly(
+				"[ WARN] msg1",
+				"[ WARN] msg2",
+				"[ WARN] msg - reactor.core.Exceptions$StaticThrowable: Operator has been terminated",
+				"reactor.core.Exceptions$StaticThrowable: Operator has been terminated");
+	}
+
+	@Test
+	void errorLogsAndPrintsThrowableStackTraceToErrContent() {
+		TestLogger testLogger = new TestLogger(false);
+		testLogger.error("msg1");
+		testLogger.error("msg{}", 2);
+		testLogger.error("msg", Exceptions.TERMINATED);
+
+		assertThat(testLogger.getOutContent()).as("out").isEmpty();
+		assertThat(testLogger.getErrContent().split(System.lineSeparator()))
+			.as("err")
+			.containsExactly(
+				"[ERROR] msg1",
+				"[ERROR] msg2",
+				"[ERROR] msg - reactor.core.Exceptions$StaticThrowable: Operator has been terminated",
+				"reactor.core.Exceptions$StaticThrowable: Operator has been terminated");
 	}
 }


### PR DESCRIPTION
This PR improves `LoggerUtils` and adds supporting JUnit5 annotations in reactor-core tests:

`LoggerUtils` now has support to _redirect_ rather than _copy/capture_ log messages when the
logger factory is installed early.

In reactor-core tests, a `TestLoggerExtension` is added that sets up a `TestLogger` and activates capture/redirection via `LoggerUtils`:
 - before the test, it creates a `TestLogger` (configured depending on test annotations) and
   sets up `LoggerUtils` with said `TestLogger`
 - as a `ParameterResolver` it injects the `TestLogger` into the test case
 - after the test it `disableCapture()`

The Extension should be applied to individual tests. Convenience annotations are provided that fine tune the `TestLogger` that will be injected:
 - `@Capture` should the loggers capture log output, ie. go both to original logger and TestLogger
 - `@Redirect` should the loggers redirect log output, ie. only go to TestLogger