### PR TITLE
deprecates `onNextDropped` and supersedes it by `onDiscard` with reason and value

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -4573,6 +4573,34 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	}
 
 	/**
+	 * Potentially modify the behavior of the <i>whole chain</i> of operators upstream of this one to
+	 * conditionally clean up elements that get <i>discarded</i> by these operators.
+	 * <p>
+	 * The {@code discardHook} MUST be idempotent and safe to use on any instance of the desired
+	 * type.
+	 * Calls to this method are additive, and the order of invocation of the {@code discardHook}
+	 * is the same as the order of declaration (calling {@code .filter(...).doOnDiscard(first).doOnDiscard(second)}
+	 * will let the filter invoke {@code first} then {@code second} handlers).
+	 * <p>
+	 * Two main categories of discarding operators exist:
+	 * <ul>
+	 *     <li>filtering operators, dropping some source elements as part of their designed behavior</li>
+	 *     <li>operators that prefetch a few elements and keep them around pending a request, but get cancelled/in error</li>
+	 * </ul>
+	 * WARNING: Not all operators support this instruction. The ones that do are identified in the javadoc by
+	 * the presence of a <strong>Discard Support</strong> section.
+	 *
+	 * @param type the {@link Class} of elements in the upstream chain of operators that
+	 * this cleanup hook should take into account.
+	 * @param discardHook a {@link BiConsumer} of elements in the upstream chain of operators
+	 * that performs the cleanup.
+	 * @return a {@link Flux} that cleans up matching elements that get discarded upstream of it.
+	 */
+	public final <R> Flux<T> doOnDiscard(final Class<R> type, final BiConsumer<? super R, Operators.DiscardReason> discardHook) {
+		return contextWrite(Operators.discardLocalAdapter(type, discardHook));
+	}
+
+	/**
 	 * Add behavior (side-effects) triggered when the {@link Flux} emits an item, fails with an error
 	 * or completes successfully. All these events are represented as a {@link Signal}
 	 * that is passed to the side-effect callback. Note that this is an advanced operator,


### PR DESCRIPTION
closes #2103 

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>