### PR TITLE
Allow blocking calls in `WorkerTask#dispose`

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/ReactorBlockHoundIntegration.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ReactorBlockHoundIntegration.java
@@ -42,6 +42,7 @@ public final class ReactorBlockHoundIntegration implements BlockHoundIntegration
 
         // Calls ScheduledFutureTask#cancel that may short park in DelayedWorkQueue#remove for getting a lock
         builder.allowBlockingCallsInside(SchedulerTask.class.getName(), "dispose");
+        builder.allowBlockingCallsInside(WorkerTask.class.getName(), "dispose");
 
         builder.allowBlockingCallsInside(ThreadPoolExecutor.class.getName(), "processWorkerExit");
     }


### PR DESCRIPTION
This avoids flagging (short-lived) blocking calls that cannot always be avoided when a `dispose` call results in the removal of a task of the worker-backed queue when access to said queue is currently held by a guard.

Fixes #3210.