### PR TITLE
SourceException wrapper for main stream errors delivered to windows

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Exceptions.java
+++ b/reactor-core/src/main/java/reactor/core/Exceptions.java
@@ -103,6 +103,18 @@ public abstract class Exceptions {
 	}
 
 	/**
+	 * Wrap a {@link Throwable} delivered via {@link org.reactivestreams.Subscriber#onError(Throwable)}
+	 * from an upstream {@link org.reactivestreams.Publisher} that itself
+	 * emits {@link org.reactivestreams.Publisher}s to distinguish the error signal from
+	 * the inner sequence's processing errors.
+	 * @param throwable the source sequence {@code error} signal
+	 * @return {@link SourceException}
+	 */
+	public static Throwable wrapSource(Throwable throwable) {
+		return new SourceException(throwable);
+	}
+
+	/**
 	 * Create a composite exception that wraps the given {@link Throwable Throwable(s)},
 	 * as suppressed exceptions. Instances create by this method can be detected using the
 	 * {@link #isMultiple(Throwable)} check. The {@link #unwrapMultiple(Throwable)} method
@@ -723,6 +735,23 @@ public abstract class Exceptions {
 		}
 
 		private static final long serialVersionUID = 2491425227432776143L;
+	}
+
+	/**
+	 * A {@link Throwable} that wraps the actual {@code cause} delivered via
+	 * {@link org.reactivestreams.Subscriber#onError(Throwable)} in case of
+	 * {@link org.reactivestreams.Publisher}s that themselves emit items of type
+	 * {@link org.reactivestreams.Publisher}. This wrapper is used to distinguish
+	 * {@code error}s delivered by the upstream sequence from the ones that happen via
+	 * the inner sequence processing chain.
+	 */
+	public static class SourceException extends ReactiveException {
+
+		SourceException(Throwable cause) {
+			super(cause);
+		}
+
+		private static final long serialVersionUID = 5747581575202629465L;
 	}
 
 	static final class ErrorCallbackNotImplemented extends UnsupportedOperationException {

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -9577,6 +9577,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
 	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
+	 *
 	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal.
 	 *
@@ -9612,6 +9617,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
 	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
+	 *
 	 * <p><strong>Discard Support:</strong> The overlapping variant DOES NOT discard elements, as they might be part of another still valid window.
 	 * The exact window and dropping window variants bot discard elements they internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal. The dropping window variant also discards elements in between windows.
@@ -9643,6 +9653,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
 	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors and those emitted by the {@code boundary} delivered to the window
+	 * {@link Flux} are wrapped in {@link reactor.core.Exceptions.SourceException}.
+	 *
 	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal.
 	 *
@@ -9669,6 +9684,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * to subscribe to a window more than once: they are unicast.
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
+	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
 	 *
 	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal.
@@ -9708,6 +9728,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
 	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
+	 *
 	 * <p><strong>Discard Support:</strong> The overlapping variant DOES NOT discard elements, as they might be part of another still valid window.
 	 * The exact window and dropping window variants bot discard elements they internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal. The dropping window variant also discards elements in between windows.
@@ -9736,6 +9761,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * to subscribe to a window more than once: they are unicast.
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
+	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
 	 *
 	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal.
@@ -9776,6 +9806,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
 	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
+	 *
 	 * <p><strong>Discard Support:</strong> The overlapping variant DOES NOT discard elements, as they might be part of another still valid window.
 	 * The exact window and dropping window variants bot discard elements they internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal. The dropping window variant also discards elements in between windows.
@@ -9811,6 +9846,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
 	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
+	 *
 	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal.
 	 *
@@ -9839,6 +9879,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * to subscribe to a window more than once: they are unicast.
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
+	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
 	 *
 	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal.
@@ -9871,6 +9916,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
 	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
+	 *
 	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal.
 	 *
@@ -9900,6 +9950,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * to subscribe to a window more than once: they are unicast.
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
+	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
 	 *
 	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal.
@@ -9935,6 +9990,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * to subscribe to a window more than once: they are unicast.
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
+	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
 	 *
 	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal. Upon cancellation of the current window,
@@ -9972,6 +10032,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * to subscribe to a window more than once: they are unicast.
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
+	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
 	 *
 	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal. Upon cancellation of the current window,
@@ -10012,6 +10077,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
 	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
+	 *
 	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal. Upon cancellation of the current window,
 	 * it also discards the remaining elements that were bound for it until the main sequence completes
@@ -10046,6 +10116,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
 	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
+	 *
 	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal. Upon cancellation of the current window,
 	 * it also discards the remaining elements that were bound for it until the main sequence completes
@@ -10071,6 +10146,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * to subscribe to a window more than once: they are unicast.
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
+	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
 	 *
 	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal. Upon cancellation of the current window,
@@ -10099,6 +10179,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * to subscribe to a window more than once: they are unicast.
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
+	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
 	 *
 	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal. Upon cancellation of the current window,
@@ -10135,6 +10220,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
 	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
+	 *
 	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal, as well as the triggering element(s) (that doesn't match
 	 * the predicate). Upon cancellation of the current window, it also discards the remaining elements
@@ -10167,6 +10257,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * to subscribe to a window more than once: they are unicast.
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
+	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
 	 *
 	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for backpressure
 	 * upon cancellation or error triggered by a data signal, as well as the triggering element(s) (that doesn't match
@@ -10206,6 +10301,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * to subscribe to a window more than once: they are unicast.
 	 * This is most noticeable when trying to {@link #retry()} or {@link #repeat()} a window,
 	 * as these operators are based on re-subscription.
+	 *
+	 * <p>
+	 * To distinguish errors emitted by the processing of individual windows, source
+	 * sequence errors delivered to the window {@link Flux} are wrapped in
+	 * {@link reactor.core.Exceptions.SourceException}.
 	 *
 	 * <p><strong>Discard Support:</strong> This operator DOES NOT discard elements.
 	 *

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindow.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,8 @@ import reactor.core.Disposable;
 import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
+
+import static reactor.core.Exceptions.wrapSource;
 
 /**
  * Splits the source sequence into possibly overlapping publishers.
@@ -195,7 +197,7 @@ final class FluxWindow<T> extends InternalFluxOperator<T, Flux<T>> {
 			Sinks.Many<T> w = window;
 			if (w != null) {
 				window = null;
-				w.emitError(t, Sinks.EmitFailureHandler.FAIL_FAST);
+				w.emitError(wrapSource(t), Sinks.EmitFailureHandler.FAIL_FAST);
 			}
 
 			actual.onError(t);
@@ -376,7 +378,7 @@ final class FluxWindow<T> extends InternalFluxOperator<T, Flux<T>> {
 			Sinks.Many<T> w = window;
 			if (w != null) {
 				window = null;
-				w.emitError(t, Sinks.EmitFailureHandler.FAIL_FAST);
+				w.emitError(wrapSource(t), Sinks.EmitFailureHandler.FAIL_FAST);
 			}
 
 			actual.onError(t);
@@ -586,7 +588,7 @@ final class FluxWindow<T> extends InternalFluxOperator<T, Flux<T>> {
 			done = true;
 
 			for (Sinks.Many<T> w : this) {
-				w.emitError(t, Sinks.EmitFailureHandler.FAIL_FAST);
+				w.emitError(wrapSource(t), Sinks.EmitFailureHandler.FAIL_FAST);
 			}
 			clear();
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,8 @@ import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
+
+import static reactor.core.Exceptions.wrapSource;
 
 /**
  * Splits the source sequence into continuous, non-overlapping windowEnds
@@ -294,7 +296,8 @@ final class FluxWindowBoundary<T, U> extends InternalFluxOperator<T, Flux<T>> {
 						q.clear();
 						Throwable e = Exceptions.terminate(ERROR, this);
 						if (e != Exceptions.TERMINATED) {
-							w.emitError(e, Sinks.EmitFailureHandler.FAIL_FAST);
+							w.emitError(wrapSource(e),
+									Sinks.EmitFailureHandler.FAIL_FAST);
 
 							a.onError(e);
 						}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,8 @@ import reactor.core.Scannable;
 import reactor.core.publisher.FluxBufferPredicate.Mode;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
+
+import static reactor.core.Exceptions.wrapSource;
 
 /**
  * Cut a sequence into non-overlapping windows where each window boundary is determined by
@@ -347,7 +349,7 @@ final class FluxWindowPredicate<T> extends InternalFluxOperator<T, Flux<T>>
 			windowCount = 0;
 			WindowFlux<T> g = window;
 			if (g != null) {
-				g.onError(e);
+				g.onError(wrapSource(e));
 			}
 			actual.onError(e);
 			window = null;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
@@ -36,6 +36,8 @@ import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
 
+import static reactor.core.Exceptions.wrapSource;
+
 /**
  * @author David Karnok
  */
@@ -207,7 +209,7 @@ final class FluxWindowTimeout<T> extends InternalFluxOperator<T, Flux<T>> {
 
 			final InnerWindow<T> window = this.window;
 			if (window != null) {
-				window.sendError(t);
+				window.sendError(wrapSource(t));
 
 				if (hasUnsentWindow(previousState)) {
 					return;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowBoundaryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,8 +152,9 @@ public class FluxWindowBoundaryTest {
 
 		toList(ts.values()
 		         .get(1)).assertValues(4, 5)
-		                 .assertError(RuntimeException.class)
-		                 .assertErrorMessage("forced failure")
+		                 .assertErrorWith(e -> assertThat(e.getCause())
+				                 .isInstanceOf(RuntimeException.class)
+				                 .hasMessage("forced failure"))
 		                 .assertNotComplete();
 
 		ts.assertError(RuntimeException.class)
@@ -194,8 +195,9 @@ public class FluxWindowBoundaryTest {
 
 		toList(ts.values()
 		         .get(1)).assertValues(4, 5)
-		                 .assertError(RuntimeException.class)
-		                 .assertErrorMessage("forced failure")
+		                 .assertErrorWith(e -> assertThat(e.getCause())
+				                 .isInstanceOf(RuntimeException.class)
+				                 .hasMessage("forced failure"))
 		                 .assertNotComplete();
 
 		ts.assertError(RuntimeException.class)

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -466,8 +466,8 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 		toList(ts.values()
 				 .get(0)).assertValues(1)
 						 .assertNotComplete()
-						 .assertError(RuntimeException.class)
-						 .assertErrorMessage("forced failure");
+						 .assertErrorWith(t -> assertThat(t.getCause())
+								 .isInstanceOf(RuntimeException.class).hasMessage("forced failure"));
 	}
 
 	@Test
@@ -495,8 +495,8 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 		toList(ts.values()
 				 .get(0)).assertValues(1)
 						 .assertNotComplete()
-						 .assertError(RuntimeException.class)
-						 .assertErrorMessage("forced failure");
+						 .assertErrorWith(t -> assertThat(t.getCause())
+								 .isInstanceOf(RuntimeException.class).hasMessage("forced failure"));
 	}
 
 	@Test
@@ -550,8 +550,8 @@ public class FluxWindowTest extends FluxOperatorTest<String, Flux<String>> {
 		toList(ts.values()
 				 .get(0)).assertValues(1)
 						 .assertNotComplete()
-						 .assertError(RuntimeException.class)
-						 .assertErrorMessage("forced failure");
+						 .assertErrorWith(t -> assertThat(t.getCause())
+								 .isInstanceOf(RuntimeException.class).hasMessage("forced failure"));
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/test/publisher/BaseOperatorTest.java
+++ b/reactor-core/src/test/java/reactor/test/publisher/BaseOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-import reactor.ReactorTestExecutionListener;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
@@ -179,9 +178,6 @@ public abstract class BaseOperatorTest<I, PI extends Publisher<? extends I>, O, 
 						}
 						throw Exceptions.propagate(e);
 					});
-//						step.expectErrorMessage(m)
-//						.verifyThenAssertThat()
-//						.hasOperatorErrorWithMessage(m);
 				}
 				catch (Throwable e) {
 					if (e instanceof AssertionError) {


### PR DESCRIPTION
In case of window operators, it might be beneficial to distinguish
between errors coming from the window chain of operators and errors
coming from the source sequence. `Exceptions.SourceException` has
been added and `Throwable`s coming from either the source
sequence, or, in case of window operators that accept `Publisher`s
to drive windowing, their errors also are wrapped.

This is a behavior change and if existing logic relied on the
properties of the delivered `Throwable` it will require reaching for
the `Throwable#getCause()` in case of `Exceptions.SourceException`.

An additional behavior change is in case of `FluxWindowWhen`,
which did not deliver source errors to the windows, despite
seemingly being intended by the implementation.

Resolves #2041