### PR TITLE
Fix "Blocking Mono Result" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,11 @@ Mono.fromCallable(System::currentTimeMillis)
 ```
 
 Blocking Mono result :
-```java    
-Tuple2<Long, Long> nowAndLater = 
-        Mono.zip(
-                Mono.just(System.currentTimeMillis()),
-                Flux.just(1).delay(1).map(i -> System.currentTimeMillis()))
-            .block();
+```java
+Tuple2<Instant, Instant> nowAndLater = Mono.zip(
+    Mono.just(Instant.now()),
+    Mono.delay(Duration.ofSeconds(1)).then(Mono.fromCallable(Instant::now)))
+  .block();
 ```
 
 ## Schedulers


### PR DESCRIPTION
The provided example did not compile for two reasons:

- no matching `Mono.zip()` signature that accepts two `Publishers` (just `Mono`s)
- no `Flux#delay` anymore

Replaced the example with a more idiomatic usage - `Mono.delay()` followed by `then()` instead of `Mono.just()` followed by argument-discarding `map()`. I allowed myself to replace `currentTimeMillis` with `Instant`s so that it's easier to see the difference when printed out