### PR TITLE
Update micrometer, micrometerTracing, contextPropagation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,10 +14,10 @@ baselinePerfExtra = "3.5.1"
 # Other shared versions
 asciidoctor = "3.3.2"
 #note that some micrometer artifacts like context-propagation has a different version directly set in libraries below
-micrometer = "1.12.0-RC1"
+micrometer = "1.12.0"
 micrometerDocsGenerator = "1.0.2"
-micrometerTracingTest="1.2.0-RC1"
-contextPropagation="1.1.0-RC1"
+micrometerTracingTest="1.2.0"
+contextPropagation="1.1.0"
 kotlin = "1.5.32"
 reactiveStreams = "1.0.4"
 


### PR DESCRIPTION
For upcoming reactor-core 3.6.0 release, update micrometer to 1.12.0, micrometerTracingTest to 1.2.0, and contextPropagation to 1.1.0

