### PR TITLE
Bump Micrometer to v1.13.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,9 +14,9 @@ baselinePerfExtra = "3.5.1"
 # Other shared versions
 asciidoctor = "4.0.2"
 #note that some micrometer artifacts like context-propagation has a different version directly set in libraries below
-micrometer = "1.12.5"
+micrometer = "1.13.0"
 micrometerDocsGenerator = "1.0.2"
-micrometerTracingTest="1.2.5"
+micrometerTracingTest="1.3.0"
 contextPropagation="1.1.1"
 kotlin = "1.8.22"
 reactiveStreams = "1.0.4"


### PR DESCRIPTION
For upcoming reactor-core 3.7.0 release, update micrometer to 1.13.0 and micrometerTracingTest to 1.3.0.