### PR TITLE
ensures context restored in RetrySpec

### DIFF
--- a/reactor-core/src/main/java/reactor/util/retry/RetryBackoffSpec.java
+++ b/reactor-core/src/main/java/reactor/util/retry/RetryBackoffSpec.java
@@ -574,7 +574,7 @@ public final class RetryBackoffSpec extends Retry {
 				//short-circuit delay == 0 case
 				if (nextBackoff.isZero()) {
 					return RetrySpec.applyHooks(copy, Mono.just(iteration),
-							syncPreRetry, syncPostRetry, asyncPreRetry, asyncPostRetry);
+							syncPreRetry, syncPostRetry, asyncPreRetry, asyncPostRetry, cv);
 				}
 
 				ThreadLocalRandom random = ThreadLocalRandom.current();
@@ -602,9 +602,8 @@ public final class RetryBackoffSpec extends Retry {
 					jitter = random.nextLong(lowBound, highBound);
 				}
 				Duration effectiveBackoff = nextBackoff.plusMillis(jitter);
-				return RetrySpec.applyHooks(copy, Mono.delay(effectiveBackoff,
-								backoffSchedulerSupplier.get()),
-						syncPreRetry, syncPostRetry, asyncPreRetry, asyncPostRetry);
+				return RetrySpec.applyHooks(copy, Mono.delay(effectiveBackoff, backoffSchedulerSupplier.get()),
+						syncPreRetry, syncPostRetry, asyncPreRetry, asyncPostRetry, cv);
 			})
 		    .contextWrite(c -> Context.empty())
 		);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
@@ -64,7 +64,8 @@ public class FluxRetryWhenTest {
 			Flux.error(new RuntimeException("forced failure 0")));
 
 	@Test
-	void doBusinessLogic() {
+	// https://github.com/reactor/reactor-core/issues/3314
+	void ensuresContextIsRestoredInRetryFunctions() {
 		PublisherProbe<Void> doBeforeRetryProbe = PublisherProbe.empty();
 		AtomicReference<ContextView> capturedContext = new AtomicReference<>();
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
@@ -24,7 +24,9 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.assertj.core.api.Assertions;
@@ -39,6 +41,7 @@ import reactor.core.Scannable;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
+import reactor.test.publisher.PublisherProbe;
 import reactor.test.scheduler.VirtualTimeScheduler;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.context.Context;
@@ -46,9 +49,11 @@ import reactor.util.context.ContextView;
 import reactor.util.function.Tuple2;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
+import reactor.util.retry.RetrySpec;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.BDDMockito.given;
 
 public class FluxRetryWhenTest {
 
@@ -57,6 +62,44 @@ public class FluxRetryWhenTest {
 
 	Flux<Integer> rangeError = Flux.concat(Flux.range(1, 2),
 			Flux.error(new RuntimeException("forced failure 0")));
+
+	@Test
+	void doBusinessLogic() {
+		PublisherProbe<Void> doBeforeRetryProbe = PublisherProbe.empty();
+		AtomicReference<ContextView> capturedContext = new AtomicReference<>();
+
+		RetrySpec spec = Retry.max(1)
+		                      .doBeforeRetryAsync(
+				                      retrySignal ->
+						                      Mono.deferContextual(cv -> {
+							                      capturedContext.set(cv);
+												  return doBeforeRetryProbe.mono();
+						                      })
+		                      );
+
+		Context context = Context.of("test", "test");
+
+        Mono.defer(new Supplier<Mono<?>>() {
+				int index = 0;
+
+                @Override
+                public Mono<?> get() {
+					if (index++ == 0) {
+						return Mono.error(new RuntimeException());
+					} else {
+						return Mono.just("someValue");
+					}
+                }
+            })
+            .retryWhen(spec)
+            .contextWrite(context)
+            .as(StepVerifier::create)
+            .expectNext("someValue")
+            .verifyComplete();
+
+		doBeforeRetryProbe.assertWasSubscribed();
+		assertThat(capturedContext).hasValueMatching(c -> c.hasKey("test"));
+	}
 
 	@Test
 	//https://github.com/reactor/reactor-core/issues/3253


### PR DESCRIPTION
closes #3314 

This PR restores context for inner Flux inside concatMap, while the concatMap leaves remain without context. It allows Retry methods to have context

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>