### PR TITLE
Optimize Scheduler initialization

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
@@ -147,7 +147,7 @@ final class BoundedElasticScheduler implements Scheduler,
 	@Override
 	public void init() {
 		SchedulerState<BoundedServices> a = this.state;
-		if (a != null) {
+		if (a != INIT) {
 			if (a.currentResource == SHUTDOWN) {
 				throw new IllegalStateException(
 						"Initializing a disposed scheduler is not permitted"

--- a/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
@@ -113,7 +113,6 @@ final class BoundedElasticScheduler implements Scheduler,
 		this.clock = Objects.requireNonNull(clock, "A Clock must be provided");
 		this.ttlMillis = ttlMillis;
 
-		// initially disposed
 		STATE.lazySet(this, INIT);
 	}
 
@@ -147,6 +146,17 @@ final class BoundedElasticScheduler implements Scheduler,
 
 	@Override
 	public void init() {
+		SchedulerState<BoundedServices> a = this.state;
+		if (a != null) {
+			if (a.currentResource == SHUTDOWN) {
+				throw new IllegalStateException(
+						"Initializing a disposed scheduler is not permitted"
+				);
+			}
+			// return early - scheduler already initialized
+			return;
+		}
+
 		SchedulerState<BoundedServices> b =
 				SchedulerState.init(new BoundedServices(this));
 		if (STATE.compareAndSet(this, INIT, b)) {
@@ -160,7 +170,11 @@ final class BoundedElasticScheduler implements Scheduler,
 				// The executor was most likely shut down in parallel.
 				// If the state is SHUTDOWN - it's ok, no eviction schedule required;
 				// If it's running - the other thread did a restart and will run its own schedule.
-				// In both cases we ignore it.
+				// In both cases we throw an exception, as the caller of init() should
+				// expect the scheduler to be running when this method returns.
+				throw new IllegalStateException(
+						"Scheduler disposed during initialization"
+				);
 			}
 		} else {
 			b.currentResource.evictor.shutdownNow();

--- a/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
@@ -117,6 +117,17 @@ final class DelegateServiceScheduler implements Scheduler, SchedulerState.Dispos
 
 	@Override
 	public void init() {
+		SchedulerState<ScheduledExecutorService> a = this.state;
+		if (a != null) {
+			if (a.currentResource == TERMINATED) {
+				throw new IllegalStateException(
+						"Initializing a disposed scheduler is not permitted"
+				);
+			}
+			// return early - scheduler already initialized
+			return;
+		}
+
 		if (!STATE.compareAndSet(this, null,
 				SchedulerState.init(Schedulers.decorateExecutorService(this, original)))) {
 			if (isDisposed()) {

--- a/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
@@ -91,6 +91,17 @@ final class ParallelScheduler implements Scheduler, Supplier<ScheduledExecutorSe
 
 	@Override
 	public void init() {
+		SchedulerState<ScheduledExecutorService[]> a = this.state;
+		if (a != null) {
+			if (a.currentResource == SHUTDOWN) {
+				throw new IllegalStateException(
+						"Initializing a disposed scheduler is not permitted"
+				);
+			}
+			// return early - scheduler already initialized
+			return;
+		}
+
 		SchedulerState<ScheduledExecutorService[]> b =
 				SchedulerState.init(new ScheduledExecutorService[n]);
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
@@ -84,7 +84,7 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 	@Override
 	public void init() {
 		SchedulerState<ScheduledExecutorService> a = this.state;
-		if (a != null) {
+		if (a != INIT) {
 			if (a.currentResource == TERMINATED) {
 				throw new IllegalStateException(
 						"Initializing a disposed scheduler is not permitted"

--- a/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
@@ -58,8 +58,8 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 			SchedulerState.init(TERMINATED);
 
 	SingleScheduler(ThreadFactory factory) {
-		this.state = INIT;
 		this.factory = factory;
+		STATE.lazySet(this, INIT);
 	}
 
 	/**
@@ -83,6 +83,17 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 
 	@Override
 	public void init() {
+		SchedulerState<ScheduledExecutorService> a = this.state;
+		if (a != null) {
+			if (a.currentResource == TERMINATED) {
+				throw new IllegalStateException(
+						"Initializing a disposed scheduler is not permitted"
+				);
+			}
+			// return early - scheduler already initialized
+			return;
+		}
+
 		SchedulerState<ScheduledExecutorService> b = SchedulerState.init(
 				Schedulers.decorateExecutorService(this, this.get())
 		);


### PR DESCRIPTION
In #3236 a new `Scheduler::init()` method was added. This change adds the following optimizations to the startup of `Scheduler` instances:

- If an instance is already initialized, fail early without having to create and instantly release resources.
- `SingleScheduler` constructor uses a AtomicReferenceFieldUpdater#lazySet in the constructor instead of volatile set to improve perf a little bit.

Credit for the suggestions goes to @OlegDokuka as this is a follow-up PR after late review of #3236.