### PR TITLE
ensures SchedulerTask uses isShutdown instead of isDisposed

### DIFF
--- a/reactor-core/src/main/java21/reactor/core/scheduler/ThreadPerTaskBoundedElasticScheduler.java
+++ b/reactor-core/src/main/java21/reactor/core/scheduler/ThreadPerTaskBoundedElasticScheduler.java
@@ -826,6 +826,10 @@ final class ThreadPerTaskBoundedElasticScheduler
 			return isShutdown(this.wipAndRefCnt) && numberOfEnqueuedTasks() == 0;
 		}
 
+		boolean isShutdown() {
+			return isShutdown(this.wipAndRefCnt);
+		}
+
 		@Override
 		public Object scanUnsafe(Attr key) {
 			if (Attr.TERMINATED == key) return isDisposed();
@@ -1037,7 +1041,7 @@ final class ThreadPerTaskBoundedElasticScheduler
 
 				previousState = isInstant ? markInitial(this) : markRescheduled(this);
 				boolean isDisposed = isDisposed(previousState);
-				boolean isShutdown = holder.isDisposed();
+				boolean isShutdown = holder.isShutdown();
 
 				if (isInstant) {
 					if (!isDisposed && !isShutdown) {
@@ -1305,8 +1309,11 @@ final class ThreadPerTaskBoundedElasticScheduler
 
 		@Override
 		public String toString() {
-			return "SchedulerTask(" + hashCode() +"){" + "carrier=" + carrier + ", " +
-					"scheduledFuture=" + scheduledFuture + "state= " + Integer.toBinaryString(get()) + '}';
+			return (isPeriodic() ? this.fixedRatePeriod == 0 ?  "InstantPeriodic" :
+					"Periodic" :
+					"") +
+					"SchedulerTask(" + hashCode() +"){" + "carrier=" + carrier + ", " +
+					"scheduledFuture=" + scheduledFuture + ", state= " + Integer.toBinaryString(get()) + '}';
 		}
 	}
 


### PR DESCRIPTION
the SchedulerTask was using the isDisposed which is showing false until both the isShutdown is true and the count of active tasks is zero. That means that any recurring task could not be interrupted since this flag never returns true while this task is active. We need to check only isShutdown which is set to true when gracefulShutdown is triggered so any recurring task can stop eventually