### PR TITLE
SinkManyUnicast discard support during subscription cancel

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManyUnicast.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManyUnicast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -411,8 +411,8 @@ final class SinkManyUnicast<T> extends Flux<T> implements InternalManySink<T>, D
 		if (once == 0 && ONCE.compareAndSet(this, 0, 1)) {
 
 			this.hasDownstream = true;
-			actual.onSubscribe(this);
 			this.actual = actual;
+			actual.onSubscribe(this);
 			if (cancelled) {
 				this.hasDownstream = false;
 			} else {


### PR DESCRIPTION
When subscription to `SinkManyUnicast` is cancelled at the time of being delivered, the discarding fails, as the actual `Subscriber` is not yet assigned. This change reorders the operations so that the actual is stored properly before delivering the `Subscription`.