### PR TITLE
Update dependencies junit, mockito, spotless, download...

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
-      - uses: gradle/gradle-build-action@cd3cedc781988c804f626f4cd2dc51d0bdf02a12 # tag=v2
+      - uses: gradle/gradle-build-action@cd579d970f8aec1cf0cae5f62a8e418768970015 # tag=v2
         name: spotless (license header)
         if: always()
         with:
           arguments: spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
-      - uses: gradle/gradle-build-action@cd3cedc781988c804f626f4cd2dc51d0bdf02a12 # tag=v2
+      - uses: gradle/gradle-build-action@cd579d970f8aec1cf0cae5f62a8e418768970015 # tag=v2
         name: api compatibility
         if: always()
         with:
@@ -46,7 +46,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 8
-    - uses: gradle/gradle-build-action@cd3cedc781988c804f626f4cd2dc51d0bdf02a12 # tag=v2
+    - uses: gradle/gradle-build-action@cd579d970f8aec1cf0cae5f62a8e418768970015 # tag=v2
       name: gradle
       with:
         arguments: :reactor-core:test --no-daemon -Pjunit-tags=!slow
@@ -60,7 +60,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 8
-    - uses: gradle/gradle-build-action@cd3cedc781988c804f626f4cd2dc51d0bdf02a12 # tag=v2
+    - uses: gradle/gradle-build-action@cd579d970f8aec1cf0cae5f62a8e418768970015 # tag=v2
       name: gradle
       with:
         arguments: :reactor-core:test --no-daemon -Pjunit-tags=slow
@@ -74,7 +74,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 8
-    - uses: gradle/gradle-build-action@cd3cedc781988c804f626f4cd2dc51d0bdf02a12 # tag=v2
+    - uses: gradle/gradle-build-action@cd579d970f8aec1cf0cae5f62a8e418768970015 # tag=v2
       name: other tests
       with:
         arguments: check -x :reactor-core:test -x spotlessCheck --no-daemon

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       run: ./gradlew qualifyVersionGha
     - name: run checks
       id: checks
-      uses: gradle/gradle-build-action@cd3cedc781988c804f626f4cd2dc51d0bdf02a12 # tag=v2
+      uses: gradle/gradle-build-action@cd579d970f8aec1cf0cae5f62a8e418768970015 # tag=v2
       with:
         arguments: check -Pjunit-tags=!slow -x jcstress
 
@@ -49,7 +49,7 @@ jobs:
           java-version: 8
       - name: run slower tests
         id: slowerTests
-        uses: gradle/gradle-build-action@cd3cedc781988c804f626f4cd2dc51d0bdf02a12 # tag=v2
+        uses: gradle/gradle-build-action@cd579d970f8aec1cf0cae5f62a8e418768970015 # tag=v2
         with:
           arguments: reactor-core:test -Pjunit-tags=slow jcstress
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ baselinePerfExtra = "3.4.8"
 asciidoctor = "3.3.2"
 bytebuddy = "1.12.12"
 jmh = "1.35"
-junit = "5.8.2"
+junit = "5.9.0"
 kotlin = "1.5.32"
 reactiveStreams = "1.0.4"
 
@@ -29,7 +29,7 @@ junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 logback = "ch.qos.logback:logback-classic:1.2.11"
 micrometer = "io.micrometer:micrometer-core:1.3.0"
-mockito = "org.mockito:mockito-core:4.6.1"
+mockito = "org.mockito:mockito-core:4.7.0"
 reactiveStreams = { module = "org.reactivestreams:reactive-streams", version.ref = "reactiveStreams" }
 reactiveStreams-tck = { module = "org.reactivestreams:reactive-streams-tck", version.ref = "reactiveStreams" }
 reactor-perfBaseline-core = { module = "io.projectreactor:reactor-core", version.ref = "baselinePerfCore" }
@@ -43,11 +43,11 @@ artifactory = { id = "com.jfrog.artifactory", version = "4.29.0" }
 asciidoctor-convert = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor" }
 asciidoctor-pdf = { id = "org.asciidoctor.jvm.pdf", version.ref = "asciidoctor" }
 bnd = { id = "biz.aQute.bnd.builder", version = "6.3.1" }
-download = { id = "de.undercouch.download", version = "5.1.0" }
+download = { id = "de.undercouch.download", version = "5.1.2" }
 japicmp = { id = "me.champeau.gradle.japicmp", version = "0.4.0" }
 jcstress = { id = "io.github.reyerizo.gradle.jcstress", version = "0.8.13" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 nohttp = { id = "io.spring.nohttp", version = "0.0.10" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
-spotless = { id = "com.diffplug.spotless", version = "6.8.0" }
+spotless = { id = "com.diffplug.spotless", version = "6.10.0" }
 testsets = { id = "org.unbroken-dome.test-sets", version = "4.0.0" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 plugins {
-	id "com.gradle.enterprise" version "3.10.3"
+	id "com.gradle.enterprise" version "3.11.1"
 }
 
 rootProject.name = 'reactor'


### PR DESCRIPTION
This commit updates the following build dependencies :

 - plugin spotless to v6.10.0, supersedes and closes #3133
 - action gradle-build to v2.2.5, supersedes and closes #3163
 - plugin download to v5.1.2, supersedes and closes #3153
 - plugin gradle-enterprise to v3.11.1, supersedes and closes #3148

It also updates the following test dependencies :

 - JUnit5 BOM to v6.10.0, supersedes and closes #3129
 - Mockito to v4.7.0, supersedes and closes #3154
