### PR TITLE
Switch jcstress mode to quick in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -146,9 +146,9 @@ jobs:
         if: ${{ matrix.branch == 'main' }}
         name: other tests
         with:
-          arguments: check -x :reactor-core:test -x :reactor-core:java9Test -x :reactor-core:java21Test -x spotlessCheck --no-daemon -DuseSnapshotMicrometerVersion=true -Pjcstress.mode=default
+          arguments: check -x :reactor-core:test -x :reactor-core:java9Test -x :reactor-core:java21Test -x spotlessCheck --no-daemon -DuseSnapshotMicrometerVersion=true -Pjcstress.mode=quick
       - uses: gradle/gradle-build-action@3b1b3b9a2104c2b47fbae53f3938079c00c9bb87 # tag=v2
         if: ${{ matrix.branch == '3.5.x' }}
         name: other tests
         with:
-          arguments: check -x :reactor-core:test -x spotlessCheck --no-daemon -DuseSnapshotMicrometerVersion=true -Pjcstress.mode=default
+          arguments: check -x :reactor-core:test -x spotlessCheck --no-daemon -DuseSnapshotMicrometerVersion=true -Pjcstress.mode=quick

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -19,7 +19,7 @@ jobs:
           - type: core-slow
             arguments: ":reactor-core:test --no-daemon -Pjunit-tags=slow -DuseSnapshotMicrometerVersion=true"
           - type: other
-            arguments: "check -x :reactor-core:test -x spotlessCheck -x :reactor-core:jcstress --no-daemon -DuseSnapshotMicrometerVersion=true -Pjcstress.mode=default"
+            arguments: "check -x :reactor-core:test -x spotlessCheck -x :reactor-core:jcstress --no-daemon -DuseSnapshotMicrometerVersion=true"
     name: Test on ${{ matrix.branch }} - ${{ matrix.test-type.type }} tests
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Due to the fact that with the current configuration the jcstress tests in default mode are estimated to run for more than 6 hours, the "nightly" job kept failing. Github Actions runner has a cap at 6 hours. The "quick" JCStress mode should finish in less than that time.