### PR TITLE
Add ContextPropagation runtime util + captureContext operator

### DIFF
--- a/docs/asciidoc/advanced-contextPropagation.adoc
+++ b/docs/asciidoc/advanced-contextPropagation.adoc
@@ -6,7 +6,7 @@ This library is intended as a means to easily adapt between various implementati
 `ContextView`/`Context` is an example, and between `ThreadLocal` variables as well.
 
 `ReactorContextAccessor` allows the Context-Propagation library to understand Reactor `Context` and `Contextview`.
-It implements the SPI and is loaded via `ServiceLoader`.
+It implements the SPI and is loaded via `java.util.ServiceLoader`.
 No user action is required, other than having a dependency on both reactor-core and `io.micrometer:context-propagation`. The `ReactorContextAccessor` class is public but shouldn't generally be accessed by user code.
 
 On top of that, Reactor-Core 3.5.0 also introduces operators that transparently deal with `ContextSnapshot`s if the library is available at runtime, for users' convenience.

--- a/docs/asciidoc/advanced-contextPropagation.adoc
+++ b/docs/asciidoc/advanced-contextPropagation.adoc
@@ -1,0 +1,38 @@
+[[context.propagation]]
+= Context-Propagation Support
+
+Since 3.5.0, Reactor-Core embeds support for the `io.micrometer:context-propagation` SPI.
+This library is intended as a mean to easily adapt between various implementations of the concept of a Context, of which
+`ContextView`/`Context` is an example, and between `ThreadLocal` variables as well.
+
+`ReactorContextAccessor` allows the Context-Propagation library to understand Reactor `Context` and `Contextview`.
+It implements the SPI and is loaded via `ServiceLoader`.
+No user action is required, other than depending on reactor-core and `context-propagation` (the class is public but shouldn't generally be accessed by user code).
+
+On top of that, Reactor-Core 3.5.0 also introduces operators that transparently deal with `ContextSnapshot`s if the library is available at runtime, for users' convenience.
+
+== `contextCapture` Operator
+
+This operator is a convenient alternative to `contextWrite` which performs a `ContextSnapshot#capture` and uses the SPI to translate that snapshot into the Reactor `Context`.
+
+As a result, if there were any threadlocals during subscription phase they would now be stored into the `Context` and visible
+at runtime in upstream operators.
+
+====
+[source,java]
+----
+//assuming TL is known to Context-Propagation as key TLKEY.
+static final ThreadLocal<String> TL = new ThreadLocal<>();
+
+//in the main thread, tl is set to "HELLO"
+TL.set("HELLO");
+
+Mono.deferContextual(ctx ->
+  Mono.delay(Duration.ofSeconds(1))
+      //we're now in another thread, tl is not set
+      .map(v -> "delayed " + ctx.getOrDefault(TLKEY, "not found") + ", tl=" + TL.get())
+)
+.contextCapture()
+.block(); // returns "delayed HELLO, tl=null"
+----
+====

--- a/docs/asciidoc/advanced-contextPropagation.adoc
+++ b/docs/asciidoc/advanced-contextPropagation.adoc
@@ -12,8 +12,10 @@ No user action is required, other than having a dependency on both reactor-core 
 On top of that, Reactor-Core 3.5.0 also introduces the `contextCapture` operator that transparently deals with `ContextSnapshot`s if the library is available at runtime, for users' convenience.
 
 == `contextCapture` Operator
+This operator can be used when one needs to capture `ThreadLocal` value(s) at subscription time and reflect these values in the Reactor `Context` for the benefit of upstream operators.
+It relies on the `context-propagation` library and notably the registered `ThreadLocalAccessor`(s) to discover relevant ThreadLocal values.
 
-This operator is a convenient alternative to `contextWrite` to perform a `ContextSnapshot#capture` and then to use that snapshot to populate the Reactor `Context`.
+This is a convenient alternative to `contextWrite` which uses the `context-propagation` API to obtain a `ContextSnapshot` and then uses that snapshot to populate the Reactor `Context`.
 
 As a result, if there were any ThreadLocal values during subscription phase, for which there is a registered `ThreadLocalAccessor`, their values would now be stored in the Reactor `Context` and visible
 at runtime in upstream operators.

--- a/docs/asciidoc/advanced-contextPropagation.adoc
+++ b/docs/asciidoc/advanced-contextPropagation.adoc
@@ -15,7 +15,7 @@ On top of that, Reactor-Core 3.5.0 also introduces operators that transparently 
 
 This operator is a convenient alternative to `contextWrite` which performs a `ContextSnapshot#capture` and uses the SPI to translate that snapshot into the Reactor `Context`.
 
-As a result, if there were any threadlocals during subscription phase they would now be stored into the `Context` and visible
+As a result, if there were any ThreadLocal values during subscription phase, for which there is a registered `ThreadLocalAccessor`, their values would now be stored in the Reactor `Context` and visible
 at runtime in upstream operators.
 
 ====

--- a/docs/asciidoc/advanced-contextPropagation.adoc
+++ b/docs/asciidoc/advanced-contextPropagation.adoc
@@ -2,7 +2,7 @@
 = Context-Propagation Support
 
 Since 3.5.0, Reactor-Core embeds support for the `io.micrometer:context-propagation` SPI.
-This library is intended as a mean to easily adapt between various implementations of the concept of a Context, of which
+This library is intended as a means to easily adapt between various implementations of the concept of a Context, of which
 `ContextView`/`Context` is an example, and between `ThreadLocal` variables as well.
 
 `ReactorContextAccessor` allows the Context-Propagation library to understand Reactor `Context` and `Contextview`.

--- a/docs/asciidoc/advanced-contextPropagation.adoc
+++ b/docs/asciidoc/advanced-contextPropagation.adoc
@@ -7,13 +7,13 @@ This library is intended as a means to easily adapt between various implementati
 
 `ReactorContextAccessor` allows the Context-Propagation library to understand Reactor `Context` and `Contextview`.
 It implements the SPI and is loaded via `ServiceLoader`.
-No user action is required, other than depending on reactor-core and `context-propagation` (the class is public but shouldn't generally be accessed by user code).
+No user action is required, other than having a dependency on both reactor-core and `io.micrometer:context-propagation`. The `ReactorContextAccessor` class is public but shouldn't generally be accessed by user code.
 
 On top of that, Reactor-Core 3.5.0 also introduces operators that transparently deal with `ContextSnapshot`s if the library is available at runtime, for users' convenience.
 
 == `contextCapture` Operator
 
-This operator is a convenient alternative to `contextWrite` which performs a `ContextSnapshot#capture` and uses the SPI to translate that snapshot into the Reactor `Context`.
+This operator is a convenient alternative to `contextWrite` to perform a `ContextSnapshot#capture` and then to use that snapshot to populate the Reactor `Context`.
 
 As a result, if there were any ThreadLocal values during subscription phase, for which there is a registered `ThreadLocalAccessor`, their values would now be stored in the Reactor `Context` and visible
 at runtime in upstream operators.

--- a/docs/asciidoc/advanced-contextPropagation.adoc
+++ b/docs/asciidoc/advanced-contextPropagation.adoc
@@ -9,7 +9,7 @@ This library is intended as a means to easily adapt between various implementati
 It implements the SPI and is loaded via `java.util.ServiceLoader`.
 No user action is required, other than having a dependency on both reactor-core and `io.micrometer:context-propagation`. The `ReactorContextAccessor` class is public but shouldn't generally be accessed by user code.
 
-On top of that, Reactor-Core 3.5.0 also introduces operators that transparently deal with `ContextSnapshot`s if the library is available at runtime, for users' convenience.
+On top of that, Reactor-Core 3.5.0 also introduces the `contextCapture` operator that transparently deals with `ContextSnapshot`s if the library is available at runtime, for users' convenience.
 
 == `contextCapture` Operator
 
@@ -24,15 +24,15 @@ at runtime in upstream operators.
 //assuming TL is known to Context-Propagation as key TLKEY.
 static final ThreadLocal<String> TL = new ThreadLocal<>();
 
-//in the main thread, tl is set to "HELLO"
+//in the main thread, TL is set to "HELLO"
 TL.set("HELLO");
 
 Mono.deferContextual(ctx ->
   Mono.delay(Duration.ofSeconds(1))
-      //we're now in another thread, tl is not set
-      .map(v -> "delayed " + ctx.getOrDefault(TLKEY, "not found") + ", tl=" + TL.get())
+      //we're now in another thread, TL is not set
+      .map(v -> "delayed ctx[" + TLKEY + "]=" + ctx.getOrDefault(TLKEY, "not found") + ", TL=" + TL.get())
 )
 .contextCapture()
-.block(); // returns "delayed HELLO, tl=null"
+.block(); // returns "delayed ctx[TLKEY]=HELLO, TL=null"
 ----
 ====

--- a/docs/asciidoc/advancedFeatures.adoc
+++ b/docs/asciidoc/advancedFeatures.adoc
@@ -11,6 +11,7 @@ This chapter covers advanced features and concepts of Reactor, including the fol
 * <<scheduler-factory>>
 * <<hooks>>
 * <<context>>
+* <<context.propagation>>
 * <<null-safety>>
 * <<cleanup>>
 
@@ -841,15 +842,6 @@ TIP: In order to read from the `Context` without misleading users into thinking 
 while data is running through the pipeline, only the `ContextView` is exposed by the operators above.
 In case one needs to use one of the remaining APIs that still require a `Context`, one can use `Context.of(contextView)` for conversion.
 
-[[context.propagation]]
-=== Micrometer Context-Propagation Support
-Since 3.5.0, Reactor-Core embeds basic support for the `io.micrometer:context-propagation` SPI.
-This library is intended as a mean to easily adapt between various implementations of the concept of a Context, of which
-`ContextView`/`Context` is an example, and between `ThreadLocal` variables as well.
-
-`ReactorContextAccessor` is one implementation of this SPI that is loaded via `ServiceLoader`. No user action is required,
-other than depending on reactor-core and `context-propagation` (the class is public but shouldn't generally be accessed by user code).
-
 === Simple `Context` Examples
 
 The examples in this section are meant as ways to better understand some of the caveats of
@@ -1087,6 +1079,8 @@ public void contextForLibraryReactivePut() {
 }
 ----
 ====
+
+include::advanced-contextPropagation.adoc[leveloffset=1]
 
 [[cleanup]]
 == Dealing with Objects that Need Cleanup

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -26,7 +26,7 @@ import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
 /**
- * Utility private class to detect if Context-Propagation is on the classpath and to offer
+ * Utility private class to detect if the <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a> is on the classpath and to offer
  * ContextSnapshot support to {@link Flux} and {@link Mono}.
  *
  * @author Simon Baslé

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import io.micrometer.context.ContextRegistry;
+import io.micrometer.context.ContextSnapshot;
+
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+
+/**
+ * Utility private class to detect if Context-Propagation is on the classpath and to offer
+ * ContextSnapshot support to {@link Flux} and {@link Mono}.
+ *
+ * @author Simon Baslé
+ */
+final class ContextPropagation {
+
+	static final boolean isContextPropagationAvailable;
+
+	static final Predicate<Object> PREDICATE_TRUE = v -> true;
+	static final Function<Context, Context> NO_OP = c -> c;
+	static final Function<Context, Context> WITH_GLOBAL_REGISTRY_NO_PREDICATE;
+
+	static {
+		boolean contextPropagation;
+		try {
+			Class.forName("io.micrometer.context.ContextRegistry", false, ContextPropagation.class.getClassLoader());
+			contextPropagation = true;
+		}
+		catch (Throwable t) {
+			contextPropagation = false;
+		}
+		isContextPropagationAvailable = contextPropagation;
+		if (contextPropagation) {
+			WITH_GLOBAL_REGISTRY_NO_PREDICATE = new ContextCaptureFunction(PREDICATE_TRUE, ContextRegistry.getInstance());
+		}
+		else {
+			WITH_GLOBAL_REGISTRY_NO_PREDICATE = NO_OP;
+		}
+	}
+
+	/**
+	 * Is Micrometer {@code context-propagation} API on the classpath?
+	 *
+	 * @return true if context-propagation is available at runtime, false otherwise
+	 */
+	static boolean isContextPropagationAvailable() {
+		return isContextPropagationAvailable;
+	}
+
+	/**
+	 * Create a support function that takes a snapshot of thread locals and merges them with the
+	 * provided {@link Context}, resulting in a new {@link Context} which includes entries
+	 * captured from threadLocals by the Context-Propagation API.
+	 *
+	 * @return the {@link Context} augmented with captured entries
+	 */
+	public static Function<Context, Context> contextCapture() {
+		if (!isContextPropagationAvailable) {
+			return NO_OP;
+		}
+		return WITH_GLOBAL_REGISTRY_NO_PREDICATE;
+	}
+
+	/**
+	 * Create a support function that takes a snapshot of thread locals and merges them with the
+	 * provided {@link Context}, resulting in a new {@link Context} which includes entries
+	 * captured from threadLocals by the Context-Propagation API.
+	 * <p>
+	 * The provided {@link Predicate} is used on keys associated to said thread locals
+	 * by the Context-Propagation API to filter which entries should be captured in the
+	 * first place.
+	 *
+	 * @param captureKeyPredicate a {@link Predicate} used on keys to determine if each entry
+	 * should be injected into the new {@link Context}
+	 * @return a {@link Function} augmenting {@link Context} with captured entries
+	 */
+	public static Function<Context, Context> contextCapture(Predicate<Object> captureKeyPredicate) {
+		if (!isContextPropagationAvailable) {
+			return NO_OP;
+		}
+		return new ContextCaptureFunction(captureKeyPredicate, null);
+	}
+
+	//the Function indirection allows tests to directly assert code in this class rather than static methods
+	static final class ContextCaptureFunction implements Function<Context, Context> {
+
+		final Predicate<Object> capturePredicate;
+		final ContextRegistry registry;
+
+		ContextCaptureFunction(Predicate<Object> capturePredicate, @Nullable ContextRegistry registry) {
+			this.capturePredicate = capturePredicate;
+			this.registry = registry != null ? registry : ContextRegistry.getInstance();
+		}
+
+		@Override
+		public Context apply(Context target) {
+			return ContextSnapshot.captureUsing(this.registry, capturePredicate).updateContext(target);
+		}
+	}
+
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -113,7 +113,7 @@ final class ContextPropagation {
 
 		@Override
 		public Context apply(Context target) {
-			return ContextSnapshot.captureUsing(this.registry, capturePredicate).updateContext(target);
+			return ContextSnapshot.captureAllUsing(capturePredicate, this.registry).updateContext(target);
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -4036,6 +4036,9 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <p>
 	 * As a result this operator should generally be used as close as possible to the end of
 	 * the chain / subscription point.
+	 * <p>
+	 * If context-propagation is not available at runtime, this operator simply returns the current {@link Flux}
+	 * instance.
 	 *
 	 * @return a new {@link Flux} where context-propagation API has been used to capture entries and
 	 * inject them into the {@link Context}

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -4030,47 +4030,21 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	}
 
 	/**
-	 * If Micrometer's {@code context-propagation} library is on the classpath, this
-	 * is a convenience shortcut to capture thread local values during the subscription phase
-	 * and put them in the {@link Context} that is visible upstream of this operator.
+	 * If <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>
+	 * is on the classpath, this is a convenience shortcut to capture thread local values during the
+	 * subscription phase and put them in the {@link Context} that is visible upstream of this operator.
 	 * <p>
 	 * As a result this operator should generally be used as close as possible to the end of
 	 * the chain / subscription point.
 	 *
 	 * @return a new {@link Flux} where context-propagation API has been used to capture entries and
 	 * inject them into the {@link Context}
-	 * @see #contextCapture(Predicate)
 	 */
 	public final Flux<T> contextCapture() {
 		if (!ContextPropagation.isContextPropagationAvailable()) {
 			return this;
 		}
 		return onAssembly(new FluxContextWrite<>(this, ContextPropagation.contextCapture()));
-	}
-
-	/**
-	 * If Micrometer's {@code context-propagation} library is on the classpath, this
-	 * is a convenience shortcut to capture thread local values during the subscription phase
-	 * and put them in the {@link Context} that is visible upstream of this operator.
-	 * <p>
-	 * As a result this operator should generally be used as close as possible to the end of
-	 * the chain / subscription point.
-	 * <p>
-	 * The provided {@link Predicate} is used on keys associated to the thread locals
-	 * by the Context-Propagation API to filter which entries should be captured in the
-	 * first place.
-	 *
-	 * @param captureFilter a {@link Predicate} used on keys to determine if each entry should be
-	 * injected into the new {@link Context}
-	 * @return a new {@link Flux} where context-propagation API has been used to capture
-	 * entries which pass the filter and inject them into the {@link Context}
-	 * @see #contextCapture()
-	 */
-	public final Flux<T> contextCapture(Predicate<Object> captureFilter) {
-		if (!ContextPropagation.isContextPropagationAvailable()) {
-			return this;
-		}
-		return onAssembly(new FluxContextWrite<>(this, ContextPropagation.contextCapture(captureFilter)));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -2228,6 +2228,27 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	}
 
 	/**
+	 * If <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>
+	 * is on the classpath, this is a convenience shortcut to capture thread local values during the
+	 * subscription phase and put them in the {@link Context} that is visible upstream of this operator.
+	 * <p>
+	 * As a result this operator should generally be used as close as possible to the end of
+	 * the chain / subscription point.
+	 * <p>
+	 * If context-propagation is not available at runtime, this operator simply returns the current {@link Mono}
+	 * instance.
+	 *
+	 * @return a new {@link Flux} where context-propagation API has been used to capture entries and
+	 * inject them into the {@link Context}
+	 */
+	public final Mono<T> contextCapture() {
+		if (!ContextPropagation.isContextPropagationAvailable()) {
+			return this;
+		}
+		return onAssembly(new MonoContextWrite<>(this, ContextPropagation.contextCapture()));
+	}
+
+	/**
 	 * Enrich the {@link Context} visible from downstream for the benefit of upstream
 	 * operators, by making all values from the provided {@link ContextView} visible on top
 	 * of pairs from downstream.

--- a/reactor-core/src/test/java/reactor/core/publisher/ContextPropagationNotThereSmokeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ContextPropagationNotThereSmokeTest.java
@@ -35,9 +35,21 @@ class ContextPropagationNotThereSmokeTest {
 	}
 
 	@Test
-	void captureContextIsNoOp() {
+	void contextCaptureIsNoOp() {
 		assertThat(ContextPropagation.contextCapture()).as("without predicate").isSameAs(ContextPropagation.NO_OP);
 		assertThat(ContextPropagation.contextCapture(v -> true)).as("with predicate").isSameAs(ContextPropagation.NO_OP);
+	}
+
+	@Test
+	void contextCaptureFluxApiIsNoOp() {
+		Flux<Integer> source = Flux.empty();
+		assertThat(source.contextCapture()).isSameAs(source);
+	}
+
+	@Test
+	void contextCaptureMonoApiIsNoOp() {
+		Mono<Integer> source = Mono.empty();
+		assertThat(source.contextCapture()).isSameAs(source);
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/ContextPropagationNotThereSmokeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ContextPropagationNotThereSmokeTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * For tests that actually assert things when context-propagation is available, see
+ * {@code withMicrometer} test set.
+ * @author Simon Baslé
+ */
+class ContextPropagationNotThereSmokeTest {
+
+	@Test
+	void contextPropagationIsNotAvailable() {
+		assertThat(ContextPropagation.isContextPropagationAvailable()).isFalse();
+	}
+
+	@Test
+	void captureContextIsNoOp() {
+		assertThat(ContextPropagation.contextCapture()).as("without predicate").isSameAs(ContextPropagation.NO_OP);
+		assertThat(ContextPropagation.contextCapture(v -> true)).as("with predicate").isSameAs(ContextPropagation.NO_OP);
+	}
+
+}

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import io.micrometer.context.ContextRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import reactor.util.context.Context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Simon Baslé
+ */
+class ContextPropagationTest {
+
+	private static final String KEY1 = "key1";
+	private static final String KEY2 = "key2";
+
+	private static final AtomicReference<String> REF1 = new AtomicReference<>();
+	private static final AtomicReference<String> REF2 = new AtomicReference<>();
+
+	//NOTE: no way to currently remove accessors from the ContextRegistry, so we recreate one on each test
+	private ContextRegistry registry;
+
+	@BeforeEach
+	void setup() {
+		registry = new ContextRegistry().loadContextAccessors();
+
+		REF1.set("ref1_init");
+		REF2.set("ref2_init");
+
+		registry.registerThreadLocalAccessor(
+			KEY1, REF1::get, REF1::set, () -> REF1.set(null));
+
+		registry.registerThreadLocalAccessor(
+			KEY2, REF2::get, REF2::set, () -> REF2.set(null));
+	}
+
+	@Test
+	void isContextPropagationAvailable() {
+		assertThat(ContextPropagation.isContextPropagationAvailable()).isTrue();
+	}
+
+
+	@Test
+	void contextCaptureWithNoPredicateReturnsTheConstantFunction() {
+		assertThat(ContextPropagation.contextCapture())
+			.as("no predicate nor registry")
+			.isSameAs(ContextPropagation.WITH_GLOBAL_REGISTRY_NO_PREDICATE)
+			.hasFieldOrPropertyWithValue("registry", ContextRegistry.getInstance());
+	}
+
+	@Test
+	void contextCaptureWithPredicateReturnsNewFunctionWithGlobalRegistry() {
+		Function<Context, Context> test = ContextPropagation.contextCapture(ContextPropagation.PREDICATE_TRUE);
+
+		assertThat(test)
+			.as("predicate, no registry")
+			.isNotNull()
+			.isNotSameAs(ContextPropagation.WITH_GLOBAL_REGISTRY_NO_PREDICATE)
+			.isNotSameAs(ContextPropagation.NO_OP)
+			// as long as a predicate is supplied, the method creates new instances of the Function
+			.isNotSameAs(ContextPropagation.contextCapture(ContextPropagation.PREDICATE_TRUE))
+			.isInstanceOfSatisfying(ContextPropagation.ContextCaptureFunction.class, f ->
+				assertThat(f.registry).as("function default registry").isSameAs(ContextRegistry.getInstance()));
+	}
+
+	@Nested
+	class ContextCaptureFunctionTest {
+
+		@Test
+		void contextCaptureFunctionWithoutFiltering() {
+			ContextPropagation.ContextCaptureFunction test = new ContextPropagation.ContextCaptureFunction(
+				ContextPropagation.PREDICATE_TRUE, registry);
+
+			Context ctx = test.apply(Context.empty());
+			Map<Object, Object> asMap = new HashMap<>();
+			ctx.forEach(asMap::put); //easier to assert
+
+			assertThat(asMap)
+				.containsEntry(KEY1, "ref1_init")
+				.containsEntry(KEY2, "ref2_init")
+				.hasSize(2);
+		}
+
+		@Test
+		void captureWithFiltering() {
+			ContextPropagation.ContextCaptureFunction test = new ContextPropagation.ContextCaptureFunction(
+				k -> k.toString().equals(KEY2), registry);
+
+			Context ctx = test.apply(Context.empty());
+			Map<Object, Object> asMap = new HashMap<>();
+			ctx.forEach(asMap::put); //easier to assert
+
+			assertThat(asMap)
+				.containsEntry(KEY2, "ref2_init")
+				.hasSize(1);
+		}
+
+		@Test
+		void captureFunctionWithNullRegistryUsesGlobalRegistry() {
+			ContextPropagation.ContextCaptureFunction test = new ContextPropagation.ContextCaptureFunction(v -> true, null);
+
+			assertThat(test.registry).as("default registry").isSameAs(ContextRegistry.getInstance());
+		}
+	}
+
+}

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
@@ -87,6 +87,28 @@ class ContextPropagationTest {
 				assertThat(f.registry).as("function default registry").isSameAs(ContextRegistry.getInstance()));
 	}
 
+	@Test
+	void fluxApiUsesContextPropagationConstantFunction() {
+		Flux<Integer> source = Flux.empty();
+		assertThat(source.contextCapture())
+			.isInstanceOfSatisfying(FluxContextWrite.class, fcw ->
+				assertThat(fcw.doOnContext)
+					.as("flux's capture function")
+					.isSameAs(ContextPropagation.WITH_GLOBAL_REGISTRY_NO_PREDICATE)
+			);
+	}
+
+	@Test
+	void monoApiUsesContextPropagationConstantFunction() {
+		Mono<Integer> source = Mono.empty();
+		assertThat(source.contextCapture())
+			.isInstanceOfSatisfying(MonoContextWrite.class, fcw ->
+				assertThat(fcw.doOnContext)
+					.as("mono's capture function")
+					.isSameAs(ContextPropagation.WITH_GLOBAL_REGISTRY_NO_PREDICATE)
+			);
+	}
+
 	@Nested
 	class ContextCaptureFunctionTest {
 


### PR DESCRIPTION
In this PR we introduce a `ContextPropagation` runtime-detection utility class
as well as a `contextCapture()` operator. If context-propagation isn't on the
classpath, this operator is NO-OP.

If context-propagation _is_ on the classpath however, the operator will use
it to capture the current context during the subscription phase (at the point
a `contextWrite` would be effected) and store it in the `ContextView` visible
from upstream of the operator.

TODO:
 - [x] `Mono` version
 - [x] mention in reference guide? whole section?
 - ~marble diagram~