### PR TITLE
Issues/3340 object array buffer implementation

### DIFF
--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinksManyReplayLatestStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinksManyReplayLatestStressTest.java
@@ -1,0 +1,68 @@
+package reactor.core.publisher;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.I_Result;
+
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE_INTERESTING;
+
+public class SinksManyReplayLatestStressTest {
+
+    @JCStressTest
+    @Outcome(id = {"6"},    expect = ACCEPTABLE, desc = "all signals go through")
+    @Outcome(               expect = ACCEPTABLE_INTERESTING, desc = "Signals are lost before replay")
+    @State
+    public static class FluxReplaySizeBoundWriteStressTest {
+        final StressSubscriber<String> target = new StressSubscriber<>();
+
+        final SinkManyReplayProcessor<String> sink = new SinkManyReplayProcessor<>(
+                new FluxReplay.ArraySizeBoundReplayBuffer<>(1)
+        );
+
+        public FluxReplaySizeBoundWriteStressTest() {
+            // subscribe before start
+            sink.subscribe(target);
+        }
+
+
+        @Actor
+        public void one() {
+            sink.tryEmitNext("Hello");
+        }
+
+        @Actor
+        public void two() {
+            sink.tryEmitNext("Hello");
+        }
+
+        @Actor
+        public void three() {
+            sink.tryEmitNext("Hello");
+        }
+
+        @Actor
+        public void four() {
+            sink.tryEmitNext("Hello");
+        }
+
+        @Actor
+        public void five() {
+            sink.tryEmitNext("Hello");
+        }
+
+        @Actor
+        public void six() {
+            sink.tryEmitNext("Hello");
+        }
+
+        @Arbiter
+        public void arbiter(I_Result r) {
+            r.r1 = target.onNextCalls.get();
+        }
+    }
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -865,6 +865,11 @@ final class FluxReplay<T> extends ConnectableFlux<T>
 					}
 				}
 
+				if (rs.isCancelled()) {
+					clear(rs);
+					return;
+				}
+
 				if (done && isEmpty(rs)) {
 					clear(rs);
 					Throwable ex = error;

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -155,7 +155,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 			buffer = new FluxReplay.UnboundedReplayBuffer<>(historySize);
 		}
 		else {
-			buffer = new FluxReplay.SizeBoundReplayBuffer<>(historySize);
+			buffer = new FluxReplay.ArraySizeBoundReplayBuffer<>(historySize);
 		}
 		return new ReplayProcessor<>(buffer);
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManyReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManyReplayProcessor.java
@@ -137,7 +137,7 @@ final class SinkManyReplayProcessor<T> extends Flux<T> implements InternalManySi
 			buffer = new FluxReplay.UnboundedReplayBuffer<>(historySize);
 		}
 		else {
-			buffer = new FluxReplay.SizeBoundReplayBuffer<>(historySize);
+			buffer = new FluxReplay.ArraySizeBoundReplayBuffer<>(historySize);
 		}
 		return new SinkManyReplayProcessor<>(buffer);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxReplayTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxReplayTest.java
@@ -591,24 +591,6 @@ public class FluxReplayTest extends FluxOperatorTest<String, String> {
 		assertThat(requests).containsExactly(8L, 6L);
 	}
 
-	@Test
-	public void minimalInitialRequestUnboundedWithFused() {
-		List<Long> requests = new ArrayList<>();
-		TwoRequestsSubscriber fiveThenEightSubscriber = new TwoRequestsSubscriber(5, 8);
-
-		ConnectableFlux<Integer> replay =
-				Flux.range(1, 11)
-				    .doOnRequest(requests::add)
-				    .replay(8);
-
-		assertThat(requests).isEmpty();
-
-		replay.subscribe(fiveThenEightSubscriber);
-		replay.subscribe(); //unbounded
-		replay.connect();
-
-		assertThat(requests).containsExactly(8L, 6L);
-	}
 
 	@Test
 	public void onlyInitialRequestWithLateUnboundedSubscriber() {


### PR DESCRIPTION
This PR replace the internal buffer-implementation of the SizeBoundReplayBuffer to be an Atomic reference to an Object-array in stead of an atomic linked list.

I didn't manage to produce sane performance metrics (but my jmh also ran weird). I did however try implementing a dummy test where an atomic linked list was read vs. an atomic object array, that showed the array to be better performance (4 times better).

The implementation is obviously more heavy on the GC (but it's easily collectible garbage).

There is a thing to say on the Sinks.Many Normal/Unsafe interfaces, and this is obviously a lot more safe in concurrent usage.

SinksManyReplayLatest stress test looks like:
 Results across all configurations:
```
  RESULT     SAMPLES     FREQ       EXPECT  DESCRIPTION
       1          12   <0,01%  Interesting  Signals are lost before replay
       2      45.432    0,34%  Interesting  Signals are lost before replay
       3      87.442    0,66%  Interesting  Signals are lost before replay
       4      81.540    0,62%  Interesting  Signals are lost before replay
       5      84.897    0,64%  Interesting  Signals are lost before replay
       6  12.875.461   97,73%   Acceptable  all signals go through
```
while for the SizeBoundReplayBuffer looks like this:
```
  RESULT     SAMPLES     FREQ       EXPECT  DESCRIPTION
       1      38.318    0,28%  Interesting  Signals are lost before replay
       2      43.811    0,32%  Interesting  Signals are lost before replay
       3      36.974    0,27%  Interesting  Signals are lost before replay
       4      43.125    0,32%  Interesting  Signals are lost before replay
       5      81.231    0,60%  Interesting  Signals are lost before replay
       6  13.371.645   98,21%   Acceptable  all signals go through
```
This was after further fixes to the `add` method, like so:

```
		@Override
		public void add(T value) {
			final Node<T> tail = this.tail;
			final Node<T> n = new Node<>(tail.index + 1, value);
			tail.set(n);
			this.tail = n;
			int s = size;
			if (s == limit) {
				head.set(Optional.ofNullable(head.get()).map(AtomicReference::get).orElse(n)); // changes here
			}
			else {
				size = s + 1;
			}
		}
```

This is very surprising since the first line has a racy non-atomic read and there are multiple racing atomic operations. I think having the head be final helped a bunch.