### PR TITLE
Limit the number of Scheduler#disposeGracefully threads

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -261,6 +261,7 @@ blockHoundTest {
 jcstress {
 	mode = 'quick' //quick, default, tough
     jcstressDependency 'org.openjdk.jcstress:jcstress-core:0.15'
+	heapPerFork = 512
 }
 
 // inherit basic test task + common configuration in root

--- a/reactor-core/src/jcstress/java/reactor/core/scheduler/SchedulersStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/scheduler/SchedulersStressTest.java
@@ -32,7 +32,7 @@ import org.openjdk.jcstress.infra.results.Z_Result;
 public abstract class SchedulersStressTest {
 
 	private static void restart(Scheduler scheduler) {
-		scheduler.disposeGracefully().block(Duration.ofMillis(100));
+		scheduler.disposeGracefully().block(Duration.ofMillis(500));
 		// TODO: in 3.6.x: remove restart capability and this validation
 		scheduler.start();
 	}
@@ -174,6 +174,11 @@ public abstract class SchedulersStressTest {
 			// by r.r1 and r.r2, which should be equal.
 			boolean consistentState = r.r1 == r.r2;
 			r.r3 = consistentState && scheduler.isDisposed();
+			if (consistentState) {
+				//when that condition is true, we erase the r1/r2 state. that should greatly limit
+				//the output of "interesting acceptable state" in the dump should and error occur
+				r.r1 = r.r2 = 0;
+			}
 		}
 	}
 
@@ -210,6 +215,11 @@ public abstract class SchedulersStressTest {
 			// by r.r1 and r.r2, which should be equal.
 			boolean consistentState = r.r1 == r.r2;
 			r.r3 = consistentState && scheduler.isDisposed();
+			if (consistentState) {
+				//when that condition is true, we erase the r1/r2 state. that should greatly limit
+				//the output of "interesting acceptable state" in the dump should and error occur
+				r.r1 = r.r2 = 0;
+			}
 		}
 	}
 
@@ -246,6 +256,11 @@ public abstract class SchedulersStressTest {
 			// by r.r1 and r.r2, which should be equal.
 			boolean consistentState = r.r1 == r.r2;
 			r.r3 = consistentState && scheduler.isDisposed();
+			if (consistentState) {
+				//when that condition is true, we erase the r1/r2 state. that should greatly limit
+				//the output of "interesting acceptable state" in the dump should and error occur
+				r.r1 = r.r2 = 0;
+			}
 		}
 	}
 
@@ -281,6 +296,11 @@ public abstract class SchedulersStressTest {
 			// by r.r1 and r.r2, which should be equal.
 			boolean consistentState = r.r1 == r.r2;
 			r.r3 = consistentState && scheduler.isDisposed();
+			if (consistentState) {
+				//when that condition is true, we erase the r1/r2 state. that should greatly limit
+				//the output of "interesting acceptable state" in the dump should and error occur
+				r.r1 = r.r2 = 0;
+			}
 		}
 	}
 
@@ -317,6 +337,11 @@ public abstract class SchedulersStressTest {
 			// by r.r1 and r.r2, which should be equal.
 			boolean consistentState = r.r1 == r.r2;
 			r.r3 = consistentState && scheduler.isDisposed();
+			if (consistentState) {
+				//when that condition is true, we erase the r1/r2 state. that should greatly limit
+				//the output of "interesting acceptable state" in the dump should and error occur
+				r.r1 = r.r2 = 0;
+			}
 		}
 	}
 
@@ -354,6 +379,11 @@ public abstract class SchedulersStressTest {
 			// by r.r1 and r.r2, which should be equal.
 			boolean consistentState = r.r1 == r.r2;
 			r.r3 = consistentState && scheduler.isDisposed();
+			if (consistentState) {
+				//when that condition is true, we erase the r1/r2 state. that should greatly limit
+				//the output of "interesting acceptable state" in the dump should and error occur
+				r.r1 = r.r2 = 0;
+			}
 		}
 	}
 }

--- a/reactor-core/src/jcstress/java/reactor/core/scheduler/SchedulersStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/scheduler/SchedulersStressTest.java
@@ -157,13 +157,13 @@ public abstract class SchedulersStressTest {
 
 		@Actor
 		public void disposeGracefully1(IIZ_Result r) {
-			scheduler.disposeGracefully().subscribe();
+			scheduler.disposeGracefully().block();
 			r.r1 = scheduler.state.initialResource.hashCode();
 		}
 
 		@Actor
 		public void disposeGracefully2(IIZ_Result r) {
-			scheduler.disposeGracefully().subscribe();
+			scheduler.disposeGracefully().block();
 			r.r2 = scheduler.state.initialResource.hashCode();
 		}
 
@@ -198,13 +198,13 @@ public abstract class SchedulersStressTest {
 
 		@Actor
 		public void disposeGracefully1(IIZ_Result r) {
-			scheduler.disposeGracefully().subscribe();
+			scheduler.disposeGracefully().block();
 			r.r1 = scheduler.state.initialResource.hashCode();
 		}
 
 		@Actor
 		public void disposeGracefully2(IIZ_Result r) {
-			scheduler.disposeGracefully().subscribe();
+			scheduler.disposeGracefully().block();
 			r.r2 = scheduler.state.initialResource.hashCode();
 		}
 
@@ -239,13 +239,13 @@ public abstract class SchedulersStressTest {
 
 		@Actor
 		public void disposeGracefully1(IIZ_Result r) {
-			scheduler.disposeGracefully().subscribe();
+			scheduler.disposeGracefully().block();
 			r.r1 = scheduler.state.initialResource.hashCode();
 		}
 
 		@Actor
 		public void disposeGracefully2(IIZ_Result r) {
-			scheduler.disposeGracefully().subscribe();
+			scheduler.disposeGracefully().block();
 			r.r2 = scheduler.state.initialResource.hashCode();
 		}
 
@@ -279,7 +279,7 @@ public abstract class SchedulersStressTest {
 
 		@Actor
 		public void disposeGracefully(IIZ_Result r) {
-			scheduler.disposeGracefully().subscribe();
+			scheduler.disposeGracefully().block();
 			r.r1 = scheduler.state.initialResource.hashCode();
 		}
 
@@ -320,7 +320,7 @@ public abstract class SchedulersStressTest {
 
 		@Actor
 		public void disposeGracefully(IIZ_Result r) {
-			scheduler.disposeGracefully().subscribe();
+			scheduler.disposeGracefully().block();
 			r.r1 = scheduler.state.initialResource.hashCode();
 		}
 
@@ -362,7 +362,7 @@ public abstract class SchedulersStressTest {
 
 		@Actor
 		public void disposeGracefully(IIZ_Result r) {
-			scheduler.disposeGracefully().subscribe();
+			scheduler.disposeGracefully().block();
 			r.r1 = scheduler.state.initialResource.hashCode();
 		}
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
@@ -219,8 +219,7 @@ final class BoundedElasticScheduler implements Scheduler,
 	}
 
 	@Override
-	public boolean await(BoundedServices boundedServices, long timeout, TimeUnit timeUnit)
-		throws InterruptedException {
+	public boolean await(BoundedServices boundedServices, long timeout, TimeUnit timeUnit) throws InterruptedException {
 		if (!boundedServices.evictor.awaitTermination(timeout, timeUnit)) {
 			return false;
 		}

--- a/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
@@ -233,19 +233,6 @@ final class BoundedElasticScheduler implements Scheduler,
 	}
 
 	@Override
-	public boolean tryAwait(BoundedServices boundedServices) {
-		if (!boundedServices.evictor.isTerminated()) {
-			return false;
-		}
-		for (BoundedState bs : boundedServices.busyStates.array) {
-			if (!bs.executor.isTerminated()) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	@Override
 	public void dispose() {
 		SchedulerState<BoundedServices> previous = state;
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
@@ -220,12 +220,25 @@ final class BoundedElasticScheduler implements Scheduler,
 
 	@Override
 	public boolean await(BoundedServices boundedServices, long timeout, TimeUnit timeUnit)
-			throws InterruptedException {
+		throws InterruptedException {
 		if (!boundedServices.evictor.awaitTermination(timeout, timeUnit)) {
 			return false;
 		}
 		for (BoundedState bs : boundedServices.busyStates.array) {
 			if (!bs.executor.awaitTermination(timeout, timeUnit)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public boolean tryAwait(BoundedServices boundedServices) {
+		if (!boundedServices.evictor.isTerminated()) {
+			return false;
+		}
+		for (BoundedState bs : boundedServices.busyStates.array) {
+			if (!bs.executor.isTerminated()) {
 				return false;
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
@@ -508,7 +508,7 @@ final class BoundedElasticScheduler implements Scheduler,
 			this.clock = parent.clock;
 			this.idleQueue = new ConcurrentLinkedDeque<>();
 			this.busyStates = ALL_IDLE;
-			this.evictor = Executors.newScheduledThreadPool(1, EVICTOR_FACTORY);
+			this.evictor = Executors.newSingleThreadScheduledExecutor(EVICTOR_FACTORY);
 		}
 
 		/**

--- a/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
@@ -146,8 +146,13 @@ final class DelegateServiceScheduler implements Scheduler, SchedulerState.Dispos
 
 	@Override
 	public boolean await(ScheduledExecutorService resource, long timeout, TimeUnit timeUnit)
-			throws InterruptedException {
+		throws InterruptedException {
 		return resource.awaitTermination(timeout, timeUnit);
+	}
+
+	@Override
+	public boolean tryAwait(ScheduledExecutorService resource) {
+		return resource.isTerminated();
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
@@ -151,11 +151,6 @@ final class DelegateServiceScheduler implements Scheduler, SchedulerState.Dispos
 	}
 
 	@Override
-	public boolean tryAwait(ScheduledExecutorService resource) {
-		return resource.isTerminated();
-	}
-
-	@Override
 	public void dispose() {
 		SchedulerState<ScheduledExecutorService> previous = state;
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ElasticScheduler.java
@@ -111,7 +111,7 @@ final class ElasticScheduler implements Scheduler, Scannable {
 			);
 		}
 
-		this.evictor = Executors.newScheduledThreadPool(1, EVICTOR_FACTORY);
+		this.evictor = Executors.newSingleThreadScheduledExecutor(EVICTOR_FACTORY);
 		this.evictor.scheduleAtFixedRate(this::eviction,
 				ttlSeconds,
 				ttlSeconds,
@@ -124,7 +124,7 @@ final class ElasticScheduler implements Scheduler, Scannable {
 		if (!shutdown) {
 			return;
 		}
-		this.evictor = Executors.newScheduledThreadPool(1, EVICTOR_FACTORY);
+		this.evictor = Executors.newSingleThreadScheduledExecutor(EVICTOR_FACTORY);
 		this.evictor.scheduleAtFixedRate(this::eviction,
 				ttlSeconds,
 				ttlSeconds,

--- a/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
@@ -145,15 +145,25 @@ final class ParallelScheduler implements Scheduler, Supplier<ScheduledExecutorSe
 		}
 	}
 
-    @Override
-    public boolean await(ScheduledExecutorService[] resource, long timeout, TimeUnit timeUnit) throws InterruptedException {
-        for (ScheduledExecutorService executor : resource) {
-            if (!executor.awaitTermination(timeout, timeUnit)) {
-                return false;
-            }
-        }
-        return true;
-    }
+	@Override
+	public boolean await(ScheduledExecutorService[] resource, long timeout, TimeUnit timeUnit) throws InterruptedException {
+		for (ScheduledExecutorService executor : resource) {
+			if (!executor.awaitTermination(timeout, timeUnit)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public boolean tryAwait(ScheduledExecutorService[] resource) {
+		for (ScheduledExecutorService executor : resource) {
+			if (!executor.isTerminated()) {
+				return false;
+			}
+		}
+		return true;
+	}
 
     @Override
 	public void dispose() {

--- a/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
@@ -155,16 +155,6 @@ final class ParallelScheduler implements Scheduler, Supplier<ScheduledExecutorSe
 		return true;
 	}
 
-	@Override
-	public boolean tryAwait(ScheduledExecutorService[] resource) {
-		for (ScheduledExecutorService executor : resource) {
-			if (!executor.isTerminated()) {
-				return false;
-			}
-		}
-		return true;
-	}
-
     @Override
 	public void dispose() {
         SchedulerState<ScheduledExecutorService[]> previous = state;

--- a/reactor-core/src/main/java/reactor/core/scheduler/SchedulerState.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SchedulerState.java
@@ -65,7 +65,7 @@ final class SchedulerState<T> {
 		static final ScheduledExecutorService TRANSITION_AWAIT_POOL;
 
 		static {
-			ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+			ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(0);
 			executor.setKeepAliveTime(10, TimeUnit.SECONDS);
 			executor.allowCoreThreadTimeOut(true);
 			executor.setMaximumPoolSize(Schedulers.DEFAULT_POOL_SIZE);

--- a/reactor-core/src/main/java/reactor/core/scheduler/SchedulerState.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SchedulerState.java
@@ -16,11 +16,18 @@
 
 package reactor.core.scheduler;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
+
+import static reactor.core.scheduler.SchedulerState.DisposeAwaiterRunnable.awaitInPool;
 
 final class SchedulerState<T> {
 
@@ -41,33 +48,102 @@ final class SchedulerState<T> {
 
 	static <T> SchedulerState<T> transition(@Nullable T initial, T next, DisposeAwaiter<T> awaiter) {
 		return new SchedulerState<T>(
-				initial,
-				next,
-				initial == null ? Mono.empty() :
-						Flux.<Void>create(sink -> {
-									// TODO(dj): consider a shared pool for all disposeGracefully background tasks
-									// as part of Schedulers internal API
-									Thread backgroundThread = new Thread(() -> {
-										while (!Thread.currentThread().isInterrupted()) {
-											try {
-												if (awaiter.await(initial, 1, TimeUnit.SECONDS)) {
-													sink.complete();
-													return;
-												}
-											} catch (InterruptedException e) {
-												return;
-											}
-										}
-									});
-									sink.onCancel(backgroundThread::interrupt);
-									backgroundThread.start();
-								})
-								.replay()
-								.refCount()
-								.next());
+			initial,
+			next,
+			initial == null ? Mono.empty() :
+				Flux.<Void>create(sink -> awaitInPool(awaiter, initial, sink, 1000, 100))
+					.replay()
+					.refCount()
+					.next());
 	}
 
 	interface DisposeAwaiter<T> {
+
 		boolean await(T resource, long timeout, TimeUnit timeUnit) throws InterruptedException;
+
+		boolean tryAwait(T resource);
+	}
+
+	static class DisposeAwaiterRunnable<T> implements Runnable {
+
+		static final ScheduledExecutorService TRANSITION_AWAIT_POOL;
+
+		static {
+			ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+			executor.setKeepAliveTime(10, TimeUnit.SECONDS);
+			executor.allowCoreThreadTimeOut(true);
+			executor.setMaximumPoolSize(Schedulers.DEFAULT_POOL_SIZE);
+
+			System.out.println("CREATED POOL");
+			TRANSITION_AWAIT_POOL = executor;
+		}
+
+		@SuppressWarnings("rawtypes")
+		static final AtomicIntegerFieldUpdater<DisposeAwaiterRunnable> STATE =
+			AtomicIntegerFieldUpdater.newUpdater(DisposeAwaiterRunnable.class, "state");
+
+		private final DisposeAwaiter<T> awaiter;
+		private final T                 initial;
+		private final int               initialAwaitMs;
+		private final int               retryDelay;
+		private final FluxSink<Void>    sink;
+
+		volatile int state;
+
+		static <R> void awaitInPool(DisposeAwaiter<R> awaiter, R initial, FluxSink<Void> sink, int initialAwaitMs, int retryDelayMs) {
+			DisposeAwaiterRunnable<R> poller = new DisposeAwaiterRunnable<>(awaiter, initial, sink, initialAwaitMs, retryDelayMs);
+			TRANSITION_AWAIT_POOL.submit(poller);
+		}
+
+		DisposeAwaiterRunnable(DisposeAwaiter<T> awaiter, T initial, FluxSink<Void> sink, int initialAwaitMs, int retryDelayMs) {
+			this.awaiter = awaiter;
+			this.initial = initial;
+			this.sink = sink;
+			this.initialAwaitMs = initialAwaitMs;
+			this.retryDelay = retryDelayMs;
+			//can only call onCancel once so we rely on DisposeAwaiterRunnable#cancel
+			sink.onCancel(this::cancel);
+		}
+
+		void cancel() {
+			STATE.set(this, 2);
+			//we don't really care about the future. next round we'll abandon the task
+		}
+
+		@Override
+		public void run() {
+			if (state == 2) {
+				return;
+			}
+			boolean awaitDone = false;
+			// should be called at the beginning when STATE == 0:
+			// we give the Scheduler a chance to terminate faster than the delay.
+			// after that, we'll poll regularly (which means the sink can't be completed faster than increments of the delay)
+			if (STATE.compareAndSet(this, 0, 1)) {
+				try {
+					awaitDone = awaiter.await(initial, initialAwaitMs, TimeUnit.MILLISECONDS);
+				}
+				catch (InterruptedException e) {
+					return;
+				}
+			}
+			else if (state == 1) {
+				awaitDone = awaiter.tryAwait(initial);
+			}
+			else {
+				return;
+			}
+
+			if (awaitDone) {
+				sink.complete();
+			}
+			else {
+				if (state == 2) {
+					return;
+				}
+				// trampoline / retry in 100ms
+				TRANSITION_AWAIT_POOL.schedule(this, this.retryDelay, TimeUnit.MILLISECONDS);
+			}
+		}
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/scheduler/SchedulerState.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SchedulerState.java
@@ -73,8 +73,6 @@ final class SchedulerState<T> {
 			executor.setKeepAliveTime(10, TimeUnit.SECONDS);
 			executor.allowCoreThreadTimeOut(true);
 			executor.setMaximumPoolSize(Schedulers.DEFAULT_POOL_SIZE);
-
-			System.out.println("CREATED POOL");
 			TRANSITION_AWAIT_POOL = executor;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
@@ -137,11 +137,6 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 	}
 
 	@Override
-	public boolean tryAwait(ScheduledExecutorService resource) {
-		return resource.isTerminated();
-	}
-
-	@Override
 	public void dispose() {
 		SchedulerState<ScheduledExecutorService> previous = state;
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
@@ -132,9 +132,13 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 	}
 
 	@Override
-	public boolean await(ScheduledExecutorService resource, long timeout, TimeUnit timeUnit)
-			throws InterruptedException {
+	public boolean await(ScheduledExecutorService resource, long timeout, TimeUnit timeUnit) throws InterruptedException {
 		return resource.awaitTermination(timeout, timeUnit);
+	}
+
+	@Override
+	public boolean tryAwait(ScheduledExecutorService resource) {
+		return resource.isTerminated();
 	}
 
 	@Override


### PR DESCRIPTION
This change introduces a `DisposeAwaiterRunnable` with a small pool of
threads dedicated to polling the termination status after a graceful
Scheduler shutdown.

Previously, one Thread would be created for each Scheduler that is
disposed gracefully. While we don't expect this to be an issue in most
production applications, this can lead to hitting native thread limits
faster. Notably, stress tests around graceful disposal create a lot of
schedulers for that purpose.

This change also ensures that the evictor executorServices of both the
BoundedElasticScheduler and ElasticScheduler are limited to at most 1
thread.

Finally, it attempts to improve the SchedulersStressTest to avoid the
OOMs as much as possible: block on disposeGracefully() calls, increase
the heap of forked JVMs for jcstress, and ultimately stop covering the
BoundedElasticScheduler in the stress test.

Fixes #3258.