### PR TITLE
Fix meters documentation generation following renames

### DIFF
--- a/docs/asciidoc/metrics-details.adoc
+++ b/docs/asciidoc/metrics-details.adoc
@@ -11,7 +11,7 @@ IMPORTANT: Please note that metrics below use a dynamic `%s` prefix.
 When applied on a `Flux` or `Mono` that uses the `name(String n)` operator, this is replaced with `n`.
 Otherwise, this is replaced by the default value of `"reactor"`.
 
-include::{root-target}meterListener.adoc[leveloffset=4]
+include::{root-target}meterListener_metrics.adoc[leveloffset=4]
 
 #### `Micrometer.timedScheduler()`
 Below is the list of meters used by the TimedScheduler feature, as exposed via
@@ -19,7 +19,7 @@ Below is the list of meters used by the TimedScheduler feature, as exposed via
 
 IMPORTANT: Please note that metrics below use a dynamic `%s` prefix. This is replaced with the provided `metricsPrefix` in practice.
 
-include::{root-target}timedScheduler.adoc[leveloffset=4]
+include::{root-target}timedScheduler_metrics.adoc[leveloffset=4]
 
 #### `Micrometer.observation()`
 Below is the list of meters used by the observation tap listener feature, as exposed via
@@ -27,4 +27,4 @@ Below is the list of meters used by the observation tap listener feature, as exp
 
 This is the ANONYMOUS observation, but you can create a similar Observation with a custom name by using the `name(String)` operator.
 
-include::{root-target}observation.adoc[leveloffset=4]
+include::{root-target}observation_metrics.adoc[leveloffset=4]

--- a/gradle/asciidoc.gradle
+++ b/gradle/asciidoc.gradle
@@ -104,19 +104,19 @@ configure(rootProject) {
 	task generateMeterListenerDocs(type: JavaExec) {
 		mainClass.set("io.micrometer.docs.metrics.DocsFromSources")
 		classpath configurations.adoc
-		args project.rootDir.getAbsolutePath(), ".*DocumentedMeter.*.java", project.rootProject.buildDir.toPath().resolve("generatedMetricsDocs/meterListener").toAbsolutePath().toString()
+		args project.rootDir.getAbsolutePath(), ".*MicrometerMeterListenerDocumentation.*.java", project.rootProject.buildDir.toPath().resolve("generatedMetricsDocs/meterListener").toAbsolutePath().toString()
 	}
 
 	task generateTimedSchedulerDocs(type: JavaExec) {
 		mainClass.set("io.micrometer.docs.metrics.DocsFromSources")
 		classpath configurations.adoc
-		args project.rootDir.getAbsolutePath(), ".*DocumentedTimedScheduler.*.java", project.rootProject.buildDir.toPath().resolve("generatedMetricsDocs/timedScheduler").toAbsolutePath().toString()
+		args project.rootDir.getAbsolutePath(), ".*TimedSchedulerMeterDocumentation.*.java", project.rootProject.buildDir.toPath().resolve("generatedMetricsDocs/timedScheduler").toAbsolutePath().toString()
 	}
 
 	task generateObservationDocs(type: JavaExec) {
 		mainClass.set("io.micrometer.docs.metrics.DocsFromSources")
 		classpath configurations.adoc
-		args project.rootDir.getAbsolutePath(), ".*DocumentedObservation.*.java", project.rootProject.buildDir.toPath().resolve("generatedMetricsDocs/observation").toAbsolutePath().toString()
+		args project.rootDir.getAbsolutePath(), ".*MicrometerObservationListenerDocumentation.*.java", project.rootProject.buildDir.toPath().resolve("generatedMetricsDocs/observation").toAbsolutePath().toString()
 	}
 
 	task polishGeneratedMetricsDocs(type: Copy) {
@@ -125,15 +125,15 @@ configure(rootProject) {
 		mustRunAfter "generateObservationDocs"
 		from(project.rootProject.buildDir.toString() + "/generatedMetricsDocs/meterListener/") {
 			include "_*.adoc"
-			rename '_metrics.adoc', 'meterListener.adoc'
+			rename '_(.*).adoc', 'meterListener_$1.adoc'
 		}
 		from(project.rootProject.buildDir.toString() + "/generatedMetricsDocs/timedScheduler/") {
 			include "_*.adoc"
-			rename '_metrics.adoc', 'timedScheduler.adoc'
+			rename '_(.*).adoc', 'timedScheduler_$1.adoc'
 		}
 		from(project.rootProject.buildDir.toString() + "/generatedMetricsDocs/observation/") {
 			include "_*.adoc"
-			rename '_metrics.adoc', 'observation.adoc'
+			rename '_(.*).adoc', 'observation_$1.adoc'
 		}
 		into project.rootProject.buildDir.toString() + "/documentedMetrics"
 		filter { String line ->


### PR DESCRIPTION
This commit fixes the generation of meters documentation now that the
scanned classes have been renamed.

It also becomes less brittle to duplicate files when copying the pure
generated asciidoc files, using a regexp to rename these.
