### PR TITLE
ensures SignalListener#addToContext exceptions are handled

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTapRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTapRestoringThreadLocals.java
@@ -72,8 +72,11 @@ final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
 			alteredContext = signalListener.addToContext(actual.currentContext());
 		}
 		catch (Throwable e) {
-			signalListener.handleListenerError(new IllegalStateException("Unable to augment tap Context at construction via addToContext", e));
-			alteredContext = actual.currentContext();
+			IllegalStateException listenerError = new IllegalStateException(
+					"Unable to augment tap Context at subscription via addToContext", e);
+			signalListener.handleListenerError(listenerError);
+			Operators.error(actual, listenerError);
+			return;
 		}
 
 		try (ContextSnapshot.Scope ignored = ContextPropagation.setThreadLocals(alteredContext)) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTap.java
@@ -22,6 +22,7 @@ import reactor.core.observability.SignalListener;
 import reactor.core.observability.SignalListenerFactory;
 import reactor.core.publisher.FluxTap.TapSubscriber;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * A generic per-Subscription side effect {@link Mono} that notifies a {@link SignalListener} of most events.
@@ -66,11 +67,24 @@ final class MonoTap<T, STATE> extends InternalMonoOperator<T, T> {
 			return null;
 		}
 
+		// Invoked AFTER doFirst
+		Context ctx;
+		try {
+			ctx = signalListener.addToContext(actual.currentContext());
+		}
+		catch (Throwable e) {
+			IllegalStateException listenerError = new IllegalStateException(
+					"Unable to augment tap Context at subscription via addToContext", e);
+			signalListener.handleListenerError(listenerError);
+			Operators.error(actual, listenerError);
+			return null;
+		}
+
 		if (actual instanceof Fuseable.ConditionalSubscriber) {
 			//noinspection unchecked
-			return new FluxTap.TapConditionalSubscriber<>((Fuseable.ConditionalSubscriber<? super T>) actual, signalListener);
+			return new FluxTap.TapConditionalSubscriber<>((Fuseable.ConditionalSubscriber<? super T>) actual, signalListener, ctx);
 		}
-		return new TapSubscriber<>(actual, signalListener);
+		return new TapSubscriber<>(actual, signalListener, ctx);
 	}
 
 	@Nullable

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTapFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTapFuseable.java
@@ -21,6 +21,7 @@ import reactor.core.Fuseable;
 import reactor.core.observability.SignalListener;
 import reactor.core.observability.SignalListenerFactory;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * A {@link Fuseable} generic per-Subscription side effect {@link Mono} that notifies a {@link SignalListener} of most events.
@@ -65,11 +66,25 @@ final class MonoTapFuseable<T, STATE> extends InternalMonoOperator<T, T> impleme
 			return null;
 		}
 
+		// Invoked AFTER doFirst
+		Context ctx;
+		try {
+			ctx = signalListener.addToContext(actual.currentContext());
+		}
+		catch (Throwable e) {
+			IllegalStateException listenerError = new IllegalStateException(
+					"Unable to augment tap Context at subscription via addToContext", e);
+			signalListener.handleListenerError(listenerError);
+			Operators.error(actual, listenerError);
+			return null;
+		}
+
 		if (actual instanceof ConditionalSubscriber) {
 			//noinspection unchecked
-			return new FluxTapFuseable.TapConditionalFuseableSubscriber<>((ConditionalSubscriber<? super T>) actual, signalListener);
+			return new FluxTapFuseable.TapConditionalFuseableSubscriber<>(
+					(ConditionalSubscriber<? super T>) actual, signalListener, ctx);
 		}
-		return new FluxTapFuseable.TapFuseableSubscriber<>(actual, signalListener);
+		return new FluxTapFuseable.TapFuseableSubscriber<>(actual, signalListener, ctx);
 	}
 
 	@Nullable


### PR DESCRIPTION
Fixes #3414