### PR TITLE
Dependabot: ignore Mockito 5.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,9 @@ updates:
       # TestNG: 7.6+ doesn't support JDK8 anymore
       - dependency-name: "org.testng:testng"
         versions: ["7.6.x"]
+      # Mockito: don't upgrade to v5 (requires JDK11+)
+      - dependency-name: "org.mockito:mockito-core"
+        version: ["5.x"]
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"
     schedule:


### PR DESCRIPTION
Since v5.0.0, Mockito no longer supports JDK8, so we will stick with v4.11.0.

Relates to #3384.