### PR TITLE
Drain SinkManyEmitterProcessor buffer after cancel

### DIFF
--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManyEmitterProcessorTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManyEmitterProcessorTest.java
@@ -1,0 +1,34 @@
+package reactor.core.publisher;
+
+import org.openjdk.jcstress.annotations.*;
+import org.openjdk.jcstress.infra.results.I_Result;
+import org.openjdk.jcstress.infra.results.LI_Result;
+
+import static org.openjdk.jcstress.annotations.Expect.*;
+
+public class SinkManyEmitterProcessorTest {
+
+    @JCStressTest
+    @Outcome(id = {"0"}, expect = ACCEPTABLE, desc = "Queue is empty")
+    @Outcome(id = {"1"}, expect = ACCEPTABLE_INTERESTING, desc = "Queue is not empty")
+    @State
+    public static class ParallelSubscribersStressTest {
+
+        final SinkManyEmitterProcessor<Integer> sink = new SinkManyEmitterProcessor(true, 1);
+
+        @Actor
+        public void subscribeAndCancel() {
+            sink.subscribe().dispose();
+        }
+
+        @Actor
+        public void tryEmitNext1(LI_Result r) {
+            sink.tryEmitNext(1);
+        }
+
+        @Arbiter
+        public void arbiter(I_Result result) {
+            result.r1 = sink.queue.size();
+        }
+    }
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManyEmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManyEmitterProcessor.java
@@ -384,6 +384,7 @@ final class SinkManyEmitterProcessor<T> extends Flux<T> implements InternalManyS
 
 	final void drain() {
 		if (WIP.getAndIncrement(this) != 0) {
+			WIP.decrementAndGet(this);
 			return;
 		}
 
@@ -398,6 +399,7 @@ final class SinkManyEmitterProcessor<T> extends Flux<T> implements InternalManyS
 			boolean empty = q == null || q.isEmpty();
 
 			if (checkTerminated(d, empty)) {
+				WIP.addAndGet(this, -missed);
 				return;
 			}
 
@@ -432,6 +434,7 @@ final class SinkManyEmitterProcessor<T> extends Flux<T> implements InternalManyS
 						v = null;
 					}
 					if (checkTerminated(d, v == null)) {
+						WIP.addAndGet(this, -missed);
 						return;
 					}
 					if (sourceMode != Fuseable.SYNC) {
@@ -459,6 +462,7 @@ final class SinkManyEmitterProcessor<T> extends Flux<T> implements InternalManyS
 					empty = v == null;
 
 					if (checkTerminated(d, empty)) {
+						WIP.addAndGet(this, -missed);
 						return;
 					}
 
@@ -593,6 +597,7 @@ final class SinkManyEmitterProcessor<T> extends Flux<T> implements InternalManyS
 				//happens when the removed inner makes the subscribers array EMPTY
 				if (autoCancel && b == EMPTY && Operators.terminate(S, this)) {
 					if (WIP.getAndIncrement(this) != 0) {
+						WIP.decrementAndGet(this);
 						return;
 					}
 					terminate();
@@ -600,6 +605,7 @@ final class SinkManyEmitterProcessor<T> extends Flux<T> implements InternalManyS
 					if (q != null) {
 						q.clear();
 					}
+					WIP.decrementAndGet(this);
 				}
 				return;
 			}

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkManyEmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkManyEmitterProcessorTest.java
@@ -921,4 +921,22 @@ class SinkManyEmitterProcessorTest {
 		            .expectTimeout(Duration.ofSeconds(1))
 		            .verify();
 	}
+
+	@Test
+	public void cancelledSinkClearsQueue() {
+		SinkManyEmitterProcessor<Integer> sinkManyEmitterProcessor = new SinkManyEmitterProcessor<>(true, 1);
+		// fill the buffer
+		assertThat(sinkManyEmitterProcessor.tryEmitNext(1)).as("filling buffer").isEqualTo(Sinks.EmitResult.OK);
+		StepVerifier.create(sinkManyEmitterProcessor)
+			.expectNext(1)
+			.expectTimeout(Duration.ofSeconds(1))
+			.verify();
+		sinkManyEmitterProcessor.asFlux().subscribe().dispose();
+
+		// fill the buffer
+		assertThat(sinkManyEmitterProcessor.tryEmitNext(1)).as("filling buffer").isEqualTo(Sinks.EmitResult.OK);
+		StepVerifier.create(sinkManyEmitterProcessor)
+			.verifyComplete();
+		assertThat(sinkManyEmitterProcessor.queue.isEmpty()).as("Buffer should be empty").isTrue();
+	}
 }


### PR DESCRIPTION
<!-- 
Thanks for contributing to Project Reactor. Please review the following notes
about formatting your PR description.
-->

<!-- What changes from the user's perspective? -->
The internal buffer/queue in SinkManyEmitterProcessor will be drained after all the subscriptions are canceled.

<!-- Next paragraph contains more technical details -->
As explained [here](https://github.com/reactor/reactor-core/issues/3715#issuecomment-2060902010) the queue/buffer in SinkManyEmitterProcessor is not drained properly after the last subscriber canceled the subscription. This was happening due to the WIP marker is left in an unclean state. This PR fixes the issue by updating the WIP marker. I am not sure if this is the ideal approach though.

<!-- The footer can contain the issue references: -->
<!-- See #{OPTIONAL_REF}. -->
<!-- Fixes #{ISSUE}. -->

Fixes #3715 

<!--
The PR description will be used to craft a final squash merge commit
and the title will be used in release notes, so please keep them up-to-date.
More detailed description of the commit message convention:
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#black_nib-commit-message-convention
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#message-convention
-->
