### PR TITLE
Adapt Shakespear perf benchmark to 2022.0.0 release

### DIFF
--- a/benchmarks/src/main/java/reactor/core/scheduler/OldBoundedElasticScheduler.java
+++ b/benchmarks/src/main/java/reactor/core/scheduler/OldBoundedElasticScheduler.java
@@ -148,6 +148,7 @@ final class OldBoundedElasticScheduler implements Scheduler, Scannable {
 		return BOUNDED_SERVICES.get(this) == SHUTDOWN;
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public void start() {
 		for (;;) {

--- a/benchmarks/src/main/java/reactor/core/scrabble/ShakespearePlaysScrabbleParallelOpt.java
+++ b/benchmarks/src/main/java/reactor/core/scrabble/ShakespearePlaysScrabbleParallelOpt.java
@@ -50,7 +50,7 @@ public class ShakespearePlaysScrabbleParallelOpt extends ShakespearePlaysScrabbl
 
 	@Setup
 	public void localSetup() {
-		scheduler = Schedulers.newElastic("RcParallel");
+		scheduler = Schedulers.newBoundedElastic(Schedulers.DEFAULT_BOUNDED_ELASTIC_SIZE, Schedulers.DEFAULT_BOUNDED_ELASTIC_QUEUESIZE, "RcParallel");
 	}
 
 	@TearDown

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 # Baselines, should be updated on every release
 baseline-core-api = "3.5.0"
-baselinePerfCore = "3.4.24"
-baselinePerfExtra = "3.4.8"
+baselinePerfCore = "3.5.0"
+baselinePerfExtra = "3.5.0"
 
 # Other shared versions
 asciidoctor = "3.3.2"


### PR DESCRIPTION
The `benchmarks` project is ready to move to the 3.5.x baseline, now
that all 2022.0.0 artifacts are released. That said, the Shakespear
benchmark still uses deprecated ElasticScheduler, which is removed in
3.5.0.

This commit switches the benchmark to use BoundedElasticScheduler in
addition to upgrading the perf dependencies to 3.5.0.

Fixes #3277.
