### PR TITLE
Remove unintended dependency on gradle enterprise plugin

### DIFF
--- a/gradle/toolchains.gradle
+++ b/gradle/toolchains.gradle
@@ -109,21 +109,3 @@ pluginManager.withPlugin("io.github.reyerizo.gradle.jcstress") {
 	}
   }
 }
-
-// Store resolved Toolchain JVM information as custom values in the build scan.
-rootProject.ext {
-	resolvedMainToolchain = false
-	resolvedTestToolchain = false
-}
-gradle.taskGraph.afterTask { Task task, TaskState state ->
-	if (!resolvedMainToolchain && task instanceof JavaCompile && task.javaCompiler.isPresent()) {
-		def metadata = task.javaCompiler.get().metadata
-		task.project.buildScan.value('Main toolchain', "$metadata.vendor $metadata.languageVersion ($metadata.installationPath)")
-		resolvedMainToolchain = true
-	}
-	if (testToolchainConfigured() && !resolvedTestToolchain && task instanceof Test && task.javaLauncher.isPresent()) {
-		def metadata = task.javaLauncher.get().metadata
-		task.project.buildScan.value('Test toolchain', "$metadata.vendor $metadata.languageVersion ($metadata.installationPath)")
-		resolvedTestToolchain = true
-	}
-}


### PR DESCRIPTION
After removing the com.gradle.enterprise plugin, we discovered unused dependency on it in the 3.6.x line. This change removes this dependency from the multirelease jar setup.