### PR TITLE
ensures `sourceMode` is obtained with happens-before relationships

### DIFF
--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
@@ -26,7 +26,8 @@ import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.IIIIII_Result;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.annotation.Nullable;
-import org.openjdk.jcstress.infra.results.III_Result;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.annotation.Nullable;
 
 import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
 

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
@@ -239,7 +239,7 @@ public abstract class FluxPublishStressTest {
 		static final Throwable testError = new RuntimeException("boom");
 
 		public RefCntConcurrentSubscriptionErrorSyncStressTest() {
-			super(Flux.error(testError).publishOn(Schedulers.immediate()), null);
+			super(Flux.error(testError), null);
 		}
 
 		@Actor
@@ -272,6 +272,38 @@ public abstract class FluxPublishStressTest {
 
 		public RefCntConcurrentSubscriptionErrorAsyncStressTest() {
 			super(Flux.error(testError).publishOn(Schedulers.immediate()), null);
+		}
+
+		@Actor
+		public void subscribe1() {
+			sharedSource.subscribe(subscriber1);
+		}
+		@Actor
+		public void subscribe2() {
+			sharedSource.subscribe(subscriber2);
+		}
+
+		@Arbiter
+		public void arbiter(IIIIII_Result r) {
+			r.r1 = subscriber1.onNextCalls.get();
+			r.r2 = subscriber2.onNextCalls.get();
+			r.r3 = subscriber1.onCompleteCalls.get();
+			r.r4 = subscriber2.onCompleteCalls.get();
+			r.r5 = subscriber1.onErrorCalls.get();
+			r.r6 = subscriber2.onErrorCalls.get();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"0, 0, 0, 0, 1, 1"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
+	@State
+	public static class RefCntConcurrentSubscriptionErrorNoneStressTest extends
+	                                                                     RefCntConcurrentSubscriptionBaseStressTest<Object> {
+
+		static final Throwable testError = new RuntimeException("boom");
+
+		public RefCntConcurrentSubscriptionErrorNoneStressTest() {
+			super(Flux.error(testError).hide(), null);
 		}
 
 		@Actor

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
@@ -55,6 +55,36 @@ public abstract class FluxPublishStressTest {
 	@JCStressTest
 	@Outcome(id = {"10, 10, 1, 1, 0, 0"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
 	@State
+	public static class RefCntConcurrentSubscriptionRangeSyncFusionStressTest extends
+	                                                                           RefCntConcurrentSubscriptionBaseStressTest<Integer> {
+
+		public RefCntConcurrentSubscriptionRangeSyncFusionStressTest() {
+			super(Flux.range(0, 10), null);
+		}
+
+		@Actor
+		public void subscribe1() {
+			sharedSource.subscribe(subscriber1);
+		}
+		@Actor
+		public void subscribe2() {
+			sharedSource.subscribe(subscriber2);
+		}
+
+		@Arbiter
+		public void arbiter(IIIIII_Result r) {
+			r.r1 = subscriber1.onNextCalls.get();
+			r.r2 = subscriber2.onNextCalls.get();
+			r.r3 = subscriber1.onCompleteCalls.get();
+			r.r4 = subscriber2.onCompleteCalls.get();
+			r.r5 = subscriber1.onErrorCalls.get();
+			r.r6 = subscriber2.onErrorCalls.get();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"10, 10, 1, 1, 0, 0"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
+	@State
 	public static class RefCntConcurrentSubscriptionRangeAsyncFusionStressTest extends
 	                                                                           RefCntConcurrentSubscriptionBaseStressTest<Integer> {
 
@@ -90,6 +120,36 @@ public abstract class FluxPublishStressTest {
 
 		public RefCntConcurrentSubscriptionRangeNoneFusionStressTest() {
 			super(Flux.range(0, 10).hide(), null);
+		}
+
+		@Actor
+		public void subscribe1() {
+			sharedSource.subscribe(subscriber1);
+		}
+		@Actor
+		public void subscribe2() {
+			sharedSource.subscribe(subscriber2);
+		}
+
+		@Arbiter
+		public void arbiter(IIIIII_Result r) {
+			r.r1 = subscriber1.onNextCalls.get();
+			r.r2 = subscriber2.onNextCalls.get();
+			r.r3 = subscriber1.onCompleteCalls.get();
+			r.r4 = subscriber2.onCompleteCalls.get();
+			r.r5 = subscriber1.onErrorCalls.get();
+			r.r6 = subscriber2.onErrorCalls.get();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"0, 0, 1, 1, 0, 0"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
+	@State
+	public static class RefCntConcurrentSubscriptionEmptySyncStressTest extends
+	                                                                     RefCntConcurrentSubscriptionBaseStressTest<Object> {
+
+		public RefCntConcurrentSubscriptionEmptySyncStressTest() {
+			super(Flux.empty(), null);
 		}
 
 		@Actor

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
@@ -26,6 +26,7 @@ import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.IIIIII_Result;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.annotation.Nullable;
+import org.openjdk.jcstress.infra.results.III_Result;
 
 import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
 
@@ -189,29 +190,6 @@ public abstract class FluxPublishStressTest {
 		@Actor
 		public void subscribe2() {
 			sharedSource.subscribe(subscriber2);
-		}
-
-		@Arbiter
-		public void arbiter(IIIIII_Result r) {
-			r.r1 = subscriber1.onNextCalls.get();
-			r.r2 = subscriber2.onNextCalls.get();
-			r.r3 = subscriber1.onCompleteCalls.get();
-			r.r4 = subscriber2.onCompleteCalls.get();
-			r.r5 = subscriber1.onErrorCalls.get();
-			r.r6 = subscriber2.onErrorCalls.get();
-		}
-	}
-
-	@JCStressTest
-	@Outcome(id = {"0, 0, 0, 0, 1, 1"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
-	@State
-	public static class RefCntConcurrentSubscriptionErrorNoneStressTest extends
-	                                                                    RefCntConcurrentSubscriptionBaseStressTest<Object> {
-
-		static final Throwable testError = new RuntimeException("boom");
-
-		public RefCntConcurrentSubscriptionErrorNoneStressTest() {
-			super(Flux.error(testError).hide(), null);
 		}
 
 		@Actor

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
@@ -26,8 +26,6 @@ import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.IIIIII_Result;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.annotation.Nullable;
-import reactor.core.scheduler.Schedulers;
-import reactor.util.annotation.Nullable;
 
 import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
 
@@ -235,12 +233,12 @@ public abstract class FluxPublishStressTest {
 	@JCStressTest
 	@Outcome(id = {"0, 0, 0, 0, 1, 1"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
 	@State
-	public static class RefCntConcurrentSubscriptionErrorAsyncStressTest extends
+	public static class RefCntConcurrentSubscriptionErrorSyncStressTest extends
 	                                                                     RefCntConcurrentSubscriptionBaseStressTest<Object> {
 
 		static final Throwable testError = new RuntimeException("boom");
 
-		public RefCntConcurrentSubscriptionErrorAsyncStressTest() {
+		public RefCntConcurrentSubscriptionErrorSyncStressTest() {
 			super(Flux.error(testError).publishOn(Schedulers.immediate()), null);
 		}
 
@@ -251,6 +249,29 @@ public abstract class FluxPublishStressTest {
 		@Actor
 		public void subscribe2() {
 			sharedSource.subscribe(subscriber2);
+		}
+
+		@Arbiter
+		public void arbiter(IIIIII_Result r) {
+			r.r1 = subscriber1.onNextCalls.get();
+			r.r2 = subscriber2.onNextCalls.get();
+			r.r3 = subscriber1.onCompleteCalls.get();
+			r.r4 = subscriber2.onCompleteCalls.get();
+			r.r5 = subscriber1.onErrorCalls.get();
+			r.r6 = subscriber2.onErrorCalls.get();
+		}
+	}
+
+	@JCStressTest
+	@Outcome(id = {"0, 0, 0, 0, 1, 1"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
+	@State
+	public static class RefCntConcurrentSubscriptionErrorAsyncStressTest extends
+	                                                                     RefCntConcurrentSubscriptionBaseStressTest<Object> {
+
+		static final Throwable testError = new RuntimeException("boom");
+
+		public RefCntConcurrentSubscriptionErrorAsyncStressTest() {
+			super(Flux.error(testError).publishOn(Schedulers.immediate()), null);
 		}
 
 		@Actor

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
@@ -298,7 +298,7 @@ public abstract class FluxPublishStressTest {
 	@Outcome(id = {"0, 0, 0, 0, 1, 1"}, expect = ACCEPTABLE, desc = "concurrent subscription succeeded")
 	@State
 	public static class RefCntConcurrentSubscriptionErrorNoneStressTest extends
-	                                                                     RefCntConcurrentSubscriptionBaseStressTest<Object> {
+	                                                                    RefCntConcurrentSubscriptionBaseStressTest<Object> {
 
 		static final Throwable testError = new RuntimeException("boom");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -407,6 +407,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 				boolean d = done;
 
 				Queue<T> q = queue;
+				int mode = sourceMode;
 
 				boolean empty = q == null || q.isEmpty();
 
@@ -448,7 +449,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 						if (checkTerminated(d, v == null)) {
 							return;
 						}
-						if (sourceMode != Fuseable.SYNC) {
+						if (mode != Fuseable.SYNC) {
 							s.request(1);
 						}
 						continue;
@@ -479,7 +480,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 
 						if (empty) {
 							//async mode only needs to break but SYNC mode needs to perform terminal cleanup here...
-							if (sourceMode == Fuseable.SYNC) {
+							if (mode == Fuseable.SYNC) {
 								done = true;
 								checkTerminated(true, true);
 							}
@@ -498,7 +499,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 						e++;
 					}
 
-					if (e != 0 && sourceMode != Fuseable.SYNC) {
+					if (e != 0 && mode != Fuseable.SYNC) {
 						s.request(e);
 					}
 
@@ -506,7 +507,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 						continue;
 					}
 				}
-				else if (sourceMode == Fuseable.SYNC) {
+				else if (q != null && mode == Fuseable.SYNC) {
 					done = true;
 					if (checkTerminated(true, empty)) {
 						break;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
@@ -233,35 +233,6 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 			}
 		}
 
-		void setRefCountMonitor(RefCountMonitor<T> connection) {
-			this.connection = connection;
-			this.actual.onSubscribe(this);
-
-			for (;;) {
-				int previousState = this.state;
-
-				if (isCancelled(previousState)) {
-					return;
-				}
-
-				if (isTerminated(previousState)) {
-					connection.upstreamFinished();
-					Throwable e = this.error;
-					if (e != null) {
-						this.actual.onError(e);
-					}
-					else {
-						this.actual.onComplete();
-					}
-					return;
-				}
-
-				if (STATE.compareAndSet(this, previousState, previousState | MONITOR_SET_FLAG)) {
-					return;
-				}
-			}
-		}
-
 		@Override
 		public void onNext(T t) {
 			actual.onNext(t);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
@@ -233,6 +233,11 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 			}
 		}
 
+		void setRefCountMonitor(RefCountMonitor<T> connection) {
+			this.connection = connection;
+			this.actual.onSubscribe(this);
+		}
+
 		@Override
 		public void onNext(T t) {
 			actual.onNext(t);


### PR DESCRIPTION
When the concurrent request call happens with an initial subscription to the initial source, the obtained `sourceMode` may indicate `unset` instead of `none` due to the nature of the given primitive

Signed-off-by: OlegDokuka <odokuka@vmware.com>