### PR TITLE
Fixes issue #3697 disposing TimedRunnable if disposed before scheduling

### DIFF
--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/TimedScheduler.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/TimedScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,53 +70,40 @@ final class TimedScheduler implements Scheduler {
 		this.submittedPeriodicIteration = registry.counter(submittedName, tags.and(SubmittedTags.SUBMISSION.asString(), SubmittedTags.SUBMISSION_PERIODIC_ITERATION));
 
 		this.pendingTasks = LongTaskTimer.builder(TASKS_PENDING.getName(metricPrefix))
-			.tags(tags).register(registry);
+				.tags(tags).register(registry);
 		this.activeTasks = LongTaskTimer.builder(TASKS_ACTIVE.getName(metricPrefix))
-			.tags(tags).register(registry);
+				.tags(tags).register(registry);
 		this.completedTasks = registry.timer(TASKS_COMPLETED.getName(metricPrefix), tags);
 
 	}
 
 	TimedRunnable wrap(Runnable task) {
-		return new TimedRunnable(registry, this, task);
+		return new SchedulerBackedTimedRunnable(registry, this, delegate, task);
 	}
 
 	TimedRunnable wrapPeriodic(Runnable task) {
-		return new TimedRunnable(registry, this, task, true);
+		return new SchedulerBackedTimedRunnable(registry, this, delegate, task, true);
 	}
 
 	@Override
 	public Disposable schedule(Runnable task) {
-		this.submittedDirect.increment();
 		TimedRunnable timedTask = wrap(task);
 
-		try {
-			return delegate.schedule(timedTask);
-		}
-		catch (RejectedExecutionException exception) {
-			timedTask.pendingSample.stop();
-			throw exception;
-		}
+		return timedTask.schedule();
 	}
 
 	@Override
 	public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
-		this.submittedDelayed.increment();
 		TimedRunnable timedTask = wrap(task);
 
-		try {
-			return delegate.schedule(timedTask, delay, unit);
-		}
-		catch (RejectedExecutionException exception) {
-			timedTask.pendingSample.stop();
-			throw exception;
-		}
+		return timedTask.schedule(delay, unit);
 	}
 
 	@Override
 	public Disposable schedulePeriodically(Runnable task, long initialDelay, long period, TimeUnit unit) {
-		this.submittedPeriodicInitial.increment();
-		return delegate.schedulePeriodically(wrapPeriodic(task), initialDelay, period, unit);
+		TimedRunnable timedTask = wrapPeriodic(task);
+
+		return timedTask.schedulePeriodically(initialDelay, period, unit);
 	}
 
 	@Override
@@ -154,6 +141,14 @@ final class TimedScheduler implements Scheduler {
 			this.delegate = delegate;
 		}
 
+		TimedRunnable wrap(Runnable task) {
+			return new WorkerBackedTimedRunnable(parent.registry, parent, delegate, task);
+		}
+
+		TimedRunnable wrapPeriodic(Runnable task) {
+			return new WorkerBackedTimedRunnable(parent.registry, parent, delegate, task, true);
+		}
+
 		@Override
 		public void dispose() {
 			delegate.dispose();
@@ -166,41 +161,26 @@ final class TimedScheduler implements Scheduler {
 
 		@Override
 		public Disposable schedule(Runnable task) {
-			parent.submittedDirect.increment();
-			TimedRunnable timedTask = parent.wrap(task);
+			TimedRunnable timedTask = wrap(task);
 
-			try {
-				return delegate.schedule(timedTask);
-			}
-			catch (RejectedExecutionException exception) {
-				timedTask.pendingSample.stop();
-				throw exception;
-			}
+			return timedTask.schedule();
 		}
 
 		@Override
 		public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
-			parent.submittedDelayed.increment();
-			TimedRunnable timedTask = parent.wrap(task);
+			TimedRunnable timedTask = wrap(task);
 
-			try {
-				return delegate.schedule(timedTask, delay, unit);
-			}
-			catch (RejectedExecutionException exception) {
-				timedTask.pendingSample.stop();
-				throw exception;
-			}
+			return timedTask.schedule(delay, unit);
 		}
 
 		@Override
 		public Disposable schedulePeriodically(Runnable task, long initialDelay, long period, TimeUnit unit) {
-			parent.submittedPeriodicInitial.increment();
-			return delegate.schedulePeriodically(parent.wrapPeriodic(task), initialDelay, period, unit);
+			TimedRunnable timedTask = wrapPeriodic(task);
+			return timedTask.schedulePeriodically(initialDelay, period, unit);
 		}
 	}
 
-	static final class TimedRunnable implements Runnable {
-
+	private static abstract class TimedRunnable implements Runnable, Disposable {
 		final MeterRegistry registry;
 		final TimedScheduler parent;
 		final Runnable task;
@@ -208,6 +188,8 @@ final class TimedScheduler implements Scheduler {
 		final LongTaskTimer.Sample pendingSample;
 
 		boolean isRerun;
+
+		Disposable disposable;
 
 		TimedRunnable(MeterRegistry registry, TimedScheduler parent, Runnable task) {
 			this(registry, parent, task, false);
@@ -244,6 +226,112 @@ final class TimedScheduler implements Scheduler {
 
 			Runnable completionTrackingTask = parent.completedTasks.wrap(this.task);
 			this.parent.activeTasks.record(completionTrackingTask);
+		}
+
+		public Disposable schedule() {
+			parent.submittedDirect.increment();
+
+			try {
+				disposable = this.internalSchedule();
+				return this;
+			} catch (RejectedExecutionException exception) {
+				this.dispose();
+				throw exception;
+			}
+		}
+
+		public Disposable schedule(long delay, TimeUnit unit) {
+			parent.submittedDelayed.increment();
+
+			try {
+				disposable = this.internalSchedule(delay, unit);
+				return this;
+			} catch (RejectedExecutionException exception) {
+				this.dispose();
+				throw exception;
+			}
+		}
+
+		public Disposable schedulePeriodically(long initialDelay, long period, TimeUnit unit) {
+			parent.submittedPeriodicInitial.increment();
+			return this.internalSchedulePeriodically(initialDelay, period, unit);
+		}
+
+		@Override
+		public void dispose() {
+			if (disposable != null) {
+				disposable.dispose();
+			}
+
+			if (pendingSample != null) {
+				pendingSample.stop();
+			}
+		}
+
+		abstract Disposable internalSchedule();
+
+		abstract Disposable internalSchedule(long delay, TimeUnit unit);
+
+		abstract Disposable internalSchedulePeriodically(long initialDelay, long period, TimeUnit unit);
+	}
+
+	static final class WorkerBackedTimedRunnable extends TimedRunnable {
+
+		final Worker worker;
+
+		WorkerBackedTimedRunnable(MeterRegistry registry, TimedScheduler parent, Worker worker, Runnable task) {
+			super(registry, parent, task);
+			this.worker = worker;
+		}
+
+		WorkerBackedTimedRunnable(MeterRegistry registry, TimedScheduler parent, Worker worker, Runnable task, boolean periodic) {
+			super(registry, parent, task, periodic);
+			this.worker = worker;
+		}
+
+		@Override
+		Disposable internalSchedule() {
+			return worker.schedule(this);
+		}
+
+		@Override
+		Disposable internalSchedule(long delay, TimeUnit unit) {
+			return worker.schedule(this, delay, unit);
+		}
+
+		@Override
+		Disposable internalSchedulePeriodically(long initialDelay, long period, TimeUnit unit) {
+			return worker.schedulePeriodically(this, initialDelay, period, unit);
+		}
+	}
+
+	static final class SchedulerBackedTimedRunnable extends TimedRunnable {
+
+		final Scheduler scheduler;
+
+		SchedulerBackedTimedRunnable(MeterRegistry registry, TimedScheduler parent, Scheduler scheduler, Runnable task) {
+			super(registry, parent, task);
+			this.scheduler = scheduler;
+		}
+
+		SchedulerBackedTimedRunnable(MeterRegistry registry, TimedScheduler parent, Scheduler scheduler, Runnable task, boolean periodic) {
+			super(registry, parent, task, periodic);
+			this.scheduler = scheduler;
+		}
+
+		@Override
+		Disposable internalSchedule() {
+			return scheduler.schedule(this);
+		}
+
+		@Override
+		Disposable internalSchedule(long delay, TimeUnit unit) {
+			return scheduler.schedule(this, delay, unit);
+		}
+
+		@Override
+		Disposable internalSchedulePeriodically(long initialDelay, long period, TimeUnit unit) {
+			return scheduler.schedulePeriodically(this, initialDelay, period, unit);
 		}
 	}
 }


### PR DESCRIPTION
Addresses the issue with TimedScheduler pending task leaks as described in https://github.com/reactor/reactor-core/issues/3697

The chosen approach splits existing TimedRunnable into two implementations and moves code from the TimedScheduler into the TimedRunnable to reduce duplication.
Two implementations `WorkerBacked/SchedulerBackedTimedRunnable` are present to differentiate between scheduler or a worker that schedules a task (since there is no shared interface between those). 
Differentiating from the initial proposed in #3697 by @nathankooij there is no extra objects being created and the scheduling is delegated to TimedRunnable.


Fixes #3697
