### PR TITLE
Improve Mono fromFuture/fromCompletionStage javadocs

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -538,8 +538,8 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/fromFuture.svg" alt="">
 	 * <p>
-	 * If the completionStage is also {@link Future}, cancelling the Mono will cancel the future.
-	 * Use {@link #fromFuture(Future, boolean)} with {@code suppressCancellation} set to
+	 * If the completionStage is also a {@link Future}, cancelling the Mono will cancel the future.
+	 * Use {@link #fromFuture(CompletableFuture, boolean)} with {@code suppressCancellation} set to
 	 * {@code true} if you need to suppress cancellation propagation.
 	 *
 	 * @param completionStage {@link CompletionStage} that will produce a value (or a null to
@@ -558,8 +558,8 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/fromFutureSupplier.svg" alt="">
 	 * <p>
-	 * If the completionStage is also {@link Future}, cancelling the Mono will cancel the future.
-	 * Use {@link #fromFuture(Future, boolean)} with {@code suppressCancellation} set to
+	 * If the completionStage is also a {@link Future}, cancelling the Mono will cancel the future.
+	 * Use {@link #fromFuture(CompletableFuture, boolean)} with {@code suppressCancellation} set to
 	 * {@code true} if you need to suppress cancellation propagation.
 	 *
 	 * @param stageSupplier The {@link Supplier} of a {@link CompletionStage} that will produce a value (or a null to
@@ -616,7 +616,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/fromFuture.svg" alt="">
 	 * <p>
-	 * Use {@link #fromFuture(Future, boolean)} with {@code suppressCancellation} set to
+	 * Use {@link #fromFuture(CompletableFuture, boolean)} with {@code suppressCancellation} set to
 	 * {@code true} if you need to suppress cancellation propagation.
 	 *
 	 * @param future {@link CompletableFuture} that will produce a value (or a null to
@@ -630,81 +630,51 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	}
 
 	/**
-	 * Create a {@link Mono}, producing its value using the provided composable {@link Future}
-	 * which implements {@link CompletionStage} and cancelling the future if the Mono gets
-	 * cancelled.
-	 * <p>
-	 * <img class="marble" src="doc-files/marbles/fromFuture.svg" alt="">
-	 * <p>
-	 * Note that unlike the simplified {@link #fromFuture(CompletableFuture)} this method
-	 * accepts any implementation that is both a {@link Future} (cancellable) and a
-	 * {@link CompletionStage} (which is a pre-requisite to hook {@link Subscriber} events
-	 * to the future). Use {@link #fromFuture(Future, boolean)} with {@code suppressCancellation}
-	 * set to {@code true} if you need to suppress cancellation propagation.
-	 *
-	 * @param future {@link Future} {@link CompletionStage} that will produce a value (or a null to
-	 * complete immediately)
-	 * @param <T> type of the expected value
-	 * @return A {@link Mono}.
-	 * @see #fromCompletionStage(CompletionStage) fromCompletionStage for a generalization
-	 */
-	public static <T, F extends Future<? extends T> & CompletionStage<? extends T>> Mono<T> fromFuture(F future) {
-		return fromFuture(future, false);
-	}
-
-	/**
-	 * Create a {@link Mono}, producing its value using the provided composable {@link Future}
-	 * which implements and optionally cancelling the future if the Mono gets cancelled
-	 * (if {@code suppressCancel == false}).
-	 * <p>
-	 * Note that unlike the simplified {@link #fromFuture(CompletableFuture)} this method
-	 * accepts any implementation that is both a {@link Future} (cancellable) and a
-	 * {@link CompletionStage} (which is a pre-requisite to hook {@link Subscriber} events
-	 * to the future).
+	 * Create a {@link Mono}, producing its value using the provided {@link CompletableFuture}
+	 * and optionally cancelling the future if the Mono gets cancelled (if {@code suppressCancel == false}).
 	 *
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/fromFuture.svg" alt="">
 	 * <p>
 	 *
-	 * @param future {@link Future} {@link CompletionStage} that will produce a value (or a null to
-	 * complete immediately)
+	 * @param future {@link CompletableFuture} that will produce a value (or a null to complete immediately)
 	 * @param suppressCancel {@code true} to prevent cancellation of the future when the Mono is cancelled,
 	 * {@code false} otherwise (the default)
 	 * @param <T> type of the expected value
 	 * @return A {@link Mono}.
 	 */
-	public static <T, F extends Future<? extends T> & CompletionStage<? extends T>> Mono<T> fromFuture(F future, boolean suppressCancel) {
+	public static <T> Mono<T> fromFuture(CompletableFuture<? extends T> future, boolean suppressCancel) {
 		return onAssembly(new MonoCompletionStage<>(future, suppressCancel));
 	}
 
 	/**
-	 * Create a {@link Mono} that wraps a lazily-supplied {@link CompletionStage} {@link Future} on subscription,
-	 * emitting the value produced by the Future and cancelling the future if the Mono gets cancelled.
+	 * Create a {@link Mono} that wraps a lazily-supplied {@link CompletableFuture} on subscription,
+	 * emitting the value produced by the future and cancelling the future if the Mono gets cancelled.
 	 *
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/fromFutureSupplier.svg" alt="">
 	 * <p>
 	 *
-	 * @param futureSupplier The {@link Supplier} of a {@link Future} {@link CompletionStage} that will produce a value
+	 * @param futureSupplier The {@link Supplier} of a {@link CompletableFuture} that will produce a value
 	 * (or a null to complete immediately). This allows lazy triggering of future-based APIs.
 	 * @param <T> type of the expected value
 	 * @return A {@link Mono}.
 	 * @see #fromCompletionStage(Supplier) fromCompletionStage for a generalization
 	 */
-	public static <T, F extends Future<? extends T> & CompletionStage<? extends T>> Mono<T> fromFuture(Supplier<F> futureSupplier) {
+	public static <T> Mono<T> fromFuture(Supplier<? extends CompletableFuture<? extends T>> futureSupplier) {
 		return fromFuture(futureSupplier, false);
 	}
 
 	/**
-	 * Create a {@link Mono} that wraps a lazily-supplied  {@link CompletionStage} {@link Future} on subscription,
-	 * emitting the value produced by the Future and optionally cancelling the future if the Mono gets cancelled
+	 * Create a {@link Mono} that wraps a lazily-supplied  {@link CompletableFuture} on subscription,
+	 * emitting the value produced by the future and optionally cancelling the future if the Mono gets cancelled
 	 * (if {@code suppressCancel == false}).
 	 *
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/fromFutureSupplier.svg" alt="">
 	 * <p>
 	 *
-	 * @param futureSupplier The {@link Supplier} of a {@link Future} {@link CompletionStage} that will produce a value
+	 * @param futureSupplier The {@link Supplier} of a {@link CompletableFuture} that will produce a value
 	 * (or a null to complete immediately). This allows lazy triggering of future-based APIs.
 	 * @param suppressCancel {@code true} to prevent cancellation of the future when the Mono is cancelled,
 	 * {@code false} otherwise (the default)
@@ -712,7 +682,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return A {@link Mono}.
 	 * @see #fromCompletionStage(Supplier) fromCompletionStage for a generalization
 	 */
-	public static <T, F extends Future<? extends T> & CompletionStage<? extends T>> Mono<T> fromFuture(Supplier<F> futureSupplier, boolean suppressCancel) {
+	public static <T> Mono<T> fromFuture(Supplier<? extends CompletableFuture<? extends T>> futureSupplier, boolean suppressCancel) {
 		return defer(() -> onAssembly(new MonoCompletionStage<>(futureSupplier.get(), suppressCancel)));
 	}
 


### PR DESCRIPTION
This commit revises javadocs of Mono fromFuture and fromCompletionStage
methods to better reflect the cancellation behavior.

Fixes #3252.