### PR TITLE
Document not to reuse/cache EmitFailureHandle#busyLooping

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -269,7 +269,8 @@ public final class Sinks {
 		 * <p>
 		 * As a result there will always be some delay between this computation and the actual first
 		 * use of the handler (at a minimum, the time it takes for the first sink emission attempt).
-		 * Consider this when choosing the {@link Duration}, and probably prefer something above 100ms.
+		 * Consider this when choosing the {@link Duration}, and probably prefer something above 100ms,
+		 * and don't cache the returning handler for later usage.
 		 *
 		 * @param duration {@link Duration} for the deadline
 		 * @return an optimistic and bounded busy-looping {@link EmitFailureHandler}


### PR DESCRIPTION
I just cached it and got an error, so I think it would be good to add some comments about `don't cache it`.