### PR TITLE
Deprecate scheduler start

### DIFF
--- a/reactor-core/src/blockHoundTest/java/reactor/core/scheduler/BoundedElasticSchedulerBlockhoundTest.java
+++ b/reactor-core/src/blockHoundTest/java/reactor/core/scheduler/BoundedElasticSchedulerBlockhoundTest.java
@@ -96,7 +96,7 @@ public class BoundedElasticSchedulerBlockhoundTest {
 	@RepeatedTest(3) //we got false positives from time to time. with repeat(3), only 1 block out of 500 was a false positive (with a total of 75 false positives out of 1500 runs)
 	void shouldNotReportEnsureQueueCapacity() {
 		BoundedElasticScheduler scheduler = autoDispose(new BoundedElasticScheduler(1, 100, Thread::new, 1));
-		scheduler.start();
+		scheduler.init();
 		ExecutorServiceWorker worker = (ExecutorServiceWorker) autoDispose(scheduler.createWorker());
 		BoundedElasticScheduler.BoundedScheduledExecutorService executor =
 			(BoundedElasticScheduler.BoundedScheduledExecutorService) worker.exec;

--- a/reactor-core/src/jcstress/java/reactor/core/scheduler/SchedulersStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/scheduler/SchedulersStressTest.java
@@ -33,6 +33,7 @@ public abstract class SchedulersStressTest {
 
 	private static void restart(Scheduler scheduler) {
 		scheduler.disposeGracefully().block(Duration.ofMillis(100));
+		// TODO: in 3.6.x: remove restart capability and this validation
 		scheduler.start();
 	}
 
@@ -58,7 +59,7 @@ public abstract class SchedulersStressTest {
 		private final SingleScheduler scheduler = new SingleScheduler(Thread::new);
 
 		{
-			scheduler.start();
+			scheduler.init();
 		}
 
 		@Actor
@@ -89,7 +90,7 @@ public abstract class SchedulersStressTest {
 				new ParallelScheduler(4, Thread::new);
 
 		{
-			scheduler.start();
+			scheduler.init();
 		}
 
 		@Actor
@@ -119,7 +120,7 @@ public abstract class SchedulersStressTest {
 		private final BoundedElasticScheduler scheduler =
 				new BoundedElasticScheduler(1, 1, Thread::new, 5);
 		{
-			scheduler.start();
+			scheduler.init();
 		}
 
 		@Actor
@@ -151,7 +152,7 @@ public abstract class SchedulersStressTest {
 		private final SingleScheduler scheduler = new SingleScheduler(Thread::new);
 
 		{
-			scheduler.start();
+			scheduler.init();
 		}
 
 		@Actor
@@ -187,7 +188,7 @@ public abstract class SchedulersStressTest {
 				new ParallelScheduler(10, Thread::new);
 
 		{
-			scheduler.start();
+			scheduler.init();
 		}
 
 		@Actor
@@ -223,7 +224,7 @@ public abstract class SchedulersStressTest {
 				new BoundedElasticScheduler(4, 4, Thread::new, 5);
 
 		{
-			scheduler.start();
+			scheduler.init();
 		}
 
 		@Actor
@@ -258,7 +259,7 @@ public abstract class SchedulersStressTest {
 		private final SingleScheduler scheduler = new SingleScheduler(Thread::new);
 
 		{
-			scheduler.start();
+			scheduler.init();
 		}
 
 		@Actor
@@ -294,7 +295,7 @@ public abstract class SchedulersStressTest {
 				new ParallelScheduler(10, Thread::new);
 
 		{
-			scheduler.start();
+			scheduler.init();
 		}
 
 		@Actor
@@ -331,7 +332,7 @@ public abstract class SchedulersStressTest {
 				new BoundedElasticScheduler(4, 4, Thread::new, 5);
 
 		{
-			scheduler.start();
+			scheduler.init();
 		}
 
 		@Actor

--- a/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
@@ -164,8 +164,14 @@ final class BoundedElasticScheduler implements Scheduler,
 			}
 		} else {
 			b.currentResource.evictor.shutdownNow();
-			throw new IllegalStateException("Failed to initialize Scheduler. " +
-					"Initialization is only possible on a fresh instance.");
+			// Currently, isDisposed() is true for non-initialized state, but that will
+			// be fixed in 3.5.0. At this stage we know however that the state is no
+			// longer INIT, so isDisposed() actually means disposed state.
+			if (isDisposed()) {
+				throw new IllegalStateException(
+						"Initializing a disposed scheduler is not permitted"
+				);
+			}
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
@@ -119,8 +119,11 @@ final class DelegateServiceScheduler implements Scheduler, SchedulerState.Dispos
 	public void init() {
 		if (!STATE.compareAndSet(this, null,
 				SchedulerState.init(Schedulers.decorateExecutorService(this, original)))) {
-			throw new IllegalStateException("Failed to initialize Scheduler. " +
-					"Initialization is only possible on a fresh instance.");
+			if (isDisposed()) {
+				throw new IllegalStateException(
+						"Initializing a disposed scheduler is not permitted"
+				);
+			}
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
@@ -73,7 +73,7 @@ final class DelegateServiceScheduler implements Scheduler, SchedulerState.Dispos
 	ScheduledExecutorService getOrCreate() {
 		SchedulerState<ScheduledExecutorService> s = state;
 		if (s == null) {
-			start();
+			init();
 			s = state;
 			if (s == null) {
 				throw new IllegalStateException("executor is null after implicit start()");
@@ -113,6 +113,15 @@ final class DelegateServiceScheduler implements Scheduler, SchedulerState.Dispos
 	public void start() {
 		STATE.compareAndSet(this, null,
 				SchedulerState.init(Schedulers.decorateExecutorService(this, original)));
+	}
+
+	@Override
+	public void init() {
+		if (!STATE.compareAndSet(this, null,
+				SchedulerState.init(Schedulers.decorateExecutorService(this, original)))) {
+			throw new IllegalStateException("Failed to initialize Scheduler. " +
+					"Initialization is only possible on a fresh instance.");
+		}
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,6 +101,21 @@ final class ElasticScheduler implements Scheduler, Scannable {
 		poolExecutor.setMaximumPoolSize(1);
 		poolExecutor.setRemoveOnCancelPolicy(true);
 		return poolExecutor;
+	}
+
+	@Override
+	public void init() {
+		if (evictor != null || !shutdown) {
+			throw new IllegalStateException("Failed to initialize Scheduler. " +
+					"Initialization is only possible on a fresh instance.");
+		}
+
+		this.evictor = Executors.newScheduledThreadPool(1, EVICTOR_FACTORY);
+		this.evictor.scheduleAtFixedRate(this::eviction,
+				ttlSeconds,
+				ttlSeconds,
+				TimeUnit.SECONDS);
+		this.shutdown = false;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
@@ -105,9 +105,10 @@ final class ElasticScheduler implements Scheduler, Scannable {
 
 	@Override
 	public void init() {
-		if (evictor != null || !shutdown) {
-			throw new IllegalStateException("Failed to initialize Scheduler. " +
-					"Initialization is only possible on a fresh instance.");
+		if (evictor != null && isDisposed()) {
+			throw new IllegalStateException(
+					"Initializing a disposed scheduler is not permitted"
+			);
 		}
 
 		this.evictor = Executors.newScheduledThreadPool(1, EVICTOR_FACTORY);

--- a/reactor-core/src/main/java/reactor/core/scheduler/ImmediateScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ImmediateScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ final class ImmediateScheduler implements Scheduler, Scannable {
 
     static {
         INSTANCE = new ImmediateScheduler();
-        INSTANCE.start();
+        INSTANCE.init();
     }
 
     public static Scheduler instance() {

--- a/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
@@ -102,8 +102,11 @@ final class ParallelScheduler implements Scheduler, Supplier<ScheduledExecutorSe
 			for (ScheduledExecutorService exec : b.currentResource) {
 				exec.shutdownNow();
 			}
-			throw new IllegalStateException("Failed to initialize Scheduler. " +
-					"Initialization is only possible on a fresh instance.");
+			if (isDisposed()) {
+				throw new IllegalStateException(
+						"Initializing a disposed scheduler is not permitted"
+				);
+			}
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
@@ -90,6 +90,24 @@ final class ParallelScheduler implements Scheduler, Supplier<ScheduledExecutorSe
 	}
 
 	@Override
+	public void init() {
+		SchedulerState<ScheduledExecutorService[]> b =
+				SchedulerState.init(new ScheduledExecutorService[n]);
+
+		for (int i = 0; i < n; i++) {
+			b.currentResource[i] = Schedulers.decorateExecutorService(this, this.get());
+		}
+
+		if (!STATE.compareAndSet(this, null, b)) {
+			for (ScheduledExecutorService exec : b.currentResource) {
+				exec.shutdownNow();
+			}
+			throw new IllegalStateException("Failed to initialize Scheduler. " +
+					"Initialization is only possible on a fresh instance.");
+		}
+	}
+
+	@Override
 	public void start() {
 		SchedulerState<ScheduledExecutorService[]> a = this.state;
 
@@ -180,10 +198,10 @@ final class ParallelScheduler implements Scheduler, Supplier<ScheduledExecutorSe
 	ScheduledExecutorService pick() {
 		SchedulerState<ScheduledExecutorService[]> a = state;
 		if (a == null) {
-			start();
+			init();
 			a = state;
 			if (a == null) {
-				throw new IllegalStateException("executors uninitialized after implicit start()");
+				throw new IllegalStateException("executors uninitialized after implicit init()");
 			}
 		}
 		if (a.currentResource != SHUTDOWN) {

--- a/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -129,12 +129,10 @@ public interface Scheduler extends Disposable {
 	 * Instructs this Scheduler to release all resources and reject
 	 * any new tasks to be executed.
 	 *
-	 * <p>The operation is thread-safe but one should avoid using
-	 * start() and dispose() concurrently as it would non-deterministically
-	 * leave the Scheduler in either active or inactive state.
+	 * <p>The operation is thread-safe.
 	 *
 	 * <p>The Scheduler may choose to ignore this instruction.
-	 * <p>When used in combination with {@link #disposeGracefully(Duration)}
+	 * <p>When used in combination with {@link #disposeGracefully()}
 	 * there are no guarantees that all resources will be forcefully shutdown.
 	 * When a graceful disposal has started, the references to the underlying
 	 * {@link java.util.concurrent.Executor}s might have already been lost.
@@ -167,8 +165,26 @@ public interface Scheduler extends Disposable {
 	 * <p>The operation is thread-safe but one should avoid using
 	 * start() and dispose() concurrently as it would non-deterministically
 	 * leave the Scheduler in either active or inactive state.
+	 *
+	 * @deprecated Use {@link #init()} instead. The use of this method is discouraged.
+	 * Some implementations allowed restarting a Scheduler, while others did not. One
+	 * of the issues with restarting is that checking
+	 * {@link #isDisposed() the disposed state} is unreliable in concurrent scenarios.
 	 */
+	@Deprecated
 	default void start() {
+	}
+
+	/**
+	 * Instructs this Scheduler to prepare itself for running tasks
+	 * directly or through its {@link Worker}s.
+	 *
+	 * <p><strong>It should be called only once</strong>. Implementations are free to
+	 * throw an exception if this method is called again either during the runtime of the
+	 * scheduler or after it has been disposed via {@link #dispose()}
+	 * or {@link #disposeGracefully()}.
+	 */
+	default void init() {
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -180,7 +180,7 @@ public interface Scheduler extends Disposable {
 	 * Instructs this Scheduler to prepare itself for running tasks
 	 * directly or through its {@link Worker}s.
 	 *
-	 * <p>Implementations can throw an exception if this method is called
+	 * <p>Implementations are encouraged to throw an exception if this method is called
 	 * after the scheduler has been disposed via {@link #dispose()}
 	 * or {@link #disposeGracefully()}.
 	 */

--- a/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -185,6 +185,7 @@ public interface Scheduler extends Disposable {
 	 * or {@link #disposeGracefully()}.
 	 */
 	default void init() {
+		start();
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java
@@ -170,6 +170,7 @@ public interface Scheduler extends Disposable {
 	 * Some implementations allowed restarting a Scheduler, while others did not. One
 	 * of the issues with restarting is that checking
 	 * {@link #isDisposed() the disposed state} is unreliable in concurrent scenarios.
+	 * @see #init()
 	 */
 	@Deprecated
 	default void start() {
@@ -179,9 +180,8 @@ public interface Scheduler extends Disposable {
 	 * Instructs this Scheduler to prepare itself for running tasks
 	 * directly or through its {@link Worker}s.
 	 *
-	 * <p><strong>It should be called only once</strong>. Implementations are free to
-	 * throw an exception if this method is called again either during the runtime of the
-	 * scheduler or after it has been disposed via {@link #dispose()}
+	 * <p>Implementations can throw an exception if this method is called
+	 * after the scheduler has been disposed via {@link #dispose()}
 	 * or {@link #disposeGracefully()}.
 	 */
 	default void init() {

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -63,7 +63,7 @@ import static reactor.core.Exceptions.unwrap;
  * <p>
  * Factories prefixed with {@code new} (eg. {@link #newBoundedElastic(int, int, String)} return a new instance of their flavor of {@link Scheduler},
  * while other factories like {@link #boundedElastic()} return a shared instance - which is the one used by operators requiring that flavor as their default Scheduler.
- * All instances are returned in a {@link Scheduler#start() started} state.
+ * All instances are returned in a {@link Scheduler#init() initialized} state.
  *
  * @author Stephane Maldini
  */
@@ -140,7 +140,7 @@ public abstract class Schedulers {
 			return fromExecutorService((ExecutorService) executor);
 		}
 		final ExecutorScheduler scheduler = new ExecutorScheduler(executor, trampoline);
-		scheduler.start();
+		scheduler.init();
 		return scheduler;
 	}
 
@@ -170,7 +170,7 @@ public abstract class Schedulers {
 	 */
 	public static Scheduler fromExecutorService(ExecutorService executorService, String executorName) {
 		final DelegateServiceScheduler scheduler = new DelegateServiceScheduler(executorName, executorService);
-		scheduler.start();
+		scheduler.init();
 		return scheduler;
 	}
 
@@ -183,7 +183,6 @@ public abstract class Schedulers {
 	 * The default time-to-live for unused thread pools is 60 seconds, use the appropriate
 	 * factory to set a different value.
 	 * <p>
-	 * This scheduler is not restartable.
 	 *
 	 * @return default instance of a {@link Scheduler} that dynamically creates ExecutorService-based
 	 * Workers and caches the threads, reusing them once the Workers have been shut
@@ -273,7 +272,6 @@ public abstract class Schedulers {
 	 * The default time-to-live for unused thread pools is 60 seconds, use the appropriate
 	 * factory to set a different value.
 	 * <p>
-	 * This scheduler is not restartable.
 	 *
 	 * @param name Thread prefix
 	 *
@@ -293,7 +291,6 @@ public abstract class Schedulers {
 	 * <p>
 	 * The maximum number of created thread pools is unbounded.
 	 * <p>
-	 * This scheduler is not restartable.
 	 *
 	 * @param name Thread prefix
 	 * @param ttlSeconds Time-to-live for an idle {@link reactor.core.scheduler.Scheduler.Worker}
@@ -314,7 +311,6 @@ public abstract class Schedulers {
 	 * <p>
 	 * The maximum number of created thread pools is unbounded.
 	 * <p>
-	 * This scheduler is not restartable.
 	 *
 	 * @param name Thread prefix
 	 * @param ttlSeconds Time-to-live for an idle {@link reactor.core.scheduler.Scheduler.Worker}
@@ -339,7 +335,6 @@ public abstract class Schedulers {
 	 * <p>
 	 * The maximum number of created thread pools is unbounded.
 	 * <p>
-	 * This scheduler is not restartable.
 	 *
 	 * @param ttlSeconds Time-to-live for an idle {@link reactor.core.scheduler.Scheduler.Worker}
 	 * @param threadFactory a {@link ThreadFactory} to use each thread initialization
@@ -352,7 +347,7 @@ public abstract class Schedulers {
 	@Deprecated
 	public static Scheduler newElastic(int ttlSeconds, ThreadFactory threadFactory) {
 		final Scheduler fromFactory = factory.newElastic(ttlSeconds, threadFactory);
-		fromFactory.start();
+		fromFactory.init();
 		return fromFactory;
 	}
 
@@ -377,7 +372,7 @@ public abstract class Schedulers {
 	 * tasks could be delayed due to two workers sharing the same backing thread and submitting long-running tasks,
 	 * despite another backing thread becoming idle in the meantime.
 	 * <p>
-	 * This scheduler is restartable. Backing threads are user threads, so they will prevent the JVM
+	 * Threads backing this scheduler are user threads, so they will prevent the JVM
 	 * from exiting until their worker has been disposed AND they've been evicted by TTL, or the whole
 	 * scheduler has been {@link Scheduler#dispose() disposed}.
 	 *
@@ -412,7 +407,7 @@ public abstract class Schedulers {
 	 * tasks could be delayed due to two workers sharing the same backing thread and submitting long-running tasks,
 	 * despite another backing thread becoming idle in the meantime.
 	 * <p>
-	 * This scheduler is restartable. Backing threads are user threads, so they will prevent the JVM
+	 * Threads backing this scheduler are user threads, so they will prevent the JVM
 	 * from exiting until their worker has been disposed AND they've been evicted by TTL, or the whole
 	 * scheduler has been {@link Scheduler#dispose() disposed}.
 	 *
@@ -448,7 +443,7 @@ public abstract class Schedulers {
 	 * tasks could be delayed due to two workers sharing the same backing thread and submitting long-running tasks,
 	 * despite another backing thread becoming idle in the meantime.
 	 * <p>
-	 * This scheduler is restartable. Depending on the {@code daemon} parameter, backing threads can be
+	 * Depending on the {@code daemon} parameter, threads backing this scheduler can be
 	 * user threads or daemon threads. Note that user threads will prevent the JVM from exiting until their
 	 * worker has been disposed AND they've been evicted by TTL, or the whole scheduler has been
 	 * {@link Scheduler#dispose() disposed}.
@@ -489,7 +484,7 @@ public abstract class Schedulers {
 	 * tasks could be delayed due to two workers sharing the same backing thread and submitting long-running tasks,
 	 * despite another backing thread becoming idle in the meantime.
 	 * <p>
-	 * This scheduler is restartable. Backing threads are created by the provided {@link ThreadFactory},
+	 * Threads backing this scheduler are created by the provided {@link ThreadFactory},
 	 * which can decide whether to create user threads or daemon threads. Note that user threads
 	 * will prevent the JVM from exiting until their worker has been disposed AND they've been evicted by TTL,
 	 * or the whole scheduler has been {@link Scheduler#dispose() disposed}.
@@ -507,7 +502,7 @@ public abstract class Schedulers {
 				queuedTaskCap,
 				threadFactory,
 				ttlSeconds);
-		fromFactory.start();
+		fromFactory.init();
 		return fromFactory;
 	}
 
@@ -572,7 +567,7 @@ public abstract class Schedulers {
 	 */
 	public static Scheduler newParallel(int parallelism, ThreadFactory threadFactory) {
 		final Scheduler fromFactory = factory.newParallel(parallelism, threadFactory);
-		fromFactory.start();
+		fromFactory.init();
 		return fromFactory;
 	}
 
@@ -616,7 +611,7 @@ public abstract class Schedulers {
 	 */
 	public static Scheduler newSingle(ThreadFactory threadFactory) {
 		final Scheduler fromFactory = factory.newSingle(threadFactory);
-		fromFactory.start();
+		fromFactory.init();
 		return fromFactory;
 	}
 
@@ -1063,8 +1058,8 @@ public abstract class Schedulers {
 	 * Wraps a single {@link reactor.core.scheduler.Scheduler.Worker} from some other
 	 * {@link Scheduler} and provides {@link reactor.core.scheduler.Scheduler.Worker}
 	 * services on top of it. Unlike with other factory methods in this class, the delegate
-	 * is assumed to be {@link Scheduler#start() started} and won't be implicitly started
-	 * by this method.
+	 * is assumed to be {@link Scheduler#init() initialized} and won't be implicitly
+	 * initialized by this method.
 	 * <p>
 	 * Use the {@link Scheduler#dispose()} to release the wrapped worker.
 	 *
@@ -1334,6 +1329,11 @@ public abstract class Schedulers {
 		@Override
 		public void start() {
 			cached.start();
+		}
+
+		@Override
+		public void init() {
+			cached.init();
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
@@ -89,8 +89,14 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 
 		if (!STATE.compareAndSet(this, INIT, b)) {
 			b.currentResource.shutdownNow();
-			throw new IllegalStateException("Failed to initialize Scheduler. " +
-					"Initialization is only possible on a fresh instance.");
+			// Currently, isDisposed() is true for non-initialized state, but that will
+			// be fixed in 3.5.0. At this stage we know however that the state is no
+			// longer INIT, so isDisposed() actually means disposed state.
+			if (isDisposed()) {
+				throw new IllegalStateException(
+						"Initializing a disposed scheduler is not permitted"
+				);
+			}
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,7 +124,6 @@ public class OnDiscardShouldNotLeakTest {
 
 	private void installScheduler(String description, int size) {
 		scheduler = Schedulers.newParallel(description + "DiscardScheduler", size);
-		scheduler.start();
 	}
 
 	@BeforeEach

--- a/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
@@ -39,7 +39,12 @@ import reactor.test.AutoDisposingExtension;
 import reactor.test.ParameterizedTestWithName;
 import reactor.test.StepVerifier;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatException;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Stephane Maldini

--- a/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
@@ -59,6 +59,12 @@ public abstract class AbstractSchedulerTest {
 	 */
 	protected abstract Scheduler scheduler();
 
+	/**
+	 * @return the {@link Scheduler} to be tested, not yet {@link Scheduler#init()
+	 * initialized}
+	 */
+	protected abstract Scheduler freshScheduler();
+
 	protected boolean shouldCheckInit() {
 		return true;
 	}
@@ -103,12 +109,16 @@ public abstract class AbstractSchedulerTest {
 	}
 
 	@Test
-	void cannotInitTwice() {
-		Assumptions.assumeThat(shouldCheckInit())
-		           .as("scheduler supports restart prevention").isTrue();
+	@org.junit.jupiter.api.Disabled("Should be enabled in 3.5.0")
+	void nonInitializedIsNotDisposed() {
+		Scheduler s = freshScheduler();
+		assertThat(s.isDisposed()).isFalse();
+	}
 
+	@Test
+	void canInitializeMultipleTimesNonDisposed() {
 		Scheduler s = scheduler();
-		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(s::init);
+		assertThatNoException().isThrownBy(s::init);
 	}
 
 	@ParameterizedTestWithName

--- a/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.assertj.core.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -109,7 +110,7 @@ public abstract class AbstractSchedulerTest {
 	}
 
 	@Test
-	@org.junit.jupiter.api.Disabled("Should be enabled in 3.5.0")
+	@Disabled("Should be enabled in 3.5.0")
 	void nonInitializedIsNotDisposed() {
 		Scheduler s = freshScheduler();
 		assertThat(s.isDisposed()).isFalse();

--- a/reactor-core/src/test/java/reactor/core/scheduler/BoundedElasticSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/BoundedElasticSchedulerTest.java
@@ -143,12 +143,18 @@ public class BoundedElasticSchedulerTest extends AbstractSchedulerTest {
 								false,
 								Schedulers::defaultUncaughtException),
 						10));
-		scheduler.init();
 		return scheduler;
 	}
 
 	@Override
 	protected BoundedElasticScheduler scheduler() {
+		BoundedElasticScheduler s = scheduler(4);
+		s.init();
+		return s;
+	}
+
+	@Override
+	protected Scheduler freshScheduler() {
 		return scheduler(4);
 	}
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/DelegateServiceSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/DelegateServiceSchedulerTest.java
@@ -44,6 +44,11 @@ public class DelegateServiceSchedulerTest extends AbstractSchedulerTest {
 
 	@Override
 	protected Scheduler scheduler() {
+		return freshScheduler();
+	}
+
+	@Override
+	protected Scheduler freshScheduler() {
 		return Schedulers.fromExecutor(Executors.newSingleThreadScheduledExecutor());
 	}
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ public class ElasticSchedulerTest extends AbstractSchedulerTest {
 		assertThatCode(scheduler::start).as("start").doesNotThrowAnyException();
 
 		scheduler.dispose();
+		// TODO: in 3.6.x: remove restart capability and this validation
 		assertThatCode(scheduler::start).as("restart").doesNotThrowAnyException();
 	}
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ElasticSchedulerTest.java
@@ -54,6 +54,16 @@ public class ElasticSchedulerTest extends AbstractSchedulerTest {
 	}
 
 	@Override
+	protected Scheduler freshScheduler() {
+		return new ElasticScheduler(
+				new ReactorThreadFactory("ElasticSchedulerTest",
+				ElasticScheduler.COUNTER, false, false,
+				Schedulers::defaultUncaughtException),
+				ElasticScheduler.DEFAULT_TTL_SECONDS
+		);
+	}
+
+	@Override
 	protected boolean shouldCheckInterrupted() {
 		return true;
 	}

--- a/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTest.java
@@ -70,6 +70,11 @@ public class ExecutorSchedulerTest extends AbstractSchedulerTest {
 		return Schedulers.fromExecutor(Runnable::run);
 	}
 
+	@Override
+	protected Scheduler freshScheduler() {
+		return new ExecutorScheduler(Runnable::run, false);
+	}
+
 	@Test
 	public void directAndWorkerTimeSchedulingRejected() {
 		Scheduler scheduler = scheduler();

--- a/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,11 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Stephane Maldini
  */
 public class ExecutorSchedulerTest extends AbstractSchedulerTest {
+
+	@Override
+	protected boolean shouldCheckInit() {
+		return false;
+	}
 
 	@Override
 	protected boolean shouldCheckDisposeTask() {

--- a/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTrampolineTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTrampolineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Stephane Maldini
  */
 public class ExecutorSchedulerTrampolineTest extends AbstractSchedulerTest {
+
+	@Override
+	protected boolean shouldCheckInit() {
+		return false;
+	}
 
 	@Override
 	protected boolean shouldCheckDisposeTask() {

--- a/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTrampolineTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ExecutorSchedulerTrampolineTest.java
@@ -44,6 +44,11 @@ public class ExecutorSchedulerTrampolineTest extends AbstractSchedulerTest {
 	}
 
 	@Override
+	protected Scheduler freshScheduler() {
+		return new ExecutorScheduler(Runnable::run, true);
+	}
+
+	@Override
 	protected boolean shouldCheckDirectTimeScheduling() {
 		return false;
 	}

--- a/reactor-core/src/test/java/reactor/core/scheduler/ImmediateSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ImmediateSchedulerTest.java
@@ -39,6 +39,11 @@ public class ImmediateSchedulerTest extends AbstractSchedulerTest {
 	}
 
 	@Override
+	protected Scheduler freshScheduler() {
+		return Schedulers.immediate();
+	}
+
+	@Override
 	protected boolean shouldCheckInit() {
 		return false;
 	}

--- a/reactor-core/src/test/java/reactor/core/scheduler/ImmediateSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ImmediateSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,11 @@ public class ImmediateSchedulerTest extends AbstractSchedulerTest {
 	@Override
 	protected Scheduler scheduler() {
 		return Schedulers.immediate();
+	}
+
+	@Override
+	protected boolean shouldCheckInit() {
+		return false;
 	}
 
 	@Override

--- a/reactor-core/src/test/java/reactor/core/scheduler/ParallelSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ParallelSchedulerTest.java
@@ -259,6 +259,7 @@ public class ParallelSchedulerTest extends AbstractSchedulerTest {
 		SchedulerState<ScheduledExecutorService[]> stateBefore = ((ParallelScheduler) s).state;
 		assertThat(stateBefore.currentResource).as("SHUTDOWN").isSameAs(ParallelScheduler.SHUTDOWN);
 
+		// TODO: in 3.6.x: remove restart capability and this validation
 		s.start();
 
 		assertThat(((ParallelScheduler) s).state.currentResource)

--- a/reactor-core/src/test/java/reactor/core/scheduler/ParallelSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ParallelSchedulerTest.java
@@ -49,6 +49,14 @@ public class ParallelSchedulerTest extends AbstractSchedulerTest {
 	}
 
 	@Override
+	protected Scheduler freshScheduler() {
+		return Schedulers.factory.newParallel(Schedulers.DEFAULT_POOL_SIZE,
+				new ReactorThreadFactory("ParallelSchedulerTest",
+						ParallelScheduler.COUNTER, false,
+				true, Schedulers::defaultUncaughtException));
+	}
+
+	@Override
 	protected boolean shouldCheckInterrupted() {
 		return true;
 	}

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -790,11 +790,6 @@ public class SchedulersTest {
 			public void start() {
 				throw new IllegalStateException("start");
 			}
-
-			@Override
-			public void init() {
-				throw new IllegalStateException("init");
-			}
 		};
 
 		Schedulers.CachedScheduler cached = new Schedulers.CachedScheduler("cached", mock);
@@ -826,7 +821,10 @@ public class SchedulersTest {
 
 		assertThatExceptionOfType(IllegalStateException.class)
 				.isThrownBy(cached::init)
-				.withMessage("init");
+//				.withMessage("init");
+				// TODO: in 3.6.x uncomment the above and add implementation to the mock.
+				//       To ease the transition, default init() delegates to start().
+				.withMessage("start");
 
 		assertThatExceptionOfType(IllegalStateException.class)
 				.isThrownBy(cached::createWorker)

--- a/reactor-core/src/test/java/reactor/core/scheduler/SingleSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SingleSchedulerTest.java
@@ -211,6 +211,7 @@ public class SingleSchedulerTest extends AbstractSchedulerTest {
 		SchedulerState<ScheduledExecutorService> stateBefore = ((SingleScheduler) s).state;
 		assertThat(stateBefore.currentResource).as("SHUTDOWN").isSameAs(TERMINATED);
 
+		// TODO: in 3.6.x: remove restart capability and this validation
 		s.start();
 
 		assertThat(((SingleScheduler) s).state.currentResource)

--- a/reactor-core/src/test/java/reactor/core/scheduler/SingleSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SingleSchedulerTest.java
@@ -44,6 +44,14 @@ public class SingleSchedulerTest extends AbstractSchedulerTest {
 	}
 
 	@Override
+	protected Scheduler freshScheduler() {
+		return Schedulers.factory.newSingle(new ReactorThreadFactory(
+				"SingleSchedulerTest", SingleScheduler.COUNTER, false, true,
+				Schedulers::defaultUncaughtException
+		));
+	}
+
+	@Override
 	protected boolean shouldCheckInterrupted() {
 		return true;
 	}

--- a/reactor-core/src/test/java/reactor/core/scheduler/SingleWorkerAroundTimerSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SingleWorkerAroundTimerSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,11 @@ public class SingleWorkerAroundTimerSchedulerTest extends AbstractSchedulerTest 
 
 	@Override
 	protected boolean shouldCheckSupportRestart() {
+		return false;
+	}
+
+	@Override
+	protected boolean shouldCheckInit() {
 		return false;
 	}
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/SingleWorkerAroundTimerSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SingleWorkerAroundTimerSchedulerTest.java
@@ -45,4 +45,12 @@ public class SingleWorkerAroundTimerSchedulerTest extends AbstractSchedulerTest 
 	protected Scheduler scheduler() {
 		return Schedulers.single(Schedulers.newSingle("singleWorkerTimer"));
 	}
+
+	@Override
+	protected Scheduler freshScheduler() {
+		return Schedulers.single(Schedulers.factory.newSingle(new ReactorThreadFactory(
+				"SingleSchedulerTest", SingleScheduler.COUNTER, false, true,
+				Schedulers::defaultUncaughtException
+		)));
+	}
 }

--- a/reactor-core/src/test/java/reactor/core/scheduler/SingleWorkerSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SingleWorkerSchedulerTest.java
@@ -32,6 +32,11 @@ public class SingleWorkerSchedulerTest extends AbstractSchedulerTest {
 	}
 
 	@Override
+	protected Scheduler freshScheduler() {
+		return Schedulers.single(Schedulers.immediate());
+	}
+
+	@Override
 	protected boolean shouldCheckInit() {
 		return false;
 	}

--- a/reactor-core/src/test/java/reactor/core/scheduler/SingleWorkerSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SingleWorkerSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,11 @@ public class SingleWorkerSchedulerTest extends AbstractSchedulerTest {
 	@Override
 	protected Scheduler scheduler() {
 		return Schedulers.single(Schedulers.immediate());
+	}
+
+	@Override
+	protected boolean shouldCheckInit() {
+		return false;
 	}
 
 	@Override

--- a/reactor-core/src/test/java/reactor/core/scheduler/TimedSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/TimedSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,14 @@ public class TimedSchedulerTest extends AbstractSchedulerTest {
 	@Override
 	protected Scheduler scheduler() {
 		return Schedulers.newSingle("TimedSchedulerTest");
+	}
+
+	@Override
+	protected Scheduler freshScheduler() {
+		return Schedulers.factory.newSingle(new ReactorThreadFactory(
+				"TimedSchedulerTest", SingleScheduler.COUNTER, false, true,
+				Schedulers::defaultUncaughtException
+		));
 	}
 
 	@Test

--- a/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
+++ b/reactor-test/src/main/java/reactor/test/scheduler/VirtualTimeScheduler.java
@@ -70,7 +70,7 @@ public class VirtualTimeScheduler implements Scheduler {
 	 */
 	public static VirtualTimeScheduler create(boolean defer) {
 		VirtualTimeScheduler instance = new VirtualTimeScheduler(defer);
-		instance.start();
+		instance.init();
 		return instance;
 	}
 


### PR DESCRIPTION
Due to dangers associated with concurrent use of `start()` interleaved with `dispose()` or `disposeGracefully()` to support restart capability in some `Scheduler`s and the unreliability of `isDisposed()` in such scenarios, the `start()` method is now deprecated in favor of a more well defined `init()` method.

Resolves #3202.