### PR TITLE
Exploring ContextSnapshot restoration in handle and tap

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -156,115 +156,121 @@ final class ContextPropagation {
 			this.context = context;
 			this.registry = registry == null ? ContextRegistry.getInstance() : registry;
 		}
+		
+		ContextSnapshot.Scope restoreThreadLocals() {
+			//FIXME use this.registry to directly restore all ThreadLocals without providing keyPredicate/keys, once that method becomes available
+			ContextSnapshot snapshot = ContextSnapshot.capture(this.context);
+			return snapshot.setThreadLocalValues();
+		}
 
 		@Override
 		public void doFirst() throws Throwable {
-			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doFirst();
 			}
 		}
 
 		@Override
 		public void doFinally(SignalType terminationType) throws Throwable {
-			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doFinally(terminationType);
 			}
 		}
 
 		@Override
 		public void doOnSubscription() throws Throwable {
-			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context)) {
+			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnSubscription();
 			}
 		}
 
 		@Override
 		public void doOnFusion(int negotiatedFusion) throws Throwable {
-			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnFusion(negotiatedFusion);
 			}
 		}
 
 		@Override
 		public void doOnRequest(long requested) throws Throwable {
-			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnRequest(requested);
 			}
 		}
 
 		@Override
 		public void doOnCancel() throws Throwable {
-			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnCancel();
 			}
 		}
 
 		@Override
 		public void doOnNext(T value) throws Throwable {
-			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnNext(value);
 			}
 		}
 
 		@Override
 		public void doOnComplete() throws Throwable {
-			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnComplete();
 			}
 		}
 
 		@Override
 		public void doOnError(Throwable error) throws Throwable {
-			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnError(error);
 			}
 		}
 
 		@Override
 		public void doAfterComplete() throws Throwable {
-			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doAfterComplete();
 			}
 		}
 
 		@Override
 		public void doAfterError(Throwable error) throws Throwable {
-			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doAfterError(error);
 			}
 		}
 
 		@Override
 		public void doOnMalformedOnNext(T value) throws Throwable {
-			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnMalformedOnNext(value);
 			}
 		}
 
 		@Override
 		public void doOnMalformedOnError(Throwable error) throws Throwable {
-			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnMalformedOnError(error);
 			}
 		}
 
 		@Override
 		public void doOnMalformedOnComplete() throws Throwable {
-			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnMalformedOnComplete();
 			}
 		}
 
 		@Override
 		public void handleListenerError(Throwable listenerError) {
-			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.handleListenerError(listenerError);
 			}
 		}
 
 		@Override
 		public Context addToContext(Context originalContext) {
-			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				return original.addToContext(originalContext);
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -16,14 +16,18 @@
 
 package reactor.core.publisher;
 
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
 import io.micrometer.context.ContextRegistry;
 import io.micrometer.context.ContextSnapshot;
 
+import reactor.core.CoreSubscriber;
+import reactor.core.observability.SignalListener;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
+import reactor.util.context.ContextView;
 
 /**
  * Utility private class to detect if the <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a> is on the classpath and to offer
@@ -34,6 +38,8 @@ import reactor.util.context.Context;
 final class ContextPropagation {
 
 	static final boolean isContextPropagationAvailable;
+
+	static final String CAPTURED_CONTEXT_MARKER = "reactor.core.contextSnapshotCaptured";
 
 	static final Predicate<Object> PREDICATE_TRUE = v -> true;
 	static final Function<Context, Context> NO_OP = c -> c;
@@ -100,6 +106,25 @@ final class ContextPropagation {
 		return new ContextCaptureFunction(captureKeyPredicate, null);
 	}
 
+	public static <T, R> BiConsumer<T, SynchronousSink<R>> contextRestoreForHandle(BiConsumer<T, SynchronousSink<R>> handler, CoreSubscriber<? super R> actual) {
+		if (!ContextPropagation.isContextPropagationAvailable() || !actual.currentContext().hasKey(ContextPropagation.CAPTURED_CONTEXT_MARKER)) {
+			return handler;
+		}
+		return (t, s) -> {
+			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(actual.currentContext())) {
+				handler.accept(t, s);
+			}
+		};
+	}
+
+	public static <T> SignalListener<T> contextRestoringSignalListener(final SignalListener<T> original,
+																	   CoreSubscriber<? super T> actual) {
+		if (!ContextPropagation.isContextPropagationAvailable() || !actual.currentContext().hasKey(ContextPropagation.CAPTURED_CONTEXT_MARKER)) {
+			return original;
+		}
+		return new ContextRestoreSignalListener<T>(original, actual.currentContext(), ContextRegistry.getInstance());
+	}
+
 	//the Function indirection allows tests to directly assert code in this class rather than static methods
 	static final class ContextCaptureFunction implements Function<Context, Context> {
 
@@ -113,8 +138,135 @@ final class ContextPropagation {
 
 		@Override
 		public Context apply(Context target) {
-			return ContextSnapshot.captureUsing(this.registry, capturePredicate).updateContext(target);
+			return ContextSnapshot.captureUsing(this.registry, capturePredicate)
+				.updateContext(target)
+				.put(CAPTURED_CONTEXT_MARKER, true);
 		}
 	}
 
+	//the SignalListener implementation can be tested independently with a test-specific ContextRegistry
+	static final class ContextRestoreSignalListener<T> implements SignalListener<T> {
+
+		final SignalListener<T> original;
+		final ContextView context;
+		final ContextRegistry registry;
+
+		public ContextRestoreSignalListener(SignalListener<T> original, ContextView context, @Nullable ContextRegistry registry) {
+			this.original = original;
+			this.context = context;
+			this.registry = registry == null ? ContextRegistry.getInstance() : registry;
+		}
+
+		@Override
+		public void doFirst() throws Throwable {
+			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+				original.doFirst();
+			}
+		}
+
+		@Override
+		public void doFinally(SignalType terminationType) throws Throwable {
+			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+				original.doFinally(terminationType);
+			}
+		}
+
+		@Override
+		public void doOnSubscription() throws Throwable {
+			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context)) {
+				original.doOnSubscription();
+			}
+		}
+
+		@Override
+		public void doOnFusion(int negotiatedFusion) throws Throwable {
+			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+				original.doOnFusion(negotiatedFusion);
+			}
+		}
+
+		@Override
+		public void doOnRequest(long requested) throws Throwable {
+			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+				original.doOnRequest(requested);
+			}
+		}
+
+		@Override
+		public void doOnCancel() throws Throwable {
+			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+				original.doOnCancel();
+			}
+		}
+
+		@Override
+		public void doOnNext(T value) throws Throwable {
+			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+				original.doOnNext(value);
+			}
+		}
+
+		@Override
+		public void doOnComplete() throws Throwable {
+			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+				original.doOnComplete();
+			}
+		}
+
+		@Override
+		public void doOnError(Throwable error) throws Throwable {
+			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+				original.doOnError(error);
+			}
+		}
+
+		@Override
+		public void doAfterComplete() throws Throwable {
+			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+				original.doAfterComplete();
+			}
+		}
+
+		@Override
+		public void doAfterError(Throwable error) throws Throwable {
+			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+				original.doAfterError(error);
+			}
+		}
+
+		@Override
+		public void doOnMalformedOnNext(T value) throws Throwable {
+			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+				original.doOnMalformedOnNext(value);
+			}
+		}
+
+		@Override
+		public void doOnMalformedOnError(Throwable error) throws Throwable {
+			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+				original.doOnMalformedOnError(error);
+			}
+		}
+
+		@Override
+		public void doOnMalformedOnComplete() throws Throwable {
+			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+				original.doOnMalformedOnComplete();
+			}
+		}
+
+		@Override
+		public void handleListenerError(Throwable listenerError) {
+			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+				original.handleListenerError(listenerError);
+			}
+		}
+
+		@Override
+		public Context addToContext(Context originalContext) {
+			try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocalsFrom(this.context, this.registry)) {
+				return original.addToContext(originalContext);
+			}
+		}
+	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
@@ -19,6 +19,7 @@ package reactor.core.publisher;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 
+import io.micrometer.context.ContextSnapshot;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
@@ -44,12 +45,13 @@ final class FluxHandle<T, R> extends InternalFluxOperator<T, R> {
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
+		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagation.contextRestoreForHandle(this.handler, actual);
 		if (actual instanceof Fuseable.ConditionalSubscriber) {
 			@SuppressWarnings("unchecked")
 			Fuseable.ConditionalSubscriber<? super R> cs = (Fuseable.ConditionalSubscriber<? super R>) actual;
-			return new HandleConditionalSubscriber<>(cs, handler);
+			return new HandleConditionalSubscriber<>(cs, handler2);
 		}
-		return new HandleSubscriber<>(actual, handler);
+		return new HandleSubscriber<>(actual, handler2);
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
@@ -19,6 +19,7 @@ package reactor.core.publisher;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 
+import io.micrometer.context.ContextSnapshot;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
@@ -57,12 +58,13 @@ final class FluxHandleFuseable<T, R> extends InternalFluxOperator<T, R> implemen
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
+		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagation.contextRestoreForHandle(this.handler, actual);
 		if (actual instanceof ConditionalSubscriber) {
 			@SuppressWarnings("unchecked")
 			ConditionalSubscriber<? super R> cs = (ConditionalSubscriber<? super R>) actual;
-			return new HandleFuseableConditionalSubscriber<>(cs, handler);
+			return new HandleFuseableConditionalSubscriber<>(cs, handler2);
 		}
-		return new HandleFuseableSubscriber<>(actual, handler);
+		return new HandleFuseableSubscriber<>(actual, handler2);
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTap.java
@@ -16,6 +16,7 @@
 
 package reactor.core.publisher;
 
+import io.micrometer.context.ContextSnapshot;
 import org.reactivestreams.Subscription;
 
 import reactor.core.CoreSubscriber;
@@ -56,6 +57,9 @@ final class FluxTap<T, STATE> extends InternalFluxOperator<T, T> {
 			Operators.error(actual, generatorError);
 			return null;
 		}
+		// Attempt to wrap the SignalListener with one that restores ThreadLocals from Context on each listener methods
+		// (only if ContextPropagation.isContextPropagationAvailable() is true)
+		signalListener = ContextPropagation.contextRestoringSignalListener(signalListener, actual);
 
 		try {
 			signalListener.doFirst();

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTapFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTapFuseable.java
@@ -56,6 +56,9 @@ final class FluxTapFuseable<T, STATE> extends InternalFluxOperator<T, T> impleme
 			Operators.error(actual, generatorError);
 			return null;
 		}
+		// Attempt to wrap the SignalListener with one that restores ThreadLocals from Context on each listener methods
+		// (only if ContextPropagation.isContextPropagationAvailable() is true)
+		signalListener = ContextPropagation.contextRestoringSignalListener(signalListener, actual);
 
 		try {
 			signalListener.doFirst();

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoHandle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoHandle.java
@@ -41,7 +41,8 @@ final class MonoHandle<T, R> extends InternalMonoOperator<T, R> {
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
-		return new FluxHandle.HandleSubscriber<>(actual, handler);
+		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagation.contextRestoreForHandle(this.handler, actual);
+		return new FluxHandle.HandleSubscriber<>(actual, handler2);
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoHandleFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoHandleFuseable.java
@@ -43,7 +43,8 @@ final class MonoHandleFuseable<T, R> extends InternalMonoOperator<T, R>
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
-		return new FluxHandleFuseable.HandleFuseableSubscriber<>(actual, handler);
+		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagation.contextRestoreForHandle(this.handler, actual);
+		return new FluxHandleFuseable.HandleFuseableSubscriber<>(actual, handler2);
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTap.java
@@ -53,6 +53,9 @@ final class MonoTap<T, STATE> extends InternalMonoOperator<T, T> {
 			Operators.error(actual, generatorError);
 			return null;
 		}
+		// Attempt to wrap the SignalListener with one that restores ThreadLocals from Context on each listener methods
+		// (only if ContextPropagation.isContextPropagationAvailable() is true)
+		signalListener = ContextPropagation.contextRestoringSignalListener(signalListener, actual);
 
 		try {
 			signalListener.doFirst();

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTapFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTapFuseable.java
@@ -52,6 +52,9 @@ final class MonoTapFuseable<T, STATE> extends InternalMonoOperator<T, T> impleme
 			Operators.error(actual, generatorError);
 			return null;
 		}
+		// Attempt to wrap the SignalListener with one that restores ThreadLocals from Context on each listener methods
+		// (only if ContextPropagation.isContextPropagationAvailable() is true)
+		signalListener = ContextPropagation.contextRestoringSignalListener(signalListener, actual);
 
 		try {
 			signalListener.doFirst();

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
@@ -16,17 +16,32 @@
 
 package reactor.core.publisher;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import io.micrometer.context.ContextRegistry;
+import net.bytebuddy.implementation.bytecode.Throw;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mockito;
+import org.reactivestreams.Publisher;
 
+import reactor.core.Fuseable;
+import reactor.core.Scannable;
+import reactor.core.observability.SignalListener;
+import reactor.core.observability.SignalListenerFactory;
+import reactor.test.ParameterizedTestWithName;
+import reactor.test.subscriber.TestSubscriber;
+import reactor.test.subscriber.TestSubscriberBuilder;
 import reactor.util.context.Context;
+import reactor.util.context.ContextView;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -124,7 +139,8 @@ class ContextPropagationTest {
 			assertThat(asMap)
 				.containsEntry(KEY1, "ref1_init")
 				.containsEntry(KEY2, "ref2_init")
-				.hasSize(2);
+				.containsEntry(ContextPropagation.CAPTURED_CONTEXT_MARKER, true)
+				.hasSize(3);
 		}
 
 		@Test
@@ -138,7 +154,8 @@ class ContextPropagationTest {
 
 			assertThat(asMap)
 				.containsEntry(KEY2, "ref2_init")
-				.hasSize(1);
+				.containsEntry(ContextPropagation.CAPTURED_CONTEXT_MARKER, true)
+				.hasSize(2);
 		}
 
 		@Test
@@ -147,6 +164,272 @@ class ContextPropagationTest {
 
 			assertThat(test.registry).as("default registry").isSameAs(ContextRegistry.getInstance());
 		}
+	}
+
+	static private enum Cases {
+		NORMAL_NO_MARKER(false, false, false),
+		NORMAL_WITH_MARKER(false, false, true),
+		CONDITIONAL_NO_MARKER(false, true, false),
+		CONDITIONAL_WITH_MARKER(false, true, true),
+		FUSED_NO_MARKER(true, false, false),
+		FUSED_WITH_MARKER(true, false, true),
+		FUSED_CONDITIONAL_NO_MARKER(true, true, false),
+		FUSED_CONDITIONAL_WITH_MARKER(true, true, true);
+
+		final boolean fusion;
+		final boolean conditional;
+		final boolean marker;
+
+		Cases(boolean fusion, boolean conditional, boolean marker) {
+			this.fusion = fusion;
+			this.conditional = conditional;
+			this.marker = marker;
+		}
+	}
+
+	@Nested
+	class ContextRestoreForTap {
+
+		@EnumSource(Cases.class)
+		@ParameterizedTestWithName
+		void properWrappingForFluxTap(Cases characteristics) {
+			SignalListener<String> originalListener = Mockito.mock(SignalListener.class);
+			SignalListenerFactory<String, Void> originalFactory = new SignalListenerFactory<String, Void>() {
+				@Override
+				public Void initializePublisherState(Publisher<? extends String> source) {
+					return null;
+				}
+
+				@Override
+				public SignalListener<String> createListener(Publisher<? extends String> source,
+															 ContextView listenerContext, Void publisherContext) {
+					return originalListener;
+				}
+			};
+
+			Publisher<String> tap;
+			TestSubscriberBuilder builder = TestSubscriber.builder();
+			if (characteristics.fusion) {
+				tap = new FluxTapFuseable<>(Flux.empty(), originalFactory);
+				builder = builder.requireFusion(Fuseable.ANY);
+			}
+			else {
+				tap = new FluxTap<>(Flux.empty(), originalFactory);
+				builder = builder.requireNotFuseable();
+			}
+
+			if (characteristics.marker) {
+				builder = builder.contextPut(ContextPropagation.CAPTURED_CONTEXT_MARKER, true);
+			}
+
+			TestSubscriber<String> testSubscriber;
+			if (characteristics.conditional) {
+				testSubscriber = builder.buildConditional(v -> true);
+			}
+			else {
+				testSubscriber = builder.build();
+			}
+
+			tap.subscribe(testSubscriber);
+			Scannable parent = testSubscriber.parents().findFirst().get();
+
+			if (!characteristics.fusion) {
+				assertThat(parent).isInstanceOfSatisfying(FluxTap.TapSubscriber.class,
+					tapSubscriber -> {
+						if (characteristics.marker) {
+							assertThat(tapSubscriber.listener).as("listener wrapped")
+								.isNotSameAs(originalListener)
+								.isInstanceOf(ContextPropagation.ContextRestoreSignalListener.class);
+						}
+						else {
+							assertThat(tapSubscriber.listener)
+								.as("listener not wrapped")
+								.isSameAs(originalListener);
+						}
+					});
+			}
+			else {
+				assertThat(parent).isInstanceOfSatisfying(FluxTapFuseable.TapFuseableSubscriber.class,
+					tapSubscriber -> {
+						if (characteristics.marker) {
+							assertThat(tapSubscriber.listener)
+								.as("listener wrapped")
+								.isNotSameAs(originalListener)
+								.isInstanceOf(ContextPropagation.ContextRestoreSignalListener.class);
+						}
+						else {
+							assertThat(tapSubscriber.listener)
+								.as("listener not wrapped")
+								.isSameAs(originalListener);
+						}
+					});
+			}
+		}
+
+		@EnumSource(Cases.class)
+		@ParameterizedTestWithName
+		void properWrappingForMonoTap(Cases characteristics) {
+			SignalListener<String> originalListener = Mockito.mock(SignalListener.class);
+			SignalListenerFactory<String, Void> originalFactory = new SignalListenerFactory<String, Void>() {
+				@Override
+				public Void initializePublisherState(Publisher<? extends String> source) {
+					return null;
+				}
+
+				@Override
+				public SignalListener<String> createListener(Publisher<? extends String> source,
+															 ContextView listenerContext, Void publisherContext) {
+					return originalListener;
+				}
+			};
+
+			Mono<String> tap;
+			TestSubscriberBuilder builder = TestSubscriber.builder();
+			if (characteristics.fusion) {
+				tap = new MonoTapFuseable<>(Mono.empty(), originalFactory);
+				builder = builder.requireFusion(Fuseable.ANY);
+			}
+			else {
+				tap = new MonoTap<>(Mono.empty(), originalFactory);
+				builder = builder.requireNotFuseable();
+			}
+
+			if (characteristics.marker) {
+				builder = builder.contextPut(ContextPropagation.CAPTURED_CONTEXT_MARKER, true);
+			}
+
+			TestSubscriber<String> testSubscriber;
+			if (characteristics.conditional) {
+				testSubscriber = builder.buildConditional(v -> true);
+			}
+			else {
+				testSubscriber = builder.build();
+			}
+
+			tap.subscribe(testSubscriber);
+			Scannable parent = testSubscriber.parents().findFirst().get();
+
+			if (!characteristics.fusion) {
+				assertThat(parent).isInstanceOfSatisfying(FluxTap.TapSubscriber.class,
+					tapSubscriber -> {
+						if (characteristics.marker) {
+							assertThat(tapSubscriber.listener)
+								.as("listener wrapped")
+								.isNotSameAs(originalListener)
+								.isInstanceOf(ContextPropagation.ContextRestoreSignalListener.class);
+
+						}
+						else {
+							assertThat(tapSubscriber.listener).as("listener not wrapped").isSameAs(originalListener);
+						}
+					});
+			}
+			else {
+				assertThat(parent).isInstanceOfSatisfying(FluxTapFuseable.TapFuseableSubscriber.class,
+					tapSubscriber -> {
+						if (characteristics.marker) {
+							assertThat(tapSubscriber.listener)
+								.as("listener wrapped")
+								.isNotSameAs(originalListener)
+								.isInstanceOf(ContextPropagation.ContextRestoreSignalListener.class);
+						}
+						else {
+							assertThat(tapSubscriber.listener).as("listener not wrapped").isSameAs(originalListener);
+						}
+					});
+			}
+		}
+
+		@Test
+		void threadLocalRestoredInSignalListener() throws InterruptedException {
+			REF1.set(null);
+			Context context = Context.of(KEY1, "expected");
+
+			ContextPropagation.ContextRestoreSignalListener<Object> listener = new ContextPropagation.ContextRestoreSignalListener<>(Mockito.mock(SignalListener.class), context, registry);
+			List<String> list = new ArrayList<>();
+
+			Thread t = new Thread(() -> {
+				try {
+					listener.doFirst();
+					list.add("doFirst: " + REF1.getAndSet(null));
+
+					listener.doOnSubscription();
+					list.add("doOnSubscription: " + REF1.getAndSet(null));
+
+					listener.doOnFusion(1);
+					list.add("doOnFusion: " + REF1.getAndSet(null));
+
+					listener.doOnFusion(1);
+					list.add("doOnFusion: " + REF1.getAndSet(null));
+
+					listener.doOnRequest(1L);
+					list.add("doOnRequest: " + REF1.getAndSet(null));
+
+					listener.doOnCancel();
+					list.add("doOnCancel: " + REF1.getAndSet(null));
+
+					listener.doOnNext(1);
+					list.add("doOnNext: " + REF1.getAndSet(null));
+
+					listener.doOnComplete();
+					list.add("doOnComplete: " + REF1.getAndSet(null));
+
+					listener.doOnError(new IllegalStateException("boom"));
+					list.add("doOnError: " + REF1.getAndSet(null));
+
+					listener.doAfterComplete();
+					list.add("doAfterComplete: " + REF1.getAndSet(null));
+
+					listener.doAfterError(new IllegalStateException("boom"));
+					list.add("doAfterError: " + REF1.getAndSet(null));
+
+					listener.doFinally(SignalType.ON_COMPLETE);
+					list.add("doFinally: " + REF1.getAndSet(null));
+
+					listener.doOnMalformedOnNext(1);
+					list.add("doOnMalformedOnNext: " + REF1.getAndSet(null));
+
+					listener.doOnMalformedOnComplete();
+					list.add("doOnMalformedOnComplete: " + REF1.getAndSet(null));
+
+					listener.doOnMalformedOnError(new IllegalStateException("boom"));
+					list.add("doOnMalformedOnComplete: " + REF1.getAndSet(null));
+
+					listener.addToContext(Context.empty());
+					list.add("addToContext: " + REF1.getAndSet(null));
+
+					listener.handleListenerError(new IllegalStateException("boom"));
+					list.add("handleListenerError: " + REF1.getAndSet(null));
+				}
+				catch (Throwable error) {
+					error.printStackTrace();
+				}
+			});
+			t.start();
+			t.join();
+
+			assertThat(list).as("extracted TLs")
+				.containsExactly(
+					"doFirst: expected",
+					"doOnSubscription: expected",
+					"doOnFusion: expected",
+					"doOnFusion: expected",
+					"doOnRequest: expected",
+					"doOnCancel: expected",
+					"doOnNext: expected",
+					"doOnComplete: expected",
+					"doOnError: expected",
+					"doAfterComplete: expected",
+					"doAfterError: expected",
+					"doFinally: expected",
+					"doOnMalformedOnNext: expected",
+					"doOnMalformedOnComplete: expected",
+					"doOnMalformedOnComplete: expected",
+					"addToContext: expected",
+					"handleListenerError: expected"
+				);
+		}
+
 	}
 
 }


### PR DESCRIPTION
- Restore TLs in handle/tap in case of contextCapture
- Polish ContextPropagationTest, document FIXME for global registry usage

This PR is a draft work in progress.
It is at least blocked until:
 - #3175 is merged
 - reactor-core can switch to latest Micrometer snapshots (in order to restore all known TLs from a context using a specific ContextRegistry)