### PR TITLE
Add FunctionX for TupleX for better readability

### DIFF
--- a/reactor-core/src/main/java/reactor/util/function/Function3.java
+++ b/reactor-core/src/main/java/reactor/util/function/Function3.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.function;
+
+/**
+ * Represents a function that accepts three arguments and produces a result.
+ *
+ * <p>This is a functional interface whose functional method is
+ * {@link #apply(Object, Object, Object)}.
+ *
+ * @param <T1> the type of the first argument to the function
+ * @param <T2> the type of the second argument to the function
+ * @param <T3> the type of the third argument to the function
+ * @param <R> the type of the result of the function
+ * @author Bohdan Petrenko
+ */
+@FunctionalInterface
+public interface Function3<T1, T2, T3, R> {
+
+	/**
+	 * Applies this function to the given arguments.
+	 *
+	 * @param t1 the first function argument
+	 * @param t2 the second function argument
+	 * @param t3 the third function argument
+	 * @return the function result
+	 */
+	R apply(T1 t1, T2 t2, T3 t3);
+}
+
+

--- a/reactor-core/src/main/java/reactor/util/function/Function4.java
+++ b/reactor-core/src/main/java/reactor/util/function/Function4.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.function;
+
+/**
+ * Represents a function that accepts four arguments and produces a result.
+ *
+ * <p>This is a functional interface whose functional method is
+ * {@link #apply(Object, Object, Object, Object)}.
+ *
+ * @param <T1> the type of the first argument to the function
+ * @param <T2> the type of the second argument to the function
+ * @param <T3> the type of the third argument to the function
+ * @param <T4> the type of the fourth argument to the function
+ * @param <R> the type of the result of the function
+ * @author Bohdan Petrenko
+ */
+@FunctionalInterface
+public interface Function4<T1, T2, T3, T4, R> {
+
+	/**
+	 * Applies this function to the given arguments.
+	 *
+	 * @param t1 the first function argument
+	 * @param t2 the second function argument
+	 * @param t3 the third function argument
+	 * @param t4 the fourth function argument
+	 * @return the function result
+	 */
+	R apply(T1 t1, T2 t2, T3 t3, T4 t4);
+}
+
+

--- a/reactor-core/src/main/java/reactor/util/function/Function5.java
+++ b/reactor-core/src/main/java/reactor/util/function/Function5.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.function;
+
+/**
+ * Represents a function that accepts five arguments and produces a result.
+ *
+ * <p>This is a functional interface whose functional method is
+ * {@link #apply(Object, Object, Object, Object, Object)}.
+ *
+ * @param <T1> the type of the first argument to the function
+ * @param <T2> the type of the second argument to the function
+ * @param <T3> the type of the third argument to the function
+ * @param <T4> the type of the fourth argument to the function
+ * @param <T5> the type of the fifth argument to the function
+ * @param <R> the type of the result of the function
+ * @author Bohdan Petrenko
+ */
+@FunctionalInterface
+public interface Function5<T1, T2, T3, T4, T5, R> {
+
+	/**
+	 * Applies this function to the given arguments.
+	 *
+	 * @param t1 the first function argument
+	 * @param t2 the second function argument
+	 * @param t3 the third function argument
+	 * @param t4 the fourth function argument
+	 * @param t5 the fifth function argument
+	 * @return the function result
+	 */
+	R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5);
+}
+
+

--- a/reactor-core/src/main/java/reactor/util/function/Function6.java
+++ b/reactor-core/src/main/java/reactor/util/function/Function6.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.function;
+
+/**
+ * Represents a function that accepts six arguments and produces a result.
+ *
+ * <p>This is a functional interface whose functional method is
+ * {@link #apply(Object, Object, Object, Object, Object, Object)}.
+ *
+ * @param <T1> the type of the first argument to the function
+ * @param <T2> the type of the second argument to the function
+ * @param <T3> the type of the third argument to the function
+ * @param <T4> the type of the fourth argument to the function
+ * @param <T5> the type of the fifth argument to the function
+ * @param <T6> the type of the sixth argument to the function
+ * @param <R> the type of the result of the function
+ * @author Bohdan Petrenko
+ */
+@FunctionalInterface
+public interface Function6<T1, T2, T3, T4, T5, T6, R> {
+
+	/**
+	 * Applies this function to the given arguments.
+	 *
+	 * @param t1 the first function argument
+	 * @param t2 the second function argument
+	 * @param t3 the third function argument
+	 * @param t4 the fourth function argument
+	 * @param t5 the fifth function argument
+	 * @param t6 the sixth function argument
+	 * @return the function result
+	 */
+	R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6);
+}
+
+

--- a/reactor-core/src/main/java/reactor/util/function/Function7.java
+++ b/reactor-core/src/main/java/reactor/util/function/Function7.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.function;
+
+/**
+ * Represents a function that accepts seven arguments and produces a result.
+ *
+ * <p>This is a functional interface whose functional method is
+ * {@link #apply(Object, Object, Object, Object, Object, Object, Object)}.
+ *
+ * @param <T1> the type of the first argument to the function
+ * @param <T2> the type of the second argument to the function
+ * @param <T3> the type of the third argument to the function
+ * @param <T4> the type of the fourth argument to the function
+ * @param <T5> the type of the fifth argument to the function
+ * @param <T6> the type of the sixth argument to the function
+ * @param <T7> the type of the seventh argument to the function
+ * @param <R> the type of the result of the function
+ * @author Bohdan Petrenko
+ */
+@FunctionalInterface
+public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> {
+
+	/**
+	 * Applies this function to the given arguments.
+	 *
+	 * @param t1 the first function argument
+	 * @param t2 the second function argument
+	 * @param t3 the third function argument
+	 * @param t4 the fourth function argument
+	 * @param t5 the fifth function argument
+	 * @param t6 the sixth function argument
+	 * @param t7 the seventh function argument
+	 * @return the function result
+	 */
+	R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7);
+}
+
+

--- a/reactor-core/src/main/java/reactor/util/function/Function8.java
+++ b/reactor-core/src/main/java/reactor/util/function/Function8.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.function;
+
+/**
+ * Represents a function that accepts eight arguments and produces a result.
+ *
+ * <p>This is a functional interface whose functional method is
+ * {@link #apply(Object, Object, Object, Object, Object, Object, Object, Object)}.
+ *
+ * @param <T1> the type of the first argument to the function
+ * @param <T2> the type of the second argument to the function
+ * @param <T3> the type of the third argument to the function
+ * @param <T4> the type of the fourth argument to the function
+ * @param <T5> the type of the fifth argument to the function
+ * @param <T6> the type of the sixth argument to the function
+ * @param <T7> the type of the seventh argument to the function
+ * @param <T8> the type of the eighth argument to the function
+ * @param <R> the type of the result of the function
+ * @author Bohdan Petrenko
+ */
+@FunctionalInterface
+public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> {
+
+	/**
+	 * Applies this function to the given arguments.
+	 *
+	 * @param t1 the first function argument
+	 * @param t2 the second function argument
+	 * @param t3 the third function argument
+	 * @param t4 the fourth function argument
+	 * @param t5 the fifth function argument
+	 * @param t6 the sixth function argument
+	 * @param t7 the seventh function argument
+	 * @param t8 the eighth function argument
+	 * @return the function result
+	 */
+	R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8);
+}
+
+

--- a/reactor-core/src/main/java/reactor/util/function/TupleMappers.java
+++ b/reactor-core/src/main/java/reactor/util/function/TupleMappers.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.function;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * A {@literal TupleMappers} is a utility class to convert function of X arguments into {@link Function} with single
+ * Tuple argument that holds X values. It's useful while transforming {@link org.reactivestreams.Publisher} of Tuple X.
+ * The following example illustrates computing sum of tuple values
+ * <pre>{@code
+ *     Mono<Integer> sum = Mono.just(Tuples.of(1, 2, 3))
+ *                      	   .map(fn((one, two, three) -> one + two + three));
+ * }</pre>
+ * @author Bohdan Petrenko
+ */
+public final class TupleMappers {
+
+	private TupleMappers() {
+	}
+
+	/**
+	 * A converting function from {@link BiFunction} to {@link Function} of {@link Tuple2} to R.
+	 *
+	 * @param <T1> The type of the first value.
+	 * @param <T2> The type of the second value.
+	 * @param <R> The type of the return value.
+	 * @param delegate the function to delegate to
+	 *
+	 * @return The conversion function to R.
+	 */
+	public static <T1, T2, R> Function<Tuple2<T1, T2>, R> fn(BiFunction<T1, T2, R> delegate) {
+		return tuple2 -> delegate.apply(tuple2.getT1(), tuple2.getT2());
+	}
+
+	/**
+	 * A converting function from {@link Function3} to {@link Function} of {@link Tuple3} to R.
+	 *
+	 * @param <T1> The type of the first value.
+	 * @param <T2> The type of the second value.
+	 * @param <T3> The type of the third value.
+	 * @param <R> The type of the return value.
+	 * @param delegate the function to delegate to
+	 *
+	 * @return The conversion function to R.
+	 */
+	public static <T1, T2, T3, R> Function<Tuple3<T1, T2, T3>, R> fn(Function3<T1, T2, T3, R> delegate) {
+		return tuple3 -> delegate.apply(tuple3.getT1(), tuple3.getT2(), tuple3.getT3());
+	}
+
+	/**
+	 * A converting function from {@link Function4} to {@link Function} of {@link Tuple4} to R.
+	 *
+	 * @param <T1> The type of the first value.
+	 * @param <T2> The type of the second value.
+	 * @param <T3> The type of the third value.
+	 * @param <T4> The type of the fourth value.
+	 * @param <R> The type of the return value.
+	 * @param delegate the function to delegate to
+	 *
+	 * @return The conversion function to R.
+	 */
+	public static <T1, T2, T3, T4, R> Function<Tuple4<T1, T2, T3, T4>, R> fn(Function4<T1, T2, T3, T4, R> delegate) {
+		return tuple4 -> delegate.apply(tuple4.getT1(), tuple4.getT2(), tuple4.getT3(), tuple4.getT4());
+	}
+
+	/**
+	 * A converting function from {@link Function5} to {@link Function} of {@link Tuple5} to R.
+	 *
+	 * @param <T1> The type of the first value.
+	 * @param <T2> The type of the second value.
+	 * @param <T3> The type of the third value.
+	 * @param <T4> The type of the fourth value.
+	 * @param <T5> The type of the fifth value.
+	 * @param <R> The type of the return value.
+	 * @param delegate the function to delegate to
+	 *
+	 * @return The conversion function to R.
+	 */
+	public static <T1, T2, T3, T4, T5, R> Function<Tuple5<T1, T2, T3, T4, T5>, R> fn(
+			Function5<T1, T2, T3, T4, T5, R> delegate) {
+		return tuple5 -> delegate.apply(tuple5.getT1(), tuple5.getT2(), tuple5.getT3(), tuple5.getT4(), tuple5.getT5());
+	}
+
+	/**
+	 * A converting function from {@link Function6} to {@link Function} of {@link Tuple6} to R.
+	 *
+	 * @param <T1> The type of the first value.
+	 * @param <T2> The type of the second value.
+	 * @param <T3> The type of the third value.
+	 * @param <T4> The type of the fourth value.
+	 * @param <T5> The type of the fifth value.
+	 * @param <T6> The type of the sixth value.
+	 * @param <R> The type of the return value.
+	 * @param delegate the function to delegate to
+	 *
+	 * @return The conversion function to R.
+	 */
+	public static <T1, T2, T3, T4, T5, T6, R> Function<Tuple6<T1, T2, T3, T4, T5, T6>, R> fn(
+			Function6<T1, T2, T3, T4, T5, T6, R> delegate) {
+		return tuple6 -> delegate.apply(tuple6.getT1(), tuple6.getT2(), tuple6.getT3(), tuple6.getT4(),
+				tuple6.getT5(), tuple6.getT6());
+	}
+
+	/**
+	 * A converting function from {@link Function7} to {@link Function} of {@link Tuple7} to R.
+	 *
+	 * @param <T1> The type of the first value.
+	 * @param <T2> The type of the second value.
+	 * @param <T3> The type of the third value.
+	 * @param <T4> The type of the fourth value.
+	 * @param <T5> The type of the fifth value.
+	 * @param <T6> The type of the sixth value.
+	 * @param <T7> The type of the seventh value.
+	 * @param <R> The type of the return value.
+	 * @param delegate the function to delegate to
+	 *
+	 * @return The conversion function to R.
+	 */
+	public static <T1, T2, T3, T4, T5, T6, T7, R> Function<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> fn(
+			Function7<T1, T2, T3, T4, T5, T6, T7, R> delegate) {
+		return tuple7 -> delegate.apply(tuple7.getT1(), tuple7.getT2(), tuple7.getT3(), tuple7.getT4(),
+				tuple7.getT5(), tuple7.getT6(), tuple7.getT7());
+	}
+
+	/**
+	 * A converting function from {@link Function8} to {@link Function} of {@link Tuple8} to R.
+	 *
+	 * @param <T1> The type of the first value.
+	 * @param <T2> The type of the second value.
+	 * @param <T3> The type of the third value.
+	 * @param <T4> The type of the fourth value.
+	 * @param <T5> The type of the fifth value.
+	 * @param <T6> The type of the sixth value.
+	 * @param <T7> The type of the seventh value.
+	 * @param <T8> The type of the eighth value.
+	 * @param <R> The type of the return value.
+	 * @param delegate the function to delegate to
+	 *
+	 * @return The conversion function to R.
+	 */
+	public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Function<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> fn(
+			Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> delegate) {
+		return tuple8 -> delegate.apply(tuple8.getT1(), tuple8.getT2(), tuple8.getT3(), tuple8.getT4(),
+				tuple8.getT5(), tuple8.getT6(), tuple8.getT7(), tuple8.getT8());
+	}
+}

--- a/reactor-core/src/test/java/reactor/util/function/TupleMappersTest.java
+++ b/reactor-core/src/test/java/reactor/util/function/TupleMappersTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.util.function;
+
+import java.util.function.BiFunction;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TupleMappersTest {
+
+	@Test
+	public void fn2() {
+		BiFunction<Integer, Integer, Integer> function = Integer::sum;
+		Tuple2<Integer, Integer> source = Tuples.of(1, 2);
+		Integer expected = 3;
+		Integer actual = TupleMappers.fn(function).apply(source);
+		assertThat(actual).isEqualTo(expected);
+	}
+
+	@Test
+	public void fn3() {
+		Function3<Integer, Integer, Integer, Integer> function = (one, two, three) -> one + two + three;
+		Tuple3<Integer, Integer, Integer> source = Tuples.of(1, 2, 3);
+		Integer expected = 6;
+		Integer actual = TupleMappers.fn(function).apply(source);
+		assertThat(actual).isEqualTo(expected);
+	}
+
+	@Test
+	public void fn4() {
+		Function4<Integer, Integer, Integer, Integer, Integer> function =
+				(one, two, three, four) -> one + two + three + four;
+		Tuple4<Integer, Integer, Integer, Integer> source = Tuples.of(1, 2, 3, 4);
+		Integer expected = 10;
+		Integer actual = TupleMappers.fn(function).apply(source);
+		assertThat(actual).isEqualTo(expected);
+	}
+
+	@Test
+	public void fn5() {
+		Function5<Integer, Integer, Integer, Integer, Integer, Integer> function =
+				(one, two, three, four, five) -> one + two + three + four + five;
+		Tuple5<Integer, Integer, Integer, Integer, Integer> source = Tuples.of(1, 2, 3, 4, 5);
+		Integer expected = 15;
+		Integer actual = TupleMappers.fn(function).apply(source);
+		assertThat(actual).isEqualTo(expected);
+	}
+
+	@Test
+	public void fn6() {
+		Function6<Integer, Integer, Integer, Integer, Integer, Integer, Integer> function =
+				(one, two, three, four, five, six) -> one + two + three + four + five + six;
+		Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> source = Tuples.of(1, 2, 3, 4, 5, 6);
+		Integer expected = 21;
+		Integer actual = TupleMappers.fn(function).apply(source);
+		assertThat(actual).isEqualTo(expected);
+	}
+
+	@Test
+	public void fn7() {
+		Function7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> function =
+				(one, two, three, four, five, six, seven) -> one + two + three + four + five + six + seven;
+		Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> source = Tuples.of(1, 2, 3, 4, 5, 6, 7);
+		Integer expected = 28;
+		Integer actual = TupleMappers.fn(function).apply(source);
+		assertThat(actual).isEqualTo(expected);
+	}
+
+	@Test
+	public void fn8() {
+		Function8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> function =
+				(one, two, three, four, five, six, seven, eight) -> one + two + three + four + five + six + seven + eight;
+		Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> source =
+				Tuples.of(1, 2, 3, 4, 5, 6, 7, 8);
+		Integer expected = 36;
+		Integer actual = TupleMappers.fn(function).apply(source);
+		assertThat(actual).isEqualTo(expected);
+	}
+}


### PR DESCRIPTION
Open questions. 
1 New functionality added to TupleMappers to not inflate and not clutter Tuples class. Is it ok?
2 Decided to separate functions and tuples to different packages. To do so I had to move tuples from util.function to util.tuple package. After release users who upgrade to the last version should be forced to refactor Tuple imports to reactor.util.tuple. Can we afford it?