### PR TITLE
MemoryUtils.Tracked used in tests releases collections

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
@@ -16,6 +16,7 @@
 
 package reactor.core.publisher;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -156,9 +157,7 @@ public class OnDiscardShouldNotLeakTest {
 			DiscardScenario.fluxSource("collect", f -> f.collect(ArrayList::new, ArrayList::add)
 			                                               .doOnSuccess(l -> l.forEach(Tracked::safeRelease))
 			                                               .thenReturn(Tracked.RELEASED)),
-			DiscardScenario.fluxSource("collectList", f -> f.collectList()
-			                                                   .doOnSuccess(l -> l.forEach(Tracked::safeRelease))
-			                                                   .thenReturn(Tracked.RELEASED))
+			DiscardScenario.fluxSource("collectList", f -> f.collectList().thenReturn(Tracked.RELEASED))
 	};
 
 	private static final boolean[][] CONDITIONAL_AND_FUSED = new boolean[][] {

--- a/reactor-core/src/test/java/reactor/test/MemoryUtils.java
+++ b/reactor-core/src/test/java/reactor/test/MemoryUtils.java
@@ -18,6 +18,7 @@ package reactor.test;
 
 import java.lang.ref.PhantomReference;
 import java.lang.ref.ReferenceQueue;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
@@ -174,9 +175,16 @@ public class MemoryUtils {
 		 *
 		 * @param t the arbitrary object
 		 */
+		@SuppressWarnings("rawtypes")
 	    public static void safeRelease(Object t) {
 	        if (t instanceof Tracked) {
 	            ((Tracked) t).release();
+	        } else if (t instanceof Collection) {
+				for (Object o : (Collection) t) {
+					if (o instanceof Tracked) {
+						((Tracked) o).release();
+					}
+				}
 	        }
 	    }
 

--- a/reactor-core/src/test/java/reactor/test/MemoryUtils.java
+++ b/reactor-core/src/test/java/reactor/test/MemoryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
In case of operators that manipulate collections of items, the `OnDiscardShouldNotLeakTest` suite needed workarounds for manually discarding items from a collection. This change adds that type of handling into the `MemoryUtils.Tracked::safeRelease` method and should simplify and allow more cases to be added in the future for operators that deal with collections.