### PR TITLE
Ignoring flaky JCStress tests

### DIFF
--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchMapStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchMapStressTest.java
@@ -270,7 +270,8 @@ public abstract class FluxSwitchMapStressTest {
 		}
 	}
 
-	@JCStressTest
+	// Ignore, flaky test (https://github.com/reactor/reactor-core/issues/3633)
+	//@JCStressTest
 	@Outcome(id = {"200, 0", "200, 1"}, expect = ACCEPTABLE, desc = "Should produced exactly what was requested")
 	@State
 	public static class RequestAndProduceStressTest2 extends FluxSwitchMapStressTest {

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchMapStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchMapStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchOnFirstConditionalStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchOnFirstConditionalStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchOnFirstConditionalStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchOnFirstConditionalStressTest.java
@@ -56,7 +56,8 @@ public abstract class FluxSwitchOnFirstConditionalStressTest {
 	abstract Flux<String> switchOnFirst(Signal<? extends String> signal,
 			Flux<String> inbound);
 
-	@JCStressTest
+	// Ignore, flaky test (https://github.com/reactor/reactor-core/issues/3627)
+	//@JCStressTest
 	@Outcome(id = {"1, 1, 1, 1, 1"}, expect = ACCEPTABLE)
 	@State
 	public static class OutboundOnSubscribeAndRequestStressTest
@@ -95,7 +96,8 @@ public abstract class FluxSwitchOnFirstConditionalStressTest {
 		}
 	}
 
-	@JCStressTest
+	// Ignore, flaky test (https://github.com/reactor/reactor-core/issues/3627)
+	//@JCStressTest
 	@Outcome(id = {
 			"1, 2, 0, 1"}, expect = ACCEPTABLE, desc = "inbound next with error happens first")
 	@Outcome(id = {
@@ -143,7 +145,8 @@ public abstract class FluxSwitchOnFirstConditionalStressTest {
 		}
 	}
 
-	@JCStressTest
+	// Ignore, flaky test (https://github.com/reactor/reactor-core/issues/3627)
+	//@JCStressTest
 	@Outcome(id = {
 			"1, 1, 2, 1, 1"}, expect = ACCEPTABLE, desc = "outbound cancel happened before inbound next")
 	@Outcome(id = {

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchOnFirstStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchOnFirstStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchOnFirstStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchOnFirstStressTest.java
@@ -57,7 +57,8 @@ public abstract class FluxSwitchOnFirstStressTest {
 	abstract Flux<String> switchOnFirst(Signal<? extends String> signal,
 			Flux<String> inbound);
 
-	@JCStressTest
+	// Ignore, flaky test (https://github.com/reactor/reactor-core/issues/3627)
+	//@JCStressTest
 	@Outcome(id = {"1, 1, 1, 1, 1"}, expect = ACCEPTABLE)
 	@State
 	public static class OutboundOnSubscribeAndRequestStressTest
@@ -96,7 +97,8 @@ public abstract class FluxSwitchOnFirstStressTest {
 		}
 	}
 
-	@JCStressTest
+	// Ignore, flaky test (https://github.com/reactor/reactor-core/issues/3627)
+	//@JCStressTest
 	@Outcome(id = {
 			"0, 0, 1, 2, 2, 0, 1, 1, 0"}, expect = ACCEPTABLE, desc = "Inbound got second request, delivered onNext('value') and delivered onComplete() before cancellation")
 	@Outcome(id = {
@@ -168,7 +170,8 @@ public abstract class FluxSwitchOnFirstStressTest {
 		}
 	}
 
-	@JCStressTest
+	// Ignore, flaky test (https://github.com/reactor/reactor-core/issues/3627)
+	//@JCStressTest
 	@Outcome(id = {
 			"0, 0, 1, 2, 2, 0, 2, 1, 0"}, expect = ACCEPTABLE, desc = "Inbound got second request, delivered onNext('value') and delivered onError() before cancellation")
 	@Outcome(id = {
@@ -241,7 +244,8 @@ public abstract class FluxSwitchOnFirstStressTest {
 		}
 	}
 
-	@JCStressTest
+	// Ignore, flaky test (https://github.com/reactor/reactor-core/issues/3627)
+	//@JCStressTest
 	@Outcome(id = {
 			"1, 2, 0, 1"}, expect = ACCEPTABLE, desc = "inbound next with error happens first")
 	@Outcome(id = {
@@ -290,7 +294,8 @@ public abstract class FluxSwitchOnFirstStressTest {
 		}
 	}
 
-	@JCStressTest
+	// Ignore, flaky test (https://github.com/reactor/reactor-core/issues/3627)
+	//@JCStressTest
 	@Outcome(id = {
 			"0, 2, 0, 0"}, expect = ACCEPTABLE, desc = "inbound error with transformation error happens first")
 	@Outcome(id = {
@@ -340,7 +345,8 @@ public abstract class FluxSwitchOnFirstStressTest {
 		}
 	}
 
-	@JCStressTest
+	// Ignore, flaky test (https://github.com/reactor/reactor-core/issues/3627)
+	//@JCStressTest
 	@Outcome(id = {
 			"0, 2, 0, 0"}, expect = ACCEPTABLE, desc = "inbound complete with transformation error happens first")
 	@Outcome(id = {
@@ -390,7 +396,8 @@ public abstract class FluxSwitchOnFirstStressTest {
 		}
 	}
 
-	@JCStressTest
+	// Ignore, flaky test (https://github.com/reactor/reactor-core/issues/3627)
+	//@JCStressTest
 	@Outcome(id = {
 			"0, 0, 1, 2, 2, 1, 0, 1, 0"}, expect = ACCEPTABLE, desc = "inbound request happened first. then inbound cancel. then outbound cancel")
 	@Outcome(id = {
@@ -464,7 +471,8 @@ public abstract class FluxSwitchOnFirstStressTest {
 		}
 	}
 
-	@JCStressTest
+	// Ignore, flaky test (https://github.com/reactor/reactor-core/issues/3627)
+	//@JCStressTest
 	@Outcome(id = {
 			"1, 1, 2, 1, 1"}, expect = ACCEPTABLE, desc = "outbound cancel happened before inbound next")
 	@Outcome(id = {
@@ -525,7 +533,8 @@ public abstract class FluxSwitchOnFirstStressTest {
 		}
 	}
 
-	@JCStressTest
+	// Ignore, flaky test (https://github.com/reactor/reactor-core/issues/3627)
+	//@JCStressTest
 	@Outcome(id = {
 			"1, 0, 1, 1, 0"}, expect = ACCEPTABLE, desc = "inbound complete happened before outbound cancel")
 	@Outcome(id = {
@@ -586,7 +595,8 @@ public abstract class FluxSwitchOnFirstStressTest {
 		}
 	}
 
-	@JCStressTest
+	// Ignore, flaky test (https://github.com/reactor/reactor-core/issues/3627)
+	//@JCStressTest
 	@Outcome(id = {
 			"1, 0, 2, 1, 0"}, expect = ACCEPTABLE, desc = "inbound error happened before outbound cancel")
 	@Outcome(id = {


### PR DESCRIPTION
`FluxSwitchMap` and `FluxSwitchOnFirst` JCStress tests are failing randomly and it needs to be investigated why. We don't want their flakiness to hide other issues when the CI fails, so they are being investigated in related issues.

Related #3633
Related #3627