### PR TITLE
Fail on missing asciidoctor pdf command

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,18 @@ Then you can build the antora documentation like this:
 ./gradlew docs
 ```
 
-The documentation is generated in `docs/build/site/index.html` and in `docs/build/distributions/reactor-core-<version-docs.zip` 
+The documentation is generated in `docs/build/site/index.html` and in `docs/build/distributions/reactor-core-<version>-docs.zip` 
+If a PDF file should also be included in the generated docs zip file, then you need to specify `-PforcePdf` option:
+
+```shell
+./gradlew docs -PforcePdf
+```
+Notice that PDF generation requires the `asciidoctor-pdf` command to be available in the PATH. 
+For example, on Mac OS, you can install such command like this:
+
+```shell
+brew install asciidoctor
+```
 
 ## Getting Started
 

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -42,7 +42,7 @@ antora {
             logger.log(LogLevel.DEBUG, "enabling antora pdf-extension")
             options.add('--extension=pdf-extension')
         } else {
-            logger.lifecycle("PDF not generated, asciidoctor-pdf not found from the PATH.")
+            throw new GradleException("PDF cannot be generated, asciidoctor-pdf not found from the PATH.")
         }
     }
 


### PR DESCRIPTION
When you want to build the documentation, you can using the following command:

```
 ./gradlew docs -PforcePdf
```

Now, PDF generation requires the `asciidoctor-pdf` command to be available in the PATH.
This PR simply makes the build failing in case the `asciidoctor-pdf` command is not available from the PATH.
Also, updated README.md to indicate that this command needs to be available when generating PDF from Antora documentation.
