### PR TITLE
Fix pendingTask count not tracking task rejection

### DIFF
--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/TimedScheduler.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/TimedScheduler.java
@@ -77,25 +77,24 @@ final class TimedScheduler implements Scheduler {
 
 	}
 
-	Runnable wrap(Runnable task) {
+	TimedRunnable wrap(Runnable task) {
 		return new TimedRunnable(registry, this, task);
 	}
 
-	Runnable wrapPeriodic(Runnable task) {
+	TimedRunnable wrapPeriodic(Runnable task) {
 		return new TimedRunnable(registry, this, task, true);
 	}
 
 	@Override
 	public Disposable schedule(Runnable task) {
 		this.submittedDirect.increment();
-		task = wrap(task);
+		TimedRunnable timedTask = wrap(task);
 
 		try {
-			return delegate.schedule(task);
+			return delegate.schedule(timedTask);
 		}
 		catch (RejectedExecutionException exception) {
-			((TimedRunnable) task).pendingSample.stop();
-
+			timedTask.pendingSample.stop();
 			throw exception;
 		}
 	}
@@ -103,13 +102,13 @@ final class TimedScheduler implements Scheduler {
 	@Override
 	public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
 		this.submittedDelayed.increment();
-		task = wrap(task);
+		TimedRunnable timedTask = wrap(task);
 
 		try {
-			return delegate.schedule(task, delay, unit);
+			return delegate.schedule(timedTask, delay, unit);
 		}
 		catch (RejectedExecutionException exception) {
-			((TimedRunnable) task).pendingSample.stop();
+			timedTask.pendingSample.stop();
 			throw exception;
 		}
 	}
@@ -168,14 +167,13 @@ final class TimedScheduler implements Scheduler {
 		@Override
 		public Disposable schedule(Runnable task) {
 			parent.submittedDirect.increment();
-			task = parent.wrap(task);
+			TimedRunnable timedTask = parent.wrap(task);
 
 			try {
-				return delegate.schedule(task);
+				return delegate.schedule(timedTask);
 			}
 			catch (RejectedExecutionException exception) {
-				((TimedRunnable) task).pendingSample.stop();
-
+				timedTask.pendingSample.stop();
 				throw exception;
 			}
 		}
@@ -183,13 +181,13 @@ final class TimedScheduler implements Scheduler {
 		@Override
 		public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
 			parent.submittedDelayed.increment();
-			task = parent.wrap(task);
+			TimedRunnable timedTask = parent.wrap(task);
 
 			try {
-				return delegate.schedule(task, delay, unit);
+				return delegate.schedule(timedTask, delay, unit);
 			}
 			catch (RejectedExecutionException exception) {
-				((TimedRunnable) task).pendingSample.stop();
+				timedTask.pendingSample.stop();
 				throw exception;
 			}
 		}

--- a/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/TimedSchedulerTest.java
+++ b/reactor-core-micrometer/src/test/java/reactor/core/observability/micrometer/TimedSchedulerTest.java
@@ -331,9 +331,9 @@ class TimedSchedulerTest {
 	}
 
 	@Test
-	void pendingScheduleRemovedOnScheduleRejection() {
+	void pendingTaskRemovedOnScheduleRejection() {
 		CountDownLatch cdl = new CountDownLatch(1);
-		ExecutorService executorService = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS,
+		ExecutorService executorService = new ThreadPoolExecutor(1, 2, 0L, TimeUnit.MILLISECONDS,
 				new SynchronousQueue<>());
 		Scheduler original = Schedulers.fromExecutorService(executorService);
 		TimedScheduler testScheduler = new TimedScheduler(original, registry, "test", Tags.empty());
@@ -349,6 +349,8 @@ class TimedSchedulerTest {
 		};
 
 		assertThatNoException().isThrownBy(() -> testScheduler.schedule(supp));
+		assertThatNoException().isThrownBy(() -> testScheduler.schedule(supp));
+		assertThat(longTaskTimer.activeTasks()).as("longTaskTimer.activeTasks()").isOne();
 		assertThatExceptionOfType(RejectedExecutionException.class).isThrownBy(() -> testScheduler.schedule(supp));
 		assertThatExceptionOfType(RejectedExecutionException.class)
 				.isThrownBy(() -> testScheduler.schedule(supp, 0, TimeUnit.SECONDS));
@@ -361,9 +363,9 @@ class TimedSchedulerTest {
 	}
 
 	@Test
-	void workerPendingScheduleRemovedOnScheduleRejection() {
+	void workerPendingTaskRemovedOnScheduleRejection() {
 		CountDownLatch cdl = new CountDownLatch(1);
-		ExecutorService executorService = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS,
+		ExecutorService executorService = new ThreadPoolExecutor(1, 2, 0L, TimeUnit.MILLISECONDS,
 				new SynchronousQueue<>());
 		Scheduler original = Schedulers.fromExecutorService(executorService);
 		TimedScheduler testScheduler = new TimedScheduler(original, registry, "test", Tags.empty());
@@ -380,6 +382,8 @@ class TimedSchedulerTest {
 		};
 
 		assertThatNoException().isThrownBy(() -> worker.schedule(supp));
+		assertThatNoException().isThrownBy(() -> worker.schedule(supp));
+		assertThat(longTaskTimer.activeTasks()).as("longTaskTimer.activeTasks()").isOne();
 		assertThatExceptionOfType(RejectedExecutionException.class).isThrownBy(() -> worker.schedule(supp));
 		assertThatExceptionOfType(RejectedExecutionException.class)
 				.isThrownBy(() -> worker.schedule(supp, 0, TimeUnit.SECONDS));


### PR DESCRIPTION
Fixes issue with `TimedScheduler` where tasks rejected by underlying scheduler would not be removed from `pendingTasks` count. Idea is to catch any `RejectedExecutionException` thrown when scheduling the task, stop its pending sample, and rethrow the error so caller knows that the task was rejected.

Fixes #3642

<!-- 
Thanks for contributing to Project Reactor. Please review the following notes
about formatting your PR description.
-->

<!-- What changes from the user's perspective? -->


<!-- Next paragraph contains more technical details -->


<!-- The footer can contain the issue references: -->
<!-- See #{OPTIONAL_REF}. -->
<!-- Fixes #{ISSUE}. -->

<!--
The PR description will be used to craft a final squash merge commit
and the title will be used in release notes, so please keep them up-to-date.
More detailed description of the commit message convention:
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#black_nib-commit-message-convention
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#message-convention
-->
