### PR TITLE
Replay terminal signals to late subscribers in Flux.replay(int) and Flux.cache(int)

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -7569,6 +7569,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 *     expiration.
 	 *
 	 * <p>
+	 *     Re-connects are not supported.
+	 * <p>
 	 * <img class="marble" src="doc-files/marbles/replayWithHistory.svg" alt="">
 	 *
 	 * @param history number of events retained in history excluding complete and

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -7663,7 +7663,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 		Objects.requireNonNull(timer, "timer");
 		if (history == 0) {
 			return onAssembly(new FluxPublish<>(this, Queues.SMALL_BUFFER_SIZE,
-					Queues.get(Queues.SMALL_BUFFER_SIZE), false));
+					Queues.get(Queues.SMALL_BUFFER_SIZE), true));
 		}
 		return onAssembly(new FluxReplay<>(this, history, ttl.toNanos(), timer));
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -7988,9 +7988,10 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * to subscribe once, late subscribers might therefore miss items.
 	 */
 	public final Flux<T> share() {
-		return onAssembly(new FluxRefCount<>(
-				new FluxPublish<>(this, Queues.SMALL_BUFFER_SIZE, Queues.small(), true)
-				, 1)
+		return onAssembly(
+				new FluxRefCount<>(new FluxPublish<>(
+						this, Queues.SMALL_BUFFER_SIZE, Queues.small(), true
+				), 1)
 		);
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -7219,7 +7219,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final ConnectableFlux<T> publish(int prefetch) {
 		return onAssembly(new FluxPublish<>(this, prefetch, Queues
-				.get(prefetch)));
+				.get(prefetch), true));
 	}
 
 	/**
@@ -7565,7 +7565,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * Will retain up to the given history size onNext signals. Completion and Error will also be
 	 * replayed.
 	 * <p>
-	 *     Note that {@code cache(0)} will only cache the terminal signal without
+	 *     Note that {@code replay(0)} will only cache the terminal signal without
 	 *     expiration.
 	 *
 	 * <p>
@@ -7579,8 +7579,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final ConnectableFlux<T> replay(int history) {
 		if (history == 0) {
-			//TODO Flux.replay with history == 0 doesn't make much sense. This was replaced by Flux.publish, but such calls will be rejected in a future version
-			return onAssembly(new FluxPublish<>(this, Queues.SMALL_BUFFER_SIZE, Queues.get(Queues.SMALL_BUFFER_SIZE)));
+			return onAssembly(new FluxPublish<>(this, Queues.SMALL_BUFFER_SIZE,
+					Queues.get(Queues.SMALL_BUFFER_SIZE), false));
 		}
 		return onAssembly(new FluxReplay<>(this, history, 0L, null));
 	}
@@ -7662,8 +7662,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	public final ConnectableFlux<T> replay(int history, Duration ttl, Scheduler timer) {
 		Objects.requireNonNull(timer, "timer");
 		if (history == 0) {
-			//TODO Flux.replay with history == 0 doesn't make much sense. This was replaced by Flux.publish, but such calls will be rejected in a future version
-			return onAssembly(new FluxPublish<>(this, Queues.SMALL_BUFFER_SIZE, Queues.get(Queues.SMALL_BUFFER_SIZE)));
+			return onAssembly(new FluxPublish<>(this, Queues.SMALL_BUFFER_SIZE,
+					Queues.get(Queues.SMALL_BUFFER_SIZE), false));
 		}
 		return onAssembly(new FluxReplay<>(this, history, ttl.toNanos(), timer));
 	}
@@ -7987,7 +7987,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final Flux<T> share() {
 		return onAssembly(new FluxRefCount<>(
-				new FluxPublish<>(this, Queues.SMALL_BUFFER_SIZE, Queues.small()), 1)
+				new FluxPublish<>(this, Queues.SMALL_BUFFER_SIZE, Queues.small(), true)
+				, 1)
 		);
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -139,9 +139,6 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 				if (c.error != null) {
 					inner.actual.onError(c.error);
 				} else {
-					if (c.queue.isEmpty()) {
-						c.drain();
-					}
 					inner.actual.onComplete();
 				}
 				break;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -127,11 +127,11 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 				c = u;
 			}
 
-			inner.parent = c;
-
 			if (c.add(inner)) {
 				if (inner.isCancelled()) {
 					c.remove(inner);
+				} else {
+					inner.parent = c;
 				}
 				c.drain();
 				break;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,11 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 
 	final Supplier<? extends Queue<T>> queueSupplier;
 
+	/**
+	 * Whether to prepare for a reconnect after the source terminates.
+	 */
+	final boolean resetUponSourceTermination;
+
 	volatile PublishSubscriber<T> connection;
 	@SuppressWarnings("rawtypes")
 	static final AtomicReferenceFieldUpdater<FluxPublish, PublishSubscriber> CONNECTION =
@@ -66,13 +71,15 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 
 	FluxPublish(Flux<? extends T> source,
 			int prefetch,
-			Supplier<? extends Queue<T>> queueSupplier) {
+			Supplier<? extends Queue<T>> queueSupplier,
+			boolean resetUponSourceTermination) {
 		if (prefetch <= 0) {
 			throw new IllegalArgumentException("bufferSize > 0 required but it was " + prefetch);
 		}
 		this.source = Objects.requireNonNull(source, "source");
 		this.prefetch = prefetch;
 		this.queueSupplier = Objects.requireNonNull(queueSupplier, "queueSupplier");
+		this.resetUponSourceTermination = resetUponSourceTermination;
 	}
 
 	@Override
@@ -111,7 +118,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 			}
 
 			PublishSubscriber<T> c = connection;
-			if (c == null) {
+			if (c == null || (this.resetUponSourceTermination && c.isTerminated())) {
 				PublishSubscriber<T> u = new PublishSubscriber<>(prefetch, this);
 				if (!CONNECTION.compareAndSet(this, c, u)) {
 					continue;
@@ -120,15 +127,15 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 				c = u;
 			}
 
-			if (inner.isCancelled()) {
-				c.remove(inner);
-			}
-			else {
-				inner.parent = c;
-			}
+			inner.parent = c;
+
 			if (c.add(inner)) {
+				if (inner.isCancelled()) {
+					c.remove(inner);
+				}
 				c.drain();
-			} else {
+				break;
+			} else if (!this.resetUponSourceTermination) {
 				if (c.error != null) {
 					inner.actual.onError(c.error);
 				} else {
@@ -137,8 +144,8 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 					}
 					inner.actual.onComplete();
 				}
+				break;
 			}
-			break;
 		}
 	}
 
@@ -524,7 +531,10 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 			if (d) {
 				Throwable e = error;
 				if (e != null && e != Exceptions.TERMINATED) {
-					e = Exceptions.terminate(ERROR, this);
+					if (parent.resetUponSourceTermination) {
+						CONNECTION.compareAndSet(parent, this, null);
+						e = Exceptions.terminate(ERROR, this);
+					}
 					queue.clear();
 					for (PubSubInner<T> inner : terminate()) {
 						inner.actual.onError(e);
@@ -532,6 +542,9 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 					return true;
 				}
 				else if (empty) {
+					if (parent.resetUponSourceTermination) {
+						CONNECTION.compareAndSet(parent, this, null);
+					}
 					for (PubSubInner<T> inner : terminate()) {
 						inner.actual.onComplete();
 					}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -1161,6 +1161,20 @@ final class FluxReplay<T> extends ConnectableFlux<T>
 		}
 	}
 
+	public static void main(String[] args) throws Exception {
+		ConnectableFlux<Integer> f = Flux.just(1, 2, 3).replay(0);
+
+		f.subscribe(System.out::println, System.out::println, () -> System.out.println(
+				"complete"));
+		f.connect();
+
+		f.subscribe(System.out::println, System.out::println, () -> System.out.println(
+				"complete"));
+
+		Thread.sleep(100);
+//		f.connect();
+	}
+
 	@Override
 	public final CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual)
 			throws Throwable {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -1161,20 +1161,6 @@ final class FluxReplay<T> extends ConnectableFlux<T>
 		}
 	}
 
-	public static void main(String[] args) throws Exception {
-		ConnectableFlux<Integer> f = Flux.just(1, 2, 3).replay(0);
-
-		f.subscribe(System.out::println, System.out::println, () -> System.out.println(
-				"complete"));
-		f.connect();
-
-		f.subscribe(System.out::println, System.out::println, () -> System.out.println(
-				"complete"));
-
-		Thread.sleep(100);
-//		f.connect();
-	}
-
 	@Override
 	public final CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual)
 			throws Throwable {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCacheTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCacheTest.java
@@ -103,7 +103,7 @@ public class FluxCacheTest {
 	}
 
 	@Test
-	public void cacheFluxTTL2() {
+	public void cacheFluxTTLReconnectsAfterTTL() {
 		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 
 		AtomicInteger i = new AtomicInteger(0);
@@ -126,7 +126,7 @@ public class FluxCacheTest {
 	}
 
 	@Test
-	void cacheZeroFlux() {
+	void cacheZeroFluxCachesCompletion() {
 		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 
 		Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
@@ -146,7 +146,7 @@ public class FluxCacheTest {
 	}
 
 	@Test
-	public void cacheZeroFluxTTL() {
+	public void cacheZeroFluxTTLReconnectsAfterSourceCompletion() {
 		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 
 		Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
@@ -163,7 +163,7 @@ public class FluxCacheTest {
 		            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 3)
 		            .verifyComplete();
 
-		StepVerifier.create(source).verifyComplete();
+		StepVerifier.create(source).expectTimeout(Duration.ofMillis(500)).verify();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxCacheTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,6 +126,47 @@ public class FluxCacheTest {
 	}
 
 	@Test
+	void cacheZeroFlux() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+
+		Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
+		                                         .delayElements(Duration.ofMillis(1000)
+				                                         , vts)
+		                                         .cache(0)
+		                                         .elapsed(vts);
+
+		StepVerifier.withVirtualTime(() -> source, () -> vts, Long.MAX_VALUE)
+		            .thenAwait(Duration.ofSeconds(3))
+		            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 1)
+		            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 2)
+		            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 3)
+		            .verifyComplete();
+
+		StepVerifier.create(source).verifyComplete();
+	}
+
+	@Test
+	public void cacheZeroFluxTTL() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+
+		Flux<Tuple2<Long, Integer>> source = Flux.just(1, 2, 3)
+		                                         .delayElements(
+														 Duration.ofMillis(1000), vts
+		                                         )
+		                                         .cache(0, Duration.ofMillis(2000), vts)
+		                                         .elapsed(vts);
+
+		StepVerifier.withVirtualTime(() -> source, () -> vts, Long.MAX_VALUE)
+		            .thenAwait(Duration.ofSeconds(3))
+		            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 1)
+		            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 2)
+		            .expectNextMatches(t -> t.getT1() == 1000 && t.getT2() == 3)
+		            .verifyComplete();
+
+		StepVerifier.create(source).verifyComplete();
+	}
+
+	@Test
 	public void cacheContextHistory() {
 		AtomicInteger contextFillCount = new AtomicInteger();
 		Flux<String> cached = Flux.just(1, 2)
@@ -154,6 +195,38 @@ public class FluxCacheTest {
 		String cacheHit3 = cached.blockLast();
 		assertThat(cacheHit3).as("cacheHit3").isEqualTo("GOOD1");
 		assertThat(contextFillCount).as("cacheHit3").hasValue(4);
+	}
+
+	@Test
+	public void cacheZeroContext() {
+		AtomicInteger contextFillCount = new AtomicInteger();
+		Flux<String> cached = Flux.just(1, 2)
+		                          .flatMap(i -> Mono.deferContextual(Mono::just)
+		                                            .map(ctx -> ctx.getOrDefault("a", "BAD"))
+		                          )
+		                          .cache(0)
+		                          .contextWrite(ctx -> ctx.put("a", "GOOD" + contextFillCount.incrementAndGet()));
+
+		// at first pass, the Context is propagated to subscriber, but not cached
+		String cacheMiss = cached.blockLast();
+		assertThat(cacheMiss).as("cacheMiss").isEqualTo("GOOD1");
+		assertThat(contextFillCount).as("cacheMiss").hasValue(1);
+
+		// at second subscribe, the Context fill attempt is still done, but ultimately
+		// ignored since source terminated
+		String zeroCache = cached.blockLast();
+		assertThat(zeroCache).as("zeroCache").isNull(); //value from the cache
+		assertThat(contextFillCount).as("zeroCache").hasValue(2); //function was still invoked
+
+		//at third subscribe, function is called for the 3rd time, but the context is still cached
+		String zeroCache2 = cached.blockLast();
+		assertThat(zeroCache2).as("zeroCache2").isNull();
+		assertThat(contextFillCount).as("zeroCache2").hasValue(3);
+
+		//at fourth subscribe, function is called for the 4th time, but the context is still cached
+		String zeroCache3 = cached.blockLast();
+		assertThat(zeroCache3).as("zeroCache3").isNull();
+		assertThat(contextFillCount).as("zeroCache3").hasValue(4);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPublishTest.java
@@ -683,8 +683,8 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 	@Test
     public void scanMain() {
         Flux<Integer> parent = Flux.just(1).map(i -> i);
-        FluxPublish<Integer> test = new FluxPublish<>(parent, 123, Queues.unbounded(),
-		        true);
+        FluxPublish<Integer> test =
+		        new FluxPublish<>(parent, 123, Queues.unbounded(), true);
 
         assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
         assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(123);
@@ -693,8 +693,8 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 
 	@Test
     public void scanSubscriber() {
-        FluxPublish<Integer> main = new FluxPublish<>(Flux.just(1), 123,
-		        Queues.unbounded(), true);
+        FluxPublish<Integer> main =
+		        new FluxPublish<>(Flux.just(1), 123, Queues.unbounded(), true);
         FluxPublish.PublishSubscriber<Integer> test = new FluxPublish.PublishSubscriber<>(789, main);
         Subscription parent = Operators.emptySubscription();
         test.onSubscribe(parent);
@@ -720,8 +720,8 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 
 	@Test
     public void scanInner() {
-		FluxPublish<Integer> main = new FluxPublish<>(Flux.just(1), 123,
-				Queues.unbounded(), true);
+		FluxPublish<Integer> main =
+				new FluxPublish<>(Flux.just(1), 123, Queues.unbounded(), true);
         FluxPublish.PublishSubscriber<Integer> parent = new FluxPublish.PublishSubscriber<>(789, main);
         Subscription sub = Operators.emptySubscription();
         parent.onSubscribe(sub);
@@ -745,8 +745,8 @@ public class FluxPublishTest extends FluxOperatorTest<String, String> {
 
 	@Test
     public void scanPubSubInner() {
-		FluxPublish<Integer> main = new FluxPublish<>(Flux.just(1), 123,
-				Queues.unbounded(), true);
+		FluxPublish<Integer> main =
+				new FluxPublish<>(Flux.just(1), 123, Queues.unbounded(), true);
         FluxPublish.PublishSubscriber<Integer> parent = new FluxPublish.PublishSubscriber<>(789, main);
         Subscription sub = Operators.emptySubscription();
         parent.onSubscribe(sub);


### PR DESCRIPTION
Supporting the caching of only terminal signals in case of `Flux.replay(int)` and `Flux.cache(int)` operators.

As it currently stands, these operators, when provided `0` as the argument, resort to behaving like `Flux.publish()` which differs in the way termination signals are handled by the `> 0` cases. This change still uses the `FluxPublish` class to implement the logic, however with a few minor changes to its implementation.
First of all, `FluxPublish` resets itself after source termination to be able to `connect()` again. `FluxReplay` on the other hand, does not reset itself in the case of only buffering signals without timeout. Therefore, for the behaviour of caching the terminals, `FluxPublish` does not reset itself and replays the terminal when it receives a late subscription.
For cases with expiry (TTL arguments), `FluxReplay` does indeed reset itself. Therefore, the behaviour for the time constrained values remains as before, using `FluxPublish` implementation for the `0` history case, but without caching terminals, while not honouring the TTL. This case can be later implemented if needed.