### PR TITLE
Improve auto context propagation in lifting and ConnectableFlux intersection

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableFlux.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableFlux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableFlux.java
@@ -34,6 +34,13 @@ import reactor.core.scheduler.Schedulers;
  */
 public abstract class ConnectableFlux<T> extends Flux<T> {
 
+	static <T> ConnectableFlux<T> from(ConnectableFlux<T> source) {
+		if (ContextPropagationSupport.shouldWrapPublisher(source)) {
+			return new ConnectableFluxRestoringThreadLocals<>(source);
+		}
+		return source;
+	}
+
 	/**
 	 * Connects this {@link ConnectableFlux} to the upstream source when the first {@link org.reactivestreams.Subscriber}
 	 * subscribes.

--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableFluxRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableFluxRestoringThreadLocals.java
@@ -1,0 +1,26 @@
+package reactor.core.publisher;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+
+class ConnectableFluxRestoringThreadLocals<T> extends ConnectableFlux<T> {
+
+	private final ConnectableFlux<T> source;
+
+	public ConnectableFluxRestoringThreadLocals(ConnectableFlux<T> source) {
+		this.source = Objects.requireNonNull(source, "source");
+	}
+
+	@Override
+	public void connect(Consumer<? super Disposable> cancelSupport) {
+		source.connect(cancelSupport);
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super T> actual) {
+		source.subscribe(Operators.restoreContextOnSubscriber(source, actual));
+	}
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableFluxRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableFluxRestoringThreadLocals.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2024 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import java.util.Objects;

--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableLift.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableLift.java
@@ -68,6 +68,7 @@ final class ConnectableLift<I, O> extends InternalConnectableFluxOperator<I, O> 
 
 	@Override
 	public final CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) {
+		// No need to wrap actual for CP, the Operators$LiftFunction handles it.
 		CoreSubscriber<? super I> input = liftFunction.lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");

--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableLift.java
@@ -68,8 +68,7 @@ final class ConnectableLift<I, O> extends InternalConnectableFluxOperator<I, O> 
 
 	@Override
 	public final CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) {
-		CoreSubscriber<? super I> input =
-				liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual));
+		CoreSubscriber<? super I> input = liftFunction.lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableLiftFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableLiftFuseable.java
@@ -70,6 +70,7 @@ final class ConnectableLiftFuseable<I, O> extends InternalConnectableFluxOperato
 
 	@Override
 	public final CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) {
+		// No need to wrap actual for CP, the Operators$LiftFunction handles it.
 		CoreSubscriber<? super I> input = liftFunction.lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");

--- a/reactor-core/src/main/java/reactor/core/publisher/ConnectableLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ConnectableLiftFuseable.java
@@ -70,8 +70,7 @@ final class ConnectableLiftFuseable<I, O> extends InternalConnectableFluxOperato
 
 	@Override
 	public final CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) {
-		CoreSubscriber<? super I> input =
-				liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual));
+		CoreSubscriber<? super I> input = liftFunction.lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -31,6 +31,7 @@ import io.micrometer.context.ContextSnapshot;
 
 import io.micrometer.context.ContextSnapshotFactory;
 import io.micrometer.context.ThreadLocalAccessor;
+import reactor.core.Fuseable;
 import reactor.core.observability.SignalListener;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
@@ -60,8 +61,10 @@ final class ContextPropagation {
 		}
 	}
 
-	static <T> Flux<T> fluxRestoreThreadLocals(Flux<? extends T> flux) {
-		return new FluxContextWriteRestoringThreadLocals<>(flux, Function.identity());
+	static <T> Flux<T> fluxRestoreThreadLocals(Flux<? extends T> flux, boolean fuseable) {
+		return fuseable ?
+				new FluxContextWriteRestoringThreadLocalsFuseable<>(flux, Function.identity())
+				: new FluxContextWriteRestoringThreadLocals<>(flux, Function.identity());
 	}
 
 	static <T> Mono<T> monoRestoreThreadLocals(Mono<? extends T> mono) {

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -11132,7 +11132,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 			if (!shouldWrap) {
 				return (Flux<I>) source;
 			}
-			return ContextPropagation.fluxRestoreThreadLocals((Flux<? extends I>) source);
+			return ContextPropagation.fluxRestoreThreadLocals(
+					(Flux<? extends I>) source, source instanceof Fuseable);
 		}
 
 		//for scalars we'll instantiate the operators directly to avoid onAssembly
@@ -11151,19 +11152,20 @@ public abstract class Flux<T> implements CorePublisher<T> {
 		}
 
 		Flux<I> target;
+		boolean fuseable = source instanceof Fuseable;
 		if (source instanceof Mono) {
-			if (source instanceof Fuseable) {
+			if (fuseable) {
 				target = new FluxSourceMonoFuseable<>((Mono<I>) source);
 			} else {
 				target = new FluxSourceMono<>((Mono<I>) source);
 			}
-		} else if (source instanceof Fuseable) {
+		} else if (fuseable) {
 			target = new FluxSourceFuseable<>(source);
 		} else {
 			target = new FluxSource<>(source);
 		}
 		if (shouldWrap) {
-			return ContextPropagation.fluxRestoreThreadLocals(target);
+			return ContextPropagation.fluxRestoreThreadLocals(target, fuseable);
 		}
 		return target;
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxAutoConnect.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxAutoConnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxAutoConnect.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxAutoConnect.java
@@ -50,7 +50,7 @@ final class FluxAutoConnect<T> extends Flux<T>
 		if (n <= 0) {
 			throw new IllegalArgumentException("n > required but it was " + n);
 		}
-		this.source = Objects.requireNonNull(source, "source");
+		this.source = ConnectableFlux.from(Objects.requireNonNull(source, "source"));
 		this.cancelSupport = Objects.requireNonNull(cancelSupport, "cancelSupport");
 		REMAINING.lazySet(this, n);
 	}
@@ -75,6 +75,7 @@ final class FluxAutoConnect<T> extends Flux<T>
 		if (key == Attr.PARENT) return source;
 		if (key == Attr.CAPACITY) return remaining;
 		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+		if (key == InternalProducerAttr.INSTANCE) return true;
 
 		return null;
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxAutoConnectFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxAutoConnectFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxAutoConnectFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxAutoConnectFuseable.java
@@ -51,7 +51,7 @@ final class FluxAutoConnectFuseable<T> extends Flux<T>
 		if (n <= 0) {
 			throw new IllegalArgumentException("n > required but it was " + n);
 		}
-		this.source = Objects.requireNonNull(source, "source");
+		this.source = ConnectableFlux.from(Objects.requireNonNull(source, "source"));
 		this.cancelSupport = Objects.requireNonNull(cancelSupport, "cancelSupport");
 		REMAINING.lazySet(this, n);
 	}
@@ -76,6 +76,7 @@ final class FluxAutoConnectFuseable<T> extends Flux<T>
 		if (key == Attr.PARENT) return source;
 		if (key == Attr.CAPACITY) return remaining;
 		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+		if (key == InternalProducerAttr.INSTANCE) return true;
 
 		return null;
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocalsFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocalsFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocalsFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocalsFuseable.java
@@ -23,15 +23,15 @@ import io.micrometer.context.ContextSnapshot;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
-import reactor.core.Fuseable.ConditionalSubscriber;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
-final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> {
+final class FluxContextWriteRestoringThreadLocalsFuseable<T> extends FluxOperator<T, T>
+		implements Fuseable {
 
 	final Function<Context, Context> doOnContext;
 
-	FluxContextWriteRestoringThreadLocals(Flux<? extends T> source,
+	FluxContextWriteRestoringThreadLocalsFuseable(Flux<? extends T> source,
 			Function<Context, Context> doOnContext) {
 		super(source);
 		this.doOnContext = Objects.requireNonNull(doOnContext, "doOnContext");
@@ -43,7 +43,7 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 		Context c = doOnContext.apply(actual.currentContext());
 
 		try (ContextSnapshot.Scope ignored = ContextPropagation.setThreadLocals(c)) {
-			source.subscribe(new ContextWriteRestoringThreadLocalsSubscriber<>(actual, c));
+			source.subscribe(new FuseableContextWriteRestoringThreadLocalsSubscriber<>(actual, c));
 		}
 	}
 
@@ -54,8 +54,9 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 		return super.scanUnsafe(key);
 	}
 
-	static class ContextWriteRestoringThreadLocalsSubscriber<T>
-			implements ConditionalSubscriber<T>, InnerOperator<T, T> {
+	static class FuseableContextWriteRestoringThreadLocalsSubscriber<T>
+			implements ConditionalSubscriber<T>, InnerOperator<T, T>,
+			           Fuseable.QueueSubscription<T> {
 
 		final CoreSubscriber<? super T>        actual;
 		final ConditionalSubscriber<? super T> actualConditional;
@@ -64,7 +65,7 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 		Subscription s;
 
 		@SuppressWarnings("unchecked")
-		ContextWriteRestoringThreadLocalsSubscriber(CoreSubscriber<? super T> actual, Context context) {
+		FuseableContextWriteRestoringThreadLocalsSubscriber(CoreSubscriber<? super T> actual, Context context) {
 			this.actual = actual;
 			this.context = context;
 			if (actual instanceof ConditionalSubscriber) {
@@ -171,6 +172,31 @@ final class FluxContextWriteRestoringThreadLocals<T> extends FluxOperator<T, T> 
 					     ContextPropagation.setThreadLocals(context)) {
 				s.cancel();
 			}
+		}
+
+		@Override
+		public T poll() {
+			throw new UnsupportedOperationException("Nope");
+		}
+
+		@Override
+		public int requestFusion(int requestedMode) {
+			return Fuseable.NONE;
+		}
+
+		@Override
+		public int size() {
+			throw new UnsupportedOperationException("Nope");
+		}
+
+		@Override
+		public boolean isEmpty() {
+			throw new UnsupportedOperationException("Nope");
+		}
+
+		@Override
+		public void clear() {
+			throw new UnsupportedOperationException("Nope");
 		}
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocalsFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxContextWriteRestoringThreadLocalsFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxLift.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxLift.java
@@ -52,8 +52,8 @@ final class FluxLift<I, O> extends InternalFluxOperator<I, O> {
 
 	@Override
 	public CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) {
-		CoreSubscriber<? super I> input =
-				liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual));
+		// No need to wrap actual for CP, the Operators$LiftFunction handles it.
+		CoreSubscriber<? super I> input = liftFunction.lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxLiftFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxLiftFuseable.java
@@ -54,8 +54,8 @@ final class FluxLiftFuseable<I, O> extends InternalFluxOperator<I, O>
 
 	@Override
 	public CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) {
-		CoreSubscriber<? super I> input =
-				liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual));
+		// No need to wrap actual for CP, the Operators$LiftFunction handles it.
+		CoreSubscriber<? super I> input = liftFunction.lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 
@@ -65,6 +65,6 @@ final class FluxLiftFuseable<I, O> extends InternalFluxOperator<I, O>
 			input = new FluxHide.SuppressFuseableSubscriber<>(input);
 		}
 		//otherwise QS is not required or user already made a compatible conversion
-		return Operators.restoreContextOnSubscriberIfAutoCPEnabled(this, input);
+		return input;
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxPublish.java
@@ -75,7 +75,7 @@ final class FluxPublish<T> extends ConnectableFlux<T> implements Scannable {
 		if (prefetch <= 0) {
 			throw new IllegalArgumentException("bufferSize > 0 required but it was " + prefetch);
 		}
-		this.source = Objects.requireNonNull(source, "source");
+		this.source = Flux.from(Objects.requireNonNull(source, "source"));
 		this.prefetch = prefetch;
 		this.queueSupplier = Objects.requireNonNull(queueSupplier, "queueSupplier");
 		this.resetUponSourceTermination = resetUponSourceTermination;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
@@ -50,7 +50,7 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 		if (n <= 0) {
 			throw new IllegalArgumentException("n > 0 required but it was " + n);
 		}
-		this.source = Objects.requireNonNull(source, "source");
+		this.source = ConnectableFlux.from(Objects.requireNonNull(source, "source"));
 		this.n = n;
 	}
 
@@ -64,6 +64,9 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 		RefCountMonitor<T> conn;
 		RefCountInner<T> inner = new RefCountInner<>(actual);
 
+		// This call assumes that inner.onSubscribe(Subscription) is delivered
+		// synchronously, because later inner.setRefCountMonitor() triggers the actual
+		// Subscriber to request.
 		source.subscribe(inner);
 
 		boolean connect = false;
@@ -125,6 +128,7 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 		if (key == Attr.PREFETCH) return getPrefetch();
 		if (key == Attr.PARENT) return source;
 		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+		if (key == InternalProducerAttr.INSTANCE) return true;
 
 		return null;
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
@@ -17,6 +17,7 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -46,7 +47,7 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 	RefConnection connection;
 
 	FluxRefCountGrace(ConnectableFlux<T> source, int n, Duration gracePeriod, Scheduler scheduler) {
-		this.source = source;
+		this.source = ConnectableFlux.from(Objects.requireNonNull(source, "source"));
 		this.n = n;
 		this.gracePeriod = gracePeriod;
 		this.scheduler = scheduler;
@@ -64,6 +65,7 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 		if (key == Attr.PREFETCH) return getPrefetch();
 		if (key == Attr.PARENT) return source;
 		if (key == Attr.RUN_STYLE) return Attr.RunStyle.SYNC;
+		if (key == InternalProducerAttr.INSTANCE) return true;
 
 		return null;
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -1072,7 +1072,7 @@ final class FluxReplay<T> extends ConnectableFlux<T>
 			int history,
 			long ttl,
 			@Nullable Scheduler scheduler) {
-		this.source = Objects.requireNonNull(source, "source");
+		this.source = Operators.toFluxOrMono(Objects.requireNonNull(source, "source"));
 		if (source instanceof OptimizableOperator) {
 			@SuppressWarnings("unchecked")
 			OptimizableOperator<?, T> optimSource = (OptimizableOperator<?, T>) source;

--- a/reactor-core/src/main/java/reactor/core/publisher/GroupedLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/GroupedLift.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/GroupedLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/GroupedLift.java
@@ -79,6 +79,7 @@ final class GroupedLift<K, I, O> extends GroupedFlux<K, O> implements Scannable 
 
 	@Override
 	public void subscribe(CoreSubscriber<? super O> actual) {
+		// No need to wrap actual for CP, the Operators$LiftFunction handles it.
 		CoreSubscriber<? super I> input = liftFunction.lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");

--- a/reactor-core/src/main/java/reactor/core/publisher/GroupedLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/GroupedLift.java
@@ -79,8 +79,7 @@ final class GroupedLift<K, I, O> extends GroupedFlux<K, O> implements Scannable 
 
 	@Override
 	public void subscribe(CoreSubscriber<? super O> actual) {
-		CoreSubscriber<? super I> input =
-				liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual));
+		CoreSubscriber<? super I> input = liftFunction.lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/GroupedLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/GroupedLiftFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/GroupedLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/GroupedLiftFuseable.java
@@ -81,6 +81,7 @@ final class GroupedLiftFuseable<K, I, O> extends GroupedFlux<K, O>
 
 	@Override
 	public void subscribe(CoreSubscriber<? super O> actual) {
+		// No need to wrap actual for CP, the Operators$LiftFunction handles it.
 		CoreSubscriber<? super I> input = liftFunction.lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");

--- a/reactor-core/src/main/java/reactor/core/publisher/GroupedLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/GroupedLiftFuseable.java
@@ -81,8 +81,7 @@ final class GroupedLiftFuseable<K, I, O> extends GroupedFlux<K, O>
 
 	@Override
 	public void subscribe(CoreSubscriber<? super O> actual) {
-		CoreSubscriber<? super I> input =
-				liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual));
+		CoreSubscriber<? super I> input = liftFunction.lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalConnectableFluxOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalConnectableFluxOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/InternalConnectableFluxOperator.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/InternalConnectableFluxOperator.java
@@ -59,7 +59,9 @@ abstract class InternalConnectableFluxOperator<I, O> extends ConnectableFlux<O> 
 				}
 				OptimizableOperator newSource = operator.nextOptimizableSource();
 				if (newSource == null) {
-					operator.source().subscribe(subscriber);
+					CorePublisher operatorSource = operator.source();
+					subscriber = Operators.restoreContextOnSubscriberIfPublisherNonInternal(operatorSource, subscriber);
+					operatorSource.subscribe(subscriber);
 					return;
 				}
 				operator = newSource;

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoLift.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoLift.java
@@ -37,8 +37,7 @@ final class MonoLift<I, O> extends InternalMonoOperator<I, O> {
 
 	@Override
 	public CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) {
-		CoreSubscriber<? super I> input =
-				liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual));
+		CoreSubscriber<? super I> input = liftFunction.lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoLift.java
@@ -37,6 +37,7 @@ final class MonoLift<I, O> extends InternalMonoOperator<I, O> {
 
 	@Override
 	public CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) {
+		// No need to wrap actual for CP, the Operators$LiftFunction handles it.
 		CoreSubscriber<? super I> input = liftFunction.lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoLiftFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoLiftFuseable.java
@@ -55,7 +55,7 @@ final class MonoLiftFuseable<I, O> extends InternalMonoOperator<I, O>
 
 	@Override
 	public CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) {
-		CoreSubscriber<? super I> input = liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual));
+		CoreSubscriber<? super I> input = liftFunction.lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoLiftFuseable.java
@@ -55,6 +55,7 @@ final class MonoLiftFuseable<I, O> extends InternalMonoOperator<I, O>
 
 	@Override
 	public CoreSubscriber<? super I> subscribeOrReturn(CoreSubscriber<? super O> actual) {
+		// No need to wrap actual for CP, the Operators$LiftFunction handles it.
 		CoreSubscriber<? super I> input = liftFunction.lifter.apply(source, actual);
 
 		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -2707,10 +2707,6 @@ public abstract class Operators {
 					// top of a custom Publisher so that user's lifter can also see
 					// have the Context properly restored to ThreadLocal values.
 					(pub, sub) -> {
-//						CoreSubscriber<? super I> userLiftedSub =
-//								lifter.apply(Scannable.from(pub),
-//										restoreContextOnSubscriberIfAutoCPEnabledInLift(pub, sub));
-//						return restoreContextOnSubscriberIfAutoCPEnabledInLift(pub, userLiftedSub);
 						CoreSubscriber<? super I> userLiftedSub =
 								lifter.apply(Scannable.from(pub),
 										restoreContextOnSubscriberIfAutoCPEnabled(pub, sub));

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -1024,7 +1024,7 @@ public abstract class Operators {
 
 	static <T> CoreSubscriber<T> restoreContextOnSubscriber(Publisher<?> publisher, CoreSubscriber<T> subscriber) {
 		if (publisher instanceof Fuseable) {
-			return new FluxContextWriteRestoringThreadLocals.FuseableContextWriteRestoringThreadLocalsSubscriber<>(
+			return new FluxContextWriteRestoringThreadLocalsFuseable.FuseableContextWriteRestoringThreadLocalsSubscriber<>(
 					subscriber, subscriber.currentContext());
 		} else {
 			return new FluxContextWriteRestoringThreadLocals.ContextWriteRestoringThreadLocalsSubscriber<>(

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelLift.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelLift.java
@@ -84,6 +84,7 @@ final class ParallelLift<I, O> extends ParallelFlux<O> implements Scannable {
 		int i = 0;
 		while (i < subscribers.length) {
 			subscribers[i] =
+					// No need to wrap actual for CP, the Operators$LiftFunction handles it.
 					Objects.requireNonNull(liftFunction.lifter.apply(source, s[i]),
 							"Lifted subscriber MUST NOT be null");
 			i++;

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelLift.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelLift.java
@@ -84,8 +84,7 @@ final class ParallelLift<I, O> extends ParallelFlux<O> implements Scannable {
 		int i = 0;
 		while (i < subscribers.length) {
 			subscribers[i] =
-					Objects.requireNonNull(liftFunction.lifter.apply(source,
-									Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, s[i])),
+					Objects.requireNonNull(liftFunction.lifter.apply(source, s[i]),
 							"Lifted subscriber MUST NOT be null");
 			i++;
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelLiftFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelLiftFuseable.java
@@ -88,8 +88,7 @@ final class ParallelLiftFuseable<I, O> extends ParallelFlux<O>
 		while (i < subscribers.length) {
 			CoreSubscriber<? super O> actual = s[i];
 			CoreSubscriber<? super I> converted =
-					Objects.requireNonNull(liftFunction.lifter.apply(source, Operators.restoreContextOnSubscriberIfAutoCPEnabled(source, actual)),
-							"Lifted subscriber MUST NOT be null");
+					Objects.requireNonNull(liftFunction.lifter.apply(source, actual), "Lifted subscriber MUST NOT be null");
 
 			Objects.requireNonNull(converted, "Lifted subscriber MUST NOT be null");
 

--- a/reactor-core/src/main/java/reactor/core/publisher/ParallelLiftFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ParallelLiftFuseable.java
@@ -88,6 +88,7 @@ final class ParallelLiftFuseable<I, O> extends ParallelFlux<O>
 		while (i < subscribers.length) {
 			CoreSubscriber<? super O> actual = s[i];
 			CoreSubscriber<? super I> converted =
+					// No need to wrap actual for CP, the Operators$LiftFunction handles it.
 					Objects.requireNonNull(liftFunction.lifter.apply(source, actual), "Lifted subscriber MUST NOT be null");
 
 			Objects.requireNonNull(converted, "Lifted subscriber MUST NOT be null");

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/AutomaticContextPropagationTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/AutomaticContextPropagationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2023-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/AutomaticContextPropagationTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/AutomaticContextPropagationTest.java
@@ -40,7 +40,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.micrometer.context.ContextRegistry;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -50,10 +49,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.CorePublisher;
 import reactor.core.CoreSubscriber;
+import reactor.core.Exceptions;
 import reactor.core.Fuseable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.publisher.TestPublisher;
@@ -391,7 +389,7 @@ public class AutomaticContextPropagationTest {
 				     .contextWrite(Context.of(KEY, "present"))
 				     .blockLast(Duration.ofMillis(5000));
 			} catch (Exception e) {
-				if (e instanceof IllegalStateException) {
+				if (!(e instanceof ExpectedException || e.getCause() instanceof TimeoutException)) {
 					throw e;
 				}
 				assertThat(e).satisfiesAnyOf(
@@ -431,7 +429,7 @@ public class AutomaticContextPropagationTest {
 				     }
 			     })
 			     .contextWrite(Context.of(KEY, "present"))
-			     .onErrorComplete()
+			     .onErrorComplete(e -> e instanceof ExpectedException || e instanceof TimeoutException)
 			     .block();
 
 			if (hadNext.get()) {
@@ -459,7 +457,7 @@ public class AutomaticContextPropagationTest {
 				executorService.submit(asyncAction)
 				               .get(100, TimeUnit.MILLISECONDS);
 
-				if (!subscriberWithContext.latch.await(500, TimeUnit.MILLISECONDS)) {
+				if (!subscriberWithContext.latch.await(2, TimeUnit.SECONDS)) {
 					throw new TimeoutException("timed out");
 				}
 
@@ -472,6 +470,7 @@ public class AutomaticContextPropagationTest {
 					assertThat(subscriberWithContext.complete).isTrue();
 				}
 				else {
+					assertThat(subscriberWithContext.error.get()).isInstanceOfAny(ExpectedException.class, TimeoutException.class);
 					assertThat(subscriberWithContext.valueInOnError.get()).isEqualTo("present");
 				}
 			});
@@ -496,7 +495,7 @@ public class AutomaticContextPropagationTest {
 				executorService.submit(asyncAction)
 				               .get(100, TimeUnit.MILLISECONDS);
 
-				if (!subscriberWithContext.latch.await(500, TimeUnit.MILLISECONDS)) {
+				if (!subscriberWithContext.latch.await(2, TimeUnit.SECONDS)) {
 					throw new TimeoutException("timed out");
 				}
 
@@ -508,6 +507,7 @@ public class AutomaticContextPropagationTest {
 					assertThat(subscriberWithContext.complete).isTrue();
 				}
 				else {
+					assertThat(subscriberWithContext.error.get()).isInstanceOfAny(ExpectedException.class, TimeoutException.class);
 					assertThat(subscriberWithContext.valueInOnError.get()).isEqualTo("present");
 				}
 			});
@@ -660,7 +660,7 @@ public class AutomaticContextPropagationTest {
 		@Test
 		void fluxRetryWhenSwitchingThread() {
 			assertThreadLocalsPresentInFlux(() ->
-					Flux.error(new RuntimeException("Oops"))
+					Flux.error(new ExpectedException("Oops"))
 					    .retryWhen(Retry.from(f -> threadSwitchingFlux())));
 		}
 
@@ -971,6 +971,20 @@ public class AutomaticContextPropagationTest {
 			});
 		}
 
+		// see https://github.com/reactor/reactor-core/issues/3762
+		@Test
+		void fluxLiftOnEveryOperator() {
+			Function<? super Publisher<Object>, ? extends Publisher<Object>>
+					everyOperatorLift = Operators.lift((a, b) -> b);
+
+			Hooks.onEachOperator("testEveryOperatorLift", everyOperatorLift);
+
+			assertThreadLocalsPresentInFlux(() -> Flux.just("Hello").hide()
+			                                          .publish().refCount().map(s -> s));
+
+			Hooks.resetOnEachOperator();
+		}
+
 		@Test
 		void fluxFlatMapSequential() {
 			assertThreadLocalsPresentInFlux(() ->
@@ -981,7 +995,7 @@ public class AutomaticContextPropagationTest {
 		@Test
 		void fluxOnErrorResume() {
 			assertThreadLocalsPresentInFlux(() ->
-					Flux.error(new RuntimeException("Oops"))
+					Flux.error(new ExpectedException("Oops"))
 					    .onErrorResume(t -> threadSwitchingFlux()));
 		}
 
@@ -1014,7 +1028,7 @@ public class AutomaticContextPropagationTest {
 			// missing along the way in the chain.
 			assertThreadLocalsPresent(
 					Flux.just("Hello").concatWith(Flux.never())
-					    .sampleFirst(s -> new ThreadSwitchingFlux<>(new RuntimeException("oops"), executorService)));
+					    .sampleFirst(s -> new ThreadSwitchingFlux<>(new ExpectedException("oops"), executorService)));
 		}
 
 		@Test
@@ -1220,7 +1234,7 @@ public class AutomaticContextPropagationTest {
 		@Test
 		void monoRetryWhenSwitchingThread() {
 			assertThreadLocalsPresentInMono(() ->
-					Mono.error(new RuntimeException("Oops"))
+					Mono.error(new ExpectedException("Oops"))
 					    .retryWhen(Retry.from(f -> threadSwitchingMono())));
 		}
 
@@ -1378,7 +1392,7 @@ public class AutomaticContextPropagationTest {
 		@Test
 		void monoOnErrorResume() {
 			assertThreadLocalsPresentInMono(() ->
-					Mono.error(new RuntimeException("oops"))
+					Mono.error(new ExpectedException("oops"))
 							.onErrorResume(e -> threadSwitchingMono()));
 		}
 
@@ -1593,6 +1607,48 @@ public class AutomaticContextPropagationTest {
 			assertThreadLocalsPresentInFlux(() ->
 					new ThreadSwitchingParallelFlux<>("Hello", executorService)
 							.sorted(Comparator.naturalOrder()));
+		}
+
+		// ConnectableFlux tests
+
+		@Test
+		void threadSwitchingPublishAutoConnect() {
+			assertThreadLocalsPresentInFlux(() -> threadSwitchingFlux().publish().autoConnect());
+		}
+
+		@Test
+		void threadSwitchingPublishRefCount() {
+			assertThreadLocalsPresentInFlux(() -> threadSwitchingFlux().publish().refCount());
+		}
+
+		@Test
+		void threadSwitchingPublishRefCountGrace() {
+			assertThreadLocalsPresentInFlux(() -> threadSwitchingFlux().publish().refCount(1, Duration.ofMillis(100)));
+		}
+
+		@Test
+		void threadSwitchingMonoPublish() {
+			assertThreadLocalsPresentInMono(() -> threadSwitchingMono().publish(Function.identity()));
+		}
+
+		@Test
+		void threadSwitchingMonoPublishSwitchingThread() {
+			assertThreadLocalsPresentInMono(() -> threadSwitchingMono().publish(m -> threadSwitchingMono()));
+		}
+
+		@Test
+		void threadSwitchingReplayAutoConnect() {
+			assertThreadLocalsPresentInFlux(() -> threadSwitchingFlux().replay(1).autoConnect());
+		}
+
+		@Test
+		void threadSwitchingReplayRefCount() {
+			assertThreadLocalsPresentInFlux(() -> threadSwitchingFlux().replay(1).refCount());
+		}
+
+		@Test
+		void threadSwitchingReplayRefCountGrace() {
+			assertThreadLocalsPresentInFlux(() -> threadSwitchingFlux().replay(1).refCount(1,	Duration.ofMillis(100)));
 		}
 
 		// Sinks tests
@@ -1875,6 +1931,13 @@ public class AutomaticContextPropagationTest {
 			}
 		}
 
+		private class ExpectedException extends RuntimeException {
+
+			public ExpectedException(String message) {
+				super(message);
+			}
+			
+		}
 		private class CoreSubscriberWithContext<T> implements CoreSubscriber<T> {
 
 			final AtomicReference<String>    valueInOnNext;

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/AutomaticContextPropagationTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/AutomaticContextPropagationTest.java
@@ -338,6 +338,10 @@ public class AutomaticContextPropagationTest {
 			return new ThreadSwitchingMono<>("Hello", executorService);
 		}
 
+		private ThreadSwitchingConnectableFlux<String> threadSwitchingConnectableFlux() {
+			return new ThreadSwitchingConnectableFlux<>("Hello", executorService);
+		}
+
 		void assertThreadLocalsPresentInFlux(Supplier<Flux<?>> chainSupplier) {
 			assertThreadLocalsPresentInFlux(chainSupplier, false);
 		}
@@ -1610,6 +1614,21 @@ public class AutomaticContextPropagationTest {
 		}
 
 		// ConnectableFlux tests
+
+		@Test
+		void threadSwitchingAutoConnect() {
+			assertThreadLocalsPresentInFlux(() -> threadSwitchingConnectableFlux().autoConnect());
+		}
+
+		@Test
+		void threadSwitchingRefCount() {
+			assertThreadLocalsPresentInFlux(() -> threadSwitchingConnectableFlux().refCount());
+		}
+
+		@Test
+		void threadSwitchingRefCountGrace() {
+			assertThreadLocalsPresentInFlux(() -> threadSwitchingConnectableFlux().refCount(1, Duration.ofMillis(100)));
+		}
 
 		@Test
 		void threadSwitchingPublishAutoConnect() {

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ThreadSwitchingConnectableFlux.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ThreadSwitchingConnectableFlux.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2024 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.publisher;
 
 import java.util.concurrent.ExecutorService;

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ThreadSwitchingConnectableFlux.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ThreadSwitchingConnectableFlux.java
@@ -1,0 +1,62 @@
+package reactor.core.publisher;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+
+public class ThreadSwitchingConnectableFlux<T> extends ConnectableFlux<T>
+		implements Subscription {
+
+	private final ExecutorService           executorService;
+	private final T                         item;
+	private final Throwable                 error;
+	private       CoreSubscriber<? super T> actual;
+	AtomicBoolean done = new AtomicBoolean();
+
+	public ThreadSwitchingConnectableFlux(T item, ExecutorService executorService) {
+		this.executorService = executorService;
+		this.item = item;
+		this.error = null;
+	}
+
+	@Override
+	public void connect(Consumer<? super Disposable> cancelSupport) {
+		// Assuming just one Subscriber
+		if (!done.get()) {
+			this.executorService.submit(this::deliver);
+		}
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super T> actual) {
+		this.actual = actual;
+		this.actual.onSubscribe(this);
+	}
+
+	private void deliver() {
+		if (done.compareAndSet(false, true)) {
+			if (this.item != null) {
+				this.actual.onNext(this.item);
+			}
+			if (this.error != null) {
+				this.actual.onError(this.error);
+			}
+			this.executorService.submit(this.actual::onComplete);
+		}
+	}
+
+	@Override
+	public void request(long n) {
+		// ignore, assume there's always request
+		Operators.validate(n);
+	}
+
+	@Override
+	public void cancel() {
+		done.set(true);
+	}
+}


### PR DESCRIPTION
Combining ConnectableFlux or Fuseable operators and wrapping via Hooks could lead to ClassCastException or lack of ThreadLocal restoration. ConnectableFlux and Fuseable handling has been improved. Also, lifting now avoids unnecessary multiple-wrapping.

Fixes #3762 