### PR TITLE
enforces ordering on concurrent subscription to `FluxRefCount`

### DIFF
--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
@@ -171,6 +171,70 @@ public abstract class FluxPublishStressTest {
 	}
 
 	@JCStressTest
+	@Outcome(id = {"0, 0, 0, 0, 1, 1"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
+	@State
+	public static class RefCntConcurrentSubscriptionErrorAsyncStressTest extends
+	                                                                     RefCntConcurrentSubscriptionBaseStressTest<Object> {
+
+		static final Throwable testError = new RuntimeException("boom");
+
+		public RefCntConcurrentSubscriptionErrorAsyncStressTest() {
+			super(Flux.error(testError).publishOn(Schedulers.immediate()), null);
+		}
+
+		@Actor
+		public void subscribe1() {
+			sharedSource.subscribe(subscriber1);
+		}
+		@Actor
+		public void subscribe2() {
+			sharedSource.subscribe(subscriber2);
+		}
+
+		@Arbiter
+		public void arbiter(IIIIII_Result r) {
+			r.r1 = subscriber1.onNextCalls.get();
+			r.r2 = subscriber2.onNextCalls.get();
+			r.r3 = subscriber1.onCompleteCalls.get();
+			r.r4 = subscriber2.onCompleteCalls.get();
+			r.r5 = subscriber1.onErrorCalls.get();
+			r.r6 = subscriber2.onErrorCalls.get();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"0, 0, 0, 0, 1, 1"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
+	@State
+	public static class RefCntConcurrentSubscriptionErrorNoneStressTest extends
+	                                                                    RefCntConcurrentSubscriptionBaseStressTest<Object> {
+
+		static final Throwable testError = new RuntimeException("boom");
+
+		public RefCntConcurrentSubscriptionErrorNoneStressTest() {
+			super(Flux.error(testError).hide(), null);
+		}
+
+		@Actor
+		public void subscribe1() {
+			sharedSource.subscribe(subscriber1);
+		}
+		@Actor
+		public void subscribe2() {
+			sharedSource.subscribe(subscriber2);
+		}
+
+		@Arbiter
+		public void arbiter(IIIIII_Result r) {
+			r.r1 = subscriber1.onNextCalls.get();
+			r.r2 = subscriber2.onNextCalls.get();
+			r.r3 = subscriber1.onCompleteCalls.get();
+			r.r4 = subscriber2.onCompleteCalls.get();
+			r.r5 = subscriber1.onErrorCalls.get();
+			r.r6 = subscriber2.onErrorCalls.get();
+		}
+	}
+
+	@JCStressTest
 	@Outcome(id = {"10, 10, 1, 1, 0, 0"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
 	@State
 	public static class RefCntGraceConcurrentSubscriptionRangeAsyncFusionStressTest extends

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
@@ -1,0 +1,45 @@
+package reactor.core.publisher;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.IIIIII_Result;
+import org.openjdk.jcstress.infra.results.III_Result;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+
+public abstract class FluxPublishStressTest {
+
+	@JCStressTest
+	@Outcome(id = {"10, 10, 1, 1, 0, 0"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
+	@State
+	public static class ConcurrentSubscriptionStressTest {
+
+		final Flux<Integer> sharedSource = Flux.range(0, 10).hide().publish().refCount(2);
+
+		final StressSubscriber<Integer> subscriber1 = new StressSubscriber<>();
+		final StressSubscriber<Integer> subscriber2 = new StressSubscriber<>();
+
+		@Actor
+		public void subscribe1() {
+			sharedSource.subscribe(subscriber1);
+		}
+		@Actor
+		public void subscribe2() {
+			sharedSource.subscribe(subscriber2);
+		}
+
+		@Actor
+		@Arbiter
+		public void arbiter(IIIIII_Result r) {
+			r.r1 = subscriber1.onNextCalls.get();
+			r.r2 = subscriber2.onNextCalls.get();
+			r.r3 = subscriber1.onCompleteCalls.get();
+			r.r4 = subscriber2.onCompleteCalls.get();
+			r.r5 = subscriber1.onErrorCalls.get();
+			r.r6 = subscriber2.onErrorCalls.get();
+		}
+	}
+}

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
@@ -1,4 +1,22 @@
+/*
+ * Copyright (c) 2023 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
+
+import java.time.Duration;
 
 import org.openjdk.jcstress.annotations.Actor;
 import org.openjdk.jcstress.annotations.Arbiter;
@@ -6,21 +24,41 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.IIIIII_Result;
-import org.openjdk.jcstress.infra.results.III_Result;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.annotation.Nullable;
 
 import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
 
 public abstract class FluxPublishStressTest {
 
+	public abstract static class RefCntConcurrentSubscriptionBaseStressTest<T> {
+
+		final Flux<T> sharedSource;
+
+		final StressSubscriber<T> subscriber1 = new StressSubscriber<>();
+		final StressSubscriber<T> subscriber2 = new StressSubscriber<>();
+
+		public RefCntConcurrentSubscriptionBaseStressTest(Flux<T> sourceToShare, @Nullable Duration duration) {
+			if (duration == null) {
+				this.sharedSource = sourceToShare.publish()
+				                                 .refCount(2);
+			}
+			else {
+				this.sharedSource = sourceToShare.publish()
+				                                 .refCount(2, duration);
+			}
+		}
+	}
+
 	@JCStressTest
 	@Outcome(id = {"10, 10, 1, 1, 0, 0"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
 	@State
-	public static class ConcurrentSubscriptionStressTest {
+	public static class RefCntConcurrentSubscriptionRangeAsyncFusionStressTest extends
+	                                                                           RefCntConcurrentSubscriptionBaseStressTest<Integer> {
 
-		final Flux<Integer> sharedSource = Flux.range(0, 10).hide().publish().refCount(2);
-
-		final StressSubscriber<Integer> subscriber1 = new StressSubscriber<>();
-		final StressSubscriber<Integer> subscriber2 = new StressSubscriber<>();
+		public RefCntConcurrentSubscriptionRangeAsyncFusionStressTest() {
+			super(Flux.range(0, 10).publishOn(Schedulers.immediate()), null);
+		}
 
 		@Actor
 		public void subscribe1() {
@@ -31,7 +69,216 @@ public abstract class FluxPublishStressTest {
 			sharedSource.subscribe(subscriber2);
 		}
 
+		@Arbiter
+		public void arbiter(IIIIII_Result r) {
+			r.r1 = subscriber1.onNextCalls.get();
+			r.r2 = subscriber2.onNextCalls.get();
+			r.r3 = subscriber1.onCompleteCalls.get();
+			r.r4 = subscriber2.onCompleteCalls.get();
+			r.r5 = subscriber1.onErrorCalls.get();
+			r.r6 = subscriber2.onErrorCalls.get();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"10, 10, 1, 1, 0, 0"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
+	@State
+	public static class RefCntConcurrentSubscriptionRangeNoneFusionStressTest extends
+	                                                                          RefCntConcurrentSubscriptionBaseStressTest<Integer> {
+
+		public RefCntConcurrentSubscriptionRangeNoneFusionStressTest() {
+			super(Flux.range(0, 10).hide(), null);
+		}
+
 		@Actor
+		public void subscribe1() {
+			sharedSource.subscribe(subscriber1);
+		}
+		@Actor
+		public void subscribe2() {
+			sharedSource.subscribe(subscriber2);
+		}
+
+		@Arbiter
+		public void arbiter(IIIIII_Result r) {
+			r.r1 = subscriber1.onNextCalls.get();
+			r.r2 = subscriber2.onNextCalls.get();
+			r.r3 = subscriber1.onCompleteCalls.get();
+			r.r4 = subscriber2.onCompleteCalls.get();
+			r.r5 = subscriber1.onErrorCalls.get();
+			r.r6 = subscriber2.onErrorCalls.get();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"0, 0, 1, 1, 0, 0"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
+	@State
+	public static class RefCntConcurrentSubscriptionEmptyAsyncStressTest extends
+	                                                                     RefCntConcurrentSubscriptionBaseStressTest<Object> {
+
+		public RefCntConcurrentSubscriptionEmptyAsyncStressTest() {
+			super(Flux.empty().publishOn(Schedulers.immediate()), null);
+		}
+
+		@Actor
+		public void subscribe1() {
+			sharedSource.subscribe(subscriber1);
+		}
+		@Actor
+		public void subscribe2() {
+			sharedSource.subscribe(subscriber2);
+		}
+
+		@Arbiter
+		public void arbiter(IIIIII_Result r) {
+			r.r1 = subscriber1.onNextCalls.get();
+			r.r2 = subscriber2.onNextCalls.get();
+			r.r3 = subscriber1.onCompleteCalls.get();
+			r.r4 = subscriber2.onCompleteCalls.get();
+			r.r5 = subscriber1.onErrorCalls.get();
+			r.r6 = subscriber2.onErrorCalls.get();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"0, 0, 1, 1, 0, 0"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
+	@State
+	public static class RefCntConcurrentSubscriptionEmptyNoneStressTest extends
+	                                                                    RefCntConcurrentSubscriptionBaseStressTest<Object> {
+
+		public RefCntConcurrentSubscriptionEmptyNoneStressTest() {
+			super(Flux.empty().hide(), null);
+		}
+
+		@Actor
+		public void subscribe1() {
+			sharedSource.subscribe(subscriber1);
+		}
+		@Actor
+		public void subscribe2() {
+			sharedSource.subscribe(subscriber2);
+		}
+
+		@Arbiter
+		public void arbiter(IIIIII_Result r) {
+			r.r1 = subscriber1.onNextCalls.get();
+			r.r2 = subscriber2.onNextCalls.get();
+			r.r3 = subscriber1.onCompleteCalls.get();
+			r.r4 = subscriber2.onCompleteCalls.get();
+			r.r5 = subscriber1.onErrorCalls.get();
+			r.r6 = subscriber2.onErrorCalls.get();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"10, 10, 1, 1, 0, 0"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
+	@State
+	public static class RefCntGraceConcurrentSubscriptionRangeAsyncFusionStressTest extends
+	                                                                                RefCntConcurrentSubscriptionBaseStressTest<Integer> {
+
+		public RefCntGraceConcurrentSubscriptionRangeAsyncFusionStressTest() {
+			super(Flux.range(0, 10).publishOn(Schedulers.immediate()), Duration.ofSeconds(1));
+		}
+
+		@Actor
+		public void subscribe1() {
+			sharedSource.subscribe(subscriber1);
+		}
+		@Actor
+		public void subscribe2() {
+			sharedSource.subscribe(subscriber2);
+		}
+
+		@Arbiter
+		public void arbiter(IIIIII_Result r) {
+			r.r1 = subscriber1.onNextCalls.get();
+			r.r2 = subscriber2.onNextCalls.get();
+			r.r3 = subscriber1.onCompleteCalls.get();
+			r.r4 = subscriber2.onCompleteCalls.get();
+			r.r5 = subscriber1.onErrorCalls.get();
+			r.r6 = subscriber2.onErrorCalls.get();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"10, 10, 1, 1, 0, 0"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
+	@State
+	public static class RefCntGraceConcurrentSubscriptionRangeNoneFusionStressTest extends
+	                                                                    RefCntConcurrentSubscriptionBaseStressTest<Integer> {
+
+		public RefCntGraceConcurrentSubscriptionRangeNoneFusionStressTest() {
+			super(Flux.range(0, 10).hide(), Duration.ofSeconds(1));
+		}
+
+		@Actor
+		public void subscribe1() {
+			sharedSource.subscribe(subscriber1);
+		}
+		@Actor
+		public void subscribe2() {
+			sharedSource.subscribe(subscriber2);
+		}
+
+		@Arbiter
+		public void arbiter(IIIIII_Result r) {
+			r.r1 = subscriber1.onNextCalls.get();
+			r.r2 = subscriber2.onNextCalls.get();
+			r.r3 = subscriber1.onCompleteCalls.get();
+			r.r4 = subscriber2.onCompleteCalls.get();
+			r.r5 = subscriber1.onErrorCalls.get();
+			r.r6 = subscriber2.onErrorCalls.get();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"0, 0, 1, 1, 0, 0"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
+	@State
+	public static class RefCntGraceConcurrentSubscriptionEmptyAsyncStressTest extends
+	                                                               RefCntConcurrentSubscriptionBaseStressTest<Object> {
+
+		public RefCntGraceConcurrentSubscriptionEmptyAsyncStressTest() {
+			super(Flux.empty().publishOn(Schedulers.immediate()), Duration.ofSeconds(1));
+		}
+
+		@Actor
+		public void subscribe1() {
+			sharedSource.subscribe(subscriber1);
+		}
+		@Actor
+		public void subscribe2() {
+			sharedSource.subscribe(subscriber2);
+		}
+
+		@Arbiter
+		public void arbiter(IIIIII_Result r) {
+			r.r1 = subscriber1.onNextCalls.get();
+			r.r2 = subscriber2.onNextCalls.get();
+			r.r3 = subscriber1.onCompleteCalls.get();
+			r.r4 = subscriber2.onCompleteCalls.get();
+			r.r5 = subscriber1.onErrorCalls.get();
+			r.r6 = subscriber2.onErrorCalls.get();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"0, 0, 1, 1, 0, 0"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
+	@State
+	public static class RefCntGraceConcurrentSubscriptionEmptyNoneStressTest extends
+	                                                              RefCntConcurrentSubscriptionBaseStressTest<Object> {
+
+		public RefCntGraceConcurrentSubscriptionEmptyNoneStressTest() {
+			super(Flux.empty().hide(), Duration.ofSeconds(1));
+		}
+
+		@Actor
+		public void subscribe1() {
+			sharedSource.subscribe(subscriber1);
+		}
+		@Actor
+		public void subscribe2() {
+			sharedSource.subscribe(subscriber2);
+		}
+
 		@Arbiter
 		public void arbiter(IIIIII_Result r) {
 			r.r1 = subscriber1.onNextCalls.get();

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,9 +170,17 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 		Subscription s;
 		QueueSubscription<T> qs;
 
-		volatile     int parentDone; //used to guard against doubly terminating subscribers (eg. double cancel)
-		static final AtomicIntegerFieldUpdater<RefCountInner> PARENT_DONE =
-				AtomicIntegerFieldUpdater.newUpdater(RefCountInner.class, "parentDone");
+		Throwable error;
+
+
+		static final int MONITOR_SET_FLAG = 0b0010_0000_0000_0000_0000_0000_0000_0000;
+		static final int TERMINATED_FLAG  = 0b0100_0000_0000_0000_0000_0000_0000_0000;
+		static final int CANCELLED_FLAG   = 0b1000_0000_0000_0000_0000_0000_0000_0000;
+
+		volatile int state; //used to guard against doubly terminating subscribers (e.g. double cancel)
+		@SuppressWarnings("rawtypes")
+		static final AtomicIntegerFieldUpdater<RefCountInner> STATE =
+				AtomicIntegerFieldUpdater.newUpdater(RefCountInner.class, "state");
 
 		RefCountInner(CoreSubscriber<? super T> actual) {
 			this.actual = actual;
@@ -182,8 +190,8 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 		@Nullable
 		public Object scanUnsafe(Attr key) {
 			if (key == Attr.PARENT) return s;
-			if (key == Attr.TERMINATED) return parentDone == 1;
-			if (key == Attr.CANCELLED) return parentDone == 2;
+			if (key == Attr.TERMINATED) return isTerminated(state);
+			if (key == Attr.CANCELLED) return isCancelled(state);
 			if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
 
 			return InnerOperator.super.scanUnsafe(key);
@@ -199,6 +207,30 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 		void setRefCountMonitor(RefCountMonitor<T> connection) {
 			this.connection = connection;
 			this.actual.onSubscribe(this);
+
+			for (;;) {
+				int previousState = this.state;
+
+				if (isCancelled(previousState)) {
+					return;
+				}
+
+				if (isTerminated(previousState)) {
+					connection.upstreamFinished();
+					Throwable e = this.error;
+					if (e != null) {
+						this.actual.onError(e);
+					}
+					else {
+						this.actual.onComplete();
+					}
+					return;
+				}
+
+				if (STATE.compareAndSet(this, previousState, previousState | MONITOR_SET_FLAG)) {
+					return;
+				}
+			}
 		}
 
 		@Override
@@ -208,20 +240,41 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 
 		@Override
 		public void onError(Throwable t) {
-			if (PARENT_DONE.compareAndSet(this, 0, 1)) {
-				connection.upstreamFinished();
-				actual.onError(t);
-			}
-			else {
-				Operators.onErrorDropped(t, actual.currentContext());
+			this.error = t;
+			for (;;) {
+				int previousState = this.state;
+
+				if (isTerminated(previousState) || isCancelled(previousState)) {
+					Operators.onErrorDropped(t, actual.currentContext());
+					return;
+				}
+
+				if (STATE.compareAndSet(this, previousState, previousState | TERMINATED_FLAG)) {
+					if (isMonitorSet(previousState)) {
+						connection.upstreamFinished();
+						actual.onError(t);
+					}
+					return;
+				}
 			}
 		}
 
 		@Override
 		public void onComplete() {
-			if (PARENT_DONE.compareAndSet(this, 0, 1)) {
-				connection.upstreamFinished();
-				actual.onComplete();
+			for (;;) {
+				int previousState = this.state;
+
+				if (isTerminated(previousState) || isCancelled(previousState)) {
+					return;
+				}
+
+				if (STATE.compareAndSet(this, previousState, previousState | TERMINATED_FLAG)) {
+					if (isMonitorSet(previousState)) {
+						connection.upstreamFinished();
+						actual.onComplete();
+					}
+					return;
+				}
 			}
 		}
 
@@ -233,7 +286,14 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 		@Override
 		public void cancel() {
 			s.cancel();
-			if (PARENT_DONE.compareAndSet(this, 0, 2)) {
+
+			int previousState = this.state;
+
+			if (isTerminated(previousState) || isCancelled(previousState)) {
+				return;
+			}
+
+			if (STATE.compareAndSet(this, previousState, previousState | CANCELLED_FLAG)) {
 				connection.innerCancelled();
 			}
 		}
@@ -272,6 +332,19 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 		@Override
 		public void clear() {
 			qs.clear();
+		}
+
+
+		static boolean isTerminated(int state) {
+			return (state & TERMINATED_FLAG) == TERMINATED_FLAG;
+		}
+
+		static boolean isCancelled(int state) {
+			return (state & CANCELLED_FLAG) == CANCELLED_FLAG;
+		}
+
+		static boolean isMonitorSet(int state) {
+			return (state & MONITOR_SET_FLAG) == MONITOR_SET_FLAG;
 		}
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
@@ -177,7 +177,7 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 		static final int TERMINATED_FLAG  = 0b0100_0000_0000_0000_0000_0000_0000_0000;
 		static final int CANCELLED_FLAG   = 0b1000_0000_0000_0000_0000_0000_0000_0000;
 
-		volatile int state; //used to guard against doubly terminating subscribers (e.g. double cancel)
+		volatile int state;
 		@SuppressWarnings("rawtypes")
 		static final AtomicIntegerFieldUpdater<RefCountInner> STATE =
 				AtomicIntegerFieldUpdater.newUpdater(RefCountInner.class, "state");

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,9 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 	@Override
 	public void subscribe(CoreSubscriber<? super T> actual) {
 		RefConnection conn;
+		RefCountInner<T> inner = new RefCountInner<>(actual, this);
+
+		source.subscribe(inner);
 
 		boolean connect = false;
 		synchronized (this) {
@@ -91,7 +94,7 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 			}
 		}
 
-		source.subscribe(new RefCountInner<>(actual, this, conn));
+		inner.setRefConnection(connection);
 
 		if (connect) {
 			source.connect(conn);
@@ -196,20 +199,55 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 
 		final FluxRefCountGrace<T> parent;
 
-		final RefConnection connection;
+		RefConnection connection;
 
 		Subscription s;
 		QueueSubscription<T> qs;
 
-		volatile int parentDone;
-		static final AtomicIntegerFieldUpdater<RefCountInner> PARENT_DONE =
-				AtomicIntegerFieldUpdater.newUpdater(RefCountInner.class, "parentDone");
+		Throwable error;
 
-		RefCountInner(CoreSubscriber<? super T> actual, FluxRefCountGrace<T> parent,
-				RefConnection connection) {
+
+		static final int MONITOR_SET_FLAG = 0b0010_0000_0000_0000_0000_0000_0000_0000;
+		static final int TERMINATED_FLAG  = 0b0100_0000_0000_0000_0000_0000_0000_0000;
+		static final int CANCELLED_FLAG   = 0b1000_0000_0000_0000_0000_0000_0000_0000;
+
+		volatile int state; //used to guard against doubly terminating subscribers (e.g. double cancel)
+		@SuppressWarnings("rawtypes")
+		static final AtomicIntegerFieldUpdater<RefCountInner> STATE =
+				AtomicIntegerFieldUpdater.newUpdater(RefCountInner.class, "state");
+
+		RefCountInner(CoreSubscriber<? super T> actual, FluxRefCountGrace<T> parent) {
 			this.actual = actual;
 			this.parent = parent;
+		}
+
+		void setRefConnection(RefConnection connection) {
 			this.connection = connection;
+			this.actual.onSubscribe(this);
+
+			for (;;) {
+				int previousState = this.state;
+
+				if (isCancelled(previousState)) {
+					return;
+				}
+
+				if (isTerminated(previousState)) {
+					this.parent.terminated(connection);
+					Throwable e = this.error;
+					if (e != null) {
+						this.actual.onError(e);
+					}
+					else {
+						this.actual.onComplete();
+					}
+					return;
+				}
+
+				if (STATE.compareAndSet(this, previousState, previousState | MONITOR_SET_FLAG)) {
+					return;
+				}
+			}
 		}
 
 		@Override
@@ -219,18 +257,42 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 
 		@Override
 		public void onError(Throwable t) {
-			if (PARENT_DONE.compareAndSet(this, 0, 1)) {
-				parent.terminated(connection);
+			this.error = t;
+			for (;;) {
+				int previousState = this.state;
+
+				if (isTerminated(previousState) || isCancelled(previousState)) {
+					Operators.onErrorDropped(t, actual.currentContext());
+					return;
+				}
+
+				if (STATE.compareAndSet(this, previousState, previousState | TERMINATED_FLAG)) {
+					if (isMonitorSet(previousState)) {
+						this.parent.terminated(connection);
+						this.actual.onError(t);
+					}
+					return;
+				}
 			}
-			actual.onError(t);
 		}
 
 		@Override
 		public void onComplete() {
-			if (PARENT_DONE.compareAndSet(this, 0, 1)) {
-				parent.terminated(connection);
+			for (;;) {
+				int previousState = this.state;
+
+				if (isTerminated(previousState) || isCancelled(previousState)) {
+					return;
+				}
+
+				if (STATE.compareAndSet(this, previousState, previousState | TERMINATED_FLAG)) {
+					if (isMonitorSet(previousState)) {
+						this.parent.terminated(connection);
+						this.actual.onComplete();
+					}
+					return;
+				}
 			}
-			actual.onComplete();
 		}
 
 		@Override
@@ -241,7 +303,14 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 		@Override
 		public void cancel() {
 			s.cancel();
-			if (PARENT_DONE.compareAndSet(this, 0, 1)) {
+
+			int previousState = this.state;
+
+			if (isTerminated(previousState) || isCancelled(previousState)) {
+				return;
+			}
+
+			if (STATE.compareAndSet(this, previousState, previousState | CANCELLED_FLAG)) {
 				parent.cancel(connection);
 			}
 		}
@@ -250,8 +319,6 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 		public void onSubscribe(Subscription s) {
 			if (Operators.validate(this.s, s)) {
 				this.s = s;
-
-				actual.onSubscribe(this);
 			}
 		}
 
@@ -294,7 +361,23 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 		@Override
 		public Object scanUnsafe(Attr key) {
 			if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+			if (key == Attr.PARENT) return s;
+			if (key == Attr.TERMINATED) return isTerminated(state);
+			if (key == Attr.CANCELLED) return isCancelled(state);
+
 			return InnerOperator.super.scanUnsafe(key);
+		}
+
+		static boolean isTerminated(int state) {
+			return (state & TERMINATED_FLAG) == TERMINATED_FLAG;
+		}
+
+		static boolean isCancelled(int state) {
+			return (state & CANCELLED_FLAG) == CANCELLED_FLAG;
+		}
+
+		static boolean isMonitorSet(int state) {
+			return (state & MONITOR_SET_FLAG) == MONITOR_SET_FLAG;
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
@@ -94,7 +94,7 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 			}
 		}
 
-		inner.setRefConnection(connection);
+		inner.setRefConnection(conn);
 
 		if (connect) {
 			source.connect(conn);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -511,7 +511,9 @@ public class FluxRefCountGraceTest {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, sub -> sub.request(100));
 		FluxRefCountGrace<Integer> parent = new FluxRefCountGrace<>(Flux.just(10).publish(), 17, Duration.ofSeconds(1), Schedulers.single());
 
-		FluxRefCountGrace.RefCountInner<Integer> test = new FluxRefCountGrace.RefCountInner<>(actual, parent, new FluxRefCountGrace.RefConnection(parent));
+		FluxRefCountGrace.RefCountInner<Integer> test = new FluxRefCountGrace.RefCountInner<>(actual, parent);
+		test.onSubscribe(Operators.emptySubscription());
+		test.setRefConnection(new FluxRefCountGrace.RefConnection(parent));
 
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -443,9 +443,10 @@ public class FluxRefCountTest {
 		}, null, sub -> sub.request(100));
 		FluxRefCount<Integer> main = new FluxRefCount<Integer>(Flux.just(10)
 																   .publish(), 17);
-		FluxRefCount.RefCountInner<Integer> test = new FluxRefCount.RefCountInner<Integer>(actual, new FluxRefCount.RefCountMonitor<>(main));
+		FluxRefCount.RefCountInner<Integer> test = new FluxRefCount.RefCountInner<Integer>(actual);
 		Subscription sub = Operators.emptySubscription();
 		test.onSubscribe(sub);
+		test.setRefCountMonitor(new FluxRefCount.RefCountMonitor<>(main));
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(sub);
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
@@ -469,9 +470,10 @@ public class FluxRefCountTest {
 		}, null, sub -> sub.request(100));
 		FluxRefCount<Integer> main = new FluxRefCount<Integer>(Flux.just(10)
 																   .publish(), 17);
-		FluxRefCount.RefCountInner<Integer> test = new FluxRefCount.RefCountInner<Integer>(actual, new FluxRefCount.RefCountMonitor<>(main));
+		FluxRefCount.RefCountInner<Integer> test = new FluxRefCount.RefCountInner<Integer>(actual);
 		Subscription sub = Operators.emptySubscription();
 		test.onSubscribe(sub);
+		test.setRefCountMonitor(new FluxRefCount.RefCountMonitor<>(main));
 		test.cancel();
 
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).as("CANCELLED after cancel")


### PR DESCRIPTION
Late subscribe may observe zero events when multiple inners subscribe to `FluxRefCount` simultaneously so the one which does not invoke the `connect` method subscribes to the `FluxPublish` too late (e.g. the one which calls the `connect` subscribe faster and invoke the `connect` method earlier than the others):

```
 subscribe 1           subscriber 2
     |                      |
count + 1 (1)               |
     |                 count + 1 (2)
     |                      |
     |                  subscribe
     |                      |
     |                   connect
     |                  onComplete
  subscribe
  (hanging)
```

to solve the problem subscribe should happen before the count is incremented so we have strong ordering guaranteed by the `synchronize` block

fixes #3487 