### PR TITLE
Contextual operators: transformWithWrappers / FunctionalWrappers

### DIFF
--- a/reactor-core/src/main/java/reactor/util/function/FunctionalWrappers.java
+++ b/reactor-core/src/main/java/reactor/util/function/FunctionalWrappers.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.function;
+
+import java.util.concurrent.Callable;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.LongConsumer;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+/**
+ * @author Simon Baslé
+ */
+public interface FunctionalWrappers {
+
+	/*
+	As of 2022, java.util.function.* classes imported by Reactor are:
+		x java.util.function.BiConsumer
+		x java.util.function.BiFunction
+		java.util.function.BinaryOperator (not used in public API)
+		x java.util.function.BiPredicate
+		x java.util.function.BooleanSupplier (used in Flux#repeat)
+		x java.util.function.Consumer
+		x java.util.function.Function
+		java.util.function.IntFunction (not used in public API)
+		x java.util.function.LongConsumer (used in Mono API)
+		x java.util.function.Predicate
+		x java.util.function.Supplier
+	 */
+
+	Runnable runnable(Runnable original);
+
+	<T> Callable<T> callable(Callable<T> original);
+
+	<T> Consumer<T> consumer(Consumer<T> original);
+
+	<T, U> BiConsumer<T, U> biConsumer(BiConsumer<T, U> original);
+
+	<T> Supplier<T> supplier(Supplier<T> original);
+
+	<T, R> Function<T, R> function(Function<T, R> original);
+
+	<T1, T2, R> BiFunction<T1, T2, R> biFunction(BiFunction<T1, T2, R> original);
+
+	<T> Predicate<T> predicate(Predicate<T> original);
+
+	<T, U> BiPredicate<T, U> biPredicate(BiPredicate<T, U> original);
+
+	BooleanSupplier booleanSupplier(BooleanSupplier original);
+
+	LongConsumer longConsumer(LongConsumer original);
+
+	/**
+	 * A constant instance of {@link FunctionalWrappers} that provides identity wrapping:
+	 * each method returns the original, making the "wrapping" no-op.
+	 */
+	FunctionalWrappers IDENTITY = new FunctionalWrappers() {
+		@Override
+		public Runnable runnable(Runnable original) {
+			return original;
+		}
+
+		@Override
+		public <T> Callable<T> callable(Callable<T> original) {
+			return original;
+		}
+
+		@Override
+		public <T> Consumer<T> consumer(Consumer<T> original) {
+			return original;
+		}
+
+		@Override
+		public <T, U> BiConsumer<T, U> biConsumer(BiConsumer<T, U> original) {
+			return original;
+		}
+
+		@Override
+		public <T> Supplier<T> supplier(Supplier<T> original) {
+			return original;
+		}
+
+		@Override
+		public <T, R> Function<T, R> function(Function<T, R> original) {
+			return original;
+		}
+
+		@Override
+		public <T1, T2, R> BiFunction<T1, T2, R> biFunction(BiFunction<T1, T2, R> original) {
+			return original;
+		}
+
+		@Override
+		public <T> Predicate<T> predicate(Predicate<T> original) {
+			return original;
+		}
+
+		@Override
+		public <T, U> BiPredicate<T, U> biPredicate(BiPredicate<T, U> original) {
+			return original;
+		}
+
+		@Override
+		public BooleanSupplier booleanSupplier(BooleanSupplier original) {
+			return original;
+		}
+
+		@Override
+		public LongConsumer longConsumer(LongConsumer original) {
+			return original;
+		}
+	};
+
+
+}

--- a/reactor-core/src/test/java/reactor/core/publisher/ContextPropagationNotThereSmokeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ContextPropagationNotThereSmokeTest.java
@@ -20,6 +20,9 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
+import reactor.util.context.Context;
+import reactor.util.function.FunctionalWrappers;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -38,6 +41,12 @@ class ContextPropagationNotThereSmokeTest {
 	void captureContextIsNoOp() {
 		assertThat(ContextPropagation.contextCapture()).as("without predicate").isSameAs(ContextPropagation.NO_OP);
 		assertThat(ContextPropagation.contextCapture(v -> true)).as("with predicate").isSameAs(ContextPropagation.NO_OP);
+	}
+
+	@Test
+	void functionalWrappersIsNoOp() {
+		assertThat(ContextPropagation.functionalWrappersOf(Context.empty())).as("without predicate").isSameAs(FunctionalWrappers.IDENTITY);
+		assertThat(ContextPropagation.functionalWrappersOf(Context.empty(), v -> true)).as("with predicate").isSameAs(FunctionalWrappers.IDENTITY);
 	}
 
 }

--- a/reactor-core/src/withMicrometerTest/java/reactor/WithMicrometerTestExecutionListener.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/WithMicrometerTestExecutionListener.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor;
+
+import io.micrometer.context.ContextRegistry;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.TestPlan;
+
+/**
+ * A custom TestExecutionListener that helps with testing Micrometer integration in reactor:<ul>
+ *     <li>defines a {@link ThreadLocal} and installs corresponding {@link io.micrometer.context.ThreadLocalAccessor}</li>
+ * </ul>
+ */
+public class WithMicrometerTestExecutionListener implements TestExecutionListener {
+
+	public static final String STRING_TL_KEY = "reactor.test.withMicrometer.threadLocal.string";
+
+	public static final ThreadLocal<String> STRING_THREAD_LOCAL = new ThreadLocal<>();
+
+	@Override
+	public void executionStarted(TestIdentifier testIdentifier) {
+		STRING_THREAD_LOCAL.set(testIdentifier.getDisplayName());
+	}
+
+	@Override
+	public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+		STRING_THREAD_LOCAL.remove();
+	}
+
+	@Override
+	public void testPlanExecutionStarted(TestPlan testPlan) {
+		ContextRegistry.getInstance().registerThreadLocalAccessor(STRING_TL_KEY, STRING_THREAD_LOCAL);
+	}
+}

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxTransformWithContextualWrappersTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxTransformWithContextualWrappersTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import reactor.WithMicrometerTestExecutionListener;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.context.Context;
+import reactor.util.function.FunctionalWrappers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Simon Baslé
+ */
+class FluxTransformWithContextualWrappersTest {
+
+	private static List<String> events ;
+
+	@BeforeEach
+	void init() {
+		events = new ArrayList<>();
+	}
+
+	static Mono<Integer> requestWithLog(Integer id) {
+		events.add("executing requestWithLog function for id " + id + " with tl=" + WithMicrometerTestExecutionListener.STRING_THREAD_LOCAL.get());
+
+		return Mono.just(id)
+			.filter(v -> {
+				events.add("sync filter on " + id + " inside requestWithLog with tl=" + WithMicrometerTestExecutionListener.STRING_THREAD_LOCAL.get());
+				return true;
+			})
+			.publishOn(Schedulers.parallel())
+			.map(v -> {
+				events.add("async mapping " + id + " inside requestWithLog with tl=" + WithMicrometerTestExecutionListener.STRING_THREAD_LOCAL.get());
+				return 100 + v;
+			});
+	}
+
+	static Mono<Integer> requestWithDeepLog(Integer id, FunctionalWrappers contextual) {
+		events.add("executing requestWithDeepLog function for id " + id + " with tl=" + WithMicrometerTestExecutionListener.STRING_THREAD_LOCAL.get());
+
+		return Mono.just(id)
+			.filter(contextual.predicate(v -> {
+				events.add("sync contextualized filter on " + id + " inside requestWithDeepLog with tl=" + WithMicrometerTestExecutionListener.STRING_THREAD_LOCAL.get());
+				return true;
+			}))
+			.publishOn(Schedulers.parallel())
+			.map(contextual.function(ignore -> {
+				events.add("async contextualized mapping " + id + " inside requestWithDeepLog with tl=" + WithMicrometerTestExecutionListener.STRING_THREAD_LOCAL.get());
+				return id - 59;
+			}));
+	}
+
+	@Test
+	void withJustTlAccessorNaturalCaptureAtScopeSubscription() {
+		Flux<Integer> source = Flux.just(1)
+			.publishOn(Schedulers.single());
+
+		source
+			.transformWithWrappers((self, contextual) -> self
+				.doOnNext(contextual.consumer(v -> events.add("wrapped doOnNext, tl=" + WithMicrometerTestExecutionListener.STRING_THREAD_LOCAL.get())))
+				.doOnNext(v -> events.add("UNWRAPPED doOnNext, tl=" + WithMicrometerTestExecutionListener.STRING_THREAD_LOCAL.get()))
+				//this demonstrates an important limitation: if the pre-existing flatMapping function doesn't account for the contextual FunctionalWrappers
+				//and has an async aspect, then TL will not be visible to the async parts
+				.flatMap(contextual.function(FluxTransformWithContextualWrappersTest::requestWithLog))
+				//this demonstrates how to fix the above, assuming the pre-existing flatmapping function can be changed to use a FunctionalWrappers
+				.flatMap(v -> requestWithDeepLog(v, contextual))
+			)
+			.blockLast();
+
+		assertThat(events).containsExactly(
+			"wrapped doOnNext, tl=withJustTlAccessorNaturalCaptureAtScopeSubscription()",
+			"UNWRAPPED doOnNext, tl=null",
+			"executing requestWithLog function for id 1 with tl=withJustTlAccessorNaturalCaptureAtScopeSubscription()",
+			"sync filter on 1 inside requestWithLog with tl=null",
+			"async mapping 1 inside requestWithLog with tl=null",
+			"executing requestWithDeepLog function for id 101 with tl=null",
+			"sync contextualized filter on 101 inside requestWithDeepLog with tl=withJustTlAccessorNaturalCaptureAtScopeSubscription()",
+			"async contextualized mapping 101 inside requestWithDeepLog with tl=withJustTlAccessorNaturalCaptureAtScopeSubscription()"
+		);
+	}
+
+	@Test
+	void whenSubscribedInAnotherThreadWithoutCapture() {
+		Flux<Integer> source = Flux.just(1)
+			.publishOn(Schedulers.single());
+
+		source
+			.transformWithWrappers((self, contextual) -> self
+				.doOnNext(contextual.consumer(v -> events.add("wrapped doOnNext, tl=" + WithMicrometerTestExecutionListener.STRING_THREAD_LOCAL.get())))
+				.doOnNext(v -> events.add("UNWRAPPED doOnNext, tl=" + WithMicrometerTestExecutionListener.STRING_THREAD_LOCAL.get()))
+				//this demonstrates an important limitation: if the pre-existing flatMapping function doesn't account for the contextual FunctionalWrappers
+				//and has an async aspect, then TL will not be visible to the async parts
+				.flatMap(contextual.function(FluxTransformWithContextualWrappersTest::requestWithLog))
+				//this demonstrates how to fix the above, assuming the pre-existing flatmapping function can be changed to use a FunctionalWrappers
+				.flatMap(v -> requestWithDeepLog(v, contextual))
+			)
+			.subscribeOn(Schedulers.parallel())
+			.blockLast();
+
+		assertThat(events).containsExactly(
+			"wrapped doOnNext, tl=null",
+			"UNWRAPPED doOnNext, tl=null",
+			"executing requestWithLog function for id 1 with tl=null",
+			"sync filter on 1 inside requestWithLog with tl=null",
+			"async mapping 1 inside requestWithLog with tl=null",
+			"executing requestWithDeepLog function for id 101 with tl=null",
+			"sync contextualized filter on 101 inside requestWithDeepLog with tl=null",
+			"async contextualized mapping 101 inside requestWithDeepLog with tl=null"
+		);
+	}
+
+	@Test
+	void whenSubscribedInAnotherThreadWithContextCapture() {
+		Flux<Integer> source = Flux.just(1)
+			.publishOn(Schedulers.single());
+
+		source
+			.transformWithWrappers((self, contextual) -> self
+				.doOnNext(contextual.consumer(v -> events.add("wrapped doOnNext, tl=" + WithMicrometerTestExecutionListener.STRING_THREAD_LOCAL.get())))
+				.doOnNext(v -> events.add("UNWRAPPED doOnNext, tl=" + WithMicrometerTestExecutionListener.STRING_THREAD_LOCAL.get()))
+				//this demonstrates an important limitation: if the pre-existing flatMapping function doesn't account for the contextual FunctionalWrappers
+				//and has an async aspect, then TL will not be visible to the async parts
+				.flatMap(contextual.function(FluxTransformWithContextualWrappersTest::requestWithLog))
+				//this demonstrates how to fix the above, assuming the pre-existing flatmapping function can be changed to use a FunctionalWrappers
+				.flatMap(v -> requestWithDeepLog(v, contextual))
+			)
+			.subscribeOn(Schedulers.parallel())
+			.contextCapture()
+			.blockLast();
+
+		assertThat(events).containsExactly(
+			"wrapped doOnNext, tl=whenSubscribedInAnotherThreadWithContextCapture()",
+			"UNWRAPPED doOnNext, tl=null",
+			"executing requestWithLog function for id 1 with tl=whenSubscribedInAnotherThreadWithContextCapture()",
+			"sync filter on 1 inside requestWithLog with tl=null",
+			"async mapping 1 inside requestWithLog with tl=null",
+			"executing requestWithDeepLog function for id 101 with tl=null",
+			"sync contextualized filter on 101 inside requestWithDeepLog with tl=whenSubscribedInAnotherThreadWithContextCapture()",
+			"async contextualized mapping 101 inside requestWithDeepLog with tl=whenSubscribedInAnotherThreadWithContextCapture()"
+		);
+	}
+
+	@Test
+	void whenSubscribedInAnotherThreadWithContextCaptureAndOverwrittenContextValue() {
+		Flux<Integer> source = Flux.just(1)
+			.publishOn(Schedulers.single());
+
+		source
+			.transformWithWrappers((self, contextual) -> self
+				.doOnNext(contextual.consumer(v -> events.add("wrapped doOnNext, tl=" + WithMicrometerTestExecutionListener.STRING_THREAD_LOCAL.get())))
+				.doOnNext(v -> events.add("UNWRAPPED doOnNext, tl=" + WithMicrometerTestExecutionListener.STRING_THREAD_LOCAL.get()))
+				//this demonstrates an important limitation: if the pre-existing flatMapping function doesn't account for the contextual FunctionalWrappers
+				//and has an async aspect, then TL will not be visible to the async parts
+				.flatMap(contextual.function(FluxTransformWithContextualWrappersTest::requestWithLog))
+				//this demonstrates how to fix the above, assuming the pre-existing flatmapping function can be changed to use a FunctionalWrappers
+				.flatMap(v -> requestWithDeepLog(v, contextual))
+			)
+			.subscribeOn(Schedulers.parallel())
+			.contextWrite(Context.of(WithMicrometerTestExecutionListener.STRING_TL_KEY, "overwriteTl()"))
+			.contextCapture()
+			.blockLast();
+
+		assertThat(events).containsExactly(
+			"wrapped doOnNext, tl=overwriteTl()",
+			"UNWRAPPED doOnNext, tl=null",
+			"executing requestWithLog function for id 1 with tl=overwriteTl()",
+			"sync filter on 1 inside requestWithLog with tl=null",
+			"async mapping 1 inside requestWithLog with tl=null",
+			"executing requestWithDeepLog function for id 101 with tl=null",
+			"sync contextualized filter on 101 inside requestWithDeepLog with tl=overwriteTl()",
+			"async contextualized mapping 101 inside requestWithDeepLog with tl=overwriteTl()"
+		);
+	}
+
+}

--- a/reactor-core/src/withMicrometerTest/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/reactor-core/src/withMicrometerTest/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+reactor.WithMicrometerTestExecutionListener


### PR DESCRIPTION
This PR introduces several concepts:
 - a generic `FunctionalWrappers` interface that defines wrappers for all functional types used by Reactor API
 - a contextual implementation of the above in `ContextPropagation`
 - an operator that will allow transformation of a sequence with a `FunctionalWrappers` instance in scope, which enables users to wrap their lambdas inside the scope and get context propagation if available

 See tests for an example of using `Flux#transformWithWrappers`.