### PR TITLE
add Flux.mergePriority that does not wait for all sources to emit

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -1504,6 +1504,115 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * Instead, this operator considers only one value from each source and picks the
 	 * smallest of all these values, then replenishes the slot for that picked source.
 	 * <p>
+	 * Unlike mergeComparing, this operator does <em>not</em> wait for a value from each source to arrive.
+	 * <p>
+	 * <img class="marble" src="doc-files/marbles/mergeComparingNaturalOrder.svg" alt="">
+	 *
+	 * @param sources {@link Publisher} sources of {@link Comparable} to merge
+	 * @param <I> a {@link Comparable} merged type that has a {@link Comparator#naturalOrder() natural order}
+	 * @return a merged {@link Flux} that , subscribing early but keeping the original ordering
+	 */
+	@SafeVarargs
+	public static <I extends Comparable<? super I>> Flux<I> mergePriority(Publisher<? extends I>... sources) {
+		return mergeComparing(Queues.SMALL_BUFFER_SIZE, Comparator.naturalOrder(), sources);
+	}
+	/**
+	 * Merge data from provided {@link Publisher} sequences into an ordered merged sequence,
+	 * by picking the smallest values from each source (as defined by the provided
+	 * {@link Comparator}). This is not a {@link #sort(Comparator)}, as it doesn't consider
+	 * the whole of each sequences.
+	 * <p>
+	 * Instead, this operator considers only one value from each source and picks the
+	 * smallest of all these values, then replenishes the slot for that picked source.
+	 * <p>
+	 * Unlike mergeComparing, this operator does <em>not</em> wait for a value from each source to arrive.
+	 * <p>
+	 * <img class="marble" src="doc-files/marbles/mergeComparing.svg" alt="">
+	 *
+	 * @param comparator the {@link Comparator} to use to find the smallest value
+	 * @param sources {@link Publisher} sources to merge
+	 * @param <T> the merged type
+	 * @return a merged {@link Flux} that compares the latest values from each source, using the
+	 * smallest value and replenishing the source that produced it
+	 */
+	@SafeVarargs
+	public static <T> Flux<T> mergePriority(Comparator<? super T> comparator, Publisher<? extends T>... sources) {
+		return mergePriority(Queues.SMALL_BUFFER_SIZE, comparator, sources);
+	}
+
+	/**
+	 * Merge data from provided {@link Publisher} sequences into an ordered merged sequence,
+	 * by picking the smallest values from each source (as defined by the provided
+	 * {@link Comparator}). This is not a {@link #sort(Comparator)}, as it doesn't consider
+	 * the whole of each sequences.
+	 * <p>
+	 * Instead, this operator considers only one value from each source and picks the
+	 * smallest of all these values, then replenishes the slot for that picked source.
+	 * <p>
+	 * Unlike mergeComparing, this operator does <em>not</em> wait for a value from each source to arrive.
+	 * <p>
+	 * <img class="marble" src="doc-files/marbles/mergeComparing.svg" alt="">
+	 *
+	 * @param prefetch the number of elements to prefetch from each source (avoiding too
+	 * many small requests to the source when picking)
+	 * @param comparator the {@link Comparator} to use to find the smallest value
+	 * @param sources {@link Publisher} sources to merge
+	 * @param <T> the merged type
+	 * @return a merged {@link Flux} that compares latest values from each source, using the
+	 * smallest value and replenishing the source that produced it
+	 */
+	@SafeVarargs
+	public static <T> Flux<T> mergePriority(int prefetch, Comparator<? super T> comparator, Publisher<? extends T>... sources) {
+		if (sources.length == 0) {
+			return empty();
+		}
+		if (sources.length == 1) {
+			return from(sources[0]);
+		}
+		return onAssembly(new FluxMergeComparing<>(prefetch, comparator, false,  false, sources));
+	}
+	/**
+	 * Merge data from provided {@link Publisher} sequences into an ordered merged sequence,
+	 * by picking the smallest values from each source (as defined by the provided
+	 * {@link Comparator}). This is not a {@link #sort(Comparator)}, as it doesn't consider
+	 * the whole of each sequences.
+	 * <p>
+	 * Instead, this operator considers only one value from each source and picks the
+	 * smallest of all these values, then replenishes the slot for that picked source.
+	 * <p>
+	 * Note that it is delaying errors until all data is consumed.
+	 * <p>
+	 * Unlike mergeComparing, this operator does <em>not</em> wait for a value from each source to arrive.
+	 * <p>
+	 * <img class="marble" src="doc-files/marbles/mergeComparing.svg" alt="">
+	 *
+	 * @param prefetch the number of elements to prefetch from each source (avoiding too
+	 * many small requests to the source when picking)
+	 * @param comparator the {@link Comparator} to use to find the smallest value
+	 * @param sources {@link Publisher} sources to merge
+	 * @param <T> the merged type
+	 * @return a merged {@link Flux} that compares latest values from each source, using the
+	 * smallest value and replenishing the source that produced it
+	 */
+	@SafeVarargs
+	public static <T> Flux<T> mergePriorityDelayError(int prefetch, Comparator<? super T> comparator, Publisher<? extends T>... sources) {
+		if (sources.length == 0) {
+			return empty();
+		}
+		if (sources.length == 1) {
+			return from(sources[0]);
+		}
+		return onAssembly(new FluxMergeComparing<>(prefetch, comparator, true, false, sources));
+	}
+
+	/**
+	 * Merge data from provided {@link Publisher} sequences into an ordered merged sequence,
+	 * by picking the smallest values from each source (as defined by their natural order).
+	 * This is not a {@link #sort()}, as it doesn't consider the whole of each sequences.
+	 * <p>
+	 * Instead, this operator considers only one value from each source and picks the
+	 * smallest of all these values, then replenishes the slot for that picked source.
+	 * <p>
 	 * <img class="marble" src="doc-files/marbles/mergeComparingNaturalOrder.svg" alt="">
 	 *
 	 * @param sources {@link Publisher} sources of {@link Comparable} to merge
@@ -1564,7 +1673,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 		if (sources.length == 1) {
 			return from(sources[0]);
 		}
-		return onAssembly(new FluxMergeComparing<>(prefetch, comparator, false, sources));
+		return onAssembly(new FluxMergeComparing<>(prefetch, comparator, false, true, sources));
 	}
 
 	/**
@@ -1596,7 +1705,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 		if (sources.length == 1) {
 			return from(sources[0]);
 		}
-		return onAssembly(new FluxMergeComparing<>(prefetch, comparator, true, sources));
+		return onAssembly(new FluxMergeComparing<>(prefetch, comparator, true, true, sources));
 	}
 
 	/**
@@ -1686,7 +1795,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 		if (sources.length == 1) {
 			return from(sources[0]);
 		}
-		return onAssembly(new FluxMergeComparing<>(prefetch, comparator, true, sources));
+		return onAssembly(new FluxMergeComparing<>(prefetch, comparator, true, true, sources));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMergeComparing.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMergeComparing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,9 +50,11 @@ final class FluxMergeComparing<T> extends Flux<T> implements SourceProducer<T> {
 	final Comparator<? super T>    valueComparator;
 	final Publisher<? extends T>[] sources;
 	final boolean delayError;
+	final boolean waitForAllSources;
 
 	@SafeVarargs
-	FluxMergeComparing(int prefetch, Comparator<? super T> valueComparator, boolean delayError, Publisher<? extends T>... sources) {
+	FluxMergeComparing(int prefetch, Comparator<? super T> valueComparator, boolean delayError,
+					   boolean waitForAllSources, Publisher<? extends T>... sources) {
 		if (prefetch <= 0) {
 			throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
 		}
@@ -68,6 +70,7 @@ final class FluxMergeComparing<T> extends Flux<T> implements SourceProducer<T> {
 		this.prefetch = prefetch;
 		this.valueComparator = valueComparator;
 		this.delayError = delayError;
+		this.waitForAllSources = waitForAllSources;
 	}
 
 	/**
@@ -91,9 +94,9 @@ final class FluxMergeComparing<T> extends Flux<T> implements SourceProducer<T> {
 			@SuppressWarnings("unchecked")
 			Comparator<T> currentComparator = (Comparator<T>) this.valueComparator;
 			final Comparator<T> newComparator = currentComparator.thenComparing(otherComparator);
-			return new FluxMergeComparing<>(prefetch, newComparator, delayError, newArray);
+			return new FluxMergeComparing<>(prefetch, newComparator, delayError, waitForAllSources, newArray);
 		}
-		return new FluxMergeComparing<>(prefetch, valueComparator, delayError, newArray);
+		return new FluxMergeComparing<>(prefetch, valueComparator, delayError, waitForAllSources, newArray);
 	}
 
 	@Override
@@ -114,7 +117,7 @@ final class FluxMergeComparing<T> extends Flux<T> implements SourceProducer<T> {
 
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
-		MergeOrderedMainProducer<T> main = new MergeOrderedMainProducer<>(actual, valueComparator, prefetch, sources.length, delayError);
+		MergeOrderedMainProducer<T> main = new MergeOrderedMainProducer<>(actual, valueComparator, prefetch, sources.length, delayError, waitForAllSources);
 		actual.onSubscribe(main);
 		main.subscribe(sources);
 	}
@@ -129,6 +132,7 @@ final class FluxMergeComparing<T> extends Flux<T> implements SourceProducer<T> {
 		final Comparator<? super T> comparator;
 		final Object[] values;
 		final boolean delayError;
+		final boolean waitForAllSources;
 
 		boolean done;
 
@@ -154,10 +158,11 @@ final class FluxMergeComparing<T> extends Flux<T> implements SourceProducer<T> {
 				AtomicIntegerFieldUpdater.newUpdater(MergeOrderedMainProducer.class, "wip");
 
 		MergeOrderedMainProducer(CoreSubscriber<? super T> actual,
-				Comparator<? super T> comparator, int prefetch, int n, boolean delayError) {
+				Comparator<? super T> comparator, int prefetch, int n, boolean delayError, boolean waitForAllSources) {
 			this.actual = actual;
 			this.comparator = comparator;
 			this.delayError = delayError;
+			this.waitForAllSources = waitForAllSources;
 
 			@SuppressWarnings("unchecked")
 			MergeOrderedInnerSubscriber<T>[] mergeOrderedInnerSub =
@@ -285,7 +290,7 @@ final class FluxMergeComparing<T> extends Flux<T> implements SourceProducer<T> {
 						return;
 					}
 
-					if (nonEmpty != n || e >= r) {
+					if ((waitForAllSources && nonEmpty != n) || (!waitForAllSources && nonEmpty == 0) || e >= r) {
 						break;
 					}
 
@@ -294,7 +299,7 @@ final class FluxMergeComparing<T> extends Flux<T> implements SourceProducer<T> {
 
 					int i = 0;
 					for (Object o : values) {
-						if (o != DONE) {
+						if (o != DONE && o != null) {
 							boolean smaller;
 							try {
 								@SuppressWarnings("unchecked")
@@ -316,12 +321,14 @@ final class FluxMergeComparing<T> extends Flux<T> implements SourceProducer<T> {
 						i++;
 					}
 
-					values[minIndex] = null;
+					if (minIndex >= 0) {
+						values[minIndex] = null;
 
-					actual.onNext(min);
+						actual.onNext(min);
 
-					e++;
-					subscribers[minIndex].request(1);
+						e++;
+						subscribers[minIndex].request(1);
+					}
 				}
 
 				this.emitted = e;

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeOrdered.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeOrdered.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ final class ParallelMergeOrdered<T> extends Flux<T> implements Scannable {
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
 		FluxMergeComparing.MergeOrderedMainProducer<T>
-				main = new FluxMergeComparing.MergeOrderedMainProducer<>(actual, valueComparator, prefetch, source.parallelism(), true);
+				main = new FluxMergeComparing.MergeOrderedMainProducer<>(actual, valueComparator, prefetch, source.parallelism(), true, true);
 		actual.onSubscribe(main);
 		source.subscribe(main.subscribers);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeComparingTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeComparingTest.java
@@ -35,6 +35,7 @@ import reactor.core.Scannable;
 import reactor.test.StepVerifier;
 import reactor.util.concurrent.Queues;
 import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -213,7 +214,7 @@ class FluxMergeComparingTest {
 		@SuppressWarnings("unchecked")
 		Publisher<Tuple2<Long, Integer>>[] sources = sourceList.toArray(new Publisher[sourceList.size()]);
 
-		Flux<Integer> test = new FluxMergeComparing<>(16, Comparator.comparing(Tuple2::getT1), false, sources)
+		Flux<Integer> test = new FluxMergeComparing<>(16, Comparator.comparing(Tuple2::getT1), false, true, sources)
 				.map(Tuple2::getT2);
 
 		StepVerifier.create(test)
@@ -240,7 +241,7 @@ class FluxMergeComparingTest {
 		Publisher<Tuple2<Long, Integer>>[] sources = sourceList.toArray(new Publisher[sourceList.size()]);
 
 		Flux<Integer> test = new FluxMergeComparing<>(16,
-				Comparator.comparing(Tuple2::getT1), false, sources)
+				Comparator.comparing(Tuple2::getT1), false, true, sources)
 				.map(Tuple2::getT2);
 
 		StepVerifier.create(test)
@@ -251,21 +252,21 @@ class FluxMergeComparingTest {
 	@Test
 	void prefetchZero() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new FluxMergeComparing<Integer>(0, Comparator.naturalOrder(), false))
+				.isThrownBy(() -> new FluxMergeComparing<Integer>(0, Comparator.naturalOrder(), false, true))
 				.withMessage("prefetch > 0 required but it was 0");
 	}
 
 	@Test
 	void prefetchNegative() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new FluxMergeComparing<Integer>(-1, Comparator.naturalOrder(), false))
+				.isThrownBy(() -> new FluxMergeComparing<Integer>(-1, Comparator.naturalOrder(), false, true))
 				.withMessage("prefetch > 0 required but it was -1");
 	}
 
 	@Test
 	void getPrefetch() {
 		FluxMergeComparing<Integer> fmo = new FluxMergeComparing<Integer>(123,
-				Comparator.naturalOrder(), false);
+				Comparator.naturalOrder(), false, true);
 
 		assertThat(fmo.getPrefetch()).isEqualTo(123);
 	}
@@ -273,7 +274,7 @@ class FluxMergeComparingTest {
 	@Test
 	void nullSources() {
 		assertThatNullPointerException()
-				.isThrownBy(() -> new FluxMergeComparing<>(2, Comparator.naturalOrder(), false,
+				.isThrownBy(() -> new FluxMergeComparing<>(2, Comparator.naturalOrder(), false, true,
 						(Publisher<Integer>[]) null))
 				.withMessage("sources must be non-null");
 	}
@@ -283,7 +284,7 @@ class FluxMergeComparingTest {
 		Comparator<Integer> originalComparator = Comparator.naturalOrder();
 		@SuppressWarnings("unchecked") //safe varargs
 		FluxMergeComparing<Integer> fmo = new FluxMergeComparing<>(2,
-				originalComparator, false,
+				originalComparator, false, true,
 				Flux.just(1, 2),
 				Flux.just(3, 4));
 
@@ -307,7 +308,7 @@ class FluxMergeComparingTest {
 		Comparator<Integer> originalComparator = Comparator.naturalOrder();
 		@SuppressWarnings("unchecked") //safe varargs
 		FluxMergeComparing<Integer> fmo = new FluxMergeComparing<>(2,
-				originalComparator, true,
+				originalComparator, true, true,
 				Flux.just(1, 2),
 				Flux.just(3, 4));
 
@@ -323,7 +324,7 @@ class FluxMergeComparingTest {
 		Flux<Integer> source2 = Flux.just(2);
 
 		@SuppressWarnings("unchecked") //safe varargs
-		FluxMergeComparing<Integer> fmo = new FluxMergeComparing<>(123, Comparator.naturalOrder(), true, source1, source2);
+		FluxMergeComparing<Integer> fmo = new FluxMergeComparing<>(123, Comparator.naturalOrder(), true, true, source1, source2);
 
 		assertThat(fmo.scan(Scannable.Attr.PARENT)).isSameAs(source1);
 		assertThat(fmo.scan(Scannable.Attr.PREFETCH)).isEqualTo(123);
@@ -339,7 +340,7 @@ class FluxMergeComparingTest {
 		CoreSubscriber<? super Integer> actual = new LambdaSubscriber<>(null, null, null, null);
 
 		FluxMergeComparing.MergeOrderedMainProducer<Integer> test =
-				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, false);
+				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, false, true);
 
 		assertThat(test.scan(Scannable.Attr.ACTUAL))
 				.isSameAs(actual)
@@ -367,7 +368,7 @@ class FluxMergeComparingTest {
 	void scanInner() {
 		CoreSubscriber<? super Integer> actual = new LambdaSubscriber<>(null, null, null, null);
 		FluxMergeComparing.MergeOrderedMainProducer<Integer> main =
-				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, false);
+				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, false, true);
 
 		FluxMergeComparing.MergeOrderedInnerSubscriber<Integer> test = new FluxMergeComparing.MergeOrderedInnerSubscriber<>(
 				main, 123);
@@ -398,7 +399,7 @@ class FluxMergeComparingTest {
 		CoreSubscriber<? super Integer> actual = new LambdaSubscriber<>(null, null, null, null);
 
 		FluxMergeComparing.MergeOrderedMainProducer<Integer> test =
-				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, false);
+				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, false, true);
 
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> {
@@ -413,7 +414,7 @@ class FluxMergeComparingTest {
 	void innerRequestAmountIgnoredAssumedOne() {
 		CoreSubscriber<? super Integer> actual = new LambdaSubscriber<>(null, null, null, null);
 		FluxMergeComparing.MergeOrderedMainProducer<Integer> main =
-				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, false);
+				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, false, true);
 
 		FluxMergeComparing.MergeOrderedInnerSubscriber<Integer> test = new FluxMergeComparing.MergeOrderedInnerSubscriber<>(
 				main, 4);
@@ -448,7 +449,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal1() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false, true,
 				Flux.just(1), Flux.just(2))
 				.as(StepVerifier::create)
 				.expectNext(1, 2)
@@ -458,7 +459,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal2() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false, true,
 				Flux.just(1, 3, 5, 7), Flux.just(2, 4, 6, 8))
 				.as(StepVerifier::create)
 				.expectNext(1, 2, 3, 4, 5, 6, 7, 8)
@@ -468,7 +469,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal3() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false, true,
 				Flux.just(1, 3, 5, 7), Flux.just(2, 4, 6))
 				.as(StepVerifier::create)
 				.expectNext(1, 2, 3, 4, 5, 6, 7)
@@ -478,7 +479,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal4() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false, true,
 				Flux.just(1, 3, 5, 7), Flux.just(1, 3, 5, 7))
 				.as(StepVerifier::create)
 				.expectNext(1, 1, 3, 3, 5, 5, 7, 7)
@@ -488,7 +489,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal1Hidden() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false, true,
 				Flux.just(1).hide(), Flux.just(2).hide())
 				.as(StepVerifier::create)
 				.expectNext(1, 2)
@@ -498,7 +499,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal2Hidden() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false, true,
 				Flux.just(1, 3, 5, 7).hide(), Flux.just(2, 4, 6, 8).hide())
 				.as(StepVerifier::create)
 				.expectNext(1, 2, 3, 4, 5, 6, 7, 8)
@@ -508,7 +509,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal3Hidden() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false, true,
 				Flux.just(1, 3, 5, 7).hide(), Flux.just(2, 4, 6).hide())
 				.as(StepVerifier::create)
 				.expectNext(1, 2, 3, 4, 5, 6, 7)
@@ -518,7 +519,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal4Hidden() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false, true,
 				Flux.just(1, 3, 5, 7).hide(), Flux.just(1, 3, 5, 7).hide())
 				.as(StepVerifier::create)
 				.expectNext(1, 1, 3, 3, 5, 5, 7, 7)
@@ -528,7 +529,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void backpressure1() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false, true,
 				Flux.just(1, 3, 5, 7).log("left")
 				, Flux.just(2, 4, 6, 8).log("right"))
 				.limitRate(1)
@@ -540,7 +541,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void backpressure2() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false, true,
 				Flux.just(1), Flux.just(2))
 				.limitRate(1)
 				.as(StepVerifier::create)
@@ -551,7 +552,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void backpressure3() {
-		new FluxMergeComparing<>(1, Comparator.naturalOrder(), false,
+		new FluxMergeComparing<>(1, Comparator.naturalOrder(), false, true,
 				Flux.just(1, 3, 5, 7), Flux.just(2, 4, 6, 8))
 				.limitRate(1)
 				.as(StepVerifier::create)
@@ -562,7 +563,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void take() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false, true,
 				Flux.just(1, 3, 5, 7), Flux.just(2, 4, 6, 8))
 				.take(5, false)
 				.as(StepVerifier::create)
@@ -573,7 +574,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void firstErrorsDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.error(new IOException("boom")),
 				Flux.just(2, 4, 6, 8))
 				.as(StepVerifier::create)
@@ -584,7 +585,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void firstErrorsBackpressuredDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.error(new IOException("boom")),
 				Flux.just(2, 4, 6, 8))
 				.as(f -> StepVerifier.create(f, 0L))
@@ -596,7 +597,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void secondErrorsDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7),
 				Flux.error(new IOException("boom"))
 		)
@@ -608,7 +609,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void secondErrorsBackpressuredDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7),
 				Flux.error(new IOException("boom"))
 		)
@@ -622,7 +623,7 @@ class FluxMergeComparingTest {
 	void bothErrorDelayed() {
 		IOException firstError = new IOException("first");
 		IOException secondError = new IOException("second");
-		new FluxMergeComparing<Integer>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<Integer>(2, Comparator.naturalOrder(), true, true,
 				Flux.error(firstError),
 				Flux.error(secondError)
 		)
@@ -634,7 +635,7 @@ class FluxMergeComparingTest {
 
 	@Test
 	void never() {
-		new FluxMergeComparing<Integer>(2, Comparator.naturalOrder(), false,
+		new FluxMergeComparing<Integer>(2, Comparator.naturalOrder(), false, true,
 				Flux.never(), Flux.never())
 				.as(StepVerifier::create)
 				.thenCancel()
@@ -644,7 +645,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void fusedThrowsInDrainLoopDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1).map(v -> { throw new IllegalArgumentException("boom"); }),
 				Flux.just(2, 3))
 				.as(StepVerifier::create)
@@ -655,7 +656,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void fusedThrowsInPostEmissionCheckDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1).map(v -> { throw new IllegalArgumentException("boom"); }),
 				Flux.just(2, 3))
 				.as(f -> StepVerifier.create(f, 0L))
@@ -670,7 +671,7 @@ class FluxMergeComparingTest {
 		assertThatNullPointerException()
 				.isThrownBy(() -> {
 					new FluxMergeComparing<>(2,
-							Comparator.naturalOrder(), false,
+							Comparator.naturalOrder(), false, true,
 							Flux.just(1), null);
 				})
 				.withMessage("sources[1] is null");
@@ -680,7 +681,7 @@ class FluxMergeComparingTest {
 	@SuppressWarnings("unchecked") //safe varargs
 	void comparatorThrows() {
 		new FluxMergeComparing<>(2,
-				(a, b) -> { throw new IllegalArgumentException("boom"); }, false,
+				(a, b) -> { throw new IllegalArgumentException("boom"); }, false, true,
 				Flux.just(1, 3), Flux.just(2, 4))
 				.as(StepVerifier::create)
 				.verifyErrorMessage("boom");
@@ -689,7 +690,7 @@ class FluxMergeComparingTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void naturalOrder() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), false, true,
 				Flux.just(1), Flux.just(2))
 				.as(StepVerifier::create)
 				.expectNext(1, 2)
@@ -746,5 +747,47 @@ class FluxMergeComparingTest {
 		FluxMergeComparing<String> fmoNoDelay = (FluxMergeComparing<String>) flux;
 
 		assertThat(fmoNoDelay.delayError).as("delayError").isFalse();
+	}
+
+	@Test
+	void shouldEmitAsyncValuesAsTheyArrive() {
+		StepVerifier.create(Flux.defer(() -> {
+						Flux<Tuple2<String, Integer>> catsAreBetterThanDogs = Flux.just(
+																					  "pickles", // 700
+																					  "leela", // 1400
+																					  "girl", // 2100
+																					  "meatloaf", // 2800
+																					  "henry" // 3500
+																				  )
+																				  .delayElements(Duration.ofMillis(700))
+																				  .map(s -> Tuples.of(s, 0));
+
+						Flux<Tuple2<String, Integer>> poorDogs = Flux.just(
+																		 "spot", // 300
+																		 "barley", // 600
+																		 "goodboy", // 900
+																		 "sammy", // 1200
+																		 "doug" // 1500
+																	 )
+																	 .delayElements(Duration.ofMillis(300))
+																	 .map(s -> Tuples.of(s, 1));
+
+						return Flux.mergePriority(Comparator.comparing(Tuple2::getT2),
+												  catsAreBetterThanDogs,
+												  poorDogs)
+								   .map(Tuple2::getT1);
+					}))
+					.expectNext("spot")
+					.expectNext("barley")
+					.expectNext("pickles")
+					.expectNext("goodboy")
+					.expectNext("sammy")
+					.expectNext("leela")
+					.expectNext("doug")
+					.expectNext("girl")
+					.expectNext("meatloaf")
+					.expectNext("henry")
+					.expectComplete()
+					.verify(Duration.ofSeconds(10));
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
@@ -187,7 +187,7 @@ class FluxMergeOrderedTest {
 		@SuppressWarnings("unchecked")
 		Publisher<Tuple2<Long, Integer>>[] sources = sourceList.toArray(new Publisher[sourceList.size()]);
 
-		Flux<Integer> test = new FluxMergeComparing<>(16, Comparator.comparing(Tuple2::getT1), true, sources)
+		Flux<Integer> test = new FluxMergeComparing<>(16, Comparator.comparing(Tuple2::getT1), true, true, sources)
 				.map(Tuple2::getT2);
 
 		StepVerifier.create(test)
@@ -214,7 +214,7 @@ class FluxMergeOrderedTest {
 		Publisher<Tuple2<Long, Integer>>[] sources = sourceList.toArray(new Publisher[sourceList.size()]);
 
 		Flux<Integer> test = new FluxMergeComparing<>(16,
-				Comparator.comparing(Tuple2::getT1), true, sources)
+				Comparator.comparing(Tuple2::getT1), true, true, sources)
 				.map(Tuple2::getT2);
 
 		StepVerifier.create(test)
@@ -225,21 +225,21 @@ class FluxMergeOrderedTest {
 	@Test
 	void prefetchZero() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new FluxMergeComparing<Integer>(0, Comparator.naturalOrder(), true))
+				.isThrownBy(() -> new FluxMergeComparing<Integer>(0, Comparator.naturalOrder(), true, true))
 				.withMessage("prefetch > 0 required but it was 0");
 	}
 
 	@Test
 	void prefetchNegative() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new FluxMergeComparing<Integer>(-1, Comparator.naturalOrder(), true))
+				.isThrownBy(() -> new FluxMergeComparing<Integer>(-1, Comparator.naturalOrder(), true, true))
 				.withMessage("prefetch > 0 required but it was -1");
 	}
 
 	@Test
 	void getPrefetch() {
 		FluxMergeComparing<Integer> fmo = new FluxMergeComparing<Integer>(123,
-				Comparator.naturalOrder(), true);
+				Comparator.naturalOrder(), true, true);
 
 		assertThat(fmo.getPrefetch()).isEqualTo(123);
 	}
@@ -247,7 +247,7 @@ class FluxMergeOrderedTest {
 	@Test
 	void nullSources() {
 		assertThatNullPointerException()
-				.isThrownBy(() -> new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+				.isThrownBy(() -> new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 						(Publisher<Integer>[]) null))
 				.withMessage("sources must be non-null");
 	}
@@ -257,7 +257,7 @@ class FluxMergeOrderedTest {
 		Comparator<Integer> originalComparator = Comparator.naturalOrder();
 		@SuppressWarnings("unchecked") //safe varargs
 		FluxMergeComparing<Integer> fmo = new FluxMergeComparing<>(2,
-				originalComparator, true,
+				originalComparator, true, true,
 				Flux.just(1, 2),
 				Flux.just(3, 4));
 
@@ -282,7 +282,7 @@ class FluxMergeOrderedTest {
 		Flux<Integer> source2 = Flux.just(2);
 
 		@SuppressWarnings("unchecked") //safe varargs
-		Scannable fmo = new FluxMergeComparing<>(123, Comparator.naturalOrder(), true, source1, source2);
+		Scannable fmo = new FluxMergeComparing<>(123, Comparator.naturalOrder(), true, true, source1, source2);
 
 		assertThat(fmo.scan(Scannable.Attr.PARENT)).isSameAs(source1);
 		assertThat(fmo.scan(Scannable.Attr.PREFETCH)).isEqualTo(123);
@@ -298,7 +298,7 @@ class FluxMergeOrderedTest {
 		CoreSubscriber<? super Integer> actual = new LambdaSubscriber<>(null, null, null, null);
 
 		FluxMergeComparing.MergeOrderedMainProducer<Integer> test =
-				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, true);
+				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, true, true);
 
 		assertThat(test.scan(Scannable.Attr.ACTUAL))
 				.isSameAs(actual)
@@ -326,7 +326,7 @@ class FluxMergeOrderedTest {
 	void scanInner() {
 		CoreSubscriber<? super Integer> actual = new LambdaSubscriber<>(null, null, null, null);
 		FluxMergeComparing.MergeOrderedMainProducer<Integer> main =
-				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, true);
+				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, true, true);
 
 		FluxMergeComparing.MergeOrderedInnerSubscriber<Integer> test = new FluxMergeComparing.MergeOrderedInnerSubscriber<>(
 				main, 123);
@@ -356,7 +356,7 @@ class FluxMergeOrderedTest {
 		CoreSubscriber<? super Integer> actual = new LambdaSubscriber<>(null, null, null, null);
 
 		FluxMergeComparing.MergeOrderedMainProducer<Integer> test =
-				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, true);
+				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, true, true);
 
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> {
@@ -371,7 +371,7 @@ class FluxMergeOrderedTest {
 	void innerRequestAmountIgnoredAssumedOne() {
 		CoreSubscriber<? super Integer> actual = new LambdaSubscriber<>(null, null, null, null);
 		FluxMergeComparing.MergeOrderedMainProducer<Integer> main =
-				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, true);
+				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, true, true);
 
 		FluxMergeComparing.MergeOrderedInnerSubscriber<Integer> test = new FluxMergeComparing.MergeOrderedInnerSubscriber<>(
 				main, 4);
@@ -406,7 +406,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal1() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1), Flux.just(2))
 				.as(StepVerifier::create)
 				.expectNext(1, 2)
@@ -416,7 +416,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal2() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7), Flux.just(2, 4, 6, 8))
 				.as(StepVerifier::create)
 				.expectNext(1, 2, 3, 4, 5, 6, 7, 8)
@@ -426,7 +426,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal3() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7), Flux.just(2, 4, 6))
 				.as(StepVerifier::create)
 				.expectNext(1, 2, 3, 4, 5, 6, 7)
@@ -436,7 +436,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal4() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7), Flux.just(1, 3, 5, 7))
 				.as(StepVerifier::create)
 				.expectNext(1, 1, 3, 3, 5, 5, 7, 7)
@@ -446,7 +446,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal1Hidden() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1).hide(), Flux.just(2).hide())
 				.as(StepVerifier::create)
 				.expectNext(1, 2)
@@ -456,7 +456,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal2Hidden() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7).hide(), Flux.just(2, 4, 6, 8).hide())
 				.as(StepVerifier::create)
 				.expectNext(1, 2, 3, 4, 5, 6, 7, 8)
@@ -466,7 +466,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal3Hidden() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7).hide(), Flux.just(2, 4, 6).hide())
 				.as(StepVerifier::create)
 				.expectNext(1, 2, 3, 4, 5, 6, 7)
@@ -476,7 +476,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal4Hidden() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7).hide(), Flux.just(1, 3, 5, 7).hide())
 				.as(StepVerifier::create)
 				.expectNext(1, 1, 3, 3, 5, 5, 7, 7)
@@ -486,7 +486,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void backpressure1() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7).log("left")
 				, Flux.just(2, 4, 6, 8).log("right"))
 				.limitRate(1)
@@ -498,7 +498,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void backpressure2() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1), Flux.just(2))
 				.limitRate(1)
 				.as(StepVerifier::create)
@@ -509,7 +509,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void backpressure3() {
-		new FluxMergeComparing<>(1, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(1, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7), Flux.just(2, 4, 6, 8))
 				.limitRate(1)
 				.as(StepVerifier::create)
@@ -520,7 +520,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void take() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7), Flux.just(2, 4, 6, 8))
 				.take(5, false)
 				.as(StepVerifier::create)
@@ -531,7 +531,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void firstErrorsDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.error(new IOException("boom")),
 				Flux.just(2, 4, 6, 8))
 				.as(StepVerifier::create)
@@ -542,7 +542,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void firstErrorsBackpressuredDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.error(new IOException("boom")),
 				Flux.just(2, 4, 6, 8))
 				.as(f -> StepVerifier.create(f, 0L))
@@ -554,7 +554,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void secondErrorsDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7),
 				Flux.error(new IOException("boom"))
 		)
@@ -566,7 +566,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void secondErrorsBackpressuredDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7),
 				Flux.error(new IOException("boom"))
 		)
@@ -580,7 +580,7 @@ class FluxMergeOrderedTest {
 	void bothErrorDelayed() {
 		IOException firstError = new IOException("first");
 		IOException secondError = new IOException("second");
-		new FluxMergeComparing<Integer>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<Integer>(2, Comparator.naturalOrder(), true, true,
 				Flux.error(firstError),
 				Flux.error(secondError)
 		)
@@ -592,7 +592,7 @@ class FluxMergeOrderedTest {
 
 	@Test
 	void never() {
-		new FluxMergeComparing<Integer>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<Integer>(2, Comparator.naturalOrder(), true, true,
 				Flux.never(), Flux.never())
 				.as(StepVerifier::create)
 				.thenCancel()
@@ -602,7 +602,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void fusedThrowsInDrainLoopDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1).map(v -> { throw new IllegalArgumentException("boom"); }),
 				Flux.just(2, 3))
 				.as(StepVerifier::create)
@@ -613,7 +613,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void fusedThrowsInPostEmissionCheckDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1).map(v -> { throw new IllegalArgumentException("boom"); }),
 				Flux.just(2, 3))
 				.as(f -> StepVerifier.create(f, 0L))
@@ -628,7 +628,7 @@ class FluxMergeOrderedTest {
 		assertThatNullPointerException()
 				.isThrownBy(() -> {
 					new FluxMergeComparing<>(2,
-							Comparator.naturalOrder(), true,
+							Comparator.naturalOrder(), true, true,
 							Flux.just(1), null);
 				})
 				.withMessage("sources[1] is null");
@@ -638,7 +638,7 @@ class FluxMergeOrderedTest {
 	@SuppressWarnings("unchecked") //safe varargs
 	void comparatorThrows() {
 		new FluxMergeComparing<>(2,
-				(a, b) -> { throw new IllegalArgumentException("boom"); }, true,
+				(a, b) -> { throw new IllegalArgumentException("boom"); }, true, true,
 				Flux.just(1, 3), Flux.just(2, 4))
 				.as(StepVerifier::create)
 				.verifyErrorMessage("boom");
@@ -647,7 +647,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void naturalOrder() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1), Flux.just(2))
 				.as(StepVerifier::create)
 				.expectNext(1, 2)


### PR DESCRIPTION
this is a solution for  #2827

modify FluxMergeComparing to support not waiting for all sources to emit an item before comparing and sending downstream.

if this approach is amenable, i will update the marble diagrams. 