### PR TITLE
Upgrade Micrometer dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ bytebuddy = "1.12.18"
 jmh = "1.35"
 junit = "5.9.1"
 #note that some micrometer artifacts like context-propagation has a different version directly set in libraries below
-micrometer = "1.10.2"
+micrometer = "1.10.3"
 reactiveStreams = "1.0.4"
 
 [libraries]
@@ -36,9 +36,9 @@ micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micro
 micrometer-commons = { module = "io.micrometer:micrometer-commons" }
 micrometer-core = { module = "io.micrometer:micrometer-core" }
 micrometer-contextPropagation = "io.micrometer:context-propagation:1.0.0"
-micrometer-docsGenerator = { module = "io.micrometer:micrometer-docs-generator", version = "1.0.0"}
+micrometer-docsGenerator = { module = "io.micrometer:micrometer-docs-generator", version = "1.0.1"}
 micrometer-observation-test = { module = "io.micrometer:micrometer-observation-test" }
-micrometer-tracing-test = "io.micrometer:micrometer-tracing-integration-test:1.0.0"
+micrometer-tracing-test = "io.micrometer:micrometer-tracing-integration-test:1.0.1"
 micrometer-test = { module = "io.micrometer:micrometer-test" }
 mockito = "org.mockito:mockito-core:4.8.1"
 reactiveStreams = { module = "org.reactivestreams:reactive-streams", version.ref = "reactiveStreams" }


### PR DESCRIPTION
- micrometer 1.10.2 -> 1.10.3
- micrometer-docs-generator 1.0.0 -> 1.0.1
- micrometer-tracing-integration-test 1.0.0 - 1.0.1