### PR TITLE
Don't cleanup docs zip in case of build errors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,7 +95,7 @@ jobs:
         with:
           name: ${{ env.DOCS_ZIP }}
           path: ${{ env.DOCS_ZIP_PATH }}
-          retention-days: 1
+          retention-days: 3
           if-no-files-found: error
 
   #deploy the snapshot artifacts to Artifactory
@@ -265,9 +265,8 @@ jobs:
 
   cleanup:
     name: Cleanup docs-zip artifact
-    needs: [ prepare, build-docs-zip, deploySnapshot, deployMilestone, deployRelease, tagMilestone, tagRelease ]
-    # Don't cleanup if any dependent job has failed.
-    if: ${{ always() && !contains(join(needs.*.result, ','), 'failure') }}
+    needs: [ deploySnapshot, tagRelease, tagMilestone ]
+    if: always() && (needs.deploySnapshot.result == 'success' || needs.tagRelease.result == 'success' || needs.tagMilestone.result == 'success')
     runs-on: ubuntu-20.04
     permissions:
       actions: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -265,8 +265,9 @@ jobs:
 
   cleanup:
     name: Cleanup docs-zip artifact
-    needs: [ deploySnapshot, tagRelease, tagMilestone ]
-    if: always() # cleanup always run after all needed jobs, regardless of whether they were successful
+    needs: [ prepare, build-docs-zip, deploySnapshot, deployMilestone, deployRelease, tagMilestone, tagRelease ]
+    # Don't cleanup if any dependent job has failed.
+    if: ${{ always() && !contains(join(needs.*.result, ','), 'failure') }}
     runs-on: ubuntu-20.04
     permissions:
       actions: write


### PR DESCRIPTION
The publication process triggered by the CI (controlled by publish.yml) may occasionally fail (like when having some flaky tests). In such cases, the cleanup job always runs and deletes any previously uploaded docs zip files created by the `build-docs-zip` job. However, it's inconvenient to remove the docs-zip when certain jobs fail because if we attempt to rerun the failed jobs later, we lose access to the docs-zip attached to the workflow run.

Ideally, the docs-zip should only be removed when the publish process succeeds. If errors occur, such as flaky tests, the docs-zip should not be removed. This ensures that we can rerun the publish jobs successfully.

It's important to note that the docs-zip is set to be retained for 1 day. If a failed jobs is not rerun within this timeframe, the docs-zip will then be automatically removed from the workflow run after one day.