### PR TITLE
Polish comment on ContextPropagation.isContextPropagationOnClasspath

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -50,7 +50,7 @@ final class ContextPropagation {
 	static final Logger LOGGER;
 
 	// Note: If reflection is used for this field, then the name of the field should end with 'Available'.
-	// The preprocessing for native-image support is Spring Framework, and is a short term solution.
+	// The preprocessing for native-image support is in Spring Framework, and is a short term solution.
 	// The field should end with 'Available'. See org.springframework.aot.nativex.feature.PreComputeFieldFeature.
 	// Ultimately the long term solution should be provided by Reactor Core.
 	static final boolean isContextPropagationOnClasspath;


### PR DESCRIPTION
This PR polishes the comment on the `ContextPropagation.isContextPropagationOnClasspath` by adding a missing "in".