### PR TITLE
Propagate ThreadLocals in tap

### DIFF
--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationIntegrationTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,24 @@
 
 package reactor.core.observability.micrometer;
 
-import java.time.Duration;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
-
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.test.SampleTestRunner;
 import io.micrometer.tracing.test.simple.SpansAssert;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,80 +46,87 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Simon Baslé
  */
-@Tag("slow")
-public class MicrometerObservationIntegrationTest extends SampleTestRunner {
+public class MicrometerObservationIntegrationTest {
 
-	MicrometerObservationIntegrationTest() {
-		super(SampleTestRunner.SampleRunnerConfig.builder()
-			.build());
-	}
+    static class ActualRunner extends SampleTestRunner {
 
-	@Override
-	public SampleTestRunnerConsumer yourCode() throws Exception {
-		Hooks.enableAutomaticContextPropagation();
-		final Scheduler delayScheduler = Schedulers.newSingle("test");
-		final IllegalStateException EXCEPTION = new IllegalStateException("expected error");
-		return (bb, meterRegistry) -> {
-			Span beforeStart = bb.getTracer().currentSpan();
+        private final boolean automatic;
 
-			Function<Integer, Mono<String>> querySimulator = id ->
-				Mono.delay(Duration.ofMillis(500), delayScheduler)
-					.tag("endpoint", "simulated/" + id)
-					.map(ignored -> "query for id " + id)
-					.doOnNext(v -> {
-						if (id == 2L) throw EXCEPTION;
-					})
-					.name("query" + id)
-					.tap(Micrometer.observation(getObservationRegistry()));
+        public ActualRunner(boolean automatic, SampleRunnerConfig sampleRunnerConfig) {
+            super(sampleRunnerConfig);
+            this.automatic = automatic;
+        }
 
-			Flux.range(0, 100)
-				.name("testFlux")
-				.tag("interval", "500ms")
-				.take(3)
-				.tag("size", "3")
-				.concatMap(querySimulator)
-				.tap(Micrometer.observation(getObservationRegistry()))
-				.onErrorReturn("ended with error") // prevent error throwing. the tap should still get notified
-				.blockLast();
+        @Override
+        public SampleTestRunner.SampleTestRunnerConsumer yourCode() throws Exception {
+            if (this.automatic) {
+                Hooks.enableAutomaticContextPropagation();
+            }
+            final ScheduledExecutorService delayExecutor = Executors.newSingleThreadScheduledExecutor();
+            final Scheduler delayScheduler = Schedulers.fromExecutorService(delayExecutor, "test");
 
-			SpansAssert spansAssert = SpansAssert.assertThat(bb.getFinishedSpans());
-			SpansAssert.SpansAssertReturningAssert assertThatMain = spansAssert.assertThatASpanWithNameEqualTo("test-flux");
-			SpansAssert.SpansAssertReturningAssert assertThatQuery2 = spansAssert.assertThatASpanWithNameEqualTo("query2");
+            final IllegalStateException EXCEPTION = new IllegalStateException("expected error");
+            return (bb, meterRegistry) -> {
+                Span beforeStart = bb.getTracer().currentSpan();
 
-			spansAssert.hasSize(4);
+                Function<Integer, Mono<String>> querySimulator = id ->
+                        Mono.delay(Duration.ofMillis(500), delayScheduler)
+                                .tag("endpoint", "simulated/" + id)
+                                .map(ignored -> "query for id " + id)
+                                .doOnNext(v -> {
+                                    if (id == 2L) throw EXCEPTION;
+                                })
+                                .name("query" + id)
+                                .tap(Micrometer.observation(getObservationRegistry()));
 
-			assertThatMain
-				.hasTag("reactor.status", "error")
-				.hasTag("reactor.type", "Flux")
-				.hasTag("interval", "500ms")
-				.hasTag("size", "3")
-				//TODO propose new duration assertion? span's timestamps should return Instant, not long. OTel is using nanos, Brave is storing long microsecond
-//				.satisfies(span -> assertThat(Duration.ofNanos(span.getEndTimestamp() - span.getStartTimestamp()))
-//					.as("duration")
-//					.isGreaterThanOrEqualTo(Duration.ofMillis(1500))
-//				)
-				//OTEL doesn't really capture the exception type, only the message
-				.thenThrowable().hasMessage(EXCEPTION.getMessage());
+                Flux.range(0, 100)
+                        .name("testFlux")
+                        .tag("interval", "500ms")
+                        .take(3)
+                        .tag("size", "3")
+                        .concatMap(querySimulator)
+                        .tap(Micrometer.observation(getObservationRegistry()))
+                        .onErrorReturn("ended with error") // prevent error throwing. the tap should still get notified
+                        .blockLast();
 
-			//query2 span
-			assertThatQuery2
-				.hasTag("endpoint", "simulated/2")
-				.thenThrowable().hasMessage(EXCEPTION.getMessage());
+                SpansAssert spansAssert = SpansAssert.assertThat(bb.getFinishedSpans());
+                SpansAssert.SpansAssertReturningAssert assertThatMain = spansAssert.assertThatASpanWithNameEqualTo("test-flux");
+                SpansAssert.SpansAssertReturningAssert assertThatQuery2 = spansAssert.assertThatASpanWithNameEqualTo("query2");
 
-			//quick assert query0 and query1
-			spansAssert
-				.thenASpanWithNameEqualTo("query0")
-				.doesNotHaveEventWithNameEqualTo("exception")
-				.hasTag("endpoint", "simulated/0")
-				.backToSpans()
-				.hasASpanWithName("query1");
+                spansAssert.hasSize(4);
 
-			assertThat(bb.getTracer().currentSpan())
-				.as("no leftover span in main thread")
-				.isNotSameAs(beforeStart) //something happened
-				.isEqualTo(beforeStart); //original span was restored
+                assertThatMain
+                        .hasTag("reactor.status", "error")
+                        .hasTag("reactor.type", "Flux")
+                        .hasTag("interval", "500ms")
+                        .hasTag("size", "3")
+                        //TODO propose new duration assertion? span's timestamps should return Instant, not long. OTel is using nanos, Brave is storing long microsecond
+//                      .satisfies(span -> assertThat(Duration.ofNanos(span.getEndTimestamp() - span.getStartTimestamp()))
+//                          .as("duration")
+//                          .isGreaterThanOrEqualTo(Duration.ofMillis(1500))
+//                      )
+                        //OTEL doesn't really capture the exception type, only the message
+                        .thenThrowable().hasMessage(EXCEPTION.getMessage());
 
-			//finally, assert that the delay thread was not polluted either
+                //query2 span
+                assertThatQuery2
+                        .hasTag("endpoint", "simulated/2")
+                        .thenThrowable().hasMessage(EXCEPTION.getMessage());
+
+                //quick assert query0 and query1
+                spansAssert
+                        .thenASpanWithNameEqualTo("query0")
+                        .doesNotHaveEventWithNameEqualTo("exception")
+                        .hasTag("endpoint", "simulated/0")
+                        .backToSpans()
+                        .hasASpanWithName("query1");
+
+                assertThat(bb.getTracer().currentSpan())
+                        .as("no leftover span in main thread")
+                        .isNotSameAs(beforeStart) //something happened
+                        .isEqualTo(beforeStart); //original span was restored
+
+                //finally, assert that the delay thread was not polluted either
 			/*
 			Impl note: This assertion is a bit redundant since we don't use Scope anyway so there shouldn't
 			be any possibility of polluting ThreadLocals. It used to fail for Brave because Brave defaults to
@@ -127,21 +136,45 @@ public class MicrometerObservationIntegrationTest extends SampleTestRunner {
 			by ensuring only the Span capture is done in separate thread (the assertion has to be done in main
 			testing thread).
 			*/
-			String notCaptured = "tracer.currentSpan() not invoked";
-			AtomicReference<Object> delaySpanRef = new AtomicReference<>(notCaptured);
-			CountDownLatch latch = new CountDownLatch(1);
-			delayScheduler.schedule(() -> {
-				try {
-					delaySpanRef.set(bb.getTracer().currentSpan());
-				}
-				finally {
-					latch.countDown();
-				}
-			});
-			latch.await(10, TimeUnit.SECONDS);
-			assertThat(delaySpanRef.get())
-				.as("no leftover span in delay thread")
-				.isNull();
-		};
-	}
+                String notCaptured = "tracer.currentSpan() not invoked";
+                AtomicReference<Object> delaySpanRef = new AtomicReference<>(notCaptured);
+                CountDownLatch latch = new CountDownLatch(1);
+
+                // Instead of using the delayScheduler, we run the check directly on the delayExecutor.
+                // That is because we have a span in scope, and in case of automatic context propagation,
+                // the span is restored when the provided Runnable is run.
+                delayExecutor.execute(() -> {
+                    try {
+                        delaySpanRef.set(bb.getTracer().currentSpan());
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+                latch.await(10, TimeUnit.SECONDS);
+                assertThat(delaySpanRef.get())
+                        .as("no leftover span in delay thread")
+                        .isNull();
+
+                delayExecutor.shutdownNow();
+            };
+        }
+    }
+
+    @Tag("slow")
+    @Nested
+    class PlainTest extends ActualRunner {
+        PlainTest() {
+            super(false,
+                    SampleTestRunner.SampleRunnerConfig.builder().build());
+        }
+    }
+
+    @Tag("slow")
+    @Nested
+    class AutomaticTest extends ActualRunner {
+        AutomaticTest() {
+            super(true,
+                    SampleTestRunner.SampleRunnerConfig.builder().build());
+        }
+    }
 }

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationIntegrationTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationIntegrationTest.java
@@ -28,6 +28,7 @@ import io.micrometer.tracing.test.simple.SpansAssert;
 import org.junit.jupiter.api.Tag;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -53,6 +54,7 @@ public class MicrometerObservationIntegrationTest extends SampleTestRunner {
 
 	@Override
 	public SampleTestRunnerConsumer yourCode() throws Exception {
+		Hooks.enableAutomaticContextPropagation();
 		final Scheduler delayScheduler = Schedulers.newSingle("test");
 		final IllegalStateException EXCEPTION = new IllegalStateException("expected error");
 		return (bb, meterRegistry) -> {

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerObservationListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,11 +26,12 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 import io.micrometer.observation.tck.TestObservationRegistry;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
+import reactor.test.ParameterizedTestWithName;
 import reactor.util.context.Context;
 import reactor.util.context.ContextView;
 
@@ -71,8 +72,12 @@ class MicrometerObservationListenerTest {
 		subscriberContext = Context.of("contextKey", "contextValue");
 	}
 
-	@Test
-	void whenStartedFluxWithDefaultName() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans =  {true, false})
+	void whenStartedFluxWithDefaultName(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		configuration = new MicrometerObservationListenerConfiguration(
 			MicrometerObservationListenerDocumentation.ANONYMOUS.getName(),
 			//note: "type" key is added by MicrometerObservationListenerConfiguration#fromFlux (which is tested separately)
@@ -100,8 +105,12 @@ class MicrometerObservationListenerTest {
 			.hasLowCardinalityKeyValue("testTag2", "testTagValue2");
 	}
 
-	@Test
-	void whenStartedFluxWithCustomName() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans =  {true, false})
+	void whenStartedFluxWithCustomName(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		configuration = new MicrometerObservationListenerConfiguration(
 			"testName",
 			//note: "type" key is added by MicrometerObservationListenerConfiguration#fromFlux (which is tested separately)
@@ -130,8 +139,12 @@ class MicrometerObservationListenerTest {
 			.hasLowCardinalityKeyValue("testTag2", "testTagValue2");
 	}
 
-	@Test
-	void whenStartedMono() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans =  {true, false})
+	void whenStartedMono(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		configuration = new MicrometerObservationListenerConfiguration(
 			MicrometerObservationListenerDocumentation.ANONYMOUS.getName(),
 			//note: "type" key is added by MicrometerObservationListenerConfiguration#fromMono (which is tested separately)
@@ -160,8 +173,12 @@ class MicrometerObservationListenerTest {
 			.hasLowCardinalityKeyValue("testTag2", "testTagValue2");
 	}
 
-	@Test
-	void tapFromFluxWithTags() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans =  {true, false})
+	void tapFromFluxWithTags(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		Flux<Integer> flux = Flux.just(1)
 			.name("testFlux")
 			.tag("testTag1", "testTagValue1")
@@ -186,8 +203,12 @@ class MicrometerObservationListenerTest {
 			.hasKeyValuesCount(4);
 	}
 
-	@Test
-	void tapFromMonoWithTags() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans =  {true, false})
+	void tapFromMonoWithTags(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		Mono<Integer> mono = Mono.just(1)
 			.name("testMono")
 			.tag("testTag1", "testTagValue1")
@@ -212,8 +233,12 @@ class MicrometerObservationListenerTest {
 			.hasKeyValuesCount(4);
 	}
 
-	@Test
-	void observationStoppedByCancellation() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans =  {true, false})
+	void observationStoppedByCancellation(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		configuration = new MicrometerObservationListenerConfiguration(
 			"flux",
 			KeyValues.of("forcedType", "Flux"),
@@ -237,8 +262,12 @@ class MicrometerObservationListenerTest {
 			.doesNotHaveError();
 	}
 
-	@Test
-	void observationStoppedByCompleteEmpty() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans =  {true, false})
+	void observationStoppedByCompleteEmpty(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		configuration = new MicrometerObservationListenerConfiguration(
 			"emptyFlux",
 			KeyValues.of("forcedType", "Flux"),
@@ -262,8 +291,12 @@ class MicrometerObservationListenerTest {
 			.doesNotHaveError();
 	}
 
-	@Test
-	void observationStoppedByCompleteWithValues() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans =  {true, false})
+	void observationStoppedByCompleteWithValues(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		configuration = new MicrometerObservationListenerConfiguration(
 			"flux",
 			KeyValues.of("forcedType", "Flux"),
@@ -288,8 +321,12 @@ class MicrometerObservationListenerTest {
 			.doesNotHaveError();
 	}
 
-	@Test
-	void observationMonoStoppedByOnNext() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans =  {true, false})
+	void observationMonoStoppedByOnNext(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		configuration = new MicrometerObservationListenerConfiguration(
 			"valuedMono",
 			KeyValues.of("forcedType", "Mono"),
@@ -323,8 +360,12 @@ class MicrometerObservationListenerTest {
 			.hasLowCardinalityKeyValue("reactor.status",  expectedStatus);
 	}
 
-	@Test
-	void observationEmptyMonoStoppedByOnComplete() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans =  {true, false})
+	void observationEmptyMonoStoppedByOnComplete(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		configuration = new MicrometerObservationListenerConfiguration(
 			"emptyMono",
 			KeyValues.of("forcedType", "Mono"),
@@ -347,8 +388,12 @@ class MicrometerObservationListenerTest {
 			.doesNotHaveError();
 	}
 
-	@Test
-	void observationStoppedByError() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans =  {true, false})
+	void observationStoppedByError(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		configuration = new MicrometerObservationListenerConfiguration(
 			"errorFlux",
 			KeyValues.of("forcedType", "Flux"),
@@ -373,8 +418,12 @@ class MicrometerObservationListenerTest {
 			.hasError(exception);
 	}
 
-	@Test
-	void observationGetsParentFromContext() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans =  {true, false})
+	void observationGetsParentFromContext(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		configuration = new MicrometerObservationListenerConfiguration(
 			MicrometerObservationListenerDocumentation.ANONYMOUS.getName(),
 			//note: "type" key is added by MicrometerObservationListenerConfiguration#fromFlux (which is tested separately)
@@ -426,9 +475,12 @@ class MicrometerObservationListenerTest {
 			.satisfies(r -> assertThat(r.getCurrentObservationScope()).as("no leftover currentObservationScope()").isNull());
 	}
 
-	@Test
-	void observationHierarchyCreatedInMonoCase() {
-		Hooks.enableAutomaticContextPropagation();
+	@ParameterizedTestWithName
+	@ValueSource(booleans =  {true, false})
+	void observationHierarchyCreatedInMonoCase(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		Observation parent = Observation.start("testParent", registry);
 		Context contextWithAParent = Context.of(subscriberContext).put(ObservationThreadLocalAccessor.KEY, parent);
 
@@ -452,8 +504,41 @@ class MicrometerObservationListenerTest {
 		assertThat(inner.get().getContext().getParentObservation()).isEqualTo(outer.get());
 	}
 
-	@Test
-	void observationWithEmptyContextHasNoParent() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans =  {true, false})
+	void observationHierarchyCreatedInFluxCase(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
+		Observation parent = Observation.start("testParent", registry);
+		Context contextWithAParent = Context.of(subscriberContext).put(ObservationThreadLocalAccessor.KEY, parent);
+
+		AtomicReference<Observation> inner = new AtomicReference<>();
+		AtomicReference<Observation> outer = new AtomicReference<>();
+
+		Flux.just("hello")
+				.delayElements(Duration.ofMillis(1))
+				.handle((v, s) -> {
+					inner.set(registry.getCurrentObservation());
+					s.next(v);
+				})
+				.tap(Micrometer.observation(registry))
+				.handle((v, s) -> {
+					outer.set(registry.getCurrentObservation());
+					s.next(v);
+				})
+				.contextWrite(contextWithAParent)
+				.blockLast();
+
+		assertThat(inner.get().getContext().getParentObservation()).isEqualTo(outer.get());
+	}
+
+	@ParameterizedTestWithName
+	@ValueSource(booleans =  {true, false})
+	void observationWithEmptyContextHasNoParent(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		configuration = new MicrometerObservationListenerConfiguration(
 			MicrometerObservationListenerDocumentation.ANONYMOUS.getName(),
 			//note: "type" key is added by MicrometerObservationListenerConfiguration#fromFlux (which is tested separately)
@@ -493,8 +578,12 @@ class MicrometerObservationListenerTest {
 			.satisfies(r -> assertThat(r.getCurrentObservationScope()).as("no leftover currentObservationScope()").isNull());
 	}
 
-	@Test
-	void observationWithEmptyContextHasParentWhenExternalScopeOpened() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans =  {true, false})
+	void observationWithEmptyContextHasParentWhenExternalScopeOpened(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		configuration = new MicrometerObservationListenerConfiguration(
 			MicrometerObservationListenerDocumentation.ANONYMOUS.getName(),
 			//note: "type" key is added by MicrometerObservationListenerConfiguration#fromFlux (which is tested separately)

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccess
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import reactor.core.publisher.Hooks;
 import reactor.core.scheduler.Scheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerTest.java
@@ -25,7 +25,6 @@ import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccess
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import reactor.core.publisher.Hooks;
 import reactor.core.scheduler.Scheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/MicrometerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -150,6 +150,17 @@ final class ContextPropagation {
 			.updateContext(target);
 	}
 
+	/**
+	 * When <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>
+	 * is available on the classpath, the provided {@link BiConsumer handler} will be
+	 * called with {@link ThreadLocal} values restored from the provided {@link Context}.
+	 * @param handler user provided handler
+	 * @param contextSupplier supplies the potentially modified {@link Context} to
+	 *                           restore {@link ThreadLocal} values from
+	 * @return potentially wrapped {@link BiConsumer} or the original
+	 * @param <T> type of handled values
+	 * @param <R> the transformed type
+	 */
 	static <T, R> BiConsumer<T, SynchronousSink<R>> contextRestoreForHandle(BiConsumer<T, SynchronousSink<R>> handler, Supplier<Context> contextSupplier) {
 		if (propagateContextToThreadLocals || !ContextPropagation.isContextPropagationAvailable()) {
 			return handler;
@@ -165,6 +176,21 @@ final class ContextPropagation {
 		};
 	}
 
+	/**
+	 * When <a href="https://github.com/micrometer-metrics/context-propagation">context-propagation library</a>
+	 * is available on the classpath, the provided {@link SignalListener} will be wrapped
+	 * with another one that restores {@link ThreadLocal} values from the provided
+	 * {@link Context}.
+	 * <p><strong>Note, this is only applied to {@link FluxTap}, {@link FluxTapFuseable},
+	 * {@link MonoTap}, and {@link MonoTapFuseable}.</strong> The automatic propagation
+	 * variants: {@link FluxTapRestoringThreadLocals} and
+	 * {@link MonoTapRestoringThreadLocals} do not use this method.
+	 * @param original the original {@link SignalListener} from the user
+	 * @param contextSupplier supplies the potentially modified {@link Context} to
+	 *                           restore {@link ThreadLocal} values from
+	 * @return potentially wrapped {@link SignalListener} or the original
+	 * @param <T> type of handled values
+	 */
 	static <T> SignalListener<T> contextRestoreForTap(final SignalListener<T> original, Supplier<Context> contextSupplier) {
 		if (!ContextPropagation.isContextPropagationAvailable()) {
 			return original;

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -166,7 +166,6 @@ final class ContextPropagation {
 	}
 
 	static <T> SignalListener<T> contextRestoreForTap(final SignalListener<T> original, Supplier<Context> contextSupplier) {
-//		if (propagateContextToThreadLocals || !ContextPropagation.isContextPropagationAvailable()) {
 		if (!ContextPropagation.isContextPropagationAvailable()) {
 			return original;
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -166,7 +166,8 @@ final class ContextPropagation {
 	}
 
 	static <T> SignalListener<T> contextRestoreForTap(final SignalListener<T> original, Supplier<Context> contextSupplier) {
-		if (propagateContextToThreadLocals || !ContextPropagation.isContextPropagationAvailable()) {
+//		if (propagateContextToThreadLocals || !ContextPropagation.isContextPropagationAvailable()) {
+		if (!ContextPropagation.isContextPropagationAvailable()) {
 			return original;
 		}
 		final Context ctx = contextSupplier.get();

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -9249,6 +9249,9 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @see #tap(Function)
 	 */
 	public final Flux<T> tap(SignalListenerFactory<T, ?> listenerFactory) {
+		if (ContextPropagation.shouldPropagateContextToThreadLocals()) {
+			return onAssembly(new FluxTapRestoringThreadLocals<>(this, listenerFactory));
+		}
 		if (this instanceof Fuseable) {
 			return onAssembly(new FluxTapFuseable<>(this, listenerFactory));
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTap.java
@@ -44,7 +44,7 @@ final class FluxTap<T, STATE> extends InternalFluxOperator<T, T> {
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) throws Throwable {
-		//if the SequenceObserver cannot be created, all we can do is error the subscriber.
+		//if the SignalListener cannot be created, all we can do is error the subscriber.
 		//after it is created, in case doFirst fails we can additionally try to invoke doFinally.
 		//note that if the later handler also fails, then that exception is thrown.
 		SignalListener<T> signalListener;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTapFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTapFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTapFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTapFuseable.java
@@ -44,7 +44,7 @@ final class FluxTapFuseable<T, STATE> extends InternalFluxOperator<T, T> impleme
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) throws Throwable {
-		//if the SequenceObserver cannot be created, all we can do is error the subscriber.
+		//if the SignalListener cannot be created, all we can do is error the subscriber.
 		//after it is created, in case doFirst fails we can additionally try to invoke doFinally.
 		//note that if the later handler also fails, then that exception is thrown.
 		SignalListener<T> signalListener;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTapRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTapRestoringThreadLocals.java
@@ -261,17 +261,17 @@ final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
 			done = true;
 
 			try {
-				try (ContextSnapshot.Scope ignored =
-							 ContextPropagation.setThreadLocals(actual.currentContext())) {
-					listener.doOnError(t);
-				}
+				listener.doOnError(t);
 			} catch (Throwable observerError) {
 				//any error in the hooks interrupts other hooks, including doFinally
 				handleListenerErrorMultipleAndTerminate(observerError, t);
 				return;
 			}
 
-			actual.onError(t); //RS: onError MUST terminate normally and not throw
+			try (ContextSnapshot.Scope ignored =
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
+				actual.onError(t); //RS: onError MUST terminate normally and not throw
+			}
 
 			try {
 				listener.doAfterError(t);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTapRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTapRestoringThreadLocals.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import io.micrometer.context.ContextSnapshot;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
+import reactor.core.Fuseable.ConditionalSubscriber;
+import reactor.core.observability.SignalListener;
+import reactor.core.observability.SignalListenerFactory;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+
+/**
+ * A generic per-Subscription side effect {@link Flux} that notifies a {@link SignalListener} of most events.
+ *
+ * @author Simon Baslé
+ */
+final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
+
+	final SignalListenerFactory<T, STATE> tapFactory;
+	final STATE                           commonTapState;
+
+	FluxTapRestoringThreadLocals(Flux<? extends T> source, SignalListenerFactory<T, STATE> tapFactory) {
+		super(source);
+		this.tapFactory = tapFactory;
+		this.commonTapState = tapFactory.initializePublisherState(source);
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super T> actual) {
+		//if the SequenceObserver cannot be created, all we can do is error the subscriber.
+		//after it is created, in case doFirst fails we can additionally try to invoke doFinally.
+		//note that if the later handler also fails, then that exception is thrown.
+		SignalListener<T> signalListener;
+		try {
+			//TODO replace currentContext() with contextView() when available
+			signalListener = tapFactory.createListener(source, actual.currentContext().readOnly(), commonTapState);
+		}
+		catch (Throwable generatorError) {
+			Operators.error(actual, generatorError);
+			return;
+		}
+		// Attempt to wrap the SignalListener with one that restores ThreadLocals from Context on each listener methods
+		// (only if ContextPropagation.isContextPropagationAvailable() is true)
+
+		try {
+			signalListener.doFirst();
+		}
+		catch (Throwable listenerError) {
+			signalListener.handleListenerError(listenerError);
+			Operators.error(actual, listenerError);
+			return;
+		}
+
+		// invoked AFTER doFirst
+		Context alteredContext;
+		try {
+			alteredContext = signalListener.addToContext(actual.currentContext());
+		}
+		catch (Throwable e) {
+			signalListener.handleListenerError(new IllegalStateException("Unable to augment tap Context at construction via addToContext", e));
+			alteredContext = actual.currentContext();
+		}
+
+		try (ContextSnapshot.Scope ignored = ContextPropagation.setThreadLocals(alteredContext)) {
+			source.subscribe(new TapSubscriber<>(actual, signalListener, alteredContext));
+		}
+	}
+
+	@Nullable
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+
+		return super.scanUnsafe(key);
+	}
+
+	//TODO support onErrorContinue around listener errors
+	static class TapSubscriber<T> implements ConditionalSubscriber<T>, InnerOperator<T, T> {
+
+		final CoreSubscriber<? super T> actual;
+		final ConditionalSubscriber<? super T> actualConditional;
+		final Context context;
+		final SignalListener<T> listener;
+
+		boolean done;
+		Subscription s;
+
+		TapSubscriber(CoreSubscriber<? super T> actual, SignalListener<T> signalListener, Context ctx) {
+			this.actual = actual;
+			this.listener = signalListener;
+			this.context = ctx;
+			if (actual instanceof ConditionalSubscriber) {
+				this.actualConditional = (ConditionalSubscriber<? super T>) actual;
+			} else {
+				this.actualConditional = null;
+			}
+		}
+
+		@Override
+		public CoreSubscriber<? super T> actual() {
+			return this.actual;
+		}
+
+		@Override
+		public Context currentContext() {
+			return this.context;
+		}
+
+		@Override
+		@Nullable
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) return s;
+			if (key == Attr.TERMINATED) return done;
+			if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+
+			return InnerOperator.super.scanUnsafe(key);
+		}
+
+		/**
+		 * Cancel the prepared subscription, pass the listener error to {@link SignalListener#handleListenerError(Throwable)}
+		 * and then terminate the downstream directly with same error (without invoking any other handler).
+		 *
+		 * @param listenerError the exception thrown from a handler method before the subscription was set
+		 * @param toCancel      the {@link Subscription} that was prepared but not sent downstream
+		 */
+		protected void handleListenerErrorPreSubscription(Throwable listenerError, Subscription toCancel) {
+			toCancel.cancel();
+			listener.handleListenerError(listenerError);
+			Operators.error(actual, listenerError);
+		}
+
+		/**
+		 * Cancel the active subscription, pass the listener error to {@link SignalListener#handleListenerError(Throwable)}
+		 * and then terminate the downstream directly with same error (without invoking any other handler).
+		 *
+		 * @param listenerError the exception thrown from a handler method
+		 */
+		protected void handleListenerErrorAndTerminate(Throwable listenerError) {
+			s.cancel();
+			listener.handleListenerError(listenerError);
+			actual.onError(listenerError); //TODO wrap ? hooks ?
+		}
+
+		/**
+		 * Cancel the active subscription, pass the listener error to {@link SignalListener#handleListenerError(Throwable)},
+		 * combine it with the original error and then terminate the downstream directly this combined exception
+		 * (without invoking any other handler).
+		 *
+		 * @param listenerError the exception thrown from a handler method
+		 * @param originalError the exception that was about to occur when handler was invoked
+		 */
+		protected void handleListenerErrorMultipleAndTerminate(Throwable listenerError, Throwable originalError) {
+			s.cancel();
+			listener.handleListenerError(listenerError);
+			RuntimeException multiple = Exceptions.multiple(listenerError, originalError);
+			actual.onError(multiple); //TODO wrap ? hooks ?
+		}
+
+		/**
+		 * After the downstream is considered terminated (or cancelled), pass the listener error to
+		 * {@link SignalListener#handleListenerError(Throwable)} then drop that error.
+		 *
+		 * @param listenerError the exception thrown from a handler method happening after sequence termination
+		 */
+		protected void handleListenerErrorPostTermination(Throwable listenerError) {
+			listener.handleListenerError(listenerError);
+			Operators.onErrorDropped(listenerError, actual.currentContext());
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.validate(this.s, s)) {
+				this.s = s;
+
+				try {
+					listener.doOnSubscription();
+				} catch (Throwable observerError) {
+					handleListenerErrorPreSubscription(observerError, s);
+					return;
+				}
+				try (ContextSnapshot.Scope ignored =
+							 ContextPropagation.setThreadLocals(actual.currentContext())) {
+					actual.onSubscribe(this);
+				}
+			}
+		}
+
+		@Override
+		public void onNext(T t) {
+			if (done) {
+				try {
+					listener.doOnMalformedOnNext(t);
+				} catch (Throwable observerError) {
+					handleListenerErrorPostTermination(observerError);
+				} finally {
+					Operators.onNextDropped(t, currentContext());
+				}
+				return;
+			}
+			try {
+				listener.doOnNext(t);
+			} catch (Throwable observerError) {
+				handleListenerErrorAndTerminate(observerError);
+				return;
+			}
+			try (ContextSnapshot.Scope ignored =
+						 ContextPropagation.setThreadLocals(actual.currentContext())) {
+				actual.onNext(t);
+			}
+		}
+
+		@Override
+		public boolean tryOnNext(T t) {
+			try (ContextSnapshot.Scope ignored =
+						 ContextPropagation.setThreadLocals(actual.currentContext())) {
+				if (actualConditional != null) {
+					if (!actualConditional.tryOnNext(t)) {
+						return false;
+					}
+				} else {
+					actual.onNext(t);
+				}
+			}
+			try {
+				listener.doOnNext(t);
+			} catch (Throwable listenerError) {
+				handleListenerErrorAndTerminate(listenerError);
+			}
+			return true;
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			if (done) {
+				try {
+					listener.doOnMalformedOnError(t);
+				} catch (Throwable observerError) {
+					handleListenerErrorPostTermination(observerError);
+				} finally {
+					Operators.onErrorDropped(t, currentContext());
+				}
+				return;
+			}
+			done = true;
+
+			try {
+				try (ContextSnapshot.Scope ignored =
+							 ContextPropagation.setThreadLocals(actual.currentContext())) {
+					listener.doOnError(t);
+				}
+			} catch (Throwable observerError) {
+				//any error in the hooks interrupts other hooks, including doFinally
+				handleListenerErrorMultipleAndTerminate(observerError, t);
+				return;
+			}
+
+			actual.onError(t); //RS: onError MUST terminate normally and not throw
+
+			try {
+				listener.doAfterError(t);
+				listener.doFinally(SignalType.ON_ERROR);
+			} catch (Throwable observerError) {
+				handleListenerErrorPostTermination(observerError);
+			}
+		}
+
+		@Override
+		public void onComplete() {
+			if (done) {
+				try {
+					listener.doOnMalformedOnComplete();
+				} catch (Throwable observerError) {
+					handleListenerErrorPostTermination(observerError);
+				}
+				return;
+			}
+			done = true;
+
+			try {
+				listener.doOnComplete();
+			} catch (Throwable observerError) {
+				handleListenerErrorAndTerminate(observerError);
+				return;
+			}
+
+			try (ContextSnapshot.Scope ignored =
+						 ContextPropagation.setThreadLocals(actual.currentContext())) {
+				actual.onComplete(); //RS: onComplete MUST terminate normally and not throw
+			}
+
+			try {
+				listener.doAfterComplete();
+				listener.doFinally(SignalType.ON_COMPLETE);
+			} catch (Throwable observerError) {
+				handleListenerErrorPostTermination(observerError);
+			}
+		}
+
+		@Override
+		public void request(long n) {
+			try (ContextSnapshot.Scope ignored =
+						 ContextPropagation.setThreadLocals(this.context)) {
+				if (Operators.validate(n)) {
+					try {
+						listener.doOnRequest(n);
+					} catch (Throwable observerError) {
+						handleListenerErrorAndTerminate(observerError);
+						return;
+					}
+					s.request(n);
+				}
+			}
+		}
+
+		@Override
+		public void cancel() {
+			try (ContextSnapshot.Scope ignored =
+						 ContextPropagation.setThreadLocals(this.context)) {
+				try {
+					listener.doOnCancel();
+				} catch (Throwable observerError) {
+					handleListenerErrorAndTerminate(observerError);
+					return;
+				}
+
+				try {
+					s.cancel();
+				} finally {
+					try {
+						listener.doFinally(SignalType.CANCEL);
+					} catch (Throwable observerError) {
+						handleListenerErrorAndTerminate(observerError); //redundant s.cancel
+					}
+				}
+			}
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTapRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTapRestoringThreadLocals.java
@@ -53,10 +53,7 @@ final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
 			signalListener = tapFactory.createListener(source, actual.currentContext().readOnly(), commonTapState);
 		}
 		catch (Throwable generatorError) {
-			try (ContextSnapshot.Scope ignored =
-					     ContextPropagation.setThreadLocals(actual.currentContext())) {
-				Operators.error(actual, generatorError);
-			}
+			Operators.error(actual, generatorError);
 			return;
 		}
 
@@ -65,10 +62,7 @@ final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
 		}
 		catch (Throwable listenerError) {
 			signalListener.handleListenerError(listenerError);
-			try (ContextSnapshot.Scope ignored =
-					     ContextPropagation.setThreadLocals(actual.currentContext())) {
-				Operators.error(actual, listenerError);
-			}
+			Operators.error(actual, listenerError);
 			return;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTapRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTapRestoringThreadLocals.java
@@ -44,7 +44,7 @@ final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
 
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
-		//if the SequenceObserver cannot be created, all we can do is error the subscriber.
+		//if the SignalListener cannot be created, all we can do is error the subscriber.
 		//after it is created, in case doFirst fails we can additionally try to invoke doFinally.
 		//note that if the later handler also fails, then that exception is thrown.
 		SignalListener<T> signalListener;
@@ -56,8 +56,6 @@ final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
 			Operators.error(actual, generatorError);
 			return;
 		}
-		// Attempt to wrap the SignalListener with one that restores ThreadLocals from Context on each listener methods
-		// (only if ContextPropagation.isContextPropagationAvailable() is true)
 
 		try {
 			signalListener.doFirst();

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -4740,6 +4740,9 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @see #tap(Function)
 	 */
 	public final Mono<T> tap(SignalListenerFactory<T, ?> listenerFactory) {
+		if (ContextPropagation.shouldPropagateContextToThreadLocals()) {
+			return onAssembly(new MonoTapRestoringThreadLocals<>(this, listenerFactory));
+		}
 		if (this instanceof Fuseable) {
 			return onAssembly(new MonoTapFuseable<>(this, listenerFactory));
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTap.java
@@ -41,7 +41,7 @@ final class MonoTap<T, STATE> extends InternalMonoOperator<T, T> {
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) throws Throwable {
-		//if the SequenceObserver cannot be created, all we can do is error the subscriber.
+		//if the SignalListener cannot be created, all we can do is error the subscriber.
 		//after it is created, in case doFirst fails we can additionally try to invoke doFinally.
 		//note that if the later handler also fails, then that exception is thrown.
 		SignalListener<T> signalListener;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTapFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTapFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTapFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTapFuseable.java
@@ -40,7 +40,7 @@ final class MonoTapFuseable<T, STATE> extends InternalMonoOperator<T, T> impleme
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) throws Throwable {
-		//if the SequenceObserver cannot be created, all we can do is error the subscriber.
+		//if the SignalListener cannot be created, all we can do is error the subscriber.
 		//after it is created, in case doFirst fails we can additionally try to invoke doFinally.
 		//note that if the later handler also fails, then that exception is thrown.
 		SignalListener<T> signalListener;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTapRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTapRestoringThreadLocals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,9 @@
 package reactor.core.publisher;
 
 import io.micrometer.context.ContextSnapshot;
-import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
-import reactor.core.Exceptions;
-import reactor.core.Fuseable;
 import reactor.core.observability.SignalListener;
 import reactor.core.observability.SignalListenerFactory;
-import reactor.core.publisher.FluxTap.TapSubscriber;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
@@ -80,7 +76,7 @@ final class MonoTapRestoringThreadLocals<T, STATE> extends MonoOperator<T, T> {
 		}
 
 		try (ContextSnapshot.Scope ignored = ContextPropagation.setThreadLocals(alteredContext)) {
-			source.subscribe(new TapSubscriber<>(actual, signalListener, alteredContext));
+			source.subscribe(new FluxTapRestoringThreadLocals.TapSubscriber<>(actual, signalListener, alteredContext));
 		}
 	}
 
@@ -91,240 +87,5 @@ final class MonoTapRestoringThreadLocals<T, STATE> extends MonoOperator<T, T> {
 		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
 
 		return super.scanUnsafe(key);
-	}
-
-	static class TapSubscriber<T> implements InnerOperator<T, T> {
-
-		final CoreSubscriber<? super T> actual;
-		final Context                   context;
-		final SignalListener<T>         listener;
-
-		boolean done;
-		Subscription s;
-
-		TapSubscriber(CoreSubscriber<? super T> actual, SignalListener<T> signalListener, Context ctx) {
-			this.actual = actual;
-			this.listener = signalListener;
-			this.context = ctx;
-		}
-
-		@Override
-		public CoreSubscriber<? super T> actual() {
-			return this.actual;
-		}
-
-		@Override
-		public Context currentContext() {
-			return this.context;
-		}
-
-		@Override
-		@Nullable
-		public Object scanUnsafe(Attr key) {
-			if (key == Attr.PARENT) return s;
-			if (key == Attr.TERMINATED) return done;
-			if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
-
-			return InnerOperator.super.scanUnsafe(key);
-		}
-
-		/**
-		 * Cancel the prepared subscription, pass the listener error to {@link SignalListener#handleListenerError(Throwable)}
-		 * and then terminate the downstream directly with same error (without invoking any other handler).
-		 *
-		 * @param listenerError the exception thrown from a handler method before the subscription was set
-		 * @param toCancel the {@link Subscription} that was prepared but not sent downstream
-		 */
-		protected void handleListenerErrorPreSubscription(Throwable listenerError, Subscription toCancel) {
-			toCancel.cancel();
-			listener.handleListenerError(listenerError);
-			Operators.error(actual, listenerError);
-		}
-
-		/**
-		 * Cancel the active subscription, pass the listener error to {@link SignalListener#handleListenerError(Throwable)}
-		 * and then terminate the downstream directly with same error (without invoking any other handler).
-		 *
-		 * @param listenerError the exception thrown from a handler method
-		 */
-		protected void handleListenerErrorAndTerminate(Throwable listenerError) {
-			s.cancel();
-			listener.handleListenerError(listenerError);
-			actual.onError(listenerError); //TODO wrap ? hooks ?
-		}
-
-		/**
-		 * Cancel the active subscription, pass the listener error to {@link SignalListener#handleListenerError(Throwable)},
-		 * combine it with the original error and then terminate the downstream directly this combined exception
-		 * (without invoking any other handler).
-		 *
-		 * @param listenerError the exception thrown from a handler method
-		 * @param originalError the exception that was about to occur when handler was invoked
-		 */
-		protected void handleListenerErrorMultipleAndTerminate(Throwable listenerError, Throwable originalError) {
-			s.cancel();
-			listener.handleListenerError(listenerError);
-			RuntimeException multiple = Exceptions.multiple(listenerError, originalError);
-			actual.onError(multiple); //TODO wrap ? hooks ?
-		}
-
-		/**
-		 * After the downstream is considered terminated (or cancelled), pass the listener error to
-		 * {@link SignalListener#handleListenerError(Throwable)} then drop that error.
-		 *
-		 * @param listenerError the exception thrown from a handler method happening after sequence termination
-		 */
-		protected void handleListenerErrorPostTermination(Throwable listenerError) {
-			listener.handleListenerError(listenerError);
-			Operators.onErrorDropped(listenerError, actual.currentContext());
-		}
-
-		@Override
-		public void onSubscribe(Subscription s) {
-			try (ContextSnapshot.Scope ignored =
-						 ContextPropagation.setThreadLocals(actual.currentContext())) {
-				if (Operators.validate(this.s, s)) {
-					this.s = s;
-
-					try {
-						listener.doOnSubscription();
-					} catch (Throwable observerError) {
-						handleListenerErrorPreSubscription(observerError, s);
-						return;
-					}
-					actual.onSubscribe(this);
-				}
-			}
-		}
-
-		@Override
-		public void onNext(T t) {
-			try (ContextSnapshot.Scope ignored =
-						 ContextPropagation.setThreadLocals(actual.currentContext())) {
-				if (done) {
-					try {
-						listener.doOnMalformedOnNext(t);
-					} catch (Throwable observerError) {
-						handleListenerErrorPostTermination(observerError);
-					} finally {
-						Operators.onNextDropped(t, currentContext());
-					}
-					return;
-				}
-				try {
-					listener.doOnNext(t);
-				} catch (Throwable observerError) {
-					handleListenerErrorAndTerminate(observerError);
-					return;
-				}
-				actual.onNext(t);
-			}
-		}
-
-		@Override
-		public void onError(Throwable t) {
-			try (ContextSnapshot.Scope ignored =
-						 ContextPropagation.setThreadLocals(actual.currentContext())) {
-				if (done) {
-					try {
-						listener.doOnMalformedOnError(t);
-					} catch (Throwable observerError) {
-						handleListenerErrorPostTermination(observerError);
-					} finally {
-						Operators.onErrorDropped(t, currentContext());
-					}
-					return;
-				}
-				done = true;
-
-				try {
-					listener.doOnError(t);
-				} catch (Throwable observerError) {
-					//any error in the hooks interrupts other hooks, including doFinally
-					handleListenerErrorMultipleAndTerminate(observerError, t);
-					return;
-				}
-
-				actual.onError(t); //RS: onError MUST terminate normally and not throw
-
-				try {
-					listener.doAfterError(t);
-					listener.doFinally(SignalType.ON_ERROR);
-				} catch (Throwable observerError) {
-					handleListenerErrorPostTermination(observerError);
-				}
-			}
-		}
-
-		@Override
-		public void onComplete() {
-			try (ContextSnapshot.Scope ignored =
-						 ContextPropagation.setThreadLocals(actual.currentContext())) {
-				if (done) {
-					try {
-						listener.doOnMalformedOnComplete();
-					} catch (Throwable observerError) {
-						handleListenerErrorPostTermination(observerError);
-					}
-					return;
-				}
-				done = true;
-
-				try {
-					listener.doOnComplete();
-				} catch (Throwable observerError) {
-					handleListenerErrorAndTerminate(observerError);
-					return;
-				}
-
-				actual.onComplete(); //RS: onComplete MUST terminate normally and not throw
-
-				try {
-					listener.doAfterComplete();
-					listener.doFinally(SignalType.ON_COMPLETE);
-				} catch (Throwable observerError) {
-					handleListenerErrorPostTermination(observerError);
-				}
-			}
-		}
-
-		@Override
-		public void request(long n) {
-			try (ContextSnapshot.Scope ignored =
-						 ContextPropagation.setThreadLocals(this.context)) {
-				if (Operators.validate(n)) {
-					try {
-						listener.doOnRequest(n);
-					} catch (Throwable observerError) {
-						handleListenerErrorAndTerminate(observerError);
-						return;
-					}
-					s.request(n);
-				}
-			}
-		}
-
-		@Override
-		public void cancel() {
-			try (ContextSnapshot.Scope ignored =
-						 ContextPropagation.setThreadLocals(this.context)) {
-				try {
-					listener.doOnCancel();
-				} catch (Throwable observerError) {
-					handleListenerErrorAndTerminate(observerError);
-					return;
-				}
-
-				try {
-					s.cancel();
-				} finally {
-					try {
-						listener.doFinally(SignalType.CANCEL);
-					} catch (Throwable observerError) {
-						handleListenerErrorAndTerminate(observerError); //redundant s.cancel
-					}
-				}
-			}
-		}
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTapRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTapRestoringThreadLocals.java
@@ -41,7 +41,7 @@ final class MonoTapRestoringThreadLocals<T, STATE> extends MonoOperator<T, T> {
 
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
-		//if the SequenceObserver cannot be created, all we can do is error the subscriber.
+		//if the SignalListener cannot be created, all we can do is error the subscriber.
 		//after it is created, in case doFirst fails we can additionally try to invoke doFinally.
 		//note that if the later handler also fails, then that exception is thrown.
 		SignalListener<T> signalListener;
@@ -53,8 +53,6 @@ final class MonoTapRestoringThreadLocals<T, STATE> extends MonoOperator<T, T> {
 			Operators.error(actual, generatorError);
 			return;
 		}
-		// Attempt to wrap the SignalListener with one that restores ThreadLocals from Context on each listener methods
-		// (only if ContextPropagation.isContextPropagationAvailable() is true)
 
 		try {
 			signalListener.doFirst();

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTapRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTapRestoringThreadLocals.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import io.micrometer.context.ContextSnapshot;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
+import reactor.core.Fuseable;
+import reactor.core.observability.SignalListener;
+import reactor.core.observability.SignalListenerFactory;
+import reactor.core.publisher.FluxTap.TapSubscriber;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+
+/**
+ * A generic per-Subscription side effect {@link Mono} that notifies a {@link SignalListener} of most events.
+ *
+ * @author Simon Baslé
+ */
+final class MonoTapRestoringThreadLocals<T, STATE> extends MonoOperator<T, T> {
+
+	final SignalListenerFactory<T, STATE> tapFactory;
+	final STATE                           commonTapState;
+
+	MonoTapRestoringThreadLocals(Mono<? extends T> source, SignalListenerFactory<T, STATE> tapFactory) {
+		super(source);
+		this.tapFactory = tapFactory;
+		this.commonTapState = tapFactory.initializePublisherState(source);
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super T> actual) {
+		//if the SequenceObserver cannot be created, all we can do is error the subscriber.
+		//after it is created, in case doFirst fails we can additionally try to invoke doFinally.
+		//note that if the later handler also fails, then that exception is thrown.
+		SignalListener<T> signalListener;
+		try {
+			//TODO replace currentContext() with contextView() when available
+			signalListener = tapFactory.createListener(source, actual.currentContext().readOnly(), commonTapState);
+		}
+		catch (Throwable generatorError) {
+			Operators.error(actual, generatorError);
+			return;
+		}
+		// Attempt to wrap the SignalListener with one that restores ThreadLocals from Context on each listener methods
+		// (only if ContextPropagation.isContextPropagationAvailable() is true)
+
+		try {
+			signalListener.doFirst();
+		}
+		catch (Throwable listenerError) {
+			signalListener.handleListenerError(listenerError);
+			Operators.error(actual, listenerError);
+			return;
+		}
+
+		// invoked AFTER doFirst
+		Context alteredContext;
+		try {
+			alteredContext = signalListener.addToContext(actual.currentContext());
+		}
+		catch (Throwable e) {
+			signalListener.handleListenerError(new IllegalStateException("Unable to augment tap Context at construction via addToContext", e));
+			alteredContext = actual.currentContext();
+		}
+
+		try (ContextSnapshot.Scope ignored = ContextPropagation.setThreadLocals(alteredContext)) {
+			source.subscribe(new TapSubscriber<>(actual, signalListener, alteredContext));
+		}
+	}
+
+	@Nullable
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PREFETCH) return -1;
+		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+
+		return super.scanUnsafe(key);
+	}
+
+	static class TapSubscriber<T> implements InnerOperator<T, T> {
+
+		final CoreSubscriber<? super T> actual;
+		final Context                   context;
+		final SignalListener<T>         listener;
+
+		boolean done;
+		Subscription s;
+
+		TapSubscriber(CoreSubscriber<? super T> actual, SignalListener<T> signalListener, Context ctx) {
+			this.actual = actual;
+			this.listener = signalListener;
+			this.context = ctx;
+		}
+
+		@Override
+		public CoreSubscriber<? super T> actual() {
+			return this.actual;
+		}
+
+		@Override
+		public Context currentContext() {
+			return this.context;
+		}
+
+		@Override
+		@Nullable
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) return s;
+			if (key == Attr.TERMINATED) return done;
+			if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+
+			return InnerOperator.super.scanUnsafe(key);
+		}
+
+		/**
+		 * Cancel the prepared subscription, pass the listener error to {@link SignalListener#handleListenerError(Throwable)}
+		 * and then terminate the downstream directly with same error (without invoking any other handler).
+		 *
+		 * @param listenerError the exception thrown from a handler method before the subscription was set
+		 * @param toCancel the {@link Subscription} that was prepared but not sent downstream
+		 */
+		protected void handleListenerErrorPreSubscription(Throwable listenerError, Subscription toCancel) {
+			toCancel.cancel();
+			listener.handleListenerError(listenerError);
+			Operators.error(actual, listenerError);
+		}
+
+		/**
+		 * Cancel the active subscription, pass the listener error to {@link SignalListener#handleListenerError(Throwable)}
+		 * and then terminate the downstream directly with same error (without invoking any other handler).
+		 *
+		 * @param listenerError the exception thrown from a handler method
+		 */
+		protected void handleListenerErrorAndTerminate(Throwable listenerError) {
+			s.cancel();
+			listener.handleListenerError(listenerError);
+			actual.onError(listenerError); //TODO wrap ? hooks ?
+		}
+
+		/**
+		 * Cancel the active subscription, pass the listener error to {@link SignalListener#handleListenerError(Throwable)},
+		 * combine it with the original error and then terminate the downstream directly this combined exception
+		 * (without invoking any other handler).
+		 *
+		 * @param listenerError the exception thrown from a handler method
+		 * @param originalError the exception that was about to occur when handler was invoked
+		 */
+		protected void handleListenerErrorMultipleAndTerminate(Throwable listenerError, Throwable originalError) {
+			s.cancel();
+			listener.handleListenerError(listenerError);
+			RuntimeException multiple = Exceptions.multiple(listenerError, originalError);
+			actual.onError(multiple); //TODO wrap ? hooks ?
+		}
+
+		/**
+		 * After the downstream is considered terminated (or cancelled), pass the listener error to
+		 * {@link SignalListener#handleListenerError(Throwable)} then drop that error.
+		 *
+		 * @param listenerError the exception thrown from a handler method happening after sequence termination
+		 */
+		protected void handleListenerErrorPostTermination(Throwable listenerError) {
+			listener.handleListenerError(listenerError);
+			Operators.onErrorDropped(listenerError, actual.currentContext());
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			try (ContextSnapshot.Scope ignored =
+						 ContextPropagation.setThreadLocals(actual.currentContext())) {
+				if (Operators.validate(this.s, s)) {
+					this.s = s;
+
+					try {
+						listener.doOnSubscription();
+					} catch (Throwable observerError) {
+						handleListenerErrorPreSubscription(observerError, s);
+						return;
+					}
+					actual.onSubscribe(this);
+				}
+			}
+		}
+
+		@Override
+		public void onNext(T t) {
+			try (ContextSnapshot.Scope ignored =
+						 ContextPropagation.setThreadLocals(actual.currentContext())) {
+				if (done) {
+					try {
+						listener.doOnMalformedOnNext(t);
+					} catch (Throwable observerError) {
+						handleListenerErrorPostTermination(observerError);
+					} finally {
+						Operators.onNextDropped(t, currentContext());
+					}
+					return;
+				}
+				try {
+					listener.doOnNext(t);
+				} catch (Throwable observerError) {
+					handleListenerErrorAndTerminate(observerError);
+					return;
+				}
+				actual.onNext(t);
+			}
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			try (ContextSnapshot.Scope ignored =
+						 ContextPropagation.setThreadLocals(actual.currentContext())) {
+				if (done) {
+					try {
+						listener.doOnMalformedOnError(t);
+					} catch (Throwable observerError) {
+						handleListenerErrorPostTermination(observerError);
+					} finally {
+						Operators.onErrorDropped(t, currentContext());
+					}
+					return;
+				}
+				done = true;
+
+				try {
+					listener.doOnError(t);
+				} catch (Throwable observerError) {
+					//any error in the hooks interrupts other hooks, including doFinally
+					handleListenerErrorMultipleAndTerminate(observerError, t);
+					return;
+				}
+
+				actual.onError(t); //RS: onError MUST terminate normally and not throw
+
+				try {
+					listener.doAfterError(t);
+					listener.doFinally(SignalType.ON_ERROR);
+				} catch (Throwable observerError) {
+					handleListenerErrorPostTermination(observerError);
+				}
+			}
+		}
+
+		@Override
+		public void onComplete() {
+			try (ContextSnapshot.Scope ignored =
+						 ContextPropagation.setThreadLocals(actual.currentContext())) {
+				if (done) {
+					try {
+						listener.doOnMalformedOnComplete();
+					} catch (Throwable observerError) {
+						handleListenerErrorPostTermination(observerError);
+					}
+					return;
+				}
+				done = true;
+
+				try {
+					listener.doOnComplete();
+				} catch (Throwable observerError) {
+					handleListenerErrorAndTerminate(observerError);
+					return;
+				}
+
+				actual.onComplete(); //RS: onComplete MUST terminate normally and not throw
+
+				try {
+					listener.doAfterComplete();
+					listener.doFinally(SignalType.ON_COMPLETE);
+				} catch (Throwable observerError) {
+					handleListenerErrorPostTermination(observerError);
+				}
+			}
+		}
+
+		@Override
+		public void request(long n) {
+			try (ContextSnapshot.Scope ignored =
+						 ContextPropagation.setThreadLocals(this.context)) {
+				if (Operators.validate(n)) {
+					try {
+						listener.doOnRequest(n);
+					} catch (Throwable observerError) {
+						handleListenerErrorAndTerminate(observerError);
+						return;
+					}
+					s.request(n);
+				}
+			}
+		}
+
+		@Override
+		public void cancel() {
+			try (ContextSnapshot.Scope ignored =
+						 ContextPropagation.setThreadLocals(this.context)) {
+				try {
+					listener.doOnCancel();
+				} catch (Throwable observerError) {
+					handleListenerErrorAndTerminate(observerError);
+					return;
+				}
+
+				try {
+					s.cancel();
+				} finally {
+					try {
+						listener.doFinally(SignalType.CANCEL);
+					} catch (Throwable observerError) {
+						handleListenerErrorAndTerminate(observerError); //redundant s.cancel
+					}
+				}
+			}
+		}
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTapRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTapRestoringThreadLocals.java
@@ -50,10 +50,7 @@ final class MonoTapRestoringThreadLocals<T, STATE> extends MonoOperator<T, T> {
 			signalListener = tapFactory.createListener(source, actual.currentContext().readOnly(), commonTapState);
 		}
 		catch (Throwable generatorError) {
-			try (ContextSnapshot.Scope ignored =
-					     ContextPropagation.setThreadLocals(actual.currentContext())) {
-				Operators.error(actual, generatorError);
-			}
+			Operators.error(actual, generatorError);
 			return;
 		}
 
@@ -73,10 +70,7 @@ final class MonoTapRestoringThreadLocals<T, STATE> extends MonoOperator<T, T> {
 		}
 		catch (Throwable e) {
 			signalListener.handleListenerError(new IllegalStateException("Unable to augment tap Context at construction via addToContext", e));
-			try (ContextSnapshot.Scope ignored =
-					     ContextPropagation.setThreadLocals(actual.currentContext())) {
-				alteredContext = actual.currentContext();
-			}
+			alteredContext = actual.currentContext();
 		}
 
 		try (ContextSnapshot.Scope ignored = ContextPropagation.setThreadLocals(alteredContext)) {

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxTapTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxTapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxTapTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxTapTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
@@ -35,6 +36,7 @@ import reactor.core.Scannable.Attr.RunStyle;
 import reactor.test.ParameterizedTestWithName;
 import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.TestSubscriber;
+import reactor.util.context.Context;
 import reactor.util.context.ContextView;
 import reactor.core.observability.SignalListener;
 import reactor.core.observability.SignalListenerFactory;
@@ -162,8 +164,12 @@ class FluxTapTest {
 		}
 	}
 
-	@Test
-	void scenarioTerminatingOnComplete() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans = {true, false})
+	void scenarioTerminatingOnComplete(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		TestSignalListener<Integer> testSignalListener = new TestSignalListener<>();
 
 		Flux<Integer> fullFlux = Flux.just(1, 2, 3).hide();
@@ -187,8 +193,12 @@ class FluxTapTest {
 			);
 	}
 
-	@Test
-	void scenarioTerminatingOnError() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans = {true, false})
+	void scenarioTerminatingOnError(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		TestSignalListener<Integer> testSignalListener = new TestSignalListener<>();
 		RuntimeException expectedError = new RuntimeException("expected");
 
@@ -213,8 +223,12 @@ class FluxTapTest {
 			);
 	}
 
-	@Test
-	void multipleRequests() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans = {true, false})
+	void multipleRequests(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		TestSignalListener<Integer> testSignalListener = new TestSignalListener<>();
 		TestSubscriber<Integer> testSubscriber = TestSubscriber.builder().initialRequest(0L).build();
 
@@ -268,8 +282,12 @@ class FluxTapTest {
 			);
 	}
 
-	@Test
-	void withCancellation() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans = {true, false})
+	void withCancellation(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		TestSignalListener<Integer> testSignalListener = new TestSignalListener<>();
 		TestSubscriber<Integer> testSubscriber = TestSubscriber.builder().initialRequest(0L).build();
 
@@ -308,8 +326,16 @@ class FluxTapTest {
 	}
 
 	@ParameterizedTestWithName
-	@ValueSource(strings = {"ON_COMPLETE", "ON_ERROR"})
-	void malformedOnNext(SignalType termination) {
+	@CsvSource({
+			"ON_COMPLETE, true",
+			"ON_COMPLETE, false",
+			"ON_ERROR, true",
+			"ON_ERROR, false",
+	})
+	void malformedOnNext(SignalType termination, boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		AtomicReference<Object> dropped = new AtomicReference<>();
 		Hooks.onNextDropped(dropped::set);
 
@@ -367,8 +393,16 @@ class FluxTapTest {
 	}
 
 	@ParameterizedTestWithName
-	@ValueSource(strings = {"ON_COMPLETE", "ON_ERROR"})
-	void malformedOnComplete(SignalType termination) {
+	@CsvSource({
+			"ON_COMPLETE, true",
+			"ON_COMPLETE, false",
+			"ON_ERROR, true",
+			"ON_ERROR, false",
+	})
+	void malformedOnComplete(SignalType termination, boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		TestSignalListener<Integer> testSignalListener = new TestSignalListener<>();
 		TestPublisher<Integer> testPublisher = TestPublisher.createNoncompliant(TestPublisher.Violation.CLEANUP_ON_TERMINATE);
 		TestSubscriber<Integer> ignored = TestSubscriber.create();
@@ -421,8 +455,16 @@ class FluxTapTest {
 	}
 
 	@ParameterizedTestWithName
-	@ValueSource(strings = {"ON_COMPLETE", "ON_ERROR"})
-	void malformedOnError(SignalType termination) {
+	@CsvSource({
+			"ON_COMPLETE, true",
+			"ON_COMPLETE, false",
+			"ON_ERROR, true",
+			"ON_ERROR, false",
+	})
+	void malformedOnError(SignalType termination, boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		AtomicReference<Throwable> dropped = new AtomicReference<>();
 		Hooks.onErrorDropped(dropped::set);
 
@@ -479,26 +521,36 @@ class FluxTapTest {
 		assertThat(dropped).as("malformed error was dropped").hasValue(malformedError);
 	}
 
-
-	@Test
-	void throwingCreateListener() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans = {true, false})
+	void throwingCreateListener(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		TestSubscriber<Integer> testSubscriber = TestSubscriber.create();
-		FluxTap<Integer, Void> test = new FluxTap<>(Flux.just(1),
-			new SignalListenerFactory<Integer, Void>() {
-				@Override
-				public Void initializePublisherState(Publisher<? extends Integer> source) {
-					return null;
-				}
+		SignalListenerFactory<Integer, Void> listenerFactory = new SignalListenerFactory<Integer, Void>() {
+			@Override
+			public Void initializePublisherState(Publisher<? extends Integer> source) {
+				return null;
+			}
 
-				@Override
-				public SignalListener<Integer> createListener(Publisher<? extends Integer> source,
-															  ContextView listenerContext, Void publisherContext) {
-					throw new IllegalStateException("expected");
-				}
-			});
+			@Override
+			public SignalListener<Integer> createListener(Publisher<? extends Integer> source,
+														  ContextView listenerContext, Void publisherContext) {
+				throw new IllegalStateException("expected");
+			}
+		};
 
-		assertThatCode(() -> test.subscribeOrReturn(testSubscriber))
-			.doesNotThrowAnyException();
+		if (automatic) {
+			FluxTapRestoringThreadLocals<Integer, Void> test =
+					new FluxTapRestoringThreadLocals<>(Flux.just(1), listenerFactory);
+			assertThatCode(() -> test.subscribe(testSubscriber))
+					.doesNotThrowAnyException();
+		} else {
+			FluxTap<Integer, Void> test = new FluxTap<>(Flux.just(1), listenerFactory);
+			assertThatCode(() -> test.subscribeOrReturn(testSubscriber))
+					.doesNotThrowAnyException();
+		}
 
 		assertThat(testSubscriber.expectTerminalError())
 			.as("downstream error")
@@ -506,8 +558,12 @@ class FluxTapTest {
 			.hasMessage("expected");
 	}
 
-	@Test
-	void doFirstListenerError() {
+	@ParameterizedTestWithName
+	@ValueSource(booleans = {true, false})
+	void doFirstListenerError(boolean automatic) {
+		if (automatic) {
+			Hooks.enableAutomaticContextPropagation();
+		}
 		Throwable listenerError = new IllegalStateException("expected from doFirst");
 
 		TestSubscriber<Integer> testSubscriber = TestSubscriber.create();
@@ -518,10 +574,18 @@ class FluxTapTest {
 			}
 		};
 
-		FluxTap<Integer, Void> test = new FluxTap<>(Flux.just(1), factoryOf(listener));
+		if (automatic) {
+			FluxTapRestoringThreadLocals<Integer, Void> test =
+					new FluxTapRestoringThreadLocals<>(Flux.just(1), factoryOf(listener));
 
-		assertThatCode(() -> test.subscribeOrReturn(testSubscriber))
-			.doesNotThrowAnyException();
+			assertThatCode(() -> test.subscribe(testSubscriber))
+					.doesNotThrowAnyException();
+		} else {
+			FluxTap<Integer, Void> test = new FluxTap<>(Flux.just(1), factoryOf(listener));
+
+			assertThatCode(() -> test.subscribeOrReturn(testSubscriber))
+					.doesNotThrowAnyException();
+		}
 
 		assertThat(listener.listenerErrors)
 			.as("listenerErrors")
@@ -898,6 +962,21 @@ class FluxTapTest {
 		}
 
 		@Test
+		void scanFluxTapRestoringThreadLocals() {
+			Flux<Integer> source = Flux.just(1);
+			FluxTapRestoringThreadLocals<Integer, Void> testPublisher =
+					new FluxTapRestoringThreadLocals<>(source, ignoredFactory());
+
+			Scannable test = Scannable.from(testPublisher);
+			assertThat(test).isSameAs(testPublisher)
+			                .matches(Scannable::isScanAvailable, "isScanAvailable");
+
+			assertThat(test.scan(Attr.PREFETCH)).as("PREFETCH").isEqualTo(-1);
+			assertThat(test.scan(Attr.RUN_STYLE)).as("RUN_STYLE").isEqualTo(RunStyle.SYNC);
+			assertThat(test.scanUnsafe(Attr.PARENT)).as("PARENT").isSameAs(source);
+		}
+
+		@Test
 		void scanFluxTapFuseable() {
 			Flux<Integer> source = Flux.just(1);
 			FluxTapFuseable<Integer, Void> testPublisher = new FluxTapFuseable<>(source, ignoredFactory());
@@ -926,6 +1005,21 @@ class FluxTapTest {
 		}
 
 		@Test
+		void scanMonoListenRestoringThreadLocals() {
+			Mono<Integer> source = Mono.just(1);
+			MonoTapRestoringThreadLocals<Integer, Void> testPublisher =
+					new MonoTapRestoringThreadLocals<>(source, ignoredFactory());
+
+			Scannable test = Scannable.from(testPublisher);
+			assertThat(test).isSameAs(testPublisher)
+			                .matches(Scannable::isScanAvailable, "isScanAvailable");
+
+			assertThat(test.scan(Attr.PREFETCH)).as("PREFETCH").isEqualTo(-1);
+			assertThat(test.scan(Attr.RUN_STYLE)).as("RUN_STYLE").isEqualTo(RunStyle.SYNC);
+			assertThat(test.scanUnsafe(Attr.PARENT)).as("PARENT").isSameAs(source);
+		}
+
+		@Test
 		void scanMonoListenFuseable() {
 			Mono<Integer> source = Mono.just(1);
 			MonoTapFuseable<Integer, Void> testPublisher = new MonoTapFuseable<>(source, ignoredFactory());
@@ -946,6 +1040,29 @@ class FluxTapTest {
 
 			FluxTap.TapSubscriber<?> subscriber = new FluxTap.TapSubscriber<>(
 				actual, new TestSignalListener<>());
+
+			subscriber.onSubscribe(subscription);
+
+			Scannable test = Scannable.from(subscriber);
+			assertThat(test.isScanAvailable()).as("isScanAvailable").isTrue();
+			assertThat(test).isSameAs(subscriber);
+
+			assertThat(test.scanUnsafe(Attr.ACTUAL)).as("ACTUAL").isSameAs(actual);
+			assertThat(test.scanUnsafe(Attr.PARENT)).as("PARENT").isSameAs(subscription);
+			assertThat(test.scan(Attr.RUN_STYLE)).as("RUN_STYLE").isSameAs(RunStyle.SYNC);
+
+			subscriber.onComplete();
+			assertThat(test.scan(Attr.TERMINATED)).as("TERMINATED").isTrue();
+		}
+
+		@Test
+		void scanListenSubscriberRestoringThreadLocals() {
+			CoreSubscriber<Integer> actual = Operators.drainSubscriber();
+			Subscription subscription = Operators.emptySubscription();
+
+			FluxTapRestoringThreadLocals.TapSubscriber<?> subscriber =
+					new FluxTapRestoringThreadLocals.TapSubscriber<>(actual,
+							new TestSignalListener<>(), Context.empty());
 
 			subscriber.onSubscribe(subscription);
 


### PR DESCRIPTION
Aside from `contextWrite()`, the tap operator also has write access to the `Context`.
New classes have been added to handle the automatic context propagation:

* `MonoTapRestoringThreadLocals`
* `FluxTapRestoringThreadLocals`

They replace the corresponding operators in tap when `Hooks.enableAutomaticContextPropagation()` is called, and when the `context-propagation` library is on the class path.

As a result of these changes, `FluxTapTest` was also moved to the `withMicrometerTest` source set, where the `context-propagation` library is present.

Fixes #3395.