### PR TITLE
Remove marker need for tap/handle context-propagation

### DIFF
--- a/docs/asciidoc/advanced-contextPropagation.adoc
+++ b/docs/asciidoc/advanced-contextPropagation.adoc
@@ -41,8 +41,12 @@ Mono.deferContextual(ctx ->
 ====
 
 == Operators that transparently restore a snapshot: `handle` and `tap`
-When using `contextCapture()` a marker is added to the Reactor `Context` in which the snapshot has been captured.
-This is detected by `Flux` and `Mono` variants of `handle` and `tap`, which restore `ThreadLocal`s from that snapshot transparently.
+Both `Flux` and `Mono` variants of `handle` and `tap` will have their behavior slightly modified
+if the Context-Propagation library is available at runtime.
+
+Namely, if their downstream `ContextView` is not empty they will assume a context capture has occurred
+(either manually or via the `contextCapture()` operator) and will attempt to restore `ThreadLocal`s from
+that snapshot transparently.
 
 These operators will ensure restoration is performed around the user-provided code, respectively:
  - `handle` will wrap the `BiConsumer` in one which restores `ThreadLocal`s

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -4032,14 +4032,13 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	/**
 	 * If <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>
 	 * is on the classpath, this is a convenience shortcut to capture thread local values during the
-	 * subscription phase and put them in the {@link Context} that is visible upstream of this operator,
-	 * alongside a marker key indicating that context capture occurred.
+	 * subscription phase and put them in the {@link Context} that is visible upstream of this operator.
 	 * <p>
 	 * As a result this operator should generally be used as close as possible to the end of
 	 * the chain / subscription point.
-	 * If the marker key is encountered upstream, a small subset of operators will automatically restore the
-	 * context snapshot ({@link #handle(BiConsumer) handle}, {@link #tap(SignalListenerFactory) tap}).
 	 * <p>
+	 * If the {@link ContextView} visible upstream is not empty, a small subset of operators will automatically
+	 * restore the context snapshot ({@link #handle(BiConsumer) handle}, {@link #tap(SignalListenerFactory) tap}).
 	 * If context-propagation is not available at runtime, this operator simply returns the current {@link Flux}
 	 * instance.
 	 *
@@ -5801,9 +5800,10 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * fusion is enabled) when the {@link BiConsumer} throws an exception or if an error is signaled explicitly via
 	 * {@link SynchronousSink#error(Throwable)}.
 	 * <p>
-	 * When used in conjunction with {@link #contextCapture()} down the chain, thread locals
-	 * are restored from the Reactor {@link ContextView} within the handler {@link BiConsumer} using the
-	 * <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>.
+	 * When the <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>
+	 * is available at runtime and the downstream {@link ContextView} is not empty, this operator implicitly uses the
+	 * library to restore thread locals around the handler {@link BiConsumer}. Typically, this would be done in conjunction
+	 * with the use of {@link #contextCapture()} operator down the chain.
 	 *
 	 * @param handler the handling {@link BiConsumer}
 	 * @param <R> the transformed type
@@ -9039,9 +9039,10 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * This simplified variant assumes the state is purely initialized within the {@link Supplier},
 	 * as it is called for each incoming {@link Subscriber} without additional context.
 	 * <p>
-	 * When used in conjunction with {@link #contextCapture()} down the chain, thread locals
-	 * are restored from the downstream {@link ContextView} around all invocations of {@link SignalListener} methods
-	 * using the <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>.
+	 * When the <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>
+	 * is available at runtime and the downstream {@link ContextView} is not empty, this operator implicitly uses the library
+	 * to restore thread locals around all invocations of {@link SignalListener} methods. Typically, this would be done
+	 * in conjunction with the use of {@link #contextCapture()} operator down the chain.
 	 *
 	 * @param simpleListenerGenerator the {@link Supplier} to create a new {@link SignalListener} on each subscription
 	 * @return a new {@link Flux} with side effects defined by generated {@link SignalListener}
@@ -9075,9 +9076,10 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * This simplified variant allows the {@link SignalListener} to be constructed for each subscription
 	 * with access to the incoming {@link Subscriber}'s {@link ContextView}.
 	 * <p>
-	 * When used in conjunction with {@link #contextCapture()} down the chain, thread locals
-	 * are restored from the same {@link ContextView} around all invocations of {@link SignalListener} methods
-	 * using the <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>.
+	 * When the <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>
+	 * is available at runtime and the {@link ContextView} is not empty, this operator implicitly uses the library
+	 * to restore thread locals around all invocations of {@link SignalListener} methods. Typically, this would be done
+	 * in conjunction with the use of {@link #contextCapture()} operator down the chain.
 	 *
 	 * @param listenerGenerator the {@link Function} to create a new {@link SignalListener} on each subscription
 	 * @return a new {@link Flux} with side effects defined by generated {@link SignalListener}
@@ -9112,9 +9114,10 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * {@link SignalListener#doAfterError(Throwable)} instead just {@link Operators#onErrorDropped(Throwable, Context) drop}
 	 * the exception.
 	 * <p>
-	 * When used in conjunction with {@link #contextCapture()} down the chain, thread locals
-	 * are restored from the downstream {@link ContextView} around all invocations of {@link SignalListener} methods
-	 * using the <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>.
+	 * When the <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>
+	 * is available at runtime and the downstream {@link ContextView} is not empty, this operator implicitly uses the library
+	 * to restore thread locals around all invocations of {@link SignalListener} methods. Typically, this would be done
+	 * in conjunction with the use of {@link #contextCapture()} operator down the chain.
 	 *
 	 * @param listenerFactory the {@link SignalListenerFactory} to create a new {@link SignalListener} on each subscription
 	 * @return a new {@link Flux} with side effects defined by generated {@link SignalListener}

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -2230,14 +2230,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	/**
 	 * If <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>
 	 * is on the classpath, this is a convenience shortcut to capture thread local values during the
-	 * subscription phase and put them in the {@link Context} that is visible upstream of this operator,
-	 * alongside a marker key indicating that context capture occurred.
+	 * subscription phase and put them in the {@link Context} that is visible upstream of this operator.
 	 * <p>
 	 * As a result this operator should generally be used as close as possible to the end of
 	 * the chain / subscription point.
-	 * If the marker key is encountered upstream, a small subset of operators will automatically restore the
-	 * context snapshot ({@link #handle(BiConsumer) handle}, {@link #tap(SignalListenerFactory) tap}).
 	 * <p>
+	 * If the {@link ContextView} visible upstream is not empty, a small subset of operators will automatically
+	 * restore the context snapshot ({@link #handle(BiConsumer) handle}, {@link #tap(SignalListenerFactory) tap}).
 	 * If context-propagation is not available at runtime, this operator simply returns the current {@link Mono}
 	 * instance.
 	 *
@@ -3147,9 +3146,10 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * call must be performed and/or 0 or 1 {@link SynchronousSink#error(Throwable)} or
 	 * {@link SynchronousSink#complete()}.
 	 * <p>
-	 * When used in conjunction with {@link #contextCapture()} down the chain, thread locals
-	 * are restored from the Reactor {@link ContextView} within the handler {@link BiConsumer} using the
-	 * <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>.
+	 * When the <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>
+	 * is available at runtime and the downstream {@link ContextView} is not empty, this operator implicitly uses the
+	 * library to restore thread locals around the handler {@link BiConsumer}. Typically, this would be done in conjunction
+	 * with the use of {@link #contextCapture()} operator down the chain.
 	 *
 	 * @param handler the handling {@link BiConsumer}
 	 * @param <R> the transformed type
@@ -4578,9 +4578,10 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * This simplified variant assumes the state is purely initialized within the {@link Supplier},
 	 * as it is called for each incoming {@link Subscriber} without additional context.
 	 * <p>
-	 * When used in conjunction with {@link #contextCapture()} down the chain, thread locals
-	 * are restored from the downstream {@link ContextView} around all invocations of {@link SignalListener} methods
-	 * using the <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>.
+	 * When the <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>
+	 * is available at runtime and the downstream {@link ContextView} is not empty, this operator implicitly uses the library
+	 * to restore thread locals around all invocations of {@link SignalListener} methods. Typically, this would be done
+	 * in conjunction with the use of {@link #contextCapture()} operator down the chain.
 	 *
 	 * @param simpleListenerGenerator the {@link Supplier} to create a new {@link SignalListener} on each subscription
 	 * @return a new {@link Mono} with side effects defined by generated {@link SignalListener}
@@ -4614,9 +4615,10 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * This simplified variant allows the {@link SignalListener} to be constructed for each subscription
 	 * with access to the incoming {@link Subscriber}'s {@link ContextView}.
 	 * <p>
-	 * When used in conjunction with {@link #contextCapture()} down the chain, thread locals
-	 * are restored from the same {@link ContextView} around all invocations of {@link SignalListener} methods
-	 * using the <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>.
+	 * When the <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>
+	 * is available at runtime and the {@link ContextView} is not empty, this operator implicitly uses the library
+	 * to restore thread locals around all invocations of {@link SignalListener} methods. Typically, this would be done
+	 * in conjunction with the use of {@link #contextCapture()} operator down the chain.
 	 *
 	 * @param listenerGenerator the {@link Function} to create a new {@link SignalListener} on each subscription
 	 * @return a new {@link Mono} with side effects defined by generated {@link SignalListener}
@@ -4651,9 +4653,10 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * {@link SignalListener#doAfterError(Throwable)} instead just {@link Operators#onErrorDropped(Throwable, Context) drop}
 	 * the exception.
 	 * <p>
-	 * When used in conjunction with {@link #contextCapture()} down the chain, thread locals
-	 * are restored from the downstream {@link ContextView} around all invocations of {@link SignalListener} methods
-	 * using the <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>.
+	 * When the <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>
+	 * is available at runtime and the downstream {@link ContextView} is not empty, this operator implicitly uses the library
+	 * to restore thread locals around all invocations of {@link SignalListener} methods. Typically, this would be done
+	 * in conjunction with the use of {@link #contextCapture()} operator down the chain.
 	 *
 	 * @param listenerFactory the {@link SignalListenerFactory} to create a new {@link SignalListener} on each subscription
 	 * @return a new {@link Flux} with side effects defined by generated {@link SignalListener}

--- a/reactor-core/src/test/java/reactor/core/publisher/ContextPropagationNotThereSmokeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ContextPropagationNotThereSmokeTest.java
@@ -16,8 +16,6 @@
 
 package reactor.core.publisher;
 
-import java.util.function.Predicate;
-
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
This commit removes the notion of a `Context` marker inserted by the
`contextCapture()` operator as a precondition for `tap` and `handle` to
restore ThreadLocals from a `ContextSnapshot` implicitely.

Now, the operators only check that A) `context-propagation` library is
available at runtime and B) the downstream context is not empty.

The javadoc and reference guide have been amended to reflect that fact.

Fixes #3250.
