### PR TITLE
FluxRefCountGraceTest coordinate assertions to avoid racing

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
`FluxRefCountGraceTest.raceSubscribeAndCancelNoTimeout` turns out to be flaky. This change coordinates assertions to run after the SUT completion to avoid racing.

Fixes #3639