### PR TITLE
InternalOperator automatic context propagation

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableLift.java
@@ -69,7 +69,7 @@ final class ConnectableLift<I, O> extends InternalConnectableFluxOperator<I, O> 
 	@Override
 	public final CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) {
 		CoreSubscriber<? super I> input =
-				liftFunction.lifter.apply(source, actual);
+				liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual));
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableLiftFuseable.java
@@ -71,7 +71,7 @@ final class ConnectableLiftFuseable<I, O> extends InternalConnectableFluxOperato
 	@Override
 	public final CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) {
 		CoreSubscriber<? super I> input =
-				liftFunction.lifter.apply(source, actual);
+				liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual));
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferBoundary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ final class FluxBufferBoundary<T, U, C extends Collection<? super T>>
 			Publisher<U> other,
 			Supplier<C> bufferSupplier) {
 		super(source);
-		this.other = Objects.requireNonNull(other, "other");
+		this.other = Operators.toFluxOrMono(Objects.requireNonNull(other, "other"));
 		this.bufferSupplier = Objects.requireNonNull(bufferSupplier, "bufferSupplier");
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferWhen.java
@@ -65,7 +65,7 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 			Supplier<BUFFER> bufferSupplier,
 			Supplier<? extends Queue<BUFFER>> queueSupplier) {
 		super(source);
-		this.start = Objects.requireNonNull(start, "start");
+		this.start = Operators.toFluxOrMono(Objects.requireNonNull(start, "start"));
 		this.end = Objects.requireNonNull(end, "end");
 		this.bufferSupplier = Objects.requireNonNull(bufferSupplier, "bufferSupplier");
 		this.queueSupplier = Objects.requireNonNull(queueSupplier, "queueSupplier");
@@ -360,7 +360,7 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 
 			BufferWhenCloseSubscriber<T, BUFFER> bc = new BufferWhenCloseSubscriber<>(this, idx);
 			subscribers.add(bc);
-			p.subscribe(bc);
+			Operators.toFluxOrMono(p).subscribe(bc);
 		}
 
 		void openComplete(BufferWhenOpenSubscriber<OPEN> os) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -448,7 +448,7 @@ final class FluxConcatMap<T, R> extends InternalFluxOperator<T, R> {
 							}
 							else {
 								active = true;
-								p.subscribe(inner);
+								Operators.toFluxOrMono(p).subscribe(inner);
 							}
 						}
 					}
@@ -805,7 +805,7 @@ final class FluxConcatMap<T, R> extends InternalFluxOperator<T, R> {
 							}
 							else {
 								active = true;
-								p.subscribe(inner);
+								Operators.toFluxOrMono(p).subscribe(inner);
 							}
 						}
 					}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -203,7 +203,7 @@ final class FluxConcatMapNoPrefetch<T, R> extends InternalFluxOperator<T, R> {
 					return;
 				}
 
-				p.subscribe(inner);
+				Operators.toFluxOrMono(p).subscribe(inner);
 			}
 			catch (Throwable e) {
 				Context ctx = actual.currentContext();

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxDelaySubscription.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxDelaySubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ final class FluxDelaySubscription<T, U> extends InternalFluxOperator<T, T>
 
 	FluxDelaySubscription(Flux<? extends T> source, Publisher<U> other) {
 		super(source);
-		this.other = Objects.requireNonNull(other, "other");
+		this.other = Operators.toFluxOrMono(Objects.requireNonNull(other, "other"));
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxExpand.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxExpand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,8 +119,8 @@ final class FluxExpand<T> extends InternalFluxOperator<T, T> {
 
 			Publisher<? extends T> p;
 			try {
-				p = Objects.requireNonNull(expander.apply(t),
-						"The expander returned a null Publisher");
+				p = Operators.toFluxOrMono(Objects.requireNonNull(expander.apply(t),
+						"The expander returned a null Publisher"));
 			}
 			catch (Throwable ex) {
 				Exceptions.throwIfFatal(ex);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilterWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilterWhen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -279,7 +279,7 @@ class FluxFilterWhen<T> extends InternalFluxOperator<T, T> {
 								FilterWhenInner inner = new FilterWhenInner(this, !(p instanceof Mono));
 								if (CURRENT.compareAndSet(this,null, inner)) {
 									state = STATE_RUNNING;
-									p.subscribe(inner);
+									Operators.toFluxOrMono(p).subscribe(inner);
 									break;
 								}
 							}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGroupJoin.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGroupJoin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ final class FluxGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R>
 			Supplier<? extends Queue<Object>> queueSupplier,
 			Supplier<? extends Queue<TRight>> processorQueueSupplier) {
 		super(source);
-		this.other = Objects.requireNonNull(other, "other");
+		this.other = Operators.toFluxOrMono(Objects.requireNonNull(other, "other"));
 		this.leftEnd = Objects.requireNonNull(leftEnd, "leftEnd");
 		this.rightEnd = Objects.requireNonNull(rightEnd, "rightEnd");
 		this.processorQueueSupplier = Objects.requireNonNull(processorQueueSupplier, "processorQueueSupplier");
@@ -336,7 +336,7 @@ final class FluxGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R>
 								new LeftRightEndSubscriber(this, true, idx);
 						cancellations.add(end);
 
-						p.subscribe(end);
+						Operators.toFluxOrMono(p).subscribe(end);
 
 						ex = error;
 						if (ex != null) {
@@ -404,7 +404,7 @@ final class FluxGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R>
 								new LeftRightEndSubscriber(this, false, idx);
 						cancellations.add(end);
 
-						p.subscribe(end);
+						Operators.toFluxOrMono(p).subscribe(end);
 
 						ex = error;
 						if (ex != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxJoin.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxJoin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ final class FluxJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
 			Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd,
 			BiFunction<? super TLeft, ? super TRight, ? extends R> resultSelector) {
 		super(source);
-		this.other = Objects.requireNonNull(other, "other");
+		this.other = Operators.toFluxOrMono(Objects.requireNonNull(other, "other"));
 		this.leftEnd = Objects.requireNonNull(leftEnd, "leftEnd");
 		this.rightEnd = Objects.requireNonNull(rightEnd, "rightEnd");
 		this.resultSelector = Objects.requireNonNull(resultSelector, "resultSelector");
@@ -289,7 +289,7 @@ final class FluxJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
 								new LeftRightEndSubscriber(this, true, idx);
 						cancellations.add(end);
 
-						p.subscribe(end);
+						Operators.toFluxOrMono(p).subscribe(end);
 
 						ex = error;
 						if (ex != null) {
@@ -366,7 +366,7 @@ final class FluxJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
 								new LeftRightEndSubscriber(this, false, idx);
 						cancellations.add(end);
 
-						p.subscribe(end);
+						Operators.toFluxOrMono(p).subscribe(end);
 
 						ex = error;
 						if (ex != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxLift.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ final class FluxLift<I, O> extends InternalFluxOperator<I, O> {
 	@Override
 	public CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) {
 		CoreSubscriber<? super I> input =
-				liftFunction.lifter.apply(source, actual);
+				liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual));
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxLiftFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ final class FluxLiftFuseable<I, O> extends InternalFluxOperator<I, O>
 	@Override
 	public CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) {
 		CoreSubscriber<? super I> input =
-				liftFunction.lifter.apply(source, actual);
+				liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual));
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 
@@ -65,6 +65,6 @@ final class FluxLiftFuseable<I, O> extends InternalFluxOperator<I, O>
 			input = new FluxHide.SuppressFuseableSubscriber<>(input);
 		}
 		//otherwise QS is not required or user already made a compatible conversion
-		return input;
+		return Operators.restoreContextOnSubscriberIfAutoCPEnabled(this, input);
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMergeSequential.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMergeSequential.java
@@ -205,7 +205,7 @@ final class FluxMergeSequential<T, R> extends InternalFluxOperator<T, R> {
 			Publisher<? extends R> publisher;
 
 			try {
-				publisher = Objects.requireNonNull(mapper.apply(t), "publisher");
+				publisher = Operators.toFluxOrMono(Objects.requireNonNull(mapper.apply(t), "publisher"));
 			}
 			catch (Throwable ex) {
 				onError(Operators.onOperatorError(s, ex, t, actual.currentContext()));

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxOnErrorResume.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxOnErrorResume.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,8 +91,8 @@ final class FluxOnErrorResume<T> extends InternalFluxOperator<T, T> {
 				Publisher<? extends T> p;
 
 				try {
-					p = Objects.requireNonNull(nextFactory.apply(t),
-					"The nextFactory returned a null Publisher");
+					p = Operators.toFluxOrMono(Objects.requireNonNull(nextFactory.apply(t),
+					"The nextFactory returned a null Publisher"));
 				}
 				catch (Throwable e) {
 					Throwable _e = Operators.onOperatorError(e, actual.currentContext());

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublishMulticast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,8 +78,9 @@ final class FluxPublishMulticast<T, R> extends InternalFluxOperator<T, R> implem
 				queueSupplier,
 				actual.currentContext());
 
-		Publisher<? extends R> out = Objects.requireNonNull(transform.apply(multicast),
-				"The transform returned a null Publisher");
+		Publisher<? extends R> out = Operators.toFluxOrMono(Objects.requireNonNull(
+				transform.apply(multicast),
+				"The transform returned a null Publisher"));
 
 		if (out instanceof Fuseable) {
 			out.subscribe(new CancelFuseableMulticaster<>(actual, multicast));

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
@@ -76,7 +76,7 @@ final class FluxRepeatWhen<T> extends InternalFluxOperator<T, T> {
 			return null;
 		}
 
-		p.subscribe(other);
+		Operators.toFluxOrMono(p).subscribe(other);
 
 		if (!main.cancelled) {
 			return main;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRetry.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRetry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
+import org.reactivestreams.Publisher;
 import reactor.core.CorePublisher;
 import reactor.core.CoreSubscriber;
 
@@ -114,7 +115,9 @@ final class FluxRetry<T> extends InternalFluxOperator<T, T> {
 						produced(c);
 					}
 
-					source.subscribe(this);
+					// Not wrapping source, but just the subscriber due to requirements
+					// in TailCallSubscribeTest#retry
+					source.subscribe(Operators.restoreContextOnSubscriberIfPublisherNonInternal(source, this));
 
 				} while (WIP.decrementAndGet(this) != 0);
 			}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSample.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ final class FluxSample<T, U> extends InternalFluxOperator<T, T> {
 
 	FluxSample(Flux<? extends T> source, Publisher<U> other) {
 		super(source);
-		this.other = Objects.requireNonNull(other, "other");
+		this.other = Operators.toFluxOrMono(Objects.requireNonNull(other, "other"));
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSampleFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSampleFirst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -191,7 +191,7 @@ final class FluxSampleFirst<T, U> extends InternalFluxOperator<T, T> {
 				SampleFirstOther<U> other = new SampleFirstOther<>(this);
 
 				if (Operators.replace(OTHER, this, other)) {
-					p.subscribe(other);
+					Operators.toFluxOrMono(p).subscribe(other);
 				}
 			}
 			else {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSampleTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSampleTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -207,7 +207,7 @@ final class FluxSampleTimeout<T, U> extends InternalFluxOperator<T, T> {
 			SampleTimeoutOther<T, U> os = new SampleTimeoutOther<>(this, t, idx);
 
 			if (Operators.replace(OTHER, this, os)) {
-				p.subscribe(os);
+				Operators.toFluxOrMono(p).subscribe(os);
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSkipUntilOther.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSkipUntilOther.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ final class FluxSkipUntilOther<T, U> extends InternalFluxOperator<T, T> {
 
 	FluxSkipUntilOther(Flux<? extends T> source, Publisher<U> other) {
 		super(source);
-		this.other = Objects.requireNonNull(other, "other");
+		this.other = Operators.toFluxOrMono(Objects.requireNonNull(other, "other"));
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchIfEmpty.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchIfEmpty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ final class FluxSwitchIfEmpty<T> extends InternalFluxOperator<T, T> {
 	FluxSwitchIfEmpty(Flux<? extends T> source,
 			Publisher<? extends T> other) {
 		super(source);
-		this.other = Objects.requireNonNull(other, "other");
+		this.other = Operators.toFluxOrMono(Objects.requireNonNull(other, "other"));
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -233,7 +233,7 @@ final class FluxSwitchMap<T, R> extends InternalFluxOperator<T, R> {
 
 			if (INNER.compareAndSet(this, si, innerSubscriber)) {
 				ACTIVE.getAndIncrement(this);
-				p.subscribe(innerSubscriber);
+				Operators.toFluxOrMono(p).subscribe(innerSubscriber);
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMapNoPrefetch.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMapNoPrefetch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -215,7 +215,7 @@ final class FluxSwitchMapNoPrefetch<T, R> extends InternalFluxOperator<T, R> {
 				return;
 			}
 
-			p.subscribe(nextInner);
+			Operators.toFluxOrMono(p).subscribe(nextInner);
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntilOther.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntilOther.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ final class FluxTakeUntilOther<T, U> extends InternalFluxOperator<T, T> {
 
 	FluxTakeUntilOther(Flux<? extends T> source, Publisher<U> other) {
 		super(source);
-		this.other = Objects.requireNonNull(other, "other");
+		this.other = Operators.toFluxOrMono(Objects.requireNonNull(other, "other"));
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,8 @@ final class FluxTimeout<T, U, V> extends InternalFluxOperator<T, T> {
 			Function<? super T, ? extends Publisher<V>> itemTimeout,
 			String timeoutDescription) {
 		super(source);
-		this.firstTimeout = Objects.requireNonNull(firstTimeout, "firstTimeout");
+		this.firstTimeout = Operators.toFluxOrMono(Objects.requireNonNull(firstTimeout,
+				"firstTimeout"));
 		this.itemTimeout = Objects.requireNonNull(itemTimeout, "itemTimeout");
 		this.other = null;
 
@@ -69,9 +70,9 @@ final class FluxTimeout<T, U, V> extends InternalFluxOperator<T, T> {
 			Function<? super T, ? extends Publisher<V>> itemTimeout,
 			Publisher<? extends T> other) {
 		super(source);
-		this.firstTimeout = Objects.requireNonNull(firstTimeout, "firstTimeout");
+		this.firstTimeout = Operators.toFluxOrMono(Objects.requireNonNull(firstTimeout, "firstTimeout"));
 		this.itemTimeout = Objects.requireNonNull(itemTimeout, "itemTimeout");
-		this.other = Objects.requireNonNull(other, "other");
+		this.other = Operators.toFluxOrMono(Objects.requireNonNull(other, "other"));
 		this.timeoutDescription = null;
 	}
 
@@ -199,7 +200,7 @@ final class FluxTimeout<T, U, V> extends InternalFluxOperator<T, T> {
 				return;
 			}
 
-			p.subscribe(ts);
+			Operators.toFluxOrMono(p).subscribe(ts);
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowBoundary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ final class FluxWindowBoundary<T, U> extends InternalFluxOperator<T, Flux<T>> {
 	FluxWindowBoundary(Flux<? extends T> source, Publisher<U> other,
 			Supplier<? extends Queue<T>> processorQueueSupplier) {
 		super(source);
-		this.other = Objects.requireNonNull(other, "other");
+		this.other = Operators.toFluxOrMono(Objects.requireNonNull(other, "other"));
 		this.processorQueueSupplier = Objects.requireNonNull(processorQueueSupplier, "processorQueueSupplier");
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowWhen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ final class FluxWindowWhen<T, U, V> extends InternalFluxOperator<T, Flux<T>> {
 			Function<? super U, ? extends Publisher<V>> end,
 			Supplier<? extends Queue<T>> processorQueueSupplier) {
 		super(source);
-		this.start = Objects.requireNonNull(start, "start");
+		this.start = Operators.toFluxOrMono(Objects.requireNonNull(start, "start"));
 		this.end = Objects.requireNonNull(end, "end");
 		this.processorQueueSupplier =
 				Objects.requireNonNull(processorQueueSupplier, "processorQueueSupplier");
@@ -308,7 +308,7 @@ final class FluxWindowWhen<T, U, V> extends InternalFluxOperator<T, Flux<T>> {
 						if (resources.add(cl)) {
 							OPEN_WINDOW_COUNT.getAndIncrement(this);
 
-							p.subscribe(cl);
+							Operators.toFluxOrMono(p).subscribe(cl);
 						}
 
 						continue;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWithLatestFrom.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWithLatestFrom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ final class FluxWithLatestFrom<T, U, R> extends InternalFluxOperator<T, R> {
 			Publisher<? extends U> other,
 			BiFunction<? super T, ? super U, ? extends R> combiner) {
 		super(source);
-		this.other = Objects.requireNonNull(other, "other");
+		this.other = Operators.toFluxOrMono(Objects.requireNonNull(other, "other"));
 		this.combiner = Objects.requireNonNull(combiner, "combiner");
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/GroupedLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/GroupedLift.java
@@ -80,7 +80,7 @@ final class GroupedLift<K, I, O> extends GroupedFlux<K, O> implements Scannable 
 	@Override
 	public void subscribe(CoreSubscriber<? super O> actual) {
 		CoreSubscriber<? super I> input =
-				liftFunction.lifter.apply(source, actual);
+				liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual));
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/GroupedLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/GroupedLiftFuseable.java
@@ -82,7 +82,7 @@ final class GroupedLiftFuseable<K, I, O> extends GroupedFlux<K, O>
 	@Override
 	public void subscribe(CoreSubscriber<? super O> actual) {
 		CoreSubscriber<? super I> input =
-				liftFunction.lifter.apply(source, actual);
+				liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual));
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -282,6 +282,9 @@ final class MonoCacheInvalidateWhen<T> extends InternalMonoOperator<T, T> {
 				for (@SuppressWarnings("unchecked") CacheMonoSubscriber<T> inner : SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
 					inner.complete(value);
 				}
+				// even though the trigger can deliver values on different threads,
+				// it's not causing any delivery to downstream, so we don't need to
+				// wrap it
 				invalidateTrigger.subscribe(new TriggerSubscriber(this.main));
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelaySubscription.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelaySubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ final class MonoDelaySubscription<T, U> extends InternalMonoOperator<T, T>
 
 	MonoDelaySubscription(Mono<? extends T> source, Publisher<U> other) {
 		super(source);
-		this.other = Objects.requireNonNull(other, "other");
+		this.other = Operators.toFluxOrMono(Objects.requireNonNull(other, "other"));
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFilterWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFilterWhen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,7 +143,7 @@ class MonoFilterWhen<T> extends InternalMonoOperator<T, T> {
 			}
 			else {
 				FilterWhenInner<T> inner = new FilterWhenInner<>(this, !(p instanceof Mono), t);
-				p.subscribe(inner);
+				Operators.toFluxOrMono(p).subscribe(inner);
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMap.java
@@ -162,7 +162,7 @@ final class MonoFlatMap<T, R> extends InternalMonoOperator<T, R> implements Fuse
 			}
 
 			try {
-				m.subscribe(new FlatMapInner<>(this));
+				Mono.fromDirect(m).subscribe(new FlatMapInner<>(this));
 			}
 			catch (Throwable e) {
 				actual.onError(Operators.onOperatorError(this, e, t,

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMapMany.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMapMany.java
@@ -192,7 +192,7 @@ final class MonoFlatMapMany<T, R> extends FluxFromMonoOperator<T, R> {
 				return;
 			}
 
-			p.subscribe(new FlatMapManyInner<>(this, actual));
+			Operators.toFluxOrMono(p).subscribe(new FlatMapManyInner<>(this, actual));
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMapMany.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMapMany.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoLift.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ final class MonoLift<I, O> extends InternalMonoOperator<I, O> {
 	@Override
 	public CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) {
 		CoreSubscriber<? super I> input =
-				liftFunction.lifter.apply(source, actual);
+				liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual));
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoLiftFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,8 +55,7 @@ final class MonoLiftFuseable<I, O> extends InternalMonoOperator<I, O>
 
 	@Override
 	public CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) {
-
-		CoreSubscriber<? super I> input = liftFunction.lifter.apply(source, actual);
+		CoreSubscriber<? super I> input = liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual));
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPublishMulticast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPublishMulticast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,8 +53,8 @@ final class MonoPublishMulticast<T, R> extends InternalMonoOperator<T, R> implem
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super R> actual) {
 		MonoPublishMulticaster<T> multicast = new MonoPublishMulticaster<>(actual.currentContext());
 
-		Mono<? extends R> out = Objects.requireNonNull(transform.apply(fromDirect(multicast)),
-				"The transform returned a null Mono");
+		Mono<? extends R> out = fromDirect(
+				Objects.requireNonNull(transform.apply(fromDirect(multicast)), "The transform returned a null Mono"));
 
 		if (out instanceof Fuseable) {
 			out.subscribe(new FluxPublishMulticast.CancelFuseableMulticaster<>(actual, multicast));

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSwitchIfEmpty.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSwitchIfEmpty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ final class MonoSwitchIfEmpty<T> extends InternalMonoOperator<T, T> {
 
 	MonoSwitchIfEmpty(Mono<? extends T> source, Mono<? extends T> other) {
 		super(source);
-		this.other = Objects.requireNonNull(other, "other");
+		this.other = fromDirect(Objects.requireNonNull(other, "other"));
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTakeUntilOther.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTakeUntilOther.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ final class MonoTakeUntilOther<T, U> extends InternalMonoOperator<T, T> {
 
 	MonoTakeUntilOther(Mono<? extends T> source, Publisher<U> other) {
 		super(source);
-		this.other = Objects.requireNonNull(other, "other");
+		this.other = Operators.toFluxOrMono(Objects.requireNonNull(other, "other"));
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTimeout.java
@@ -48,7 +48,7 @@ final class MonoTimeout<T, U, V> extends InternalMonoOperator<T, T> {
 			Publisher<U> firstTimeout,
 			String timeoutDescription) {
 		super(source);
-		this.firstTimeout = Objects.requireNonNull(firstTimeout, "firstTimeout");
+		this.firstTimeout = Mono.fromDirect(Objects.requireNonNull(firstTimeout, "firstTimeout"));
 		this.other = null;
 		this.timeoutDescription = timeoutDescription;
 	}
@@ -57,8 +57,8 @@ final class MonoTimeout<T, U, V> extends InternalMonoOperator<T, T> {
 			Publisher<U> firstTimeout,
 			Publisher<? extends T> other) {
 		super(source);
-		this.firstTimeout = Objects.requireNonNull(firstTimeout, "firstTimeout");
-		this.other = Objects.requireNonNull(other, "other");
+		this.firstTimeout = Mono.fromDirect(Objects.requireNonNull(firstTimeout, "firstTimeout"));
+		this.other = Mono.fromDirect(Objects.requireNonNull(other, "other"));
 		this.timeoutDescription = null;
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -2701,7 +2701,7 @@ public abstract class Operators {
 			}
 
 			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>>
-					effectiveLifter = (pub, sub) -> lifter.apply(Scannable.from(pub), sub);
+					effectiveLifter = (pub, sub) -> lifter.apply(Scannable.from(pub), restoreContextOnSubscriberIfAutoCPEnabled(pub, sub));
 
 			return new LiftFunction<>(effectiveFilter, effectiveLifter, lifter.toString());
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelLift.java
@@ -62,9 +62,9 @@ final class ParallelLift<I, O> extends ParallelFlux<O> implements Scannable {
 		if (key == Attr.LIFTER) {
 			return liftFunction.name;
 		}
-		// We don't control what the lifter does, so we play it safe.
-		if (key == InternalProducerAttr.INSTANCE) return false;
-
+		if (key == InternalProducerAttr.INSTANCE) {
+			return true;
+		}
 		return null;
 	}
 
@@ -83,13 +83,9 @@ final class ParallelLift<I, O> extends ParallelFlux<O> implements Scannable {
 
 		int i = 0;
 		while (i < subscribers.length) {
-			// As this is not an INTERNAL_PRODUCER, the subscribers should be protected
-			// in case of automatic context propagation.
-			// If a user directly subscribes with a set of rails, there is no
-			// protection against that, so a ThreadLocal restoring subscriber would
-			// need to be provided.
 			subscribers[i] =
-					Objects.requireNonNull(liftFunction.lifter.apply(source, s[i]),
+					Objects.requireNonNull(liftFunction.lifter.apply(source,
+									Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, s[i])),
 							"Lifted subscriber MUST NOT be null");
 			i++;
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelLiftFuseable.java
@@ -65,9 +65,9 @@ final class ParallelLiftFuseable<I, O> extends ParallelFlux<O>
 		if (key == Attr.LIFTER) {
 			return liftFunction.name;
 		}
-		// We don't control what the lifter does, so we play it safe.
-		if (key == InternalProducerAttr.INSTANCE) return false;
-
+		if (key == InternalProducerAttr.INSTANCE) {
+			return true;
+		}
 		return null;
 	}
 
@@ -87,13 +87,8 @@ final class ParallelLiftFuseable<I, O> extends ParallelFlux<O>
 		int i = 0;
 		while (i < subscribers.length) {
 			CoreSubscriber<? super O> actual = s[i];
-			// As this is not an INTERNAL_PRODUCER, the subscribers should be protected
-			// in case of automatic context propagation.
-			// If a user directly subscribes with a set of rails, there is no
-			// protection against that, so a ThreadLocal restoring subscriber would
-			// need to be provided.
 			CoreSubscriber<? super I> converted =
-					Objects.requireNonNull(liftFunction.lifter.apply(source, actual),
+					Objects.requireNonNull(liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual)),
 							"Lifted subscriber MUST NOT be null");
 
 			Objects.requireNonNull(converted, "Lifted subscriber MUST NOT be null");

--- a/reactor-core/src/main/java/reactor/core/publisher/SignalLogger.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SignalLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package reactor.core.publisher;
 
+import java.time.Instant;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/AutomaticContextPropagationTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/AutomaticContextPropagationTest.java
@@ -802,7 +802,7 @@ public class AutomaticContextPropagationTest {
 					Flux.concat(
 							Stream.of(Flux.<String>empty(), threadSwitchingFlux()).collect(Collectors.toList())));
 
-			// core subscriber case doesn't work
+			// Direct subscription
 		}
 
 		@Test
@@ -879,6 +879,10 @@ public class AutomaticContextPropagationTest {
 		@Test
 		void fluxExpand() {
 			AtomicBoolean done = new AtomicBoolean(false);
+			// We don't validate direct subscription via CoreSubscriber with Context in
+			// this case as it can happen that the drain loop is in the main thread
+			// and won't restore TLs from the Context when contextWrite operator is
+			// missing along the way in the chain.
 			assertThreadLocalsPresent(
 					Flux.just("hello").expand(s -> {
 						if (done.get()) {
@@ -888,19 +892,17 @@ public class AutomaticContextPropagationTest {
 							return threadSwitchingFlux();
 						}
 					}));
-
-			// core subscriber case doesn't work
 		}
 
 		@Test
 		void fluxFilterWhen() {
+			// We don't validate direct subscription via CoreSubscriber with Context in
+			// this case as it can happen that the drain loop is in the main thread
+			// and won't restore TLs from the Context when contextWrite operator is
+			// missing along the way in the chain.
 			assertThreadLocalsPresent(
 					Flux.just("hello")
 					    .filterWhen(s -> new ThreadSwitchingFlux<>(Boolean.TRUE, executorService)));
-
-			// it can happen that the drain loop is in the main thread and won't
-			// restore TLs from CoreSubscriber Context when contextWrite operator is
-			// missing along the way
 		}
 
 		@Test
@@ -1054,10 +1056,13 @@ public class AutomaticContextPropagationTest {
 
 		@Test
 		void fluxSampleFirst() {
+			// We don't validate direct subscription via CoreSubscriber with Context in
+			// this case as it can happen that the drain loop is in the main thread
+			// and won't restore TLs from the Context when contextWrite operator is
+			// missing along the way in the chain.
 			assertThreadLocalsPresent(
 					Flux.just("Hello").concatWith(Flux.never())
 					    .sampleFirst(s -> new ThreadSwitchingFlux<>(new RuntimeException("oops"), executorService)));
-			// core subscriber case doesn't work
 		}
 
 		@Test
@@ -1090,10 +1095,13 @@ public class AutomaticContextPropagationTest {
 
 		@Test
 		void fluxTakeUntilOther() {
+			// We don't validate direct subscription via CoreSubscriber with Context in
+			// this case as it can happen that the drain loop is in the main thread
+			// and won't restore TLs from the Context when contextWrite operator is
+			// missing along the way in the chain.
 			assertThreadLocalsPresent(
 					Flux.concat(Flux.just("Hello"), Flux.never())
 					    .takeUntilOther(threadSwitchingFlux()));
-			// core subscriber case doesn't work
 		}
 
 		@Test
@@ -1155,10 +1163,13 @@ public class AutomaticContextPropagationTest {
 
 		@Test
 		void fluxWithLatestFrom() {
+			// We don't validate direct subscription via CoreSubscriber with Context in
+			// this case as it can happen that the drain loop is in the main thread
+			// and won't restore TLs from the Context when contextWrite operator is
+			// missing along the way in the chain.
 			assertThreadLocalsPresent(
 					Flux.just("Hello")
 					    .withLatestFrom(threadSwitchingFlux(), (s1, s2) -> s1));
-			// core subscriber case doesn't work
 		}
 
 		@Test

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/AutomaticContextPropagationTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/AutomaticContextPropagationTest.java
@@ -581,6 +581,14 @@ public class AutomaticContextPropagationTest {
 		}
 
 		@Test
+		void internalMonoFlatMapSubscribeNoFusion() {
+			assertThreadLocalsPresentInMono(() ->
+					Mono.just("hello")
+					    .hide()
+					    .flatMap(item -> threadSwitchingMono()));
+		}
+
+		@Test
 		void directMonoSubscribeAsCoreSubscriber() throws InterruptedException, TimeoutException {
 			AtomicReference<String> valueInOnNext = new AtomicReference<>();
 			AtomicReference<String> valueInOnComplete = new AtomicReference<>();
@@ -938,6 +946,21 @@ public class AutomaticContextPropagationTest {
 			assertThreadLocalsPresentInMono(() ->
 					Mono.usingWhen(Mono.just("Hello"), s -> threadSwitchingMono(),
 							s -> Mono.empty()));
+		}
+
+		@Test
+		void monoFlatMapMany() {
+			assertThreadLocalsPresentInFlux(() ->
+					Mono.just("hello")
+						.hide()
+					    .flatMapMany(item -> threadSwitchingFlux()));
+		}
+
+		@Test
+		void monoFlatMapManyFuseable() {
+			assertThreadLocalsPresentInFlux(() ->
+					Mono.just("hello")
+					    .flatMapMany(item -> threadSwitchingFlux()));
 		}
 
 		// ParallelFlux tests

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/AutomaticContextPropagationTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/AutomaticContextPropagationTest.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import java.io.File;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -39,6 +40,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.micrometer.context.ContextRegistry;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -48,6 +50,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.CorePublisher;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
@@ -59,6 +63,7 @@ import reactor.util.context.Context;
 import reactor.util.function.Tuples;
 import reactor.util.retry.Retry;
 
+import static org.assertj.core.api.Assertions.anyOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
@@ -317,7 +322,7 @@ public class AutomaticContextPropagationTest {
 
 		@BeforeEach
 		void enableAutomaticContextPropagation() {
-			executorService = Executors.newFixedThreadPool(3);
+			executorService = Executors.newSingleThreadExecutor();
 		}
 
 		@AfterEach
@@ -342,11 +347,9 @@ public class AutomaticContextPropagationTest {
 		void assertThreadLocalsPresentInFlux(Supplier<Flux<?>> chainSupplier,
 				boolean skipCoreSubscriber) {
 			assertThreadLocalsPresent(chainSupplier.get());
-			assertThatNoException().isThrownBy(() ->
-					assertThatThreadLocalsPresentDirectRawSubscribe(chainSupplier.get()));
+			assertThatThreadLocalsPresentDirectRawSubscribe(chainSupplier.get());
 			if (!skipCoreSubscriber) {
-				assertThatNoException().isThrownBy(() ->
-						assertThatThreadLocalsPresentDirectCoreSubscribe(chainSupplier.get()));
+				assertThatThreadLocalsPresentDirectCoreSubscribe(chainSupplier.get());
 			}
 		}
 
@@ -357,11 +360,9 @@ public class AutomaticContextPropagationTest {
 		void assertThreadLocalsPresentInMono(Supplier<Mono<?>> chainSupplier,
 				boolean skipCoreSubscriber) {
 			assertThreadLocalsPresent(chainSupplier.get());
-			assertThatNoException().isThrownBy(() ->
-					assertThatThreadLocalsPresentDirectRawSubscribe(chainSupplier.get()));
+			assertThatThreadLocalsPresentDirectRawSubscribe(chainSupplier.get());
 			if (!skipCoreSubscriber) {
-				assertThatNoException().isThrownBy(() ->
-						assertThatThreadLocalsPresentDirectCoreSubscribe(chainSupplier.get()));
+				assertThatThreadLocalsPresentDirectCoreSubscribe(chainSupplier.get());
 			}
 		}
 
@@ -371,26 +372,37 @@ public class AutomaticContextPropagationTest {
 			AtomicReference<String> tlInOnError = new AtomicReference<>();
 
 			AtomicBoolean hadNext = new AtomicBoolean(false);
-			AtomicBoolean hadError = new AtomicBoolean(false);
+			AtomicReference<Throwable> error = new AtomicReference<>();
 
-			chain.doOnEach(signal -> {
-				     if (signal.isOnNext()) {
-					     tlInOnNext.set(REF.get());
-					     hadNext.set(true);
-				     } else if (signal.isOnError()) {
-					     tlInOnError.set(REF.get());
-					     hadError.set(true);
-				     } else if (signal.isOnComplete()) {
-					     tlInOnComplete.set(REF.get());
-				     }
-			     })
-			     .contextWrite(Context.of(KEY, "present"))
-			     .blockLast();
+			try {
+				chain.doOnEach(signal -> {
+					     if (signal.isOnNext()) {
+						     tlInOnNext.set(REF.get());
+						     hadNext.set(true);
+					     }
+					     else if (signal.isOnError()) {
+						     tlInOnError.set(REF.get());
+						     error.set(signal.getThrowable());
+					     }
+					     else if (signal.isOnComplete()) {
+						     tlInOnComplete.set(REF.get());
+					     }
+				     })
+				     .contextWrite(Context.of(KEY, "present"))
+				     .blockLast(Duration.ofMillis(5000));
+			} catch (Exception e) {
+				if (e instanceof IllegalStateException) {
+					throw e;
+				}
+				assertThat(e).satisfiesAnyOf(
+						exception -> assertThat(exception).isEqualTo(error.get()),
+						exception -> assertThat(exception).hasCause(error.get()));
+			}
 
 			if (hadNext.get()) {
 				assertThat(tlInOnNext.get()).isEqualTo("present");
 			}
-			if (hadError.get()) {
+			if (error.get() != null) {
 				assertThat(tlInOnError.get()).isEqualTo("present");
 			} else {
 				assertThat(tlInOnComplete.get()).isEqualTo("present");
@@ -406,17 +418,20 @@ public class AutomaticContextPropagationTest {
 			AtomicBoolean hadError = new AtomicBoolean(false);
 
 			chain.doOnEach(signal -> {
-				if (signal.isOnNext()) {
-					tlInOnNext.set(REF.get());
-					hadNext.set(true);
-				} else if (signal.isOnError()) {
-					tlInOnError.set(REF.get());
-					hadError.set(true);
-				} else if (signal.isOnComplete()) {
-					tlInOnComplete.set(REF.get());
-				}
-			})
+				     if (signal.isOnNext()) {
+					     tlInOnNext.set(REF.get());
+					     hadNext.set(true);
+				     }
+				     else if (signal.isOnError()) {
+					     tlInOnError.set(REF.get());
+					     hadError.set(true);
+				     }
+				     else if (signal.isOnComplete()) {
+					     tlInOnComplete.set(REF.get());
+				     }
+			     })
 			     .contextWrite(Context.of(KEY, "present"))
+			     .onErrorComplete()
 			     .block();
 
 			if (hadNext.get()) {
@@ -430,42 +445,49 @@ public class AutomaticContextPropagationTest {
 		}
 
 		<T> void assertThatThreadLocalsPresentDirectCoreSubscribe(
-				CorePublisher<? extends T> source) throws InterruptedException, TimeoutException {
+				CorePublisher<? extends T> source) {
 			assertThatThreadLocalsPresentDirectCoreSubscribe(source, () -> {});
 		}
 
 		<T> void assertThatThreadLocalsPresentDirectCoreSubscribe(
-				CorePublisher<? extends T> source, Runnable asyncAction) throws InterruptedException, TimeoutException {
-			AtomicReference<String> valueInOnNext = new AtomicReference<>();
-			AtomicReference<String> valueInOnComplete = new AtomicReference<>();
-			AtomicReference<String> valueInOnError = new AtomicReference<>();
-			AtomicReference<Throwable> error = new AtomicReference<>();
-			AtomicBoolean complete = new AtomicBoolean();
-			AtomicBoolean hadNext = new AtomicBoolean();
-			CountDownLatch latch = new CountDownLatch(1);
+				CorePublisher<? extends T> source, Runnable asyncAction) {
+			assertThatNoException().isThrownBy(() -> {
+				AtomicReference<String> valueInOnNext = new AtomicReference<>();
+				AtomicReference<String> valueInOnComplete = new AtomicReference<>();
+				AtomicReference<String> valueInOnError = new AtomicReference<>();
+				AtomicReference<Throwable> error = new AtomicReference<>();
+				AtomicBoolean complete = new AtomicBoolean();
+				AtomicBoolean hadNext = new AtomicBoolean();
+				CountDownLatch latch = new CountDownLatch(1);
 
-			CoreSubscriberWithContext<T> subscriberWithContext =
-					new CoreSubscriberWithContext<>(
-							valueInOnNext, valueInOnComplete, valueInOnError,
-							error, latch, hadNext, complete);
+				CoreSubscriberWithContext<T> subscriberWithContext = new CoreSubscriberWithContext<>(valueInOnNext,
+						valueInOnComplete,
+						valueInOnError,
+						error,
+						latch,
+						hadNext,
+						complete);
 
-			source.subscribe(subscriberWithContext);
+				source.subscribe(subscriberWithContext);
 
-			executorService.submit(asyncAction);
+				executorService.submit(asyncAction)
+				               .get(100, TimeUnit.MILLISECONDS);
 
-			if (!latch.await(100, TimeUnit.MILLISECONDS)) {
-				throw new TimeoutException("timed out");
-			}
+				if (!latch.await(500, TimeUnit.MILLISECONDS)) {
+					throw new TimeoutException("timed out");
+				}
 
-			if (hadNext.get()) {
-				assertThat(valueInOnNext.get()).isEqualTo("present");
-			}
-			if (error.get() == null) {
-				assertThat(valueInOnComplete.get()).isEqualTo("present");
-				assertThat(complete).isTrue();
-			} else {
-				assertThat(valueInOnError.get()).isEqualTo("present");
-			}
+				if (hadNext.get()) {
+					assertThat(valueInOnNext.get()).isEqualTo("present");
+				}
+				if (error.get() == null) {
+					assertThat(valueInOnComplete.get()).isEqualTo("present");
+					assertThat(complete).isTrue();
+				}
+				else {
+					assertThat(valueInOnError.get()).isEqualTo("present");
+				}
+			});
 		}
 
 		// We force the use of subscribe(Subscriber) override instead of
@@ -473,42 +495,49 @@ public class AutomaticContextPropagationTest {
 		// are able to wrap the Subscriber and restore ThreadLocal values for the
 		// signals received downstream.
 		<T> void assertThatThreadLocalsPresentDirectRawSubscribe(
-				Publisher<? extends T> source) throws InterruptedException, TimeoutException {
+				Publisher<? extends T> source) {
 			assertThatThreadLocalsPresentDirectRawSubscribe(source, () -> {});
 		}
 
 		<T> void assertThatThreadLocalsPresentDirectRawSubscribe(
-				Publisher<? extends T> source, Runnable asyncAction) throws InterruptedException, TimeoutException {
-			AtomicReference<String> valueInOnNext = new AtomicReference<>();
-			AtomicReference<String> valueInOnComplete = new AtomicReference<>();
-			AtomicReference<String> valueInOnError = new AtomicReference<>();
-			AtomicReference<Throwable> error = new AtomicReference<>();
-			AtomicBoolean hadNext = new AtomicBoolean();
-			AtomicBoolean complete = new AtomicBoolean();
-			CountDownLatch latch = new CountDownLatch(1);
+				Publisher<? extends T> source, Runnable asyncAction) {
+			assertThatNoException().isThrownBy(() -> {
+				AtomicReference<String> valueInOnNext = new AtomicReference<>();
+				AtomicReference<String> valueInOnComplete = new AtomicReference<>();
+				AtomicReference<String> valueInOnError = new AtomicReference<>();
+				AtomicReference<Throwable> error = new AtomicReference<>();
+				AtomicBoolean hadNext = new AtomicBoolean();
+				AtomicBoolean complete = new AtomicBoolean();
+				CountDownLatch latch = new CountDownLatch(1);
 
-			CoreSubscriberWithContext<T> subscriberWithContext =
-					new CoreSubscriberWithContext<>(
-							valueInOnNext, valueInOnComplete, valueInOnError,
-							error, latch, hadNext, complete);
+				CoreSubscriberWithContext<T> subscriberWithContext = new CoreSubscriberWithContext<>(valueInOnNext,
+						valueInOnComplete,
+						valueInOnError,
+						error,
+						latch,
+						hadNext,
+						complete);
 
-			source.subscribe(subscriberWithContext);
+				source.subscribe(subscriberWithContext);
 
-			executorService.submit(asyncAction);
+				executorService.submit(asyncAction)
+				               .get(100, TimeUnit.MILLISECONDS);
 
-			if (!latch.await(500, TimeUnit.MILLISECONDS)) {
-				throw new TimeoutException("timed out");
-			}
+				if (!latch.await(500, TimeUnit.MILLISECONDS)) {
+					throw new TimeoutException("timed out");
+				}
 
-			if (hadNext.get()) {
-				assertThat(valueInOnNext.get()).isEqualTo("present");
-			}
-			if (error.get() == null) {
-				assertThat(valueInOnComplete.get()).isEqualTo("present");
-				assertThat(complete).isTrue();
-			} else {
-				assertThat(valueInOnError.get()).isEqualTo("present");
-			}
+				if (hadNext.get()) {
+					assertThat(valueInOnNext.get()).isEqualTo("present");
+				}
+				if (error.get() == null) {
+					assertThat(valueInOnComplete.get()).isEqualTo("present");
+					assertThat(complete).isTrue();
+				}
+				else {
+					assertThat(valueInOnError.get()).isEqualTo("present");
+				}
+			});
 		}
 
 		// Fundamental tests for Flux
@@ -528,8 +557,7 @@ public class AutomaticContextPropagationTest {
 		@Test
 		void internalFluxSubscribeNoFusion() {
 			assertThreadLocalsPresentInFlux(() ->
-					Flux.just("hello")
-					    .hide()
+					threadSwitchingFlux()
 					    .flatMap(item -> threadSwitchingFlux()));
 		}
 
@@ -685,6 +713,20 @@ public class AutomaticContextPropagationTest {
 		}
 
 		@Test
+		void fluxRepeatWhen() {
+			assertThreadLocalsPresentInFlux(() ->
+					threadSwitchingFlux()
+							.repeatWhen(s -> Flux.just(1)));
+		}
+
+		@Test
+		void fluxRepeatWhenSwitchingThread() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.just("Hello")
+					    .repeatWhen(s -> threadSwitchingFlux()));
+		}
+
+		@Test
 		void fluxWindowUntil() {
 			assertThreadLocalsPresentInFlux(() ->
 					threadSwitchingFlux().windowUntil(s -> true)
@@ -756,9 +798,11 @@ public class AutomaticContextPropagationTest {
 
 		@Test
 		void fluxConcatIterable() {
-			assertThreadLocalsPresentInFlux(() ->
+			assertThreadLocalsPresent(
 					Flux.concat(
 							Stream.of(Flux.<String>empty(), threadSwitchingFlux()).collect(Collectors.toList())));
+
+			// core subscriber case doesn't work
 		}
 
 		@Test
@@ -795,6 +839,332 @@ public class AutomaticContextPropagationTest {
 			assertThreadLocalsPresentInFlux(() ->
 					Flux.zip(Stream.of(Flux.just(""), threadSwitchingFlux()).collect(Collectors.toList()),
 					obj -> Tuples.of((String) obj[0], (String) obj[1])));
+		}
+
+		@Test
+		void fluxBufferBoundary() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.just("Hello").delayElements(Duration.ofMillis(20))
+					    .buffer(threadSwitchingFlux()));
+		}
+
+		@Test
+		void fluxBufferWhen() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.just("hello").delayElements(Duration.ofMillis(20))
+					    .bufferWhen(threadSwitchingFlux(), x -> Flux.empty()));
+		}
+
+		@Test
+		void fluxConcatMap() {
+			assertThreadLocalsPresentInFlux(() ->
+					threadSwitchingFlux()
+					    .concatMap(s -> threadSwitchingFlux(), 1));
+		}
+
+		@Test
+		void fluxConcatMapNoPrefetch() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.just("hello").hide()
+					    .concatMap(s -> threadSwitchingFlux()));
+		}
+
+		@Test
+		void fluxDelaySubscription() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.just("hello")
+					    .delaySubscription(threadSwitchingFlux()));
+		}
+
+		@Test
+		void fluxExpand() {
+			AtomicBoolean done = new AtomicBoolean(false);
+			assertThreadLocalsPresent(
+					Flux.just("hello").expand(s -> {
+						if (done.get()) {
+							return Flux.empty();
+						} else {
+							done.set(true);
+							return threadSwitchingFlux();
+						}
+					}));
+
+			// core subscriber case doesn't work
+		}
+
+		@Test
+		void fluxFilterWhen() {
+			assertThreadLocalsPresent(
+					Flux.just("hello")
+					    .filterWhen(s -> new ThreadSwitchingFlux<>(Boolean.TRUE, executorService)));
+
+			// it can happen that the drain loop is in the main thread and won't
+			// restore TLs from CoreSubscriber Context when contextWrite operator is
+			// missing along the way
+		}
+
+		@Test
+		void fluxGroupJoinFlattened() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.just("hello").groupJoin(threadSwitchingFlux(),
+							l -> Flux.never(), r -> Flux.never(),
+							(s, f) -> f.map(i -> s)).flatMap(Function.identity()));
+		}
+
+		@Test
+		void fluxGroupJoin() {
+			assertThreadLocalsPresent(
+					Flux.just("hello").groupJoin(threadSwitchingFlux(),
+							l -> Flux.never(), r -> Flux.never(),
+							(s, f) -> f.map(i -> s)));
+
+			// works only with contextWrite because the group is delivered using the
+			// signal from the left hand side
+		}
+
+		@Test
+		void fluxGroupJoinSubscribed() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.just("hello").groupJoin(threadSwitchingFlux(),
+							l -> Flux.never(), r -> Flux.never(),
+							(s, f) -> f.map(i -> s))
+					    .flatMap(Function.identity()));
+		}
+
+		@Disabled("Only contextWrite/contextCapture usages are supported")
+		@Test
+		void fluxJustRawSubscribe() {
+			assertThatNoException().isThrownBy(() ->
+				assertThatThreadLocalsPresentDirectRawSubscribe(Flux.just("hello"))
+			);
+		}
+
+		@Test
+		void fluxJoin() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.just("hello").join(threadSwitchingFlux(), l -> Flux.never(),
+							r -> Flux.never(), (s1, s2) -> s1 + s2));
+		}
+
+		@Test
+		void fluxLift() {
+			assertThreadLocalsPresentInFlux(() -> {
+				Flux<String> flux = Flux.just("Hello").hide();
+
+				Publisher<String> lifted =
+						Operators.<String, String>liftPublisher((pub, sub) -> new CoreSubscriber<String>() {
+							         @Override
+							         public void onSubscribe(Subscription s) {
+								         executorService.submit(() -> sub.onSubscribe(s));
+							         }
+
+							         @Override
+							         public void onNext(String s) {
+								         executorService.submit(() -> sub.onNext(s));
+							         }
+
+							         @Override
+							         public void onError(Throwable t) {
+								         executorService.submit(() -> sub.onError(t));
+							         }
+
+							         @Override
+							         public void onComplete() {
+								         executorService.submit(sub::onComplete);
+							         }
+
+							         @Override
+							         public Context currentContext() {
+								         return sub.currentContext();
+							         }
+						         })
+						         .apply(flux);
+
+				return (Flux<String>) lifted;
+			});
+		}
+
+		@Test
+		void fluxLiftFuseable() {
+			assertThreadLocalsPresentInFlux(() -> {
+				Flux<String> flux = Flux.just("Hello");
+
+				Publisher<String> lifted =
+						Operators.<String, String>liftPublisher((pub, sub) -> new CoreSubscriber<String>() {
+							         @Override
+							         public void onSubscribe(Subscription s) {
+								         executorService.submit(() -> sub.onSubscribe(s));
+							         }
+
+							         @Override
+							         public void onNext(String s) {
+								         executorService.submit(() -> sub.onNext(s));
+							         }
+
+							         @Override
+							         public void onError(Throwable t) {
+								         executorService.submit(() -> sub.onError(t));
+							         }
+
+							         @Override
+							         public void onComplete() {
+								         executorService.submit(sub::onComplete);
+							         }
+						         })
+						         .apply(flux);
+
+				return (Flux<String>) lifted;
+			});
+		}
+
+		@Test
+		void fluxFlatMapSequential() {
+			assertThreadLocalsPresentInFlux(() ->
+					threadSwitchingFlux()
+					    .flatMapSequential(s -> threadSwitchingFlux()));
+		}
+
+		@Test
+		void fluxOnErrorResume() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.error(new RuntimeException("Oops"))
+					    .onErrorResume(t -> threadSwitchingFlux()));
+		}
+
+		@Test
+		void fluxPublishMulticast() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.just("Hello")
+							.publish(s -> threadSwitchingFlux()));
+		}
+
+		@Test
+		void fluxSkipUntilOther() {
+			assertThreadLocalsPresentInFlux(() ->
+					threadSwitchingFlux()
+					    .skipUntilOther(threadSwitchingFlux()));
+		}
+
+		@Test
+		void fluxSample() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.just("Hello").concatWith(Flux.never())
+					    .sample(threadSwitchingFlux()));
+		}
+
+		@Test
+		void fluxSampleFirst() {
+			assertThreadLocalsPresent(
+					Flux.just("Hello").concatWith(Flux.never())
+					    .sampleFirst(s -> new ThreadSwitchingFlux<>(new RuntimeException("oops"), executorService)));
+			// core subscriber case doesn't work
+		}
+
+		@Test
+		void fluxSampleTimeout() {
+			assertThreadLocalsPresentInFlux(() ->
+					threadSwitchingFlux().concatWith(Mono.delay(Duration.ofMillis(10)).map(l -> "").concatWith(Mono.empty()))
+					    .sampleTimeout(s -> threadSwitchingFlux()));
+		}
+
+		@Test
+		void fluxSwitchIfEmpty() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.empty()
+					    .switchIfEmpty(threadSwitchingFlux()));
+		}
+
+		@Test
+		void fluxSwitchMapNoPrefetch() {
+			assertThreadLocalsPresentInFlux(() ->
+					threadSwitchingFlux()
+					    .switchMap(s -> threadSwitchingFlux()));
+		}
+
+		@Test
+		void fluxSwitchMap() {
+			assertThreadLocalsPresentInFlux(() ->
+					threadSwitchingFlux()
+					    .switchMap(s -> threadSwitchingFlux(), 1));
+		}
+
+		@Test
+		void fluxTakeUntilOther() {
+			assertThreadLocalsPresent(
+					Flux.concat(Flux.just("Hello"), Flux.never())
+					    .takeUntilOther(threadSwitchingFlux()));
+			// core subscriber case doesn't work
+		}
+
+		@Test
+		void fluxTimeoutFirst() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.never()
+					    .timeout(threadSwitchingFlux()));
+		}
+
+		@Test
+		void fluxTimeoutOther() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.never()
+					    .timeout(threadSwitchingFlux(), i -> Flux.never(), threadSwitchingFlux()));
+		}
+
+		@Test
+		void fluxWindowBoundary() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.just("Hello").delayElements(Duration.ofMillis(20))
+							.window(threadSwitchingFlux()));
+		}
+
+		@Test
+		void fluxWindowBoundaryFlattened() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.just("Hello").delayElements(Duration.ofMillis(20))
+					    .window(threadSwitchingFlux())
+					    .flatMap(Function.identity()));
+		}
+
+		@Test
+		@Disabled("Publisher delivering the window has no notion of Context so nothing " +
+				"can be restored in onNext")
+		void fluxWindowWhen() {
+			assertThreadLocalsPresent(
+					threadSwitchingFlux()
+					    .windowWhen(threadSwitchingFlux(), s -> threadSwitchingFlux()));
+		}
+
+		@Test
+		@Disabled("Publisher delivering the window has no notion of Context so nothing " +
+				"can be restored in onNext")
+		void fluxDelayedWindowWhen() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.just("Hello").delayElements(Duration.ofMillis(100))
+					    .windowWhen(threadSwitchingFlux(), s -> threadSwitchingFlux()));
+		}
+
+		@Test
+		@Disabled("Publisher completing the window has no notion of Context so nothing " +
+				"can be restored in onComplete")
+		void fluxWindowWhenFlatMapped() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.just("Hello").delayElements(Duration.ofMillis(100))
+					    .windowWhen(threadSwitchingFlux(), s -> threadSwitchingFlux())
+					    .flatMap(Function.identity()));
+		}
+
+		@Test
+		void fluxWithLatestFrom() {
+			assertThreadLocalsPresent(
+					Flux.just("Hello")
+					    .withLatestFrom(threadSwitchingFlux(), (s1, s2) -> s1));
+			// core subscriber case doesn't work
+		}
+
+		@Test
+		void continuationBrokenByThreadSwitch() {
+			assertThreadLocalsPresentInFlux(() ->
+					Flux.concat(Mono.empty(), threadSwitchingMono().retry()));
 		}
 
 		// Mono tests
@@ -963,6 +1333,125 @@ public class AutomaticContextPropagationTest {
 					    .flatMapMany(item -> threadSwitchingFlux()));
 		}
 
+		@Test
+		void monoDelaySubscription() {
+			assertThreadLocalsPresentInMono(() ->
+					Mono.just("Hello").delaySubscription(threadSwitchingMono()));
+		}
+
+		@Test
+		void monoFilterWhen() {
+			assertThreadLocalsPresentInMono(() ->
+					Mono.just("Hello").hide()
+					    .filterWhen(s -> new ThreadSwitchingMono<>(Boolean.TRUE, executorService)));
+		}
+
+		@Test
+		void monoLift() {
+			assertThreadLocalsPresentInMono(() -> {
+				Mono<String> mono = Mono.just("Hello").hide();
+
+				Publisher<String> lifted =
+						Operators.<String, String>liftPublisher((pub, sub) -> new CoreSubscriber<String>() {
+							         @Override
+							         public void onSubscribe(Subscription s) {
+								         executorService.submit(() -> sub.onSubscribe(s));
+							         }
+
+							         @Override
+							         public void onNext(String s) {
+								         executorService.submit(() -> sub.onNext(s));
+							         }
+
+							         @Override
+							         public void onError(Throwable t) {
+								         executorService.submit(() -> sub.onError(t));
+							         }
+
+							         @Override
+							         public void onComplete() {
+								         executorService.submit(sub::onComplete);
+							         }
+						         })
+						         .apply(mono);
+
+				return (Mono<String>) lifted;
+			});
+		}
+
+		@Test
+		void monoLiftFuseable() {
+			assertThreadLocalsPresentInMono(() -> {
+				Mono<String> mono = Mono.just("Hello");
+
+				Publisher<String> lifted =
+						Operators.<String, String>liftPublisher((pub, sub) -> new CoreSubscriber<String>() {
+							         @Override
+							         public void onSubscribe(Subscription s) {
+								         executorService.submit(() -> sub.onSubscribe(s));
+							         }
+
+							         @Override
+							         public void onNext(String s) {
+								         executorService.submit(() -> sub.onNext(s));
+							         }
+
+							         @Override
+							         public void onError(Throwable t) {
+								         executorService.submit(() -> sub.onError(t));
+							         }
+
+							         @Override
+							         public void onComplete() {
+								         executorService.submit(sub::onComplete);
+							         }
+						         })
+						         .apply(mono);
+
+				return (Mono<String>) lifted;
+			});
+		}
+
+		@Test
+		void monoOnErrorResume() {
+			assertThreadLocalsPresentInMono(() ->
+					Mono.error(new RuntimeException("oops"))
+							.onErrorResume(e -> threadSwitchingMono()));
+		}
+
+		@Test
+		void monoPublishMulticast() {
+			assertThreadLocalsPresentInMono(() ->
+					Mono.just("Hello")
+					    .publish(s -> threadSwitchingMono()));
+		}
+
+		@Test
+		void monoSwitchIfEmpty() {
+			assertThreadLocalsPresentInMono(() ->
+					Mono.empty()
+					    .switchIfEmpty(threadSwitchingMono()));
+		}
+
+		@Test
+		void monoTakeUntilOther() {
+			assertThreadLocalsPresentInMono(() ->
+					Mono.delay(Duration.ofDays(1)).then(Mono.just("Hello"))
+					    .takeUntilOther(threadSwitchingMono()));
+		}
+
+		@Test
+		void monoTimeoutFirst() {
+			assertThreadLocalsPresentInMono(() ->
+					Mono.never().timeout(threadSwitchingMono()));
+		}
+
+		@Test
+		void monoTimeoutFallback() {
+			assertThreadLocalsPresentInMono(() ->
+					Mono.never().timeout(threadSwitchingMono(), threadSwitchingMono()));
+		}
+
 		// ParallelFlux tests
 
 		@Test
@@ -1027,7 +1516,7 @@ public class AutomaticContextPropagationTest {
 			assertThreadLocalsPresentInFlux(() -> {
 				ParallelFlux<ArrayList<String>> parallelFlux =
 						ParallelFlux.from(Flux.just("Hello"))
-						            .collect(ArrayList::new, ArrayList::add);
+						            .collect(ArrayList<String>::new, ArrayList::add);
 
 				Publisher<ArrayList<String>> lifted =
 						Operators.<ArrayList<String>, ArrayList<String>>liftPublisher((pub, sub) -> new CoreSubscriber<ArrayList<String>>() {
@@ -1170,7 +1659,7 @@ public class AutomaticContextPropagationTest {
 		}
 
 		@Test
-		void sinkDirect() throws InterruptedException, TimeoutException {
+		void sinkDirect() throws InterruptedException, TimeoutException, ExecutionException {
 			Sinks.One<String> sink1 = Sinks.one();
 			assertThatThreadLocalsPresentDirectCoreSubscribe(sink1.asMono(),
 					() -> sink1.tryEmitValue("Hello"));

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ThreadSwitchingMono.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ThreadSwitchingMono.java
@@ -26,11 +26,19 @@ public class ThreadSwitchingMono<T> extends Mono<T> implements Subscription, Run
 
 	private final ExecutorService executorService;
 	private final T item;
+	private final Throwable error;
 	private CoreSubscriber<? super T> actual;
 	AtomicBoolean done = new AtomicBoolean();
 
 	public ThreadSwitchingMono(T item, ExecutorService executorService) {
 		this.item = item;
+		this.error = null;
+		this.executorService = executorService;
+	}
+
+	public ThreadSwitchingMono(ExecutorService executorService, Throwable error) {
+		this.item = null;
+		this.error = error;
 		this.executorService = executorService;
 	}
 
@@ -47,7 +55,12 @@ public class ThreadSwitchingMono<T> extends Mono<T> implements Subscription, Run
 
 	private void deliver() {
 		if (done.compareAndSet(false, true)) {
-			this.actual.onNext(this.item);
+			if (this.item != null) {
+				this.actual.onNext(this.item);
+			}
+			if (this.error != null) {
+				this.actual.onError(this.error);
+			}
 			this.executorService.submit(this.actual::onComplete);
 		}
 	}


### PR DESCRIPTION
This change revisits InternalMonoOperator and InternalFluxOperator implementations and wraps their async sources with a context restoring Subscriber implementation.

This is a follow-up for #3549.