### PR TITLE
Throw wrapped `TimeoutException` on `Mono.block*` and `Flux.block*`

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/BlockingOptionalMonoSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/BlockingOptionalMonoSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package reactor.core.publisher;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.reactivestreams.Subscription;
 import reactor.core.Disposable;
@@ -148,7 +149,8 @@ final class BlockingOptionalMonoSubscriber<T> extends CountDownLatch
 			try {
 				if (!await(timeout, unit)) {
 					dispose();
-					throw new IllegalStateException("Timeout on blocking read for " + timeout + " " + unit);
+					String errorMessage = "Timeout on blocking read for " + timeout + " " + unit;
+					throw new IllegalStateException(errorMessage, new TimeoutException(errorMessage));
 				}
 			}
 			catch (InterruptedException ex) {

--- a/reactor-core/src/main/java/reactor/core/publisher/BlockingSingleSubscriber.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/BlockingSingleSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.reactivestreams.Subscription;
 import reactor.core.Disposable;
@@ -124,7 +125,8 @@ abstract class BlockingSingleSubscriber<T> extends CountDownLatch
 			try {
 				if (!await(timeout, unit)) {
 					dispose();
-					throw new IllegalStateException("Timeout on blocking read for " + timeout + " " + unit);
+					String errorMessage = "Timeout on blocking read for " + timeout + " " + unit;
+					throw new IllegalStateException(errorMessage, new TimeoutException(errorMessage));
 				}
 			}
 			catch (InterruptedException ex) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -2771,7 +2771,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * signals its first value, completes or a timeout expires. Returns that value,
 	 * or null if the Flux completes empty. In case the Flux errors, the original
 	 * exception is thrown (wrapped in a {@link RuntimeException} if it was a checked
-	 * exception). If the provided timeout expires, a {@link RuntimeException} is thrown.
+	 * exception). If the provided timeout expires, a {@link RuntimeException} is thrown
+	 * with a {@link TimeoutException} as the cause.
 	 * <p>
 	 * Note that each blockFirst() will trigger a new subscription: in other words,
 	 * the result might miss signal from hot publishers.
@@ -2780,6 +2781,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <img class="marble" src="doc-files/marbles/blockFirstWithTimeout.svg" alt="">
 	 *
  	 * @param timeout maximum time period to wait for before raising a {@link RuntimeException}
+	 * with a {@link TimeoutException} as the cause
 	 * @return the first value or null
 	 */
 	@Nullable
@@ -2821,7 +2823,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * signals its last value, completes or a timeout expires. Returns that value,
 	 * or null if the Flux completes empty. In case the Flux errors, the original
 	 * exception is thrown (wrapped in a {@link RuntimeException} if it was a checked
-	 * exception). If the provided timeout expires, a {@link RuntimeException} is thrown.
+	 * exception). If the provided timeout expires, a {@link RuntimeException} is thrown
+	 * with a {@link TimeoutException} as the cause.
 	 * <p>
 	 * Note that each blockLast() will trigger a new subscription: in other words,
 	 * the result might miss signal from hot publishers.
@@ -2830,6 +2833,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <img class="marble" src="doc-files/marbles/blockLastWithTimeout.svg" alt="">
 	 *
 	 * @param timeout maximum time period to wait for before raising a {@link RuntimeException}
+	 * with a {@link TimeoutException} as the cause
 	 * @return the last value or null
 	 */
 	@Nullable

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1784,7 +1784,8 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * received or a timeout expires. Returns that value, or null if the Mono completes
 	 * empty. In case the Mono errors, the original exception is thrown (wrapped in a
 	 * {@link RuntimeException} if it was a checked exception).
-	 * If the provided timeout expires, a {@link RuntimeException} is thrown.
+	 * If the provided timeout expires, a {@link RuntimeException} is thrown
+	 * with a {@link TimeoutException} as the cause.
 	 *
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/blockWithTimeout.svg" alt="">
@@ -1793,6 +1794,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * might miss signal from hot publishers.
 	 *
 	 * @param timeout maximum time period to wait for before raising a {@link RuntimeException}
+	 * with a {@link TimeoutException} as the cause
 	 *
 	 * @return T the result
 	 */
@@ -1836,7 +1838,8 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * Exception via {@link Optional#orElseThrow(Supplier)}.
 	 * In case the Mono itself errors, the original exception is thrown (wrapped in a
 	 * {@link RuntimeException} if it was a checked exception).
-	 * If the provided timeout expires, a {@link RuntimeException} is thrown.
+	 * If the provided timeout expires, a {@link RuntimeException} is thrown
+	 * with a {@link TimeoutException} as the cause.
 	 *
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/blockOptionalWithTimeout.svg" alt="">
@@ -1845,6 +1848,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * might miss signal from hot publishers.
 	 *
 	 * @param timeout maximum time period to wait for before raising a {@link RuntimeException}
+	 * with a {@link TimeoutException} as the cause
 	 *
 	 * @return T the result
 	 */

--- a/reactor-core/src/test/java/reactor/core/publisher/BlockingOptionalMonoSubscriberTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BlockingOptionalMonoSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package reactor.core.publisher;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
@@ -103,7 +104,8 @@ public class BlockingOptionalMonoSubscriberTest {
 		// Using sub-millis timeouts after gh-1734
 		assertThatExceptionOfType(IllegalStateException.class)
 				.isThrownBy(() -> source.blockOptional(Duration.ofNanos(100)))
-				.withMessage("Timeout on blocking read for 100 NANOSECONDS");
+				.withMessage("Timeout on blocking read for 100 NANOSECONDS")
+				.withCause(new TimeoutException("Timeout on blocking read for 100 NANOSECONDS"));
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/BlockingTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/BlockingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -87,7 +88,8 @@ public class BlockingTests {
 		assertThatIllegalStateException().isThrownBy(() ->
 				Flux.just(1).delayElements(Duration.ofSeconds(1))
 				.blockFirst(Duration.ofMillis(1)))
-			.withMessage("Timeout on blocking read for 1000000 NANOSECONDS");
+			.withMessage("Timeout on blocking read for 1000000 NANOSECONDS")
+			.withCause(new TimeoutException("Timeout on blocking read for 1000000 NANOSECONDS"));
 	}
 
 	@Test
@@ -115,7 +117,8 @@ public class BlockingTests {
 		assertThatIllegalStateException().isThrownBy(() ->
 				Flux.just(1).delayElements(Duration.ofMillis(100))
 						.blockLast(Duration.ofNanos(50)))
-				.withMessage("Timeout on blocking read for 50 NANOSECONDS");
+				.withMessage("Timeout on blocking read for 50 NANOSECONDS")
+				.withCause(new TimeoutException("Timeout on blocking read for 50 NANOSECONDS"));
 	}
 
 
@@ -287,7 +290,8 @@ public class BlockingTests {
 	@Test
 	public void monoBlockSupportsNanos() {
 		assertThatIllegalStateException().isThrownBy(() -> Mono.never().block(Duration.ofNanos(9_000L)))
-				.withMessage("Timeout on blocking read for 9000 NANOSECONDS");
+				.withMessage("Timeout on blocking read for 9000 NANOSECONDS")
+				.withCause(new TimeoutException("Timeout on blocking read for 9000 NANOSECONDS"));
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkOneMulticastTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkOneMulticastTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -247,7 +248,8 @@ class SinkOneMulticastTest {
 
 		assertThatExceptionOfType(IllegalStateException.class)
 			.isThrownBy(() -> sink.block(Duration.ofNanos(-1)))
-			.withMessage("Timeout on blocking read for 0 NANOSECONDS");
+			.withMessage("Timeout on blocking read for 0 NANOSECONDS")
+			.withCause(new TimeoutException("Timeout on blocking read for 0 NANOSECONDS"));
 
 		assertThat(Duration.ofNanos(System.nanoTime() - start))
 			.isLessThan(Duration.ofMillis(500));
@@ -260,7 +262,8 @@ class SinkOneMulticastTest {
 
 		assertThatExceptionOfType(IllegalStateException.class)
 			.isThrownBy(() -> sink.block(Duration.ZERO))
-			.withMessage("Timeout on blocking read for 0 NANOSECONDS");
+			.withMessage("Timeout on blocking read for 0 NANOSECONDS")
+			.withCause(new TimeoutException("Timeout on blocking read for 0 NANOSECONDS"));
 
 		assertThat(Duration.ofNanos(System.nanoTime() - start))
 			.isLessThan(Duration.ofMillis(500));


### PR DESCRIPTION

<!-- 
Thanks for contributing to Project Reactor. Please review the following notes
about formatting your PR description.
-->

<!-- What changes from the user's perspective? -->
Throw wrapped `TimeoutException` on `Mono.block*` and `Flux.block*` so that user can use this when timeout instead of digging into IllegalStateException message.

<!-- Next paragraph contains more technical details -->


<!-- The footer can contain the issue references: -->
<!-- See #{OPTIONAL_REF}. -->
<!-- Fixes #{ISSUE}. -->
Fixes #3709.
<!--
The PR description will be used to craft a final squash merge commit
and the title will be used in release notes, so please keep them up-to-date.
More detailed description of the commit message convention:
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#black_nib-commit-message-convention
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#message-convention
-->
