### PR TITLE
Fix a couple reactor-core-micrometer module compilation errors

### DIFF
--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/Micrometer.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/Micrometer.java
@@ -100,15 +100,16 @@ public final class Micrometer {
 	 * Set-up a decorator that will instrument any {@link ExecutorService} that backs a reactor-core {@link Scheduler}
 	 * (or scheduler implementations which use {@link Schedulers#decorateExecutorService(Scheduler, ScheduledExecutorService)}).
 	 * <p>
-	 * The {@link MeterRegistry} to use can be configured via {@link #useRegistry(MeterRegistry)}
+	 * The {@link MeterRegistry} to use can be configured via {@link reactor.util.Metrics.MicrometerConfiguration#useRegistry(MeterRegistry)}
 	 * prior to using this method, the default being {@link io.micrometer.core.instrument.Metrics#globalRegistry}.
 	 *
 	 * @implNote Note that this is added as a decorator via Schedulers when enabling metrics for schedulers,
 	 * which doesn't change the Factory.
 	 */
+	@Deprecated
 	public static void enableSchedulersMetricsDecorator() {
 		Schedulers.addExecutorServiceDecorator(SCHEDULERS_DECORATOR_KEY,
-			new MicrometerSchedulerMetricsDecorator(getRegistry()));
+			new MicrometerSchedulerMetricsDecorator(reactor.util.Metrics.MicrometerConfiguration.getRegistry()));
 	}
 
 	/**

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerConfigurationTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerConfigurationTest.java
@@ -125,7 +125,7 @@ class MicrometerObservationListenerConfigurationTest {
 		KeyValues resolvedKeyValues = MicrometerObservationListenerConfiguration.resolveKeyValues(flux, defaultKeyValues);
 
 		assertThat(resolvedKeyValues.stream().map(Object::toString))
-			.containsExactly("tag(common1=commonValue1)");
+			.containsExactly("keyValue(common1=commonValue1)");
 	}
 
 	@Test
@@ -138,8 +138,8 @@ class MicrometerObservationListenerConfigurationTest {
 		KeyValues resolvedKeyValues = MicrometerObservationListenerConfiguration.resolveKeyValues(flux, defaultKeyValues);
 
 		assertThat(resolvedKeyValues.stream().map(Object::toString)).containsExactlyInAnyOrder(
-			"tag(common1=commonValue1)",
-			"tag(k1=v1)"
+			"keyValue(common1=commonValue1)",
+			"keyValue(k1=v1)"
 		);
 	}
 
@@ -155,8 +155,8 @@ class MicrometerObservationListenerConfigurationTest {
 		KeyValues resolvedKeyValues = MicrometerObservationListenerConfiguration.resolveKeyValues(flux, defaultKeyValues);
 
 		assertThat(resolvedKeyValues.stream().map(Object::toString)).containsExactlyInAnyOrder(
-			"tag(common1=commonValue1)",
-			"tag(k1=v1)"
+			"keyValue(common1=commonValue1)",
+			"keyValue(k1=v1)"
 		);
 	}
 
@@ -172,9 +172,9 @@ class MicrometerObservationListenerConfigurationTest {
 		KeyValues resolvedKeyValues = MicrometerObservationListenerConfiguration.resolveKeyValues(flux, defaultKeyValues);
 
 		assertThat(resolvedKeyValues.stream().map(Object::toString)).containsExactlyInAnyOrder(
-			"tag(common1=commonValue1)",
-			"tag(k1=v1)",
-			"tag(k2=v2)"
+			"keyValue(common1=commonValue1)",
+			"keyValue(k1=v1)",
+			"keyValue(k2=v2)"
 		);
 	}
 
@@ -191,9 +191,9 @@ class MicrometerObservationListenerConfigurationTest {
 		KeyValues resolvedKeyValues = MicrometerObservationListenerConfiguration.resolveKeyValues(flux, defaultKeyValues);
 
 		assertThat(resolvedKeyValues.stream().map(Object::toString)).containsExactly(
-			"tag(common1=commonValue1)",
-			"tag(k1=v1)",
-			"tag(k2=v2)"
+			"keyValue(common1=commonValue1)",
+			"keyValue(k1=v1)",
+			"keyValue(k2=v2)"
 		);
 	}
 
@@ -204,6 +204,6 @@ class MicrometerObservationListenerConfigurationTest {
 
 		KeyValues resolvedKeyValues = MicrometerObservationListenerConfiguration.resolveKeyValues(publisher, defaultKeyValues);
 
-		assertThat(resolvedKeyValues.stream().map(Object::toString)).containsExactly("tag(common1=commonValue1)");
+		assertThat(resolvedKeyValues.stream().map(Object::toString)).containsExactly("keyValue(common1=commonValue1)");
 	}
 }

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerFactoryTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerFactoryTest.java
@@ -46,7 +46,7 @@ class MicrometerObservationListenerFactoryTest {
 
 		assertThat(configuration.registry).as("registry").isSameAs(CUSTOM_REGISTRY);
 		assertThat(configuration.isMono).as("isMono").isTrue();
-		assertThat(configuration.commonKeyValues).map(Object::toString).containsExactly("tag(" + "reactor.type" + "=Mono)");
+		assertThat(configuration.commonKeyValues).map(Object::toString).containsExactly("keyValue(" + "reactor.type" + "=Mono)");
 	}
 
 	@Test
@@ -55,7 +55,7 @@ class MicrometerObservationListenerFactoryTest {
 
 		assertThat(configuration.registry).as("registry").isSameAs(CUSTOM_REGISTRY);
 		assertThat(configuration.isMono).as("isMono").isFalse();
-		assertThat(configuration.commonKeyValues).map(Object::toString).containsExactly("tag(" + "reactor.type" + "=Flux)");
+		assertThat(configuration.commonKeyValues).map(Object::toString).containsExactly("keyValue(" + "reactor.type" + "=Flux)");
 	}
 
 	@Test


### PR DESCRIPTION
The Micrometer#useRegistry has been removed but the scheduler hook
was still referencing it instead of the (deprecated) one in core.

This fixes the situation by using core's Metrics.MicrometerConfiguration
getRegistry.

The hook could be removed entirely from the micrometer module with the
upcoming introduction of TimedScheduler there.
