### PR TITLE
Cleanup changelog and dependency upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,27 @@ updates:
     schedule:
       interval: "daily"
     labels:
+      "type/enhancement"
+    reviewers:
+      - "reactor/core-team"
+    target-branch: "3.4.x"
+    allow:
+      - dependency-name: "org.reactivestreams:*"
+      - dependency-name: "net.bytebuddy:*"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
       - "type/dependency-upgrade"
     reviewers:
       - "reactor/core-team"
     # updates in oldest maintenance branch, we'll forward-merge up to main
     target-branch: "3.4.x"
     ignore:
+      # Updated by the enhancement type grouping
+      - dependency-name: "org.reactivestreams:*"
+      - dependency-name: "net.bytebuddy:*"
       # JSR166 backport is fixed
       - dependency-name: "io.projectreactor:jsr166"
       # JSR305 backport is fixed to last version with annotations (3.0.1)
@@ -50,7 +65,7 @@ updates:
     schedule:
       interval: "weekly"
     labels:
-      - "type/chores"
+      - "type/dependency-upgrade"
     reviewers:
       - "reactor/core-team"
     # updates in oldest maintenance branch, we'll forward-merge up to main

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,9 @@ changelog:
   exclude:
     labels:
       - ignore-changelog
+      - type/test
+      - type/chore
+      - type/dependency-upgrade
   categories:
     - title: ":warning: Update considerations and deprecations"
       labels:
@@ -16,14 +19,9 @@ changelog:
     - title: ":lady_beetle: Bug fixes"
       labels:
         - "type/bug"
-    - title: ":book: Documentation, Tests and Build"
+    - title: ":book: Documentation"
       labels:
         - "type/documentation"
-        - "type/chores"
-        - "type/test"
-    - title: ":up: Dependency Upgrades"
-      labels:
-        - "type/dependency-upgrade"
     - title: ":question: Other Changes"
       labels:
         - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,7 +3,7 @@ changelog:
     labels:
       - ignore-changelog
       - type/test
-      - type/chore
+      - type/chores
       - type/dependency-upgrade
   categories:
     - title: ":warning: Update considerations and deprecations"


### PR DESCRIPTION
Excluded chores, dependency upgrades and test changes from the release notes. Also, labeling transitive or shaded dependencies upgraded by Dependabot as enhancements to be included in the changelog.