### PR TITLE
Update dependencies junit, mockito, bytebuddy, jcstress, spotless...

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,9 +6,9 @@ baselinePerfExtra = "3.4.8"
 
 # Other shared versions
 asciidoctor = "3.3.2"
-bytebuddy = "1.12.14"
+bytebuddy = "1.12.17"
 jmh = "1.35"
-junit = "5.9.0"
+junit = "5.9.1"
 kotlin = "1.5.32"
 reactiveStreams = "1.0.4"
 
@@ -29,25 +29,25 @@ junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 logback = "ch.qos.logback:logback-classic:1.2.11"
 micrometer = "io.micrometer:micrometer-core:1.3.0"
-mockito = "org.mockito:mockito-core:4.7.0"
+mockito = "org.mockito:mockito-core:4.8.0"
 reactiveStreams = { module = "org.reactivestreams:reactive-streams", version.ref = "reactiveStreams" }
 reactiveStreams-tck = { module = "org.reactivestreams:reactive-streams-tck", version.ref = "reactiveStreams" }
 reactor-perfBaseline-core = { module = "io.projectreactor:reactor-core", version.ref = "baselinePerfCore" }
 reactor-perfBaseline-extra = { module = "io.projectreactor.addons:reactor-extra", version.ref = "baselinePerfExtra" }
 slf4j = "org.slf4j:slf4j-api:1.7.36"
-testNg = "org.testng:testng:7.5"
+testNg = "org.testng:testng:7.5" # since 7.6 JDK8 is unsupported, don't bump
 throwingFunction = "com.pivovarit:throwing-function:1.5.1"
 
 [plugins]
-artifactory = { id = "com.jfrog.artifactory", version = "4.29.0" }
+artifactory = { id = "com.jfrog.artifactory", version = "4.29.1" }
 asciidoctor-convert = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor" }
 asciidoctor-pdf = { id = "org.asciidoctor.jvm.pdf", version.ref = "asciidoctor" }
 bnd = { id = "biz.aQute.bnd.builder", version = "6.3.1" }
-download = { id = "de.undercouch.download", version = "5.1.2" }
+download = { id = "de.undercouch.download", version = "5.2.1" }
 japicmp = { id = "me.champeau.gradle.japicmp", version = "0.4.1" }
-jcstress = { id = "io.github.reyerizo.gradle.jcstress", version = "0.8.13" }
+jcstress = { id = "io.github.reyerizo.gradle.jcstress", version = "0.8.14" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 nohttp = { id = "io.spring.nohttp", version = "0.0.10" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
-spotless = { id = "com.diffplug.spotless", version = "6.10.0" }
+spotless = { id = "com.diffplug.spotless", version = "6.11.0" }
 testsets = { id = "org.unbroken-dome.test-sets", version = "4.0.0" }

--- a/reactor-tools/src/buildPluginTest/resources/mock-gradle/build.gradle
+++ b/reactor-tools/src/buildPluginTest/resources/mock-gradle/build.gradle
@@ -22,8 +22,6 @@ buildscript {
 		//the plugin feature only works with the -original jar !!
 		//otherwise implemented Plugin interface is the shaded one
 		classpath files("@AGENT@")
-		//version 1.12.13 cannot be found on Gradle Plugin Repository, this syntax allows looking it up on MavenCentral
-		classpath 'net.bytebuddy:byte-buddy-gradle-plugin:@BYTE_BUDDY_VERSION@'
 	}
 }
 

--- a/reactor-tools/src/buildPluginTest/resources/mock-gradle/build.gradle
+++ b/reactor-tools/src/buildPluginTest/resources/mock-gradle/build.gradle
@@ -22,6 +22,8 @@ buildscript {
 		//the plugin feature only works with the -original jar !!
 		//otherwise implemented Plugin interface is the shaded one
 		classpath files("@AGENT@")
+		//version 1.12.17 cannot be found on Gradle Plugin Repository, this syntax allows looking it up on MavenCentral
+		classpath 'net.bytebuddy:byte-buddy-gradle-plugin:@BYTE_BUDDY_VERSION@'
 	}
 }
 


### PR DESCRIPTION
This commit updates the following dependencies:

- bytebuddy 1.12.14 -> 1.12.17, supersedes and closes #3186

It also updates the following build dependencies:

- plugin artifactory 4.29.0 -> 4.29.1, supersedes and closes #3207
- plugin jcstress 0.8.13 -> 0.8.14, supersedes and closes #3171
- plugin download 5.1.2 -> 5.2.1, supersedes and closes #3188
- plugin spotless 6.10.0 -> 6.11.0, supersedes and closes #3193

And also updates the following test dependencies:

- JUnit 5.9.0 -> 5.9.1, supersedes and closes #3186
- Mockito 4.7.0 -> 4.8.0, supersedes and closes #3185