### PR TITLE
[build] Freeze Artifactory Gradle Plugin at 4.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,10 @@ updates:
       - dependency-name: "biz.aQute.bnd.builder:biz.aQute.bnd.builder.gradle.plugin"
         versions:
           - ">= 7.0.a"
+      # artifactory: don't upgrade to v5 (collides with Kotlin plugin) - Remove once 3.4 is out of support
+      - dependency-name: "com.jfrog.artifactory:com.jfrog.artifactory.gradle.plugin"
+        versions:
+          - ">= 5.0.a"
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"
     schedule:


### PR DESCRIPTION
The upgrade to 5.x causes collisions with the Kotlin plugin. Perhaps once 3.4.x is no longer supported we can make the bump. For now it shall be ignored by Dependabot.

Supersedes #3730