### PR TITLE
Allow registering a custom `Predicate` for determining non-blocking threads

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Related issue: #3833
Motivation:

It is currently not possible to create a non-blocking threads without implementing the `reactor.core.scheduler.NonBlocking` interface. Some third-party libraries and frameworks don't directly depend on `reactor-core`, yet they want to mark the threads they manage as non-blocking.

Modifications:

- Added a new method `Schedulers.registerNonBlockingThreadPredicate()` so that a user can register their own `Predicate` that determines whether a given thread is non-blocking or not
  - Also added `Schedulers.resetNonBlockingThreadPredicate()` so that a user can unregister all previous `Predicate`s
- Fixed an incorrectly implemented test that doesn't really test anything:
  - `SchedulersTest.isInNonBlockingThreadTrue()`

Result:

- A user can now mark their own `Thread` classes as non-blocking without depending on `reactor-core` or implementing the `NonBlocking` marker interface.