### PR TITLE
adds global `onDiscard` hook

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBuffer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBuffer.java
@@ -134,8 +134,9 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends InternalFluxO
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
-				Operators.onDiscard(t, actual.currentContext());
+				Context ctx = actual.currentContext();
+				Operators.onDiscard(t, ctx);
+				Operators.onNextDropped(t, ctx);
 				return;
 			}
 
@@ -284,8 +285,9 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends InternalFluxO
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, this.ctx);
-				Operators.onDiscard(t, this.ctx);
+				Context ctx = this.ctx;
+				Operators.onDiscard(t, ctx);
+				Operators.onNextDropped(t, ctx);
 				return;
 			}
 
@@ -475,8 +477,9 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends InternalFluxO
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
-				Operators.onDiscard(t, actual.currentContext());
+				Context ctx = actual.currentContext();
+				Operators.onDiscard(t, ctx);
+				Operators.onNextDropped(t, ctx);
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBuffer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,6 +135,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends InternalFluxO
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 
@@ -284,6 +285,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends InternalFluxO
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, this.ctx);
+				Operators.onDiscard(t, this.ctx);
 				return;
 			}
 
@@ -474,6 +476,7 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends InternalFluxO
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,6 +173,7 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 			}
 
 			Operators.onNextDropped(t, this.ctx);
+			Operators.onDiscard(t, this.ctx);
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
@@ -172,8 +172,9 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 				}
 			}
 
-			Operators.onNextDropped(t, this.ctx);
-			Operators.onDiscard(t, this.ctx);
+			Context ctx = this.ctx;
+			Operators.onDiscard(t, ctx);
+			Operators.onNextDropped(t, ctx);
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
@@ -205,8 +205,8 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,6 +206,7 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,6 +174,7 @@ final class FluxConcatMapNoPrefetch<T, R> extends InternalFluxOperator<T, R> {
 						break;
 					case TERMINATED:
 						Operators.onNextDropped(t, currentContext());
+						Operators.onDiscard(t, currentContext());
 						break;
 				}
 				return;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
@@ -173,8 +173,8 @@ final class FluxConcatMapNoPrefetch<T, R> extends InternalFluxOperator<T, R> {
 						Operators.onDiscard(t, currentContext());
 						break;
 					case TERMINATED:
-						Operators.onNextDropped(t, currentContext());
 						Operators.onDiscard(t, currentContext());
+						Operators.onNextDropped(t, currentContext());
 						break;
 				}
 				return;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
@@ -153,8 +153,8 @@ final class FluxCreate<T> extends Flux<T> implements SourceProducer<T> {
 		public FluxSink<T> next(T t) {
 			Objects.requireNonNull(t, "t is null in sink.next(t)");
 			if (sink.isTerminated() || done) {
-				Operators.onNextDropped(t, sink.currentContext());
 				Operators.onDiscard(t, sink.currentContext());
+				Operators.onNextDropped(t, sink.currentContext());
 				return this;
 			}
 			if (WIP.get(this) == 0 && WIP.compareAndSet(this, 0, 1)) {
@@ -629,8 +629,8 @@ final class FluxCreate<T> extends Flux<T> implements SourceProducer<T> {
 		@Override
 		public FluxSink<T> next(T t) {
 			if (isTerminated()) {
-				Operators.onNextDropped(t, ctx);
 				Operators.onDiscard(t, ctx);
+				Operators.onNextDropped(t, ctx);
 				return this;
 			}
 			if (isCancelled()) {
@@ -663,8 +663,8 @@ final class FluxCreate<T> extends Flux<T> implements SourceProducer<T> {
 		@Override
 		public final FluxSink<T> next(T t) {
 			if (isTerminated()) {
-				Operators.onNextDropped(t, ctx);
 				Operators.onDiscard(t, ctx);
+				Operators.onNextDropped(t, ctx);
 				return this;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxCreate.java
@@ -154,6 +154,7 @@ final class FluxCreate<T> extends Flux<T> implements SourceProducer<T> {
 			Objects.requireNonNull(t, "t is null in sink.next(t)");
 			if (sink.isTerminated() || done) {
 				Operators.onNextDropped(t, sink.currentContext());
+				Operators.onDiscard(t, sink.currentContext());
 				return this;
 			}
 			if (WIP.get(this) == 0 && WIP.compareAndSet(this, 0, 1)) {
@@ -629,6 +630,7 @@ final class FluxCreate<T> extends Flux<T> implements SourceProducer<T> {
 		public FluxSink<T> next(T t) {
 			if (isTerminated()) {
 				Operators.onNextDropped(t, ctx);
+				Operators.onDiscard(t, ctx);
 				return this;
 			}
 			if (isCancelled()) {
@@ -662,6 +664,7 @@ final class FluxCreate<T> extends Flux<T> implements SourceProducer<T> {
 		public final FluxSink<T> next(T t) {
 			if (isTerminated()) {
 				Operators.onNextDropped(t, ctx);
+				Operators.onDiscard(t, ctx);
 				return this;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDelaySequence.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDelaySequence.java
@@ -94,8 +94,8 @@ final class FluxDelaySequence<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public void onNext(final T t) {
 			if (done || delayed < 0) {
-				Operators.onNextDropped(t, currentContext());
 				Operators.onDiscard(t, currentContext());
+				Operators.onNextDropped(t, currentContext());
 				return;
 			}
 			//keep track of the number of delayed onNext so that

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDelaySequence.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDelaySequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,6 +95,7 @@ final class FluxDelaySequence<T> extends InternalFluxOperator<T, T> {
 		public void onNext(final T t) {
 			if (done || delayed < 0) {
 				Operators.onNextDropped(t, currentContext());
+				Operators.onDiscard(t, currentContext());
 				return;
 			}
 			//keep track of the number of delayed onNext so that

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDematerialize.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDematerialize.java
@@ -82,8 +82,8 @@ final class FluxDematerialize<T> extends InternalFluxOperator<Signal<T>, T> {
 		public void onNext(Signal<T> t) {
 			if (done) {
 				//TODO interpret the Signal and drop differently?
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDematerialize.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDematerialize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,6 +83,7 @@ final class FluxDematerialize<T> extends InternalFluxOperator<Signal<T>, T> {
 			if (done) {
 				//TODO interpret the Signal and drop differently?
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDistinct.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDistinct.java
@@ -133,8 +133,8 @@ final class FluxDistinct<T, K, C> extends InternalFluxOperator<T, T> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, this.ctx);
 				Operators.onDiscard(t, this.ctx);
+				Operators.onNextDropped(t, this.ctx);
 				return true;
 			}
 
@@ -262,8 +262,8 @@ final class FluxDistinct<T, K, C> extends InternalFluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, this.ctx);
 				Operators.onDiscard(t, this.ctx);
+				Operators.onNextDropped(t, this.ctx);
 				return;
 			}
 
@@ -302,8 +302,8 @@ final class FluxDistinct<T, K, C> extends InternalFluxOperator<T, T> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, this.ctx);
 				Operators.onDiscard(t, this.ctx);
+				Operators.onNextDropped(t, this.ctx);
 				return true;
 			}
 
@@ -446,8 +446,8 @@ final class FluxDistinct<T, K, C> extends InternalFluxOperator<T, T> {
 				return true;
 			}
 			if (done) {
-				Operators.onNextDropped(t, this.ctx);
 				Operators.onDiscard(t, this.ctx);
+				Operators.onNextDropped(t, this.ctx);
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDistinct.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDistinct.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,6 +134,7 @@ final class FluxDistinct<T, K, C> extends InternalFluxOperator<T, T> {
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, this.ctx);
+				Operators.onDiscard(t, this.ctx);
 				return true;
 			}
 
@@ -262,6 +263,7 @@ final class FluxDistinct<T, K, C> extends InternalFluxOperator<T, T> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, this.ctx);
+				Operators.onDiscard(t, this.ctx);
 				return;
 			}
 
@@ -301,6 +303,7 @@ final class FluxDistinct<T, K, C> extends InternalFluxOperator<T, T> {
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, this.ctx);
+				Operators.onDiscard(t, this.ctx);
 				return true;
 			}
 
@@ -444,6 +447,7 @@ final class FluxDistinct<T, K, C> extends InternalFluxOperator<T, T> {
 			}
 			if (done) {
 				Operators.onNextDropped(t, this.ctx);
+				Operators.onDiscard(t, this.ctx);
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
@@ -107,8 +107,8 @@ final class FluxDistinctUntilChanged<T, K> extends InternalFluxOperator<T, T> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, ctx);
 				Operators.onDiscard(t, ctx);
+				Operators.onNextDropped(t, ctx);
 				return true;
 			}
 
@@ -244,8 +244,8 @@ final class FluxDistinctUntilChanged<T, K> extends InternalFluxOperator<T, T> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, ctx);
 				Operators.onDiscard(t, ctx);
+				Operators.onNextDropped(t, ctx);
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDistinctUntilChanged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,6 +108,7 @@ final class FluxDistinctUntilChanged<T, K> extends InternalFluxOperator<T, T> {
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, ctx);
+				Operators.onDiscard(t, ctx);
 				return true;
 			}
 
@@ -244,6 +245,7 @@ final class FluxDistinctUntilChanged<T, K> extends InternalFluxOperator<T, T> {
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, ctx);
+				Operators.onDiscard(t, ctx);
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDoOnEach.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDoOnEach.java
@@ -147,6 +147,7 @@ final class FluxDoOnEach<T> extends InternalFluxOperator<T, T> {
 		public void onNext(T t) {
 			if (state == STATE_DONE) {
 				Operators.onNextDropped(t, cachedContext);
+				Operators.onDiscard(t, cachedContext);
 				return;
 			}
 			try {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDoOnEach.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDoOnEach.java
@@ -146,8 +146,8 @@ final class FluxDoOnEach<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (state == STATE_DONE) {
-				Operators.onNextDropped(t, cachedContext);
 				Operators.onDiscard(t, cachedContext);
+				Operators.onNextDropped(t, cachedContext);
 				return;
 			}
 			try {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilter.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilter.java
@@ -89,8 +89,8 @@ final class FluxFilter<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t,  this.ctx);
 				Operators.onDiscard(t, this.ctx);
+				Operators.onNextDropped(t,  this.ctx);
 				return;
 			}
 
@@ -122,8 +122,8 @@ final class FluxFilter<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t,  this.ctx);
 				Operators.onDiscard(t, this.ctx);
+				Operators.onNextDropped(t,  this.ctx);
 				return false;
 			}
 
@@ -225,8 +225,8 @@ final class FluxFilter<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t,  this.ctx);
 				Operators.onDiscard(t, this.ctx);
+				Operators.onNextDropped(t,  this.ctx);
 				return;
 			}
 
@@ -258,8 +258,8 @@ final class FluxFilter<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t,  this.ctx);
 				Operators.onDiscard(t, this.ctx);
+				Operators.onNextDropped(t,  this.ctx);
 				return false;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilter.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,6 +90,7 @@ final class FluxFilter<T> extends InternalFluxOperator<T, T> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t,  this.ctx);
+				Operators.onDiscard(t, this.ctx);
 				return;
 			}
 
@@ -122,6 +123,7 @@ final class FluxFilter<T> extends InternalFluxOperator<T, T> {
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t,  this.ctx);
+				Operators.onDiscard(t, this.ctx);
 				return false;
 			}
 
@@ -224,6 +226,7 @@ final class FluxFilter<T> extends InternalFluxOperator<T, T> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t,  this.ctx);
+				Operators.onDiscard(t, this.ctx);
 				return;
 			}
 
@@ -256,6 +259,7 @@ final class FluxFilter<T> extends InternalFluxOperator<T, T> {
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t,  this.ctx);
+				Operators.onDiscard(t, this.ctx);
 				return false;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,6 +96,7 @@ final class FluxFilterFuseable<T> extends InternalFluxOperator<T, T> implements 
 			else {
 				if (done) {
 					Operators.onNextDropped(t, this.ctx);
+					Operators.onDiscard(t, this.currentContext());
 					return;
 				}
 				boolean b;
@@ -128,6 +129,7 @@ final class FluxFilterFuseable<T> extends InternalFluxOperator<T, T> implements 
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, this.ctx);
+				Operators.onDiscard(t, this.ctx);
 				return false;
 			}
 
@@ -315,6 +317,7 @@ final class FluxFilterFuseable<T> extends InternalFluxOperator<T, T> implements 
 			else {
 				if (done) {
 					Operators.onNextDropped(t, this.ctx);
+					Operators.onDiscard(t, this.ctx);
 					return;
 				}
 				boolean b;
@@ -347,6 +350,7 @@ final class FluxFilterFuseable<T> extends InternalFluxOperator<T, T> implements 
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, this.ctx);
+				Operators.onDiscard(t, this.ctx);
 				return false;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilterFuseable.java
@@ -95,8 +95,8 @@ final class FluxFilterFuseable<T> extends InternalFluxOperator<T, T> implements 
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t, this.ctx);
 					Operators.onDiscard(t, this.currentContext());
+					Operators.onNextDropped(t, this.ctx);
 					return;
 				}
 				boolean b;
@@ -128,8 +128,8 @@ final class FluxFilterFuseable<T> extends InternalFluxOperator<T, T> implements 
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, this.ctx);
 				Operators.onDiscard(t, this.ctx);
+				Operators.onNextDropped(t, this.ctx);
 				return false;
 			}
 
@@ -316,8 +316,8 @@ final class FluxFilterFuseable<T> extends InternalFluxOperator<T, T> implements 
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t, this.ctx);
 					Operators.onDiscard(t, this.ctx);
+					Operators.onNextDropped(t, this.ctx);
 					return;
 				}
 				boolean b;
@@ -349,8 +349,8 @@ final class FluxFilterFuseable<T> extends InternalFluxOperator<T, T> implements 
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, this.ctx);
 				Operators.onDiscard(t, this.ctx);
+				Operators.onNextDropped(t, this.ctx);
 				return false;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -377,6 +377,7 @@ final class FluxFlatMap<T, R> extends InternalFluxOperator<T, R> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 
@@ -973,6 +974,7 @@ final class FluxFlatMap<T, R> extends InternalFluxOperator<T, R> {
 			else {
 				if (done) {
 					Operators.onNextDropped(t, parent.currentContext());
+					Operators.onDiscard(t, parent.currentContext());
 					return;
 				}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -376,8 +376,8 @@ final class FluxFlatMap<T, R> extends InternalFluxOperator<T, R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -973,8 +973,8 @@ final class FluxFlatMap<T, R> extends InternalFluxOperator<T, R> {
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t, parent.currentContext());
 					Operators.onDiscard(t, parent.currentContext());
+					Operators.onNextDropped(t, parent.currentContext());
 					return;
 				}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGenerate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGenerate.java
@@ -160,6 +160,7 @@ extends Flux<T> implements Fuseable, SourceProducer<T> {
 		public void next(T t) {
 			if (terminate) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 			if (hasValue) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGenerate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGenerate.java
@@ -159,8 +159,8 @@ extends Flux<T> implements Fuseable, SourceProducer<T> {
 		@Override
 		public void next(T t) {
 			if (terminate) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			if (hasValue) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGroupBy.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGroupBy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -176,6 +176,7 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 		public void onNext(T t) {
 			if(done){
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGroupBy.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGroupBy.java
@@ -175,8 +175,8 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 		@Override
 		public void onNext(T t) {
 			if(done){
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
@@ -102,8 +102,8 @@ final class FluxHandle<T, R> extends InternalFluxOperator<T, R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -156,8 +156,8 @@ final class FluxHandle<T, R> extends InternalFluxOperator<T, R> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return false;
 			}
 
@@ -318,8 +318,8 @@ final class FluxHandle<T, R> extends InternalFluxOperator<T, R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -373,8 +373,8 @@ final class FluxHandle<T, R> extends InternalFluxOperator<T, R> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return false;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
@@ -103,6 +103,7 @@ final class FluxHandle<T, R> extends InternalFluxOperator<T, R> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 
@@ -156,6 +157,7 @@ final class FluxHandle<T, R> extends InternalFluxOperator<T, R> {
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return false;
 			}
 
@@ -317,6 +319,7 @@ final class FluxHandle<T, R> extends InternalFluxOperator<T, R> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 
@@ -371,6 +374,7 @@ final class FluxHandle<T, R> extends InternalFluxOperator<T, R> {
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return false;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
@@ -109,6 +109,7 @@ final class FluxHandleFuseable<T, R> extends InternalFluxOperator<T, R> implemen
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return true;
 			}
 
@@ -170,6 +171,7 @@ final class FluxHandleFuseable<T, R> extends InternalFluxOperator<T, R> implemen
 			else {
 				if (done) {
 					Operators.onNextDropped(t, actual.currentContext());
+					Operators.onDiscard(t, actual.currentContext());
 					return;
 				}
 				try {
@@ -480,6 +482,7 @@ final class FluxHandleFuseable<T, R> extends InternalFluxOperator<T, R> implemen
 			else  {
 				if (done) {
 					Operators.onNextDropped(t, actual.currentContext());
+					Operators.onDiscard(t, actual.currentContext());
 					return;
 				}
 				try {
@@ -535,6 +538,7 @@ final class FluxHandleFuseable<T, R> extends InternalFluxOperator<T, R> implemen
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
@@ -108,8 +108,8 @@ final class FluxHandleFuseable<T, R> extends InternalFluxOperator<T, R> implemen
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 
@@ -170,8 +170,8 @@ final class FluxHandleFuseable<T, R> extends InternalFluxOperator<T, R> implemen
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t, actual.currentContext());
 					Operators.onDiscard(t, actual.currentContext());
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 				try {
@@ -481,8 +481,8 @@ final class FluxHandleFuseable<T, R> extends InternalFluxOperator<T, R> implemen
 			}
 			else  {
 				if (done) {
-					Operators.onNextDropped(t, actual.currentContext());
 					Operators.onDiscard(t, actual.currentContext());
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 				try {
@@ -537,8 +537,8 @@ final class FluxHandleFuseable<T, R> extends InternalFluxOperator<T, R> implemen
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxIndex.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxIndex.java
@@ -90,8 +90,8 @@ final class FluxIndex<T, I> extends InternalFluxOperator<T, I> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -182,8 +182,8 @@ final class FluxIndex<T, I> extends InternalFluxOperator<T, I> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 
@@ -204,8 +204,8 @@ final class FluxIndex<T, I> extends InternalFluxOperator<T, I> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxIndex.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,6 +91,7 @@ final class FluxIndex<T, I> extends InternalFluxOperator<T, I> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 
@@ -182,6 +183,7 @@ final class FluxIndex<T, I> extends InternalFluxOperator<T, I> {
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return true;
 			}
 
@@ -203,6 +205,7 @@ final class FluxIndex<T, I> extends InternalFluxOperator<T, I> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxIndexFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxIndexFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,6 +114,7 @@ final class FluxIndexFuseable<T, I> extends InternalFluxOperator<T, I>
 			else {
 				if (done) {
 					Operators.onNextDropped(t, actual.currentContext());
+					Operators.onDiscard(t, actual.currentContext());
 					return;
 				}
 
@@ -252,6 +253,7 @@ final class FluxIndexFuseable<T, I> extends InternalFluxOperator<T, I>
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return true;
 			}
 
@@ -277,6 +279,7 @@ final class FluxIndexFuseable<T, I> extends InternalFluxOperator<T, I>
 			else {
 				if (done) {
 					Operators.onNextDropped(t, actual.currentContext());
+					Operators.onDiscard(t, actual.currentContext());
 					return;
 				}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxIndexFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxIndexFuseable.java
@@ -113,8 +113,8 @@ final class FluxIndexFuseable<T, I> extends InternalFluxOperator<T, I>
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t, actual.currentContext());
 					Operators.onDiscard(t, actual.currentContext());
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 
@@ -252,8 +252,8 @@ final class FluxIndexFuseable<T, I> extends InternalFluxOperator<T, I>
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 
@@ -278,8 +278,8 @@ final class FluxIndexFuseable<T, I> extends InternalFluxOperator<T, I>
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t, actual.currentContext());
 					Operators.onDiscard(t, actual.currentContext());
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxLimitRequest.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxLimitRequest.java
@@ -90,8 +90,8 @@ final class FluxLimitRequest<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			long r = toProduce;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxLimitRequest.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxLimitRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,6 +91,7 @@ final class FluxLimitRequest<T> extends InternalFluxOperator<T, T> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 			long r = toProduce;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMap.java
@@ -96,8 +96,8 @@ final class FluxMap<T, R> extends InternalFluxOperator<T, R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -199,8 +199,8 @@ final class FluxMap<T, R> extends InternalFluxOperator<T, R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -229,8 +229,8 @@ final class FluxMap<T, R> extends InternalFluxOperator<T, R> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMap.java
@@ -97,6 +97,7 @@ final class FluxMap<T, R> extends InternalFluxOperator<T, R> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 
@@ -199,6 +200,7 @@ final class FluxMap<T, R> extends InternalFluxOperator<T, R> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 
@@ -228,6 +230,7 @@ final class FluxMap<T, R> extends InternalFluxOperator<T, R> {
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMapFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMapFuseable.java
@@ -104,8 +104,8 @@ final class FluxMapFuseable<T, R> extends InternalFluxOperator<T, R> implements 
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t, actual.currentContext());
 					Operators.onDiscard(t, actual.currentContext());
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 				R v;
@@ -274,8 +274,8 @@ final class FluxMapFuseable<T, R> extends InternalFluxOperator<T, R> implements 
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t, actual.currentContext());
 					Operators.onDiscard(t, actual.currentContext());
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 
@@ -305,8 +305,8 @@ final class FluxMapFuseable<T, R> extends InternalFluxOperator<T, R> implements 
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMapFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMapFuseable.java
@@ -105,6 +105,7 @@ final class FluxMapFuseable<T, R> extends InternalFluxOperator<T, R> implements 
 			else {
 				if (done) {
 					Operators.onNextDropped(t, actual.currentContext());
+					Operators.onDiscard(t, actual.currentContext());
 					return;
 				}
 				R v;
@@ -274,6 +275,7 @@ final class FluxMapFuseable<T, R> extends InternalFluxOperator<T, R> implements 
 			else {
 				if (done) {
 					Operators.onNextDropped(t, actual.currentContext());
+					Operators.onDiscard(t, actual.currentContext());
 					return;
 				}
 
@@ -304,6 +306,7 @@ final class FluxMapFuseable<T, R> extends InternalFluxOperator<T, R> implements 
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMapSignal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMapSignal.java
@@ -131,6 +131,7 @@ final class FluxMapSignal<T, R> extends InternalFluxOperator<T, R> {
         public void onNext(T t) {
 	        if (done) {
 	            Operators.onNextDropped(t, actual.currentContext());
+		        Operators.onDiscard(t, actual.currentContext());
                 return;
             }
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMapSignal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMapSignal.java
@@ -130,8 +130,8 @@ final class FluxMapSignal<T, R> extends InternalFluxOperator<T, R> {
         @Override
         public void onNext(T t) {
 	        if (done) {
-	            Operators.onNextDropped(t, actual.currentContext());
 		        Operators.onDiscard(t, actual.currentContext());
+	            Operators.onNextDropped(t, actual.currentContext());
                 return;
             }
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMaterialize.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMaterialize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,6 +108,7 @@ final class FluxMaterialize<T> extends InternalFluxOperator<T, Signal<T>> {
 		public void onNext(T ev) {
 			if(terminalSignal != null){
 				Operators.onNextDropped(ev, this.cachedContext);
+				Operators.onDiscard(ev, actual.currentContext());
 				return;
 			}
 		    produced++;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMaterialize.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMaterialize.java
@@ -107,8 +107,8 @@ final class FluxMaterialize<T> extends InternalFluxOperator<T, Signal<T>> {
 		@Override
 		public void onNext(T ev) {
 			if(terminalSignal != null){
-				Operators.onNextDropped(ev, this.cachedContext);
 				Operators.onDiscard(ev, actual.currentContext());
+				Operators.onNextDropped(ev, this.cachedContext);
 				return;
 			}
 		    produced++;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMergeComparing.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMergeComparing.java
@@ -426,8 +426,8 @@ final class FluxMergeComparing<T> extends Flux<T> implements SourceProducer<T> {
 		@Override
 		public void onNext(T item) {
 			if (parent.done || done) {
-				Operators.onNextDropped(item, actual().currentContext());
 				Operators.onDiscard(item, actual().currentContext());
+				Operators.onNextDropped(item, actual().currentContext());
 				return;
 			}
 			queue.offer(item);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMergeComparing.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMergeComparing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -427,6 +427,7 @@ final class FluxMergeComparing<T> extends Flux<T> implements SourceProducer<T> {
 		public void onNext(T item) {
 			if (parent.done || done) {
 				Operators.onNextDropped(item, actual().currentContext());
+				Operators.onDiscard(item, actual().currentContext());
 				return;
 			}
 			queue.offer(item);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
@@ -172,6 +172,7 @@ final class FluxMetrics<T> extends InternalFluxOperator<T, T> {
 			if (done) {
 				recordMalformed(sequenceName, commonTags, registry);
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetrics.java
@@ -171,8 +171,8 @@ final class FluxMetrics<T> extends InternalFluxOperator<T, T> {
 		public void onNext(T t) {
 			if (done) {
 				recordMalformed(sequenceName, commonTags, registry);
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetricsFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetricsFuseable.java
@@ -108,8 +108,8 @@ final class FluxMetricsFuseable<T> extends InternalFluxOperator<T, T> implements
 
 			if (done) {
 				recordMalformed(sequenceName, commonTags, registry);
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetricsFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetricsFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMetricsFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMetricsFuseable.java
@@ -109,6 +109,7 @@ final class FluxMetricsFuseable<T> extends InternalFluxOperator<T, T> implements
 			if (done) {
 				recordMalformed(sequenceName, commonTags, registry);
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBuffer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBuffer.java
@@ -166,8 +166,8 @@ final class FluxOnBackpressureBuffer<O> extends InternalFluxOperator<O, O> imple
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, ctx);
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, ctx);
 				return;
 			}
 			if (cancelled) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBuffer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,6 +167,7 @@ final class FluxOnBackpressureBuffer<O> extends InternalFluxOperator<O, O> imple
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, ctx);
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 			if (cancelled) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
@@ -146,8 +146,8 @@ final class FluxOnBackpressureBufferStrategy<O> extends InternalFluxOperator<O, 
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, ctx);
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, ctx);
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnBackpressureBufferStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,6 +147,7 @@ final class FluxOnBackpressureBufferStrategy<O> extends InternalFluxOperator<O, 
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, ctx);
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPeek.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPeek.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -176,6 +176,7 @@ final class FluxPeek<T> extends InternalFluxOperator<T, T> implements SignalPeek
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPeek.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPeek.java
@@ -175,8 +175,8 @@ final class FluxPeek<T> extends InternalFluxOperator<T, T> implements SignalPeek
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
@@ -186,8 +186,8 @@ final class FluxPeekFuseable<T> extends InternalFluxOperator<T, T>
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t, actual.currentContext());
 					Operators.onDiscard(t, actual.currentContext());
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 
@@ -480,8 +480,8 @@ final class FluxPeekFuseable<T> extends InternalFluxOperator<T, T>
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t, actual.currentContext());
 					Operators.onDiscard(t, actual.currentContext());
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 
@@ -509,8 +509,8 @@ final class FluxPeekFuseable<T> extends InternalFluxOperator<T, T>
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return false;
 			}
 
@@ -833,8 +833,8 @@ final class FluxPeekFuseable<T> extends InternalFluxOperator<T, T>
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -861,8 +861,8 @@ final class FluxPeekFuseable<T> extends InternalFluxOperator<T, T>
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return false;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -187,6 +187,7 @@ final class FluxPeekFuseable<T> extends InternalFluxOperator<T, T>
 			else {
 				if (done) {
 					Operators.onNextDropped(t, actual.currentContext());
+					Operators.onDiscard(t, actual.currentContext());
 					return;
 				}
 
@@ -480,6 +481,7 @@ final class FluxPeekFuseable<T> extends InternalFluxOperator<T, T>
 			else {
 				if (done) {
 					Operators.onNextDropped(t, actual.currentContext());
+					Operators.onDiscard(t, actual.currentContext());
 					return;
 				}
 
@@ -508,6 +510,7 @@ final class FluxPeekFuseable<T> extends InternalFluxOperator<T, T>
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return false;
 			}
 
@@ -831,6 +834,7 @@ final class FluxPeekFuseable<T> extends InternalFluxOperator<T, T>
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 
@@ -858,6 +862,7 @@ final class FluxPeekFuseable<T> extends InternalFluxOperator<T, T>
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return false;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -260,8 +260,8 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 		public void onNext(T t) {
 			if (done) {
 				if (t != null) {
-					Operators.onNextDropped(t, currentContext());
 					Operators.onDiscard(t, currentContext());
+					Operators.onNextDropped(t, currentContext());
 				}
 				return;
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -261,6 +261,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 			if (done) {
 				if (t != null) {
 					Operators.onNextDropped(t, currentContext());
+					Operators.onDiscard(t, currentContext());
 				}
 				return;
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
@@ -260,8 +260,8 @@ final class FluxPublishMulticast<T, R> extends InternalFluxOperator<T, R> implem
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, context);
 				Operators.onDiscard(t, context);
+				Operators.onNextDropped(t, context);
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -261,6 +261,7 @@ final class FluxPublishMulticast<T, R> extends InternalFluxOperator<T, R> implem
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, context);
+				Operators.onDiscard(t, context);
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -219,6 +219,7 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 
@@ -782,6 +783,7 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishOn.java
@@ -218,8 +218,8 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 			}
 
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -782,8 +782,8 @@ final class FluxPublishOn<T> extends InternalFluxOperator<T, T> implements Fusea
 			}
 
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -1316,6 +1316,7 @@ final class FluxReplay<T> extends ConnectableFlux<T>
 			ReplayBuffer<T> b = buffer;
 			if (b.isDone()) {
 				Operators.onNextDropped(t, currentContext());
+				Operators.onDiscard(t, currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -1315,8 +1315,8 @@ final class FluxReplay<T> extends ConnectableFlux<T>
 		public void onNext(T t) {
 			ReplayBuffer<T> b = buffer;
 			if (b.isDone()) {
-				Operators.onNextDropped(t, currentContext());
 				Operators.onDiscard(t, currentContext());
+				Operators.onNextDropped(t, currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxScan.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxScan.java
@@ -91,8 +91,8 @@ final class FluxScan<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxScan.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,6 +92,7 @@ final class FluxScan<T> extends InternalFluxOperator<T, T> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxScanSeed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxScanSeed.java
@@ -218,8 +218,8 @@ final class FluxScanSeed<T, R> extends InternalFluxOperator<T, R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxScanSeed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxScanSeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -219,6 +219,7 @@ final class FluxScanSeed<T, R> extends InternalFluxOperator<T, R> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSkipUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSkipUntil.java
@@ -83,8 +83,8 @@ final class FluxSkipUntil<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, ctx);
 				Operators.onDiscard(t, ctx);
+				Operators.onNextDropped(t, ctx);
 				return;
 			}
 
@@ -114,8 +114,8 @@ final class FluxSkipUntil<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, ctx);
 				Operators.onDiscard(t, ctx);
+				Operators.onNextDropped(t, ctx);
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSkipUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSkipUntil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,6 +84,7 @@ final class FluxSkipUntil<T> extends InternalFluxOperator<T, T> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, ctx);
+				Operators.onDiscard(t, ctx);
 				return;
 			}
 
@@ -114,6 +115,7 @@ final class FluxSkipUntil<T> extends InternalFluxOperator<T, T> {
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, ctx);
+				Operators.onDiscard(t, ctx);
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSkipWhile.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSkipWhile.java
@@ -82,8 +82,8 @@ final class FluxSkipWhile<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, ctx);
 				Operators.onDiscard(t, ctx);
+				Operators.onNextDropped(t, ctx);
 				return;
 			}
 
@@ -114,8 +114,8 @@ final class FluxSkipWhile<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, ctx);
 				Operators.onDiscard(t, ctx);
+				Operators.onNextDropped(t, ctx);
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSkipWhile.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSkipWhile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,6 +83,7 @@ final class FluxSkipWhile<T> extends InternalFluxOperator<T, T> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, ctx);
+				Operators.onDiscard(t, ctx);
 				return;
 			}
 
@@ -114,6 +115,7 @@ final class FluxSkipWhile<T> extends InternalFluxOperator<T, T> {
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, ctx);
+				Operators.onDiscard(t, ctx);
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,6 +206,7 @@ final class FluxSwitchMap<T, R> extends InternalFluxOperator<T, R> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
@@ -205,8 +205,8 @@ final class FluxSwitchMap<T, R> extends InternalFluxOperator<T, R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMapNoPrefetch.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMapNoPrefetch.java
@@ -151,8 +151,8 @@ final class FluxSwitchMapNoPrefetch<T, R> extends InternalFluxOperator<T, R> {
 		@Override
 		public void onNext(T t) {
 			if (this.done) {
-				Operators.onNextDropped(t, this.actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, this.actual.currentContext());
 				return;
 			}
 
@@ -383,8 +383,8 @@ final class FluxSwitchMapNoPrefetch<T, R> extends InternalFluxOperator<T, R> {
 		@Override
 		public void onNext(R t) {
 			if (this.done) {
-				Operators.onNextDropped(t, this.actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, this.actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMapNoPrefetch.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMapNoPrefetch.java
@@ -152,6 +152,7 @@ final class FluxSwitchMapNoPrefetch<T, R> extends InternalFluxOperator<T, R> {
 		public void onNext(T t) {
 			if (this.done) {
 				Operators.onNextDropped(t, this.actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 
@@ -383,6 +384,7 @@ final class FluxSwitchMapNoPrefetch<T, R> extends InternalFluxOperator<T, R> {
 		public void onNext(R t) {
 			if (this.done) {
 				Operators.onNextDropped(t, this.actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
@@ -504,8 +504,8 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 		@Override
 		public final void onNext(T t) {
 			if (this.done) {
-				Operators.onNextDropped(t, currentContext());
 				Operators.onDiscard(t, currentContext());
+				Operators.onNextDropped(t, currentContext());
 				return;
 			}
 
@@ -830,8 +830,8 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 		@SuppressWarnings("unchecked")
 		public boolean tryOnNext(T t) {
 			if (this.done) {
-				Operators.onNextDropped(t, currentContext());
 				Operators.onDiscard(t, currentContext());
+				Operators.onNextDropped(t, currentContext());
 				return false;
 			}
 
@@ -926,8 +926,8 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 		@Override
 		public final void onNext(T t) {
 			if (this.done) {
-				Operators.onNextDropped(t, currentContext());
 				Operators.onDiscard(t, currentContext());
+				Operators.onNextDropped(t, currentContext());
 				return;
 			}
 
@@ -1036,8 +1036,8 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (this.done) {
-				Operators.onNextDropped(t, currentContext());
 				Operators.onDiscard(t, currentContext());
+				Operators.onNextDropped(t, currentContext());
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
@@ -505,6 +505,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 		public final void onNext(T t) {
 			if (this.done) {
 				Operators.onNextDropped(t, currentContext());
+				Operators.onDiscard(t, currentContext());
 				return;
 			}
 
@@ -830,6 +831,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 		public boolean tryOnNext(T t) {
 			if (this.done) {
 				Operators.onNextDropped(t, currentContext());
+				Operators.onDiscard(t, currentContext());
 				return false;
 			}
 
@@ -925,6 +927,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 		public final void onNext(T t) {
 			if (this.done) {
 				Operators.onNextDropped(t, currentContext());
+				Operators.onDiscard(t, currentContext());
 				return;
 			}
 
@@ -1034,6 +1037,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 		public boolean tryOnNext(T t) {
 			if (this.done) {
 				Operators.onNextDropped(t, currentContext());
+				Operators.onDiscard(t, currentContext());
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTake.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,6 +111,7 @@ final class FluxTake<T> extends InternalFluxOperator<T, T> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 
@@ -233,6 +234,7 @@ final class FluxTake<T> extends InternalFluxOperator<T, T> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 
@@ -260,6 +262,7 @@ final class FluxTake<T> extends InternalFluxOperator<T, T> {
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return true;
 			}
 
@@ -390,6 +393,7 @@ final class FluxTake<T> extends InternalFluxOperator<T, T> {
 			}
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTake.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTake.java
@@ -110,8 +110,8 @@ final class FluxTake<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -233,8 +233,8 @@ final class FluxTake<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -261,8 +261,8 @@ final class FluxTake<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return true;
 			}
 
@@ -392,8 +392,8 @@ final class FluxTake<T> extends InternalFluxOperator<T, T> {
 				return;
 			}
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntil.java
@@ -77,8 +77,8 @@ final class FluxTakeUntil<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,7 @@ final class FluxTakeUntil<T> extends InternalFluxOperator<T, T> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTakeWhile.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTakeWhile.java
@@ -76,8 +76,8 @@ final class FluxTakeWhile<T> extends InternalFluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTakeWhile.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTakeWhile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,7 @@ final class FluxTakeWhile<T> extends InternalFluxOperator<T, T> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTimed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTimed.java
@@ -164,8 +164,8 @@ final class FluxTimed<T> extends InternalFluxOperator<T, Timed<T>> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, currentContext());
 				Operators.onDiscard(t, currentContext());
+				Operators.onNextDropped(t, currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTimed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTimed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,6 +165,7 @@ final class FluxTimed<T> extends InternalFluxOperator<T, Timed<T>> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, currentContext());
+				Operators.onDiscard(t, currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -169,11 +169,13 @@ final class FluxTimeout<T, U, V> extends InternalFluxOperator<T, T> {
 			if (idx == Long.MIN_VALUE) {
 				s.cancel();
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 			if (!INDEX.compareAndSet(this, idx, idx + 1)) {
 				s.cancel();
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTimeout.java
@@ -168,14 +168,14 @@ final class FluxTimeout<T, U, V> extends InternalFluxOperator<T, T> {
 			long idx = index;
 			if (idx == Long.MIN_VALUE) {
 				s.cancel();
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			if (!INDEX.compareAndSet(this, idx, idx + 1)) {
 				s.cancel();
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxUsingWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxUsingWhen.java
@@ -185,8 +185,8 @@ final class FluxUsingWhen<T, S> extends Flux<T> implements SourceProducer<T> {
 		@Override
 		public void onNext(S resource) {
 			if (resourceProvided) {
-				Operators.onNextDropped(resource, actual.currentContext());
 				Operators.onDiscard(resource, actual.currentContext());
+				Operators.onNextDropped(resource, actual.currentContext());
 				return;
 			}
 			resourceProvided = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxUsingWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxUsingWhen.java
@@ -186,6 +186,7 @@ final class FluxUsingWhen<T, S> extends Flux<T> implements SourceProducer<T> {
 		public void onNext(S resource) {
 			if (resourceProvided) {
 				Operators.onNextDropped(resource, actual.currentContext());
+				Operators.onDiscard(resource, actual.currentContext());
 				return;
 			}
 			resourceProvided = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindow.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindow.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindow.java
@@ -155,8 +155,8 @@ final class FluxWindow<T> extends InternalFluxOperator<T, Flux<T>> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 
@@ -326,8 +326,8 @@ final class FluxWindow<T> extends InternalFluxOperator<T, Flux<T>> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, ctx);
 				Operators.onDiscard(t, ctx);
+				Operators.onNextDropped(t, ctx);
 				return;
 			}
 
@@ -533,8 +533,8 @@ final class FluxWindow<T> extends InternalFluxOperator<T, Flux<T>> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindow.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindow.java
@@ -156,6 +156,7 @@ final class FluxWindow<T> extends InternalFluxOperator<T, Flux<T>> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 
@@ -326,6 +327,7 @@ final class FluxWindow<T> extends InternalFluxOperator<T, Flux<T>> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, ctx);
+				Operators.onDiscard(t, ctx);
 				return;
 			}
 
@@ -532,6 +534,7 @@ final class FluxWindow<T> extends InternalFluxOperator<T, Flux<T>> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
@@ -182,6 +182,7 @@ final class FluxWindowBoundary<T, U> extends InternalFluxOperator<T, Flux<T>> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 			synchronized (this) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
@@ -181,8 +181,8 @@ final class FluxWindowBoundary<T, U> extends InternalFluxOperator<T, Flux<T>> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			synchronized (this) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
@@ -210,8 +210,8 @@ final class FluxWindowPredicate<T> extends InternalFluxOperator<T, Flux<T>>
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, ctx);
 				Operators.onDiscard(t, ctx);
+				Operators.onNextDropped(t, ctx);
 				return;
 			}
 			WindowFlux<T> g = window;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
@@ -211,6 +211,7 @@ final class FluxWindowPredicate<T> extends InternalFluxOperator<T, Flux<T>>
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, ctx);
+				Operators.onDiscard(t, ctx);
 				return;
 			}
 			WindowFlux<T> g = window;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
@@ -173,6 +173,7 @@ final class FluxWindowTimeout<T> extends InternalFluxOperator<T, Flux<T>> {
 		public void onNext(T t) {
 			if (this.done) {
 				Operators.onNextDropped(t, this.actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
@@ -172,8 +172,8 @@ final class FluxWindowTimeout<T> extends InternalFluxOperator<T, Flux<T>> {
 		@Override
 		public void onNext(T t) {
 			if (this.done) {
-				Operators.onNextDropped(t, this.actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, this.actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
@@ -142,6 +142,7 @@ final class FluxWindowWhen<T, U, V> extends InternalFluxOperator<T, Flux<T>> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 			if (fastEnter()) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
@@ -141,8 +141,8 @@ final class FluxWindowWhen<T, U, V> extends InternalFluxOperator<T, Flux<T>> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			if (fastEnter()) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxZip.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxZip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxZip.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxZip.java
@@ -507,6 +507,7 @@ final class FluxZip<T, R> extends Flux<R> implements SourceProducer<R> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, parent.currentContext());
+				Operators.onDiscard(t, parent.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxZip.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxZip.java
@@ -506,8 +506,8 @@ final class FluxZip<T, R> extends Flux<R> implements SourceProducer<R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, parent.currentContext());
 				Operators.onDiscard(t, parent.currentContext());
+				Operators.onNextDropped(t, parent.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxZipIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxZipIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,6 +111,7 @@ final class FluxZipIterable<T, U, R> extends InternalFluxOperator<T, R> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxZipIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxZipIterable.java
@@ -110,8 +110,8 @@ final class FluxZipIterable<T, U, R> extends InternalFluxOperator<T, R> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalManySink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalManySink.java
@@ -50,8 +50,8 @@ interface InternalManySink<T> extends Sinks.Many<T>, ContextHolder {
 					Operators.onDiscard(value, currentContext());
 					return;
 				case FAIL_TERMINATED:
-					Operators.onNextDropped(value, currentContext());
 					Operators.onDiscard(value, currentContext());
+					Operators.onNextDropped(value, currentContext());
 					return;
 				case FAIL_NON_SERIALIZED:
 					throw new EmissionException(emitResult,

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalManySink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalManySink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ interface InternalManySink<T> extends Sinks.Many<T>, ContextHolder {
 					return;
 				case FAIL_TERMINATED:
 					Operators.onNextDropped(value, currentContext());
+					Operators.onDiscard(value, currentContext());
 					return;
 				case FAIL_NON_SERIALIZED:
 					throw new EmissionException(emitResult,

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalOneSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalOneSink.java
@@ -56,8 +56,8 @@ interface InternalOneSink<T> extends Sinks.One<T>, InternalEmptySink<T> {
 					Operators.onDiscard(value, currentContext());
 					return;
 				case FAIL_TERMINATED:
-					Operators.onNextDropped(value, currentContext());
 					Operators.onDiscard(value, currentContext());
+					Operators.onNextDropped(value, currentContext());
 					return;
 				case FAIL_NON_SERIALIZED:
 					throw new EmissionException(emitResult,

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalOneSink.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalOneSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ interface InternalOneSink<T> extends Sinks.One<T>, InternalEmptySink<T> {
 					return;
 				case FAIL_TERMINATED:
 					Operators.onNextDropped(value, currentContext());
+					Operators.onDiscard(value, currentContext());
 					return;
 				case FAIL_NON_SERIALIZED:
 					throw new EmissionException(emitResult,

--- a/reactor-core/src/main/java/reactor/core/publisher/LambdaMonoSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/LambdaMonoSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -164,6 +164,7 @@ final class LambdaMonoSubscriber<T> implements InnerConsumer<T>, Disposable {
 		Subscription s = S.getAndSet(this, Operators.cancelledSubscription());
 		if (s == Operators.cancelledSubscription()) {
 			Operators.onNextDropped(x, this.initialContext);
+			Operators.onDiscard(x, this.initialContext);
 			return;
 		}
 		if (consumer != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/LambdaMonoSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/LambdaMonoSubscriber.java
@@ -163,8 +163,8 @@ final class LambdaMonoSubscriber<T> implements InnerConsumer<T>, Disposable {
 	public final void onNext(T x) {
 		Subscription s = S.getAndSet(this, Operators.cancelledSubscription());
 		if (s == Operators.cancelledSubscription()) {
-			Operators.onNextDropped(x, this.initialContext);
 			Operators.onDiscard(x, this.initialContext);
+			Operators.onNextDropped(x, this.initialContext);
 			return;
 		}
 		if (consumer != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateIf.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateIf.java
@@ -308,8 +308,8 @@ final class MonoCacheInvalidateIf<T> extends InternalMonoOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (main.state != this || done) {
-				Operators.onNextDropped(t, currentContext());
 				Operators.onDiscard(t, currentContext());
+				Operators.onNextDropped(t, currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateIf.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateIf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -309,6 +309,7 @@ final class MonoCacheInvalidateIf<T> extends InternalMonoOperator<T, T> {
 		public void onNext(T t) {
 			if (main.state != this || done) {
 				Operators.onNextDropped(t, currentContext());
+				Operators.onDiscard(t, currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
@@ -325,8 +325,8 @@ class MonoCacheTime<T> extends InternalMonoOperator<T, T> implements Runnable {
 					//error during TTL generation, signal != updatedSignal, aka dropped
 					if (signal.isOnNext()) {
 						T s = signal.get();
-						Operators.onNextDropped(s, currentContext());
 						Operators.onDiscard(s, currentContext());
+						Operators.onNextDropped(s, currentContext());
 					}
 					//if signal.isOnError(), avoid dropping the error. it is not really dropped but already suppressed
 					//in all cases, unless nextDropped hook throws, immediate cache clear

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -324,7 +324,9 @@ class MonoCacheTime<T> extends InternalMonoOperator<T, T> implements Runnable {
 				else {
 					//error during TTL generation, signal != updatedSignal, aka dropped
 					if (signal.isOnNext()) {
-						Operators.onNextDropped(signal.get(), currentContext());
+						T s = signal.get();
+						Operators.onNextDropped(s, currentContext());
+						Operators.onDiscard(s, currentContext());
 					}
 					//if signal.isOnError(), avoid dropping the error. it is not really dropped but already suppressed
 					//in all cases, unless nextDropped hook throws, immediate cache clear

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollect.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollect.java
@@ -109,6 +109,7 @@ final class MonoCollect<T, R> extends MonoFromFluxOperator<T, R>
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 			R c;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollect.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollect.java
@@ -108,8 +108,8 @@ final class MonoCollect<T, R> extends MonoFromFluxOperator<T, R>
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			R c;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
@@ -85,6 +85,7 @@ final class MonoCollectList<T> extends MonoFromFluxOperator<T, List<T>> implemen
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 			List<T> l;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCollectList.java
@@ -84,8 +84,8 @@ final class MonoCollectList<T> extends MonoFromFluxOperator<T, List<T>> implemen
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			List<T> l;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
@@ -157,15 +157,15 @@ final class MonoCreate<T> extends Mono<T> implements SourceProducer<T> {
 				return;
 			}
 			else if (d == TERMINATED) {
-				Operators.onNextDropped(value, actual.currentContext());
 				Operators.onDiscard(value, actual.currentContext());
+				Operators.onNextDropped(value, actual.currentContext());
 				return;
 			}
 			for (; ; ) {
 				int s = state;
 				if (s == HAS_REQUEST_HAS_VALUE || s == NO_REQUEST_HAS_VALUE) {
-					Operators.onNextDropped(value, actual.currentContext());
 					Operators.onDiscard(value, actual.currentContext());
+					Operators.onNextDropped(value, actual.currentContext());
 					return;
 				}
 				if (s == HAS_REQUEST_NO_VALUE) {
@@ -181,8 +181,8 @@ final class MonoCreate<T> extends Mono<T> implements SourceProducer<T> {
 							disposeResource(false);
 						}
 					} else {
-						Operators.onNextDropped(value, actual.currentContext());
 						Operators.onDiscard(value, actual.currentContext());
+						Operators.onNextDropped(value, actual.currentContext());
 					}
 					return;
 				}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCreate.java
@@ -158,12 +158,14 @@ final class MonoCreate<T> extends Mono<T> implements SourceProducer<T> {
 			}
 			else if (d == TERMINATED) {
 				Operators.onNextDropped(value, actual.currentContext());
+				Operators.onDiscard(value, actual.currentContext());
 				return;
 			}
 			for (; ; ) {
 				int s = state;
 				if (s == HAS_REQUEST_HAS_VALUE || s == NO_REQUEST_HAS_VALUE) {
 					Operators.onNextDropped(value, actual.currentContext());
+					Operators.onDiscard(value, actual.currentContext());
 					return;
 				}
 				if (s == HAS_REQUEST_NO_VALUE) {
@@ -180,6 +182,7 @@ final class MonoCreate<T> extends Mono<T> implements SourceProducer<T> {
 						}
 					} else {
 						Operators.onNextDropped(value, actual.currentContext());
+						Operators.onDiscard(value, actual.currentContext());
 					}
 					return;
 				}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelayElement.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelayElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelayElement.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelayElement.java
@@ -117,8 +117,8 @@ final class MonoDelayElement<T> extends InternalMonoOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			this.done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelayElement.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelayElement.java
@@ -118,6 +118,7 @@ final class MonoDelayElement<T> extends InternalMonoOperator<T, T> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 			this.done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoElementAt.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoElementAt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoElementAt.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoElementAt.java
@@ -122,8 +122,8 @@ final class MonoElementAt<T> extends MonoFromFluxOperator<T, T>
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoElementAt.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoElementAt.java
@@ -123,6 +123,7 @@ final class MonoElementAt<T> extends MonoFromFluxOperator<T, T>
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMap.java
@@ -114,8 +114,8 @@ final class MonoFlatMap<T, R> extends InternalMonoOperator<T, R> implements Fuse
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -243,8 +243,8 @@ final class MonoFlatMap<T, R> extends InternalMonoOperator<T, R> implements Fuse
 		@Override
 		public void onNext(R t) {
 			if (done) {
-				Operators.onNextDropped(t, parent.currentContext());
 				Operators.onDiscard(t, parent.currentContext());
+				Operators.onNextDropped(t, parent.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMap.java
@@ -115,6 +115,7 @@ final class MonoFlatMap<T, R> extends InternalMonoOperator<T, R> implements Fuse
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 			done = true;
@@ -243,6 +244,7 @@ final class MonoFlatMap<T, R> extends InternalMonoOperator<T, R> implements Fuse
 		public void onNext(R t) {
 			if (done) {
 				Operators.onNextDropped(t, parent.currentContext());
+				Operators.onDiscard(t, parent.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMaterialize.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMaterialize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,6 +96,7 @@ final class MonoMaterialize<T> extends InternalMonoOperator<T, Signal<T>> {
 			if (alreadyReceivedSignalFromSource || !requested) {
 				//protocol error: there was an onNext, onComplete or onError before (which are all breaking RS or Mono contract)
 				Operators.onNextDropped(t, currentContext());
+				Operators.onDiscard(t, currentContext());
 				return;
 			}
 			alreadyReceivedSignalFromSource = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMaterialize.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMaterialize.java
@@ -95,8 +95,8 @@ final class MonoMaterialize<T> extends InternalMonoOperator<T, Signal<T>> {
 		public void onNext(T t) {
 			if (alreadyReceivedSignalFromSource || !requested) {
 				//protocol error: there was an onNext, onComplete or onError before (which are all breaking RS or Mono contract)
-				Operators.onNextDropped(t, currentContext());
 				Operators.onDiscard(t, currentContext());
+				Operators.onNextDropped(t, currentContext());
 				return;
 			}
 			alreadyReceivedSignalFromSource = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
@@ -120,6 +120,7 @@ final class MonoMetrics<T> extends InternalMonoOperator<T, T> {
 			if (done) {
 				recordMalformed(sequenceName, commonTags, registry);
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMetrics.java
@@ -119,8 +119,8 @@ final class MonoMetrics<T> extends InternalMonoOperator<T, T> {
 		public void onNext(T t) {
 			if (done) {
 				recordMalformed(sequenceName, commonTags, registry);
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMetricsFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMetricsFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMetricsFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMetricsFuseable.java
@@ -122,6 +122,7 @@ final class MonoMetricsFuseable<T> extends InternalMonoOperator<T, T> implements
 				if (done) {
 					FluxMetrics.recordMalformed(sequenceName, commonTags, registry);
 					Operators.onNextDropped(t, actual.currentContext());
+					Operators.onDiscard(t, actual.currentContext());
 					return;
 				}
 				done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoMetricsFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoMetricsFuseable.java
@@ -121,8 +121,8 @@ final class MonoMetricsFuseable<T> extends InternalMonoOperator<T, T> implements
 			else {
 				if (done) {
 					FluxMetrics.recordMalformed(sequenceName, commonTags, registry);
-					Operators.onNextDropped(t, actual.currentContext());
 					Operators.onDiscard(t, actual.currentContext());
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 				done = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoNext.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoNext.java
@@ -74,8 +74,8 @@ final class MonoNext<T> extends MonoFromFluxOperator<T, T> {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoNext.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoNext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,7 @@ final class MonoNext<T> extends MonoFromFluxOperator<T, T> {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPeekTerminal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPeekTerminal.java
@@ -160,6 +160,7 @@ final class MonoPeekTerminal<T> extends InternalMonoOperator<T, T> implements Fu
 			else {
 				if (done) {
 					Operators.onNextDropped(t, actual.currentContext());
+					Operators.onDiscard(t, actual.currentContext());
 					return;
 				}
 				//implementation note: this operator doesn't expect the source to be anything but a Mono
@@ -197,6 +198,7 @@ final class MonoPeekTerminal<T> extends InternalMonoOperator<T, T> implements Fu
 		public boolean tryOnNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return false;
 			}
 			if (actualConditional == null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPeekTerminal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPeekTerminal.java
@@ -159,8 +159,8 @@ final class MonoPeekTerminal<T> extends InternalMonoOperator<T, T> implements Fu
 			}
 			else {
 				if (done) {
-					Operators.onNextDropped(t, actual.currentContext());
 					Operators.onDiscard(t, actual.currentContext());
+					Operators.onNextDropped(t, actual.currentContext());
 					return;
 				}
 				//implementation note: this operator doesn't expect the source to be anything but a Mono
@@ -197,8 +197,8 @@ final class MonoPeekTerminal<T> extends InternalMonoOperator<T, T> implements Fu
 		@Override
 		public boolean tryOnNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return false;
 			}
 			if (actualConditional == null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPublishMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPublishMulticast.java
@@ -184,8 +184,8 @@ final class MonoPublishMulticast<T, R> extends InternalMonoOperator<T, R> implem
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, context);
 				Operators.onDiscard(t, context);
+				Operators.onNextDropped(t, context);
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPublishMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPublishMulticast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -185,6 +185,7 @@ final class MonoPublishMulticast<T, R> extends InternalMonoOperator<T, R> implem
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, context);
+				Operators.onDiscard(t, context);
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoReduce.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoReduce.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoReduce.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoReduce.java
@@ -89,8 +89,8 @@ final class MonoReduce<T> extends MonoFromFluxOperator<T, T>
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			T r = this.value;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoReduce.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoReduce.java
@@ -90,6 +90,7 @@ final class MonoReduce<T> extends MonoFromFluxOperator<T, T>
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 			T r = this.value;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSingle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSingle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -125,6 +125,7 @@ final class MonoSingle<T> extends MonoFromFluxOperator<T, T> {
 			}
 			if (done) {
 				Operators.onNextDropped(t, actual().currentContext());
+				Operators.onDiscard(t, actual().currentContext());
 				return;
 			}
 			if (++count > 1) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSingle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSingle.java
@@ -124,8 +124,8 @@ final class MonoSingle<T> extends MonoFromFluxOperator<T, T> {
 				return;
 			}
 			if (done) {
-				Operators.onNextDropped(t, actual().currentContext());
 				Operators.onDiscard(t, actual().currentContext());
+				Operators.onNextDropped(t, actual().currentContext());
 				return;
 			}
 			if (++count > 1) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoStreamCollector.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoStreamCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoStreamCollector.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoStreamCollector.java
@@ -125,8 +125,8 @@ final class MonoStreamCollector<T, A, R> extends MonoFromFluxOperator<T, R>
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 			try {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoStreamCollector.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoStreamCollector.java
@@ -126,6 +126,7 @@ final class MonoStreamCollector<T, A, R> extends MonoFromFluxOperator<T, R>
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 			try {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoToCompletableFuture.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoToCompletableFuture.java
@@ -67,8 +67,8 @@ final class MonoToCompletableFuture<T> extends CompletableFuture<T> implements C
 			}
 		}
 		else {
-			Operators.onNextDropped(t, currentContext());
 			Operators.onDiscard(t, currentContext());
+			Operators.onNextDropped(t, currentContext());
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoToCompletableFuture.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoToCompletableFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,7 @@ final class MonoToCompletableFuture<T> extends CompletableFuture<T> implements C
 		}
 		else {
 			Operators.onNextDropped(t, currentContext());
+			Operators.onDiscard(t, currentContext());
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoUsingWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoUsingWhen.java
@@ -173,8 +173,8 @@ final class MonoUsingWhen<T, S> extends Mono<T> implements SourceProducer<T> {
 		@Override
 		public void onNext(S resource) {
 			if (resourceProvided) {
-				Operators.onNextDropped(resource, actual.currentContext());
 				Operators.onDiscard(resource, actual.currentContext());
+				Operators.onNextDropped(resource, actual.currentContext());
 				return;
 			}
 			resourceProvided = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoUsingWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoUsingWhen.java
@@ -174,6 +174,7 @@ final class MonoUsingWhen<T, S> extends Mono<T> implements SourceProducer<T> {
 		public void onNext(S resource) {
 			if (resourceProvided) {
 				Operators.onNextDropped(resource, actual.currentContext());
+				Operators.onDiscard(resource, actual.currentContext());
 				return;
 			}
 			resourceProvided = true;

--- a/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
@@ -264,6 +264,7 @@ class NextProcessor<O> extends MonoProcessor<O> {
 					return;
 				case FAIL_TERMINATED:
 					Operators.onNextDropped(value, currentContext());
+					Operators.onDiscard(value, currentContext());
 					return;
 				case FAIL_NON_SERIALIZED:
 					throw new EmissionException(emitResult,

--- a/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/NextProcessor.java
@@ -263,8 +263,8 @@ class NextProcessor<O> extends MonoProcessor<O> {
 					Operators.onDiscard(value, currentContext());
 					return;
 				case FAIL_TERMINATED:
-					Operators.onNextDropped(value, currentContext());
 					Operators.onDiscard(value, currentContext());
+					Operators.onNextDropped(value, currentContext());
 					return;
 				case FAIL_NON_SERIALIZED:
 					throw new EmissionException(emitResult,

--- a/reactor-core/src/main/java/reactor/core/publisher/OnNextFailureStrategy.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/OnNextFailureStrategy.java
@@ -222,8 +222,8 @@ interface OnNextFailureStrategy extends BiFunction<Throwable, Object, Throwable>
 			}
 			try {
 				if (value != null) {
-					Operators.onNextDropped(value, context);
 					Operators.onDiscard(value, context);
+					Operators.onNextDropped(value, context);
 				}
 				Operators.onErrorDropped(error, context);
 				return null;

--- a/reactor-core/src/main/java/reactor/core/publisher/OnNextFailureStrategy.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/OnNextFailureStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -223,6 +223,7 @@ interface OnNextFailureStrategy extends BiFunction<Throwable, Object, Throwable>
 			try {
 				if (value != null) {
 					Operators.onNextDropped(value, context);
+					Operators.onDiscard(value, context);
 				}
 				Operators.onErrorDropped(error, context);
 				return null;

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -657,7 +657,12 @@ public abstract class Operators {
 			hook = Hooks.onNextDroppedHook;
 		}
 		if (hook != null) {
-			hook.accept(t);
+			try {
+				hook.accept(t);
+			}
+			catch (Throwable ex) {
+				log.warn("Error in onNextDropped hook", t);
+			}
 		}
 		else if (log.isDebugEnabled()) {
 			log.debug("onNextDropped: " + t);
@@ -1395,8 +1400,8 @@ public abstract class Operators {
 	static <T> void onNextDroppedMulticast(T t,	InnerProducer<?>[] multicastInners) {
 		//TODO let this method go through multiple contexts and use their local handlers
 		//if at least one has no local handler, also call onNextDropped(t, Context.empty())
-		onNextDropped(t, multiSubscribersContext(multicastInners));
 		onDiscard(t, multiSubscribersContext(multicastInners));
+		onNextDropped(t, multiSubscribersContext(multicastInners));
 	}
 
 	static <T> long producedCancellable(AtomicLongFieldUpdater<T> updater, T instance, long n) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -435,7 +435,7 @@ public abstract class Operators {
 	 * @see #onDiscardQueueWithClear(Queue, Context, Function)
 	 */
 	public static <T> void onDiscard(@Nullable T element, Context context) {
-		Consumer<Object> hook = context.getOrDefault(Hooks.KEY_ON_DISCARD, null);
+		Consumer<Object> hook = context.getOrDefault(Hooks.KEY_ON_DISCARD, Hooks.onDiscardHook);
 		if (element != null && hook != null) {
 			try {
 				hook.accept(element);
@@ -469,7 +469,7 @@ public abstract class Operators {
 			return;
 		}
 
-		Consumer<Object> hook = context.getOrDefault(Hooks.KEY_ON_DISCARD, null);
+		Consumer<Object> hook = context.getOrDefault(Hooks.KEY_ON_DISCARD, Hooks.onDiscardHook);
 		if (hook == null) {
 			queue.clear();
 			return;
@@ -526,7 +526,7 @@ public abstract class Operators {
    * @see #onDiscardQueueWithClear(Queue, Context, Function)
    */
   public static void onDiscardMultiple(Stream<?> multiple, Context context) {
-		Consumer<Object> hook = context.getOrDefault(Hooks.KEY_ON_DISCARD, null);
+		Consumer<Object> hook = context.getOrDefault(Hooks.KEY_ON_DISCARD, Hooks.onDiscardHook);
 		if (hook != null) {
 			try {
 				multiple.filter(Objects::nonNull)
@@ -558,7 +558,7 @@ public abstract class Operators {
    */
 	public static void onDiscardMultiple(@Nullable Collection<?> multiple, Context context) {
 		if (multiple == null) return;
-		Consumer<Object> hook = context.getOrDefault(Hooks.KEY_ON_DISCARD, null);
+		Consumer<Object> hook = context.getOrDefault(Hooks.KEY_ON_DISCARD, Hooks.onDiscardHook);
 		if (hook != null) {
 			try {
 				if (multiple.isEmpty()) {
@@ -598,7 +598,7 @@ public abstract class Operators {
 		if (multiple == null) return;
 		if (!knownToBeFinite) return;
 
-		Consumer<Object> hook = context.getOrDefault(Hooks.KEY_ON_DISCARD, null);
+		Consumer<Object> hook = context.getOrDefault(Hooks.KEY_ON_DISCARD, Hooks.onDiscardHook);
 		if (hook != null) {
 			try {
 				multiple.forEachRemaining(o -> {
@@ -1396,6 +1396,7 @@ public abstract class Operators {
 		//TODO let this method go through multiple contexts and use their local handlers
 		//if at least one has no local handler, also call onNextDropped(t, Context.empty())
 		onNextDropped(t, multiSubscribersContext(multicastInners));
+		onDiscard(t, multiSubscribersContext(multicastInners));
 	}
 
 	static <T> long producedCancellable(AtomicLongFieldUpdater<T> updater, T instance, long n) {

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelCollect.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelCollect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelCollect.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelCollect.java
@@ -139,8 +139,8 @@ final class ParallelCollect<T, C> extends ParallelFlux<C> implements Scannable, 
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelCollect.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelCollect.java
@@ -140,6 +140,7 @@ final class ParallelCollect<T, C> extends ParallelFlux<C> implements Scannable, 
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeReduce.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeReduce.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeReduce.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeReduce.java
@@ -258,8 +258,8 @@ final class ParallelMergeReduce<T> extends Mono<T> implements Scannable, Fuseabl
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, currentContext());
 				Operators.onDiscard(t, currentContext());
+				Operators.onNextDropped(t, currentContext());
 				return;
 			}
 			T v = value;

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeReduce.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeReduce.java
@@ -259,6 +259,7 @@ final class ParallelMergeReduce<T> extends Mono<T> implements Scannable, Fuseabl
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, currentContext());
+				Operators.onDiscard(t, currentContext());
 				return;
 			}
 			T v = value;

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelReduceSeed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelReduceSeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelReduceSeed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelReduceSeed.java
@@ -140,6 +140,7 @@ final class ParallelReduceSeed<T, R> extends ParallelFlux<R> implements
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelReduceSeed.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelReduceSeed.java
@@ -139,8 +139,8 @@ final class ParallelReduceSeed<T, R> extends ParallelFlux<R> implements
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelSource.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelSource.java
@@ -224,8 +224,8 @@ final class ParallelSource<T> extends ParallelFlux<T> implements Scannable {
 		@Override
 		public void onNext(T t) {
 			if (done) {
-				Operators.onNextDropped(t, currentContext());
 				Operators.onDiscard(t, currentContext());
+				Operators.onNextDropped(t, currentContext());
 				return;
 			}
 			if (sourceMode == Fuseable.NONE) {

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelSource.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -225,6 +225,7 @@ final class ParallelSource<T> extends ParallelFlux<T> implements Scannable {
 		public void onNext(T t) {
 			if (done) {
 				Operators.onNextDropped(t, currentContext());
+				Operators.onDiscard(t, currentContext());
 				return;
 			}
 			if (sourceMode == Fuseable.NONE) {

--- a/reactor-core/src/main/java/reactor/core/publisher/SerializedSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SerializedSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,7 @@ final class SerializedSubscriber<T> implements InnerOperator<T, T> {
 		}
 		if (done) {
 			Operators.onNextDropped(t, actual.currentContext());
+			Operators.onDiscard(t, actual.currentContext());
 			return;
 		}
 
@@ -84,6 +85,7 @@ final class SerializedSubscriber<T> implements InnerOperator<T, T> {
 			}
 			if (done) {
 				Operators.onNextDropped(t, actual.currentContext());
+				Operators.onDiscard(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/SerializedSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SerializedSubscriber.java
@@ -73,8 +73,8 @@ final class SerializedSubscriber<T> implements InnerOperator<T, T> {
 			return;
 		}
 		if (done) {
-			Operators.onNextDropped(t, actual.currentContext());
 			Operators.onDiscard(t, actual.currentContext());
+			Operators.onNextDropped(t, actual.currentContext());
 			return;
 		}
 
@@ -84,8 +84,8 @@ final class SerializedSubscriber<T> implements InnerOperator<T, T> {
 				return;
 			}
 			if (done) {
-				Operators.onNextDropped(t, actual.currentContext());
 				Operators.onDiscard(t, actual.currentContext());
+				Operators.onNextDropped(t, actual.currentContext());
 				return;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -453,6 +453,8 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 				else if (done) {
 					Operators.onNextDropped(dataSignalOfferedBeforeDrain,
 							currentContext());
+					Operators.onDiscard(dataSignalOfferedBeforeDrain,
+							currentContext());
 				}
 			}
 			return;

--- a/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/UnicastProcessor.java
@@ -451,9 +451,9 @@ public final class UnicastProcessor<T> extends FluxProcessor<T, T>
 							actual.currentContext());
 				}
 				else if (done) {
-					Operators.onNextDropped(dataSignalOfferedBeforeDrain,
-							currentContext());
 					Operators.onDiscard(dataSignalOfferedBeforeDrain,
+							currentContext());
+					Operators.onNextDropped(dataSignalOfferedBeforeDrain,
 							currentContext());
 				}
 			}

--- a/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/HooksTest.java
@@ -556,6 +556,17 @@ public class HooksTest {
 
 		assertThat(ref).hasValue("foobar");
 
+		Hooks.onDiscard(d -> {
+			ref.set(d.toString());
+		});
+		Hooks.onDiscard(d -> {
+			ref.set(ref.get()+"bar1");
+		});
+
+		Operators.onDiscard("foo", Context.empty());
+
+		assertThat(ref).hasValue("foobar1");
+
 		Hooks.onErrorDropped(d -> {
 			ref.set(d.getMessage());
 		});
@@ -750,7 +761,7 @@ public class HooksTest {
 			assemblyExceptions.add(e.getSuppressed()[0]);
 			try {
 				//live evaluation, error hasn't been emitted everywhere so we only have one occurrence so far
-				assertThat(e.getSuppressed()[0]).hasMessageContaining("|_ Flux.publish ⇢ at reactor.core.publisher.HooksTest.testMultiReceiver(HooksTest.java:747)");
+				assertThat(e.getSuppressed()[0]).hasMessageContaining("|_ Flux.publish ⇢ at reactor.core.publisher.HooksTest.testMultiReceiver(HooksTest.java:758)");
 			}
 			catch (AssertionError ae) {
 				assertionErrors[0] = ae;
@@ -761,7 +772,7 @@ public class HooksTest {
 			assemblyExceptions.add(e.getSuppressed()[0]);
 			try {
 				//live evaluation, error hasn't been emitted everywhere so we only have two occurrences so far
-				assertThat(e.getSuppressed()[0]).hasMessageContaining("|_ Flux.publish ⇢ at reactor.core.publisher.HooksTest.testMultiReceiver(HooksTest.java:747) (observed 2 times)");
+				assertThat(e.getSuppressed()[0]).hasMessageContaining("|_ Flux.publish ⇢ at reactor.core.publisher.HooksTest.testMultiReceiver(HooksTest.java:758) (observed 2 times)");
 			}
 			catch (AssertionError ae) {
 				assertionErrors[1] = ae;
@@ -772,7 +783,7 @@ public class HooksTest {
 			try {
 				//live evaluation, error has been emitted everywhere so we have the three occurrences now
 				// (note that the indentation has grown by 1 due to distinct operator getting in the mix)
-				assertThat(e.getSuppressed()[0]).hasMessageContaining("|_  Flux.publish ⇢ at reactor.core.publisher.HooksTest.testMultiReceiver(HooksTest.java:747) (observed 3 times)");
+				assertThat(e.getSuppressed()[0]).hasMessageContaining("|_  Flux.publish ⇢ at reactor.core.publisher.HooksTest.testMultiReceiver(HooksTest.java:758) (observed 3 times)");
 			}
 			catch (AssertionError ae) {
 				assertionErrors[2] = ae;
@@ -787,7 +798,7 @@ public class HooksTest {
 			.allMatch(Objects::nonNull)
 			.containsOnly(assemblyExceptions.get(0))
 			.first(InstanceOfAssertFactories.THROWABLE)
-			.hasMessageContaining("|_  Flux.publish ⇢ at reactor.core.publisher.HooksTest.testMultiReceiver(HooksTest.java:747) (observed 3 times)")
+			.hasMessageContaining("|_  Flux.publish ⇢ at reactor.core.publisher.HooksTest.testMultiReceiver(HooksTest.java:758) (observed 3 times)")
 			.hasMessageNotContainingAny("(observed 2 times)");
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
@@ -130,14 +130,14 @@ public class OnDiscardShouldNotLeakTest {
 	@BeforeEach
 	void setUp() {
 		tracker = new MemoryUtils.OffHeapDetector();
-		Hooks.onNextDropped(Tracked::safeRelease);
+		Hooks.onDiscard(Tracked::safeRelease);
 		Hooks.onErrorDropped(e -> {});
 		Hooks.onOperatorError((e, v) -> null);
 	}
 
 	@AfterEach
 	void tearDown() {
-		Hooks.resetOnNextDropped();
+		Hooks.resetOnDiscard();
 		Hooks.resetOnErrorDropped();
 		Hooks.resetOnNextError();
 		Hooks.resetOnOperatorError();

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
@@ -362,6 +362,22 @@ public class OperatorsTest {
 	}
 
 	@Test
+	public void onDiscardLocal() {
+		try {
+			AtomicReference<Object> hookState = new AtomicReference<>();
+			Hooks.onDiscard((value) -> hookState.set(value + " is unexpected here."));
+			Consumer<Object> localHook = hookState::set;
+			Context c = Context.of(Hooks.KEY_ON_DISCARD, localHook);
+
+			Operators.onDiscard("foo", c);
+
+			assertThat(hookState).hasValue("foo");
+		} finally {
+			Hooks.resetOnDiscard();
+		}
+	}
+
+	@Test
 	public void onOperatorErrorLocal() {
 		BiFunction<Throwable, Object, Throwable> localHook = (e, v) ->
 				new IllegalStateException("boom_" + v, e);


### PR DESCRIPTION
This PR introduces the global `onDiscard` hook
Also, it improves the existing operators to use `onDiscard` in places where `onNextDropped` is used as well

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>