### PR TITLE
Remove Traces$SharedSecretsCallSiteSupplierFactory from the native-image configuration

### DIFF
--- a/reactor-core/src/main/resources/META-INF/native-image/io.projectreactor/reactor-core/reflect-config.json
+++ b/reactor-core/src/main/resources/META-INF/native-image/io.projectreactor/reactor-core/reflect-config.json
@@ -15,18 +15,6 @@
     "condition": {
       "typeReachable": "reactor.core.publisher.Traces"
     },
-    "name": "reactor.core.publisher.Traces$SharedSecretsCallSiteSupplierFactory",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "reactor.core.publisher.Traces"
-    },
     "name": "reactor.core.publisher.Traces$ExceptionCallSiteSupplierFactory",
     "methods": [
       {


### PR DESCRIPTION
`Traces$SharedSecretsCallSiteSupplierFactory` is targeting `JDK 8`, it uses `sun.misc.SharedSecrets` which is unavailable on `Java 9+`

Current `GraalVM` `v22.3.1` provides `Java 11/17/19-based` `GraalVM` https://www.graalvm.org/release-notes/22_3/

Fixes #3334