### PR TITLE
Rework the refguide section on metrics to focus on new module

### DIFF
--- a/docs/asciidoc/metrics-details.adoc
+++ b/docs/asciidoc/metrics-details.adoc
@@ -3,6 +3,7 @@
 
 ### Meters and tags for Reactor-Core-Micrometer module
 
+[[micrometer-details-metrics]]
 #### `Micrometer.metrics()`
 Below is the list of meters used by the metrics tap listener feature, as exposed via
 `Micrometer.metrics(MeterRegistry meterRegistry)`.
@@ -13,6 +14,7 @@ Otherwise, this is replaced by the default value of `"reactor"`.
 
 include::{root-target}meterListener.adoc[leveloffset=4]
 
+[[micrometer-details-timedScheduler]]
 #### `Micrometer.timedScheduler()`
 Below is the list of meters used by the TimedScheduler feature, as exposed via
 `Micrometer.timedScheduler(Scheduler original, MeterRegistry meterRegistry, String metricsPrefix)`.
@@ -21,6 +23,7 @@ IMPORTANT: Please note that metrics below use a dynamic `%s` prefix. This is rep
 
 include::{root-target}timedScheduler.adoc[leveloffset=4]
 
+[[micrometer-details-observation]]
 #### `Micrometer.observation()`
 Below is the list of meters used by the observation tap listener feature, as exposed via
 `Micrometer.observation(ObservationRegistry registry)`.

--- a/docs/asciidoc/metrics.adoc
+++ b/docs/asciidoc/metrics.adoc
@@ -4,41 +4,54 @@
 Project Reactor is a library designed for performance and better utilization of resources.
 But to truly understand the performance of a system, it is best to be able to monitor its various components.
 
-This is why Reactor provides a built-in integration with https://micrometer.io[Micrometer].
+This is why Reactor provides a built-in integration with https://micrometer.io[Micrometer] via the `reactor-core-micrometer` module.
+Introduced in the `2022.0 BOM` release, the module provides an explicit dependency to Micrometer, which allows it to offer fine-tuned APIs for metrics and observations.
 
-TIP: If Micrometer is not on the classpath, metrics will be a no-op.
+NOTE: Up to Reactor-Core `3.5.0`, metrics were implemented as operators that would be no-op if Micrometer wasn't on the classpath.
+
+The `reactor-core-micrometer` APIs require the user to provide a form of _registry_ explicitly instead of relying on a hardcoded global registry.
+When applying instrumentation to classes that have a NATIVE notion of naming or tags, these APIs will attempt to discover such elements in the reactive chain.
+Otherwise, the API will expect that a _prefix_ for naming meters is provided alongside the registry.
 
 == Scheduler metrics
 
 Every async operation in Reactor is done via the Scheduler abstraction described in <<schedulers>>.
 This is why it is important to monitor your schedulers, watch out for key metrics that start to look suspicious and react accordingly.
 
-To enable scheduler metrics, you will need to use the following method:
+The `reactor-core-micrometer` module offers a "timed" `Scheduler` wrapper that perform measurements around tasks submitted through it, which can be used as follows:
 ====
 [source,java]
 ----
-Schedulers.enableMetrics();
+Scheduler originalScheduler = Schedulers.newParallel("test", 4);
+
+Scheduler schedulerWithMetrics = Micrometer.timedScheduler(
+	originalScheduler, // <1>
+	applicationDefinedMeterRegistry, // <2>
+	"testingMetrics", // <3>
+	Tags.of(Tag.of("additionalTag", "yes")) // <4>
+);
 ----
 ====
+<1> the `Scheduler` to wrap
+<2> the `MeterRegistry` in which to publish metrics
+<3> the prefix to use in naming meters. This would for example lead to a `testingMetrics.scheduler.tasks.completed` meter being created.
+<4> optional tags to add to all the meters created for that wrapping `Scheduler`
 
-WARNING: The instrumentation is performed when a scheduler is created. It is recommended to call this method as early as possible.
+IMPORTANT: When wrapping a common `Scheduler` (eg. `Schedulers.single()`) or a `Scheduler` that is used in multiple places, only the `Runnable` tasks that are
+submitted through the wrapper instance returned by `Micrometer#timedScheduler` are going to be instrumented.
 
-TIP: If you're using Spring Boot, it is a good idea to place the invocation before `SpringApplication.run(Application.class, args)` call.
+See <<micrometer-details-timedScheduler>> for produced meters and associated default tags.
 
-Once scheduler metrics are enabled and provided it is on the classpath, Reactor will use Micrometer's support for instrumenting the executors that back most schedulers.
-
-Please refer to https://micrometer.io/docs/ref/jvm[Micrometer's documentation] for the exposed metrics.
-
-Since one scheduler may have multiple executors, every executor metric has a `reactor_scheduler_id` tag.
-
-TIP: Grafana + Prometheus users can use https://raw.githubusercontent.com/reactor/reactor-monitoring-demo/master/dashboards/schedulers.json[a pre-built dashboard] which includes panels for threads, completed tasks, task queues and other handy metrics.
+// FIXME reactor-monitoring-demo won't be in sync with 3.5.0 anymore
+//TIP: Grafana + Prometheus users can use https://raw.githubusercontent.com/reactor/reactor-monitoring-demo/master/dashboards/schedulers.json[a pre-built dashboard] which includes panels for threads, completed tasks, task queues and other handy metrics.
 
 == Publisher metrics
 Sometimes it is useful to be able to record metrics at some stage in your reactive pipeline.
 
-One way to do it would be to manually push the values to your metrics backend of choice.
-Another option would be to use Reactor's built-in metrics integration for `Flux`/`Mono` and interpret them.
+One way to do it would be to manually push the values to your metrics backend of choice from a custom `SignalListener`
+provided to the `tap` operator.
 
+An out-of-the-box implementation is actually provided by the `reactor-core-micrometer` module, via `Micrometer#metrics` APIs.
 Consider the following pipeline:
 ====
 [source,java]
@@ -51,70 +64,81 @@ listenToEvents()
 ----
 ====
 
-To enable the metrics for this source `Flux` (returned from `listenToEvents()`), we need to turn on the metrics collecting:
+To enable the metrics for this source `Flux` (returned from `listenToEvents()`), we need to turn on the metrics collection:
 
 ====
 [source,java]
 ----
 listenToEvents()
-    .name("events") <1>
-    .metrics() <2>
+    .name("events") // <1>
+    .tap(Micrometer.metrics( // <2>
+        applicationDefinedMeterRegistry // <3>
+    ))
     .doOnNext(event -> log.info("Received {}", event))
     .delayUntil(this::processEvent)
     .retry()
     .subscribe();
 ----
-<1> Every metric at this stage will be identified as "events" (optional).
-<2> `Flux#metrics` operator enables the reporting of metrics, using the name provided in when calling `Flux#name` operator. In case `Flux#name` operator has not been used, the default name will be `reactor`.
+<1> Every metric at this stage of the reactive pipeline will use "events" as a naming prefix (optional, defaults to `reactor` prefix).
+<2> We use the `tap` operator combined with a `SignalListener` implementation provided in `reactor-core-micrometer` for metrics collection.
+<3> As with other APIs in that module, the `MeterRegistry` into which to publish metrics needs to be explicitly provided.
 ====
 
-Just adding these two operators will expose a whole bunch of useful metrics!
+The detail of the exposed metrics is available in <<micrometer-details-metrics>>.
 
-[width="100%",options="header"]
-|=======
-| metric name | type | description
-
-| [name].subscribed | Counter | Counts how many Reactor sequences have been subscribed to
-
-| [name].malformed.source | Counter | Counts the number of events received from a malformed source (ie an onNext after an onComplete)
-
-| [name].requested | DistributionSummary | Counts the amount requested to a named Flux by all subscribers, until at least one requests an unbounded amount
-
-| [name].onNext.delay | Timer | Measures delays between onNext signals (or between onSubscribe and first onNext)
-
-| [name].flow.duration | Timer | Times the duration elapsed between a subscription and the termination or cancellation of the sequence. A status tag is added to specify what event caused the timer to end (`completed`, `completedEmpty`, `error`, `cancelled`).
-|=======
-
-Want to know how many times your event processing has restarted due to some error? Read `[name].subscribed`, because `retry()` operator will re-subscribe to the source publisher on error.
-
-Interested in "events per second" metric? Measure the rate of `[name].onNext.delay` 's count.
-
-Want to be alerted when the listener throws an error? `[name].flow.duration` with `status=error` tag is your friend.
-Similarly, `status=completed` and `status=completedEmpty` will allow you to distinguish sequences that completed with elements from sequences that completed empty.
-
-Please note that when giving a name to a sequence, this sequence could not be aggregated with others anymore. As a compromise if you want to identify your sequence but still make it possible to aggregate with other views, you can use a <<Tags>> for the name by calling `(tag("flow", "events"))` for example.
+//TODO update and reintroduce tips for using the metrics
+//Want to know how many times your event processing has restarted due to some error? Read `[name].subscribed`, because `retry()` operator will re-subscribe to the source publisher on error.
+//
+//Interested in "events per second" metric? Measure the rate of `[name].onNext.delay` 's count.
+//
+//Want to be alerted when the listener throws an error? `[name].flow.duration` with `status=error` tag is your friend.
+//Similarly, `status=completed` and `status=completedEmpty` will allow you to distinguish sequences that completed with elements from sequences that completed empty.
+//
+//Please note that when giving a name to a sequence, this sequence could not be aggregated with others anymore. As a compromise if you want to identify your sequence but still make it possible to aggregate with other views, you can use a <<Tags>> for the name by calling `(tag("flow", "events"))` for example.
 
 === Tags
 
-Every metric will have a `type` tag in common, which value will be either `Flux` or `Mono` depending on the publisher's nature.
-
-Users are allowed to add custom tags to their reactive chains:
+In addition to the common tags described in <<micrometer-details-metrics>>, users can add custom tags to their reactive chains via the `tag` operator:
 ====
 [source,java]
 ----
 listenToEvents()
-    .name("events") <1>
-    .tag("source", "kafka") <2>
-    .metrics() <3>
+    .name("events") // <1>
+    .tag("source", "kafka") // <2>
+    .tap(Micrometer.metrics(applicationDefinedRegistry)) // <3>
     .doOnNext(event -> log.info("Received {}", event))
     .delayUntil(this::processEvent)
     .retry()
     .subscribe();
 ----
-<1> Every metric at this stage will be identified as "events".
+<1> Every metric at this stage will be identified with the "events" prefix.
 <2> Set a custom tag "source" to value "kafka".
-<3> All reported metrics will have `source=kafka` tag assigned in addition to the common tag described above.
+<3> All reported metrics will have `source=kafka` tag assigned in addition to the common tags.
 ====
 
 Please note that depending on the monitoring system you're using, using a name can be considered mandatory when using tags, since it would otherwise result in a different set of tags between two default-named sequences.
 Some systems like Prometheus might also require to have the exact same set of tags for each metric with the same name.
+
+=== Observation
+In addition to full metrics, the `reactor-core-micrometer` module offers an alternative based on Micrometer's `Observation`.
+Depending on the configuration and runtime classpath, an `Observation` could translate to timers, spans, logging statements or any combination.
+
+A reactive chain can be observed via the `tap` operator and `Micrometer.observation` utility, as follows:
+====
+[source,java]
+----
+listenToEvents()
+    .name("events") // <1>
+    .tap(Micrometer.observation( // <2>
+		applicationDefinedRegistry)) // <3>
+    .doOnNext(event -> log.info("Received {}", event))
+    .delayUntil(this::processEvent)
+    .retry()
+    .subscribe();
+----
+<1> The `Observation` for this pipeline will be identified with the "events" prefix.
+<2> We use the `tap` operator with the `observation` utility.
+<3> A registry must be provided into which to publish the observation results. Note this is an `ObservationRegistry`.
+====
+
+The detail of the observation and its tags is provided in <<micrometer-details-observation>>.

--- a/gradle/asciidoc.gradle
+++ b/gradle/asciidoc.gradle
@@ -19,7 +19,6 @@ configure(rootProject) {
 	apply plugin: 'org.asciidoctor.jvm.pdf'
 
 	repositories {
-		maven { url 'https://repo.spring.io/snapshot' }
 		maven { url 'https://repo.spring.io/milestone' }
 	}
 

--- a/gradle/asciidoc.gradle
+++ b/gradle/asciidoc.gradle
@@ -19,6 +19,7 @@ configure(rootProject) {
 	apply plugin: 'org.asciidoctor.jvm.pdf'
 
 	repositories {
+		maven { url 'https://repo.spring.io/snapshot' }
 		maven { url 'https://repo.spring.io/milestone' }
 	}
 


### PR DESCRIPTION
This commit reworks the reference guide section on metrics which now
focuses on `reactor-core-micrometer` module:
 - replacement APIs for publisher and scheduler metrics
 - `Observation` API which is entirely new

Since meters and tags documentation is now generated, relevant cross
links have been added.

Fixes #3108.
