### PR TITLE
fixes breaking change for `fromFuture` source cancellation

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -537,10 +537,9 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/fromFuture.svg" alt="">
 	 * <p>
-	 * Note that the completion stage is not cancelled when that Mono is cancelled, but
-	 * that behavior can be obtained by using {@link #doFinally(Consumer)} that checks
-	 * for a {@link SignalType#CANCEL} and calls eg.
-	 * {@link CompletionStage#toCompletableFuture() .toCompletableFuture().cancel(false)}.
+	 * Note, use {@link #fromFuture(CompletableFuture, boolean)} with {@code
+	 * suppressCancellation} set to {@code true} if you need to suppress cancellation
+	 * propagation
 	 *
 	 * @param completionStage {@link CompletionStage} that will produce a value (or a null to
 	 * complete immediately)
@@ -548,7 +547,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return A {@link Mono}.
 	 */
 	public static <T> Mono<T> fromCompletionStage(CompletionStage<? extends T> completionStage) {
-		return onAssembly(new MonoCompletionStage<>(completionStage));
+		return onAssembly(new MonoCompletionStage<>(completionStage, false));
 	}
 
 	/**
@@ -558,10 +557,9 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/fromFutureSupplier.svg" alt="">
 	 * <p>
-	 * Note that the completion stage is not cancelled when that Mono is cancelled, but
-	 * that behavior can be obtained by using {@link #doFinally(Consumer)} that checks
-	 * for a {@link SignalType#CANCEL} and calls eg.
-	 * {@link CompletionStage#toCompletableFuture() .toCompletableFuture().cancel(false)}.
+	 * Note, use {@link #fromFuture(CompletableFuture, boolean)} with {@code
+	 * suppressCancellation} set to {@code true} if you need to suppress cancellation
+	 * propagation
 	 *
 	 * @param stageSupplier The {@link Supplier} of a {@link CompletionStage} that will produce a value (or a null to
 	 * complete immediately). This allows lazy triggering of CompletionStage-based APIs.
@@ -569,7 +567,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return A {@link Mono}.
 	 */
 	public static <T> Mono<T> fromCompletionStage(Supplier<? extends CompletionStage<? extends T>> stageSupplier) {
-		return defer(() -> onAssembly(new MonoCompletionStage<>(stageSupplier.get())));
+		return defer(() -> onAssembly(new MonoCompletionStage<>(stageSupplier.get(), false)));
 	}
 
 	/**
@@ -616,9 +614,6 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/fromFuture.svg" alt="">
 	 * <p>
-	 * Note that the future is not cancelled when that Mono is cancelled, but that behavior
-	 * can be obtained by using a {@link #fromFuture(CompletableFuture, boolean)}
-	 * overload with the {@code cancel} parameter set to {@code true}.
 	 *
 	 * @param future {@link CompletableFuture} that will produce a value (or a null to
 	 * complete immediately)
@@ -639,14 +634,14 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 *
 	 * @param future {@link CompletableFuture} that will produce a value (or a null to
 	 * complete immediately)
-	 * @param cancel specifies whether future should be cancelled or not via the
-	 * {@link CompletableFuture#cancel(boolean)} call
+	 * @param suppressCancel specifies whether future should have cancellation signall
+	 *                          suppressed
 	 * @param <T> type of the expected value
 	 * @return A {@link Mono}.
 	 * @see #fromCompletionStage(CompletionStage) fromCompletionStage for a generalization
 	 */
-	public static <T> Mono<T> fromFuture(CompletableFuture<? extends T> future, boolean cancel) {
-		return onAssembly(new MonoCompletionStage<>(future, cancel));
+	public static <T> Mono<T> fromFuture(CompletableFuture<? extends T> future, boolean suppressCancel) {
+		return onAssembly(new MonoCompletionStage<>(future, suppressCancel));
 	}
 
 	/**
@@ -667,7 +662,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @see #fromCompletionStage(Supplier) fromCompletionStage for a generalization
 	 */
 	public static <T> Mono<T> fromFuture(Supplier<? extends CompletableFuture<? extends T>> futureSupplier) {
-		return defer(() -> onAssembly(new MonoCompletionStage<>(futureSupplier.get())));
+		return defer(() -> onAssembly(new MonoCompletionStage<>(futureSupplier.get(), false)));
 	}
 
 	/**
@@ -686,8 +681,8 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return A {@link Mono}.
 	 * @see #fromCompletionStage(Supplier) fromCompletionStage for a generalization
 	 */
-	public static <T> Mono<T> fromFuture(Supplier<? extends CompletableFuture<? extends T>> futureSupplier, boolean cancel) {
-		return defer(() -> onAssembly(new MonoCompletionStage<>(futureSupplier.get(), cancel)));
+	public static <T> Mono<T> fromFuture(Supplier<? extends CompletableFuture<? extends T>> futureSupplier, boolean suppressCancel) {
+		return defer(() -> onAssembly(new MonoCompletionStage<>(futureSupplier.get(), suppressCancel)));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -614,6 +614,9 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/fromFuture.svg" alt="">
 	 * <p>
+	 * Note, use {@link #fromFuture(CompletableFuture, boolean)} with {@code
+	 * suppressCancellation} set to {@code true} if you need to suppress cancellation
+	 * propagation
 	 *
 	 * @param future {@link CompletableFuture} that will produce a value (or a null to
 	 * complete immediately)
@@ -634,8 +637,8 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 *
 	 * @param future {@link CompletableFuture} that will produce a value (or a null to
 	 * complete immediately)
-	 * @param suppressCancel specifies whether future should have cancellation signall
-	 *                          suppressed
+	 * @param suppressCancel specifies whether future should have cancellation signal
+	 *                          to be suppressed
 	 * @param <T> type of the expected value
 	 * @return A {@link Mono}.
 	 * @see #fromCompletionStage(CompletionStage) fromCompletionStage for a generalization
@@ -651,9 +654,6 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/fromFutureSupplier.svg" alt="">
 	 * <p>
-	 * Note that the future is not cancelled when that Mono is cancelled, but that behavior
-	 * can be obtained by using a {@link #fromFuture(Supplier, boolean)}
-	 * overload with the {@code cancel} parameter set to {@code true}.
 	 *
 	 * @param futureSupplier The {@link Supplier} of a {@link CompletableFuture} that will produce a value (or a null to
 	 * complete immediately). This allows lazy triggering of future-based APIs.
@@ -662,7 +662,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @see #fromCompletionStage(Supplier) fromCompletionStage for a generalization
 	 */
 	public static <T> Mono<T> fromFuture(Supplier<? extends CompletableFuture<? extends T>> futureSupplier) {
-		return defer(() -> onAssembly(new MonoCompletionStage<>(futureSupplier.get(), false)));
+		return fromFuture(futureSupplier, false);
 	}
 
 	/**
@@ -675,8 +675,8 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 *
 	 * @param futureSupplier The {@link Supplier} of a {@link CompletableFuture} that will produce a value (or a null to
 	 * complete immediately). This allows lazy triggering of future-based APIs.
-	 * @param cancel specifies whether future should be cancelled or not via the
-	 * {@link CompletableFuture#cancel(boolean)} call
+	 * @param suppressCancel specifies whether future should have cancellation signal
+	 *                          to be suppressed
 	 * @param <T> type of the expected value
 	 * @return A {@link Mono}.
 	 * @see #fromCompletionStage(Supplier) fromCompletionStage for a generalization

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -617,8 +617,8 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * <img class="marble" src="doc-files/marbles/fromFuture.svg" alt="">
 	 * <p>
 	 * Note that the future is not cancelled when that Mono is cancelled, but that behavior
-	 * can be obtained by using a {@link #doFinally(Consumer)} that checks
-	 * for a {@link SignalType#CANCEL} and calls {@link CompletableFuture#cancel(boolean)}.
+	 * can be obtained by using a {@link #fromFuture(CompletableFuture, boolean)}
+	 * overload with the {@code cancel} parameter set to {@code true}.
 	 *
 	 * @param future {@link CompletableFuture} that will produce a value (or a null to
 	 * complete immediately)
@@ -627,7 +627,26 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @see #fromCompletionStage(CompletionStage) fromCompletionStage for a generalization
 	 */
 	public static <T> Mono<T> fromFuture(CompletableFuture<? extends T> future) {
-		return onAssembly(new MonoCompletionStage<>(future));
+		return fromFuture(future, false);
+	}
+
+	/**
+	 * Create a {@link Mono}, producing its value using the provided {@link CompletableFuture}.
+	 *
+	 * <p>
+	 * <img class="marble" src="doc-files/marbles/fromFuture.svg" alt="">
+	 * <p>
+	 *
+	 * @param future {@link CompletableFuture} that will produce a value (or a null to
+	 * complete immediately)
+	 * @param cancel specifies whether future should be cancelled or not via the
+	 * {@link CompletableFuture#cancel(boolean)} call
+	 * @param <T> type of the expected value
+	 * @return A {@link Mono}.
+	 * @see #fromCompletionStage(CompletionStage) fromCompletionStage for a generalization
+	 */
+	public static <T> Mono<T> fromFuture(CompletableFuture<? extends T> future, boolean cancel) {
+		return onAssembly(new MonoCompletionStage<>(future, cancel));
 	}
 
 	/**
@@ -638,8 +657,8 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * <img class="marble" src="doc-files/marbles/fromFutureSupplier.svg" alt="">
 	 * <p>
 	 * Note that the future is not cancelled when that Mono is cancelled, but that behavior
-	 * can be obtained by using a {@link #doFinally(Consumer)} that checks
-	 * for a {@link SignalType#CANCEL} and calls {@link CompletableFuture#cancel(boolean)}.
+	 * can be obtained by using a {@link #fromFuture(Supplier, boolean)}
+	 * overload with the {@code cancel} parameter set to {@code true}.
 	 *
 	 * @param futureSupplier The {@link Supplier} of a {@link CompletableFuture} that will produce a value (or a null to
 	 * complete immediately). This allows lazy triggering of future-based APIs.
@@ -649,6 +668,26 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 */
 	public static <T> Mono<T> fromFuture(Supplier<? extends CompletableFuture<? extends T>> futureSupplier) {
 		return defer(() -> onAssembly(new MonoCompletionStage<>(futureSupplier.get())));
+	}
+
+	/**
+	 * Create a {@link Mono} that wraps a {@link CompletableFuture} on subscription,
+	 * emitting the value produced by the Future.
+	 *
+	 * <p>
+	 * <img class="marble" src="doc-files/marbles/fromFutureSupplier.svg" alt="">
+	 * <p>
+	 *
+	 * @param futureSupplier The {@link Supplier} of a {@link CompletableFuture} that will produce a value (or a null to
+	 * complete immediately). This allows lazy triggering of future-based APIs.
+	 * @param cancel specifies whether future should be cancelled or not via the
+	 * {@link CompletableFuture#cancel(boolean)} call
+	 * @param <T> type of the expected value
+	 * @return A {@link Mono}.
+	 * @see #fromCompletionStage(Supplier) fromCompletionStage for a generalization
+	 */
+	public static <T> Mono<T> fromFuture(Supplier<? extends CompletableFuture<? extends T>> futureSupplier, boolean cancel) {
+		return defer(() -> onAssembly(new MonoCompletionStage<>(futureSupplier.get(), cancel)));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCompletionStage.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCompletionStage.java
@@ -18,7 +18,6 @@ package reactor.core.publisher;
 
 import java.util.Objects;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
@@ -41,30 +40,27 @@ final class MonoCompletionStage<T> extends Mono<T>
         implements Fuseable, Scannable {
 
     final CompletionStage<? extends T> future;
-    final boolean cancel;
+    final boolean suppressCancellation;
 
-    MonoCompletionStage(CompletionStage<? extends T> future) {
+    MonoCompletionStage(CompletionStage<? extends T> future, boolean suppressCancellation) {
         this.future = Objects.requireNonNull(future, "future");
-        this.cancel = false;
-    }
-
-    MonoCompletionStage(CompletableFuture<? extends T> future, boolean cancel) {
-        this.future = Objects.requireNonNull(future, "future");
-        this.cancel = cancel;
+        this.suppressCancellation = suppressCancellation;
     }
 
     @Override
     public void subscribe(CoreSubscriber<? super T> actual) {
         Operators.MonoSubscriber<T, T>
-                sds = new Operators.MonoSubscriber<T, T>(actual) {
-            @Override
-            public void cancel() {
-                super.cancel();
-                if (cancel) {
-                    ((Future<?>) future).cancel(true);
-                }
-            }
-        };
+                sds = suppressCancellation
+                ? new Operators.MonoSubscriber<>(actual)
+                : new Operators.MonoSubscriber<T, T>(actual) {
+                    @Override
+                    public void cancel() {
+                        super.cancel();
+                        if (future instanceof Future) {
+                            ((Future<?>) future).cancel(true);
+                        }
+                    }
+                };
 
         actual.onSubscribe(sds);
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCompletionStage.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCompletionStage.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import java.util.Objects;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
@@ -40,9 +41,16 @@ final class MonoCompletionStage<T> extends Mono<T>
         implements Fuseable, Scannable {
 
     final CompletionStage<? extends T> future;
+    final boolean cancel;
 
     MonoCompletionStage(CompletionStage<? extends T> future) {
         this.future = Objects.requireNonNull(future, "future");
+        this.cancel = false;
+    }
+
+    MonoCompletionStage(CompletableFuture<? extends T> future, boolean cancel) {
+        this.future = Objects.requireNonNull(future, "future");
+        this.cancel = cancel;
     }
 
     @Override
@@ -52,7 +60,7 @@ final class MonoCompletionStage<T> extends Mono<T>
             @Override
             public void cancel() {
                 super.cancel();
-                if (future instanceof Future) {
+                if (cancel) {
                     ((Future<?>) future).cancel(true);
                 }
             }

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCompletionStageTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCompletionStageTest.java
@@ -39,7 +39,7 @@ MonoCompletionStageTest {
 		CompletableFuture<Integer> future = new CompletableFuture<>();
 
 		Mono<Integer> mono = Mono
-				.fromFuture(future, true);
+				.fromFuture(future);
 
 		StepVerifier.create(mono)
 		            .expectSubscription()
@@ -55,7 +55,7 @@ MonoCompletionStageTest {
 		AtomicReference<Subscription> subRef = new AtomicReference<>();
 
 		Mono<Integer> mono = Mono
-				.fromFuture(future)
+				.fromFuture(future, true)
 				.doOnSubscribe(subRef::set);
 
 		StepVerifier.create(mono)
@@ -76,7 +76,7 @@ MonoCompletionStageTest {
 		AtomicReference<Subscription> subRef = new AtomicReference<>();
 
 		Mono<Integer> mono = Mono
-				.fromFuture(future, true)
+				.fromFuture(future)
 				.doOnSubscribe(subRef::set);
 
 		StepVerifier.create(mono)
@@ -96,10 +96,7 @@ MonoCompletionStageTest {
 		for (int i = 0; i < 10000; i++) {
 			CompletableFuture<Integer> future = new CompletableFuture<>();
 			Mono<Integer> mono = Mono
-					.fromFuture(future)
-					.doFinally(sig -> {
-						if (sig == SignalType.CANCEL) future.cancel(false);
-					});
+					.fromFuture(future);
 
 			StepVerifier.create(mono)
 			            .expectSubscription()
@@ -117,10 +114,7 @@ MonoCompletionStageTest {
 		for (int i = 0; i < 500; i++) {
 			CompletableFuture<Integer> future = new CompletableFuture<>();
 			Mono<Integer> mono = Mono
-					.fromFuture(future)
-					.doFinally(sig -> {
-						if (sig == SignalType.CANCEL) future.cancel(false);
-					});
+					.fromFuture(future);
 
 			StepVerifier.create(mono)
 			            .expectSubscription()
@@ -139,10 +133,7 @@ MonoCompletionStageTest {
 		for (int i = 0; i < 500; i++) {
 			CompletableFuture<Integer> future = new CompletableFuture<>();
 			Mono<Integer> mono = Mono
-					.fromFuture(future)
-					.doFinally(sig -> {
-						if (sig == SignalType.CANCEL) future.cancel(false);
-					});
+					.fromFuture(future);
 
 			StepVerifier.create(mono.timeout(Duration.ofMillis(10)))
 			            .expectSubscription()
@@ -192,7 +183,7 @@ MonoCompletionStageTest {
 	@Test
 	public void scanOperator(){
 		CompletionStage<String> completionStage = CompletableFuture.supplyAsync(() -> "helloFuture");
-		MonoCompletionStage<String> test = new MonoCompletionStage<>(completionStage);
+		MonoCompletionStage<String> test = new MonoCompletionStage<>(completionStage, false);
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.ASYNC);
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isNull();


### PR DESCRIPTION
This PR rollbacks changes introduces by #3146 and reintroduce through a new configurable overload

closes #3235

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>
