### PR TITLE
Improve documentation about subscribeOn

### DIFF
--- a/docs/asciidoc/coreFeatures.adoc
+++ b/docs/asciidoc/coreFeatures.adoc
@@ -318,9 +318,9 @@ the part of the chain after them.
 * Picks one thread from the `Scheduler`
 
 - NOTE: Only the closest `subscribeOn` call in the downstream chain effectively
- schedules subscription and request signals to upstream operators that can intercept them
- (`doFirst`, `doOnRequest`). Using multiple `subscribeOn` calls will introduce unnecessary
- Thread switches that have no value.
+ schedules subscription and request signals to the source or operators that can
+ intercept them (`doFirst`, `doOnRequest`). Using multiple `subscribeOn` calls will
+ introduce unnecessary Thread switches that have no value.
 
 The following example uses the `subscribeOn` method:
 

--- a/docs/asciidoc/coreFeatures.adoc
+++ b/docs/asciidoc/coreFeatures.adoc
@@ -306,16 +306,16 @@ The print happens on the latest execution context, which is the one from `publis
 
 === The `subscribeOn` Method
 
-`subscribeOn` applies to the subscription process, when that backward chain is
-constructed. As a consequence, no matter where you place the `subscribeOn` in the chain,
-*it always affects the context of the source emission*. However, this does not affect the
+`subscribeOn` applies to the subscription process, when the backward chain is being
+constructed. It is usually recommended to place it immediately after the source of data,
+as intermediate operators can affect the context of the execution.
+
+However, this does not affect the
 behavior of subsequent calls to `publishOn` -- they still switch the execution context for
 the part of the chain after them.
 
 * Changes the `Thread` from which the *whole chain* of operators subscribes
 * Picks one thread from the `Scheduler`
-
-NOTE: Only the earliest `subscribeOn` call in the chain is actually taken into account.
 
 The following example uses the `subscribeOn` method:
 

--- a/docs/asciidoc/coreFeatures.adoc
+++ b/docs/asciidoc/coreFeatures.adoc
@@ -317,6 +317,11 @@ the part of the chain after them.
 * Changes the `Thread` from which the *whole chain* of operators subscribes
 * Picks one thread from the `Scheduler`
 
+- NOTE: Only the closest `subscribeOn` call in the downstream chain effectively
+ schedules subscription and request signals to upstream operators that can intercept them
+ (`doFirst`, `doOnRequest`). Using multiple `subscribeOn` calls will introduce unnecessary
+ Thread switches that have no value.
+
 The following example uses the `subscribeOn` method:
 
 ====

--- a/docs/asciidoc/faq.adoc
+++ b/docs/asciidoc/faq.adoc
@@ -41,6 +41,9 @@ that can be enqueued and deferred during a spike.
 Note that `subscribeOn` does not subscribe to the `Mono`. It specifies what
 kind of `Scheduler` to use when a subscribe call happens.
 
+Also, note that `subscribeOn` operator should immediately follow the source and any
+further operators are defined after the `subscribeOn` wrapper.
+
 [[faq.chain]]
 == I Used an Operator on my `Flux` but it Doesn't Seem to Apply. What Gives?
 


### PR DESCRIPTION
The documentation can be misleading with regards to ordering guarantees of subscibeOn with regards to other operators. This change improves the wording.

Resolves #3452.