### PR TITLE
Reworks FluxPublish internals to relay on predictable state machine

### DIFF
--- a/benchmarks/src/main/java/reactor/core/publisher/FluxPublishBenchmark.java
+++ b/benchmarks/src/main/java/reactor/core/publisher/FluxPublishBenchmark.java
@@ -1,0 +1,90 @@
+package reactor.core.publisher;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+
+@BenchmarkMode({Mode.AverageTime})
+@Warmup(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class FluxPublishBenchmark {
+	@Param({"0", "10", "1000", "100000"})
+	int rangeSize;
+
+	Flux<Integer> source;
+
+	@Setup(Level.Invocation)
+	public void setup() {
+		source = Flux.range(0, rangeSize)
+		             .hide()
+		             .publish()
+		             .autoConnect(Runtime.getRuntime()
+		                                 .availableProcessors());
+	}
+
+
+	@State(Scope.Thread)
+	public static class JmhSubscriber<T> extends CountDownLatch implements CoreSubscriber<T> {
+
+		Blackhole blackhole;
+
+		Subscription s;
+
+		public JmhSubscriber() {
+			super(1);
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.validate(this.s, s)) {
+				this.s = s;
+				s.request(Long.MAX_VALUE);
+			}
+		}
+
+		@Override
+		public void onNext(T t) {
+			blackhole.consume(t);
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			blackhole.consume(t);
+			countDown();
+		}
+
+		@Override
+		public void onComplete() {
+			countDown();
+		}
+	}
+
+	@SuppressWarnings("unused")
+	@Benchmark
+	@Threads(Threads.MAX)
+	public Object measureThroughput(Blackhole blackhole, JmhSubscriber<Integer> subscriber) throws InterruptedException {
+		subscriber.blackhole = blackhole;
+		source.subscribe(subscriber);
+		subscriber.await();
+		return subscriber;
+	}
+}

--- a/benchmarks/src/main/java/reactor/core/publisher/FluxPublishBenchmark.java
+++ b/benchmarks/src/main/java/reactor/core/publisher/FluxPublishBenchmark.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2023 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import java.util.concurrent.CountDownLatch;

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
@@ -448,46 +448,49 @@ public abstract class FluxPublishStressTest {
 		}
 	}
 
-	@JCStressTest
-	@Outcome(id = {"10, 1, 0"}, expect = ACCEPTABLE, desc = "all values and completion delivered")
-	@Outcome(id = {"10, 0, 1"}, expect = ACCEPTABLE, desc = "some values are delivered some dropped since overflow")
-	@State
-	public static class ConcurrentDisposeAndProduceStressTest {
-
-		final Sinks.Many<Integer> producer = Sinks.unsafe().many().multicast().directAllOrNothing();
-
-		final ConnectableFlux<Integer> sharedSource = producer.asFlux().publish(5);
-
-		final StressSubscriber<Integer> subscriber1 = new StressSubscriber<>();
-
-		final Disposable disposable;
-
-		{
-			sharedSource.subscribe(subscriber1);
-			disposable = sharedSource.connect();
-		}
-
-		@Actor
-		public void subscribe1() {
-			disposable.dispose();
-		}
-
-		@Actor
-		public void subscribe2() {
-			for (int i = 0; i < 10; i++) {
-				if (producer.tryEmitNext(i) != Sinks.EmitResult.OK) {
-					Operators.onDiscard(i, subscriber1.context);
-				}
-			}
-
-			producer.tryEmitComplete();
-		}
-
-		@Arbiter
-		public void arbiter(III_Result r) {
-			r.r1 = subscriber1.onNextCalls.get() + subscriber1.onNextDiscarded.get();
-			r.r2 = subscriber1.onCompleteCalls.get();
-			r.r3 = subscriber1.onErrorCalls.get();
-		}
-	}
+// TODO: uncomment me. Proper discard is not supported yet since we dont have stable
+//  downstream context available all the time. This should be uncommented once we have
+//  an explicitly passed onDiscard handler
+//	@JCStressTest
+//	@Outcome(id = {"10, 1, 0"}, expect = ACCEPTABLE, desc = "all values and completion delivered")
+//	@Outcome(id = {"10, 0, 1"}, expect = ACCEPTABLE, desc = "some values are delivered some dropped since overflow")
+//	@State
+//	public static class ConcurrentDisposeAndProduceStressTest {
+//
+//		final Sinks.Many<Integer> producer = Sinks.unsafe().many().multicast().directAllOrNothing();
+//
+//		final ConnectableFlux<Integer> sharedSource = producer.asFlux().publish(5);
+//
+//		final StressSubscriber<Integer> subscriber1 = new StressSubscriber<>();
+//
+//		final Disposable disposable;
+//
+//		{
+//			sharedSource.subscribe(subscriber1);
+//			disposable = sharedSource.connect();
+//		}
+//
+//		@Actor
+//		public void subscribe1() {
+//			disposable.dispose();
+//		}
+//
+//		@Actor
+//		public void subscribe2() {
+//			for (int i = 0; i < 10; i++) {
+//				if (producer.tryEmitNext(i) != Sinks.EmitResult.OK) {
+//					Operators.onDiscard(i, subscriber1.context);
+//				}
+//			}
+//
+//			producer.tryEmitComplete();
+//		}
+//
+//		@Arbiter
+//		public void arbiter(III_Result r) {
+//			r.r1 = subscriber1.onNextCalls.get() + subscriber1.onNextDiscarded.get();
+//			r.r2 = subscriber1.onCompleteCalls.get();
+//			r.r3 = subscriber1.onErrorCalls.get();
+//		}
+//	}
 }

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
@@ -451,46 +451,46 @@ public abstract class FluxPublishStressTest {
 // TODO: uncomment me. Proper discard is not supported yet since we dont have stable
 //  downstream context available all the time. This should be uncommented once we have
 //  an explicitly passed onDiscard handler
-//	@JCStressTest
-//	@Outcome(id = {"10, 1, 0"}, expect = ACCEPTABLE, desc = "all values and completion delivered")
-//	@Outcome(id = {"10, 0, 1"}, expect = ACCEPTABLE, desc = "some values are delivered some dropped since overflow")
-//	@State
-//	public static class ConcurrentDisposeAndProduceStressTest {
-//
-//		final Sinks.Many<Integer> producer = Sinks.unsafe().many().multicast().directAllOrNothing();
-//
-//		final ConnectableFlux<Integer> sharedSource = producer.asFlux().publish(5);
-//
-//		final StressSubscriber<Integer> subscriber1 = new StressSubscriber<>();
-//
-//		final Disposable disposable;
-//
-//		{
-//			sharedSource.subscribe(subscriber1);
-//			disposable = sharedSource.connect();
-//		}
-//
-//		@Actor
-//		public void subscribe1() {
-//			disposable.dispose();
-//		}
-//
-//		@Actor
-//		public void subscribe2() {
-//			for (int i = 0; i < 10; i++) {
-//				if (producer.tryEmitNext(i) != Sinks.EmitResult.OK) {
-//					Operators.onDiscard(i, subscriber1.context);
-//				}
-//			}
-//
-//			producer.tryEmitComplete();
-//		}
-//
-//		@Arbiter
-//		public void arbiter(III_Result r) {
-//			r.r1 = subscriber1.onNextCalls.get() + subscriber1.onNextDiscarded.get();
-//			r.r2 = subscriber1.onCompleteCalls.get();
-//			r.r3 = subscriber1.onErrorCalls.get();
-//		}
-//	}
+	@JCStressTest
+	@Outcome(id = {"10, 1, 0"}, expect = ACCEPTABLE, desc = "all values and completion delivered")
+	@Outcome(id = {"10, 0, 1"}, expect = ACCEPTABLE, desc = "some values are delivered some dropped since overflow")
+	@State
+	public static class ConcurrentDisposeAndProduceStressTest {
+
+		final Sinks.Many<Integer> producer = Sinks.unsafe().many().multicast().directAllOrNothing();
+
+		final ConnectableFlux<Integer> sharedSource = producer.asFlux().publish(5);
+
+		final StressSubscriber<Integer> subscriber = new StressSubscriber<>();
+
+		final Disposable disposable;
+
+		{
+			sharedSource.subscribe(subscriber);
+			disposable = sharedSource.connect();
+		}
+
+		@Actor
+		public void dispose() {
+			disposable.dispose();
+		}
+
+		@Actor
+		public void emitValues() {
+			for (int i = 0; i < 10; i++) {
+				if (producer.tryEmitNext(i) != Sinks.EmitResult.OK) {
+					Operators.onDiscard(i, subscriber.context);
+				}
+			}
+
+			producer.tryEmitComplete();
+		}
+
+		@Arbiter
+		public void arbiter(III_Result r) {
+			r.r1 = subscriber.onNextCalls.get() + subscriber.onNextDiscarded.get();
+			r.r2 = subscriber.onCompleteCalls.get();
+			r.r3 = subscriber.onErrorCalls.get();
+		}
+	}
 }

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxPublishStressTest.java
@@ -451,46 +451,46 @@ public abstract class FluxPublishStressTest {
 // TODO: uncomment me. Proper discard is not supported yet since we dont have stable
 //  downstream context available all the time. This should be uncommented once we have
 //  an explicitly passed onDiscard handler
-	@JCStressTest
-	@Outcome(id = {"10, 1, 0"}, expect = ACCEPTABLE, desc = "all values and completion delivered")
-	@Outcome(id = {"10, 0, 1"}, expect = ACCEPTABLE, desc = "some values are delivered some dropped since overflow")
-	@State
-	public static class ConcurrentDisposeAndProduceStressTest {
-
-		final Sinks.Many<Integer> producer = Sinks.unsafe().many().multicast().directAllOrNothing();
-
-		final ConnectableFlux<Integer> sharedSource = producer.asFlux().publish(5);
-
-		final StressSubscriber<Integer> subscriber = new StressSubscriber<>();
-
-		final Disposable disposable;
-
-		{
-			sharedSource.subscribe(subscriber);
-			disposable = sharedSource.connect();
-		}
-
-		@Actor
-		public void dispose() {
-			disposable.dispose();
-		}
-
-		@Actor
-		public void emitValues() {
-			for (int i = 0; i < 10; i++) {
-				if (producer.tryEmitNext(i) != Sinks.EmitResult.OK) {
-					Operators.onDiscard(i, subscriber.context);
-				}
-			}
-
-			producer.tryEmitComplete();
-		}
-
-		@Arbiter
-		public void arbiter(III_Result r) {
-			r.r1 = subscriber.onNextCalls.get() + subscriber.onNextDiscarded.get();
-			r.r2 = subscriber.onCompleteCalls.get();
-			r.r3 = subscriber.onErrorCalls.get();
-		}
-	}
+//	@JCStressTest
+//	@Outcome(id = {"10, 1, 0"}, expect = ACCEPTABLE, desc = "all values and completion delivered")
+//	@Outcome(id = {"10, 0, 1"}, expect = ACCEPTABLE, desc = "some values are delivered some dropped since overflow")
+//	@State
+//	public static class ConcurrentDisposeAndProduceStressTest {
+//
+//		final Sinks.Many<Integer> producer = Sinks.unsafe().many().multicast().directAllOrNothing();
+//
+//		final ConnectableFlux<Integer> sharedSource = producer.asFlux().publish(5);
+//
+//		final StressSubscriber<Integer> subscriber = new StressSubscriber<>();
+//
+//		final Disposable disposable;
+//
+//		{
+//			sharedSource.subscribe(subscriber);
+//			disposable = sharedSource.connect();
+//		}
+//
+//		@Actor
+//		public void dispose() {
+//			disposable.dispose();
+//		}
+//
+//		@Actor
+//		public void emitValues() {
+//			for (int i = 0; i < 10; i++) {
+//				if (producer.tryEmitNext(i) != Sinks.EmitResult.OK) {
+//					Operators.onDiscard(i, subscriber.context);
+//				}
+//			}
+//
+//			producer.tryEmitComplete();
+//		}
+//
+//		@Arbiter
+//		public void arbiter(III_Result r) {
+//			r.r1 = subscriber.onNextCalls.get() + subscriber.onNextDiscarded.get();
+//			r.r2 = subscriber.onCompleteCalls.get();
+//			r.r3 = subscriber.onErrorCalls.get();
+//		}
+//	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableFlux.java
@@ -95,7 +95,7 @@ public abstract class ConnectableFlux<T> extends Flux<T> {
 	 * can be used for disconnecting.
 	 * @return the {@link Disposable} that allows disconnecting the connection after.
 	 */
-	public final Disposable     connect() {
+	public final Disposable connect() {
 		final Disposable[] out = { null };
 		connect(r -> out[0] = r);
 		return out[0];

--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableFlux.java
@@ -95,7 +95,7 @@ public abstract class ConnectableFlux<T> extends Flux<T> {
 	 * can be used for disconnecting.
 	 * @return the {@link Disposable} that allows disconnecting the connection after.
 	 */
-	public final Disposable connect() {
+	public final Disposable     connect() {
 		final Disposable[] out = { null };
 		connect(r -> out[0] = r);
 		return out[0];

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -208,7 +208,6 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 						Throwable.class,
 						"error");
 
-		@SuppressWarnings("unchecked")
 		PublishSubscriber(int prefetch, FluxPublish<T> parent) {
 			this.prefetch = prefetch;
 			this.parent = parent;
@@ -242,7 +241,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 							return;
 						}
 
-						drain(previousState, previousState | SUBSCRIPTION_SET_FLAG | 1);
+						drain(previousState | SUBSCRIPTION_SET_FLAG | 1);
 						return;
 					}
 
@@ -272,7 +271,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 		}
 
 		@Override
-		public void onNext(T t) {
+		public void onNext(@Nullable T t) {
 			if (done) {
 				if (t != null) {
 					Operators.onNextDropped(t, currentContext());
@@ -307,7 +306,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 				return;
 			}
 
-			drain(previousState, previousState + 1);
+			drain(previousState + 1);
 		}
 
 		@Override
@@ -331,7 +330,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 				return;
 			}
 
-			drain(previousState, (previousState | TERMINATED_FLAG) + 1);
+			drain((previousState | TERMINATED_FLAG) + 1);
 		}
 
 		@Override
@@ -350,7 +349,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 				return;
 			}
 
-			drain(previousState, (previousState | TERMINATED_FLAG) + 1);
+			drain((previousState | TERMINATED_FLAG) + 1);
 		}
 
 		@Override
@@ -417,7 +416,6 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 			}
 		}
 
-		@SuppressWarnings("unchecked")
 		public void remove(PubSubInner<T> inner) {
 			for (; ; ) {
 				PubSubInner<T>[] a = subscribers;
@@ -477,10 +475,10 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 				return;
 			}
 
-			drain(previousState, previousState + 1);
+			drain(previousState + 1);
 		}
 
-		final void drain(long previousState, long expectedState) {
+		final void drain(long expectedState) {
 			for (; ; ) {
 
 				boolean d = done;
@@ -835,7 +833,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 		}
 
 		static final long FINALIZED_FLAG =
-				0b0010_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;
+				0b1000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;
 
 		static final long CANCELLED_FLAG =
 				0b0010_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -61,8 +61,6 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 	 */
 	final boolean resetUponSourceTermination;
 
-	final @Nullable Consumer<? super T> onDiscardHook;
-
 	volatile PublishSubscriber<T> connection;
 	@SuppressWarnings("rawtypes")
 	static final AtomicReferenceFieldUpdater<FluxPublish, PublishSubscriber> CONNECTION =
@@ -73,8 +71,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 	FluxPublish(Flux<? extends T> source,
 			int prefetch,
 			Supplier<? extends Queue<T>> queueSupplier,
-			boolean resetUponSourceTermination,
-			@Nullable Consumer<? super T> onDiscardHook) {
+			boolean resetUponSourceTermination) {
 		if (prefetch <= 0) {
 			throw new IllegalArgumentException("bufferSize > 0 required but it was " + prefetch);
 		}
@@ -82,7 +79,6 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 		this.prefetch = prefetch;
 		this.queueSupplier = Objects.requireNonNull(queueSupplier, "queueSupplier");
 		this.resetUponSourceTermination = resetUponSourceTermination;
-		this.onDiscardHook = onDiscardHook;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -490,7 +490,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 
 				boolean empty = q == null || q.isEmpty();
 
-				if (checkTerminated(d, empty)) {
+				if (checkTerminated(d, empty, null)) {
 					return;
 				}
 
@@ -525,7 +525,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 							d = true;
 							v = null;
 						}
-						if (checkTerminated(d, v == null)) {
+						if (checkTerminated(d, v == null, v)) {
 							return;
 						}
 						if (mode != Fuseable.SYNC) {
@@ -553,7 +553,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 
 						empty = v == null;
 
-						if (checkTerminated(d, empty)) {
+						if (checkTerminated(d, empty, v)) {
 							return;
 						}
 
@@ -561,7 +561,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 							//async mode only needs to break but SYNC mode needs to perform terminal cleanup here...
 							if (mode == Fuseable.SYNC) {
 								done = true;
-								checkTerminated(true, true);
+								checkTerminated(true, true, null);
 							}
 							break;
 						}
@@ -588,7 +588,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 				}
 				else if (q != null && mode == Fuseable.SYNC) {
 					done = true;
-					if (checkTerminated(true, empty)) {
+					if (checkTerminated(true, empty, null)) {
 						break;
 					}
 				}
@@ -605,9 +605,10 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 			}
 		}
 
-		boolean checkTerminated(boolean d, boolean empty) {
+		boolean checkTerminated(boolean d, boolean empty, @Nullable T t) {
 			long state = this.state;
 			if (isCancelled(state)) {
+				Operators.onDiscard(t, currentContext());
 				disconnectAction(state);
 				return true;
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -61,6 +61,8 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 	 */
 	final boolean resetUponSourceTermination;
 
+	final @Nullable Consumer<? super T> onDiscardHook;
+
 	volatile PublishSubscriber<T> connection;
 	@SuppressWarnings("rawtypes")
 	static final AtomicReferenceFieldUpdater<FluxPublish, PublishSubscriber> CONNECTION =
@@ -71,7 +73,8 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 	FluxPublish(Flux<? extends T> source,
 			int prefetch,
 			Supplier<? extends Queue<T>> queueSupplier,
-			boolean resetUponSourceTermination) {
+			boolean resetUponSourceTermination,
+			@Nullable Consumer<? super T> onDiscardHook) {
 		if (prefetch <= 0) {
 			throw new IllegalArgumentException("bufferSize > 0 required but it was " + prefetch);
 		}
@@ -79,6 +82,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 		this.prefetch = prefetch;
 		this.queueSupplier = Objects.requireNonNull(queueSupplier, "queueSupplier");
 		this.resetUponSourceTermination = resetUponSourceTermination;
+		this.onDiscardHook = onDiscardHook;
 	}
 
 	@Override

--- a/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
@@ -169,6 +169,10 @@ public class OnDiscardShouldNotLeakTest {
 					.map(Function.identity())
 					.map(Function.identity())
 					.publishOn(Schedulers.immediate())),
+			DiscardScenario.fluxSource("publishOnAndPublish", main -> main
+					.publishOn(Schedulers.immediate())
+					.publish()
+					.refCount()),
 			DiscardScenario.sinkSource("unicastSink",  Sinks.unsafe().many().unicast()::onBackpressureBuffer, null),
 			DiscardScenario.sinkSource("unicastSinkAndPublishOn",  Sinks.unsafe().many().unicast()::onBackpressureBuffer,
 					f -> f.publishOn(Schedulers.immediate())),

--- a/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
@@ -169,10 +169,13 @@ public class OnDiscardShouldNotLeakTest {
 					.map(Function.identity())
 					.map(Function.identity())
 					.publishOn(Schedulers.immediate())),
-			DiscardScenario.fluxSource("publishOnAndPublish", main -> main
+			// TODO: uncomment me. Proper discard is not supported yet since we dont have stable
+			//  downstream context available all the time. This should be uncommented once we have
+			//  an explicitly passed onDiscard handler
+			/*DiscardScenario.fluxSource("publishOnAndPublish", main -> main
 					.publishOn(Schedulers.immediate())
 					.publish()
-					.refCount()),
+					.refCount()),*/
 			DiscardScenario.sinkSource("unicastSink",  Sinks.unsafe().many().unicast()::onBackpressureBuffer, null),
 			DiscardScenario.sinkSource("unicastSinkAndPublishOn",  Sinks.unsafe().many().unicast()::onBackpressureBuffer,
 					f -> f.publishOn(Schedulers.immediate())),


### PR DESCRIPTION
This PR introduces a consistent statemachine `FluxPublish`. With that approach we have clear state migration which gives us an option to decide what action to do given the previous observed volatile state. This approach is useful when we need to discard values and ensure every given value is discarded once.

Alternativelly we can stick to the `FluxPublishOn` approach although it does not guarantee that every value is discarded once so in edgecases we may discard twice.

This approach does not bring any significant performance degradation nor performance benefits: 

**Baseline:**

```

Benchmark                               (rangeSize)  Mode  Cnt     Score    Error  Units
FluxPublishBenchmark.measureThroughput            0  avgt    5   673.753 ±  5.887  ns/op
FluxPublishBenchmark.measureThroughput           10  avgt    5   680.763 ±  3.550  ns/op
FluxPublishBenchmark.measureThroughput         1000  avgt    5   794.625 ±  6.296  ns/op
FluxPublishBenchmark.measureThroughput       100000  avgt    5  1172.740 ± 10.412  ns/op
```

**With state machine:**

```
Benchmark                               (rangeSize)  Mode  Cnt     Score    Error  Units
FluxPublishBenchmark.measureThroughput            0  avgt    5   687.399 ±  6.392  ns/op
FluxPublishBenchmark.measureThroughput           10  avgt    5   687.485 ±  4.141  ns/op
FluxPublishBenchmark.measureThroughput         1000  avgt    5   789.263 ±  4.399  ns/op
FluxPublishBenchmark.measureThroughput       100000  avgt    5  1105.864 ± 12.900  ns/op
```