### PR TITLE
Allow registering a custom `Predicate` for determining non-blocking threads

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -120,6 +121,10 @@ public abstract class Schedulers {
 			Optional.ofNullable(System.getProperty("reactor.schedulers.defaultBoundedElasticOnVirtualThreads"))
 			        .map(Boolean::parseBoolean)
 			        .orElse(false);
+
+	static final Predicate<Thread> DEFAULT_NON_BLOCKING_THREAD_PREDICATE = thread -> false;
+
+	static Predicate<Thread> nonBlockingThreadPredicate = DEFAULT_NON_BLOCKING_THREAD_PREDICATE;
 
 	/**
 	 * Create a {@link Scheduler} which uses a backing {@link Executor} to schedule
@@ -659,24 +664,42 @@ public abstract class Schedulers {
 
 	/**
 	 * Check if calling a Reactor blocking API in the current {@link Thread} is forbidden
-	 * or not, by checking if the thread implements {@link NonBlocking} (in which case it is
-	 * forbidden and this method returns {@code true}).
+	 * or not. This method returns {@code true} and will forbid the Reactor blocking API if
+	 * any of the following conditions meet:
+	 * <ul>
+	 *   <li>the thread implements {@link NonBlocking}; or</li>
+	 *   <li>any of the {@link Predicate}s registered via {@link #registerNonBlockingThreadPredicate(Predicate)}
+	 *       returns {@code true}.</li>
+	 * </ul>
 	 *
 	 * @return {@code true} if blocking is forbidden in this thread, {@code false} otherwise
 	 */
 	public static boolean isInNonBlockingThread() {
-		return Thread.currentThread() instanceof NonBlocking;
+		return isNonBlockingThread(Thread.currentThread());
 	}
 
 	/**
 	 * Check if calling a Reactor blocking API in the given {@link Thread} is forbidden
-	 * or not, by checking if the thread implements {@link NonBlocking} (in which case it is
-	 * forbidden and this method returns {@code true}).
+	 * or not. This method returns {@code true} and will forbid the Reactor blocking API if
+	 * any of the following conditions meet:
+	 * <ul>
+	 *   <li>the thread implements {@link NonBlocking}; or</li>
+	 *   <li>any of the {@link Predicate}s registered via {@link #registerNonBlockingThreadPredicate(Predicate)}
+	 *       returns {@code true}.</li>
+	 * </ul>
 	 *
 	 * @return {@code true} if blocking is forbidden in that thread, {@code false} otherwise
 	 */
 	public static boolean isNonBlockingThread(Thread t) {
-		return t instanceof NonBlocking;
+		return t instanceof NonBlocking || nonBlockingThreadPredicate.test(t);
+	}
+
+	/**
+	 * Registers the specified {@link Predicate} that determines whether it is forbidden to call
+	 * a Reactor blocking API in a given {@link Thread} or not.
+	 */
+	public static void registerNonBlockingThreadPredicate(Predicate<Thread> predicate) {
+		nonBlockingThreadPredicate = nonBlockingThreadPredicate.or(predicate);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -703,6 +703,14 @@ public abstract class Schedulers {
 	}
 
 	/**
+	 * Unregisters all the {@link Predicate}s registered so far via
+	 * {@link #registerNonBlockingThreadPredicate(Predicate)}.
+	 */
+	public static void resetNonBlockingThreadPredicate() {
+		nonBlockingThreadPredicate = DEFAULT_NON_BLOCKING_THREAD_PREDICATE;
+	}
+
+	/**
 	 * If Micrometer is available, set-up a decorator that will instrument any
 	 * {@link ExecutorService} that backs a {@link Scheduler}.
 	 * No-op if Micrometer isn't available.

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -19,6 +19,7 @@ package reactor.core.scheduler;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -359,10 +360,49 @@ public class SchedulersTest {
 
 	@Test
 	public void isInNonBlockingThreadTrue() {
-		new ReactorThreadFactory.NonBlockingThread(() -> assertThat(Schedulers.isInNonBlockingThread())
-				.as("isInNonBlockingThread")
-				.isFalse(),
-				"isInNonBlockingThreadTrue");
+		assertNonBlockingThread(ReactorThreadFactory.NonBlockingThread::new, true);
+	}
+
+	@Test
+	public void customNonBlockingThreadPredicate() {
+		assertThat(Schedulers.nonBlockingThreadPredicate)
+				.as("nonBlockingThreadPredicate")
+				.isSameAs(Schedulers.DEFAULT_NON_BLOCKING_THREAD_PREDICATE);
+
+		// The custom `Predicate` is not registered yet,
+		// so `CustomNonBlockingThread` will be considered blocking.
+		assertNonBlockingThread(CustomNonBlockingThread::new, false);
+
+		// Now register the `Predicate` and ensure `CustomNonBlockingThread` is non-blocking.
+		Schedulers.registerNonBlockingThreadPredicate(t -> t instanceof CustomNonBlockingThread);
+		try {
+			assertNonBlockingThread(CustomNonBlockingThread::new, true);
+		} finally {
+			// Restore the global predicate.
+			Schedulers.nonBlockingThreadPredicate = Schedulers.DEFAULT_NON_BLOCKING_THREAD_PREDICATE;
+		}
+	}
+
+	private void assertNonBlockingThread(BiFunction<Runnable, String, Thread> threadFactory,
+										 boolean expectedNonBlocking) {
+		CompletableFuture<Void> future = new CompletableFuture<>();
+		Thread thread = threadFactory.apply(() -> {
+			try {
+				assertThat(Schedulers.isInNonBlockingThread())
+						.as("isInNonBlockingThread")
+						.isEqualTo(expectedNonBlocking);
+				future.complete(null);
+			} catch (Throwable cause) {
+				future.completeExceptionally(cause);
+			}
+		}, "assertNonBlockingThread");
+
+		assertThat(Schedulers.isNonBlockingThread(thread))
+				.as("isNonBlockingThread")
+				.isEqualTo(expectedNonBlocking);
+
+		thread.start();
+		future.join();
 	}
 
 	@Test
@@ -1455,6 +1495,12 @@ public class SchedulersTest {
 			@Override
 			public void dispose() {
 			}
+		}
+	}
+
+	final static class CustomNonBlockingThread extends Thread {
+		CustomNonBlockingThread(Runnable target, String name) {
+			super(target, name);
 		}
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -379,12 +379,16 @@ public class SchedulersTest {
 			assertNonBlockingThread(CustomNonBlockingThread::new, true);
 		} finally {
 			// Restore the global predicate.
-			Schedulers.nonBlockingThreadPredicate = Schedulers.DEFAULT_NON_BLOCKING_THREAD_PREDICATE;
+			Schedulers.resetNonBlockingThreadPredicate();
 		}
+
+		assertThat(Schedulers.nonBlockingThreadPredicate)
+				.as("nonBlockingThreadPredicate (after reset)")
+				.isSameAs(Schedulers.DEFAULT_NON_BLOCKING_THREAD_PREDICATE);
 	}
 
-	private void assertNonBlockingThread(BiFunction<Runnable, String, Thread> threadFactory,
-										 boolean expectedNonBlocking) {
+	private static void assertNonBlockingThread(BiFunction<Runnable, String, Thread> threadFactory,
+												boolean expectedNonBlocking) {
 		CompletableFuture<Void> future = new CompletableFuture<>();
 		Thread thread = threadFactory.apply(() -> {
 			try {


### PR DESCRIPTION
Related issue: #3833
Motivation:

It is currently not possible to create a non-blocking threads without implementing the `reactor.core.scheduler.NonBlocking` interface. Some third-party libraries and frameworks don't directly depend on `reactor-core`, yet they want to mark the threads they manage as non-blocking.

Modifications:

- Added a new method `Schedulers.registerNonBlockingThreadPredicate()` so that a user can register their own `Predicate` that determines whether a given thread is non-blocking or not
  - Also added `Schedulers.resetNonBlockingThreadPredicate()` so that a user can reset the registrations.
- Fixed an incorrectly implemented test that doesn't really test anything:
  - `SchedulersTest.isInNonBlockingThreadTrue()`

Result:

- A user can now mark their own `Thread` classes as non-blocking without depending on `reactor-core` or implementing the `NonBlocking` marker interface.