### PR TITLE
Restore where onLastOperatorHook is applied

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferWhen.java
@@ -360,7 +360,8 @@ final class FluxBufferWhen<T, OPEN, CLOSE, BUFFER extends Collection<? super T>>
 
 			BufferWhenCloseSubscriber<T, BUFFER> bc = new BufferWhenCloseSubscriber<>(this, idx);
 			subscribers.add(bc);
-			Operators.toFluxOrMono(p).subscribe(bc);
+			p = Operators.toFluxOrMono(p);
+			p.subscribe(bc);
 		}
 
 		void openComplete(BufferWhenOpenSubscriber<OPEN> os) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatArray.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatArray.java
@@ -61,7 +61,8 @@ final class FluxConcatArray<T> extends Flux<T> implements SourceProducer<T> {
 			if (p == null) {
 				Operators.error(actual, new NullPointerException("The single source Publisher is null"));
 			} else {
-				Operators.toFluxOrMono(p).subscribe(actual);
+				p = Operators.toFluxOrMono(p);
+				p.subscribe(actual);
 			}
 			return;
 		}
@@ -255,7 +256,8 @@ final class FluxConcatArray<T> extends Flux<T> implements SourceProducer<T> {
 				if (this.cancelled) {
 					return;
 				}
-				Operators.toFluxOrMono(p).subscribe(this);
+				p = Operators.toFluxOrMono(p);
+				p.subscribe(this);
 
 				final Object state = this.get();
 				if (state != DONE) {
@@ -404,7 +406,7 @@ final class FluxConcatArray<T> extends Flux<T> implements SourceProducer<T> {
 					return;
 				}
 
-				final Publisher<? extends T> p = a[i];
+				Publisher<? extends T> p = a[i];
 
 				if (p == null) {
 					this.remove();
@@ -440,7 +442,8 @@ final class FluxConcatArray<T> extends Flux<T> implements SourceProducer<T> {
 					return;
 				}
 
-				Operators.toFluxOrMono(p).subscribe(this);
+				p = Operators.toFluxOrMono(p);
+				p.subscribe(this);
 
 				final Object state = this.get();
 				if (state != DONE) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatIterable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatIterable.java
@@ -144,7 +144,8 @@ final class FluxConcatIterable<T> extends Flux<T> implements SourceProducer<T> {
 						produced(c);
 					}
 
-					Operators.toFluxOrMono(p).subscribe(this);
+					p = Operators.toFluxOrMono(p);
+					p.subscribe(this);
 
 					if (isCancelled()) {
 						return;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
@@ -448,7 +448,8 @@ final class FluxConcatMap<T, R> extends InternalFluxOperator<T, R> {
 							}
 							else {
 								active = true;
-								Operators.toFluxOrMono(p).subscribe(inner);
+								p = Operators.toFluxOrMono(p);
+								p.subscribe(inner);
 							}
 						}
 					}
@@ -805,7 +806,8 @@ final class FluxConcatMap<T, R> extends InternalFluxOperator<T, R> {
 							}
 							else {
 								active = true;
-								Operators.toFluxOrMono(p).subscribe(inner);
+								p = Operators.toFluxOrMono(p);
+								p.subscribe(inner);
 							}
 						}
 					}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMapNoPrefetch.java
@@ -203,7 +203,8 @@ final class FluxConcatMapNoPrefetch<T, R> extends InternalFluxOperator<T, R> {
 					return;
 				}
 
-				Operators.toFluxOrMono(p).subscribe(inner);
+				p = Operators.toFluxOrMono(p);
+				p.subscribe(inner);
 			}
 			catch (Throwable e) {
 				Context ctx = actual.currentContext();

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilterWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilterWhen.java
@@ -279,7 +279,8 @@ class FluxFilterWhen<T> extends InternalFluxOperator<T, T> {
 								FilterWhenInner inner = new FilterWhenInner(this, !(p instanceof Mono));
 								if (CURRENT.compareAndSet(this,null, inner)) {
 									state = STATE_RUNNING;
-									Operators.toFluxOrMono(p).subscribe(inner);
+									p = Operators.toFluxOrMono(p);
+									p.subscribe(inner);
 									break;
 								}
 							}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFirstWithSignal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFirstWithSignal.java
@@ -127,7 +127,8 @@ final class FluxFirstWithSignal<T> extends Flux<T> implements SourceProducer<T> 
 						new NullPointerException("The single source Publisher is null"));
 			}
 			else {
-				Operators.toFluxOrMono(p).subscribe(actual);
+				p = Operators.toFluxOrMono(p);
+				p.subscribe(actual);
 			}
 			return;
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFirstWithValue.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFirstWithValue.java
@@ -227,6 +227,8 @@ final class FluxFirstWithValue<T> extends Flux<T> implements SourceProducer<T> {
 
 			actual.onSubscribe(this);
 
+			Operators.toFluxOrMono(sources);
+
 			for (int i = 0; i < n; i++) {
 				if (cancelled || winner != Integer.MIN_VALUE) {
 					return;
@@ -237,7 +239,7 @@ final class FluxFirstWithValue<T> extends Flux<T> implements SourceProducer<T> {
 					return;
 				}
 
-				Operators.toFluxOrMono(sources[i]).subscribe(subscribers[i]);
+				sources[i].subscribe(subscribers[i]);
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGroupJoin.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGroupJoin.java
@@ -336,7 +336,8 @@ final class FluxGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R>
 								new LeftRightEndSubscriber(this, true, idx);
 						cancellations.add(end);
 
-						Operators.toFluxOrMono(p).subscribe(end);
+						p = Operators.toFluxOrMono(p);
+						p.subscribe(end);
 
 						ex = error;
 						if (ex != null) {
@@ -404,7 +405,8 @@ final class FluxGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R>
 								new LeftRightEndSubscriber(this, false, idx);
 						cancellations.add(end);
 
-						Operators.toFluxOrMono(p).subscribe(end);
+						p = Operators.toFluxOrMono(p);
+						p.subscribe(end);
 
 						ex = error;
 						if (ex != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxJoin.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxJoin.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.reactivestreams.Publisher;
@@ -289,7 +288,8 @@ final class FluxJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
 								new LeftRightEndSubscriber(this, true, idx);
 						cancellations.add(end);
 
-						Operators.toFluxOrMono(p).subscribe(end);
+						p = Operators.toFluxOrMono(p);
+						p.subscribe(end);
 
 						ex = error;
 						if (ex != null) {
@@ -366,7 +366,8 @@ final class FluxJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
 								new LeftRightEndSubscriber(this, false, idx);
 						cancellations.add(end);
 
-						Operators.toFluxOrMono(p).subscribe(end);
+						p = Operators.toFluxOrMono(p);
+						p.subscribe(end);
 
 						ex = error;
 						if (ex != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRepeatWhen.java
@@ -76,7 +76,8 @@ final class FluxRepeatWhen<T> extends InternalFluxOperator<T, T> {
 			return null;
 		}
 
-		Operators.toFluxOrMono(p).subscribe(other);
+		p = Operators.toFluxOrMono(p);
+		p.subscribe(other);
 
 		if (!main.cancelled) {
 			return main;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRetryWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRetryWhen.java
@@ -74,7 +74,8 @@ final class FluxRetryWhen<T> extends InternalFluxOperator<T, T> {
 			return;
 		}
 
-		Operators.toFluxOrMono(p).subscribe(other);
+		p = Operators.toFluxOrMono(p);
+		p.subscribe(other);
 
 		if (!main.cancelled) {
 			wrapped.subscribe(main);

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSampleFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSampleFirst.java
@@ -191,7 +191,8 @@ final class FluxSampleFirst<T, U> extends InternalFluxOperator<T, T> {
 				SampleFirstOther<U> other = new SampleFirstOther<>(this);
 
 				if (Operators.replace(OTHER, this, other)) {
-					Operators.toFluxOrMono(p).subscribe(other);
+					p = Operators.toFluxOrMono(p);
+					p.subscribe(other);
 				}
 			}
 			else {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSampleTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSampleTimeout.java
@@ -207,7 +207,8 @@ final class FluxSampleTimeout<T, U> extends InternalFluxOperator<T, T> {
 			SampleTimeoutOther<T, U> os = new SampleTimeoutOther<>(this, t, idx);
 
 			if (Operators.replace(OTHER, this, os)) {
-				Operators.toFluxOrMono(p).subscribe(os);
+				p = Operators.toFluxOrMono(p);
+				p.subscribe(os);
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
@@ -233,7 +233,8 @@ final class FluxSwitchMap<T, R> extends InternalFluxOperator<T, R> {
 
 			if (INNER.compareAndSet(this, si, innerSubscriber)) {
 				ACTIVE.getAndIncrement(this);
-				Operators.toFluxOrMono(p).subscribe(innerSubscriber);
+				p = Operators.toFluxOrMono(p);
+				p.subscribe(innerSubscriber);
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMapNoPrefetch.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMapNoPrefetch.java
@@ -215,7 +215,8 @@ final class FluxSwitchMapNoPrefetch<T, R> extends InternalFluxOperator<T, R> {
 				return;
 			}
 
-			Operators.toFluxOrMono(p).subscribe(nextInner);
+			p = Operators.toFluxOrMono(p);
+			p.subscribe(nextInner);
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
@@ -519,7 +519,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 					return;
 				}
 
-				final Publisher<? extends R> outboundPublisher;
+				Publisher<? extends R> outboundPublisher;
 				final SwitchOnFirstControlSubscriber<? super R> o = this.outboundSubscriber;
 
 				try {
@@ -542,7 +542,8 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 					return;
 				}
 
-				Operators.toFluxOrMono(outboundPublisher).subscribe(o);
+				outboundPublisher = Operators.toFluxOrMono(outboundPublisher);
+				outboundPublisher.subscribe(o);
 				return;
 			}
 
@@ -575,7 +576,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 			}
 
 			if (!hasFirstValueReceived(previousState)) {
-				final Publisher<? extends R> result;
+				Publisher<? extends R> result;
 				final CoreSubscriber<? super R> o = this.outboundSubscriber;
 				try {
 					final Signal<T> signal = Signal.error(t, o.currentContext());
@@ -586,7 +587,8 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 					return;
 				}
 
-				Operators.toFluxOrMono(result).subscribe(o);
+				result = Operators.toFluxOrMono(result);
+				result.subscribe(o);
 			}
 		}
 
@@ -611,7 +613,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 			}
 
 			if (!hasFirstValueReceived(previousState)) {
-				final Publisher<? extends R> result;
+				Publisher<? extends R> result;
 				final CoreSubscriber<? super R> o = this.outboundSubscriber;
 
 				try {
@@ -623,7 +625,8 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 					return;
 				}
 
-				Operators.toFluxOrMono(result).subscribe(o);
+				result = Operators.toFluxOrMono(result);
+				result.subscribe(o);
 			}
 		}
 
@@ -844,7 +847,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 					return true;
 				}
 
-				final Publisher<? extends R> result;
+				Publisher<? extends R> result;
 				final SwitchOnFirstControlSubscriber<? super R> o = this.outboundSubscriber;
 
 				try {
@@ -868,7 +871,8 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 					return true;
 				}
 
-				Operators.toFluxOrMono(result).subscribe(o);
+				result = Operators.toFluxOrMono(result);
+				result.subscribe(o);
 				return true;
 			}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoDelayUntil.java
@@ -287,7 +287,7 @@ final class MonoDelayUntil<T> extends Mono<T> implements Scannable,
 			final Function<? super T, ? extends Publisher<?>> generator =
 					this.otherGenerators[this.index];
 
-			final Publisher<?> p;
+			Publisher<?> p;
 
 			try {
 				p = generator.apply(this.value);
@@ -304,7 +304,8 @@ final class MonoDelayUntil<T> extends Mono<T> implements Scannable,
 				this.triggerSubscriber = triggerSubscriber;
 			}
 
-			Operators.toFluxOrMono(p).subscribe(triggerSubscriber);
+			p = Operators.toFluxOrMono(p);
+			p.subscribe(triggerSubscriber);
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFilterWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFilterWhen.java
@@ -143,7 +143,8 @@ class MonoFilterWhen<T> extends InternalMonoOperator<T, T> {
 			}
 			else {
 				FilterWhenInner<T> inner = new FilterWhenInner<>(this, !(p instanceof Mono), t);
-				Operators.toFluxOrMono(p).subscribe(inner);
+				p = Operators.toFluxOrMono(p);
+				p.subscribe(inner);
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFirstWithSignal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFirstWithSignal.java
@@ -136,7 +136,8 @@ final class MonoFirstWithSignal<T> extends Mono<T> implements SourceProducer<T> 
 								actual.currentContext()));
 			}
 			else {
-				Operators.toFluxOrMono(p).subscribe(actual);
+				p = Operators.toFluxOrMono(p);
+				p.subscribe(actual);
 			}
 			return;
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMapMany.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFlatMapMany.java
@@ -192,7 +192,8 @@ final class MonoFlatMapMany<T, R> extends FluxFromMonoOperator<T, R> {
 				return;
 			}
 
-			Operators.toFluxOrMono(p).subscribe(new FlatMapManyInner<>(this, actual));
+			p = Operators.toFluxOrMono(p);
+			p.subscribe(new FlatMapManyInner<>(this, actual));
 		}
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoIgnoreThen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoIgnoreThen.java
@@ -242,15 +242,15 @@ final class MonoIgnoreThen<T> extends Mono<T> implements Scannable {
                     }
                     return;
                 } else {
-                    final Publisher<?> m = a[i];
+                    Publisher<?> p = a[i];
 
-                    if (m instanceof Callable) {
+                    if (p instanceof Callable) {
                         if (isCancelled(this.state)) {
                             //NB: in the non-callable case, this is handled by activeSubscription.cancel()
                             return;
                         }
                         try {
-                            Operators.onDiscard(((Callable<?>) m).call(), currentContext());
+                            Operators.onDiscard(((Callable<?>) p).call(), currentContext());
                         }
                         catch (Throwable ex) {
                             onError(Operators.onOperatorError(ex, currentContext()));
@@ -261,7 +261,8 @@ final class MonoIgnoreThen<T> extends Mono<T> implements Scannable {
                         continue;
                     }
 
-                    Operators.toFluxOrMono(m).subscribe((CoreSubscriber) this);
+                    p = Operators.toFluxOrMono(p);
+                    p.subscribe((CoreSubscriber) this);
                     return;
                 }
             }

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoUsingWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoUsingWhen.java
@@ -93,10 +93,9 @@ final class MonoUsingWhen<T, S> extends Mono<T> implements SourceProducer<T> {
 			return;
 		}
 
-		Operators.toFluxOrMono(resourceSupplier).subscribe(new ResourceSubscriber(actual,
-				resourceClosure,
-				asyncComplete, asyncError, asyncCancel,
-				resourceSupplier instanceof Mono));
+		// Ensure onLastOperatorHook is called by invoking Publisher::subscribe(Subscriber)
+		((Publisher<?>) Operators.toFluxOrMono(resourceSupplier)).subscribe(
+				new ResourceSubscriber(actual, resourceClosure, asyncComplete, asyncError, asyncCancel, resourceSupplier instanceof Mono));
 	}
 
 	@Override


### PR DESCRIPTION
Recent improvements in the automatic context propagation (#3549) resulted in a regression – some sites where the "last operator" hook was previously applied no longer saw that behaviour. This change restores it.

Implementation wise, it's worth noting that the "last operator" functionality relies on executing the subscribe(Subscriber) method from the base reactive-streams Publisher instead of the overloads that come from CorePublisher. The implementations of the reactive-streams base method in reactor-core apply this hook and that is when something is considered a "last operator". The wrapping of the Publisher when a non-internal producer is encountered to restore ThreadLocal values has changed the compiler's inference of the signature to use the CoreSubscriber argument variant, breaking the behaviour.

This commit does not bring any tests as the functionality was not extensively tested before. The issue was discovered in spring-security in https://github.com/spring-projects/spring-security/issues/14207 and the change has been validated against the actual use case.

<!-- 
Thanks for contributing to Project Reactor. Please review the following notes
about formatting your PR description.
-->

<!-- What changes from the user's perspective? -->


<!-- Next paragraph contains more technical details -->


<!-- The footer can contain the issue references: -->
<!-- See #{OPTIONAL_REF}. -->
<!-- Fixes #{ISSUE}. -->

<!--
The PR description will be used to craft a final squash merge commit
and the title will be used in release notes, so please keep them up-to-date.
More detailed description of the commit message convention:
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#black_nib-commit-message-convention
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#message-convention
-->
