### PR TITLE
Replace 'long' padding by 'byte' padding to avoid fields re-ordering on modern JDK

### DIFF
--- a/reactor-core/src/main/java/reactor/util/concurrent/SpscArrayQueue.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/SpscArrayQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/util/concurrent/SpscArrayQueue.java
+++ b/reactor-core/src/main/java/reactor/util/concurrent/SpscArrayQueue.java
@@ -178,9 +178,23 @@ class SpscArrayQueueCold<T> extends AtomicReferenceArray<T> {
 class SpscArrayQueueP1<T> extends SpscArrayQueueCold<T> {
 	/** */
 	private static final long serialVersionUID = -4461305682174876914L;
-	
-	long p00, p01, p02, p03, p04, p05, p06, p07;
-	long p08, p09, p0A, p0B, p0C, p0D, p0E;
+
+	byte b000,b001,b002,b003,b004,b005,b006,b007;//  8b
+	byte b010,b011,b012,b013,b014,b015,b016,b017;// 16b
+	byte b020,b021,b022,b023,b024,b025,b026,b027;// 24b
+	byte b030,b031,b032,b033,b034,b035,b036,b037;// 32b
+	byte b040,b041,b042,b043,b044,b045,b046,b047;// 40b
+	byte b050,b051,b052,b053,b054,b055,b056,b057;// 48b
+	byte b060,b061,b062,b063,b064,b065,b066,b067;// 56b
+	byte b070,b071,b072,b073,b074,b075,b076,b077;// 64b
+	byte b100,b101,b102,b103,b104,b105,b106,b107;// 72b
+	byte b110,b111,b112,b113,b114,b115,b116,b117;// 80b
+	byte b120,b121,b122,b123,b124,b125,b126,b127;// 88b
+	byte b130,b131,b132,b133,b134,b135,b136,b137;// 96b
+	byte b140,b141,b142,b143,b144,b145,b146,b147;//104b
+	byte b150,b151,b152,b153,b154,b155,b156,b157;//112b
+	byte b160,b161,b162,b163,b164,b165,b166,b167;//120b
+	byte b170,b171,b172,b173,b174,b175,b176,b177;//128b
 
 	SpscArrayQueueP1(int length) {
 		super(length);
@@ -206,9 +220,23 @@ class SpscArrayQueueProducer<T> extends SpscArrayQueueP1<T> {
 class SpscArrayQueueP2<T> extends SpscArrayQueueProducer<T> {
 	/** */
 	private static final long serialVersionUID = -5400235061461013116L;
-	
-	long p00, p01, p02, p03, p04, p05, p06, p07;
-	long p08, p09, p0A, p0B, p0C, p0D, p0E;
+
+	byte b000,b001,b002,b003,b004,b005,b006,b007;//  8b
+	byte b010,b011,b012,b013,b014,b015,b016,b017;// 16b
+	byte b020,b021,b022,b023,b024,b025,b026,b027;// 24b
+	byte b030,b031,b032,b033,b034,b035,b036,b037;// 32b
+	byte b040,b041,b042,b043,b044,b045,b046,b047;// 40b
+	byte b050,b051,b052,b053,b054,b055,b056,b057;// 48b
+	byte b060,b061,b062,b063,b064,b065,b066,b067;// 56b
+	byte b070,b071,b072,b073,b074,b075,b076,b077;// 64b
+	byte b100,b101,b102,b103,b104,b105,b106,b107;// 72b
+	byte b110,b111,b112,b113,b114,b115,b116,b117;// 80b
+	byte b120,b121,b122,b123,b124,b125,b126,b127;// 88b
+	byte b130,b131,b132,b133,b134,b135,b136,b137;// 96b
+	byte b140,b141,b142,b143,b144,b145,b146,b147;//104b
+	byte b150,b151,b152,b153,b154,b155,b156,b157;//112b
+	byte b160,b161,b162,b163,b164,b165,b166,b167;//120b
+	byte b170,b171,b172,b173,b174,b175,b176,b177;//128b
 
 	SpscArrayQueueP2(int length) {
 		super(length);
@@ -234,9 +262,23 @@ class SpscArrayQueueConsumer<T> extends SpscArrayQueueP2<T> {
 class SpscArrayQueueP3<T> extends SpscArrayQueueConsumer<T> {
 	/** */
 	private static final long serialVersionUID = -2684922090021364171L;
-	
-	long p00, p01, p02, p03, p04, p05, p06, p07;
-	long p08, p09, p0A, p0B, p0C, p0D, p0E;
+
+	byte b000,b001,b002,b003,b004,b005,b006,b007;//  8b
+	byte b010,b011,b012,b013,b014,b015,b016,b017;// 16b
+	byte b020,b021,b022,b023,b024,b025,b026,b027;// 24b
+	byte b030,b031,b032,b033,b034,b035,b036,b037;// 32b
+	byte b040,b041,b042,b043,b044,b045,b046,b047;// 40b
+	byte b050,b051,b052,b053,b054,b055,b056,b057;// 48b
+	byte b060,b061,b062,b063,b064,b065,b066,b067;// 56b
+	byte b070,b071,b072,b073,b074,b075,b076,b077;// 64b
+	byte b100,b101,b102,b103,b104,b105,b106,b107;// 72b
+	byte b110,b111,b112,b113,b114,b115,b116,b117;// 80b
+	byte b120,b121,b122,b123,b124,b125,b126,b127;// 88b
+	byte b130,b131,b132,b133,b134,b135,b136,b137;// 96b
+	byte b140,b141,b142,b143,b144,b145,b146,b147;//104b
+	byte b150,b151,b152,b153,b154,b155,b156,b157;//112b
+	byte b160,b161,b162,b163,b164,b165,b166,b167;//120b
+	byte b170,b171,b172,b173,b174,b175,b176,b177;//128b
 
 	SpscArrayQueueP3(int length) {
 		super(length);


### PR DESCRIPTION
Hello,
On modern JDK (15+) good old trick using `long` fields as padding is no longer [reliable](https://shipilev.net/jvm/objects-inside-out/#_superhierarchy_gaps_in_java_15). To prevent false-sharing we could use `byte` padding in the same way, as in original [SpscArrayQueue](https://github.com/JCTools/JCTools/commit/d43b774ae40a34a6449b49d49ae96b8080a69abf#diff-26cefaad7d67f5b07622f85638bafd2496526c5a092da3e66b6c1e1f15df4d97) 