### PR TITLE
#3487 fixes FluxRefCount onSubscribe race conditions

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
@@ -77,9 +77,9 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 				connect = true;
 				conn.connected = true;
 			}
-		}
 
-		source.subscribe(new RefCountInner<>(actual, conn));
+			source.subscribe(new RefCountInner<>(actual, conn));
+		}
 
 		if (connect) {
 			source.connect(conn);


### PR DESCRIPTION
When many subscribers subscribe from different threads, some of them may get stuck not being able to consume the source Flux, while this does not happen if they subscribe from the single thread.