### PR TITLE
adds support for gradle 8.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ plugins {
 	alias(libs.plugins.asciidoctor.pdf) apply false
 	alias(libs.plugins.japicmp)
 	alias(libs.plugins.download)
-	alias(libs.plugins.testsets)
 	// note: build scan plugin now must be applied in settings.gradle
 	// plugin portal is now outdated due to bintray sunset, at least for artifactory gradle plugin
 	alias(libs.plugins.bnd) apply false

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-enableFeaturePreview("VERSION_CATALOGS")
-
 //import the catalog from main project
 dependencyResolutionManagement {
 	versionCatalogs {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
     cglibVersion = "3.3.0"
     javaObjectLayoutVersion = "0.17"
     jmhVersion = "1.36"
-    junitVersion = "5.9.2"
+    junitVersion = "5.9.3"
     logbackVersion = "1.2.11"
     mockitoVersion = "4.11.0"
     slf4jVersion = "1.7.36"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,11 +41,11 @@ reactor-perfBaseline-extra = { module = "io.projectreactor.addons:reactor-extra"
 artifactory = { id = "com.jfrog.artifactory", version = "4.31.0" }
 asciidoctor-convert = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor" }
 asciidoctor-pdf = { id = "org.asciidoctor.jvm.pdf", version.ref = "asciidoctor" }
-bnd = { id = "biz.aQute.bnd.builder", version = "6.3.1" }
+bnd = { id = "biz.aQute.bnd.builder", version = "6.4.0" }
 download = { id = "de.undercouch.download", version = "5.4.0" }
 japicmp = { id = "me.champeau.gradle.japicmp", version = "0.4.1" }
 jcstress = { id = "io.github.reyerizo.gradle.jcstress", version = "0.8.15" }
-nohttp = { id = "io.spring.nohttp", version = "0.0.10" }
-shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
+nohttp = { id = "io.spring.nohttp", version = "0.0.11" }
+shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
 spotless = { id = "com.diffplug.spotless", version = "6.13.0" }
-testsets = { id = "org.unbroken-dome.test-sets", version = "4.0.0" }
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import me.champeau.gradle.japicmp.JapicmpTask
 
 apply plugin: 'idea' // needed to avoid IDEA seeing the jmh folder as source
 apply plugin: 'biz.aQute.bnd.builder'
-apply plugin: 'org.unbroken-dome.test-sets'
+apply plugin: 'jvm-test-suite'
 apply plugin: 'jcstress'
 apply plugin: 'java-library'
 
@@ -43,17 +43,61 @@ ext {
 	]
 }
 
-testSets {
-	blockHoundTest
-	//TODO once can probably be removed in 3.6.0, but MUST keep the ReactorContextAccessorTest in that case
-	withMicrometerTest
-	withContextPropagation102Test
-	tckTest
+testing {
+  suites {
+	test {
+	  useJUnitJupiter()
+	}
+	blockHoundTest(JvmTestSuite) {
+	  useJUnitJupiter()
+	  sources.java.srcDirs = ['src/blockHoundTest/java']
+	  dependencies {
+		implementation project()
+	  }
+	}
+	tckTest(JvmTestSuite) {
+	  useTestNG()
+	  sources.java.srcDirs = ['src/tckTest/java']
+	  dependencies {
+		implementation project()
+		implementation sourceSets.test.output
+	  }
+	}
+	withMicrometerTest(JvmTestSuite) {
+	  useJUnitJupiter()
+	  sources.java.srcDirs = ['src/withMicrometerTest/java']
+	  dependencies {
+		implementation project()
+		implementation sourceSets.test.output
+	  }
+	}
+	withContextPropagation102Test(JvmTestSuite) {
+	  useJUnitJupiter()
+	  sources.java.srcDirs = ['src/withContextPropagation102Test/java']
+	  dependencies {
+		implementation project()
+		implementation sourceSets.test.output
+	  }
+	}
+  }
 }
 
 configurations {
 	compileOnly.extendsFrom jsr166backport
 	testCompileOnly.extendsFrom jsr166backport
+
+  	blockHoundTestApi.extendsFrom testApi
+  	blockHoundTestImplementation.extendsFrom testImplementation
+  	blockHoundTestCompileOnly.extendsFrom testCompileOnly
+  	tckTestApi.extendsFrom testApi
+  	tckTestImplementation.extendsFrom testImplementation
+  	tckTestCompileOnly.extendsFrom testCompileOnly
+  	withMicrometerTestApi.extendsFrom testApi
+  	withMicrometerTestImplementation.extendsFrom testImplementation
+  	withMicrometerTestCompileOnly.extendsFrom testCompileOnly
+  	withContextPropagation102TestApi.extendsFrom testApi
+  	withContextPropagation102TestImplementation.extendsFrom testImplementation
+  	withContextPropagation102TestCompileOnly.extendsFrom testCompileOnly
 }
 
 dependencies {
@@ -236,28 +280,33 @@ task loops(type: Test, group: 'verification') {
 	}
 }
 
-tasks.withType(Test).all {
-	if (it.name == "test") {
-		//configure tag support for the core test task
-		def tags = rootProject.findProperty("junit-tags")
-		if (tags != null) {
-			println "junit5 tags for core: $tags"
-			useJUnitPlatform() {
-				includeTags "$tags"
-			}
-		}
-		else {
-			useJUnitPlatform()
-		}
+test {
+  def tags = rootProject.findProperty("junit-tags")
+  if (tags != null) {
+	println "junit5 tags for core: $tags"
+	useJUnitPlatform() {
+	  includeTags "$tags"
 	}
-	else if (it.name != "tckTest") {
-		//default to JunitPlatform
-		useJUnitPlatform()
+  }
+  else {
+	useJUnitPlatform()
+  }
+}
+
+tasks.withType(Test).matching { !(it.name in testing.suites.names) }.configureEach {
+  def tags = rootProject.findProperty("junit-tags")
+  if (tags != null) {
+	println "junit5 tags for core: $tags"
+	useJUnitPlatform() {
+	  includeTags "$tags"
 	}
+  }
+  else {
+	useJUnitPlatform()
+  }
 }
 
 tckTest {
-	useTestNG()
 	include '**/*Verification.*'
 	doFirst {
 		println "Additional tests from `${name}` (${includes})"
@@ -305,6 +354,15 @@ jar {
 			'Automatic-Module-Name': 'reactor.core'
 	}
 	bnd(bndOptions)
+
+	bundle {
+	  // workaround for multi-version JARs
+	  //  see https://github.com/bndtools/bnd/issues/2227
+	  bnd '''\
+						  -fixupmessages: '^Classes found in the wrong directory: .*'
+						  -exportcontents: io.micrometer.*
+						  '''.stripIndent()
+	}
 }
 
 jacocoTestReport.dependsOn test

--- a/reactor-tools/build.gradle
+++ b/reactor-tools/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,52 @@
  * limitations under the License.
  */
 
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.apache.tools.ant.filters.ReplaceTokens
 
 apply plugin: 'com.github.johnrengelman.shadow'
-apply plugin: 'org.unbroken-dome.test-sets'
+apply plugin: 'jvm-test-suite'
 apply plugin: 'java-library'
 
 description = 'Reactor Tools'
 
-testSets {
-    jarFileTest
-    javaAgentTest
-    buildPluginTest
+testing {
+    suites {
+        test {
+            useJUnitJupiter()
+        }
+        jarFileTest(JvmTestSuite) {
+            useJUnitJupiter()
+            sources.java.srcDirs = ['src/jarFileTest/java']
+            dependencies {
+                implementation project()
+            }
+        }
+        javaAgentTest(JvmTestSuite) {
+            useJUnitJupiter()
+            sources.java.srcDirs = ['src/javaAgentTest/java']
+            dependencies {
+                implementation project()
+            }
+        }
+        buildPluginTest(JvmTestSuite) {
+            useJUnitJupiter()
+            sources.java.srcDirs = ['src/buildPluginTest/java']
+            dependencies {
+                implementation project()
+            }
+        }
+    }
 }
 
 configurations {
     shaded
+    jarFileTestApi.extendsFrom testApi
+    jarFileTestImplementation.extendsFrom testImplementation
+    javaAgentTestApi.extendsFrom testApi
+    javaAgentTestImplementation.extendsFrom testImplementation
+    buildPluginTestApi.extendsFrom testApi
+    buildPluginTestImplementation.extendsFrom testImplementation
 }
 
 dependencies {
@@ -87,7 +117,9 @@ jar {
 }
 
 shadowJar {
-    classifier = null
+    enableRelocation true
+    relocationPrefix "reactor.tools.shaded"
+    archiveClassifier.set('')
 
     dependsOn(project.tasks.jar)
     manifest {
@@ -120,13 +152,6 @@ shadowJar {
 }
 
 project.tasks.build.dependsOn(shadowJar)
-
-task relocateShadowJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation) {
-    target = tasks.shadowJar
-    prefix = "reactor.tools.shaded"
-}
-
-tasks.shadowJar.dependsOn tasks.relocateShadowJar
 
 project.tasks.jarFileTest.configure {
     systemProperty("jarFile", shadowJar.outputs.files.singleFile)
@@ -191,7 +216,7 @@ buildPluginTest {
 project.tasks.buildPluginTest.dependsOn(generateMockGradle)
 project.tasks.check.dependsOn(buildPluginTest)
 
-tasks.withType(Test).all {
+tasks.withType(Test).matching { !(it.name in testing.suites.names) }.configureEach {
     useJUnitPlatform()
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,7 +20,3 @@ plugins {
 rootProject.name = 'reactor'
 
 include 'benchmarks', 'reactor-core', 'reactor-test', 'reactor-tools', 'reactor-core-micrometer'
-
-//libs catalog is declared in ./gradle/libs.versions.toml
-//TODO remove once Version Catalogs are stabilized. It is also activated in buildSrc
-enableFeaturePreview("VERSION_CATALOGS")


### PR DESCRIPTION
This PR introduces support for Gradle 8 which requires:
	1. removal of the `testsets` plugin which uses (gradle 7 deprecated and then removed in gradle 8) `classifier` jar properties (https://github.com/unbroken-dome/gradle-testsets-plugin/issues/131)
	2. the `bnd` plugin needs an extra workaround (https://github.com/bndtools/bnd/issues/2227)
    3. the `ShadowJar` plugin needs an update for relocation (https://imperceptiblethoughts.com/shadow/changes/#v8-1-0-2023-02-26)

Signed-off-by: OlegDokuka <odokuka@vmware.com>