### PR TITLE
Fix "Flux.create" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Flux.create(sink -> {
     },
     // Overflow (backpressure) handling, default is BUFFER
     FluxSink.OverflowStrategy.LATEST)
-    .timeout(3)
+    .timeout(Duration.ofSeconds(3))
     .doOnComplete(() -> System.out.println("completed!"))
     .subscribe(System.out::println)
 ```


### PR DESCRIPTION
The example used the old `timeout()` method with the number of seconds as a parameter. 

Replaced it with the new method accepting a `Duration` object.