### PR TITLE
removes NotNull annotation from jetbrains

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.assertj.core.api.Assertions;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -148,13 +147,9 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
 		AtomicInteger calls = new AtomicInteger();
 
 		Flux.range(1, 5)
-				.concatMapIterable(v -> new Iterable<String>() {
-					@NotNull
-					@Override
-					public Iterator<String> iterator() {
-						calls.incrementAndGet();
-						return Arrays.asList("hello " + v).iterator();
-					}
+				.concatMapIterable(v -> (Iterable<String>) () -> {
+					calls.incrementAndGet();
+					return Arrays.asList("hello " + v).iterator();
 				})
 				.as(StepVerifier::create)
 				.expectNext("hello 1", "hello 2", "hello 3", "hello 4", "hello 5")

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxIterableTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
@@ -54,13 +53,9 @@ public class FluxIterableTest {
 	//https://github.com/reactor/reactor-core/issues/3295
 	public void useIterableOncePerSubscriber() {
 		AtomicInteger calls = new AtomicInteger();
-		Iterable<String> strings = new Iterable<String>() {
-			@NotNull
-			@Override
-			public Iterator<String> iterator() {
-				calls.incrementAndGet();
-				return Arrays.asList("hello").iterator();
-			}
+		Iterable<String> strings = () -> {
+			calls.incrementAndGet();
+			return Arrays.asList("hello").iterator();
 		};
 		StepVerifier.create(Flux.fromIterable(strings))
 				.expectNext("hello")


### PR DESCRIPTION
added import `org.jetbrains.annotations.NotNull` by accident. this PR removes it

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>
Signed-off-by: OlegDokuka <odokuka@vmware.com>