### PR TITLE
Add Flux.mergePriority, does not wait for all sources to emit

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -1526,7 +1526,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * Instead, this operator considers only one value from each source and picks the
 	 * smallest of all these values, then replenishes the slot for that picked source.
 	 * <p>
-	 * <img class="marble" src="doc-files/marbles/mergeComparingNaturalOrder.svg" alt="">
+	 * <img class="marble" src="doc-files/marbles/mergePriorityNaturalOrder.svg" alt="">
 	 *
 	 * @param sources {@link Publisher} sources of {@link Comparable} to merge
 	 * @param <I> a {@link Comparable} merged type that has a {@link Comparator#naturalOrder() natural order}
@@ -1549,7 +1549,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * Instead, this operator considers only one value from each source and picks the
 	 * smallest of all these values, then replenishes the slot for that picked source.
 	 * <p>
-	 * <img class="marble" src="doc-files/marbles/mergeComparing.svg" alt="">
+	 * <img class="marble" src="doc-files/marbles/mergePriority.svg" alt="">
 	 *
 	 * @param comparator the {@link Comparator} to use to find the smallest value
 	 * @param sources {@link Publisher} sources to merge
@@ -1573,7 +1573,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * Instead, this operator considers only one value from each source and picks the
 	 * smallest of all these values, then replenishes the slot for that picked source.
 	 * <p>
-	 * <img class="marble" src="doc-files/marbles/mergeComparing.svg" alt="">
+	 * <img class="marble" src="doc-files/marbles/mergePriority.svg" alt="">
 	 *
 	 * @param prefetch the number of elements to prefetch from each source (avoiding too
 	 * many small requests to the source when picking)
@@ -1607,7 +1607,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <p>
 	 * Note that it is delaying errors until all data is consumed.
 	 * <p>
-	 * <img class="marble" src="doc-files/marbles/mergeComparing.svg" alt="">
+	 * <img class="marble" src="doc-files/marbles/mergePriority.svg" alt="">
 	 *
 	 * @param prefetch the number of elements to prefetch from each source (avoiding too
 	 * many small requests to the source when picking)

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -1520,11 +1520,12 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * Merge data from provided {@link Publisher} sequences into an ordered merged sequence,
 	 * by picking the smallest values from each source (as defined by their natural order) <strong>as they arrive</strong>.
 	 * This is not a {@link #sort()}, as it doesn't consider the whole of each sequences. Unlike mergeComparing,
-	 * this operator does <em>not</em> wait for a value from each source to arrive. It is best suited for asynchronous
-	 * sources where you do not want to wait for a value from each source before emitting a value downstream.
+	 * this operator does <em>not</em> wait for a value from each source to arrive either.
 	 * <p>
-	 * Instead, this operator considers only one value from each source and picks the
-	 * smallest of all these values, then replenishes the slot for that picked source.
+	 * While this operator does retrieve at most one value from each source, it only compares values when two or more
+	 * sources emit at the same time. In that case it picks the smallest of these competing values and continues doing so
+	 * as long as there is demand. It is therefore best suited for asynchronous sources where you do not want to wait
+	 * for a value from each source before emitting a value downstream.
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/mergePriorityNaturalOrder.svg" alt="">
 	 *
@@ -1543,11 +1544,12 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * by picking the smallest values from each source (as defined by the provided
 	 * {@link Comparator}) <strong>as they arrive</strong>. This is not a {@link #sort(Comparator)}, as it doesn't consider
 	 * the whole of each sequences. Unlike mergeComparing, this operator does <em>not</em> wait for a value from each
-	 * source to arrive. It is best suited for asynchronous sources where you do not want to wait for a value from
-	 * each source before emitting a value downstream.
+	 * source to arrive either.
 	 * <p>
-	 * Instead, this operator considers only one value from each source and picks the
-	 * smallest of all these values, then replenishes the slot for that picked source.
+	 * While this operator does retrieve at most one value from each source, it only compares values when two or more
+	 * sources emit at the same time. In that case it picks the smallest of these competing values and continues doing so
+	 * as long as there is demand. It is therefore best suited for asynchronous sources where you do not want to wait
+	 * for a value from each source before emitting a value downstream.
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/mergePriority.svg" alt="">
 	 *
@@ -1567,11 +1569,12 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * by picking the smallest values from each source (as defined by the provided
 	 * {@link Comparator}) <strong>as they arrive</strong>. This is not a {@link #sort(Comparator)}, as it doesn't consider
 	 * the whole of each sequences. Unlike mergeComparing, this operator does <em>not</em> wait for a value from each
-	 * source to arrive. It is best suited for asynchronous sources where you do not want to wait for a value from each
-	 * source before emitting a value downstream.
+	 * source to arrive either.
 	 * <p>
-	 * Instead, this operator considers only one value from each source and picks the
-	 * smallest of all these values, then replenishes the slot for that picked source.
+	 * While this operator does retrieve at most one value from each source, it only compares values when two or more
+	 * sources emit at the same time. In that case it picks the smallest of these competing values and continues doing so
+	 * as long as there is demand. It is therefore best suited for asynchronous sources where you do not want to wait
+	 * for a value from each source before emitting a value downstream.
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/mergePriority.svg" alt="">
 	 *
@@ -1599,11 +1602,12 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * by picking the smallest values from each source (as defined by the provided
 	 * {@link Comparator}) <strong>as they arrive</strong>. This is not a {@link #sort(Comparator)}, as it doesn't consider
 	 * the whole of each sequences. Unlike mergeComparing, this operator does <em>not</em> wait for a value from each
-	 * source to arrive. It is best suited for asynchronous sources where you do not want to wait for a value from each
-	 * source before emitting a value downstream.
+	 * source to arrive either.
 	 * <p>
-	 * Instead, this operator considers only one value from each source and picks the
-	 * smallest of all these values, then replenishes the slot for that picked source.
+	 * While this operator does retrieve at most one value from each source, it only compares values when two or more
+	 * sources emit at the same time. In that case it picks the smallest of these competing values and continues doing so
+	 * as long as there is demand. It is therefore best suited for asynchronous sources where you do not want to wait
+	 * for a value from each source before emitting a value downstream.
 	 * <p>
 	 * Note that it is delaying errors until all data is consumed.
 	 * <p>

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeOrdered.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelMergeOrdered.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ final class ParallelMergeOrdered<T> extends Flux<T> implements Scannable {
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
 		FluxMergeComparing.MergeOrderedMainProducer<T>
-				main = new FluxMergeComparing.MergeOrderedMainProducer<>(actual, valueComparator, prefetch, source.parallelism(), true);
+				main = new FluxMergeComparing.MergeOrderedMainProducer<>(actual, valueComparator, prefetch, source.parallelism(), true, true);
 		actual.onSubscribe(main);
 		source.subscribe(main.subscribers);
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergePriority.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergePriority.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="712" height="366" viewBox="20 19 712 366">
+ <defs>
+  <marker id="a" stroke-linejoin="miter" stroke-miterlimit="10" color="#34302c" markerHeight="10.44" markerUnits="strokeWidth" markerWidth="13.92" orient="auto" overflow="visible" preserveAspectRatio="xMidYMid" refX="0" refY="0" viewBox="0 0 13.92 10.44">
+   <path fill="currentColor" stroke="currentColor" d="M12 0 0-4v9z"/>
+  </marker>
+  <marker id="b" stroke-linejoin="miter" stroke-miterlimit="10" color="#34302c" markerHeight="7.44" markerUnits="strokeWidth" markerWidth="9.92" orient="auto" overflow="visible" preserveAspectRatio="xMidYMid" refX="0" refY="0" viewBox="0 0 9.92 7.44">
+   <path fill="currentColor" stroke="currentColor" d="M8 0 0-3v6z"/>
+  </marker>
+  <marker id="c" markerHeight="9" markerWidth="13" orient="auto" overflow="visible" preserveAspectRatio="xMidYMid" refX="0" refY="0" viewBox="0 0 13 9">
+   <path fill-rule="evenodd" stroke="#000" stroke-linejoin="round" d="M-11-4 1 0l-12 4c2-2 2-6 0-8z"/>
+  </marker>
+ </defs>
+ <path fill="#fff" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M28 25h696l2 4v248c0 3-1 4-2 4H28c-1 0-2-1-2-4V29Z"/>
+ <path fill="none" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#a)" d="M36 63h656"/>
+ <circle cx="82" cy="63" r="23" fill="#6cb33e" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <circle cx="153" cy="64" r="23" fill="#e6ba31" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <path fill="#34302c" d="M672 39h1l2 2v44l-2 2h-1l-2-2V41Z"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2,6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M82 86v110"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2,6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="m306.02 87 1 109"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M672 87v110"/>
+ <path fill="none" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#a)" d="M36.28 137.7h493.74"/>
+ <circle cx="152" cy="138" r="23" fill="#ff5a01"/>
+ <circle cx="152" cy="138" r="23" fill="none" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <circle cx="454.03" cy="138" r="23" fill="#e739ce" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <path fill="#34302c" d="M515.23 114h1l2 2v44l-2 2h-1l-2-2v-44z"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2,6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M515.23 162v34"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2,6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M454.03 162v34"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2,6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M152 162v34"/>
+ <path fill="none" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#a)" d="M27 355h672"/>
+ <circle cx="82" cy="351.77" r="23" fill="#6cb33e" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <circle cx="153.24" cy="351.53" r="23" fill="#e6ba31" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <circle cx="307.78" cy="355.02" r="23" fill="#45b8de" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <path fill="#34302c" d="M672 331c2 0 2 1 2 2v44c0 1 0 2-2 2l-2-2v-44z"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M82 283v28"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M152 281v29"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M455.23 282.42v28"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M672 283v28"/>
+ <circle cx="237.02" cy="351.69" r="23" fill="#ff5a01" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <circle cx="455.61" cy="354.26" r="23" fill="#e739ce" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M306.03 283v28"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M237.02 283v28"/>
+ <text x="63" y="340.77" fill="#fff"><tspan x="77" y="356.77" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">5</tspan></text>
+ <text x="217.89" y="340.69" fill="#fff"><tspan x="231.89" y="356.69" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">3</tspan></text>
+ <text x="286.78" y="344.02" fill="#fff"><tspan x="300.78" y="360.02" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">2</tspan></text>
+ <text x="134.24" y="340.53" fill="#fff"><tspan x="148.24" y="356.53" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">4</tspan></text>
+ <text x="436.61" y="343.26" fill="#fff"><tspan x="450.61" y="359.26" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">1</tspan></text>
+ <path fill="none" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M36 221h655"/>
+ <text x="63" y="52" fill="#fff"><tspan x="77" y="68" font-family="Tahoma,'Nimbus Sans L'" font-size="16" font-weight="700">5</tspan></text>
+ <text x="133" y="128" fill="#fff"><tspan x="147" y="144" font-family="Tahoma,'Nimbus Sans L'" font-size="16" font-weight="700">3</tspan></text>
+ <text x="135" y="53" fill="#fff"><tspan x="149" y="69" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">4</tspan></text>
+ <text x="433.78" y="127" fill="#fff"><tspan x="447.78" y="143" font-family="Tahoma,'Nimbus Sans L'" font-size="16" font-weight="700">1</tspan></text>
+ <circle cx="567" cy="63" r="23" fill="#ff5a01" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <text x="548" y="52" fill="#fff"><tspan x="562" y="68" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">0</tspan></text>
+ <circle cx="570" cy="353.77" r="23" fill="#ff5a01" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M570 283v28"/>
+ <text x="551" y="342.77" fill="#fff"><tspan x="565" y="358.77" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">0</tspan></text>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="m567 87 1 109"/>
+ <text x="-85.58" y="236" fill="#34302c"><tspan x="165.42" y="258" dx="0 0 0 0 0" font-family="Tahoma, 'Nimbus Sans L'" font-size="24" font-weight="700">mergePriority(</tspan></text>
+ <circle cx="384.42" cy="249" r="23" fill="#fff" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <text x="352.42" y="238"><tspan x="366.42" y="254" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="400">small</tspan></text>
+ <circle cx="444.42" cy="249" r="23" fill="#fff" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <text x="417.42" y="238"><tspan x="431.42" y="254" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">big</tspan></text>
+ <circle cx="558.42" cy="249" r="23" fill="#fff" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <text x="354.42" y="241" fill="#34302c"><tspan x="410.42" y="263" font-family="Tahoma, 'Nimbus Sans L'" font-size="24" font-weight="400">,</tspan></text>
+ <text x="86.42" y="237" fill="#34302c"><tspan x="346.42" y="259" font-family="Tahoma, 'Nimbus Sans L'" font-size="24" font-weight="400">(</tspan></text>
+ <text x="210.42" y="237" fill="#34302c"><tspan x="470.42" y="259" font-family="Tahoma, 'Nimbus Sans L'" font-size="24" font-weight="400">)</tspan></text>
+ <path fill="none" stroke="#000" marker-end="url(#c)" d="M487.42 251h39"/>
+ <text x="337.42" y="236" fill="#34302c"><tspan x="588.42" y="258" font-family="Tahoma, 'Nimbus Sans L'" font-size="24" font-weight="700">)</tspan></text>
+ <text x="530.6" y="238"><tspan x="544.6" y="254" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">big</tspan></text>
+ <circle cx="306.02" cy="63" r="23" fill="#45b8de" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <text x="287.02" y="52" fill="#fff"><tspan x="301.02" y="68" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">2</tspan></text>
+ <path d="m152 88.71.57 25.72" style="fill:#000;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2,6;stroke-dashoffset:0;stroke-opacity:1"/>
+</svg>

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergePriorityNaturalOrder.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mergePriorityNaturalOrder.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="712" height="366" viewBox="20 19 712 366">
+ <defs>
+  <marker id="a" stroke-linejoin="miter" stroke-miterlimit="10" color="#34302c" markerHeight="10.44" markerUnits="strokeWidth" markerWidth="13.92" orient="auto" overflow="visible" preserveAspectRatio="xMidYMid" refX="0" refY="0" viewBox="0 0 13.92 10.44">
+   <path fill="currentColor" stroke="currentColor" d="M12 0 0-4v9z"/>
+  </marker>
+  <marker id="b" stroke-linejoin="miter" stroke-miterlimit="10" color="#34302c" markerHeight="7.44" markerUnits="strokeWidth" markerWidth="9.92" orient="auto" overflow="visible" preserveAspectRatio="xMidYMid" refX="0" refY="0" viewBox="0 0 9.92 7.44">
+   <path fill="currentColor" stroke="currentColor" d="M8 0 0-3v6z"/>
+  </marker>
+ </defs>
+ <path fill="#fff" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M28 25h696l2 4v248c0 3-1 4-2 4H28c-1 0-2-1-2-4V29Z"/>
+ <path fill="none" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#a)" d="M36 63h656"/>
+ <circle cx="82" cy="63" r="23" fill="#6cb33e" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <circle cx="153" cy="64" r="23" fill="#e6ba31" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <path fill="#34302c" d="M672 39h1l2 2v44l-2 2h-1l-2-2V41Z"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2,6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M82 86v110"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2,6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="m306.02 87 1 109"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M672 87v110"/>
+ <path fill="none" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#a)" d="M36.28 137.7h493.74"/>
+ <circle cx="152" cy="138" r="23" fill="#ff5a01"/>
+ <circle cx="152" cy="138" r="23" fill="none" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <circle cx="454.03" cy="138" r="23" fill="#e739ce" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <path fill="#34302c" d="M515.23 114h1l2 2v44l-2 2h-1l-2-2v-44z"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2,6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M515.23 162v34"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2,6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M454.03 162v34"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2,6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M152 162v34"/>
+ <path fill="none" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#a)" d="M27 355h672"/>
+ <circle cx="82" cy="351.77" r="23" fill="#6cb33e" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <circle cx="153.24" cy="351.53" r="23" fill="#e6ba31" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <circle cx="307.78" cy="355.02" r="23" fill="#45b8de" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <path fill="#34302c" d="M672 331c2 0 2 1 2 2v44c0 1 0 2-2 2l-2-2v-44z"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M82 283v28"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M152 281v29"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M455.23 282.42v28"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M672 283v28"/>
+ <circle cx="237.02" cy="351.69" r="23" fill="#ff5a01" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <circle cx="455.61" cy="354.26" r="23" fill="#e739ce" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M306.03 283v28"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M237.02 283v28"/>
+ <text x="63" y="340.77" fill="#fff"><tspan x="77" y="356.77" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">1</tspan></text>
+ <text x="217.89" y="340.69" fill="#fff"><tspan x="231.89" y="356.69" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">3</tspan></text>
+ <text x="286.78" y="344.02" fill="#fff"><tspan x="300.78" y="360.02" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">7</tspan></text>
+ <text x="134.24" y="340.53" fill="#fff"><tspan x="148.24" y="356.53" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">2</tspan></text>
+ <text x="436.61" y="343.26" fill="#fff"><tspan x="450.61" y="359.26" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">4</tspan></text>
+ <path fill="none" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M36 221h655"/>
+ <text x="63" y="52" fill="#fff"><tspan x="77" y="68" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">1</tspan></text>
+ <text x="133" y="128" fill="#fff"><tspan x="147" y="144" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">3</tspan></text>
+ <text x="135" y="53" fill="#fff"><tspan x="149" y="69" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">2</tspan></text>
+ <text x="433.78" y="127" fill="#fff"><tspan x="447.78" y="143" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">4</tspan></text>
+ <circle cx="567" cy="63" r="23" fill="#ff5a01" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <text x="548" y="52" fill="#fff"><tspan x="562" y="68" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">0</tspan></text>
+ <circle cx="570" cy="353.77" r="23" fill="#ff5a01" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="M570 283v28"/>
+ <text x="551" y="342.77" fill="#fff"><tspan x="565" y="358.77" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">0</tspan></text>
+ <path fill="none" stroke="#34302c" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="m567 87 1 109"/>
+ <text x="16.71" y="233.14" fill="#34302c"><tspan x="267.71" y="255.14" dx="0 0 0 0 0" font-family="Tahoma, 'Nimbus Sans L'" font-size="24" font-weight="700">mergePriority</tspan></text>
+ <circle cx="306.02" cy="63" r="23" fill="#45b8de" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <text x="287.02" y="52" fill="#fff"><tspan x="301.02" y="68" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="700">7</tspan></text>
+ <path d="m152 88.71.57 25.72" style="fill:#000;stroke:#34302c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:2,6;stroke-dashoffset:0;stroke-opacity:1"/>
+</svg>

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -187,7 +187,7 @@ class FluxMergeOrderedTest {
 		@SuppressWarnings("unchecked")
 		Publisher<Tuple2<Long, Integer>>[] sources = sourceList.toArray(new Publisher[sourceList.size()]);
 
-		Flux<Integer> test = new FluxMergeComparing<>(16, Comparator.comparing(Tuple2::getT1), true, sources)
+		Flux<Integer> test = new FluxMergeComparing<>(16, Comparator.comparing(Tuple2::getT1), true, true, sources)
 				.map(Tuple2::getT2);
 
 		StepVerifier.create(test)
@@ -214,7 +214,7 @@ class FluxMergeOrderedTest {
 		Publisher<Tuple2<Long, Integer>>[] sources = sourceList.toArray(new Publisher[sourceList.size()]);
 
 		Flux<Integer> test = new FluxMergeComparing<>(16,
-				Comparator.comparing(Tuple2::getT1), true, sources)
+				Comparator.comparing(Tuple2::getT1), true, true, sources)
 				.map(Tuple2::getT2);
 
 		StepVerifier.create(test)
@@ -225,21 +225,21 @@ class FluxMergeOrderedTest {
 	@Test
 	void prefetchZero() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new FluxMergeComparing<Integer>(0, Comparator.naturalOrder(), true))
+				.isThrownBy(() -> new FluxMergeComparing<Integer>(0, Comparator.naturalOrder(), true, true))
 				.withMessage("prefetch > 0 required but it was 0");
 	}
 
 	@Test
 	void prefetchNegative() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new FluxMergeComparing<Integer>(-1, Comparator.naturalOrder(), true))
+				.isThrownBy(() -> new FluxMergeComparing<Integer>(-1, Comparator.naturalOrder(), true, true))
 				.withMessage("prefetch > 0 required but it was -1");
 	}
 
 	@Test
 	void getPrefetch() {
 		FluxMergeComparing<Integer> fmo = new FluxMergeComparing<Integer>(123,
-				Comparator.naturalOrder(), true);
+				Comparator.naturalOrder(), true, true);
 
 		assertThat(fmo.getPrefetch()).isEqualTo(123);
 	}
@@ -247,7 +247,7 @@ class FluxMergeOrderedTest {
 	@Test
 	void nullSources() {
 		assertThatNullPointerException()
-				.isThrownBy(() -> new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+				.isThrownBy(() -> new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 						(Publisher<Integer>[]) null))
 				.withMessage("sources must be non-null");
 	}
@@ -257,7 +257,7 @@ class FluxMergeOrderedTest {
 		Comparator<Integer> originalComparator = Comparator.naturalOrder();
 		@SuppressWarnings("unchecked") //safe varargs
 		FluxMergeComparing<Integer> fmo = new FluxMergeComparing<>(2,
-				originalComparator, true,
+				originalComparator, true, true,
 				Flux.just(1, 2),
 				Flux.just(3, 4));
 
@@ -282,7 +282,7 @@ class FluxMergeOrderedTest {
 		Flux<Integer> source2 = Flux.just(2);
 
 		@SuppressWarnings("unchecked") //safe varargs
-		Scannable fmo = new FluxMergeComparing<>(123, Comparator.naturalOrder(), true, source1, source2);
+		Scannable fmo = new FluxMergeComparing<>(123, Comparator.naturalOrder(), true, true, source1, source2);
 
 		assertThat(fmo.scan(Scannable.Attr.PARENT)).isSameAs(source1);
 		assertThat(fmo.scan(Scannable.Attr.PREFETCH)).isEqualTo(123);
@@ -298,7 +298,7 @@ class FluxMergeOrderedTest {
 		CoreSubscriber<? super Integer> actual = new LambdaSubscriber<>(null, null, null, null);
 
 		FluxMergeComparing.MergeOrderedMainProducer<Integer> test =
-				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, true);
+				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, true, true);
 
 		assertThat(test.scan(Scannable.Attr.ACTUAL))
 				.isSameAs(actual)
@@ -326,7 +326,7 @@ class FluxMergeOrderedTest {
 	void scanInner() {
 		CoreSubscriber<? super Integer> actual = new LambdaSubscriber<>(null, null, null, null);
 		FluxMergeComparing.MergeOrderedMainProducer<Integer> main =
-				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, true);
+				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, true, true);
 
 		FluxMergeComparing.MergeOrderedInnerSubscriber<Integer> test = new FluxMergeComparing.MergeOrderedInnerSubscriber<>(
 				main, 123);
@@ -356,7 +356,7 @@ class FluxMergeOrderedTest {
 		CoreSubscriber<? super Integer> actual = new LambdaSubscriber<>(null, null, null, null);
 
 		FluxMergeComparing.MergeOrderedMainProducer<Integer> test =
-				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, true);
+				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, true, true);
 
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> {
@@ -371,7 +371,7 @@ class FluxMergeOrderedTest {
 	void innerRequestAmountIgnoredAssumedOne() {
 		CoreSubscriber<? super Integer> actual = new LambdaSubscriber<>(null, null, null, null);
 		FluxMergeComparing.MergeOrderedMainProducer<Integer> main =
-				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, true);
+				new FluxMergeComparing.MergeOrderedMainProducer<Integer>(actual, Comparator.naturalOrder(), 123, 4, true, true);
 
 		FluxMergeComparing.MergeOrderedInnerSubscriber<Integer> test = new FluxMergeComparing.MergeOrderedInnerSubscriber<>(
 				main, 4);
@@ -406,7 +406,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal1() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1), Flux.just(2))
 				.as(StepVerifier::create)
 				.expectNext(1, 2)
@@ -416,7 +416,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal2() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7), Flux.just(2, 4, 6, 8))
 				.as(StepVerifier::create)
 				.expectNext(1, 2, 3, 4, 5, 6, 7, 8)
@@ -426,7 +426,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal3() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7), Flux.just(2, 4, 6))
 				.as(StepVerifier::create)
 				.expectNext(1, 2, 3, 4, 5, 6, 7)
@@ -436,7 +436,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal4() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7), Flux.just(1, 3, 5, 7))
 				.as(StepVerifier::create)
 				.expectNext(1, 1, 3, 3, 5, 5, 7, 7)
@@ -446,7 +446,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal1Hidden() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1).hide(), Flux.just(2).hide())
 				.as(StepVerifier::create)
 				.expectNext(1, 2)
@@ -456,7 +456,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal2Hidden() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7).hide(), Flux.just(2, 4, 6, 8).hide())
 				.as(StepVerifier::create)
 				.expectNext(1, 2, 3, 4, 5, 6, 7, 8)
@@ -466,7 +466,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal3Hidden() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7).hide(), Flux.just(2, 4, 6).hide())
 				.as(StepVerifier::create)
 				.expectNext(1, 2, 3, 4, 5, 6, 7)
@@ -476,7 +476,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void normal4Hidden() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7).hide(), Flux.just(1, 3, 5, 7).hide())
 				.as(StepVerifier::create)
 				.expectNext(1, 1, 3, 3, 5, 5, 7, 7)
@@ -486,7 +486,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void backpressure1() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7).log("left")
 				, Flux.just(2, 4, 6, 8).log("right"))
 				.limitRate(1)
@@ -498,7 +498,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void backpressure2() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1), Flux.just(2))
 				.limitRate(1)
 				.as(StepVerifier::create)
@@ -509,7 +509,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void backpressure3() {
-		new FluxMergeComparing<>(1, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(1, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7), Flux.just(2, 4, 6, 8))
 				.limitRate(1)
 				.as(StepVerifier::create)
@@ -520,7 +520,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void take() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7), Flux.just(2, 4, 6, 8))
 				.take(5)
 				.as(StepVerifier::create)
@@ -531,7 +531,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void firstErrorsDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.error(new IOException("boom")),
 				Flux.just(2, 4, 6, 8))
 				.as(StepVerifier::create)
@@ -542,7 +542,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void firstErrorsBackpressuredDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.error(new IOException("boom")),
 				Flux.just(2, 4, 6, 8))
 				.as(f -> StepVerifier.create(f, 0L))
@@ -554,7 +554,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void secondErrorsDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7),
 				Flux.error(new IOException("boom"))
 		)
@@ -566,7 +566,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void secondErrorsBackpressuredDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1, 3, 5, 7),
 				Flux.error(new IOException("boom"))
 		)
@@ -580,7 +580,7 @@ class FluxMergeOrderedTest {
 	void bothErrorDelayed() {
 		IOException firstError = new IOException("first");
 		IOException secondError = new IOException("second");
-		new FluxMergeComparing<Integer>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<Integer>(2, Comparator.naturalOrder(), true, true,
 				Flux.error(firstError),
 				Flux.error(secondError)
 		)
@@ -592,7 +592,7 @@ class FluxMergeOrderedTest {
 
 	@Test
 	void never() {
-		new FluxMergeComparing<Integer>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<Integer>(2, Comparator.naturalOrder(), true, true,
 				Flux.never(), Flux.never())
 				.as(StepVerifier::create)
 				.thenCancel()
@@ -602,7 +602,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void fusedThrowsInDrainLoopDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1).map(v -> { throw new IllegalArgumentException("boom"); }),
 				Flux.just(2, 3))
 				.as(StepVerifier::create)
@@ -613,7 +613,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void fusedThrowsInPostEmissionCheckDelayed() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1).map(v -> { throw new IllegalArgumentException("boom"); }),
 				Flux.just(2, 3))
 				.as(f -> StepVerifier.create(f, 0L))
@@ -628,7 +628,7 @@ class FluxMergeOrderedTest {
 		assertThatNullPointerException()
 				.isThrownBy(() -> {
 					new FluxMergeComparing<>(2,
-							Comparator.naturalOrder(), true,
+							Comparator.naturalOrder(), true, true,
 							Flux.just(1), null);
 				})
 				.withMessage("sources[1] is null");
@@ -638,7 +638,7 @@ class FluxMergeOrderedTest {
 	@SuppressWarnings("unchecked") //safe varargs
 	void comparatorThrows() {
 		new FluxMergeComparing<>(2,
-				(a, b) -> { throw new IllegalArgumentException("boom"); }, true,
+				(a, b) -> { throw new IllegalArgumentException("boom"); }, true, true,
 				Flux.just(1, 3), Flux.just(2, 4))
 				.as(StepVerifier::create)
 				.verifyErrorMessage("boom");
@@ -647,7 +647,7 @@ class FluxMergeOrderedTest {
 	@Test
 	@SuppressWarnings("unchecked") //safe varargs
 	void naturalOrder() {
-		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true,
+		new FluxMergeComparing<>(2, Comparator.naturalOrder(), true, true,
 				Flux.just(1), Flux.just(2))
 				.as(StepVerifier::create)
 				.expectNext(1, 2)


### PR DESCRIPTION
this is a solution for https://github.com/reactor/reactor-core/issues/2827

modify FluxMergeComparing to support not waiting for all sources to emit an item before comparing and sending downstream.
