### PR TITLE
Apply dependencies.gradle in root project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ plugins {
 apply plugin: "io.reactor.gradle.detect-ci"
 apply from: "gradle/asciidoc.gradle" // asciidoc (which is generated from root dir)
 apply from: "gradle/releaser.gradle"
+apply from: "gradle/dependencies.gradle"
 
 repositories { //needed at root for asciidoctor and nohttp-checkstyle
 	mavenCentral()
@@ -136,7 +137,6 @@ configure(subprojects) { p ->
 	apply plugin: 'java'
 	apply plugin: 'jacoco'
 	apply from: "${rootDir}/gradle/setup.gradle"
-	apply from: "${rootDir}/gradle/dependencies.gradle"
 
 	description = 'Non-Blocking Reactive Foundation for the JVM'
 	group = 'io.projectreactor'


### PR DESCRIPTION
Dependabot seems to have trouble resolving the
dependencies.gradle file when it is used as a script plugin in the subprojects section.
The urls it uses contain the `${rootDir}` instead of the resolved path.
However, it can be run in the root build file, as it modifies the `ext` section, which stands for [Extra properties](https://docs.gradle.org/current/userguide/writing_build_scripts.html#sec:extra_properties) in Gradle's vocabulary and is made available to all the subprojects.