### PR TITLE
Remove Flux#thenMany optimization breaking concat

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -9243,12 +9243,6 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * this Flux completes.
 	 */
 	public final <V> Flux<V> thenMany(Publisher<V> other) {
-		if (this instanceof FluxConcatArray) {
-			@SuppressWarnings({ "unchecked" })
-			FluxConcatArray<T> fluxConcatArray = (FluxConcatArray<T>) this;
-			return fluxConcatArray.concatAdditionalIgnoredLast(other);
-		}
-
 		@SuppressWarnings("unchecked")
 		Flux<V> concat = (Flux<V>)concat(ignoreElements(), other);
 		return concat;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatArray.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatArray.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatArray.java
@@ -106,28 +106,6 @@ final class FluxConcatArray<T> extends Flux<T> implements SourceProducer<T> {
 	}
 
 	/**
-	 * Returns a new instance which has the additional source to be merged together with
-	 * the current array of sources.
-	 * <p>
-	 * This operation doesn't change the current FluxMerge instance.
-	 *
-	 * @param source the new source to merge with the others
-	 * @return the new FluxConcatArray instance
-	 */
-	@SuppressWarnings("unchecked")
-	<V> FluxConcatArray<V> concatAdditionalIgnoredLast(Publisher<? extends V>
-			source) {
-		int n = array.length;
-		Publisher<? extends V>[] newArray = new Publisher[n + 1];
-		//noinspection SuspiciousSystemArraycopy
-		System.arraycopy(array, 0, newArray, 0, n);
-		newArray[n - 1] = Mono.ignoreElements(newArray[n - 1]);
-		newArray[n] = source;
-
-		return new FluxConcatArray<>(delayError, newArray);
-	}
-
-	/**
 	 * Returns a new instance which has the additional first source to be concatenated together with
 	 * the current array of sources.
 	 * <p>

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxThenManyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxThenManyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxThenManyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxThenManyTest.java
@@ -17,6 +17,7 @@
 package reactor.core.publisher;
 
 import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,7 +47,7 @@ public class FluxThenManyTest {
 		assertThat(test).isInstanceOf(FluxConcatArray.class);
 		FluxConcatArray<Integer> s = (FluxConcatArray<Integer>)test;
 
-		assertThat(s.array).hasSize(3);
+		assertThat(s.array).hasSize(2);
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		test.subscribe(ts);
@@ -62,5 +63,24 @@ public class FluxThenManyTest {
 		test.subscribe(ts);
 		ts.assertValues("C", "D");
 		ts.assertComplete();
+	}
+
+	@Test
+	void testThenManyOnConcatArrayFused() {
+		Flux.concat(Flux.just("a"), Flux.just("b"))
+		    .thenMany(Flux.just("c"))
+		    .as(StepVerifier::create)
+		    .expectNext("c")
+		    .verifyComplete();
+	}
+
+	@Test
+	void testThenManyOnConcatArray() {
+		Flux.concat(Flux.just("a"), Flux.just("b"))
+			.hide()
+		    .thenMany(Flux.just("c"))
+		    .as(StepVerifier::create)
+		    .expectNext("c")
+		    .verifyComplete();
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxThenManyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxThenManyTest.java
@@ -39,7 +39,7 @@ public class FluxThenManyTest {
 	}
 
 	@Test
-	public void testThenManyFusion() throws InterruptedException {
+	public void testThenManyRepeated() throws InterruptedException {
 		Flux<Integer> test = Flux.just("A", "B")
 		                        .thenMany(Flux.just("C", "D"))
 		                        .thenMany(Flux.just(1, 2));
@@ -66,18 +66,8 @@ public class FluxThenManyTest {
 	}
 
 	@Test
-	void testThenManyOnConcatArrayFused() {
-		Flux.concat(Flux.just("a"), Flux.just("b"))
-		    .thenMany(Flux.just("c"))
-		    .as(StepVerifier::create)
-		    .expectNext("c")
-		    .verifyComplete();
-	}
-
-	@Test
 	void testThenManyOnConcatArray() {
 		Flux.concat(Flux.just("a"), Flux.just("b"))
-			.hide()
 		    .thenMany(Flux.just("c"))
 		    .as(StepVerifier::create)
 		    .expectNext("c")

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoThenManyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoThenManyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package reactor.core.publisher;
 
 import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,7 +39,7 @@ public class MonoThenManyTest {
 	}
 
 	@Test
-	public void testThenManyFusion() {
+	public void testThenManyRepeated() {
 		Flux<Integer> test = Mono.just("A")
 		                         .thenMany(Flux.just("C", "D"))
 		                         .thenMany(Flux.just(1, 2));
@@ -46,7 +47,7 @@ public class MonoThenManyTest {
 		assertThat(test).isInstanceOf(FluxConcatArray.class);
 		FluxConcatArray<Integer> s = (FluxConcatArray<Integer>) test;
 
-		assertThat(s.array).hasSize(3);
+		assertThat(s.array).hasSize(2);
 
 		AssertSubscriber<Integer> ts = AssertSubscriber.create();
 		test.subscribe(ts);


### PR DESCRIPTION
The optimization incorrectly ignored only the last Publisher instead of all currently concatenated Publishers causing undesired values to be emitted.

Fixes #3777