### PR TITLE
Upgrade Micrometer/Context-Propagation dependencies to 1.10.0 GA

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ bytebuddy = "1.12.18"
 jmh = "1.35"
 junit = "5.9.1"
 #note that some micrometer artifacts like context-propagation has a different version directly set in libraries below
-micrometer = "1.10.0-RC1"
+micrometer = "1.10.0"
 reactiveStreams = "1.0.4"
 
 [libraries]
@@ -35,10 +35,10 @@ logback = "ch.qos.logback:logback-classic:1.2.11"
 micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometer" }
 micrometer-commons = { module = "io.micrometer:micrometer-commons" }
 micrometer-core = { module = "io.micrometer:micrometer-core" }
-micrometer-contextPropagation = "io.micrometer:context-propagation:1.0.0-SNAPSHOT"
-micrometer-docsGenerator = { module = "io.micrometer:micrometer-docs-generator", version = "1.0.0-RC1"}
+micrometer-contextPropagation = "io.micrometer:context-propagation:1.0.0"
+micrometer-docsGenerator = { module = "io.micrometer:micrometer-docs-generator", version = "1.0.0"}
 micrometer-observation-test = { module = "io.micrometer:micrometer-observation-test" }
-micrometer-tracing-test = "io.micrometer:micrometer-tracing-integration-test:1.0.0-RC1"
+micrometer-tracing-test = "io.micrometer:micrometer-tracing-integration-test:1.0.0"
 micrometer-test = { module = "io.micrometer:micrometer-test" }
 mockito = "org.mockito:mockito-core:4.8.1"
 reactiveStreams = { module = "org.reactivestreams:reactive-streams", version.ref = "reactiveStreams" }


### PR DESCRIPTION
In the case of `context-propagation`, `micrometer-docs-generator` and 
`micrometer-tracing-integration-test`, we're in fact dealing with version
`1.0.0` instead.