### PR TITLE
Adding Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ about formatting your PR description.
 
 <!--
 The PR description will be used to craft a final squash merge commit
-and the titled will be used in release notes, so please keep them up-to-date.
+and the title will be used in release notes, so please keep them up-to-date.
 More detailed description of the commit message convention:
 https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#black_nib-commit-message-convention
 https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#message-convention


### PR DESCRIPTION
With the template, contributors can learn our conventions and strategy for squash merge commit so that the PR description is properly formatted.