### PR TITLE
fix regression in FluxTakeUntilOther

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntilOther.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntilOther.java
@@ -99,7 +99,14 @@ final class FluxTakeUntilOther<T, U> extends InternalFluxOperator<T, T> {
 
 		@Override
 		public void onNext(U t) {
-			onComplete();
+			if (once) {
+				return;
+			}
+			once = true;
+			//in case more values are coming, cancel main.other (which is basically this one's upstream, see main.setOther)
+ 			main.cancelOther();
+			 //now cancel main.main, and ensure that if this happens early an empty Subscription is passed down
+ 			main.cancelMainAndComplete();
 		}
 
 		@Override
@@ -117,6 +124,7 @@ final class FluxTakeUntilOther<T, U> extends InternalFluxOperator<T, T> {
 				return;
 			}
 			once = true;
+			//cancel main.main, and ensure that if this happens early an empty Subscription is passed down
 			main.cancelMainAndComplete();
 		}
 	}
@@ -183,20 +191,13 @@ final class FluxTakeUntilOther<T, U> extends InternalFluxOperator<T, T> {
 				}
 
 				if (s == null) {
+					// this indicates the Other completed early, even before `main` was set.
+					// let's pass an empty Subscription down and complete immediately
 					Operators.complete(actual);
 				}
 				else {
+					// if s wasn't null then Main Subscription was set and actual.onSubscribe already called
 					actual.onComplete();
-				}
-			}
-		}
-
-		void cancelMain() {
-			Subscription s = main;
-			if (s != Operators.cancelledSubscription()) {
-				s = MAIN.getAndSet(this, Operators.cancelledSubscription());
-				if (s != null && s != Operators.cancelledSubscription()) {
-					s.cancel();
 				}
 			}
 		}
@@ -213,7 +214,15 @@ final class FluxTakeUntilOther<T, U> extends InternalFluxOperator<T, T> {
 
 		@Override
 		public void cancel() {
-			cancelMain();
+			//similar to cancelMainAndComplete() but at this stage we only care about cancellation upstream
+			Subscription s = main;
+			if (s != Operators.cancelledSubscription()) {
+				s = MAIN.getAndSet(this, Operators.cancelledSubscription());
+				if (s != null && s != Operators.cancelledSubscription()) {
+					s.cancel();
+				}
+			}
+			//we do cancel the other subscriber too
 			cancelOther();
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeUntilOtherTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeUntilOtherTest.java
@@ -46,6 +46,13 @@ public class FluxTakeUntilOtherTest {
 		});
 	}
 
+	//https://github.com/reactor/reactor-core/issues/3268
+@Test
+void whenOtherAlreadyCompleted() {
+	StepVerifier.create(Flux.just(1, 2, 3).takeUntilOther(Flux.empty()))
+		.verifyComplete();
+}
+
 	@Test
 	public void takeAll() {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
@@ -105,7 +112,8 @@ public class FluxTakeUntilOtherTest {
 
 		ts.assertNoValues()
 		  .assertComplete()
-		  .assertNoError();
+		  .assertNoError()
+		  .assertSubscribed();
 		Assertions.assertThat(mainCancelled).isTrue();
 		Assertions.assertThat(otherCancelled).isTrue();
 	}
@@ -120,7 +128,8 @@ public class FluxTakeUntilOtherTest {
 
 		ts.assertNoValues()
 		  .assertNoError()
-		  .assertComplete();
+		  .assertComplete()
+		  .assertSubscribed();
 	}
 
 	@Test
@@ -139,7 +148,8 @@ public class FluxTakeUntilOtherTest {
 
 		ts.assertNoValues()
 		  .assertComplete()
-		  .assertNoError();
+		  .assertNoError()
+		  .assertSubscribed();
 
 		Assertions.assertThat(mainCancelled).isTrue();
 		Assertions.assertThat(otherCancelled).isTrue();
@@ -155,7 +165,8 @@ public class FluxTakeUntilOtherTest {
 
 		ts.assertNoValues()
 		  .assertNoError()
-		  .assertComplete();
+		  .assertComplete()
+		  .assertSubscribed();
 	}
 
 	@Test


### PR DESCRIPTION
- test the error
- fix #3268
- better fix: split cancelMain and add notion of completion/onSubscribe
