### PR TITLE
Removes the Operators.serialize in MonoTimeout#subscribeOrReturn

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ final class MonoTimeout<T, U, V> extends InternalMonoOperator<T, T> {
 	@SuppressWarnings("unchecked")
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
 		return new FluxTimeout.TimeoutMainSubscriber<T, T>(
-				Operators.serialize(actual),
+				actual,
 				firstTimeout,
 				NEVER,
 				other,


### PR DESCRIPTION
When I debug the code, I find a small problem, the operation of the MonoTimeout#subscribeOrReturn class causes the CoreSubscriber to be serialized twice, which I think can be optimized has.

So I PR the removes the Operators.serialize operation in MonoTimeout#subscribeOrReturn that is unnecessary for CoreSubscriber, because FluxTimeout. TimeoutMainSubscriber has carries on the Operators. Serialize operation