### PR TITLE
fix reactor#3539 takeUntil Predicate test before emit

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -9206,6 +9206,9 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	/**
 	 * Relay values from this {@link Flux} until the given {@link Predicate} matches.
 	 * This includes the matching data (unlike {@link #takeWhile}).
+	 * The predicate is tested before the element is emitted,
+	 * so if the element is modified by the consumer, this won't affect the predicate.
+	 * In case of an error during the predicate test, the current element is emitted before the error.
 	 *
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/takeUntil.svg" alt="">

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,17 +81,18 @@ final class FluxTakeUntil<T> extends InternalFluxOperator<T, T> {
 				return;
 			}
 
-			actual.onNext(t);
-
 			boolean b;
 
 			try {
 				b = predicate.test(t);
 			} catch (Throwable e) {
+				actual.onNext(t);
 				onError(Operators.onOperatorError(s, e, t, actual.currentContext()));
 
 				return;
 			}
+
+			actual.onNext(t);
 
 			if (b) {
 				s.cancel();

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeUntilPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeUntilPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.test.subscriber.AssertSubscriber;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -88,6 +89,21 @@ public class FluxTakeUntilPredicateTest {
 		Flux.range(1, 5)
 		    .takeUntil(v -> v == 3)
 		    .subscribe(ts);
+
+		ts.assertValues(1, 2, 3)
+		  .assertComplete()
+		  .assertNoError();
+	}
+
+	@Test
+	public void takeSomeWithChangedValue() {
+		AssertSubscriber<Integer> ts = AssertSubscriber.create();
+
+		Flux.range(1, 5)
+			.map(AtomicInteger::new)
+			.takeUntil(v -> v.get() == 3)
+			.map(v -> v.getAndSet(0))
+			.subscribe(ts);
 
 		ts.assertValues(1, 2, 3)
 		  .assertComplete()


### PR DESCRIPTION
This fixes issue #3539 
The documentation does not specify when takeUntil tests the predicate.
The current implementation does this after the element has been emitted. If the emitted element is modified by downstream consumers, this affects the predicate function.
This behavior might be confusing and lead to unwanted results.
This PR moves the test up and documents the behavior in order to avoid this caveat.
