### PR TITLE
SingleScheduler.isDisposed() only true on disposed instance

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
@@ -78,7 +78,7 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 	public boolean isDisposed() {
 		// we only consider disposed as actually shutdown
 		SchedulerState<ScheduledExecutorService> current = state;
-		return current != null && current.currentResource == TERMINATED;
+		return current != INIT && current.currentResource == TERMINATED;
 	}
 
 	@Override


### PR DESCRIPTION
This change restores the behaviour which was recently changed for the purpose of introducing a new init() method, but accidentally changed the behavior.