### PR TITLE
Context propagation with automatic ThreadLocals restoration

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ logback = "ch.qos.logback:logback-classic:1.2.11"
 micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometer" }
 micrometer-commons = { module = "io.micrometer:micrometer-commons" }
 micrometer-core = { module = "io.micrometer:micrometer-core" }
-micrometer-contextPropagation = "io.micrometer:context-propagation:1.0.2-SNAPSHOT"
+micrometer-contextPropagation = "io.micrometer:context-propagation:1.0.1"
 micrometer-docsGenerator = { module = "io.micrometer:micrometer-docs-generator", version = "1.0.1"}
 micrometer-observation-test = { module = "io.micrometer:micrometer-observation-test" }
 micrometer-tracing-test = "io.micrometer:micrometer-tracing-integration-test:1.0.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ logback = "ch.qos.logback:logback-classic:1.2.11"
 micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometer" }
 micrometer-commons = { module = "io.micrometer:micrometer-commons" }
 micrometer-core = { module = "io.micrometer:micrometer-core" }
-micrometer-contextPropagation = "io.micrometer:context-propagation:1.0.0"
+micrometer-contextPropagation = "io.micrometer:context-propagation:1.1.0-SNAPSHOT"
 micrometer-docsGenerator = { module = "io.micrometer:micrometer-docs-generator", version = "1.0.0"}
 micrometer-observation-test = { module = "io.micrometer:micrometer-observation-test" }
 micrometer-tracing-test = "io.micrometer:micrometer-tracing-integration-test:1.0.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ logback = "ch.qos.logback:logback-classic:1.2.11"
 micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometer" }
 micrometer-commons = { module = "io.micrometer:micrometer-commons" }
 micrometer-core = { module = "io.micrometer:micrometer-core" }
-micrometer-contextPropagation = "io.micrometer:context-propagation:1.0.1"
+micrometer-contextPropagation = "io.micrometer:context-propagation:1.0.2-SNAPSHOT"
 micrometer-docsGenerator = { module = "io.micrometer:micrometer-docs-generator", version = "1.0.1"}
 micrometer-observation-test = { module = "io.micrometer:micrometer-observation-test" }
 micrometer-tracing-test = "io.micrometer:micrometer-tracing-integration-test:1.0.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ logback = "ch.qos.logback:logback-classic:1.2.11"
 micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometer" }
 micrometer-commons = { module = "io.micrometer:micrometer-commons" }
 micrometer-core = { module = "io.micrometer:micrometer-core" }
-micrometer-contextPropagation = "io.micrometer:context-propagation:1.0.1-SNAPSHOT"
+micrometer-contextPropagation = "io.micrometer:context-propagation:1.0.1"
 micrometer-docsGenerator = { module = "io.micrometer:micrometer-docs-generator", version = "1.0.1"}
 micrometer-observation-test = { module = "io.micrometer:micrometer-observation-test" }
 micrometer-tracing-test = "io.micrometer:micrometer-tracing-integration-test:1.0.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ logback = "ch.qos.logback:logback-classic:1.2.11"
 micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometer" }
 micrometer-commons = { module = "io.micrometer:micrometer-commons" }
 micrometer-core = { module = "io.micrometer:micrometer-core" }
-micrometer-contextPropagation = "io.micrometer:context-propagation:1.1.0-SNAPSHOT"
+micrometer-contextPropagation = "io.micrometer:context-propagation:1.0.1-SNAPSHOT"
 micrometer-docsGenerator = { module = "io.micrometer:micrometer-docs-generator", version = "1.0.1"}
 micrometer-observation-test = { module = "io.micrometer:micrometer-observation-test" }
 micrometer-tracing-test = "io.micrometer:micrometer-tracing-integration-test:1.0.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ logback = "ch.qos.logback:logback-classic:1.2.11"
 micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometer" }
 micrometer-commons = { module = "io.micrometer:micrometer-commons" }
 micrometer-core = { module = "io.micrometer:micrometer-core" }
-micrometer-contextPropagation = "io.micrometer:context-propagation:1.0.1"
+micrometer-contextPropagation = "io.micrometer:context-propagation:1.0.2"
 micrometer-docsGenerator = { module = "io.micrometer:micrometer-docs-generator", version = "1.0.1"}
 micrometer-observation-test = { module = "io.micrometer:micrometer-observation-test" }
 micrometer-tracing-test = "io.micrometer:micrometer-tracing-integration-test:1.0.1"

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxContextWrite.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxContextWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxContextWrite.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxContextWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package reactor.core.publisher;
 import java.util.Objects;
 import java.util.function.Function;
 
+import io.micrometer.context.ContextSnapshot;
 import org.reactivestreams.Subscription;
 
 import reactor.core.CoreSubscriber;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxContextWrite.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxContextWrite.java
@@ -19,7 +19,6 @@ package reactor.core.publisher;
 import java.util.Objects;
 import java.util.function.Function;
 
-import io.micrometer.context.ContextSnapshot;
 import org.reactivestreams.Subscription;
 
 import reactor.core.CoreSubscriber;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocals.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import io.micrometer.context.ContextSnapshot;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+
+final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> implements Fuseable {
+
+	final Function<Context, Context> doOnContext;
+
+	FluxContextWriteRestoringThreadLocals(Flux<? extends T> source,
+			Function<Context, Context> doOnContext) {
+		super(source);
+		this.doOnContext = Objects.requireNonNull(doOnContext, "doOnContext");
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super T> actual) {
+		Context c = doOnContext.apply(actual.currentContext());
+		try (ContextSnapshot.Scope __ = ContextSnapshot.setAllThreadLocalsFrom(c)) {
+			source.subscribe(new ContextWriteRestoringThreadLocalsSubscriber<>(actual, c));
+		}
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+		return super.scanUnsafe(key);
+	}
+
+	static final class ContextWriteRestoringThreadLocalsSubscriber<T>
+			implements ConditionalSubscriber<T>, InnerOperator<T, T>,
+			           QueueSubscription<T> {
+
+		final CoreSubscriber<? super T>        actual;
+		final ConditionalSubscriber<? super T> actualConditional;
+		final Context                          context;
+
+		QueueSubscription<T> qs;
+		Subscription         s;
+
+		@SuppressWarnings("unchecked")
+		ContextWriteRestoringThreadLocalsSubscriber(CoreSubscriber<? super T> actual, Context context) {
+			this.actual = actual;
+			this.context = context;
+			if (actual instanceof ConditionalSubscriber) {
+				this.actualConditional = (ConditionalSubscriber<? super T>) actual;
+			}
+			else {
+				this.actualConditional = null;
+			}
+		}
+
+		@Override
+		@Nullable
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) {
+				return s;
+			}
+			if (key == Attr.RUN_STYLE) {
+			    return Attr.RunStyle.SYNC;
+			}
+			return InnerOperator.super.scanUnsafe(key);
+		}
+
+		@Override
+		public Context currentContext() {
+			return this.context;
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			// This is needed, as the downstream can then switch threads,
+			// continue the subscription using different primitives and omit this operator
+			try (ContextSnapshot.Scope __ =
+					     ContextSnapshot.setAllThreadLocalsFrom(actual.currentContext())) {
+				if (Operators.validate(this.s, s)) {
+					this.s = s;
+					if (s instanceof QueueSubscription) {
+						this.qs = (QueueSubscription<T>) s;
+					}
+					actual.onSubscribe(this);
+				}
+			}
+		}
+
+		@Override
+		public void onNext(T t) {
+			// We probably ended up here from a request, which set thread locals to
+			// current context, but we need to clean up and restore thread locals for
+			// the actual subscriber downstream, as it can expect TLs to match the
+			// different context.
+			// FIXME: setThreadLocalsFrom should clear TL value in case its key is
+			//  missing in the given context when running for a particular Accessor
+			//  This implementation assumes https://github.com/micrometer-metrics/context-propagation/pull/67/
+			//  to be merged -> consider an alternative.
+
+			try (ContextSnapshot.Scope __ =
+					     ContextSnapshot.setAllThreadLocalsFrom(actual.currentContext())) {
+				actual.onNext(t);
+			}
+		}
+
+		@Override
+		public boolean tryOnNext(T t) {
+			try (ContextSnapshot.Scope __ =
+					     ContextSnapshot.setAllThreadLocalsFrom(actual.currentContext())) {
+				if (actualConditional != null) {
+					return actualConditional.tryOnNext(t);
+				}
+				actual.onNext(t);
+				return true;
+			}
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			try (ContextSnapshot.Scope __ =
+					     ContextSnapshot.setAllThreadLocalsFrom(actual.currentContext())) {
+				actual.onError(t);
+			}
+		}
+
+		@Override
+		public void onComplete() {
+			try (ContextSnapshot.Scope __ =
+					     ContextSnapshot.setAllThreadLocalsFrom(actual.currentContext())) {
+				actual.onComplete();
+			}
+		}
+
+		@Override
+		public CoreSubscriber<? super T> actual() {
+			return actual;
+		}
+
+		@Override
+		public void request(long n) {
+			try (ContextSnapshot.Scope __ =
+					     ContextSnapshot.setAllThreadLocalsFrom(context)) {
+				s.request(n);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			try (ContextSnapshot.Scope __ =
+					     ContextSnapshot.setAllThreadLocalsFrom(context)) {
+				s.cancel();
+			}
+		}
+
+		@Override
+		public int requestFusion(int requestedMode) {
+			return Fuseable.NONE;
+		}
+
+		@Override
+		@Nullable
+		public T poll() {
+			throw new UnsupportedOperationException("Operator does not support fusion");
+		}
+
+		@Override
+		public boolean isEmpty() {
+			throw new UnsupportedOperationException("Operator does not support fusion");
+		}
+
+		@Override
+		public void clear() {
+			throw new UnsupportedOperationException("Operator does not support fusion");
+		}
+
+		@Override
+		public int size() {
+			throw new UnsupportedOperationException("Operator does not support fusion");
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocals.java
@@ -44,7 +44,7 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 		final ContextWriteRestoringThreadLocalsSubscriber<T> threadLocalsSubscriber =
 				new ContextWriteRestoringThreadLocalsSubscriber<>(actual, c);
 
-		try (ContextSnapshot.Scope ignored = ContextSnapshot.setAllThreadLocalsFrom(c)) {
+		try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocals(c)) {
 			source.subscribe(threadLocalsSubscriber);
 		}
 
@@ -117,7 +117,7 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 			// the actual subscriber downstream, as it can expect TLs to match the
 			// different context.
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setAllThreadLocalsFrom(actual.currentContext())) {
+					     ContextSnapshot.setThreadLocals(actual.currentContext())) {
 				actual.onNext(t);
 			}
 		}
@@ -126,7 +126,7 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 		@Override
 		public boolean tryOnNext(T t) {
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setAllThreadLocalsFrom(actual.currentContext())) {
+					     ContextSnapshot.setThreadLocals(actual.currentContext())) {
 				if (actualConditional != null) {
 					return actualConditional.tryOnNext(t);
 				}
@@ -139,7 +139,7 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 		@Override
 		public void onError(Throwable t) {
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setAllThreadLocalsFrom(actual.currentContext())) {
+					     ContextSnapshot.setThreadLocals(actual.currentContext())) {
 				actual.onError(t);
 			}
 		}
@@ -148,7 +148,7 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 		@Override
 		public void onComplete() {
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setAllThreadLocalsFrom(actual.currentContext())) {
+					     ContextSnapshot.setThreadLocals(actual.currentContext())) {
 				actual.onComplete();
 			}
 		}
@@ -162,7 +162,7 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 		@Override
 		public void request(long n) {
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setAllThreadLocalsFrom(context)) {
+					     ContextSnapshot.setThreadLocals(context)) {
 				s.request(n);
 			}
 		}
@@ -171,7 +171,7 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 		@Override
 		public void cancel() {
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setAllThreadLocalsFrom(context)) {
+					     ContextSnapshot.setThreadLocals(context)) {
 				s.cancel();
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocals.java
@@ -44,7 +44,7 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 		final ContextWriteRestoringThreadLocalsSubscriber<T> threadLocalsSubscriber =
 				new ContextWriteRestoringThreadLocalsSubscriber<>(actual, c);
 
-		try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocals(c)) {
+		try (ContextSnapshot.Scope ignored = ContextPropagation.setThreadLocals(c)) {
 			source.subscribe(threadLocalsSubscriber);
 		}
 
@@ -117,7 +117,7 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 			// the actual subscriber downstream, as it can expect TLs to match the
 			// different context.
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setThreadLocals(actual.currentContext())) {
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
 				actual.onNext(t);
 			}
 		}
@@ -126,7 +126,7 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 		@Override
 		public boolean tryOnNext(T t) {
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setThreadLocals(actual.currentContext())) {
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
 				if (actualConditional != null) {
 					return actualConditional.tryOnNext(t);
 				}
@@ -139,7 +139,7 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 		@Override
 		public void onError(Throwable t) {
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setThreadLocals(actual.currentContext())) {
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
 				actual.onError(t);
 			}
 		}
@@ -148,7 +148,7 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 		@Override
 		public void onComplete() {
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setThreadLocals(actual.currentContext())) {
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
 				actual.onComplete();
 			}
 		}
@@ -162,7 +162,7 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 		@Override
 		public void request(long n) {
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setThreadLocals(context)) {
+					     ContextPropagation.setThreadLocals(context)) {
 				s.request(n);
 			}
 		}
@@ -171,7 +171,7 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 		@Override
 		public void cancel() {
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setThreadLocals(context)) {
+					     ContextPropagation.setThreadLocals(context)) {
 				s.cancel();
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
@@ -536,9 +536,13 @@ public abstract class Hooks {
 	 */
 	public static void enableAutomaticContextPropagation() {
 		if (ContextPropagation.isContextPropagationAvailable) {
-			Hooks.addQueueWrapper(CONTEXT_IN_THREAD_LOCALS_KEY,
-					q -> new ContextPropagation.ContextQueue<>(q, null));
-			Schedulers.onScheduleHook(CONTEXT_IN_THREAD_LOCALS_KEY, ContextPropagation.scopePassingOnScheduleHook());
+			Hooks.addQueueWrapper(
+					CONTEXT_IN_THREAD_LOCALS_KEY, ContextPropagation.ContextQueue::new
+			);
+			Schedulers.onScheduleHook(
+					CONTEXT_IN_THREAD_LOCALS_KEY,
+					ContextPropagation.scopePassingOnScheduleHook()
+			);
 			ContextPropagation.propagateContextToThreadLocals = true;
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
@@ -513,10 +513,23 @@ public abstract class Hooks {
 		DETECT_CONTEXT_LOSS = false;
 	}
 
-	public static void automaticContextPropagation() {
-		Hooks.addQueueWrapper("CONTEXT_IN_THREAD_LOCALS", q -> new ContextPropagation.ContextQueue<>(q,	null));
-		Schedulers.onScheduleHook("CONTEXT_IN_THREAD_LOCALS", ContextPropagation.scopePassingOnScheduleHook());
-		ContextPropagation.propagateContextToThreadLocals = true;
+	private static final String CONTEXT_IN_THREAD_LOCALS_KEY = "CONTEXT_IN_THREAD_LOCALS";
+
+	public static void enableAutomaticContextPropagation() {
+		if (ContextPropagation.isContextPropagationAvailable) {
+			Hooks.addQueueWrapper(CONTEXT_IN_THREAD_LOCALS_KEY,
+					q -> new ContextPropagation.ContextQueue<>(q, null));
+			Schedulers.onScheduleHook(CONTEXT_IN_THREAD_LOCALS_KEY, ContextPropagation.scopePassingOnScheduleHook());
+			ContextPropagation.propagateContextToThreadLocals = true;
+		}
+	}
+
+	public static void disableAutomaticContextPropagation() {
+		if (ContextPropagation.isContextPropagationAvailable) {
+			Hooks.removeQueueWrapper(CONTEXT_IN_THREAD_LOCALS_KEY);
+			Schedulers.resetOnScheduleHook(CONTEXT_IN_THREAD_LOCALS_KEY);
+			ContextPropagation.propagateContextToThreadLocals = false;
+		}
 	}
 
 	@Nullable
@@ -619,8 +632,6 @@ public abstract class Hooks {
 
 
 	static boolean DETECT_CONTEXT_LOSS = false;
-
-	static boolean PROPAGATE_CONTEXT_TO_THREAD_LOCALS = false;
 
 	static {
 		onEachOperatorHooks = new LinkedHashMap<>(1);

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -2284,6 +2284,11 @@ public abstract class Mono<T> implements CorePublisher<T> {
 		if (!ContextPropagation.isContextPropagationAvailable()) {
 			return this;
 		}
+		if (ContextPropagation.propagateContextToThreadLocals) {
+			return onAssembly(new MonoContextWriteRestoringThreadLocals<>(
+					this, ContextPropagation.contextCapture()
+			));
+		}
 		return onAssembly(new MonoContextWrite<>(this, ContextPropagation.contextCapture()));
 	}
 
@@ -2330,6 +2335,11 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @see Context
 	 */
 	public final Mono<T> contextWrite(Function<Context, Context> contextModifier) {
+		if (ContextPropagation.shouldPropagateContextToThreadLocals()) {
+			return onAssembly(new MonoContextWriteRestoringThreadLocals<>(
+					this, contextModifier
+			));
+		}
 		return onAssembly(new MonoContextWrite<>(this, contextModifier));
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoContextWriteRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoContextWriteRestoringThreadLocals.java
@@ -44,7 +44,7 @@ final class MonoContextWriteRestoringThreadLocals<T> extends MonoOperator<T, T> 
 		final ContextWriteRestoringThreadLocalsSubscriber<T> threadLocalsSubscriber =
 				new ContextWriteRestoringThreadLocalsSubscriber<>(actual, c);
 
-		try (ContextSnapshot.Scope ignored = ContextSnapshot.setAllThreadLocalsFrom(c)) {
+		try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocals(c)) {
 			source.subscribe(threadLocalsSubscriber);
 		}
 
@@ -110,7 +110,7 @@ final class MonoContextWriteRestoringThreadLocals<T> extends MonoOperator<T, T> 
 			// the actual subscriber downstream, as it can expect TLs to match the
 			// different context.
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setAllThreadLocalsFrom(actual.currentContext())) {
+					     ContextSnapshot.setThreadLocals(actual.currentContext())) {
 				actual.onNext(t);
 				actual.onComplete();
 			}
@@ -127,7 +127,7 @@ final class MonoContextWriteRestoringThreadLocals<T> extends MonoOperator<T, T> 
 			this.done = true;
 
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setAllThreadLocalsFrom(actual.currentContext())) {
+					     ContextSnapshot.setThreadLocals(actual.currentContext())) {
 				actual.onError(t);
 			}
 		}
@@ -142,7 +142,7 @@ final class MonoContextWriteRestoringThreadLocals<T> extends MonoOperator<T, T> 
 			this.done = true;
 
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setAllThreadLocalsFrom(actual.currentContext())) {
+					     ContextSnapshot.setThreadLocals(actual.currentContext())) {
 				actual.onComplete();
 			}
 		}
@@ -156,7 +156,7 @@ final class MonoContextWriteRestoringThreadLocals<T> extends MonoOperator<T, T> 
 		@Override
 		public void request(long n) {
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setAllThreadLocalsFrom(context)) {
+					     ContextSnapshot.setThreadLocals(context)) {
 				s.request(n);
 			}
 		}
@@ -165,7 +165,7 @@ final class MonoContextWriteRestoringThreadLocals<T> extends MonoOperator<T, T> 
 		@Override
 		public void cancel() {
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setAllThreadLocalsFrom(context)) {
+					     ContextSnapshot.setThreadLocals(context)) {
 				s.cancel();
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoContextWriteRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoContextWriteRestoringThreadLocals.java
@@ -41,18 +41,9 @@ final class MonoContextWriteRestoringThreadLocals<T> extends MonoOperator<T, T> 
 	public void subscribe(CoreSubscriber<? super T> actual) {
 		final Context c = doOnContext.apply(actual.currentContext());
 
-		final ContextWriteRestoringThreadLocalsSubscriber<T> threadLocalsSubscriber =
-				new ContextWriteRestoringThreadLocalsSubscriber<>(actual, c);
-
 		try (ContextSnapshot.Scope ignored = ContextPropagation.setThreadLocals(c)) {
-			source.subscribe(threadLocalsSubscriber);
+			source.subscribe(new ContextWriteRestoringThreadLocalsSubscriber<>(actual, c));
 		}
-
-		// The onSubscribe signal is delivered outside the ThreadLocal scope
-		// associated with the augmented Context. The corresponding onSubscribe
-		// in ContextWriteRestoringThreadLocalsSubscriber implementation doesn't deliver
-		// the signal, but we do it here to avoid unnecessary restoration.
-		actual.onSubscribe(threadLocalsSubscriber);
 	}
 
 	@Override
@@ -92,12 +83,17 @@ final class MonoContextWriteRestoringThreadLocals<T> extends MonoOperator<T, T> 
 			return this.context;
 		}
 
+		@SuppressWarnings("try")
 		@Override
 		public void onSubscribe(Subscription s) {
-			// The signal to downstream subscriber is delivered by the operator's
-			// subscribe method to prevent additional ThreadLocal context restoration.
-			if (Operators.validate(this.s, s)) {
-				this.s = s;
+			// This is needed, as the downstream can then switch threads,
+			// continue the subscription using different primitives and omit this operator
+			try (ContextSnapshot.Scope ignored =
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
+				if (Operators.validate(this.s, s)) {
+					this.s = s;
+					actual.onSubscribe(this);
+				}
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoContextWriteRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoContextWriteRestoringThreadLocals.java
@@ -44,7 +44,7 @@ final class MonoContextWriteRestoringThreadLocals<T> extends MonoOperator<T, T> 
 		final ContextWriteRestoringThreadLocalsSubscriber<T> threadLocalsSubscriber =
 				new ContextWriteRestoringThreadLocalsSubscriber<>(actual, c);
 
-		try (ContextSnapshot.Scope ignored = ContextSnapshot.setThreadLocals(c)) {
+		try (ContextSnapshot.Scope ignored = ContextPropagation.setThreadLocals(c)) {
 			source.subscribe(threadLocalsSubscriber);
 		}
 
@@ -110,7 +110,7 @@ final class MonoContextWriteRestoringThreadLocals<T> extends MonoOperator<T, T> 
 			// the actual subscriber downstream, as it can expect TLs to match the
 			// different context.
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setThreadLocals(actual.currentContext())) {
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
 				actual.onNext(t);
 				actual.onComplete();
 			}
@@ -127,7 +127,7 @@ final class MonoContextWriteRestoringThreadLocals<T> extends MonoOperator<T, T> 
 			this.done = true;
 
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setThreadLocals(actual.currentContext())) {
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
 				actual.onError(t);
 			}
 		}
@@ -142,7 +142,7 @@ final class MonoContextWriteRestoringThreadLocals<T> extends MonoOperator<T, T> 
 			this.done = true;
 
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setThreadLocals(actual.currentContext())) {
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
 				actual.onComplete();
 			}
 		}
@@ -156,7 +156,7 @@ final class MonoContextWriteRestoringThreadLocals<T> extends MonoOperator<T, T> 
 		@Override
 		public void request(long n) {
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setThreadLocals(context)) {
+					     ContextPropagation.setThreadLocals(context)) {
 				s.request(n);
 			}
 		}
@@ -165,7 +165,7 @@ final class MonoContextWriteRestoringThreadLocals<T> extends MonoOperator<T, T> 
 		@Override
 		public void cancel() {
 			try (ContextSnapshot.Scope ignored =
-					     ContextSnapshot.setThreadLocals(context)) {
+					     ContextPropagation.setThreadLocals(context)) {
 				s.cancel();
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoContextWriteRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoContextWriteRestoringThreadLocals.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import io.micrometer.context.ContextSnapshot;
+import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
+import reactor.util.context.Context;
+
+final class MonoContextWriteRestoringThreadLocals<T> extends MonoOperator<T, T> {
+
+	final Function<Context, Context> doOnContext;
+
+	MonoContextWriteRestoringThreadLocals(Mono<? extends T> source,
+			Function<Context, Context> doOnContext) {
+		super(source);
+		this.doOnContext = Objects.requireNonNull(doOnContext, "doOnContext");
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super T> actual) {
+		Context c = doOnContext.apply(actual.currentContext());
+		try (ContextSnapshot.Scope __ = ContextSnapshot.setAllThreadLocalsFrom(c)) {
+			source.subscribe(
+					new FluxContextWriteRestoringThreadLocals
+							.ContextWriteRestoringThreadLocalsSubscriber<>(actual, c)
+			);
+		}
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+		return super.scanUnsafe(key);
+	}
+}

--- a/reactor-core/src/test/java/reactor/ReactorTestExecutionListener.java
+++ b/reactor-core/src/test/java/reactor/ReactorTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,8 @@ public class ReactorTestExecutionListener implements TestExecutionListener {
 		Hooks.resetOnOperatorError();
 
 		Hooks.removeQueueWrappers();
+
+		Hooks.disableAutomaticContextPropagation();
 
 		Schedulers.resetOnHandleError();
 		Schedulers.resetFactory();

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
@@ -18,19 +18,17 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import io.micrometer.context.ContextRegistry;
-import io.micrometer.context.ContextSnapshot;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -41,7 +39,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
-
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
@@ -55,6 +52,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.ParameterizedTestWithName;
 import reactor.test.subscriber.TestSubscriber;
 import reactor.test.subscriber.TestSubscriberBuilder;
+import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
 import reactor.util.context.ContextView;
 
@@ -96,92 +94,185 @@ class ContextPropagationTest {
 
 	}
 
+	@Test
+	void threadLocalsPresentAfterSubscribeOn() {
+		Hooks.enableAutomaticContextPropagation();
 
+		AtomicReference<String> tlValue = new AtomicReference<>();
+
+		Flux.just(1)
+		    .subscribeOn(Schedulers.boundedElastic())
+		    .doOnNext(i -> tlValue.set(REF1.get()))
+		    .contextWrite(Context.of(KEY1, "present"))
+		    .blockLast();
+
+		assertThat(tlValue.get()).isEqualTo("present");
+	}
+
+	@Test
+	void threadLocalsPresentAfterPublishOn() {
+		Hooks.enableAutomaticContextPropagation();
+
+		AtomicReference<String> tlValue = new AtomicReference<>();
+
+		Flux.just(1)
+		    .publishOn(Schedulers.boundedElastic())
+		    .doOnNext(i -> tlValue.set(REF1.get()))
+		    .contextWrite(Context.of(KEY1, "present"))
+		    .blockLast();
+
+		assertThat(tlValue.get()).isEqualTo("present");
+	}
+
+	@Test
+	void threadLocalsPresentInFlatMap() {
+		Hooks.enableAutomaticContextPropagation();
+
+		AtomicReference<String> tlValue = new AtomicReference<>();
+
+		Flux.just(1)
+		    .flatMap(i -> Mono.just(i)
+		                      .doOnNext(j -> tlValue.set(REF1.get())))
+		    .contextWrite(Context.of(KEY1, "present"))
+		    .blockLast();
+
+		assertThat(tlValue.get()).isEqualTo("present");
+	}
+
+	@Test
+	void threadLocalsPresentAfterDelay() {
+		Hooks.enableAutomaticContextPropagation();
+
+		AtomicReference<String> tlValue = new AtomicReference<>();
+
+		Flux.just(1)
+		    .delayElements(Duration.ofMillis(1))
+		    .doOnNext(i -> tlValue.set(REF1.get()))
+		    .contextWrite(Context.of(KEY1, "present"))
+		    .blockLast();
+
+		assertThat(tlValue.get()).isEqualTo("present");
+	}
+
+	@Test
+	void threadLocalsRestoredAfterPollution() {
+		// this test validates Queue wrapping takes place
+		Hooks.enableAutomaticContextPropagation();
+		ArrayBlockingQueue<String> modifiedThreadLocals = new ArrayBlockingQueue<>(10);
+		ArrayBlockingQueue<String> restoredThreadLocals = new ArrayBlockingQueue<>(10);
+
+		Flux.range(0, 10)
+				.doOnNext(i -> {
+					REF1.set("i: " + i);
+				})
+				.publishOn(Schedulers.parallel())
+		        // the validation below shows that modifications to TLs are propagated
+		        // across thread boundaries via queue wrapping, so explicit control
+		        // is required from users to clean up after such modifications
+				.doOnNext(i -> modifiedThreadLocals.add(REF1.get()))
+				.contextWrite(Function.identity())
+                // the contextWrite above creates a barrier that ensures the downstream
+		        // operator sees TLs from the subscriber context
+				.doOnNext(i -> restoredThreadLocals.add(REF1.get()))
+				.contextWrite(Context.of(KEY1, "present"))
+				.blockLast();
+
+		assertThat(modifiedThreadLocals).containsExactly(
+				"i: 0", "i: 1", "i: 2", "i: 3", "i: 4",
+				"i: 5", "i: 6", "i: 7", "i: 8", "i: 9"
+		);
+		assertThat(restoredThreadLocals).containsExactly(
+				Collections.nCopies(10, "present").toArray(new String[] {})
+		);
+	}
 
 	@Test
 	@SuppressWarnings("unchecked")
-	void checkThreadLocalsArePropagatedThroughTheWholeStack() {
-		Hooks.automaticContextPropagation();
+	void contextCapturePropagatedAutomaticallyToAllSignals() throws InterruptedException {
+		Hooks.enableAutomaticContextPropagation();
 
+		AtomicReference<String> requestTlValue = new AtomicReference<>();
+		AtomicReference<String> subscribeTlValue = new AtomicReference<>();
+		AtomicReference<String> firstNextTlValue = new AtomicReference<>();
+		AtomicReference<String> secondNextTlValue = new AtomicReference<>();
+		AtomicReference<String> cancelTlValue = new AtomicReference<>();
 
-		REF1.set("expectedX");
-		REF2.set("expected2");
+		CountDownLatch itemDelivered = new CountDownLatch(1);
+		CountDownLatch cancelled = new CountDownLatch(1);
 
-		Flux<Integer> flux = Flux.range(0, 10)
-		                         .doOnRequest(r -> System.out.println("Requesting: " + REF1.get()))
-		                         .doOnNext(i -> {
-			                         System.out.println("BEFORE " + i + ": " + REF1.get());
-		                         })
-		                         .doOnNext(e -> REF1.set(REF1.get()
-		                                                     .substring(0,
-				                                                     REF1.get()
-				                                                         .length() - 1) + e))
-		                         .delayElements(Duration.ofMillis(100),
-				                         Schedulers.fromExecutorService(Executors.newSingleThreadScheduledExecutor()))
-		                         .publishOn(Schedulers.parallel())
-		                         .doOnNext(i -> {
-			                         System.out.println("AFTER  " + i + ": " + REF1.get());
-		                         })
-		                         .contextWrite(ctx -> ctx.put(KEY1, "blabla"))
-		                         .subscribeOn(Schedulers.boundedElastic());
-//		                         .contextCapture();
+		TestSubscriber<Integer> subscriber =
+				TestSubscriber.builder().initialRequest(1).build();
 
-		Flux.defer(() -> flux).subscribeOn(Schedulers.parallel()).blockLast();
-//		flux.blockLast();
+		REF1.set("downstreamContext");
+
+		Flux.just(1, 2)
+		    .hide()
+		    .doOnRequest(r -> requestTlValue.set(REF1.get()))
+		    .doOnNext(i -> firstNextTlValue.set(REF1.get()))
+		    .doOnSubscribe(s -> subscribeTlValue.set(REF1.get()))
+		    .doOnCancel(() -> {
+			    cancelTlValue.set(REF1.get());
+			    cancelled.countDown();
+		    })
+		    .delayElements(Duration.ofMillis(1))
+		    .contextWrite(Context.of(KEY1, "upstreamContext"))
+		    // disabling prefetching to observe cancellation
+		    .publishOn(Schedulers.parallel(), 1)
+		    .doOnNext(i -> {
+			    System.out.println(REF1.get());
+				secondNextTlValue.set(REF1.get());
+				itemDelivered.countDown();
+		    })
+		    .subscribeOn(Schedulers.boundedElastic())
+		    .contextCapture()
+		    .subscribe(subscriber);
+
+		itemDelivered.await();
+
+		subscriber.cancel();
+
+		cancelled.await();
+
+		assertThat(requestTlValue.get()).isEqualTo("upstreamContext");
+		assertThat(subscribeTlValue.get()).isEqualTo("upstreamContext");
+		assertThat(firstNextTlValue.get()).isEqualTo("upstreamContext");
+		assertThat(cancelTlValue.get()).isEqualTo("upstreamContext");
+		assertThat(secondNextTlValue.get()).isEqualTo("downstreamContext");
 	}
 
 	@Test
-	void checkThreadLocalsRestoredInEveryOperator() {
-		Hooks.automaticContextPropagation();
+	void prefetchingShouldMaintainThreadLocals() {
+		Hooks.enableAutomaticContextPropagation();
 
-		Flux<Integer> flux =
-				Flux.range(0, 10)
-//					.filter(i -> i < 5)
-//					.doOnRequest(r -> System.out.println("Requested " + r + ": " + REF1.get()))
-//				    .doOnNext(i -> System.out.println(i + ": " + REF1.get()))
-//					.flatMap(i -> Mono.just(i).doOnNext(j -> System.out.println(("inside j: " + REF1.get()))))
-					.flatMap(i -> {
-						System.out.println(i + ": " + REF1.get());
-						return Mono.just(i)
-						           .doOnNext(j -> System.out.println("inside: " + REF1.get()))
-						           .contextWrite(ctx -> ctx.put(KEY1, "expectedY"))
-						           .doOnNext(x -> System.out.println("outside: " + REF1.get()));
-					})
-				    .contextWrite(ctx -> ctx.put(KEY1, "expectedX"))
-					.doOnNext(i -> System.out.println("After contextWrite: " + REF1.get()))
-				    .subscribeOn(Schedulers.boundedElastic());
+		// We validate streams of items above default prefetch size
+		// (max concurrency of flatMap == Queues.SMALL_BUFFER_SIZE == 256)
+		// are able to maintain the context propagation to ThreadLocals
+		// in the presence of prefetching
+		int size = Queues.SMALL_BUFFER_SIZE * 10;
 
-		flux.blockLast();
-		System.out.println("After: " + REF1.get());
-	}
-
-	@Test
-	void fuseableContextPropagation() {
-		Hooks.automaticContextPropagation();
-		Flux<Integer> source1 = Flux.fromIterable(
-				Stream.of(1, 2, 3).collect(Collectors.toList())
-		);
-		Flux<Integer> source2 = Flux.create(s -> {
-			for (int i = 0; i < 3000; i++) {
+		Flux<Integer> source = Flux.create(s -> {
+			for (int i = 0; i < size; i++) {
 				s.next(i);
 			}
 			s.complete();
 		});
 
-		Flux<String> flux = source2
-		                        .publishOn(Schedulers.boundedElastic())
-		                        .flatMap(i ->
-				                        Mono.just(i)
-				                            .delayElement(Duration.ofMillis(1))
-				                            .doOnNext(
-													j -> System.out.println("Inside flatMap: " + REF1.get())
-				                            ))
-		                        .map(String::valueOf)
-		                        .contextWrite(ctx -> ctx.put(KEY1, "present"))
-		                        .publishOn(Schedulers.parallel())
-		                        .doOnNext(i -> System.out.println("After contextWrite: " + REF1.get()));
+		assertThat(REF1.get()).isEqualTo("ref1_init");
 
-		System.out.println(flux.blockLast());
+		ArrayBlockingQueue<String> innerThreadLocals = new ArrayBlockingQueue<>(size);
+		ArrayBlockingQueue<String> outerThreadLocals = new ArrayBlockingQueue<>(size);
+
+		source.publishOn(Schedulers.boundedElastic())
+		      .flatMap(i -> Mono.just(i)
+		                        .delayElement(Duration.ofMillis(1))
+		                        .doOnNext(j -> innerThreadLocals.add(REF1.get())))
+		      .contextWrite(ctx -> ctx.put(KEY1, "present"))
+		      .publishOn(Schedulers.parallel())
+		      .doOnNext(i -> outerThreadLocals.add(REF1.get()))
+		      .blockLast();
+
+		assertThat(innerThreadLocals).containsOnly("present").hasSize(size);
+		assertThat(outerThreadLocals).containsOnly("ref1_init").hasSize(size);
 	}
 
 	@Test
@@ -231,6 +322,29 @@ class ContextPropagationTest {
 			);
 	}
 
+	@Test
+	void fluxApiUsesContextPropagationConstantFunctionWhenAutomaticPropagationEnabled() {
+		Hooks.enableAutomaticContextPropagation();
+		Flux<Integer> source = Flux.empty();
+		assertThat(source.contextCapture())
+				.isInstanceOfSatisfying(FluxContextWriteRestoringThreadLocals.class,
+						fcw -> assertThat(fcw.doOnContext)
+								.as("flux's capture function")
+								.isSameAs(ContextPropagation.WITH_GLOBAL_REGISTRY_NO_PREDICATE)
+				);
+	}
+
+	@Test
+	void monoApiUsesContextPropagationConstantFunctionWhenAutomaticPropagationEnabled() {
+		Hooks.enableAutomaticContextPropagation();
+		Mono<Integer> source = Mono.empty();
+		assertThat(source.contextCapture())
+				.isInstanceOfSatisfying(MonoContextWriteRestoringThreadLocals.class,
+						fcw -> assertThat(fcw.doOnContext)
+								.as("mono's capture function")
+								.isSameAs(ContextPropagation.WITH_GLOBAL_REGISTRY_NO_PREDICATE));
+	}
+
 	@Nested
 	class ContextCaptureFunctionTest {
 
@@ -263,8 +377,8 @@ class ContextPropagationTest {
 			ctx.forEach(asMap::put); //easier to assert
 
 			assertThat(asMap)
-				.containsEntry(KEY2, "expected")
-				.hasSize(1);
+					.containsEntry(KEY2, "expected")
+					.hasSize(1);
 		}
 	}
 
@@ -610,11 +724,11 @@ class ContextPropagationTest {
 				softly.assertThat(publisherFuseable.handler).as("publisherFuseable.handler").isSameAs(originalHandler);
 
 				softly.assertThat(sub.handler)
-					.as("sub.handler")
-					.isNotSameAs(originalHandler);
+				      .as("sub.handler")
+				      .isNotSameAs(originalHandler);
 				softly.assertThat(subFused.handler)
-					.as("subFused.handler")
-					.isNotSameAs(originalHandler);
+				      .as("subFused.handler")
+				      .isNotSameAs(originalHandler);
 			});
 		}
 	}

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocalsTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocalsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Scannable;
+import reactor.util.context.Context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FluxContextWriteRestoringThreadLocalsTest {
+
+	@Test
+	public void scanOperator(){
+		Flux<Integer> parent = Flux.just(1);
+		FluxContextWriteRestoringThreadLocals<Integer> test =
+				new FluxContextWriteRestoringThreadLocals<>(parent, c -> c);
+
+		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
+	}
+
+	@Test
+	public void scanSubscriber(){
+		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+		FluxContextWriteRestoringThreadLocals
+				.ContextWriteRestoringThreadLocalsSubscriber<Integer> test =
+				new FluxContextWriteRestoringThreadLocals
+						.ContextWriteRestoringThreadLocalsSubscriber<>(
+								actual, Context.empty()
+				);
+
+		Subscription parent = Operators.emptySubscription();
+		test.onSubscribe(parent);
+
+		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
+		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
+		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
+	}
+
+}

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoContextWriteRestoringThreadLocalsTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoContextWriteRestoringThreadLocalsTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+
+import org.junit.jupiter.api.Test;
+import reactor.core.Scannable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MonoContextWriteRestoringThreadLocalsTest {
+
+    @Test
+    public void scanOperator(){
+        MonoContextWriteRestoringThreadLocals<Integer> test =
+                new MonoContextWriteRestoringThreadLocals<>(Mono.just(1), c -> c);
+
+        assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
+    }
+}


### PR DESCRIPTION
This PR adds a few primitives necessary for propagating reactor Context to ThreadLocals using the context-propagation library. It adds the following primitives:
- dedicated Scheduler task wrapping
- dedicated global Queue wrapper
- dedicated alternative to FluxContextWrite and MonoContextWrite operators

All of these use the context restoration mechanism from context-propagation.

Currently, to properly clean up the context before propagating signals to downstream operators, this PR depends on https://github.com/micrometer-metrics/context-propagation/pull/67.

[update] the above PR has been integrated into the context-propagation library.
[update-2] the necessary functionality has been introduced as internal temporary code before the API in context-propagation library stabilises to cover all usage patterns.