### PR TITLE
Fix ThreadPerTaskScheduler busyness accounting

### DIFF
--- a/reactor-core/src/main/java21/reactor/core/scheduler/BoundedElasticThreadPerTaskScheduler.java
+++ b/reactor-core/src/main/java21/reactor/core/scheduler/BoundedElasticThreadPerTaskScheduler.java
@@ -882,7 +882,7 @@ final class BoundedElasticThreadPerTaskScheduler
 
 		static long incrementRefCnt(long state) {
 			long rawRefCnt = state & REF_CNT_MASK;
-			return (rawRefCnt) == REF_CNT_MASK ? state : (rawRefCnt >> 31 + 1) << 31 | (state &~ REF_CNT_MASK);
+			return (rawRefCnt) == REF_CNT_MASK ? state : ((rawRefCnt >> 31) + 1) << 31 | (state &~ REF_CNT_MASK);
 		}
 
 		static long release(SequentialThreadPerTaskExecutor instance) {

--- a/reactor-core/src/main/java21/reactor/core/scheduler/BoundedElasticThreadPerTaskScheduler.java
+++ b/reactor-core/src/main/java21/reactor/core/scheduler/BoundedElasticThreadPerTaskScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2023-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This change prevents the same `BoundedElasticThreadPerTaskScheduler` being picked up when the maximum number of Virtual Threads are already being executed in parallel. The consequence of improper busyness accounting was that tasks were executed sequentially instead of being run in parallel because the same `Worker` was being picked by operators.

Resolves #3857