### PR TITLE
Further improve detection of ContextPropagation (see #3246)

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/ReactorBlockHoundIntegration.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ReactorBlockHoundIntegration.java
@@ -45,5 +45,10 @@ public final class ReactorBlockHoundIntegration implements BlockHoundIntegration
         builder.allowBlockingCallsInside(WorkerTask.class.getName(), "dispose");
 
         builder.allowBlockingCallsInside(ThreadPoolExecutor.class.getName(), "processWorkerExit");
+
+        // Most allowances are from the schedulers package but this one is from the publisher package.
+        // For now, let's not add a separate integration, but rather let's define the class name manually
+        // ContextRegistry reads files as part of the Service Loader aspect. If class is initialized in a non-blocking thread, BlockHound would complain
+        builder.allowBlockingCallsInside("reactor.core.publisher.ContextPropagation", "<clinit>");
     }
 }


### PR DESCRIPTION
In #3246 the ContextPropagation initialization was altered to avoid
a `NoClassDefFoundError` discovered in Reactor-Netty. While the fix does
appear to prevent that exception, the true root cause was not correctly
identified.

It appears that the underlying issue is not the way classloading of
`ContextRegistry` is performed, but rather the fact that it can load
accessors via the Service Loader mecanism. Given that there is a
singleton instance which does load accessors and that Service Loader
implies file reading, the true root cause is... BlockHound!

In the failing Reactor-Netty test, BlockHound was active. Note that now
the first use of a `handle` operator references `ContextPropagation` and
thus triggers lazy initialization of the class. It turns out that this
first use was occurring in a non-blocking thread in the test, tripping
BlockHound _inside the static initializer of ContextPropagation_.

This commit replaces the `Class.forName` with an attempt to get a
reference to `ContextRegistry.getInstance()` since the next step is to
use it anyway, to initialize a `Function`.

It modifies the logic to better distinguish between a rather expected
`ClassNotFoundException` (context-propagation library is not there) and
other exceptions like the BlockHound one (unexpected initialization
errors), logging the later to ease future investigations.

Finally, this commit alters the `ReactorBlockHoundIntegration` to allow
blocking calls inside of `ContextPropagation`'s static initializer.

Replaces fix in #3246.
