### PR TITLE
Dispose picked worker when BoundedElasticScheduler rejects task

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
@@ -253,7 +253,7 @@ final class BoundedElasticScheduler implements Scheduler,
 		try {
 			return Schedulers.directSchedule(picked.executor, task, picked, 0L, TimeUnit.MILLISECONDS);
 		} catch (RejectedExecutionException ex) {
-			//if task rejected need releases the BoundedState for decreases its usage by one
+			// ensure to free the BoundedState so it can be reused
 			picked.dispose();
 			throw ex;
 		}
@@ -266,7 +266,7 @@ final class BoundedElasticScheduler implements Scheduler,
 		try {
 			return Schedulers.directSchedule(picked.executor, task, picked, delay, unit);
 		} catch (RejectedExecutionException ex) {
-			//if task rejected need releases the BoundedState for decreases its usage by one
+			// ensure to free the BoundedState so it can be reused
 			picked.dispose();
 			throw ex;
 		}
@@ -288,7 +288,7 @@ final class BoundedElasticScheduler implements Scheduler,
 			// (ie decreases its usage by one)
 			return Disposables.composite(scheduledTask, picked);
 		} catch (RejectedExecutionException ex) {
-			//if task rejected need releases the BoundedState for decreases its usage by one
+			// ensure to free the BoundedState so it can be reused
 			picked.dispose();
 			throw ex;
 		}

--- a/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
@@ -250,14 +250,26 @@ final class BoundedElasticScheduler implements Scheduler,
 	public Disposable schedule(Runnable task) {
 		//tasks running once will call dispose on the BoundedState, decreasing its usage by one
 		BoundedState picked = state.currentResource.pick();
-		return Schedulers.directSchedule(picked.executor, task, picked, 0L, TimeUnit.MILLISECONDS);
+		try {
+			return Schedulers.directSchedule(picked.executor, task, picked, 0L, TimeUnit.MILLISECONDS);
+		} catch (RejectedExecutionException ex) {
+			//if task rejected need releases the BoundedState for decreases its usage by one
+			picked.dispose();
+			throw ex;
+		}
 	}
 
 	@Override
 	public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
 		//tasks running once will call dispose on the BoundedState, decreasing its usage by one
 		final BoundedState picked = state.currentResource.pick();
-		return Schedulers.directSchedule(picked.executor, task, picked, delay, unit);
+		try {
+			return Schedulers.directSchedule(picked.executor, task, picked, delay, unit);
+		} catch (RejectedExecutionException ex) {
+			//if task rejected need releases the BoundedState for decreases its usage by one
+			picked.dispose();
+			throw ex;
+		}
 	}
 
 	@Override
@@ -266,14 +278,20 @@ final class BoundedElasticScheduler implements Scheduler,
 			long period,
 			TimeUnit unit) {
 		final BoundedState picked = state.currentResource.pick();
-		Disposable scheduledTask = Schedulers.directSchedulePeriodically(picked.executor,
-				task,
-				initialDelay,
-				period,
-				unit);
-		//a composite with picked ensures the cancellation of the task releases the BoundedState
-		// (ie decreases its usage by one)
-		return Disposables.composite(scheduledTask, picked);
+		try {
+			Disposable scheduledTask = Schedulers.directSchedulePeriodically(picked.executor,
+					task,
+					initialDelay,
+					period,
+					unit);
+			//a composite with picked ensures the cancellation of the task releases the BoundedState
+			// (ie decreases its usage by one)
+			return Disposables.composite(scheduledTask, picked);
+		} catch (RejectedExecutionException ex) {
+			//if task rejected need releases the BoundedState for decreases its usage by one
+			picked.dispose();
+			throw ex;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
If BoundedState picked and rejected, BoundedState not decrement markCount. After RejectedExecutionException BoundedState never move to idle.

Fixes #3182.

Signed-off-by: Stanislav Kotik <STAlkerS-05@yandex.ru>
Co-authored-by: Stanislav Kotik <STAlkerS-05@yandex.ru>