### PR TITLE
Upgrade several plugins and test dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ baselinePerfExtra = "3.4.8"
 
 # Other shared versions
 asciidoctor = "3.3.2"
-bytebuddy = "1.12.17"
+bytebuddy = "1.12.18"
 jmh = "1.35"
 junit = "5.9.1"
 kotlin = "1.5.32"
@@ -29,7 +29,7 @@ junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 logback = "ch.qos.logback:logback-classic:1.2.11"
 micrometer = "io.micrometer:micrometer-core:1.3.0"
-mockito = "org.mockito:mockito-core:4.8.0"
+mockito = "org.mockito:mockito-core:4.8.1"
 reactiveStreams = { module = "org.reactivestreams:reactive-streams", version.ref = "reactiveStreams" }
 reactiveStreams-tck = { module = "org.reactivestreams:reactive-streams-tck", version.ref = "reactiveStreams" }
 reactor-perfBaseline-core = { module = "io.projectreactor:reactor-core", version.ref = "baselinePerfCore" }
@@ -39,11 +39,11 @@ testNg = "org.testng:testng:7.5" # since 7.6 JDK8 is unsupported, don't bump
 throwingFunction = "com.pivovarit:throwing-function:1.5.1"
 
 [plugins]
-artifactory = { id = "com.jfrog.artifactory", version = "4.29.1" }
+artifactory = { id = "com.jfrog.artifactory", version = "4.29.2" }
 asciidoctor-convert = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor" }
 asciidoctor-pdf = { id = "org.asciidoctor.jvm.pdf", version.ref = "asciidoctor" }
 bnd = { id = "biz.aQute.bnd.builder", version = "6.3.1" }
-download = { id = "de.undercouch.download", version = "5.2.1" }
+download = { id = "de.undercouch.download", version = "5.3.0" }
 japicmp = { id = "me.champeau.gradle.japicmp", version = "0.4.1" }
 jcstress = { id = "io.github.reyerizo.gradle.jcstress", version = "0.8.14" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 plugins {
-	id "com.gradle.enterprise" version "3.11.1"
+	id "com.gradle.enterprise" version "3.11.2"
 }
 
 rootProject.name = 'reactor'


### PR DESCRIPTION
This commit upgrades the following dependencies:
 - byteBuddy to `v1.12.18` (supersedes and closes #3230)
 - mockito to `v4.8.1` (supersedes and closes #3230)
 - artifactory to `v4.29.2` (supersedes and closes #3238)
 - download to `v5.3.0` (supersedes and closes #3233)
 - gradle-entreprise to `v3.11.2` (supersedes and closes #3231)
