### PR TITLE
removes queue-wrapping from acp

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
@@ -542,7 +542,6 @@ public abstract class Hooks {
 	 */
 	public static void enableAutomaticContextPropagation() {
 		if (ContextPropagationSupport.isContextPropagationOnClasspath) {
-			Hooks.addQueueWrapper(CONTEXT_IN_THREAD_LOCALS_KEY, ContextPropagation.ContextQueue::new);
 			Schedulers.onScheduleHook(CONTEXT_IN_THREAD_LOCALS_KEY,
 					ContextPropagation.scopePassingOnScheduleHook());
 			ContextPropagationSupport.propagateContextToThreadLocals = true;

--- a/reactor-core/src/withContextPropagation102Test/java/reactor/core/publisher/ContextPropagationTest.java
+++ b/reactor-core/src/withContextPropagation102Test/java/reactor/core/publisher/ContextPropagationTest.java
@@ -40,6 +40,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -164,6 +165,7 @@ class ContextPropagationTest {
 	}
 
 	@Test
+	@Disabled("queue wrapping is removed starting from 3.5.7")
 	void threadLocalsRestoredAfterPollution() {
 		// this test validates Queue wrapping takes place
 		Hooks.enableAutomaticContextPropagation();
@@ -285,6 +287,7 @@ class ContextPropagationTest {
 	}
 
 	@Test
+	@Disabled("queue wrapping is removed starting from 3.5.7")
 	void queueWrapperWorksWithQueues() {
 		Hooks.enableAutomaticContextPropagation();
 		Queue<Object> queue = Queues.small()

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
@@ -41,6 +41,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -165,6 +166,7 @@ class ContextPropagationTest {
 	}
 
 	@Test
+	@Disabled("queue wrapping is removed starting from 3.5.7")
 	void threadLocalsRestoredAfterPollution() {
 		// this test validates Queue wrapping takes place
 		Hooks.enableAutomaticContextPropagation();
@@ -285,6 +287,7 @@ class ContextPropagationTest {
 	}
 
 	@Test
+	@Disabled("queue wrapping is removed starting from 3.5.7")
 	void queueWrapperWorksWithQueues() {
 		Hooks.enableAutomaticContextPropagation();
 		Queue<Object> queue = Queues.small()


### PR DESCRIPTION
Existing Queue wrapping mechanism leaks TLA.Scope unclosed which may causes memory leak (e.g. in case of micrometer-observability). Removing QueueWrapping from the automaticContextPropagation is non-harmful since the current design is not supposing propagation of the ThreadLocals from the upstream (along with values) to the downstream.