### PR TITLE
Remove Micrometer#useRegistry, remove notion of Clock

### DIFF
--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListener.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListener.java
@@ -126,7 +126,7 @@ final class MicrometerMeterListener<T> implements SignalListener<T> {
 		}
 		//record the delay since previous onNext/onSubscribe. This also records the count.
 		long last = this.lastNextEventNanos;
-		this.lastNextEventNanos = configuration.clock.monotonicTime();
+		this.lastNextEventNanos = configuration.registry.config().clock().monotonicTime();
 		this.onNextIntervalTimer.record(lastNextEventNanos - last, TimeUnit.NANOSECONDS);
 	}
 
@@ -138,8 +138,8 @@ final class MicrometerMeterListener<T> implements SignalListener<T> {
 	@Override
 	public void doOnSubscription() {
 		recordOnSubscribe(configuration.sequenceName, configuration.commonTags, configuration.registry);
-		this.subscribeToTerminateSample = Timer.start(configuration.clock);
-		this.lastNextEventNanos = configuration.clock.monotonicTime();
+		this.subscribeToTerminateSample = Timer.start(configuration.registry);
+		this.lastNextEventNanos = configuration.registry.config().clock().monotonicTime();
 	}
 
 	@Override

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListenerConfiguration.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListenerConfiguration.java
@@ -41,20 +41,20 @@ final class MicrometerMeterListenerConfiguration {
 
 	private static final Logger LOGGER = Loggers.getLogger(MicrometerMeterListenerConfiguration.class);
 
-	static MicrometerMeterListenerConfiguration fromFlux(Flux<?> source, MeterRegistry meterRegistry, Clock clock) {
+	static MicrometerMeterListenerConfiguration fromFlux(Flux<?> source, MeterRegistry meterRegistry) {
 		Tags defaultTags = MicrometerMeterListener.DEFAULT_TAGS_FLUX;
 		final String name = resolveName(source, LOGGER, Micrometer.DEFAULT_METER_PREFIX);
 		final Tags tags = resolveTags(source, defaultTags);
 
-		return new MicrometerMeterListenerConfiguration(name, tags, meterRegistry, clock, false);
+		return new MicrometerMeterListenerConfiguration(name, tags, meterRegistry, false);
 	}
 
-	static MicrometerMeterListenerConfiguration fromMono(Mono<?> source, MeterRegistry meterRegistry, Clock clock) {
+	static MicrometerMeterListenerConfiguration fromMono(Mono<?> source, MeterRegistry meterRegistry) {
 		Tags defaultTags = MicrometerMeterListener.DEFAULT_TAGS_MONO;
 		final String name = resolveName(source, LOGGER, Micrometer.DEFAULT_METER_PREFIX);
 		final Tags tags = resolveTags(source, defaultTags);
 
-		return new MicrometerMeterListenerConfiguration(name, tags, meterRegistry, clock, true);
+		return new MicrometerMeterListenerConfiguration(name, tags, meterRegistry, true);
 	}
 
 	/**
@@ -103,7 +103,6 @@ final class MicrometerMeterListenerConfiguration {
 		return tags;
 	}
 
-	final Clock   clock;
 	final Tags    commonTags;
 	final boolean isMono;
 	final String  sequenceName;
@@ -112,9 +111,7 @@ final class MicrometerMeterListenerConfiguration {
 	// separator is the dot, not camelCase...
 	final MeterRegistry registry;
 
-	MicrometerMeterListenerConfiguration(String sequenceName, Tags tags, MeterRegistry registryCandidate, Clock clock,
-										 boolean isMono) {
-		this.clock = clock;
+	MicrometerMeterListenerConfiguration(String sequenceName, Tags tags, MeterRegistry registryCandidate, boolean isMono) {
 		this.commonTags = tags;
 		this.isMono = isMono;
 		this.sequenceName = sequenceName;

--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListenerFactory.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/MicrometerMeterListenerFactory.java
@@ -17,6 +17,7 @@
 package reactor.core.observability.micrometer;
 
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.reactivestreams.Publisher;
 
@@ -33,22 +34,19 @@ import reactor.util.context.ContextView;
  */
 class MicrometerMeterListenerFactory<T> implements SignalListenerFactory<T, MicrometerMeterListenerConfiguration> {
 
-	protected Clock useClock() {
-		return Clock.SYSTEM;
-	}
+	final MeterRegistry registry;
 
-	@SuppressWarnings("deprecation")
-	protected MeterRegistry useRegistry() {
-		return Micrometer.getRegistry();
+	MicrometerMeterListenerFactory(MeterRegistry registry) {
+		this.registry = registry;
 	}
 
 	@Override
 	public MicrometerMeterListenerConfiguration initializePublisherState(Publisher<? extends T> source) {
 		if (source instanceof Mono) {
-			return MicrometerMeterListenerConfiguration.fromMono((Mono<?>) source, useRegistry(), useClock());
+			return MicrometerMeterListenerConfiguration.fromMono((Mono<?>) source, this.registry);
 		}
 		else if (source instanceof Flux) {
-			return MicrometerMeterListenerConfiguration.fromFlux((Flux<?>) source, useRegistry(), useClock());
+			return MicrometerMeterListenerConfiguration.fromFlux((Flux<?>) source, this.registry);
 		}
 		else {
 			throw new IllegalArgumentException("MicrometerMeterListenerFactory must only be used via the tap operator / with a Flux or Mono");

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerMeterListenerConfigurationTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerMeterListenerConfigurationTest.java
@@ -58,9 +58,9 @@ class MicrometerMeterListenerConfigurationTest {
 			flux = flux.tag("tag", tag);
 		}
 
-	MicrometerMeterListenerConfiguration configuration = MicrometerMeterListenerConfiguration.fromFlux(flux, expectedRegistry, expectedClock);
+	MicrometerMeterListenerConfiguration configuration = MicrometerMeterListenerConfiguration.fromFlux(flux, expectedRegistry);
 
-		assertThat(configuration.clock).as("clock").isSameAs(expectedClock);
+		assertThat(configuration.registry.config().clock()).as("clock").isSameAs(expectedClock);
 		assertThat(configuration.registry).as("registry").isSameAs(expectedRegistry);
 		assertThat(configuration.isMono).as("isMono").isFalse();
 
@@ -100,9 +100,9 @@ class MicrometerMeterListenerConfigurationTest {
 			mono = mono.tag("tag", tag);
 		}
 
-		MicrometerMeterListenerConfiguration configuration = MicrometerMeterListenerConfiguration.fromMono(mono, expectedRegistry, expectedClock);
+		MicrometerMeterListenerConfiguration configuration = MicrometerMeterListenerConfiguration.fromMono(mono, expectedRegistry);
 
-		assertThat(configuration.clock).as("clock").isSameAs(expectedClock);
+		assertThat(configuration.registry.config().clock()).as("clock").isSameAs(expectedClock);
 		assertThat(configuration.registry).as("registry").isSameAs(expectedRegistry);
 		assertThat(configuration.isMono).as("isMono").isTrue();
 

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerMeterListenerTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerMeterListenerTest.java
@@ -23,6 +23,7 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,7 +43,6 @@ class MicrometerMeterListenerTest {
 
 	@BeforeEach
 	void initRegistry() {
-		registry = new SimpleMeterRegistry();
 		virtualClockTime = new AtomicLong();
 		virtualClock = new Clock() {
 			@Override
@@ -55,11 +55,11 @@ class MicrometerMeterListenerTest {
 				return virtualClockTime.get();
 			}
 		};
+		registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, virtualClock);
 		configuration = new MicrometerMeterListenerConfiguration(
 			"testName",
 			Tags.of("testTag1", "testTagValue1","testTag2", "testTagValue2"),
 			registry,
-			virtualClock,
 			false);
 	}
 
@@ -69,7 +69,6 @@ class MicrometerMeterListenerTest {
 			Micrometer.DEFAULT_METER_PREFIX,
 			Tags.of("testTag1", "testTagValue1","testTag2", "testTagValue2"),
 			registry,
-			virtualClock,
 			false);
 
 		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
@@ -95,7 +94,6 @@ class MicrometerMeterListenerTest {
 			"testName",
 			Tags.of("testTag1", "testTagValue1","testTag2", "testTagValue2"),
 			registry,
-			virtualClock,
 			false);
 
 		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
@@ -126,7 +124,6 @@ class MicrometerMeterListenerTest {
 			Micrometer.DEFAULT_METER_PREFIX,
 			Tags.of("testTag1", "testTagValue1","testTag2", "testTagValue2"),
 			registry,
-			virtualClock,
 			true);
 
 		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
@@ -284,7 +281,7 @@ class MicrometerMeterListenerTest {
 	@Test
 	void doOnNextRecordsInterval_defaultName() {
 		configuration = new MicrometerMeterListenerConfiguration(Micrometer.DEFAULT_METER_PREFIX, Tags.empty(),
-			registry, virtualClock, false);
+			registry, false);
 		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 		listener.doOnSubscription();
 
@@ -309,7 +306,7 @@ class MicrometerMeterListenerTest {
 	@Test
 	void doOnNext_monoRecordsCompletionOnly() {
 		configuration = new MicrometerMeterListenerConfiguration("testName", Tags.empty(),
-			registry, virtualClock, true);
+			registry, true);
 		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 
 		listener.doOnSubscription();
@@ -369,7 +366,7 @@ class MicrometerMeterListenerTest {
 
 	@Test
 	void doOnRequestMonoIgnoresRequest() {
-		configuration = new MicrometerMeterListenerConfiguration("testName", Tags.empty(), registry, virtualClock, true);
+		configuration = new MicrometerMeterListenerConfiguration("testName", Tags.empty(), registry, true);
 		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 		assertThatCode(() -> listener.doOnRequest(100L)).doesNotThrowAnyException();
 		assertThat(listener.requestedCounter).isNull();
@@ -377,7 +374,7 @@ class MicrometerMeterListenerTest {
 
 	@Test
 	void doOnRequestDefaultNameIgnoresRequest() {
-		configuration = new MicrometerMeterListenerConfiguration(Micrometer.DEFAULT_METER_PREFIX, Tags.empty(), registry, virtualClock, false);
+		configuration = new MicrometerMeterListenerConfiguration(Micrometer.DEFAULT_METER_PREFIX, Tags.empty(), registry, false);
 		MicrometerMeterListener<Integer> listener = new MicrometerMeterListener<>(configuration);
 		assertThatCode(() -> listener.doOnRequest(100L)).doesNotThrowAnyException();
 		assertThat(listener.requestedCounter).isNull();


### PR DESCRIPTION
~This PR depends on #3127 as it builds on top of the scheduler-related breaking changes.~

It breaks the `reactor-core-micrometer` `Micrometer` API introduced in previous
milestones:
 - remove `useRegistry` and the notion of a default global registry
 - remove `metrics()` and `metrics(MeterRegistry, Clock)`
 - replace the above by `metrics(MeterRegistry)` (as the `Clock` can be provided through the `MeterRegistry#config()`)