### PR TITLE
Add reflection hints for native-image support

### DIFF
--- a/reactor-core/src/main/resources/META-INF/native-image/io.projectreactor/reactor-core/reflect-config.json
+++ b/reactor-core/src/main/resources/META-INF/native-image/io.projectreactor/reactor-core/reflect-config.json
@@ -1,0 +1,38 @@
+[
+  {
+    "condition": {
+      "typeReachable": "reactor.core.publisher.Traces"
+    },
+    "name": "reactor.core.publisher.Traces$StackWalkerCallSiteSupplierFactory",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "reactor.core.publisher.Traces"
+    },
+    "name": "reactor.core.publisher.Traces$SharedSecretsCallSiteSupplierFactory",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "reactor.core.publisher.Traces"
+    },
+    "name": "reactor.core.publisher.Traces$ExceptionCallSiteSupplierFactory",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]


### PR DESCRIPTION
`native-image` support is needed only for `3.5.x` version

Fixes #3321