### PR TITLE
Fix the remote branch used by spotless when running locally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ spotless {
 		enforceCheck false
 	}
 	else {
-		String spotlessBranch = "origin/main"
+		String spotlessBranch = "origin/3.5.x"
 		println "[Spotless] Local run detected, ratchet from $spotlessBranch"
 		ratchetFrom spotlessBranch
 	}


### PR DESCRIPTION
We need to change this for branch `3.6.x` when forward merge.