### PR TITLE
Avoid IllegalStateException: Cannot resolve type description for io.micrometer.context.ContextRegistry

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -72,9 +72,6 @@ final class ContextPropagation {
 	 * @return the {@link Context} augmented with captured entries
 	 */
 	static Function<Context, Context> contextCapture() {
-		if (!ContextPropagationSupport.isContextPropagationOnClasspath) {
-			return NO_OP;
-		}
 		return WITH_GLOBAL_REGISTRY_NO_PREDICATE;
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagationSupport.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagationSupport.java
@@ -56,7 +56,7 @@ final class ContextPropagationSupport {
         return isContextPropagationOnClasspath && propagateContextToThreadLocals;
     }
 
-    static boolean dontRestoreContextForHandle() {
-        return propagateContextToThreadLocals || !isContextPropagationOnClasspath;
+    static boolean shouldRestoreThreadLocalsInSomeOperators() {
+        return isContextPropagationOnClasspath && !propagateContextToThreadLocals;
     }
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagationSupport.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagationSupport.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+final class ContextPropagationSupport {
+    static final Logger LOGGER = Loggers.getLogger(ContextPropagationSupport.class);
+
+    // Note: If reflection is used for this field, then the name of the field should end with 'Available'.
+    // The preprocessing for native-image support is in Spring Framework, and is a short term solution.
+    // The field should end with 'Available'. See org.springframework.aot.nativex.feature.PreComputeFieldFeature.
+    // Ultimately the long term solution should be provided by Reactor Core.
+    static final boolean isContextPropagationOnClasspath;
+    static boolean propagateContextToThreadLocals = false;
+
+    static {
+        boolean contextPropagation = false;
+        try {
+            Class.forName("io.micrometer.context.ContextRegistry");
+            contextPropagation = true;
+        } catch (ClassNotFoundException notFound) {
+        } catch (LinkageError linkageErr) {
+        } catch (Throwable err) {
+            LOGGER.error("Unexpected exception while detecting ContextPropagation feature." +
+                    " The feature is considered disabled due to this:", err);
+        }
+        isContextPropagationOnClasspath = contextPropagation;
+    }
+
+    /**
+     * Is Micrometer {@code context-propagation} API on the classpath?
+     *
+     * @return true if context-propagation is available at runtime, false otherwise
+     */
+    static boolean isContextPropagationAvailable() {
+        return isContextPropagationOnClasspath;
+    }
+
+    static boolean shouldPropagateContextToThreadLocals() {
+        return isContextPropagationOnClasspath && propagateContextToThreadLocals;
+    }
+
+    static boolean dontRestoreContextForHandle() {
+        return propagateContextToThreadLocals || !isContextPropagationOnClasspath;
+    }
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -44,7 +44,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.stream.Collector;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -4163,10 +4162,10 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @see #tap(SignalListenerFactory)
 	 */
 	public final Flux<T> contextCapture() {
-		if (!ContextPropagation.isContextPropagationAvailable()) {
+		if (!ContextPropagationSupport.isContextPropagationAvailable()) {
 			return this;
 		}
-		if (ContextPropagation.propagateContextToThreadLocals) {
+		if (ContextPropagationSupport.propagateContextToThreadLocals) {
 			return onAssembly(new FluxContextWriteRestoringThreadLocals<>(
 					this, ContextPropagation.contextCapture()
 			));
@@ -4217,7 +4216,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @see Context
 	 */
 	public final Flux<T> contextWrite(Function<Context, Context> contextModifier) {
-		if (ContextPropagation.shouldPropagateContextToThreadLocals()) {
+		if (ContextPropagationSupport.shouldPropagateContextToThreadLocals()) {
 			return onAssembly(new FluxContextWriteRestoringThreadLocals<>(
 					this, contextModifier
 			));
@@ -9249,7 +9248,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @see #tap(Function)
 	 */
 	public final Flux<T> tap(SignalListenerFactory<T, ?> listenerFactory) {
-		if (ContextPropagation.shouldPropagateContextToThreadLocals()) {
+		if (ContextPropagationSupport.shouldPropagateContextToThreadLocals()) {
 			return onAssembly(new FluxTapRestoringThreadLocals<>(this, listenerFactory));
 		}
 		if (this instanceof Fuseable) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,8 @@ final class FluxHandle<T, R> extends InternalFluxOperator<T, R> {
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
-		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagation.contextRestoreForHandle(this.handler, actual::currentContext);
+		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagationSupport.dontRestoreContextForHandle() ?
+				this.handler : ContextPropagation.contextRestoreForHandle(this.handler, actual::currentContext);
 		if (actual instanceof Fuseable.ConditionalSubscriber) {
 			@SuppressWarnings("unchecked")
 			Fuseable.ConditionalSubscriber<? super R> cs = (Fuseable.ConditionalSubscriber<? super R>) actual;
@@ -270,7 +271,7 @@ final class FluxHandle<T, R> extends InternalFluxOperator<T, R> {
 		public void request(long n) {
 			s.request(n);
 		}
-		
+
 		@Override
 		public void cancel() {
 			s.cancel();
@@ -471,12 +472,12 @@ final class FluxHandle<T, R> extends InternalFluxOperator<T, R> {
 			}
 			data = Objects.requireNonNull(o, "data");
 		}
-		
+
 		@Override
 		public void request(long n) {
 			s.request(n);
 		}
-		
+
 		@Override
 		public void cancel() {
 			s.cancel();

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
@@ -45,8 +45,8 @@ final class FluxHandle<T, R> extends InternalFluxOperator<T, R> {
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
-		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagationSupport.dontRestoreContextForHandle() ?
-				this.handler : ContextPropagation.contextRestoreForHandle(this.handler, actual::currentContext);
+		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagationSupport.shouldRestoreThreadLocalsInSomeOperators() ?
+				ContextPropagation.contextRestoreForHandle(this.handler, actual::currentContext) : this.handler;
 		if (actual instanceof Fuseable.ConditionalSubscriber) {
 			@SuppressWarnings("unchecked")
 			Fuseable.ConditionalSubscriber<? super R> cs = (Fuseable.ConditionalSubscriber<? super R>) actual;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandle.java
@@ -271,7 +271,7 @@ final class FluxHandle<T, R> extends InternalFluxOperator<T, R> {
 		public void request(long n) {
 			s.request(n);
 		}
-
+		
 		@Override
 		public void cancel() {
 			s.cancel();
@@ -472,12 +472,12 @@ final class FluxHandle<T, R> extends InternalFluxOperator<T, R> {
 			}
 			data = Objects.requireNonNull(o, "data");
 		}
-
+		
 		@Override
 		public void request(long n) {
 			s.request(n);
 		}
-
+		
 		@Override
 		public void cancel() {
 			s.cancel();

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
@@ -58,8 +58,8 @@ final class FluxHandleFuseable<T, R> extends InternalFluxOperator<T, R> implemen
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
-		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagationSupport.dontRestoreContextForHandle() ?
-				this.handler : ContextPropagation.contextRestoreForHandle(this.handler, actual::currentContext);
+		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagationSupport.shouldRestoreThreadLocalsInSomeOperators() ?
+				ContextPropagation.contextRestoreForHandle(this.handler, actual::currentContext) : this.handler;
 		if (actual instanceof ConditionalSubscriber) {
 			@SuppressWarnings("unchecked")
 			ConditionalSubscriber<? super R> cs = (ConditionalSubscriber<? super R>) actual;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxHandleFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,8 @@ final class FluxHandleFuseable<T, R> extends InternalFluxOperator<T, R> implemen
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
-		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagation.contextRestoreForHandle(this.handler, actual::currentContext);
+		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagationSupport.dontRestoreContextForHandle() ?
+				this.handler : ContextPropagation.contextRestoreForHandle(this.handler, actual::currentContext);
 		if (actual instanceof ConditionalSubscriber) {
 			@SuppressWarnings("unchecked")
 			ConditionalSubscriber<? super R> cs = (ConditionalSubscriber<? super R>) actual;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSource.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSource.java
@@ -68,7 +68,7 @@ final class FluxSource<I> extends Flux<I> implements SourceProducer<I>,
 	@Override
 	@SuppressWarnings("unchecked")
 	public void subscribe(CoreSubscriber<? super I> actual) {
-		if (ContextPropagation.shouldPropagateContextToThreadLocals()) {
+		if (ContextPropagationSupport.shouldPropagateContextToThreadLocals()) {
 			source.subscribe(new FluxSourceRestoringThreadLocalsSubscriber<>(actual));
 		} else {
 			source.subscribe(actual);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTap.java
@@ -58,7 +58,8 @@ final class FluxTap<T, STATE> extends InternalFluxOperator<T, T> {
 		}
 		// Attempt to wrap the SignalListener with one that restores ThreadLocals from Context on each listener methods
 		// (only if ContextPropagation.isContextPropagationAvailable() is true)
-		signalListener = ContextPropagation.contextRestoreForTap(signalListener, actual::currentContext);
+		signalListener = ContextPropagationSupport.isContextPropagationAvailable() ?
+				ContextPropagation.contextRestoreForTap(signalListener, actual::currentContext) : signalListener;
 
 		try {
 			signalListener.doFirst();

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTapFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTapFuseable.java
@@ -59,7 +59,8 @@ final class FluxTapFuseable<T, STATE> extends InternalFluxOperator<T, T> impleme
 		}
 		// Attempt to wrap the SignalListener with one that restores ThreadLocals from Context on each listener methods
 		// (only if ContextPropagation.isContextPropagationAvailable() is true)
-		signalListener = ContextPropagation.contextRestoreForTap(signalListener, actual::currentContext);
+		signalListener = ContextPropagationSupport.isContextPropagationAvailable() ?
+				ContextPropagation.contextRestoreForTap(signalListener, actual::currentContext) : signalListener;
 
 		try {
 			signalListener.doFirst();

--- a/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
@@ -535,7 +535,7 @@ public abstract class Hooks {
 	 * a logical boundary for the context propagation mechanism.
 	 */
 	public static void enableAutomaticContextPropagation() {
-		if (ContextPropagation.isContextPropagationOnClasspath) {
+		if (ContextPropagationSupport.isContextPropagationOnClasspath) {
 			Hooks.addQueueWrapper(
 					CONTEXT_IN_THREAD_LOCALS_KEY, ContextPropagation.ContextQueue::new
 			);
@@ -543,7 +543,7 @@ public abstract class Hooks {
 					CONTEXT_IN_THREAD_LOCALS_KEY,
 					ContextPropagation.scopePassingOnScheduleHook()
 			);
-			ContextPropagation.propagateContextToThreadLocals = true;
+			ContextPropagationSupport.propagateContextToThreadLocals = true;
 		}
 	}
 
@@ -552,10 +552,10 @@ public abstract class Hooks {
 	 * @see #enableAutomaticContextPropagation()
 	 */
 	public static void disableAutomaticContextPropagation() {
-		if (ContextPropagation.isContextPropagationOnClasspath) {
+		if (ContextPropagationSupport.isContextPropagationOnClasspath) {
 			Hooks.removeQueueWrapper(CONTEXT_IN_THREAD_LOCALS_KEY);
 			Schedulers.resetOnScheduleHook(CONTEXT_IN_THREAD_LOCALS_KEY);
-			ContextPropagation.propagateContextToThreadLocals = false;
+			ContextPropagationSupport.propagateContextToThreadLocals = false;
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -2281,10 +2281,10 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @see #tap(SignalListenerFactory)
 	 */
 	public final Mono<T> contextCapture() {
-		if (!ContextPropagation.isContextPropagationAvailable()) {
+		if (!ContextPropagationSupport.isContextPropagationAvailable()) {
 			return this;
 		}
-		if (ContextPropagation.propagateContextToThreadLocals) {
+		if (ContextPropagationSupport.propagateContextToThreadLocals) {
 			return onAssembly(new MonoContextWriteRestoringThreadLocals<>(
 					this, ContextPropagation.contextCapture()
 			));
@@ -2335,7 +2335,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @see Context
 	 */
 	public final Mono<T> contextWrite(Function<Context, Context> contextModifier) {
-		if (ContextPropagation.shouldPropagateContextToThreadLocals()) {
+		if (ContextPropagationSupport.shouldPropagateContextToThreadLocals()) {
 			return onAssembly(new MonoContextWriteRestoringThreadLocals<>(
 					this, contextModifier
 			));
@@ -4740,7 +4740,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @see #tap(Function)
 	 */
 	public final Mono<T> tap(SignalListenerFactory<T, ?> listenerFactory) {
-		if (ContextPropagation.shouldPropagateContextToThreadLocals()) {
+		if (ContextPropagationSupport.shouldPropagateContextToThreadLocals()) {
 			return onAssembly(new MonoTapRestoringThreadLocals<>(this, listenerFactory));
 		}
 		if (this instanceof Fuseable) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCompletionStage.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCompletionStage.java
@@ -52,7 +52,7 @@ final class MonoCompletionStage<T> extends Mono<T>
 
     @Override
     public void subscribe(CoreSubscriber<? super T> actual) {
-        if (ContextPropagation.shouldPropagateContextToThreadLocals()) {
+        if (ContextPropagationSupport.shouldPropagateContextToThreadLocals()) {
             actual.onSubscribe(
                     new MonoCompletionStageRestoringThreadLocalsSubscription<>(
                             actual, future, suppressCancellation));

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFromPublisher.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFromPublisher.java
@@ -55,7 +55,7 @@ final class MonoFromPublisher<T> extends Mono<T> implements Scannable,
 	@Override
 	@SuppressWarnings("unchecked")
 	public void subscribe(CoreSubscriber<? super T> actual) {
-		if (ContextPropagation.shouldPropagateContextToThreadLocals()) {
+		if (ContextPropagationSupport.shouldPropagateContextToThreadLocals()) {
 			actual = new MonoSource.MonoSourceRestoringThreadLocalsSubscriber<>(actual);
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoHandle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,8 @@ final class MonoHandle<T, R> extends InternalMonoOperator<T, R> {
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
-		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagation.contextRestoreForHandle(this.handler, actual::currentContext);
+		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagationSupport.dontRestoreContextForHandle() ?
+				this.handler : ContextPropagation.contextRestoreForHandle(this.handler, actual::currentContext);
 		return new FluxHandle.HandleSubscriber<>(actual, handler2);
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoHandle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoHandle.java
@@ -41,8 +41,8 @@ final class MonoHandle<T, R> extends InternalMonoOperator<T, R> {
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
-		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagationSupport.dontRestoreContextForHandle() ?
-				this.handler : ContextPropagation.contextRestoreForHandle(this.handler, actual::currentContext);
+		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagationSupport.shouldRestoreThreadLocalsInSomeOperators() ?
+				ContextPropagation.contextRestoreForHandle(this.handler, actual::currentContext) : this.handler;
 		return new FluxHandle.HandleSubscriber<>(actual, handler2);
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoHandleFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoHandleFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,8 @@ final class MonoHandleFuseable<T, R> extends InternalMonoOperator<T, R>
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
-		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagation.contextRestoreForHandle(this.handler, actual::currentContext);
+		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagationSupport.dontRestoreContextForHandle() ?
+				this.handler : ContextPropagation.contextRestoreForHandle(this.handler, actual::currentContext);
 		return new FluxHandleFuseable.HandleFuseableSubscriber<>(actual, handler2);
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoHandleFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoHandleFuseable.java
@@ -43,8 +43,8 @@ final class MonoHandleFuseable<T, R> extends InternalMonoOperator<T, R>
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
-		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagationSupport.dontRestoreContextForHandle() ?
-				this.handler : ContextPropagation.contextRestoreForHandle(this.handler, actual::currentContext);
+		BiConsumer<? super T, SynchronousSink<R>> handler2 = ContextPropagationSupport.shouldRestoreThreadLocalsInSomeOperators() ?
+				ContextPropagation.contextRestoreForHandle(this.handler, actual::currentContext) : this.handler;
 		return new FluxHandleFuseable.HandleFuseableSubscriber<>(actual, handler2);
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSource.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSource.java
@@ -65,7 +65,7 @@ final class MonoSource<I> extends Mono<I> implements Scannable, SourceProducer<I
 	 */
 	@Override
 	public void subscribe(CoreSubscriber<? super I> actual) {
-		if (ContextPropagation.shouldPropagateContextToThreadLocals()) {
+		if (ContextPropagationSupport.shouldPropagateContextToThreadLocals()) {
 			source.subscribe(new MonoSourceRestoringThreadLocalsSubscriber<>(actual));
 		} else {
 			source.subscribe(actual);

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTap.java
@@ -56,7 +56,8 @@ final class MonoTap<T, STATE> extends InternalMonoOperator<T, T> {
 		}
 		// Attempt to wrap the SignalListener with one that restores ThreadLocals from Context on each listener methods
 		// (only if ContextPropagation.isContextPropagationAvailable() is true)
-		signalListener = ContextPropagation.contextRestoreForTap(signalListener, actual::currentContext);
+		signalListener = ContextPropagationSupport.isContextPropagationAvailable() ?
+				ContextPropagation.contextRestoreForTap(signalListener, actual::currentContext) : signalListener;
 
 		try {
 			signalListener.doFirst();

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTapFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTapFuseable.java
@@ -55,7 +55,8 @@ final class MonoTapFuseable<T, STATE> extends InternalMonoOperator<T, T> impleme
 		}
 		// Attempt to wrap the SignalListener with one that restores ThreadLocals from Context on each listener methods
 		// (only if ContextPropagation.isContextPropagationAvailable() is true)
-		signalListener = ContextPropagation.contextRestoreForTap(signalListener, actual::currentContext);
+		signalListener = ContextPropagationSupport.isContextPropagationAvailable() ?
+				ContextPropagation.contextRestoreForTap(signalListener, actual::currentContext) : signalListener;
 
 		try {
 			signalListener.doFirst();

--- a/reactor-core/src/test/java/reactor/core/publisher/ContextPropagationNotThereSmokeTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ContextPropagationNotThereSmokeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ class ContextPropagationNotThereSmokeTest {
 
 	@Test
 	void contextPropagationIsNotAvailable() {
-		assertThat(ContextPropagation.isContextPropagationAvailable()).isFalse();
+		assertThat(ContextPropagationSupport.isContextPropagationAvailable()).isFalse();
 	}
 
 	@Test

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
@@ -328,7 +328,7 @@ class ContextPropagationTest {
 
 	@Test
 	void isContextPropagationAvailable() {
-		assertThat(ContextPropagation.isContextPropagationAvailable()).isTrue();
+		assertThat(ContextPropagationSupport.isContextPropagationAvailable()).isTrue();
 	}
 
 	@Test
@@ -890,8 +890,8 @@ class ContextPropagationTest {
 				context = Context.empty();
 			}
 
-			BiConsumer<String, SynchronousSink<String>> decoratedHandler = ContextPropagation.contextRestoreForHandle(originalHandler,
-				() -> context);
+			BiConsumer<String, SynchronousSink<String>> decoratedHandler = ContextPropagationSupport.dontRestoreContextForHandle() ?
+					originalHandler : ContextPropagation.contextRestoreForHandle(originalHandler, () -> context);
 
 			if (withContext) {
 				assertThat(decoratedHandler).as("context not empty: decorated handler").isNotSameAs(originalHandler);
@@ -912,8 +912,8 @@ class ContextPropagationTest {
 			final String expected = "bar=expected";
 			final Context context = Context.of(KEY1, "expected");
 
-			BiConsumer<String, SynchronousSink<String>> decoratedHandler =
-				ContextPropagation.contextRestoreForHandle(originalHandler, () -> context);
+			BiConsumer<String, SynchronousSink<String>> decoratedHandler = ContextPropagationSupport.dontRestoreContextForHandle() ?
+					originalHandler : ContextPropagation.contextRestoreForHandle(originalHandler, () -> context);
 
 			SynchronousSink<String> mockSink = Mockito.mock(SynchronousSink.class);
 			decoratedHandler.accept("bar", mockSink);

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
@@ -890,8 +890,8 @@ class ContextPropagationTest {
 				context = Context.empty();
 			}
 
-			BiConsumer<String, SynchronousSink<String>> decoratedHandler = ContextPropagationSupport.dontRestoreContextForHandle() ?
-					originalHandler : ContextPropagation.contextRestoreForHandle(originalHandler, () -> context);
+			BiConsumer<String, SynchronousSink<String>> decoratedHandler = ContextPropagationSupport.shouldRestoreThreadLocalsInSomeOperators() ?
+					ContextPropagation.contextRestoreForHandle(originalHandler, () -> context) : originalHandler;
 
 			if (withContext) {
 				assertThat(decoratedHandler).as("context not empty: decorated handler").isNotSameAs(originalHandler);
@@ -912,8 +912,8 @@ class ContextPropagationTest {
 			final String expected = "bar=expected";
 			final Context context = Context.of(KEY1, "expected");
 
-			BiConsumer<String, SynchronousSink<String>> decoratedHandler = ContextPropagationSupport.dontRestoreContextForHandle() ?
-					originalHandler : ContextPropagation.contextRestoreForHandle(originalHandler, () -> context);
+			BiConsumer<String, SynchronousSink<String>> decoratedHandler = ContextPropagationSupport.shouldRestoreThreadLocalsInSomeOperators() ?
+					ContextPropagation.contextRestoreForHandle(originalHandler, () -> context) : originalHandler;
 
 			SynchronousSink<String> mockSink = Mockito.mock(SynchronousSink.class);
 			decoratedHandler.accept("bar", mockSink);


### PR DESCRIPTION
@chemicL, as we have discussed, this is the PR from my old patch, which seems to avoid the `IllegalStateException: Cannot resolve type description for io.micrometer.context.ContextRegistry` when context-propagation jar is not in the classpath and when Blockhound is used.
Can you take a look ? 

This patch avoids direct access to the `ContextPropagation` class if we know that the context-propagation jar is not in the classpath; so in this case, it will avoid Blockhound instrumenting the class; hence it will avoid any IllegalStateException.

tested with reactor-netty, as well as with https://github.com/violetagg/GH-3334

The PR should also fix https://github.com/reactor/BlockHound/issues/356

side notes: 

- as we have discussed, I have left unchanged the `ContextPropagationSupport.dontRestoreContextForHandle()` method; maybe you will want to refactor it. 
- I have left the extra checks in the ContextPropagation various methods, maybe you will want to remove them.
-  some static final inner classes from the reactor.core.publisher package are referring to some context propagation types, like the `FluxSource.FluxSourceRestoringThreadLocalsSubscriber` which is using `ContextSnapshot.Scope`. So, when context-propagation is unavailable, these inner classes are not used, but are part of classes which are used. So for the moment, we don't seem to have any problems, but who knows ... so, if we still have any IllegalStateExceptions even with this PR, then most likely that the static inner classes that are using the context-propagation types will have to be moved to the ContextPropagation class. Let's do not rush to do this for the moment, but we may consider to do this at some point in the future if the problem remains.

thanks.
