### PR TITLE
[build] Parallelize tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
           echo -e "   \033[38;5;0;48;5;255m ./gradlew japicmp \033[0m"
           echo ""
           exit -1
-  core-fast:
-    name: core fast tests
+  core:
+    name: core tests
     runs-on: ubuntu-latest
     needs: preliminary
     steps:
@@ -52,21 +52,7 @@ jobs:
     - uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # tag=v3
       name: gradle
       with:
-        arguments: :reactor-core:test --no-daemon -Pjunit-tags=!slow
-  core-slow:
-    name: core slower tests
-    runs-on: ubuntu-latest
-    needs: preliminary
-    steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4
-    - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # tag=v3
-      with:
-        distribution: 'temurin'
-        java-version: 8
-    - uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # tag=v3
-      name: gradle
-      with:
-        arguments: :reactor-core:test --no-daemon -Pjunit-tags=slow
+        arguments: :reactor-core:test --no-daemon
   other:
     name: other tests
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
   deploySnapshot:
     name: deploySnapshot
     runs-on: ubuntu-20.04
-    needs: [ prepare, slowerChecks ]
+    needs: prepare
     if: needs.prepare.outputs.versionType == 'SNAPSHOT'
     environment: snapshots
     steps:
@@ -60,7 +60,7 @@ jobs:
   deployMilestone:
     name: deployMilestone
     runs-on: ubuntu-20.04
-    needs: [ prepare, slowerChecks ]
+    needs: prepare
     if: needs.prepare.outputs.versionType == 'MILESTONE'
     environment: releases
     steps:
@@ -82,7 +82,7 @@ jobs:
   deployRelease:
     name: deployRelease
     runs-on: ubuntu-20.04
-    needs: [ prepare, slowerChecks ]
+    needs: prepare
     if: needs.prepare.outputs.versionType == 'RELEASE'
     environment: releases
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,24 +34,7 @@ jobs:
       id: checks
       uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # tag=v3
       with:
-        arguments: check -Pjunit-tags=!slow -x jcstress
-
-  slowerChecks:
-    # similar limitations as in prepare, but we parallelize slower tests here
-    name: slowerChecks
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4
-      - name: setup java
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # tag=v3
-        with:
-          distribution: 'temurin'
-          java-version: 8
-      - name: run slower tests
-        id: slowerTests
-        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # tag=v3
-        with:
-          arguments: reactor-core:test -Pjunit-tags=slow -Pjcstress.mode=sanity
+        arguments: check -x jcstress
 
   #deploy the snapshot artifacts to Artifactory
   deploySnapshot:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 version=3.4.37-SNAPSHOT
 bomVersion=2020.0.42
+
+org.gradle.parallel=true

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -259,7 +259,7 @@ task loops(type: Test, group: 'verification') {
 }
 
 test {
-  maxParallelForks = (int) (Runtime.runtime.availableProcessors() / 2 + 1)
+  maxParallelForks = Math.max(Runtime.runtime.availableProcessors() - 1, 1)
   def tags = rootProject.findProperty("junit-tags")
   if (tags != null) {
 	println "junit5 tags for core: $tags"

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -259,6 +259,7 @@ task loops(type: Test, group: 'verification') {
 }
 
 test {
+  maxParallelForks = (int) (Runtime.runtime.availableProcessors() / 2 + 1)
   def tags = rootProject.findProperty("junit-tags")
   if (tags != null) {
 	println "junit5 tags for core: $tags"

--- a/reactor-core/src/blockHoundTest/java/reactor/core/scheduler/ReactorBlockHoundIntegrationTest.java
+++ b/reactor-core/src/blockHoundTest/java/reactor/core/scheduler/ReactorBlockHoundIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/blockHoundTest/java/reactor/core/scheduler/ReactorBlockHoundIntegrationTest.java
+++ b/reactor-core/src/blockHoundTest/java/reactor/core/scheduler/ReactorBlockHoundIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/blockHoundTest/java/reactor/core/scheduler/ReactorBlockHoundIntegrationTest.java
+++ b/reactor-core/src/blockHoundTest/java/reactor/core/scheduler/ReactorBlockHoundIntegrationTest.java
@@ -86,7 +86,7 @@ public class ReactorBlockHoundIntegrationTest {
 				}
 				Disposable disposable = taskScheduler.schedule(dummyRunnable, 1, TimeUnit.SECONDS);
 
-				RaceTestUtils.race(Schedulers.parallel(), disposable::dispose);
+				RaceTestUtils.race(20, Schedulers.parallel(), disposable::dispose);
 			}
 			finally {
 				taskScheduler.dispose();
@@ -109,7 +109,7 @@ public class ReactorBlockHoundIntegrationTest {
 				}
 				Disposable disposable = worker.schedule(dummyRunnable, 1, TimeUnit.SECONDS);
 
-				RaceTestUtils.race(Schedulers.parallel(), disposable::dispose);
+				RaceTestUtils.race(20, Schedulers.parallel(), disposable::dispose);
 			}
 			finally {
 				worker.dispose();

--- a/reactor-core/src/blockHoundTest/java/reactor/core/scheduler/ReactorBlockHoundIntegrationTest.java
+++ b/reactor-core/src/blockHoundTest/java/reactor/core/scheduler/ReactorBlockHoundIntegrationTest.java
@@ -86,7 +86,7 @@ public class ReactorBlockHoundIntegrationTest {
 				}
 				Disposable disposable = taskScheduler.schedule(dummyRunnable, 1, TimeUnit.SECONDS);
 
-				RaceTestUtils.race(20, Schedulers.parallel(), disposable::dispose);
+				RaceTestUtils.race(Schedulers.parallel(), disposable::dispose);
 			}
 			finally {
 				taskScheduler.dispose();
@@ -109,7 +109,7 @@ public class ReactorBlockHoundIntegrationTest {
 				}
 				Disposable disposable = worker.schedule(dummyRunnable, 1, TimeUnit.SECONDS);
 
-				RaceTestUtils.race(20, Schedulers.parallel(), disposable::dispose);
+				RaceTestUtils.race(Schedulers.parallel(), disposable::dispose);
 			}
 			finally {
 				worker.dispose();

--- a/reactor-tools/build.gradle
+++ b/reactor-tools/build.gradle
@@ -188,6 +188,8 @@ javaAgentTest {
 }
 project.tasks.check.dependsOn(javaAgentTest)
 
+// This is required when org.gradle.parallel=true as tests in this module conflict with
+// concurrently running BlockHound tests.
 project.tasks.each {it.mustRunAfter(":reactor-core:blockHoundTest")}
 project.tasks.buildPluginTest.mustRunAfter(shadowJar)
 project.tasks.buildPluginTest.dependsOn(shadowJar)

--- a/reactor-tools/build.gradle
+++ b/reactor-tools/build.gradle
@@ -188,6 +188,7 @@ javaAgentTest {
 }
 project.tasks.check.dependsOn(javaAgentTest)
 
+project.tasks.each {it.mustRunAfter(":reactor-core:blockHoundTest")}
 project.tasks.buildPluginTest.mustRunAfter(shadowJar)
 project.tasks.buildPluginTest.dependsOn(shadowJar)
 


### PR DESCRIPTION
Introduces parallel gradle execution of all the modules. Also, runs JUnit tests in parallel.

With this change the JUnit tests run faster. This removes the need for separating "slow" tests in CI and during publishing. Also, because the modules are executed in parallel, the overall time is better. As an expected outcome, our Gradle workflow files should be simplified.

Resolves #2270