### PR TITLE
ensures onLastAssembly does not break fusion chain

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -8445,6 +8445,10 @@ public abstract class Flux<T> implements CorePublisher<T> {
 		CorePublisher publisher = Operators.onLastAssembly(this);
 		CoreSubscriber subscriber = Operators.toCoreSubscriber(actual);
 
+		if (subscriber instanceof Fuseable.QueueSubscription && !(publisher instanceof Fuseable)) {
+			subscriber = new FluxHide.SuppressFuseableSubscriber<>(subscriber);
+		}
+
 		try {
 			if (publisher instanceof OptimizableOperator) {
 				OptimizableOperator operator = (OptimizableOperator) publisher;

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -8445,7 +8445,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 		CorePublisher publisher = Operators.onLastAssembly(this);
 		CoreSubscriber subscriber = Operators.toCoreSubscriber(actual);
 
-		if (subscriber instanceof Fuseable.QueueSubscription && !(publisher instanceof Fuseable)) {
+		if (subscriber instanceof Fuseable.QueueSubscription && this != publisher && this instanceof Fuseable && !(publisher instanceof Fuseable)) {
 			subscriber = new FluxHide.SuppressFuseableSubscriber<>(subscriber);
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -4375,6 +4375,10 @@ public abstract class Mono<T> implements CorePublisher<T> {
 		CorePublisher publisher = Operators.onLastAssembly(this);
 		CoreSubscriber subscriber = Operators.toCoreSubscriber(actual);
 
+		if (subscriber instanceof Fuseable.QueueSubscription && !(publisher instanceof Fuseable)) {
+			subscriber = new FluxHide.SuppressFuseableSubscriber<>(subscriber);
+		}
+
 		try {
 			if (publisher instanceof OptimizableOperator) {
 				OptimizableOperator operator = (OptimizableOperator) publisher;

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -4375,7 +4375,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 		CorePublisher publisher = Operators.onLastAssembly(this);
 		CoreSubscriber subscriber = Operators.toCoreSubscriber(actual);
 
-		if (subscriber instanceof Fuseable.QueueSubscription && !(publisher instanceof Fuseable)) {
+		if (subscriber instanceof Fuseable.QueueSubscription && this != publisher && this instanceof Fuseable && !(publisher instanceof Fuseable)) {
 			subscriber = new FluxHide.SuppressFuseableSubscriber<>(subscriber);
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
@@ -67,14 +67,17 @@ public class HooksTest {
 			}
 		});
 
-		Mono.just(1)
-		    .flatMap(fsm ->
-				    Mono.just(1)
-				        .doOnSubscribe(subscription -> {})
-		    )
-		    .doOnSubscribe(subscription -> {
-		    })
-		    .block();
+		try {
+			Mono.just(1)
+			    .flatMap(fsm -> Mono.just(1)
+			                        .doOnSubscribe(subscription -> {
+			                        }))
+			    .doOnSubscribe(subscription -> {
+			    })
+			    .block();
+		} finally {
+			Hooks.resetOnLastOperator();
+		}
 	}
 
 	void simpleFlux(){
@@ -164,6 +167,7 @@ public class HooksTest {
 	public void onEachOperatorOneHookNoComposite() {
 		Function<? super Publisher<Object>, ? extends Publisher<Object>> hook = p -> p;
 		Hooks.onEachOperator(hook);
+
 
 		assertThat(Hooks.onEachOperatorHook).isSameAs(hook);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
@@ -54,32 +54,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  */
 public class HooksTest {
 
-	// https://github.com/reactor/reactor-core/issues/3137
-	@Test
-	public void reproduceClassCastExceptionWithHooks() {
-		Hooks.onLastOperator(objectPublisher -> {
-			if (objectPublisher instanceof Mono) {
-				return Hooks.convertToMonoBypassingHooks(objectPublisher, false)
-				            .doFinally(signalType -> {
-				            });
-			} else {
-				return objectPublisher;
-			}
-		});
-
-		try {
-			Mono.just(1)
-			    .flatMap(fsm -> Mono.just(1)
-			                        .doOnSubscribe(subscription -> {
-			                        }))
-			    .doOnSubscribe(subscription -> {
-			    })
-			    .block();
-		} finally {
-			Hooks.resetOnLastOperator();
-		}
-	}
-
 	void simpleFlux(){
 		Flux.just(1)
 		    .map(d -> d + 1)
@@ -95,7 +69,6 @@ public class HooksTest {
 			super(message);
 		}
 	}
-
 
 	@Test
 	public void staticActivationOfOperatorDebug() {
@@ -1280,5 +1253,31 @@ public class HooksTest {
 				sub.onComplete();
 			}
 		};
+	}
+
+	// https://github.com/reactor/reactor-core/issues/3137
+	@Test
+	public void reproduceClassCastExceptionWithHooks() {
+		Hooks.onLastOperator(objectPublisher -> {
+			if (objectPublisher instanceof Mono) {
+				return Hooks.convertToMonoBypassingHooks(objectPublisher, false)
+				            .doFinally(signalType -> {
+				            });
+			} else {
+				return objectPublisher;
+			}
+		});
+
+		try {
+			Mono.just(1)
+			    .flatMap(fsm -> Mono.just(1)
+			                        .doOnSubscribe(subscription -> {
+			                        }))
+			    .doOnSubscribe(subscription -> {
+			    })
+			    .block();
+		} finally {
+			Hooks.resetOnLastOperator();
+		}
 	}
 }


### PR DESCRIPTION
closes #3137 

as it was observed, `onLastOperator` may add extra operators to the chain. In the case of scalar fusion at flatMap operators ( https://github.com/reactor/reactor-core/blob/main/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java#L118) the inner chain may be fused with the outer downstream. Since `onLastOperator` must be applied to the inner chain, modification added by the call may break fusion which leads to the `ClastCastException`

Signed-off-by: OlegDokuka <odokuka@vmware.com>