### PR TITLE
Add type info to expectNext method's failure messages

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPeekAfterTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPeekAfterTest.java
@@ -469,7 +469,7 @@ public class MonoPeekAfterTest {
 			catch (Throwable t) {
 				Throwable e = Exceptions.unwrap(t);
 				assertThat(e).isExactlyInstanceOf(AssertionError.class)
-						.hasMessage("expectation \"expectNext(bar)\" failed (expected value: bar; actual value: foo)");
+						.hasMessage("expectation \"expectNext(bar)\" failed (expected value: java.lang.String<bar>; actual value: java.lang.String<foo>)");
 			}
 
 			assertThat(invoked.intValue()).isEqualTo(1);
@@ -505,7 +505,7 @@ public class MonoPeekAfterTest {
 			catch (Throwable t) {
 				Throwable e = Exceptions.unwrap(t);
 				assertThat(e).isExactlyInstanceOf(AssertionError.class)
-						.hasMessage("expectation \"expectNext(bar)\" failed (expected value: bar; actual value: foo)");
+						.hasMessage("expectation \"expectNext(bar)\" failed (expected value: java.lang.String<bar>; actual value: java.lang.String<foo>)");
 			}
 
 			assertThat(invoked.intValue()).isEqualTo(1);

--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -509,7 +509,8 @@ final class DefaultStepVerifierBuilder<T>
 				return messageFormatter.failOptional(se, "expected: onNext(%s); actual: %s", value, signal);
 			}
 			else if (!Objects.equals(value, signal.get())) {
-				return messageFormatter.failOptional(se, "expected value: %s; actual value: %s", value, signal.get());
+				return messageFormatter.failOptional(se, "expected value: %s<%s>; actual value: %s<%s>",
+						value.getClass().getName(), value, signal.get().getClass().getName(), signal.get());
 			}
 			else {
 				return Optional.empty();


### PR DESCRIPTION
This commit add type information to DefaultStepVerifierBuilder#expectNext method's failure messages.
By this commit, we expect to see a clearer failure message if the expectNext method fails due to a type mismatch.

### AS-IS
![image](https://user-images.githubusercontent.com/41561652/184348454-3c5ba08a-b952-4a63-90fe-b1edfd65a503.png)


### TO-BE
![image](https://user-images.githubusercontent.com/41561652/184348336-a600a2f5-d82d-4ac4-a99c-c0fa5efb1c00.png)
