### PR TITLE
Scheduler.isDisposed() only true for disposed instances

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
@@ -144,7 +144,9 @@ final class BoundedElasticScheduler implements Scheduler,
 
 	@Override
 	public boolean isDisposed() {
-		return state.currentResource == SHUTDOWN;
+		// we only consider disposed as actually shutdown
+		SchedulerState<BoundedServices> current = this.state;
+		return current != INIT && current.currentResource == SHUTDOWN;
 	}
 
 	@Override

--- a/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
@@ -110,7 +110,6 @@ public abstract class AbstractSchedulerTest {
 	}
 
 	@Test
-	@Disabled("Should be enabled in 3.5.0")
 	void nonInitializedIsNotDisposed() {
 		Scheduler s = freshScheduler();
 		assertThat(s.isDisposed()).isFalse();


### PR DESCRIPTION
Some schedulers for optimization purposes started in a state which was considered as disposed (`Scheduler#isDisposed()`). This change affects only `BoundedElasticScheduler` as it was the last one which behaved this way.
This is a change of behavior, however one which was not documented.