### PR TITLE
Allow null previous value

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ jsr305 = "com.google.code.findbugs:jsr305:3.0.1"
 micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometer" }
 micrometer-commons = { module = "io.micrometer:micrometer-commons" }
 micrometer-core = { module = "io.micrometer:micrometer-core" }
-micrometer-contextPropagation = "io.micrometer:context-propagation:1.0.2"
+micrometer-contextPropagation = "io.micrometer:context-propagation:1.0.3-SNAPSHOT"
 micrometer-docsGenerator = { module = "io.micrometer:micrometer-docs-generator", version = "1.0.1"}
 micrometer-observation-test = { module = "io.micrometer:micrometer-observation-test" }
 micrometer-tracing-test = "io.micrometer:micrometer-tracing-integration-test:1.0.4"

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -417,7 +417,11 @@ final class ContextPropagation {
 
 		previousValues = (previousValues != null ? previousValues : new HashMap<>());
 		previousValues.put(key, accessor.getValue());
-		((ThreadLocalAccessor<V>) accessor).setValue(value);
+		if (value != null) {
+			((ThreadLocalAccessor<V>) accessor).setValue(value);
+		} else {
+			accessor.setValue();
+		}
 		return previousValues;
 	}
 
@@ -449,7 +453,7 @@ final class ContextPropagation {
 				((ThreadLocalAccessor<V>) accessor).restore(previousValue);
 			}
 			else {
-				accessor.reset();
+				accessor.restore();
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -417,12 +417,7 @@ final class ContextPropagation {
 
 		previousValues = (previousValues != null ? previousValues : new HashMap<>());
 		previousValues.put(key, accessor.getValue());
-		if (value != null) {
-			((ThreadLocalAccessor<V>) accessor).setValue(value);
-		}
-		else {
-			accessor.reset();
-		}
+		((ThreadLocalAccessor<V>) accessor).setValue(value);
 		return previousValues;
 	}
 


### PR DESCRIPTION
without this change we can't distinguish in Micrometer (e.g. via `ObservationThreadLocalAccessor`) whether we're introducing an empty value (`setValue(null)`) or resetting `reset()`. 

with this change we always set a value regardless whether it's `null` or not

This change is a prerequisite to fix current issues with OTLA and Reactor and scope leaks and memory leaks etc.

