### PR TITLE
ensures reactor is backward compatible with latest context propagation changes

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ jsr305 = "com.google.code.findbugs:jsr305:3.0.1"
 micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometer" }
 micrometer-commons = { module = "io.micrometer:micrometer-commons" }
 micrometer-core = { module = "io.micrometer:micrometer-core" }
+micrometer-contextPropagation102 = "io.micrometer:context-propagation:1.0.2"
 micrometer-contextPropagation = "io.micrometer:context-propagation:1.0.3"
 micrometer-docsGenerator = { module = "io.micrometer:micrometer-docs-generator", version = "1.0.1"}
 micrometer-observation-test = { module = "io.micrometer:micrometer-observation-test" }

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -47,6 +47,7 @@ testSets {
 	blockHoundTest
 	//TODO once can probably be removed in 3.6.0, but MUST keep the ReactorContextAccessorTest in that case
 	withMicrometerTest
+	withContextPropagation102Test
 	tckTest
 }
 
@@ -123,6 +124,13 @@ dependencies {
 	withMicrometerTestImplementation libs.micrometer.core
 	withMicrometerTestImplementation libs.micrometer.contextPropagation
 	withMicrometerTestImplementation sourceSets.test.output
+
+
+  	withContextPropagation102TestImplementation platform(libs.micrometer.bom)
+    withContextPropagation102TestImplementation libs.micrometer.commons
+  	withContextPropagation102TestImplementation libs.micrometer.core
+  	withContextPropagation102TestImplementation libs.micrometer.contextPropagation102
+  	withContextPropagation102TestImplementation sourceSets.test.output
 
 	jcstressImplementation(project(":reactor-test")) {
 		exclude module: 'reactor-core'
@@ -274,6 +282,7 @@ jcstress {
 // always depend on withMicrometerTest, blockHoundTest and tckTest, skip loops when not releasing
 // note that this way the tasks can be run individually
 check {
+	dependsOn withContextPropagation102Test
 	dependsOn withMicrometerTest
 	dependsOn blockHoundTest
 	dependsOn tckTest

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -17,17 +17,20 @@
 package reactor.core.publisher;
 
 import java.util.AbstractQueue;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Queue;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import io.micrometer.context.ContextAccessor;
 import io.micrometer.context.ContextRegistry;
 import io.micrometer.context.ContextSnapshot;
 
 import io.micrometer.context.ContextSnapshotFactory;
+import io.micrometer.context.ThreadLocalAccessor;
 import reactor.core.observability.SignalListener;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
@@ -41,7 +44,6 @@ import reactor.util.context.ContextView;
  */
 final class ContextPropagation {
 
-	static final Predicate<Object> PREDICATE_TRUE = v -> true;
 	static final Function<Context, Context> NO_OP = c -> c;
 	static final Function<Context, Context> WITH_GLOBAL_REGISTRY_NO_PREDICATE;
 
@@ -51,7 +53,7 @@ final class ContextPropagation {
 		WITH_GLOBAL_REGISTRY_NO_PREDICATE = ContextPropagationSupport.isContextPropagationAvailable() ?
 				new ContextCaptureNoPredicate() : NO_OP;
 
-		if (ContextPropagationSupport.isContextPropagationAvailable()) {
+		if (ContextPropagationSupport.isContextPropagation103Available()) {
 			globalContextSnapshotFactory = ContextSnapshotFactory.builder()
 			                                                     .clearMissing(false)
 			                                                     .build();
@@ -59,17 +61,58 @@ final class ContextPropagation {
 	}
 
 	static void configureContextSnapshotFactory(boolean clearMissing) {
-		globalContextSnapshotFactory =
-				ContextSnapshotFactory.builder().clearMissing(clearMissing).build();
+		if (ContextPropagationSupport.isContextPropagation103OnClasspath) {
+			globalContextSnapshotFactory = ContextSnapshotFactory.builder()
+			                                                     .clearMissing(clearMissing)
+			                                                     .build();
+		}
 	}
 
+	@SuppressWarnings("unchecked")
 	static <C> ContextSnapshot.Scope setThreadLocals(Object context) {
-		return globalContextSnapshotFactory.setThreadLocalsFrom(context);
+		if (ContextPropagationSupport.isContextPropagation103OnClasspath) {
+			return globalContextSnapshotFactory.setThreadLocalsFrom(context);
+		}
+		else {
+			ContextRegistry registry = ContextRegistry.getInstance();
+			ContextAccessor<?, ?> contextAccessor = registry.getContextAccessorForRead(context);
+			Map<Object, Object> previousValues = null;
+			for (ThreadLocalAccessor<?> threadLocalAccessor : registry.getThreadLocalAccessors()) {
+				Object key = threadLocalAccessor.key();
+				Object value = ((ContextAccessor<C, ?>) contextAccessor).readValue((C) context, key);
+				previousValues = setThreadLocal(key, value, threadLocalAccessor, previousValues);
+			}
+			return ReactorScopeImpl.from(previousValues, registry);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <V> Map<Object, Object> setThreadLocal(Object key, @Nullable V value,
+			ThreadLocalAccessor<?> accessor, @Nullable Map<Object, Object> previousValues) {
+
+		previousValues = (previousValues != null ? previousValues : new HashMap<>());
+		previousValues.put(key, accessor.getValue());
+		if (value != null) {
+			((ThreadLocalAccessor<V>) accessor).setValue(value);
+		}
+		else {
+			accessor.reset();
+		}
+		return previousValues;
+	}
+
+	static ContextSnapshot captureThreadLocals() {
+		if (ContextPropagationSupport.isContextPropagation103OnClasspath) {
+			return globalContextSnapshotFactory.captureAll();
+		}
+		else {
+			return ContextSnapshot.captureAll();
+		}
 	}
 
 	public static Function<Runnable, Runnable> scopePassingOnScheduleHook() {
 		return delegate -> {
-			ContextSnapshot contextSnapshot = globalContextSnapshotFactory.captureAll();
+			ContextSnapshot contextSnapshot = captureThreadLocals();
 			return contextSnapshot.wrap(delegate);
 		};
 	}
@@ -111,7 +154,7 @@ final class ContextPropagation {
 				return handler;
 			}
 			return (v, sink) -> {
-				try (ContextSnapshot.Scope ignored = globalContextSnapshotFactory.setThreadLocalsFrom(ctx)) {
+				try (ContextSnapshot.Scope ignored = setThreadLocals(ctx)) {
 					handler.accept(v, sink);
 				}
 			};
@@ -144,137 +187,157 @@ final class ContextPropagation {
 		if (ctx.isEmpty()) {
 			return original;
 		}
-		return new ContextRestoreSignalListener<T>(original, ctx, globalContextSnapshotFactory);
+
+		if (ContextPropagationSupport.isContextPropagation103OnClasspath) {
+			return new ContextRestore103SignalListener<>(original, ctx, globalContextSnapshotFactory);
+		}
+		else {
+			return new ContextRestoreSignalListener<>(original, ctx);
+		}
 	}
 
 	//the SignalListener implementation can be tested independently with a test-specific ContextRegistry
-	static final class ContextRestoreSignalListener<T> implements SignalListener<T> {
+	static class ContextRestoreSignalListener<T> implements SignalListener<T> {
 
 		final SignalListener<T> original;
 		final ContextView context;
-		final ContextSnapshotFactory contextSnapshotFactory;
 
 		public ContextRestoreSignalListener(SignalListener<T> original,
-				ContextView context, ContextSnapshotFactory contextSnapshotFactory) {
+				ContextView context) {
 			this.original = original;
 			this.context = context;
-			this.contextSnapshotFactory = contextSnapshotFactory;
 		}
 
 		ContextSnapshot.Scope restoreThreadLocals() {
-			return contextSnapshotFactory.setThreadLocalsFrom(this.context);
+			return setThreadLocals(this.context);
 		}
 
 		@Override
-		public void doFirst() throws Throwable {
+		public final void doFirst() throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doFirst();
 			}
 		}
 
 		@Override
-		public void doFinally(SignalType terminationType) throws Throwable {
+		public final void doFinally(SignalType terminationType) throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doFinally(terminationType);
 			}
 		}
 
 		@Override
-		public void doOnSubscription() throws Throwable {
+		public final void doOnSubscription() throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnSubscription();
 			}
 		}
 
 		@Override
-		public void doOnFusion(int negotiatedFusion) throws Throwable {
+		public final void doOnFusion(int negotiatedFusion) throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnFusion(negotiatedFusion);
 			}
 		}
 
 		@Override
-		public void doOnRequest(long requested) throws Throwable {
+		public final void doOnRequest(long requested) throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnRequest(requested);
 			}
 		}
 
 		@Override
-		public void doOnCancel() throws Throwable {
+		public final void doOnCancel() throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnCancel();
 			}
 		}
 
 		@Override
-		public void doOnNext(T value) throws Throwable {
+		public final void doOnNext(T value) throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnNext(value);
 			}
 		}
 
 		@Override
-		public void doOnComplete() throws Throwable {
+		public final void doOnComplete() throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnComplete();
 			}
 		}
 
 		@Override
-		public void doOnError(Throwable error) throws Throwable {
+		public final void doOnError(Throwable error) throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnError(error);
 			}
 		}
 
 		@Override
-		public void doAfterComplete() throws Throwable {
+		public final void doAfterComplete() throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doAfterComplete();
 			}
 		}
 
 		@Override
-		public void doAfterError(Throwable error) throws Throwable {
+		public final void doAfterError(Throwable error) throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doAfterError(error);
 			}
 		}
 
 		@Override
-		public void doOnMalformedOnNext(T value) throws Throwable {
+		public final void doOnMalformedOnNext(T value) throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnMalformedOnNext(value);
 			}
 		}
 
 		@Override
-		public void doOnMalformedOnError(Throwable error) throws Throwable {
+		public final void doOnMalformedOnError(Throwable error) throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnMalformedOnError(error);
 			}
 		}
 
 		@Override
-		public void doOnMalformedOnComplete() throws Throwable {
+		public final void doOnMalformedOnComplete() throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnMalformedOnComplete();
 			}
 		}
 
 		@Override
-		public void handleListenerError(Throwable listenerError) {
+		public final void handleListenerError(Throwable listenerError) {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.handleListenerError(listenerError);
 			}
 		}
 
 		@Override
-		public Context addToContext(Context originalContext) {
+		public final Context addToContext(Context originalContext) {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				return original.addToContext(originalContext);
 			}
+		}
+	}
+
+	//the SignalListener implementation can be tested independently with a test-specific ContextRegistry
+	static final class ContextRestore103SignalListener<T> extends ContextRestoreSignalListener<T> {
+
+		final ContextSnapshotFactory contextSnapshotFactory;
+
+		public ContextRestore103SignalListener(SignalListener<T> original,
+				ContextView context, ContextSnapshotFactory contextSnapshotFactory) {
+			super(original, context);
+			this.contextSnapshotFactory = contextSnapshotFactory;
+		}
+
+		ContextSnapshot.Scope restoreThreadLocals() {
+			return contextSnapshotFactory.setThreadLocalsFrom(this.context);
 		}
 	}
 
@@ -282,7 +345,7 @@ final class ContextPropagation {
 
 		@Override
 		public Context apply(Context context) {
-			return globalContextSnapshotFactory.captureAll().updateContext(context);
+			return captureThreadLocals().updateContext(context);
 		}
 	}
 
@@ -312,7 +375,7 @@ final class ContextPropagation {
 
 		@Override
 		public boolean offer(T o) {
-			ContextSnapshot contextSnapshot = globalContextSnapshotFactory.captureAll();
+			ContextSnapshot contextSnapshot = captureThreadLocals();
 			return envelopeQueue.offer(new Envelope<>(o, contextSnapshot));
 		}
 
@@ -339,7 +402,7 @@ final class ContextPropagation {
 		private void restoreTheContext(Envelope<T> envelope) {
 			ContextSnapshot contextSnapshot = envelope.contextSnapshot;
 			// tries to read existing Thread for existing ThreadLocals
-			ContextSnapshot currentContextSnapshot = globalContextSnapshotFactory.captureAll();
+			ContextSnapshot currentContextSnapshot = captureThreadLocals();
 			if (!contextSnapshot.equals(currentContextSnapshot)) {
 				if (!hasPrevious || !Thread.currentThread().equals(this.lastReader)) {
 					// means context was restored form the envelope,
@@ -378,6 +441,45 @@ final class ContextPropagation {
 		Envelope(T body, ContextSnapshot contextSnapshot) {
 			this.body = body;
 			this.contextSnapshot = contextSnapshot;
+		}
+	}
+
+	private static class ReactorScopeImpl implements ContextSnapshot.Scope {
+
+
+		private final Map<Object, Object> previousValues;
+
+		private final ContextRegistry contextRegistry;
+
+		private ReactorScopeImpl(Map<Object, Object> previousValues,
+				ContextRegistry contextRegistry) {
+			this.previousValues = previousValues;
+			this.contextRegistry = contextRegistry;
+		}
+
+		@Override
+		public void close() {
+			for (ThreadLocalAccessor<?> accessor : this.contextRegistry.getThreadLocalAccessors()) {
+				if (this.previousValues.containsKey(accessor.key())) {
+					Object previousValue = this.previousValues.get(accessor.key());
+					resetThreadLocalValue(accessor, previousValue);
+				}
+			}
+		}
+
+		@SuppressWarnings("unchecked")
+		private <V> void resetThreadLocalValue(ThreadLocalAccessor<?> accessor, @Nullable V previousValue) {
+			if (previousValue != null) {
+				((ThreadLocalAccessor<V>) accessor).restore(previousValue);
+			}
+			else {
+				accessor.reset();
+			}
+		}
+
+		public static ContextSnapshot.Scope from(@Nullable Map<Object, Object> previousValues, ContextRegistry registry) {
+			return (previousValues != null ? new ReactorScopeImpl(previousValues, registry) : () -> {
+			});
 		}
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagationSupport.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagationSupport.java
@@ -27,14 +27,17 @@ final class ContextPropagationSupport {
     // The field should end with 'Available'. See org.springframework.aot.nativex.feature.PreComputeFieldFeature.
     // Ultimately the long term solution should be provided by Reactor Core.
     static final boolean isContextPropagationOnClasspath;
-    static boolean propagateContextToThreadLocals = false;
+    static final boolean isContextPropagation103OnClasspath;
+    static boolean       propagateContextToThreadLocals = false;
 
     static {
         boolean contextPropagation = false;
+        boolean contextPropagation103 = false;
         try {
             Class.forName("io.micrometer.context.ContextRegistry");
-            Class.forName("io.micrometer.context.ContextSnapshotFactory");
             contextPropagation = true;
+            Class.forName("io.micrometer.context.ContextSnapshotFactory");
+            contextPropagation103 = true;
         } catch (ClassNotFoundException notFound) {
         } catch (LinkageError linkageErr) {
         } catch (Throwable err) {
@@ -42,6 +45,7 @@ final class ContextPropagationSupport {
                     " The feature is considered disabled due to this:", err);
         }
         isContextPropagationOnClasspath = contextPropagation;
+        isContextPropagation103OnClasspath = contextPropagation103;
     }
 
     /**
@@ -51,6 +55,10 @@ final class ContextPropagationSupport {
      */
     static boolean isContextPropagationAvailable() {
         return isContextPropagationOnClasspath;
+    }
+
+    static boolean isContextPropagation103Available() {
+        return isContextPropagation103OnClasspath;
     }
 
     static boolean shouldPropagateContextToThreadLocals() {

--- a/reactor-core/src/withContextPropagation102Test/java/reactor/core/publisher/ContextPropagationTest.java
+++ b/reactor-core/src/withContextPropagation102Test/java/reactor/core/publisher/ContextPropagationTest.java
@@ -36,7 +36,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import io.micrometer.context.ContextRegistry;
-import io.micrometer.context.ContextSnapshotFactory;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -197,6 +196,7 @@ class ContextPropagationTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	void contextCapturePropagatedAutomaticallyToAllSignals() throws InterruptedException {
 		Hooks.enableAutomaticContextPropagation();
 
@@ -672,7 +672,7 @@ class ContextPropagationTest {
 						if (characteristics.withContext) {
 							assertThat(tapSubscriber.listener).as("listener wrapped")
 								.isNotSameAs(originalListener)
-								.isInstanceOf(ContextPropagation.ContextRestore103SignalListener.class);
+								.isExactlyInstanceOf(ContextPropagation.ContextRestoreSignalListener.class);
 						}
 						else {
 							assertThat(tapSubscriber.listener)
@@ -688,7 +688,7 @@ class ContextPropagationTest {
 							assertThat(tapSubscriber.listener)
 								.as("listener wrapped")
 								.isNotSameAs(originalListener)
-								.isInstanceOf(ContextPropagation.ContextRestore103SignalListener.class);
+								.isExactlyInstanceOf(ContextPropagation.ContextRestoreSignalListener.class);
 						}
 						else {
 							assertThat(tapSubscriber.listener)
@@ -749,7 +749,7 @@ class ContextPropagationTest {
 							assertThat(tapSubscriber.listener)
 								.as("listener wrapped")
 								.isNotSameAs(originalListener)
-								.isInstanceOf(ContextPropagation.ContextRestore103SignalListener.class);
+								.isExactlyInstanceOf(ContextPropagation.ContextRestoreSignalListener.class);
 
 						}
 						else {
@@ -764,7 +764,7 @@ class ContextPropagationTest {
 							assertThat(tapSubscriber.listener)
 								.as("listener wrapped")
 								.isNotSameAs(originalListener)
-								.isInstanceOf(ContextPropagation.ContextRestore103SignalListener.class);
+								.isExactlyInstanceOf(ContextPropagation.ContextRestoreSignalListener.class);
 						}
 						else {
 							assertThat(tapSubscriber.listener).as("listener not wrapped").isSameAs(originalListener);
@@ -784,12 +784,8 @@ class ContextPropagationTest {
 				return null;
 			});
 
-			ContextPropagation.ContextRestore103SignalListener<Object> listener =
-				new ContextPropagation.ContextRestore103SignalListener<>(
-						tlReadingListener, context,
-						ContextSnapshotFactory.builder()
-						                      .contextRegistry(ContextRegistry.getInstance())
-						                      .build());
+			ContextPropagation.ContextRestoreSignalListener<Object> listener =
+				new ContextPropagation.ContextRestoreSignalListener<>(tlReadingListener, context);
 
 			Thread t = new Thread(() -> {
 				try {


### PR DESCRIPTION
this PR incorporates old changes with the new ones so it makes the reactor backward compatible with context-propagation libs <= 1.0.2