### PR TITLE
Call init() on delegate from TimedScheduler

### DIFF
--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/TimedScheduler.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/TimedScheduler.java
@@ -135,6 +135,11 @@ final class TimedScheduler implements Scheduler {
 		delegate.start();
 	}
 
+	@Override
+	public void init() {
+		delegate.init();
+	}
+
 	static final class TimedWorker implements Worker {
 
 		final TimedScheduler parent;


### PR DESCRIPTION
This fixes an issue where wrapping a `BoundedElasticThreadPerTaskScheduler` with `Micrometer#timedScheduler()` causes it to error out immediately.

The [TimedScheduler](https://github.com/reactor/reactor-core/blob/ef152df80d57713f9d33cb6080d8f2ee2b90d093/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/TimedScheduler.java) class doesn't currently override the `init()` method, so it calls the [default](https://github.com/reactor/reactor-core/blob/ef152df80d57713f9d33cb6080d8f2ee2b90d093/reactor-core/src/main/java/reactor/core/scheduler/Scheduler.java#L187-L189) from the interface, which delegates to `start()`. This works fine for other scheduler implementations because they still implement `start()`, but for the virtual thread scheduler, it simply [throws an error](https://github.com/reactor/reactor-core/blob/ef152df80d57713f9d33cb6080d8f2ee2b90d093/reactor-core/src/main/java21/reactor/core/scheduler/BoundedElasticThreadPerTaskScheduler.java#L127-L129). When we wrap it in a timed scheduler, it crashes on this error as soon as `init()` gets called.

<!-- 
Thanks for contributing to Project Reactor. Please review the following notes
about formatting your PR description.
-->

<!-- What changes from the user's perspective? -->


<!-- Next paragraph contains more technical details -->


<!-- The footer can contain the issue references: -->
<!-- See #{OPTIONAL_REF}. -->
<!-- Fixes #{ISSUE}. -->

<!--
The PR description will be used to craft a final squash merge commit
and the title will be used in release notes, so please keep them up-to-date.
More detailed description of the commit message convention:
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#black_nib-commit-message-convention
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#message-convention
-->
