### PR TITLE
Fix return a value that will be nullalbe on mapNotNull

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -70,6 +70,7 @@ import reactor.core.scheduler.Scheduler.Worker;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.Logger;
 import reactor.util.Metrics;
+import reactor.util.annotation.NonNull;
 import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
@@ -6539,7 +6540,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 *
 	 * @return a transformed {@link Flux}
 	 */
-	public final <V> Flux<V> mapNotNull(Function <? super T, ? extends V> mapper) {
+	public final <V> @NonNull Flux<V> mapNotNull(Function <? super T, ? extends V> mapper) {
 		return this.handle((t, sink) -> {
 			V v = mapper.apply(t);
 			if (v != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -61,6 +61,7 @@ import reactor.core.scheduler.Scheduler.Worker;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.Logger;
 import reactor.util.Metrics;
+import reactor.util.annotation.NonNull;
 import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
@@ -3443,7 +3444,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 *
 	 * @return a new {@link Mono}
 	 */
-	public final <R> Mono<R> mapNotNull(Function <? super T, ? extends R> mapper) {
+	public final <R> @NonNull Mono<R> mapNotNull(Function <? super T, ? extends R> mapper) {
 		return this.handle((t, sink) -> {
 			R r = mapper.apply(t);
 			if (r != null) {


### PR DESCRIPTION
<!-- 
Thanks for contributing to Project Reactor. Please review the following notes
about formatting your PR description.
-->

<!-- What changes from the user's perspective? -->


<!-- Next paragraph contains more technical details -->


<!-- The footer can contain the issue references: -->
<!-- See #{OPTIONAL_REF}. -->
<!-- Fixes #{ISSUE}. -->
https://github.com/reactor/reactor-kotlin-extensions/issues/52

The above issue explains `mapNotNull` does not change values into non-null values.

Thus, below code occurs an error such as `Operator call corresponds to a dot-qualified call 'it.times(3)' which is not allowed on a nullable receiver 'it'.` 
```
    Flux.just(1, 2, 3, null).mapNotNull {
        it
    }.map {
        println(it * 3)
    }
```

<img width="442" alt="image" src="https://github.com/reactor/reactor-core/assets/29705162/2c0aeaad-450f-4989-aa62-4ee5dec662d4">

Therefore, `mapNotNull` method must return `@Nonnull` value only.

<!--
The PR description will be used to craft a final squash merge commit
and the title will be used in release notes, so please keep them up-to-date.
More detailed description of the commit message convention:
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#black_nib-commit-message-convention
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#message-convention
-->
