### PR TITLE
[build] Use 'sanity' mode for JCStress for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,4 +80,4 @@ jobs:
     - uses: gradle/gradle-build-action@3b1b3b9a2104c2b47fbae53f3938079c00c9bb87 # tag=v2
       name: other tests
       with:
-        arguments: check -x :reactor-core:test -x spotlessCheck --no-daemon
+        arguments: check -x :reactor-core:test -x spotlessCheck --no-daemon -Pjcstress.mode=sanity

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
         id: slowerTests
         uses: gradle/gradle-build-action@3b1b3b9a2104c2b47fbae53f3938079c00c9bb87 # tag=v2
         with:
-          arguments: reactor-core:test -Pjunit-tags=slow
+          arguments: reactor-core:test -Pjunit-tags=slow -Pjcstress.mode=sanity
 
   #deploy the snapshot artifacts to Artifactory
   deploySnapshot:

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -299,7 +299,7 @@ blockHoundTest {
 }
 
 jcstress {
-	mode = 'quick' //quick, default, tough
+	mode = project.hasProperty('jcstress.mode') ? project.getProperty('jcstress.mode') : 'quick' //sanity, quick, default, tough
     jcstressDependency 'org.openjdk.jcstress:jcstress-core:0.16'
 	heapPerFork = 512
 }


### PR DESCRIPTION
This should improve the duration of the regular CI (PRs and merges).