### PR TITLE
ExecutorScheduler should use onScheduleHook

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/ExecutorScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ExecutorScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,9 @@ final class ExecutorScheduler implements Scheduler, Scannable {
 			throw Exceptions.failWithRejected();
 		}
 		Objects.requireNonNull(task, "task");
+
+		task = Schedulers.onSchedule(task);
+
 		ExecutorPlainRunnable r = new ExecutorPlainRunnable(task);
 		//RejectedExecutionException are propagated up, but since Executor doesn't from
 		//failing tasks we'll also wrap the execute call in a try catch:
@@ -220,18 +223,25 @@ final class ExecutorScheduler implements Scheduler, Scannable {
 	 */
 	static final class ExecutorSchedulerWorker implements Scheduler.Worker, WorkerDelete, Scannable {
 
+		private final boolean wrapSchedule;
+
 		final Executor executor;
 
 		final Disposable.Composite tasks;
 
 		ExecutorSchedulerWorker(Executor executor) {
 			this.executor = executor;
+			this.wrapSchedule = executor instanceof Scheduler;
 			this.tasks = Disposables.composite();
 		}
 
 		@Override
 		public Disposable schedule(Runnable task) {
 			Objects.requireNonNull(task, "task");
+
+			if (wrapSchedule) {
+				task = Schedulers.onSchedule(task);
+			}
 
 			ExecutorTrackedRunnable r = new ExecutorTrackedRunnable(task, this, true);
 			if (!tasks.add(r)) {
@@ -286,6 +296,8 @@ final class ExecutorScheduler implements Scheduler, Scannable {
 	static final class ExecutorSchedulerTrampolineWorker
 			implements Scheduler.Worker, WorkerDelete, Runnable, Scannable {
 
+		private final boolean wrapSchedule;
+
 		final Executor executor;
 
 		final Queue<ExecutorTrackedRunnable> queue;
@@ -299,6 +311,7 @@ final class ExecutorScheduler implements Scheduler, Scannable {
 
 		ExecutorSchedulerTrampolineWorker(Executor executor) {
 			this.executor = executor;
+			this.wrapSchedule = executor instanceof Scheduler;
 			this.queue = new ConcurrentLinkedQueue<>();
 		}
 
@@ -307,6 +320,10 @@ final class ExecutorScheduler implements Scheduler, Scannable {
 			Objects.requireNonNull(task, "task");
 			if (terminated) {
 				throw Exceptions.failWithRejected();
+			}
+
+			if (wrapSchedule) {
+				task = Schedulers.onSchedule(task);
 			}
 
 			ExecutorTrackedRunnable r = new ExecutorTrackedRunnable(task, this, false);

--- a/reactor-core/src/main/java/reactor/core/scheduler/ExecutorScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ExecutorScheduler.java
@@ -231,7 +231,7 @@ final class ExecutorScheduler implements Scheduler, Scannable {
 
 		ExecutorSchedulerWorker(Executor executor) {
 			this.executor = executor;
-			this.wrapSchedule = executor instanceof Scheduler;
+			this.wrapSchedule = !(executor instanceof Scheduler);
 			this.tasks = Disposables.composite();
 		}
 
@@ -311,7 +311,7 @@ final class ExecutorScheduler implements Scheduler, Scannable {
 
 		ExecutorSchedulerTrampolineWorker(Executor executor) {
 			this.executor = executor;
-			this.wrapSchedule = executor instanceof Scheduler;
+			this.wrapSchedule = !(executor instanceof Scheduler);
 			this.queue = new ConcurrentLinkedQueue<>();
 		}
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulerWorkersHooksTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulerWorkersHooksTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2019-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.scheduler;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import reactor.core.scheduler.SchedulersHooksTest.ApplicationOrderRecordingDecorator;
+import reactor.core.scheduler.SchedulersHooksTest.TrackingDecorator;
+import reactor.test.AutoDisposingExtension;
+import reactor.test.ParameterizedTestWithName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class SchedulerWorkersHooksTest {
+
+	@RegisterExtension
+	public AutoDisposingExtension afterTest = new AutoDisposingExtension();
+
+	@AfterEach
+	public void resetAllHooks() {
+		Schedulers.resetOnScheduleHooks();
+		Schedulers.resetOnHandleError();
+	}
+
+	static Stream<Arguments> workers() {
+		return Stream.of(
+				arguments(Named.named("PARALLEL", (Supplier<Scheduler.Worker>)
+						() -> Schedulers.newParallel("A", 1).createWorker())), 
+				arguments(Named.named("BOUNDED_ELASTIC", (Supplier<Scheduler.Worker>)
+						() -> Schedulers.newBoundedElastic(4, Integer.MAX_VALUE, "A").createWorker())),
+				arguments(Named.named("SINGLE", (Supplier<Scheduler.Worker>)
+						() -> Schedulers.newSingle("A").createWorker())),
+				arguments(Named.named("EXECUTOR_SERVICE", (Supplier<Scheduler.Worker>)
+						() -> Schedulers.fromExecutorService(Executors.newCachedThreadPool(), "A").createWorker())),
+				arguments(Named.named("EXECUTOR", (Supplier<Scheduler.Worker>)
+						() -> Schedulers.fromExecutor(task -> {
+							Thread thread = new Thread(task);
+							thread.setDaemon(true);
+							thread.start();
+						}).createWorker())));
+	}
+
+	@ParameterizedTestWithName
+	@MethodSource("workers")
+	@Tag("slow")
+	public void onScheduleIsAdditive(Supplier<Scheduler.Worker> workerType) throws Exception {
+		AtomicInteger tracker = new AtomicInteger();
+		Schedulers.onScheduleHook("k1", new TrackingDecorator(tracker, 1));
+		Schedulers.onScheduleHook("k2", new TrackingDecorator(tracker, 10));
+		Schedulers.onScheduleHook("k3", new TrackingDecorator(tracker, 100));
+
+		CountDownLatch latch = new CountDownLatch(3);
+		afterTest.autoDispose(workerType.get()).schedule(latch::countDown);
+		latch.await(5, TimeUnit.SECONDS);
+
+		assertThat(tracker).as("3 decorators invoked").hasValue(111);
+	}
+
+	@ParameterizedTestWithName
+	@MethodSource("workers")
+	public void onScheduleReplaces(Supplier<Scheduler.Worker> workerType) throws Exception {
+		AtomicInteger tracker = new AtomicInteger();
+		Schedulers.onScheduleHook("k1", new TrackingDecorator(tracker, 1));
+		Schedulers.onScheduleHook("k1", new TrackingDecorator(tracker, 10));
+		Schedulers.onScheduleHook("k1", new TrackingDecorator(tracker, 100));
+
+		CountDownLatch latch = new CountDownLatch(1);
+		afterTest.autoDispose(workerType.get()).schedule(latch::countDown);
+		latch.await(5, TimeUnit.SECONDS);
+
+		assertThat(tracker).hasValue(100);
+	}
+
+	@ParameterizedTestWithName
+	@MethodSource("workers")
+	public void onScheduleWorksWhenEmpty(Supplier<Scheduler.Worker> workerType) throws Exception {
+		AtomicInteger tracker = new AtomicInteger();
+		Schedulers.onScheduleHook("k1", new TrackingDecorator(tracker, 1));
+		Schedulers.resetOnScheduleHook("k1");
+
+		CountDownLatch latch = new CountDownLatch(1);
+		afterTest.autoDispose(workerType.get()).schedule(latch::countDown);
+		latch.await(5, TimeUnit.SECONDS);
+
+		assertThat(tracker).hasValue(0);
+	}
+
+	@ParameterizedTestWithName
+	@MethodSource("workers")
+	@Tag("slow")
+	public void onScheduleResetOne(Supplier<Scheduler.Worker> workerType) throws InterruptedException {
+		AtomicInteger tracker = new AtomicInteger();
+		Schedulers.onScheduleHook("k1", new TrackingDecorator(tracker, 1));
+		Schedulers.onScheduleHook("k2", new TrackingDecorator(tracker, 10));
+		Schedulers.onScheduleHook("k3", new TrackingDecorator(tracker, 100));
+		Schedulers.resetOnScheduleHook("k2");
+
+		CountDownLatch latch = new CountDownLatch(3);
+		afterTest.autoDispose(workerType.get()).schedule(latch::countDown);
+		latch.await(5, TimeUnit.SECONDS);
+
+		assertThat(tracker).hasValue(101);
+	}
+
+	@ParameterizedTestWithName
+	@MethodSource("workers")
+	public void onScheduleResetAll(Supplier<Scheduler.Worker> workerType) throws InterruptedException {
+		AtomicInteger tracker = new AtomicInteger();
+		Schedulers.onScheduleHook("k1", new TrackingDecorator(tracker, 1));
+		Schedulers.onScheduleHook("k2", new TrackingDecorator(tracker, 10));
+		Schedulers.onScheduleHook("k3", new TrackingDecorator(tracker, 100));
+		Schedulers.resetOnScheduleHooks();
+
+		CountDownLatch latch = new CountDownLatch(1);
+		afterTest.autoDispose(workerType.get()).schedule(latch::countDown);
+		latch.await(5, TimeUnit.SECONDS);
+
+		assertThat(tracker).hasValue(0);
+	}
+
+	@ParameterizedTestWithName
+	@MethodSource("workers")
+	public void onSchedulesAreOrdered(Supplier<Scheduler.Worker> workerType) throws Exception {
+		CopyOnWriteArrayList<String> items = new CopyOnWriteArrayList<>();
+		Schedulers.onScheduleHook("k1", new ApplicationOrderRecordingDecorator(items, "k1"));
+		Schedulers.onScheduleHook("k2", new ApplicationOrderRecordingDecorator(items, "k2"));
+		Schedulers.onScheduleHook("k3", new ApplicationOrderRecordingDecorator(items, "k3"));
+
+		CountDownLatch latch = new CountDownLatch(1);
+		afterTest.autoDispose(workerType.get()).schedule(latch::countDown);
+		latch.await(5, TimeUnit.SECONDS);
+
+		assertThat(items).containsExactly(
+				"k1#0",
+				"k2#0",
+				"k3#0"
+		);
+	}
+}

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersHooksTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersHooksTest.java
@@ -266,11 +266,11 @@ public class SchedulersHooksTest {
 		assertThat(tracker).hasValue(100);
 	}
 
-	private static class TrackingDecorator implements Function<Runnable, Runnable> {
+	static class TrackingDecorator implements Function<Runnable, Runnable> {
 		final AtomicInteger tracker;
 		final int dx;
 
-		private TrackingDecorator(AtomicInteger tracker, int dx) {
+		TrackingDecorator(AtomicInteger tracker, int dx) {
 			this.tracker = tracker;
 			this.dx = dx;
 		}
@@ -284,7 +284,7 @@ public class SchedulersHooksTest {
 		}
 	}
 
-	private static class ApplicationOrderRecordingDecorator
+	static class ApplicationOrderRecordingDecorator
 			implements Function<Runnable, Runnable> {
 
 		final List<String> items;


### PR DESCRIPTION
`ExecutorScheduler` did not wrap tasks with `onScheduleHook` configured in `Schedulers`. This can lead to various unexpected situations, but an apparent one is that automatic context propagation to `ThreadLocal`s does not work when an `ExecutorScheduler` is used by any operator.

Fixes #3355.