### PR TITLE
Add `doAfterSubscirbe` method on Flux and Mono

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -4800,7 +4800,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final Flux<T> doAfterTerminate(Runnable afterTerminate) {
 		Objects.requireNonNull(afterTerminate, "afterTerminate");
-		return doOnSignal(this, null, null, null, null, afterTerminate, null, null);
+		return doOnSignal(this, null, null, null, null, null, afterTerminate, null, null);
 	}
 
 	/**
@@ -4817,7 +4817,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final Flux<T> doOnCancel(Runnable onCancel) {
 		Objects.requireNonNull(onCancel, "onCancel");
-		return doOnSignal(this, null, null, null, null, null, null, onCancel);
+		return doOnSignal(this, null, null, null, null, null, null, null, onCancel);
 	}
 
 	/**
@@ -4834,7 +4834,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final Flux<T> doOnComplete(Runnable onComplete) {
 		Objects.requireNonNull(onComplete, "onComplete");
-		return doOnSignal(this, null, null, null, onComplete, null, null, null);
+		return doOnSignal(this, null, null, null, null, onComplete, null, null, null);
 	}
 
 	/**
@@ -4908,7 +4908,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final Flux<T> doOnError(Consumer<? super Throwable> onError) {
 		Objects.requireNonNull(onError, "onError");
-		return doOnSignal(this, null, null, onError, null, null, null, null);
+		return doOnSignal(this, null, null, null, onError, null, null, null, null);
 	}
 
 	/**
@@ -4978,7 +4978,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final Flux<T> doOnNext(Consumer<? super T> onNext) {
 		Objects.requireNonNull(onNext, "onNext");
-		return doOnSignal(this, null, onNext, null, null, null, null, null);
+		return doOnSignal(this, null, null, onNext, null, null, null, null, null);
 	}
 
 	/**
@@ -5000,7 +5000,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final Flux<T> doOnRequest(LongConsumer consumer) {
 		Objects.requireNonNull(consumer, "consumer");
-		return doOnSignal(this, null, null, null, null, null, consumer, null);
+		return doOnSignal(this, null, null, null, null, null, null, consumer, null);
 	}
 
 	/**
@@ -5024,7 +5024,29 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 */
 	public final Flux<T> doOnSubscribe(Consumer<? super Subscription> onSubscribe) {
 		Objects.requireNonNull(onSubscribe, "onSubscribe");
-		return doOnSignal(this, onSubscribe, null, null, null, null, null, null);
+		return doOnSignal(this, onSubscribe, null, null, null, null, null, null, null);
+	}
+
+	/**
+	 * Add behavior (side-effect) triggered after the {@link Flux} is subscribed.
+	 * <p>
+	 * This method is <strong>not</strong> intended for capturing the subscription and calling its methods,
+	 * but for side effects like monitoring. For instance, the correct way to cancel a subscription is
+	 * to call {@link Disposable#dispose()} on the Disposable returned by {@link Flux#subscribe()}.
+	 * <p>
+	 * <img class="marble" src="doc-files/marbles/doAfterSubscribe.svg" alt="">
+	 * <p>
+	 * The {@link Consumer} is executed after the {@link Subscription} is propagated
+	 * downstream to the next subscriber in the chain that is being established.
+	 *
+	 * @param afterSubscribe the callback to call after {@link Subscriber#onSubscribe}
+	 *
+	 * @return an observed  {@link Flux}
+	 * @see #doFirst(Runnable)
+	 */
+	public final Flux<T> doAfterSubscribe(Consumer<? super Subscription> afterSubscribe) {
+		Objects.requireNonNull(afterSubscribe, "afterSubscribe");
+		return doOnSignal(this, null, afterSubscribe, null, null, null, null, null, null);
 	}
 
 	/**
@@ -5043,6 +5065,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	public final Flux<T> doOnTerminate(Runnable onTerminate) {
 		Objects.requireNonNull(onTerminate, "onTerminate");
 		return doOnSignal(this,
+				null,
 				null,
 				null,
 				e -> onTerminate.run(),
@@ -10966,6 +10989,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 
 	static <T> Flux<T> doOnSignal(Flux<T> source,
 			@Nullable Consumer<? super Subscription> onSubscribe,
+			@Nullable Consumer<? super Subscription> onAfterSubscribe,
 			@Nullable Consumer<? super T> onNext,
 			@Nullable Consumer<? super Throwable> onError,
 			@Nullable Runnable onComplete,
@@ -10975,6 +10999,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 		if (source instanceof Fuseable) {
 			return onAssembly(new FluxPeekFuseable<>(source,
 					onSubscribe,
+					onAfterSubscribe,
 					onNext,
 					onError,
 					onComplete,
@@ -10984,6 +11009,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 		}
 		return onAssembly(new FluxPeek<>(source,
 				onSubscribe,
+				onAfterSubscribe,
 				onNext,
 				onError,
 				onComplete,

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPeek.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPeek.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,8 @@ final class FluxPeek<T> extends InternalFluxOperator<T, T> implements SignalPeek
 
 	final Consumer<? super Subscription> onSubscribeCall;
 
+	final Consumer<? super Subscription> onAfterSubscribeCall;
+
 	final Consumer<? super T> onNextCall;
 
 	final Consumer<? super Throwable> onErrorCall;
@@ -58,6 +60,7 @@ final class FluxPeek<T> extends InternalFluxOperator<T, T> implements SignalPeek
 
 	FluxPeek(Flux<? extends T> source,
 			@Nullable Consumer<? super Subscription> onSubscribeCall,
+		 	@Nullable Consumer<? super Subscription> onAfterSubscribeCall,
 			@Nullable Consumer<? super T> onNextCall,
 			@Nullable Consumer<? super Throwable> onErrorCall,
 			@Nullable Runnable onCompleteCall,
@@ -66,6 +69,7 @@ final class FluxPeek<T> extends InternalFluxOperator<T, T> implements SignalPeek
 			@Nullable Runnable onCancelCall) {
 		super(source);
 		this.onSubscribeCall = onSubscribeCall;
+		this.onAfterSubscribeCall = onAfterSubscribeCall;
 		this.onNextCall = onNextCall;
 		this.onErrorCall = onErrorCall;
 		this.onCompleteCall = onCompleteCall;
@@ -169,6 +173,17 @@ final class FluxPeek<T> extends InternalFluxOperator<T, T> implements SignalPeek
 				}
 				this.s = s;
 				actual.onSubscribe(this);
+
+				final Consumer<? super Subscription> afterSubscribeHook = parent.onAfterSubscribeCall();
+				if (afterSubscribeHook != null) {
+					try {
+						afterSubscribeHook.accept(s);
+					}
+					catch (Throwable e) {
+						Operators.error(actual, Operators.onOperatorError(s, e,
+								actual.currentContext()));
+					}
+				}
 			}
 		}
 
@@ -281,6 +296,12 @@ final class FluxPeek<T> extends InternalFluxOperator<T, T> implements SignalPeek
 	@Nullable
 	public Consumer<? super Subscription> onSubscribeCall() {
 		return onSubscribeCall;
+	}
+
+	@Override
+	@Nullable
+	public Consumer<? super Subscription> onAfterSubscribeCall() {
+		return onAfterSubscribeCall;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPeekFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,8 @@ final class FluxPeekFuseable<T> extends InternalFluxOperator<T, T>
 
 	final Consumer<? super Subscription> onSubscribeCall;
 
+	final Consumer<? super Subscription> onAfterSubscribeCall;
+
 	final Consumer<? super T> onNextCall;
 
 	final Consumer<? super Throwable> onErrorCall;
@@ -59,6 +61,7 @@ final class FluxPeekFuseable<T> extends InternalFluxOperator<T, T>
 
 	FluxPeekFuseable(Flux<? extends T> source,
 			@Nullable Consumer<? super Subscription> onSubscribeCall,
+		 	@Nullable Consumer<? super Subscription> onAfterSubscribeCall,
 			@Nullable Consumer<? super T> onNextCall,
 			@Nullable Consumer<? super Throwable> onErrorCall,
 			@Nullable Runnable onCompleteCall,
@@ -68,6 +71,7 @@ final class FluxPeekFuseable<T> extends InternalFluxOperator<T, T>
 		super(source);
 
 		this.onSubscribeCall = onSubscribeCall;
+		this.onAfterSubscribeCall = onAfterSubscribeCall;
 		this.onNextCall = onNextCall;
 		this.onErrorCall = onErrorCall;
 		this.onCompleteCall = onCompleteCall;
@@ -176,6 +180,17 @@ final class FluxPeekFuseable<T> extends InternalFluxOperator<T, T>
 				}
 				this.s = (QueueSubscription<T>) s;
 				actual.onSubscribe(this);
+
+				final Consumer<? super Subscription> afterSubscribeHook = parent.onAfterSubscribeCall();
+				if (afterSubscribeHook != null) {
+					try {
+						afterSubscribeHook.accept(s);
+					}
+					catch (Throwable e) {
+						Operators.error(actual, Operators.onOperatorError(s, e,
+								actual.currentContext()));
+					}
+				}
 			}
 		}
 
@@ -469,6 +484,17 @@ final class FluxPeekFuseable<T> extends InternalFluxOperator<T, T>
 				}
 				this.s = (QueueSubscription<T>) s;
 				actual.onSubscribe(this);
+
+				final Consumer<? super Subscription> afterSubscribeHook = parent.onAfterSubscribeCall();
+				if (afterSubscribeHook != null) {
+					try {
+						afterSubscribeHook.accept(s);
+					}
+					catch (Throwable e) {
+						Operators.error(actual, Operators.onOperatorError(s, e,
+								actual.currentContext()));
+					}
+				}
 			}
 		}
 
@@ -709,6 +735,12 @@ final class FluxPeekFuseable<T> extends InternalFluxOperator<T, T>
 
 	@Override
 	@Nullable
+	public Consumer<? super Subscription> onAfterSubscribeCall() {
+		return onAfterSubscribeCall;
+	}
+
+	@Override
+	@Nullable
 	public Consumer<? super T> onNextCall() {
 		return onNextCall;
 	}
@@ -814,6 +846,17 @@ final class FluxPeekFuseable<T> extends InternalFluxOperator<T, T>
 				}
 				this.s = s;
 				actual.onSubscribe(this);
+
+				final Consumer<? super Subscription> afterSubscribeHook = parent.onAfterSubscribeCall();
+				if (afterSubscribeHook != null) {
+					try {
+						afterSubscribeHook.accept(s);
+					}
+					catch (Throwable e) {
+						Operators.error(actual, Operators.onOperatorError(s, e,
+								actual.currentContext()));
+					}
+				}
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPeek.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPeek.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,8 @@ final class MonoPeek<T> extends InternalMonoOperator<T, T> implements SignalPeek
 
 	final Consumer<? super Subscription> onSubscribeCall;
 
+	final Consumer<? super Subscription> onAfterSubscribeCall;
+
 	final Consumer<? super T> onNextCall;
 
 	final LongConsumer onRequestCall;
@@ -43,11 +45,13 @@ final class MonoPeek<T> extends InternalMonoOperator<T, T> implements SignalPeek
 
 	MonoPeek(Mono<? extends T> source,
 			@Nullable Consumer<? super Subscription> onSubscribeCall,
+		 	@Nullable Consumer<? super Subscription> onAfterSubscribeCall,
 			@Nullable Consumer<? super T> onNextCall,
 			@Nullable LongConsumer onRequestCall,
 			@Nullable Runnable onCancelCall) {
 		super(source);
 		this.onSubscribeCall = onSubscribeCall;
+		this.onAfterSubscribeCall = onAfterSubscribeCall;
 		this.onNextCall = onNextCall;
 		this.onRequestCall = onRequestCall;
 		this.onCancelCall = onCancelCall;
@@ -67,6 +71,12 @@ final class MonoPeek<T> extends InternalMonoOperator<T, T> implements SignalPeek
 	@Nullable
 	public Consumer<? super Subscription> onSubscribeCall() {
 		return onSubscribeCall;
+	}
+
+	@Override
+	@Nullable
+	public Consumer<? super Subscription> onAfterSubscribeCall() {
+		return onAfterSubscribeCall;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPeekFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPeekFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ final class MonoPeekFuseable<T> extends InternalMonoOperator<T, T>
 
 	final Consumer<? super Subscription> onSubscribeCall;
 
+	final Consumer<? super Subscription> onAfterSubscribeCall;
+
 	final Consumer<? super T> onNextCall;
 
 	final LongConsumer onRequestCall;
@@ -44,12 +46,14 @@ final class MonoPeekFuseable<T> extends InternalMonoOperator<T, T>
 
 	MonoPeekFuseable(Mono<? extends T> source,
 			@Nullable Consumer<? super Subscription> onSubscribeCall,
+		 	@Nullable Consumer<? super Subscription> onAfterSubscribeCall,
 			@Nullable Consumer<? super T> onNextCall,
 			@Nullable LongConsumer onRequestCall,
 			@Nullable Runnable onCancelCall) {
 		super(source);
 
 		this.onSubscribeCall = onSubscribeCall;
+		this.onAfterSubscribeCall = onAfterSubscribeCall;
 		this.onNextCall = onNextCall;
 		this.onRequestCall = onRequestCall;
 		this.onCancelCall = onCancelCall;
@@ -69,6 +73,12 @@ final class MonoPeekFuseable<T> extends InternalMonoOperator<T, T>
 	@Nullable
 	public Consumer<? super Subscription> onSubscribeCall() {
 		return onSubscribeCall;
+	}
+
+	@Override
+	@Nullable
+	public Consumer<? super Subscription> onAfterSubscribeCall() {
+		return onAfterSubscribeCall;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelDoOnEach.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelDoOnEach.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,6 +119,11 @@ final class ParallelDoOnEach<T> extends ParallelFlux<T> implements Scannable {
 
 		@Override
 		public Consumer<? super Subscription> onSubscribeCall() {
+			return null;
+		}
+
+		@Override
+		public Consumer<? super Subscription> onAfterSubscribeCall() {
 			return null;
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelFlux.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -369,7 +369,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 */
 	public final ParallelFlux<T> doAfterTerminate(Runnable afterTerminate) {
 		Objects.requireNonNull(afterTerminate, "afterTerminate");
-		return doOnSignal(this, null, null, null, null, afterTerminate, null, null, null);
+		return doOnSignal(this, null, null, null, null, afterTerminate, null, null, null, null);
 	}
 
 	/**
@@ -381,7 +381,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 */
 	public final ParallelFlux<T> doOnCancel(Runnable onCancel) {
 		Objects.requireNonNull(onCancel, "onCancel");
-		return doOnSignal(this, null, null, null, null, null, null, null, onCancel);
+		return doOnSignal(this, null, null, null, null, null, null, null, null, onCancel);
 	}
 
 	/**
@@ -393,7 +393,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 */
 	public final ParallelFlux<T> doOnComplete(Runnable onComplete) {
 		Objects.requireNonNull(onComplete, "onComplete");
-		return doOnSignal(this, null, null, null, onComplete, null, null, null, null);
+		return doOnSignal(this, null, null, null, onComplete, null, null, null, null, null);
 	}
 
 	/**
@@ -438,7 +438,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 */
 	public final ParallelFlux<T> doOnError(Consumer<? super Throwable> onError) {
 		Objects.requireNonNull(onError, "onError");
-		return doOnSignal(this, null, null, onError, null, null, null, null, null);
+		return doOnSignal(this, null, null, onError, null, null, null, null, null, null);
 	}
 
 	/**
@@ -455,7 +455,24 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 */
 	public final ParallelFlux<T> doOnSubscribe(Consumer<? super Subscription> onSubscribe) {
 		Objects.requireNonNull(onSubscribe, "onSubscribe");
-		return doOnSignal(this, null, null, null, null, null, onSubscribe, null, null);
+		return doOnSignal(this, null, null, null, null, null, onSubscribe, null, null, null);
+	}
+
+	/**
+	 * Call the specified callback after a 'rail' receives a Subscription from its
+	 * upstream.
+	 * <p>
+	 * This method is <strong>not</strong> intended for capturing the subscription and calling its methods,
+	 * but for side effects like monitoring. For instance, the correct way to cancel a subscription is
+	 * to call {@link Disposable#dispose()} on the Disposable returned by {@link ParallelFlux#subscribe()}.
+	 *
+	 * @param afterSubscribe the callback
+	 *
+	 * @return the new {@link ParallelFlux} instance
+	 */
+	public final ParallelFlux<T> doAfterSubscribe(Consumer<? super Subscription> afterSubscribe) {
+		Objects.requireNonNull(afterSubscribe, "afterSubscribe");
+		return doOnSignal(this, null, null, null, null, null, null, afterSubscribe, null, null);
 	}
 
 	/**
@@ -467,7 +484,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 */
 	public final ParallelFlux<T> doOnNext(Consumer<? super T> onNext) {
 		Objects.requireNonNull(onNext, "onNext");
-		return doOnSignal(this, onNext, null, null, null, null, null, null, null);
+		return doOnSignal(this, onNext, null, null, null, null, null, null, null, null);
 	}
 
 	/**
@@ -480,7 +497,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 	 */
 	public final ParallelFlux<T> doOnRequest(LongConsumer onRequest) {
 		Objects.requireNonNull(onRequest, "onRequest");
-		return doOnSignal(this, null, null, null, null, null, null, onRequest, null);
+		return doOnSignal(this, null, null, null, null, null, null, null, onRequest, null);
 	}
 
 	/**
@@ -496,6 +513,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 				null,
 				e -> onTerminate.run(),
 				onTerminate,
+				null,
 				null,
 				null,
 				null,
@@ -1287,6 +1305,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 			@Nullable Runnable onComplete,
 			@Nullable Runnable onAfterTerminate,
 			@Nullable Consumer<? super Subscription> onSubscribe,
+		  	@Nullable Consumer<? super Subscription> onAfterSubscribe,
 			@Nullable LongConsumer onRequest,
 			@Nullable Runnable onCancel) {
 		return onAssembly(new ParallelPeek<>(source,
@@ -1296,6 +1315,7 @@ public abstract class ParallelFlux<T> implements CorePublisher<T> {
 				onComplete,
 				onAfterTerminate,
 				onSubscribe,
+				onAfterSubscribe,
 				onRequest,
 				onCancel));
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelPeek.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelPeek.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ final class ParallelPeek<T> extends ParallelFlux<T> implements SignalPeek<T>{
 	final Runnable onComplete;
 	final Runnable onAfterTerminated;
 	final Consumer<? super Subscription> onSubscribe;
+	final Consumer<? super Subscription> onAfterSubscribeCall;
 	final LongConsumer onRequest;
 	final Runnable onCancel;
 
@@ -49,6 +50,7 @@ final class ParallelPeek<T> extends ParallelFlux<T> implements SignalPeek<T>{
 			@Nullable Runnable onComplete,
 			@Nullable Runnable onAfterTerminated,
 			@Nullable Consumer<? super Subscription> onSubscribe,
+		 	@Nullable Consumer<? super Subscription> onAfterSubscribeCall,
 			@Nullable LongConsumer onRequest,
 			@Nullable Runnable onCancel
 	) {
@@ -60,6 +62,7 @@ final class ParallelPeek<T> extends ParallelFlux<T> implements SignalPeek<T>{
 		this.onComplete = onComplete;
 		this.onAfterTerminated = onAfterTerminated;
 		this.onSubscribe = onSubscribe;
+		this.onAfterSubscribeCall = onAfterSubscribeCall;
 		this.onRequest = onRequest;
 		this.onCancel = onCancel;
 	}
@@ -104,6 +107,12 @@ final class ParallelPeek<T> extends ParallelFlux<T> implements SignalPeek<T>{
 	@Nullable
 	public Consumer<? super Subscription> onSubscribeCall() {
 		return onSubscribe;
+	}
+
+	@Override
+	@Nullable
+	public Consumer<? super Subscription> onAfterSubscribeCall() {
+		return onAfterSubscribeCall;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/SignalLogger.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SignalLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,17 +42,18 @@ import reactor.util.context.Context;
  */
 final class SignalLogger<IN> implements SignalPeek<IN> {
 
-	final static int CONTEXT_PARENT    = 0b0100000000;
-	final static int SUBSCRIBE         = 0b0010000000;
-	final static int ON_SUBSCRIBE      = 0b0001000000;
-	final static int ON_NEXT           = 0b0000100000;
-	final static int ON_ERROR          = 0b0000010000;
-	final static int ON_COMPLETE       = 0b0000001000;
-	final static int REQUEST           = 0b0000000100;
-	final static int CANCEL            = 0b0000000010;
-	final static int AFTER_TERMINATE   = 0b0000000001;
+	final static int CONTEXT_PARENT    = 0b01000000000;
+	final static int SUBSCRIBE         = 0b00100000000;
+	final static int ON_SUBSCRIBE      = 0b00010000000;
+	final static int AFTER_SUBSCRIBE   = 0b00001000000;
+	final static int ON_NEXT           = 0b00000100000;
+	final static int ON_ERROR          = 0b00000010000;
+	final static int ON_COMPLETE       = 0b00000001000;
+	final static int REQUEST           = 0b00000000100;
+	final static int CANCEL            = 0b00000000010;
+	final static int AFTER_TERMINATE   = 0b00000000001;
 	final static int ALL               =
-			CONTEXT_PARENT | CANCEL | ON_COMPLETE | ON_ERROR | REQUEST | ON_SUBSCRIBE | ON_NEXT | SUBSCRIBE;
+			CONTEXT_PARENT | CANCEL | ON_COMPLETE | ON_ERROR | REQUEST | ON_SUBSCRIBE | AFTER_SUBSCRIBE | ON_NEXT | SUBSCRIBE;
 
 	final static AtomicLong IDS = new AtomicLong(1);
 
@@ -134,6 +135,9 @@ final class SignalLogger<IN> implements SignalPeek<IN> {
 				}
 				else if (option == SignalType.ON_SUBSCRIBE) {
 					opts |= ON_SUBSCRIBE;
+				}
+				else if (option == SignalType.AFTER_SUBSCRIBE) {
+					opts |= AFTER_SUBSCRIBE;
 				}
 				else if (option == SignalType.REQUEST) {
 					opts |= REQUEST;
@@ -251,6 +255,14 @@ final class SignalLogger<IN> implements SignalPeek<IN> {
 	public Consumer<? super Subscription> onSubscribeCall() {
 		if ((options & ON_SUBSCRIBE) == ON_SUBSCRIBE && (level != Level.INFO || log.isInfoEnabled())) {
 			return s -> log(SignalType.ON_SUBSCRIBE, subscriptionAsString(s));
+		}
+		return null;
+	}
+
+	@Override
+	public Consumer<? super Subscription> onAfterSubscribeCall() {
+		if ((options & AFTER_SUBSCRIBE) == AFTER_SUBSCRIBE && (level != Level.INFO || log.isInfoEnabled())) {
+			return s -> log(SignalType.AFTER_SUBSCRIBE, subscriptionAsString(s));
 		}
 		return null;
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/SignalPeek.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SignalPeek.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,14 @@ interface SignalPeek<T> extends Scannable {
 	 */
 	@Nullable
 	Consumer<? super Subscription> onSubscribeCall();
+
+	/**
+	 * A consumer that will run after {@link Subscriber#onSubscribe(Subscription)}
+	 *
+	 * @return A consumer that will run after {@link Subscriber#onSubscribe(Subscription)}
+	 */
+	@Nullable
+	Consumer<? super Subscription> onAfterSubscribeCall();
 
 	/**
 	 * A consumer that will observe {@link Subscriber#onNext(Object)}

--- a/reactor-core/src/main/java/reactor/core/publisher/SignalType.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SignalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,10 @@ public enum SignalType {
 	 * A signal when an operator receives a subscription
 	 */
 	ON_SUBSCRIBE,
+	/**
+	 * A signal when after an operator receives a subscription
+	 */
+	AFTER_SUBSCRIBE,
 	/**
 	 * A signal when an operator receives an emitted value
 	 */

--- a/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doAfterSubscribe.svg
+++ b/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/doAfterSubscribe.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="450" height="387" viewBox="20 33 450 387">
+ <defs>
+  <marker id="a" stroke-linejoin="miter" stroke-miterlimit="10" color="#34302c" markerHeight="12" markerUnits="strokeWidth" markerWidth="14" orient="auto" overflow="visible" viewBox="-1 -6 14 12">
+   <path fill="currentColor" stroke="currentColor" d="M12 0 0-4v9z"/>
+  </marker>
+  <marker id="b" stroke-linejoin="miter" stroke-miterlimit="10" color="#45b8de" markerHeight="10" markerUnits="strokeWidth" markerWidth="11" orient="auto" overflow="visible" viewBox="-1 -5 11 10">
+   <path fill="currentColor" stroke="currentColor" d="M8 0 0-3v6z"/>
+  </marker>
+  <marker id="c" stroke-linejoin="miter" stroke-miterlimit="10" color="#45b8de" markerHeight="10" markerUnits="strokeWidth" markerWidth="11" orient="auto" overflow="visible" viewBox="-1 -5 11 10">
+   <path fill="currentColor" stroke="currentColor" d="M8 0 0-3v6z"/>
+  </marker>
+  <marker id="d" orient="auto" overflow="visible" refX="0" refY="0">
+   <path fill-rule="evenodd" stroke="#000" stroke-linejoin="round" d="M-11-4 1 0l-12 4c2-2 2-6 0-8z"/>
+  </marker>
+ </defs>
+ <path fill="none" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.06" marker-end="url(#a)" d="M26.06 47h401.3"/>
+ <path fill="none" stroke="#45b8de" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="m179 49-1 123"/>
+ <text x="261" y="-178" fill="#45b8de" transform="rotate(90)"><tspan x="261" y="-163" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="400">onSubscribe()</tspan></text>
+ <path fill="#fff" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.99" d="M37.17 192.05h415.78l1.1 1v63.9l-1.1 1H37.17l-1.12-1v-63.9z"/>
+ <path fill="none" stroke="#34302c" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.06" marker-end="url(#a)" d="M26.06 403h400.5"/>
+ <path fill="none" stroke="#45b8de" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#b)" d="m179 259-1 123"/>
+ <text x="52" y="-177" fill="#45b8de" transform="rotate(90)"><tspan x="53" y="-162" font-family="Tahoma, 'Nimbus Sans L'" font-size="16" font-weight="400">onSubscribe()</tspan></text>
+ <path fill="none" stroke="#45b8de" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#c)" d="M63 398V275"/>
+ <text x="-391" y="43" fill="#45b8de" transform="rotate(-90)"><tspan x="-391" y="56" font-family="Tahoma, 'Nimbus Sans L'" font-size="14" font-weight="400">subscribe()</tspan></text>
+ <path fill="none" stroke="#45b8de" stroke-dasharray="2, 6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" marker-end="url(#c)" d="M63 190V67"/>
+ <text x="-183" y="43" fill="#45b8de" transform="rotate(-90)"><tspan x="-183" y="56" font-family="Tahoma, 'Nimbus Sans L'" font-size="14" font-weight="400">subscribe()</tspan></text>
+ <rect width="38" height="38" x="201" y="343" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" rx="10" ry="10"/>
+ <path fill="none" stroke="#000" stroke-width="2" d="M212 344v-8h1m7 8v-8h1m7 8v-8h1m-17 53v-8h1m7 8v-8h1m7 8v-8h1m10-19h7m-7-9h7v1"/>
+ <path d="m192.38 353.94-9.54 3.25v-6.49z"/>
+ <path fill="none" stroke="#000" stroke-width="2" d="M194 354h7m-7 16h7m38 0h7m-52-8h7"/>
+ <text x="167" y="209" fill="#34302c" transform="translate(-117 3)"><tspan x="167" y="231" font-family="Tahoma, 'Nimbus Sans L'" font-size="24" font-weight="700">doAfterSubscribe (sub</tspan></text>
+ <text x="547" y="209" fill="#34302c" transform="translate(-117 3)"><tspan x="547" y="231" font-family="Tahoma, 'Nimbus Sans L'" font-size="24" font-weight="700">)</tspan></text>
+ <path fill="none" stroke="#000" marker-end="url(#d)" d="M446 226h39" transform="translate(-117 3)"/>
+ <g fill="none" stroke="#000" stroke-width="2" transform="matrix(.6 0 0 .6 445.95 321.55)">
+  <rect width="55" height="55" x="-101" y="-186" stroke-linecap="round" stroke-linejoin="round" rx="11" ry="11"/>
+  <path d="M-85-185v-11m12 11v-11m11 11v-11m-23 75v-11m12 11v-11m11 11v-11m15-38h10m-10 11h10v1m-10 11h10m-75-23h11m-11 11h11v1m-11 11h11"/>
+ </g>
+ <text x="505" y="209" fill="#34302c" transform="translate(-117 3)"><tspan x="505" y="231" font-family="Tahoma, 'Nimbus Sans L'" font-size="19" font-weight="400" style="-inkscape-font-specification:&quot;Tahoma, Nimbus Sans L, Normal&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start">sub</tspan></text>
+ <text x="205" y="347" fill="#34302c"><tspan x="205" y="369" font-family="Tahoma, 'Nimbus Sans L'" font-size="19" font-weight="400" style="-inkscape-font-specification:&quot;Tahoma, Nimbus Sans L, Normal&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start">sub</tspan></text>
+</svg>

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxPeekFuseableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ public class FluxPeekFuseableTest {
 	@Test
 	public void nullSource() {
 		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
-			new FluxPeekFuseable<>(null, null, null, null, null, null, null, null);
+			new FluxPeekFuseable<>(null, null, null, null, null, null, null, null, null);
 		});
 	}
 
@@ -71,6 +71,7 @@ public class FluxPeekFuseableTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		AtomicReference<Subscription> onSubscribe = new AtomicReference<>();
+		AtomicReference<Subscription> onAfterSubscribe = new AtomicReference<>();
 		AtomicReference<Integer> onNext = new AtomicReference<>();
 		AtomicReference<Throwable> onError = new AtomicReference<>();
 		AtomicBoolean onComplete = new AtomicBoolean();
@@ -78,9 +79,10 @@ public class FluxPeekFuseableTest {
 		AtomicBoolean onAfterComplete = new AtomicBoolean();
 		AtomicBoolean onCancel = new AtomicBoolean();
 
-		new FluxPeekFuseable<>(Flux.just(1), onSubscribe::set, onNext::set, onError::set, () -> onComplete.set(true), () -> onAfterComplete.set(true), onRequest::set, () -> onCancel.set(true)).subscribe(ts);
+		new FluxPeekFuseable<>(Flux.just(1), onSubscribe::set, onAfterSubscribe::set, onNext::set, onError::set, () -> onComplete.set(true), () -> onAfterComplete.set(true), onRequest::set, () -> onCancel.set(true)).subscribe(ts);
 
 		assertThat(onSubscribe.get()).isNotNull();
+		assertThat(onAfterSubscribe.get()).isNotNull();
 		assertThat(onNext).hasValue((Integer) 1);
 		assertThat(onError.get()).isNull();
 		assertThat(onComplete.get()).isTrue();
@@ -94,6 +96,7 @@ public class FluxPeekFuseableTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		AtomicReference<Subscription> onSubscribe = new AtomicReference<>();
+		AtomicReference<Subscription> onAfterSubscribe = new AtomicReference<>();
 		AtomicReference<Integer> onNext = new AtomicReference<>();
 		AtomicReference<Throwable> onError = new AtomicReference<>();
 		AtomicBoolean onComplete = new AtomicBoolean();
@@ -101,9 +104,10 @@ public class FluxPeekFuseableTest {
 		AtomicBoolean onAfterComplete = new AtomicBoolean();
 		AtomicBoolean onCancel = new AtomicBoolean();
 
-		new FluxPeekFuseable<>(Flux.error(new RuntimeException("forced failure")), onSubscribe::set, onNext::set, onError::set, () -> onComplete.set(true), () -> onAfterComplete.set(true), onRequest::set, () -> onCancel.set(true)).subscribe(ts);
+		new FluxPeekFuseable<>(Flux.error(new RuntimeException("forced failure")), onSubscribe::set, onAfterSubscribe::set, onNext::set, onError::set, () -> onComplete.set(true), () -> onAfterComplete.set(true), onRequest::set, () -> onCancel.set(true)).subscribe(ts);
 
 		assertThat(onSubscribe.get()).isNotNull();
+		assertThat(onAfterSubscribe.get()).isNotNull();
 		assertThat(onNext.get()).isNull();
 		assertThat(onError.get()).isInstanceOf(RuntimeException.class);
 		assertThat(onComplete.get()).isFalse();
@@ -117,6 +121,7 @@ public class FluxPeekFuseableTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		AtomicReference<Subscription> onSubscribe = new AtomicReference<>();
+		AtomicReference<Subscription> onAfterSubscribe = new AtomicReference<>();
 		AtomicReference<Integer> onNext = new AtomicReference<>();
 		AtomicReference<Throwable> onError = new AtomicReference<>();
 		AtomicBoolean onComplete = new AtomicBoolean();
@@ -124,9 +129,10 @@ public class FluxPeekFuseableTest {
 		AtomicBoolean onAfterComplete = new AtomicBoolean();
 		AtomicBoolean onCancel = new AtomicBoolean();
 
-		new FluxPeekFuseable<>(Flux.empty(), onSubscribe::set, onNext::set, onError::set, () -> onComplete.set(true), () -> onAfterComplete.set(true), onRequest::set, () -> onCancel.set(true)).subscribe(ts);
+		new FluxPeekFuseable<>(Flux.empty(), onSubscribe::set, onAfterSubscribe::set, onNext::set, onError::set, () -> onComplete.set(true), () -> onAfterComplete.set(true), onRequest::set, () -> onCancel.set(true)).subscribe(ts);
 
 		assertThat(onSubscribe.get()).isNotNull();
+		assertThat(onAfterSubscribe.get()).isNotNull();
 		assertThat(onNext.get()).isNull();
 		assertThat(onError.get()).isNull();
 		assertThat(onComplete.get()).isTrue();
@@ -140,6 +146,7 @@ public class FluxPeekFuseableTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		AtomicReference<Subscription> onSubscribe = new AtomicReference<>();
+		AtomicReference<Subscription> onAfterSubscribe = new AtomicReference<>();
 		AtomicReference<Integer> onNext = new AtomicReference<>();
 		AtomicReference<Throwable> onError = new AtomicReference<>();
 		AtomicBoolean onComplete = new AtomicBoolean();
@@ -147,9 +154,10 @@ public class FluxPeekFuseableTest {
 		AtomicBoolean onAfterComplete = new AtomicBoolean();
 		AtomicBoolean onCancel = new AtomicBoolean();
 
-		new FluxPeekFuseable<>(Flux.never(), onSubscribe::set, onNext::set, onError::set, () -> onComplete.set(true), () -> onAfterComplete.set(true), onRequest::set, () -> onCancel.set(true)).subscribe(ts);
+		new FluxPeekFuseable<>(Flux.never(), onSubscribe::set, onAfterSubscribe::set, onNext::set, onError::set, () -> onComplete.set(true), () -> onAfterComplete.set(true), onRequest::set, () -> onCancel.set(true)).subscribe(ts);
 
 		assertThat(onSubscribe.get()).isNotNull();
+		assertThat(onAfterSubscribe.get()).isNotNull();
 		assertThat(onNext.get()).isNull();
 		assertThat(onError.get()).isNull();
 		assertThat(onComplete.get()).isFalse();
@@ -163,6 +171,7 @@ public class FluxPeekFuseableTest {
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 
 		AtomicReference<Subscription> onSubscribe = new AtomicReference<>();
+		AtomicReference<Subscription> onAfterSubscribe = new AtomicReference<>();
 		AtomicReference<Integer> onNext = new AtomicReference<>();
 		AtomicReference<Throwable> onError = new AtomicReference<>();
 		AtomicBoolean onComplete = new AtomicBoolean();
@@ -170,9 +179,10 @@ public class FluxPeekFuseableTest {
 		AtomicBoolean onAfterComplete = new AtomicBoolean();
 		AtomicBoolean onCancel = new AtomicBoolean();
 
-		new FluxPeekFuseable<>(Flux.never(), onSubscribe::set, onNext::set, onError::set, () -> onComplete.set(true), () -> onAfterComplete.set(true), onRequest::set, () -> onCancel.set(true)).subscribe(ts);
+		new FluxPeekFuseable<>(Flux.never(), onSubscribe::set, onAfterSubscribe::set, onNext::set, onError::set, () -> onComplete.set(true), () -> onAfterComplete.set(true), onRequest::set, () -> onCancel.set(true)).subscribe(ts);
 
 		assertThat(onSubscribe.get()).isNotNull();
+		assertThat(onAfterSubscribe.get()).isNotNull();
 		assertThat(onNext.get()).isNull();
 		assertThat(onError.get()).isNull();
 		assertThat(onComplete.get()).isFalse();
@@ -251,7 +261,7 @@ public class FluxPeekFuseableTest {
 	public void errorCallbackError() {
 		IllegalStateException err = new IllegalStateException("test");
 
-		FluxPeekFuseable<String> flux = new FluxPeekFuseable<>(Flux.error(new IllegalArgumentException("bar")), null, null, e -> {
+		FluxPeekFuseable<String> flux = new FluxPeekFuseable<>(Flux.error(new IllegalArgumentException("bar")), null, null, null, e -> {
 			throw err;
 		}, null, null, null, null);
 
@@ -331,6 +341,7 @@ public class FluxPeekFuseableTest {
 		FluxPeekFuseable<String> flux = new FluxPeekFuseable<>(Flux.empty(),
 			null,
 			null,
+			null,
 			errorCallbackCapture::set,
 			null,
 			() -> {
@@ -357,7 +368,7 @@ public class FluxPeekFuseableTest {
 	public void afterTerminateCallbackFatalIsThrownDirectly() {
 		AtomicReference<Throwable> errorCallbackCapture = new AtomicReference<>();
 		Error fatal = new LinkageError();
-		FluxPeekFuseable<String> flux = new FluxPeekFuseable<>(Flux.empty(), null, null, errorCallbackCapture::set, null, () -> {
+		FluxPeekFuseable<String> flux = new FluxPeekFuseable<>(Flux.empty(), null, null, null, errorCallbackCapture::set, null, () -> {
 			throw fatal;
 		}, null, null);
 
@@ -378,7 +389,7 @@ public class FluxPeekFuseableTest {
 
 		//same with after error
 		errorCallbackCapture.set(null);
-		flux = new FluxPeekFuseable<>(Flux.error(new NullPointerException()), null, null, errorCallbackCapture::set, null, () -> {
+		flux = new FluxPeekFuseable<>(Flux.error(new NullPointerException()), null, null, null, errorCallbackCapture::set, null, () -> {
 			throw fatal;
 		}, null, null);
 
@@ -404,7 +415,7 @@ public class FluxPeekFuseableTest {
 		IllegalArgumentException error2 = new IllegalArgumentException("error");
 
 		FluxPeekFuseable<String> flux =
-			new FluxPeekFuseable<>(Flux.empty(), null, null, e -> {
+			new FluxPeekFuseable<>(Flux.empty(), null, null, null, e -> {
 				throw error2;
 			}, null, () -> {
 				throw error;
@@ -430,7 +441,7 @@ public class FluxPeekFuseableTest {
 		NullPointerException error2 = new NullPointerException();
 
 		FluxPeekFuseable<String> flux =
-			new FluxPeekFuseable<>(Flux.error(error2), null, null, e -> {
+			new FluxPeekFuseable<>(Flux.error(error2), null, null, null, e -> {
 				throw error;
 			}, null, () -> {
 				throw afterTerminate;
@@ -560,6 +571,41 @@ public class FluxPeekFuseableTest {
 		  .assertComplete();
 
 		assertThat(onTerminate.get()).as("onComplete not called back").isTrue();
+	}
+
+	@Test
+	public void syncPollAfterSubscribeCalled() {
+		AtomicInteger counter = new AtomicInteger();
+		AtomicInteger onSubscribe = new AtomicInteger();
+		AtomicInteger afterSubscribe = new AtomicInteger();
+		Flux<Integer> f = Flux.just(1)
+				.doOnSubscribe(s -> onSubscribe.set(counter.incrementAndGet()))
+				.doAfterSubscribe(s -> afterSubscribe.set(counter.incrementAndGet()));
+		StepVerifier.create(f)
+				.expectFusion()
+				.expectNext(1)
+				.verifyComplete();
+
+		assertThat(onSubscribe.get()).isEqualTo(1);
+		assertThat(afterSubscribe.get()).isEqualTo(2);
+	}
+
+	@Test
+	public void syncPollConditionalAfterSubscribeCalled() {
+		AtomicInteger counter = new AtomicInteger();
+		AtomicInteger onSubscribe = new AtomicInteger();
+		AtomicInteger afterSubscribe = new AtomicInteger();
+		Flux<Integer> f = Flux.just(1)
+				.doOnSubscribe(s -> onSubscribe.set(counter.incrementAndGet()))
+				.doAfterSubscribe(s -> afterSubscribe.set(counter.incrementAndGet()))
+				.filter(v -> true);
+		StepVerifier.create(f)
+				.expectFusion()
+				.expectNext(1)
+				.verifyComplete();
+
+		assertThat(onSubscribe.get()).isEqualTo(1);
+		assertThat(afterSubscribe.get()).isEqualTo(2);
 	}
 
 	@Test
@@ -862,7 +908,7 @@ public class FluxPeekFuseableTest {
 	@Test
 	public void scanOperator(){
 		Flux<Integer> parent = Flux.just(1);
-		FluxPeekFuseable<Integer> test = new FluxPeekFuseable<>(parent, s -> {}, s -> {},
+		FluxPeekFuseable<Integer> test = new FluxPeekFuseable<>(parent, s -> {}, s -> {}, s -> {},
 				e -> {}, () -> {}, () -> {}, r -> {}, () -> {});
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(parent);
@@ -874,6 +920,7 @@ public class FluxPeekFuseableTest {
 		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {
 		}, null, null);
 		FluxPeek<Integer> peek = new FluxPeek<>(Flux.just(1), s -> {
+		}, s -> {
 		}, s -> {
 		}, e -> {
 		}, () -> {
@@ -898,6 +945,7 @@ public class FluxPeekFuseableTest {
 	public void scanFuseableConditionalSubscriber() {
 		@SuppressWarnings("unchecked") Fuseable.ConditionalSubscriber<Integer> actual = Mockito.mock(MockUtils.TestScannableConditionalSubscriber.class);
 		FluxPeek<Integer> peek = new FluxPeek<>(Flux.just(1), s -> {
+		}, s -> {
 		}, s -> {
 		}, e -> {
 		}, () -> {
@@ -936,6 +984,12 @@ public class FluxPeekFuseableTest {
 		@Nullable
 		@Override
 		public Consumer<? super Subscription> onSubscribeCall() {
+			return null;
+		}
+
+		@Nullable
+		@Override
+		public Consumer<? super Subscription> onAfterSubscribeCall() {
 			return null;
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoPeekTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,13 +84,63 @@ public class MonoPeekTest {
 	@Test
 	public void onMonoDoOnSubscribe() {
 		Mono<String> mp = Mono.just("test");
-		AtomicReference<Subscription> ref = new AtomicReference<>();
+		AtomicInteger counter = new AtomicInteger();
+		AtomicInteger onSubscribe = new AtomicInteger();
+		AtomicInteger afterSubscribe = new AtomicInteger();
 
-		StepVerifier.create(mp.doOnSubscribe(ref::set))
-		            .expectNext("test")
-		            .verifyComplete();
+		StepVerifier.create(mp.doOnSubscribe(s -> onSubscribe.set(counter.incrementAndGet()))
+						.doAfterSubscribe(s -> afterSubscribe.set(counter.incrementAndGet())))
+				.expectNext("test")
+				.verifyComplete();
 
-		assertThat(ref.get()).isNotNull();
+		assertThat(onSubscribe.get()).isEqualTo(1);
+		assertThat(afterSubscribe.get()).isEqualTo(2);
+	}
+
+	@Test
+	public void onMonoDoAfterSubscribe() {
+		Mono<String> mp = Mono.just("test");
+		AtomicInteger counter = new AtomicInteger();
+		AtomicInteger onSubscribe = new AtomicInteger();
+		AtomicInteger afterSubscribe = new AtomicInteger();
+
+		StepVerifier.create(mp.doOnSubscribe(s -> onSubscribe.set(counter.incrementAndGet()))
+						.doAfterSubscribe(s -> afterSubscribe.set(counter.incrementAndGet())))
+				.expectNext("test")
+				.verifyComplete();
+
+		assertThat(onSubscribe.get()).isEqualTo(1);
+		assertThat(afterSubscribe.get()).isEqualTo(2);
+	}
+
+	@Test
+	public void onMonoRejectedDoAfterSubscribe() {
+		Mono<String> mp = Mono.error(new Exception("test"));
+		AtomicInteger counter = new AtomicInteger();
+		AtomicInteger onSubscribe = new AtomicInteger();
+		AtomicInteger afterSubscribe = new AtomicInteger();
+
+		StepVerifier.create(mp.doOnSubscribe(s -> onSubscribe.set(counter.incrementAndGet()))
+						.doAfterSubscribe(s -> afterSubscribe.set(counter.incrementAndGet())))
+				.verifyError();
+
+		assertThat(onSubscribe.get()).isEqualTo(1);
+		assertThat(afterSubscribe.get()).isEqualTo(2);
+	}
+
+	@Test
+	public void onMonoEmptyDoAfterSubscribe() {
+		Mono<String> mp = Mono.empty();
+		AtomicInteger counter = new AtomicInteger();
+		AtomicInteger onSubscribe = new AtomicInteger();
+		AtomicInteger afterSubscribe = new AtomicInteger();
+
+		StepVerifier.create(mp.doOnSubscribe(s -> onSubscribe.set(counter.incrementAndGet()))
+							  .doAfterSubscribe(s -> afterSubscribe.set(counter.incrementAndGet())))
+					.verifyComplete();
+
+		assertThat(onSubscribe.get()).isEqualTo(1);
+		assertThat(afterSubscribe.get()).isEqualTo(2);
 	}
 
 	@Test
@@ -154,14 +204,14 @@ public class MonoPeekTest {
 
 	@Test
 	public void scanOperator(){
-	    MonoPeek<Integer> test = new MonoPeek<>(Mono.just(1), null, null, null, null);
+	    MonoPeek<Integer> test = new MonoPeek<>(Mono.just(1), null, null, null, null, null);
 
 	    assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}
 
 	@Test
 	public void scanFuseableOperator(){
-		MonoPeekFuseable<Integer> test = new MonoPeekFuseable<>(Mono.just(1), null, null, null, null);
+		MonoPeekFuseable<Integer> test = new MonoPeekFuseable<>(Mono.just(1), null, null, null, null, null);
 
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/ParallelPeekTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/ParallelPeekTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ public class ParallelPeekTest {
 	@Test
 	public void parallelism() {
 		ParallelFlux<Integer> source = Flux.just(500, 300).parallel(10);
-		ParallelPeek<Integer> test = new ParallelPeek<>(source, null, null, null, null, null, null, null, null);
+		ParallelPeek<Integer> test = new ParallelPeek<>(source, null, null, null, null, null, null, null, null, null);
 
 		assertThat(test.parallelism())
 				.isEqualTo(source.parallelism())
@@ -38,7 +38,7 @@ public class ParallelPeekTest {
 	@Test
 	public void scanOperator() {
 		ParallelSource<Integer> source = new ParallelSource<>(Flux.just(500, 300), 10, 123, Queues.one());
-		ParallelPeek<Integer> test = new ParallelPeek<>(source, null, null, null, null, null, null, null, null);
+		ParallelPeek<Integer> test = new ParallelPeek<>(source, null, null, null, null, null, null, null, null, null);
 
 		assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(source);
 		assertThat(test.scan(Scannable.Attr.PREFETCH))

--- a/reactor-core/src/test/java/reactor/core/publisher/SignalLoggerTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SignalLoggerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ public class SignalLoggerTests {
 	@Test
 	public void testLogCollectionSubscription() {
 		Flux<Integer> source = Flux.just(1, 2, 3);
-		FluxPeekFuseable<Integer> flux = new FluxPeekFuseable<>(source, null, null, null, null, null, null, null);
+		FluxPeekFuseable<Integer> flux = new FluxPeekFuseable<>(source, null, null, null, null, null, null, null, null);
 		SignalLogger<Integer> signalLogger = new SignalLogger<>(flux,
 				"test",
 				Level.INFO,
@@ -103,7 +103,7 @@ public class SignalLoggerTests {
 		Flux<Flux<Integer>> source = Flux.just(1, 2, 3)
 				.window(2); //windows happen to be UnicastProcessor, which implements QueueSubscription directly :o
 
-		FluxPeek<Flux<Integer>> flux = new FluxPeek<>(source, null, null, null, null, null, null, null);
+		FluxPeek<Flux<Integer>> flux = new FluxPeek<>(source, null, null, null, null, null, null, null, null);
 		SignalLogger<Flux<Integer>> signalLogger = new SignalLogger<>(flux,
 				"test",
 				Level.INFO,


### PR DESCRIPTION
<!-- 
Thanks for contributing to Project Reactor. Please review the following notes
about formatting your PR description.
-->

<!-- What changes from the user's perspective? -->
Add `doAfterSubscirbe` method on Flux and Mono.

<!-- Next paragraph contains more technical details -->


<!-- The footer can contain the issue references: -->
<!-- See #{OPTIONAL_REF}. -->
<!-- Fixes #{ISSUE}. -->
Fixes #3286.

<!--
The PR description will be used to craft a final squash merge commit
and the title will be used in release notes, so please keep them up-to-date.
More detailed description of the commit message convention:
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#black_nib-commit-message-convention
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#message-convention
-->
