### PR TITLE
Add thread interrupt state propagate (#3451)

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/BlockingIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/BlockingIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -181,6 +181,7 @@ final class BlockingIterable<T> implements Iterable<T>, Scannable {
 					}
 					catch (InterruptedException ex) {
 						run();
+						Thread.currentThread().interrupt();
 						throw Exceptions.propagate(ex);
 					}
 					finally {

--- a/reactor-core/src/main/java/reactor/core/publisher/BlockingOptionalMonoSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/BlockingOptionalMonoSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,6 +112,8 @@ final class BlockingOptionalMonoSubscriber<T> extends CountDownLatch
 				RuntimeException re = Exceptions.propagate(ex);
 				//this is ok, as re is always a new non-singleton instance
 				re.addSuppressed(new Exception("#blockOptional() has been interrupted"));
+				
+				Thread.currentThread().interrupt();
 				throw re;
 			}
 		}
@@ -151,6 +153,8 @@ final class BlockingOptionalMonoSubscriber<T> extends CountDownLatch
 				RuntimeException re = Exceptions.propagate(ex);
 				//this is ok, as re is always a new non-singleton instance
 				re.addSuppressed(new Exception("#blockOptional(timeout) has been interrupted"));
+				
+				Thread.currentThread().interrupt();
 				throw re;
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/BlockingSingleSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/BlockingSingleSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,6 +88,7 @@ abstract class BlockingSingleSubscriber<T> extends CountDownLatch
 			}
 			catch (InterruptedException ex) {
 				dispose();
+				Thread.currentThread().interrupt();
 				throw Exceptions.propagate(ex);
 			}
 		}
@@ -128,6 +129,7 @@ abstract class BlockingSingleSubscriber<T> extends CountDownLatch
 				RuntimeException re = Exceptions.propagate(ex);
 				//this is ok, as re is always a new non-singleton instance
 				re.addSuppressed(new Exception("#block has been interrupted"));
+				Thread.currentThread().interrupt();
 				throw re;
 			}
 		}

--- a/reactor-core/src/test/java/reactor/core/publisher/BlockingIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BlockingIterableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -233,6 +233,31 @@ public class BlockingIterableTest {
 
 		test.onNext("b");
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).describedAs("after CANCELLED").isTrue();
+	}
+	
+	@Test
+	@Timeout(1)
+	public void hasNextInterrupt() throws InterruptedException {
+		BlockingIterable.SubscriberIterator<String> test = new BlockingIterable.SubscriberIterator<>(
+				Queues.<String>one().get(),
+				123
+		);
+		
+		Thread t = new Thread(() -> {
+			try {
+				test.hasNext();
+			}
+			catch (Exception e) {
+				assertThat(Thread.currentThread().isInterrupted()).as("check thread interrupted").isTrue();
+				assertThat(e)
+						.isInstanceOf(RuntimeException.class)
+						.hasCauseInstanceOf(InterruptedException.class);
+			}
+		});
+		
+		t.start();
+		t.interrupt();
+		t.join();
 	}
 
 	@Test


### PR DESCRIPTION
Fix interrupt state not being propagated when interrupted while thread is in wait state by calling blocking method

Fixes #3451