### PR TITLE
provides separate CF for non-cancel scenario

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -548,7 +548,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return A {@link Mono}.
 	 */
 	public static <T> Mono<T> fromCompletionStage(CompletionStage<? extends T> completionStage) {
-		return onAssembly(new MonoCompletionStage<>(completionStage, false));
+		return onAssembly(new MonoCompletionStage<>(completionStage));
 	}
 
 	/**
@@ -568,7 +568,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return A {@link Mono}.
 	 */
 	public static <T> Mono<T> fromCompletionStage(Supplier<? extends CompletionStage<? extends T>> stageSupplier) {
-		return defer(() -> onAssembly(new MonoCompletionStage<>(stageSupplier.get(), false)));
+		return defer(() -> onAssembly(new MonoCompletionStage<>(stageSupplier.get())));
 	}
 
 	/**
@@ -644,7 +644,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return A {@link Mono}.
 	 */
 	public static <T> Mono<T> fromFuture(CompletableFuture<? extends T> future, boolean suppressCancel) {
-		return onAssembly(new MonoCompletionStage<>(future, suppressCancel));
+		return onAssembly(suppressCancel ? new MonoCompletableFuture<>(future) : new MonoCompletionStage<>(future));
 	}
 
 	/**
@@ -683,7 +683,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @see #fromCompletionStage(Supplier) fromCompletionStage for a generalization
 	 */
 	public static <T> Mono<T> fromFuture(Supplier<? extends CompletableFuture<? extends T>> futureSupplier, boolean suppressCancel) {
-		return defer(() -> onAssembly(new MonoCompletionStage<>(futureSupplier.get(), suppressCancel)));
+		return defer(() -> onAssembly(suppressCancel ? new MonoCompletableFuture<>(futureSupplier.get()) : new MonoCompletionStage<>(futureSupplier.get())));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCompletableFuture.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCompletableFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,14 @@ import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Future;
+import java.util.function.BiFunction;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
+import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
 /**
@@ -35,19 +38,19 @@ import reactor.util.context.Context;
  *
  * @param <T> the value type
  */
-final class MonoCompletionStage<T> extends Mono<T>
+final class MonoCompletableFuture<T> extends Mono<T>
         implements Fuseable, Scannable {
 
     final CompletionStage<? extends T> future;
 
-    MonoCompletionStage(CompletionStage<? extends T> future) {
+    MonoCompletableFuture(CompletionStage<? extends T> future) {
         this.future = Objects.requireNonNull(future, "future");
     }
 
     @Override
     public void subscribe(CoreSubscriber<? super T> actual) {
-        Operators.MonoSubscriber<T, T>
-                sds = new Operators.MonoSubscriber<>(actual);
+        MonoCompletableFutureSubscription<T> sds
+                = new MonoCompletableFutureSubscription<>(future, actual);
 
         actual.onSubscribe(sds);
 
@@ -55,10 +58,30 @@ final class MonoCompletionStage<T> extends Mono<T>
             return;
         }
 
-        future.handle((v, e) -> {
-            if (sds.isCancelled()) {
+        future.handle(sds);
+    }
+
+    @Override
+    public Object scanUnsafe(Attr key) {
+        if (key == Attr.RUN_STYLE) return Attr.RunStyle.ASYNC;
+        return null;
+    }
+
+    static final class MonoCompletableFutureSubscription<T> extends Operators.MonoSubscriber<T, T> implements
+                                                                                                   BiFunction<T, Throwable, Void> {
+
+        final CompletionStage<? extends T> future;
+
+        public MonoCompletableFutureSubscription(CompletionStage<? extends T> future, CoreSubscriber<? super T> actual) {
+            super(actual);
+            this.future = future;
+        }
+
+        @Override
+        public Void apply(@Nullable T v, @Nullable Throwable e) {
+            if (this.isCancelled()) {
                 //nobody is interested in the Mono anymore, don't risk dropping errors
-                Context ctx = sds.currentContext();
+                Context ctx = this.currentContext();
                 if (e == null || e instanceof CancellationException) {
                     //we discard any potential value and ignore Future cancellations
                     Operators.onDiscard(v, ctx);
@@ -74,29 +97,31 @@ final class MonoCompletionStage<T> extends Mono<T>
             }
             try {
                 if (e instanceof CompletionException) {
-                    actual.onError(e.getCause());
+                    this.actual.onError(e.getCause());
                 }
                 else if (e != null) {
-                    actual.onError(e);
+                    this.actual.onError(e);
                 }
                 else if (v != null) {
-                    sds.complete(v);
+                    this.complete(v);
                 }
                 else {
-                    actual.onComplete();
+                    this.actual.onComplete();
                 }
             }
             catch (Throwable e1) {
-                Operators.onErrorDropped(e1, actual.currentContext());
+                Operators.onErrorDropped(e1, this.actual.currentContext());
                 throw Exceptions.bubble(e1);
             }
             return null;
-        });
-    }
+        }
 
-    @Override
-    public Object scanUnsafe(Attr key) {
-        if (key == Attr.RUN_STYLE) return Attr.RunStyle.ASYNC;
-        return null;
+        @Override
+        public void cancel() {
+            super.cancel();
+            if (this.future instanceof Future) {
+                ((Future<?>) this.future).cancel(true);
+            }
+        }
     }
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCompletionStage.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCompletionStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoCompletionStageTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoCompletionStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
this dedicated implementation ensures that the compiler does not reference the future anyhow during different optimizations so GC can freely deallocate associated the object when CF is terminated

closes #3464 