### PR TITLE
Ignore bnd plugin from dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,10 @@ updates:
       - dependency-name: "com.tngtech.archunit:archunit"
         versions:
         - ">= 1.0.a"
+      # bnd: don't upgrade to v7 (requires JDK17+)
+      - dependency-name: "biz.aQute.bnd.builder:biz.aQute.bnd.builder.gradle.plugin"
+        versions:
+          - ">= 7.0.a"
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"
     schedule:


### PR DESCRIPTION
Starting from 7.0.0, biz.aQute.bnd.builder requires JDK 17 to run, so we are not upgrading.

Supersedes #3616