### PR TITLE
Only initialize logging once per test session

### DIFF
--- a/reactor-core/src/test/java/reactor/ReactorLauncherSessionListener.java
+++ b/reactor-core/src/test/java/reactor/ReactorLauncherSessionListener.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor;
 
 import org.junit.platform.launcher.LauncherSession;

--- a/reactor-core/src/test/java/reactor/ReactorLauncherSessionListener.java
+++ b/reactor-core/src/test/java/reactor/ReactorLauncherSessionListener.java
@@ -1,0 +1,25 @@
+package reactor;
+
+import org.junit.platform.launcher.LauncherSession;
+import org.junit.platform.launcher.LauncherSessionListener;
+import reactor.test.AssertionsUtils;
+import reactor.test.util.LoggerUtils;
+import reactor.util.Loggers;
+
+public class ReactorLauncherSessionListener implements LauncherSessionListener {
+
+    /**
+     * Reset the {@link Loggers} factory to defaults suitable for reactor-core tests.
+     * Notably, it installs an indirection via {@link LoggerUtils#useCurrentLoggersWithCapture()}.
+     */
+    public static void resetLoggersFactory() {
+        Loggers.resetLoggerFactory();
+        LoggerUtils.useCurrentLoggersWithCapture();
+    }
+
+    @Override
+    public void launcherSessionOpened(LauncherSession session) {
+        AssertionsUtils.installAssertJTestRepresentation();
+        ReactorLauncherSessionListener.resetLoggersFactory();
+    }
+}

--- a/reactor-core/src/test/java/reactor/ReactorTestExecutionListener.java
+++ b/reactor-core/src/test/java/reactor/ReactorTestExecutionListener.java
@@ -25,9 +25,7 @@ import org.junit.platform.launcher.TestPlan;
 import reactor.core.publisher.Hooks;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.AssertionsUtils;
-import reactor.test.util.LoggerUtils;
 import reactor.util.Logger;
-import reactor.util.Loggers;
 
 /**
  * A custom TestExecutionListener that helps with tests in reactor:<ul>
@@ -61,23 +59,8 @@ public class ReactorTestExecutionListener implements TestExecutionListener {
 		// TODO capture non-default schedulers and shutdown them
 	}
 
-	/**
-	 * Reset the {@link Loggers} factory to defaults suitable for reactor-core tests.
-	 * Notably, it installs an indirection via {@link LoggerUtils#useCurrentLoggersWithCapture()}.
-	 */
-	public static void resetLoggersFactory() {
-		Loggers.resetLoggerFactory();
-		LoggerUtils.useCurrentLoggersWithCapture();
-	}
-
 	@Override
 	public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
 		resetHooksAndSchedulers();
-	}
-
-	@Override
-	public void testPlanExecutionStarted(TestPlan testPlan) {
-		AssertionsUtils.installAssertJTestRepresentation();
-		resetLoggersFactory();
 	}
 }

--- a/reactor-core/src/test/java/reactor/ReactorTestExecutionListener.java
+++ b/reactor-core/src/test/java/reactor/ReactorTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/util/LoggersTest.java
+++ b/reactor-core/src/test/java/reactor/util/LoggersTest.java
@@ -19,7 +19,7 @@ package reactor.util;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
-import reactor.ReactorTestExecutionListener;
+import reactor.ReactorLauncherSessionListener;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,8 +27,8 @@ class LoggersTest {
 
 	@AfterAll
 	static void resetLoggerFactory() {
-		//delegate to ReactorTestExecutionListener to centralize the logic
-		ReactorTestExecutionListener.resetLoggersFactory();
+		//delegate to ReactorLauncherSessionListener to centralize the logic
+		ReactorLauncherSessionListener.resetLoggersFactory();
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/util/LoggersTest.java
+++ b/reactor-core/src/test/java/reactor/util/LoggersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/reactor-core/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+reactor.ReactorLauncherSessionListener


### PR DESCRIPTION
When using Gradle Enterprise Test Distribution or Predictive Test
Selection, smaller partitions are created that result in multiple test
plans being created. The prior assumption that
`testPlanExecutionStarted` is only called once no longer holds in such
cases which led to failing tests when they were executed in different
test plans.
