### PR TITLE
Remove `gradle/actions/setup-gradle` deprecated functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,16 +32,14 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
-      - uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # tag=v3
-        name: spotless (license header)
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582
+      - name: spotless (license header)
         if: always()
-        with:
-          arguments: spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
-      - uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # tag=v3
-        name: api compatibility
+        run: ./gradlew spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
+      - name: api compatibility
         if: always()
-        with:
-          arguments: japicmp
+        run: ./gradlew japicmp
       - name: how to fix
         if: failure()
         # the foreground (38;5) color code 208 is orange. we also have bold, white bg (38;5;0;48;5;255m), white fg on black bg...
@@ -97,7 +95,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 8
-    - uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # tag=v3
-      name: Run Gradle Tests
-      with:
-        arguments: ${{ matrix.test-type.arguments }}
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582
+    - name: Run Gradle Tests
+      run: ./gradlew ${{ matrix.test-type.arguments }}

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582
       - name: Run Gradle Tests
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # tag=v3
-        with:
-          arguments: ${{ matrix.test-type.arguments }}
+        run: ./gradlew ${{ matrix.test-type.arguments }}

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag=v4
-      - uses: gradle/actions/wrapper-validation@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # tag=v3
+      - uses: gradle/actions/wrapper-validation@af1da67850ed9a4cedd57bfd976089dd991e2582

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,8 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 8
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582
     - name: interpret version
       id: version
       #we only run the qualifyVersionGha task so that no other console printing can hijack this step's output
@@ -60,9 +62,7 @@ jobs:
       run: ./gradlew qualifyVersionGha
     - name: run checks
       id: checks
-      uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # tag=v3
-      with:
-        arguments: ${{ matrix.test-type.arguments }}
+      run: ./gradlew ${{ matrix.test-type.arguments }}
   #deploy the snapshot artifacts to Artifactory
   deploySnapshot:
     name: deploySnapshot

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582
       - name: Run Gradle Tests
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # tag=v3
-        with:
-          arguments: ${{ matrix.test-type.arguments }}
+        run: ./gradlew ${{ matrix.test-type.arguments }}


### PR DESCRIPTION
- Bump the version
- Using the action to execute Gradle via the `arguments` parameter is deprecated https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated
