### PR TITLE
Exclude `ContextPropagation#isContextPropagationAvailable` from the preprocessing for `native-image` support

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -49,7 +49,8 @@ final class ContextPropagation {
 
 	static final Logger LOGGER;
 
-	static final boolean isContextPropagationAvailable;
+	// Note: If a reflection is used for this field, then the name of the field should end with 'Available'
+	static final boolean isContextPropagationOnClasspath;
 	static boolean propagateContextToThreadLocals = false;
 
 	static final Predicate<Object> PREDICATE_TRUE = v -> true;
@@ -80,7 +81,7 @@ final class ContextPropagation {
 					" The feature is considered disabled due to this:", t);
 		}
 
-		isContextPropagationAvailable = contextPropagation;
+		isContextPropagationOnClasspath = contextPropagation;
 		WITH_GLOBAL_REGISTRY_NO_PREDICATE = contextCaptureFunction;
 	}
 
@@ -90,11 +91,11 @@ final class ContextPropagation {
 	 * @return true if context-propagation is available at runtime, false otherwise
 	 */
 	static boolean isContextPropagationAvailable() {
-		return isContextPropagationAvailable;
+		return isContextPropagationOnClasspath;
 	}
 
 	static boolean shouldPropagateContextToThreadLocals() {
-		return isContextPropagationAvailable && propagateContextToThreadLocals;
+		return isContextPropagationOnClasspath && propagateContextToThreadLocals;
 	}
 
 	public static Function<Runnable, Runnable> scopePassingOnScheduleHook() {
@@ -116,7 +117,7 @@ final class ContextPropagation {
 	 * @return the {@link Context} augmented with captured entries
 	 */
 	static Function<Context, Context> contextCapture() {
-		if (!isContextPropagationAvailable) {
+		if (!isContextPropagationOnClasspath) {
 			return NO_OP;
 		}
 		return WITH_GLOBAL_REGISTRY_NO_PREDICATE;
@@ -139,7 +140,7 @@ final class ContextPropagation {
 	 * @return a {@link Function} augmenting {@link Context} with captured entries
 	 */
 	static Function<Context, Context> contextCapture(Predicate<Object> captureKeyPredicate) {
-		if (!isContextPropagationAvailable) {
+		if (!isContextPropagationOnClasspath) {
 			return NO_OP;
 		}
 		return target -> ContextSnapshot.captureAllUsing(captureKeyPredicate, ContextRegistry.getInstance())

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -49,7 +49,10 @@ final class ContextPropagation {
 
 	static final Logger LOGGER;
 
-	// Note: If a reflection is used for this field, then the name of the field should end with 'Available'
+	// Note: If reflection is used for this field, then the name of the field should end with 'Available'.
+	// The preprocessing for native-image support is Spring Framework, and is a short term solution.
+	// The field should end with 'Available'. See org.springframework.aot.nativex.feature.PreComputeFieldFeature.
+	// Ultimately the long term solution should be provided by Reactor Core.
 	static final boolean isContextPropagationOnClasspath;
 	static boolean propagateContextToThreadLocals = false;
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
@@ -535,7 +535,7 @@ public abstract class Hooks {
 	 * a logical boundary for the context propagation mechanism.
 	 */
 	public static void enableAutomaticContextPropagation() {
-		if (ContextPropagation.isContextPropagationAvailable) {
+		if (ContextPropagation.isContextPropagationOnClasspath) {
 			Hooks.addQueueWrapper(
 					CONTEXT_IN_THREAD_LOCALS_KEY, ContextPropagation.ContextQueue::new
 			);
@@ -552,7 +552,7 @@ public abstract class Hooks {
 	 * @see #enableAutomaticContextPropagation()
 	 */
 	public static void disableAutomaticContextPropagation() {
-		if (ContextPropagation.isContextPropagationAvailable) {
+		if (ContextPropagation.isContextPropagationOnClasspath) {
 			Hooks.removeQueueWrapper(CONTEXT_IN_THREAD_LOCALS_KEY);
 			Schedulers.resetOnScheduleHook(CONTEXT_IN_THREAD_LOCALS_KEY);
 			ContextPropagation.propagateContextToThreadLocals = false;


### PR DESCRIPTION
Reflection is not used for identifying whether this library is available or not, thus this field can be excluded from the preprocessing for `native-image` support.

Related to https://github.com/spring-projects/spring-framework/issues/30058