### PR TITLE
ensures CP is enabled only when ContextFactory is really available

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagationSupport.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagationSupport.java
@@ -33,6 +33,7 @@ final class ContextPropagationSupport {
         boolean contextPropagation = false;
         try {
             Class.forName("io.micrometer.context.ContextRegistry");
+            Class.forName("io.micrometer.context.ContextSnapshotFactory");
             contextPropagation = true;
         } catch (ClassNotFoundException notFound) {
         } catch (LinkageError linkageErr) {


### PR DESCRIPTION
makes sure we set `isContextPropagationOnClasspath` only when the new `ContextSnapshotFactory` is here as well