### PR TITLE
Fix the way context-propagation is detected

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -48,7 +48,7 @@ final class ContextPropagation {
 	static {
 		boolean contextPropagation;
 		try {
-			Class.forName("io.micrometer.context.ContextRegistry", false, ContextPropagation.class.getClassLoader());
+			Class.forName("io.micrometer.context.ContextRegistry");
 			contextPropagation = true;
 		}
 		catch (Throwable t) {


### PR DESCRIPTION
This commit changes the way the context-propagation is detected,
preventing an issue where the boolean would become true while actually
using the registry would throw.

Reactor-Netty CI would fail with a NoClassDefFoundError due to this.