### PR TITLE
Propagate ThreadLocals for non-Reactor upstream sources

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSource.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,13 @@ final class FluxSource<I> extends Flux<I> implements SourceProducer<I>,
 	@Override
 	@SuppressWarnings("unchecked")
 	public void subscribe(CoreSubscriber<? super I> actual) {
-		source.subscribe(actual);
+		if (ContextPropagation.shouldPropagateContextToThreadLocals()) {
+			source.subscribe(new FluxContextWriteRestoringThreadLocals
+					.ContextWriteRestoringThreadLocalsSubscriber<>(
+							actual, actual.currentContext()));
+		} else {
+			source.subscribe(actual);
+		}
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSource.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSource.java
@@ -18,12 +18,16 @@ package reactor.core.publisher;
 
 import java.util.Objects;
 
+import io.micrometer.context.ContextSnapshot;
 import org.reactivestreams.Publisher;
 
+import org.reactivestreams.Subscription;
 import reactor.core.CorePublisher;
 import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 /**
  * A connecting {@link Flux} Publisher (right-to-left from a composition chain perspective)
@@ -65,9 +69,7 @@ final class FluxSource<I> extends Flux<I> implements SourceProducer<I>,
 	@SuppressWarnings("unchecked")
 	public void subscribe(CoreSubscriber<? super I> actual) {
 		if (ContextPropagation.shouldPropagateContextToThreadLocals()) {
-			source.subscribe(new FluxContextWriteRestoringThreadLocals
-					.ContextWriteRestoringThreadLocalsSubscriber<>(
-							actual, actual.currentContext()));
+			source.subscribe(new FluxSourceRestoringThreadLocalsSubscriber<>(actual));
 		} else {
 			source.subscribe(actual);
 		}
@@ -97,4 +99,94 @@ final class FluxSource<I> extends Flux<I> implements SourceProducer<I>,
 		return null;
 	}
 
+	static final class FluxSourceRestoringThreadLocalsSubscriber<T>
+			implements Fuseable.ConditionalSubscriber<T>, InnerConsumer<T> {
+
+		final CoreSubscriber<? super T>                 actual;
+		final Fuseable.ConditionalSubscriber<? super T> actualConditional;
+
+		Subscription s;
+
+		@SuppressWarnings("unchecked")
+		FluxSourceRestoringThreadLocalsSubscriber(CoreSubscriber<? super T> actual) {
+			this.actual = actual;
+			if (actual instanceof Fuseable.ConditionalSubscriber) {
+				this.actualConditional = (Fuseable.ConditionalSubscriber<? super T>) actual;
+			}
+			else {
+				this.actualConditional = null;
+			}
+		}
+
+		@Override
+		@Nullable
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) {
+				return s;
+			}
+			if (key == Attr.RUN_STYLE) {
+				return Attr.RunStyle.SYNC;
+			}
+			if (key == Attr.ACTUAL) {
+				return actual;
+			}
+			return null;
+		}
+
+		@Override
+		public Context currentContext() {
+			return actual.currentContext();
+		}
+
+		@SuppressWarnings("try")
+		@Override
+		public void onSubscribe(Subscription s) {
+			// This is needed, as the downstream can then switch threads,
+			// continue the subscription using different primitives and omit this operator
+			try (ContextSnapshot.Scope ignored =
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
+				actual.onSubscribe(s);
+			}
+		}
+
+		@SuppressWarnings("try")
+		@Override
+		public void onNext(T t) {
+			try (ContextSnapshot.Scope ignored =
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
+				actual.onNext(t);
+			}
+		}
+
+		@SuppressWarnings("try")
+		@Override
+		public boolean tryOnNext(T t) {
+			try (ContextSnapshot.Scope ignored =
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
+				if (actualConditional != null) {
+					return actualConditional.tryOnNext(t);
+				}
+				actual.onNext(t);
+				return true;
+			}
+		}
+
+		@SuppressWarnings("try")
+		@Override
+		public void onError(Throwable t) {
+			try (ContextSnapshot.Scope ignored =
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
+				actual.onError(t);
+			}
+		}
+
+		@SuppressWarnings("try")
+		@Override
+		public void onComplete() {
+			try (ContextSnapshot.Scope ignored =
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
+				actual.onComplete();
+			}
+		}
+	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFromPublisher.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFromPublisher.java
@@ -56,9 +56,7 @@ final class MonoFromPublisher<T> extends Mono<T> implements Scannable,
 	@SuppressWarnings("unchecked")
 	public void subscribe(CoreSubscriber<? super T> actual) {
 		if (ContextPropagation.shouldPropagateContextToThreadLocals()) {
-			actual = new MonoContextWriteRestoringThreadLocals
-					.ContextWriteRestoringThreadLocalsSubscriber<>(
-							actual, actual.currentContext());
+			actual = new MonoSource.MonoSourceRestoringThreadLocalsSubscriber<>(actual);
 		}
 
 		try {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFromPublisher.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFromPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,12 @@ final class MonoFromPublisher<T> extends Mono<T> implements Scannable,
 	@Override
 	@SuppressWarnings("unchecked")
 	public void subscribe(CoreSubscriber<? super T> actual) {
+		if (ContextPropagation.shouldPropagateContextToThreadLocals()) {
+			actual = new MonoContextWriteRestoringThreadLocals
+					.ContextWriteRestoringThreadLocalsSubscriber<>(
+							actual, actual.currentContext());
+		}
+
 		try {
 			CoreSubscriber<? super T> subscriber = subscribeOrReturn(actual);
 			if (subscriber == null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSource.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,13 @@ final class MonoSource<I> extends Mono<I> implements Scannable, SourceProducer<I
 	@Override
 	@SuppressWarnings("unchecked")
 	public void subscribe(CoreSubscriber<? super I> actual) {
-		source.subscribe(actual);
+		if (ContextPropagation.shouldPropagateContextToThreadLocals()) {
+			source.subscribe(new MonoContextWriteRestoringThreadLocals
+					.ContextWriteRestoringThreadLocalsSubscriber<>(
+							actual, actual.currentContext()));
+		} else {
+			source.subscribe(actual);
+		}
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSource.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSource.java
@@ -18,15 +18,15 @@ package reactor.core.publisher;
 
 import java.util.Objects;
 
+import io.micrometer.context.ContextSnapshot;
 import org.reactivestreams.Publisher;
 
+import org.reactivestreams.Subscription;
 import reactor.core.CorePublisher;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.util.annotation.Nullable;
-
-import static reactor.core.Scannable.Attr.RUN_STYLE;
-import static reactor.core.Scannable.Attr.RunStyle.SYNC;
+import reactor.util.context.Context;
 
 /**
  * A decorating {@link Mono} {@link Publisher} that exposes {@link Mono} API over an arbitrary {@link Publisher}
@@ -64,12 +64,9 @@ final class MonoSource<I> extends Mono<I> implements Scannable, SourceProducer<I
 	 * @param actual
 	 */
 	@Override
-	@SuppressWarnings("unchecked")
 	public void subscribe(CoreSubscriber<? super I> actual) {
 		if (ContextPropagation.shouldPropagateContextToThreadLocals()) {
-			source.subscribe(new MonoContextWriteRestoringThreadLocals
-					.ContextWriteRestoringThreadLocalsSubscriber<>(
-							actual, actual.currentContext()));
+			source.subscribe(new MonoSourceRestoringThreadLocalsSubscriber<>(actual));
 		} else {
 			source.subscribe(actual);
 		}
@@ -102,4 +99,89 @@ final class MonoSource<I> extends Mono<I> implements Scannable, SourceProducer<I
 		return null;
 	}
 
+	static final class MonoSourceRestoringThreadLocalsSubscriber<T>
+			implements InnerConsumer<T> {
+
+		final CoreSubscriber<? super T> actual;
+
+		Subscription s;
+		boolean      done;
+
+		MonoSourceRestoringThreadLocalsSubscriber(CoreSubscriber<? super T> actual) {
+			this.actual = actual;
+		}
+
+		@Override
+		@Nullable
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.PARENT) {
+				return s;
+			}
+			if (key == Attr.RUN_STYLE) {
+				return Attr.RunStyle.SYNC;
+			}
+			if (key == Attr.ACTUAL) {
+				return actual;
+			}
+			return null;
+		}
+
+		@Override
+		public Context currentContext() {
+			return actual.currentContext();
+		}
+
+		@SuppressWarnings("try")
+		@Override
+		public void onSubscribe(Subscription s) {
+			// This is needed, as the downstream can then switch threads,
+			// continue the subscription using different primitives and omit this operator
+			try (ContextSnapshot.Scope ignored =
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
+				actual.onSubscribe(s);
+			}
+		}
+
+		@SuppressWarnings("try")
+		@Override
+		public void onNext(T t) {
+			this.done = true;
+			try (ContextSnapshot.Scope ignored =
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
+				actual.onNext(t);
+				actual.onComplete();
+			}
+		}
+
+		@SuppressWarnings("try")
+		@Override
+		public void onError(Throwable t) {
+			try (ContextSnapshot.Scope ignored =
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
+				if (this.done) {
+					Operators.onErrorDropped(t, actual.currentContext());
+					return;
+				}
+
+				this.done = true;
+
+				actual.onError(t);
+			}
+		}
+
+		@SuppressWarnings("try")
+		@Override
+		public void onComplete() {
+			if (this.done) {
+				return;
+			}
+
+			this.done = true;
+
+			try (ContextSnapshot.Scope ignored =
+					     ContextPropagation.setThreadLocals(actual.currentContext())) {
+				actual.onComplete();
+			}
+		}
+	}
 }

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
@@ -608,10 +608,7 @@ class ContextPropagationTest {
 			TestSubscriber<String> testSubscriber = TestSubscriber.create();
 
 			Mono.fromFuture(future)
-			    .doOnNext(s -> {
-				    System.out.println("Called from " + Thread.currentThread().getName());
-					value.set(REF1.get());
-			    })
+			    .doOnNext(s -> value.set(REF1.get()))
 			    .contextWrite(Context.of(KEY1, "present"))
 			    .subscribe(testSubscriber);
 


### PR DESCRIPTION
Factory methods for creating `Flux` and `Mono` from non-Reactor sources now restore `ThreadLocal` values when `Hooks.enableAutomaticContextPropagation()` was called in the following cases:

* `Flux.from(Publisher)`
* `Mono.from(Publisher)`
* `Mono.fromDirect(Publisher)`
* `Mono.fromFuture(CompletableFuture)`
* `Mono.fromCompletionStage(CompletionStage)`

and relevant overloads.

Fixes #3366.