### PR TITLE
Remove Fuseable interface from ContextWriteRestoringThreadLocals

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocals.java
@@ -22,11 +22,11 @@ import java.util.function.Function;
 import io.micrometer.context.ContextSnapshot;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
-import reactor.core.Fuseable;
+import reactor.core.Fuseable.ConditionalSubscriber;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
-final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> implements Fuseable {
+final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> {
 
 	final Function<Context, Context> doOnContext;
 
@@ -53,8 +53,7 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 	}
 
 	static final class ContextWriteRestoringThreadLocalsSubscriber<T>
-			implements ConditionalSubscriber<T>, InnerOperator<T, T>,
-			           QueueSubscription<T> {
+			implements ConditionalSubscriber<T>, InnerOperator<T, T> {
 
 		final CoreSubscriber<? super T>        actual;
 		final ConditionalSubscriber<? super T> actualConditional;
@@ -170,32 +169,6 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 					     ContextPropagation.setThreadLocals(context)) {
 				s.cancel();
 			}
-		}
-
-		@Override
-		public int requestFusion(int requestedMode) {
-			return Fuseable.NONE;
-		}
-
-		@Override
-		@Nullable
-		public T poll() {
-			throw new UnsupportedOperationException("Operator does not support fusion");
-		}
-
-		@Override
-		public boolean isEmpty() {
-			throw new UnsupportedOperationException("Operator does not support fusion");
-		}
-
-		@Override
-		public void clear() {
-			throw new UnsupportedOperationException("Operator does not support fusion");
-		}
-
-		@Override
-		public int size() {
-			throw new UnsupportedOperationException("Operator does not support fusion");
 		}
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoContextWriteRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoContextWriteRestoringThreadLocals.java
@@ -22,7 +22,6 @@ import java.util.function.Function;
 import io.micrometer.context.ContextSnapshot;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
-import reactor.core.Fuseable;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
@@ -53,7 +52,7 @@ final class MonoContextWriteRestoringThreadLocals<T> extends MonoOperator<T, T> 
 	}
 
 	static final class ContextWriteRestoringThreadLocalsSubscriber<T>
-			implements InnerOperator<T, T>, Fuseable.QueueSubscription<T> {
+			implements InnerOperator<T, T> {
 
 		final CoreSubscriber<? super T> actual;
 		final Context                   context;
@@ -164,32 +163,6 @@ final class MonoContextWriteRestoringThreadLocals<T> extends MonoOperator<T, T> 
 					     ContextPropagation.setThreadLocals(context)) {
 				s.cancel();
 			}
-		}
-
-		@Override
-		public int requestFusion(int requestedMode) {
-			return Fuseable.NONE;
-		}
-
-		@Override
-		@Nullable
-		public T poll() {
-			throw new UnsupportedOperationException("Operator does not support fusion");
-		}
-
-		@Override
-		public boolean isEmpty() {
-			throw new UnsupportedOperationException("Operator does not support fusion");
-		}
-
-		@Override
-		public void clear() {
-			throw new UnsupportedOperationException("Operator does not support fusion");
-		}
-
-		@Override
-		public int size() {
-			throw new UnsupportedOperationException("Operator does not support fusion");
 		}
 	}
 }


### PR DESCRIPTION
`FluxContextWriteRestoringThreadLocals` and `MonoContextWriteRestoringThreadLocals` implement `Fuseable`, but their `Subscription` implementations don't support fusion.
The `FluxContextWrite` and `MonoContextWrite` operators support fusion, but are not a hard `Thread` barrier, such as the propagating counterparts. Fusion is forbidden in the automatic propagation case as `ThreadLocal`s need to be set for every signal. This simplification is compatible, as the modified classes are not public.