### PR TITLE
Improve Loggers.useConsoleLoggers() thread safety

### DIFF
--- a/reactor-core/src/main/java/reactor/util/Loggers.java
+++ b/reactor-core/src/main/java/reactor/util/Loggers.java
@@ -473,13 +473,11 @@ public abstract class Loggers {
 		private final ConsoleLoggerKey identifier;
 		private final PrintStream err;
 		private final PrintStream log;
-		private final boolean verbose;
 
 		ConsoleLogger(ConsoleLoggerKey identifier, PrintStream log, PrintStream err) {
 			this.identifier = identifier;
 			this.log = log;
 			this.err = err;
-			this.verbose = identifier.verbose;
 		}
 
 		ConsoleLogger(String name, PrintStream log, PrintStream err, boolean verbose) {
@@ -511,12 +509,12 @@ public abstract class Loggers {
 
 		@Override
 		public boolean isTraceEnabled() {
-			return verbose;
+			return identifier.verbose;
 		}
 
 		@Override
 		public synchronized void trace(String msg) {
-			if (!verbose) {
+			if (!identifier.verbose) {
 				return;
 			}
 			this.log.format("[TRACE] (%s) %s\n", Thread.currentThread().getName(), msg);
@@ -524,14 +522,14 @@ public abstract class Loggers {
 
 		@Override
 		public synchronized void trace(String format, Object... arguments) {
-			if (!verbose) {
+			if (!identifier.verbose) {
 				return;
 			}
 			this.log.format("[TRACE] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
 		}
 		@Override
 		public synchronized void trace(String msg, Throwable t) {
-			if (!verbose) {
+			if (!identifier.verbose) {
 				return;
 			}
 			this.log.format("[TRACE] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
@@ -540,12 +538,12 @@ public abstract class Loggers {
 
 		@Override
 		public boolean isDebugEnabled() {
-			return verbose;
+			return identifier.verbose;
 		}
 
 		@Override
 		public synchronized void debug(String msg) {
-			if (!verbose) {
+			if (!identifier.verbose) {
 				return;
 			}
 			this.log.format("[DEBUG] (%s) %s\n", Thread.currentThread().getName(), msg);
@@ -553,7 +551,7 @@ public abstract class Loggers {
 
 		@Override
 		public synchronized void debug(String format, Object... arguments) {
-			if (!verbose) {
+			if (!identifier.verbose) {
 				return;
 			}
 			this.log.format("[DEBUG] (%s) %s\n", Thread.currentThread().getName(), format(format, arguments));
@@ -561,7 +559,7 @@ public abstract class Loggers {
 
 		@Override
 		public synchronized void debug(String msg, Throwable t) {
-			if (!verbose) {
+			if (!identifier.verbose) {
 				return;
 			}
 			this.log.format("[DEBUG] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
@@ -633,7 +631,7 @@ public abstract class Loggers {
 
 		@Override
 		public String toString() {
-			return "ConsoleLogger[name="+getName()+", verbose="+verbose+"]";
+			return "ConsoleLogger[name="+getName()+", verbose="+identifier.verbose+"]";
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/util/Loggers.java
+++ b/reactor-core/src/main/java/reactor/util/Loggers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -619,13 +619,13 @@ public abstract class Loggers {
 		}
 	}
 
-	private static final class ConsoleLoggerFactory implements Function<String, Logger> {
+	static final class ConsoleLoggerFactory implements Function<String, Logger> {
 
 		private static final HashMap<String, Logger> consoleLoggers = new HashMap<>();
 
 		final boolean verbose;
 
-		private ConsoleLoggerFactory(boolean verbose) {
+		ConsoleLoggerFactory(boolean verbose) {
 			this.verbose = verbose;
 		}
 

--- a/reactor-core/src/main/java/reactor/util/Loggers.java
+++ b/reactor-core/src/main/java/reactor/util/Loggers.java
@@ -132,6 +132,12 @@ public abstract class Loggers {
 	 * The previously active logger factory is simply replaced without
 	 * any particular clean-up.
 	 *
+	 * <h4>Thread-safety</h4>
+	 *
+	 * Given logger acquisition function <em>must</em> be thread-safe.
+	 * It means that it is user responsibility to ensure that any internal state and cache
+	 * used by the provided function is properly synchronized.
+	 *
 	 * @param loggerFactory the {@link Function} that provides a (possibly cached) {@link Logger}
 	 * given a name.
 	 */

--- a/reactor-core/src/main/java/reactor/util/Loggers.java
+++ b/reactor-core/src/main/java/reactor/util/Loggers.java
@@ -617,6 +617,11 @@ public abstract class Loggers {
 			this.err.format("[ERROR] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
 			t.printStackTrace(this.err);
 		}
+
+		@Override
+		public String toString() {
+			return "ConsoleLogger[name="+getName()+", verbose="+verbose+"]";
+		}
 	}
 
 	static final class ConsoleLoggerFactory implements Function<String, Logger> {

--- a/reactor-core/src/test/java/reactor/util/ConsoleLoggerTest.java
+++ b/reactor-core/src/test/java/reactor/util/ConsoleLoggerTest.java
@@ -321,4 +321,17 @@ public class ConsoleLoggerTest {
 			fail("Cannot acquire a console logger", e);
 		}
 	}
+
+	@Test
+	public void consoleLoggerCacheDoesNotCorruptVerbosity() {
+		final String loggerName = "console.cache.test";
+		final Logger verboseLogger = new Loggers.ConsoleLoggerFactory(true)
+				.apply(loggerName);
+		final Logger notVerboseLogger = new Loggers.ConsoleLoggerFactory(false)
+						.apply(loggerName);
+
+		assertThat(verboseLogger)
+				.as("Logger verbosity should not match")
+				.isNotEqualTo(notVerboseLogger);
+	}
 }


### PR DESCRIPTION
Fix for #3170 

Rework ConsoleLoggerFactory cache to provide a more consistent behavior.

Notes:

 - As a cache strategy, I've chosen `synchronized` keyword + `WeakHashMap` combination. I've made this choice as a tradeoff between code complexity and proper cache eviction. There might be better solutions, maybe you have suggestions ?
     - I've thought about using `StampedLock` instead of `synchronized`, but I decided to leave it aside and provide a simpler code for first review 
 - I've added a regression test for the concurrent error, but I would appreciate advise on how I could improve it because:
    - Failure is inconsistent due to the concurrent nature of the problem. I could add a loop to the test, to force failure behavior, but I'm afraid that it would make it too long to execute.
    - Maybe it is too heavy, as it starts its own thread-pool.
 - Independently from the current issue, I've seen that there's a duplicated function `format` used both on console logger and JDK logger. I wonder if it is really needed on JdkLogger, because this work should be done internally by the logger. If you agree, I can rework that as a bonus in this PR.
