### PR TITLE
Optimize `Scannable#name()` and related logic

### DIFF
--- a/benchmarks/src/main/java/reactor/core/publisher/MonoAllBenchmark.java
+++ b/benchmarks/src/main/java/reactor/core/publisher/MonoAllBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,8 +49,8 @@ public class MonoAllBenchmark {
 
 	@SuppressWarnings("unused")
 	@Benchmark
-	public void measureThroughput() {
-		Flux.range(0, rangeSize)
+	public Boolean measureThroughput() {
+		return Flux.range(0, rangeSize)
 			.all(i -> i < Integer.MAX_VALUE)
 			.block();
 	}

--- a/benchmarks/src/main/java/reactor/core/publisher/TracesBenchmark.java
+++ b/benchmarks/src/main/java/reactor/core/publisher/TracesBenchmark.java
@@ -37,17 +37,17 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
 public class TracesBenchmark {
-	@Param({"0", "10", "100", "1000"})
+	@Param({"0", "1", "2"})
 	private int reactorLeadingLines;
 
-	@Param({"0", "10", "100", "1000"})
+	@Param({"0", "1", "2"})
 	private int trailingLines;
 
 	private String stackTrace;
 
 	@Setup(Level.Iteration)
 	public void setup() {
-		stackTrace = createLargeStackTrace(reactorLeadingLines, trailingLines);
+		stackTrace = createStackTrace(reactorLeadingLines, trailingLines);
 	}
 
 	@SuppressWarnings("unused")
@@ -56,7 +56,7 @@ public class TracesBenchmark {
 		return Traces.extractOperatorAssemblyInformation(stackTrace);
 	}
 
-	private static String createLargeStackTrace(int reactorLeadingLines, int trailingLines) {
+	private static String createStackTrace(int reactorLeadingLines, int trailingLines) {
 		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < reactorLeadingLines; i++) {
 			sb.append("\tat reactor.core.publisher.Flux.someOperation(Flux.java:42)\n");

--- a/benchmarks/src/main/java/reactor/core/publisher/TracesBenchmark.java
+++ b/benchmarks/src/main/java/reactor/core/publisher/TracesBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,16 @@
 package reactor.core.publisher;
 
 import java.util.concurrent.TimeUnit;
-
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
@@ -35,23 +36,35 @@ import org.openjdk.jmh.annotations.Warmup;
 @Fork(value = 1)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
-public class MonoCallableBenchmark {
+public class TracesBenchmark {
+	@Param({"0", "10", "100", "1000"})
+	private int reactorLeadingLines;
 
-	@Param({"10", "1000", "100000"})
-	int rangeSize;
+	@Param({"0", "10", "100", "1000"})
+	private int trailingLines;
 
-	public static void main(String[] args) throws Exception {
-		reactor.core.scrabble.ShakespearePlaysScrabbleOpt
-				s = new reactor.core.scrabble.ShakespearePlaysScrabbleOpt();
-		s.init();
-		System.out.println(s.measureThroughput());
+	private String stackTrace;
+
+	@Setup(Level.Iteration)
+	public void setup() {
+		stackTrace = createLargeStackTrace(reactorLeadingLines, trailingLines);
 	}
 
 	@SuppressWarnings("unused")
 	@Benchmark
-	public Boolean measureThroughput() {
-		return Flux.range(0, rangeSize)
-			.all(i -> i < Integer.MAX_VALUE)
-			.block();
+	public String measureThroughput() {
+		return Traces.extractOperatorAssemblyInformation(stackTrace);
+	}
+
+	private static String createLargeStackTrace(int reactorLeadingLines, int trailingLines) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < reactorLeadingLines; i++) {
+			sb.append("\tat reactor.core.publisher.Flux.someOperation(Flux.java:42)\n");
+		}
+		sb.append("\tat some.user.package.SomeUserClass.someOperation(SomeUserClass.java:1234)\n");
+		for (int i = 0; i < trailingLines; i++) {
+			sb.append("\tat any.package.AnyClass.anyOperation(AnyClass.java:1)\n");
+		}
+		return sb.toString();
 	}
 }

--- a/reactor-core/src/main/java/reactor/core/Scannable.java
+++ b/reactor-core/src/main/java/reactor/core/Scannable.java
@@ -449,7 +449,7 @@ public interface Scannable {
 				.map(s -> s.scan(Attr.NAME))
 				.filter(Objects::nonNull)
 				.findFirst()
-				.orElse(stepName());
+				.orElseGet(this::stepName);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/core/publisher/Traces.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Traces.java
@@ -28,8 +28,6 @@ import reactor.util.annotation.Nullable;
  * @author Sergei Egorov
  */
 final class Traces {
-	private static final String PUBLISHER_PACKAGE_PREFIX = "reactor.core.publisher.";
-
 	/**
 	 * If set to true, the creation of FluxOnAssembly will capture the raw stacktrace
 	 * instead of the sanitized version.
@@ -46,6 +44,8 @@ final class Traces {
 	 * newline.
 	 */
 	static final Supplier<Supplier<String>> callSiteSupplierFactory = new CallSiteSupplierFactory();
+
+	private static final String PUBLISHER_PACKAGE_PREFIX = "reactor.core.publisher.";
 
 	/**
 	 * Return true for strings (usually from a stack trace element) that should be
@@ -71,7 +71,7 @@ final class Traces {
 	}
 
 	/**
-	 * Extract operator information out of an assembly stack trace in {@link String} form
+	 * Extracts operator information out of an assembly stack trace in {@link String} form
 	 * (see {@link Traces#callSiteSupplierFactory}).
 	 * <p>
 	 * Most operators will result in a line of the form {@code "Flux.map ⇢ user.code.Class.method(Class.java:123)"},
@@ -82,10 +82,9 @@ final class Traces {
 	 *     (eg. {@code "Flux.map"})</li>
 	 *     <li>The next stacktrace element is considered user code and is appended to the
 	 *     result with a {@code ⇢} separator. (eg. {@code " ⇢ user.code.Class.method(Class.java:123)"})</li>
-	 *     <li>If no user code is found in the sanitized stack, then the API reference is outputed in the later format only.</li>
+	 *     <li>If no user code is found in the sanitized stack, then the API reference is output in the later format only.</li>
 	 *     <li>If the sanitized stack is empty, returns {@code "[no operator assembly information]"}</li>
 	 * </ol>
-	 *
 	 *
 	 * @param source the sanitized assembly stacktrace in String format.
 	 * @return a {@link String} representing operator and operator assembly site extracted
@@ -106,26 +105,15 @@ final class Traces {
 	}
 
 	/**
-	 * Extract operator information out of an assembly stack trace in {@link String} form
-	 * (see {@link Traces#callSiteSupplierFactory}) which potentially
-	 * has a header line that one can skip by setting {@code skipFirst} to {@code true}.
+	 * Extracts operator information out of an assembly stack trace in {@link String} array form
+	 * (see {@link Traces#callSiteSupplierFactory}).
 	 * <p>
-	 * Most operators will result in a line of the form {@code "Flux.map ⇢ user.code.Class.method(Class.java:123)"},
-	 * that is:
-	 * <ol>
-	 *     <li>The top of the stack is inspected for Reactor API references, and the deepest
-	 *     one is kept, since multiple API references generally denote an alias operator.
-	 *     (eg. {@code "Flux.map"})</li>
-	 *     <li>The next stacktrace element is considered user code and is appended to the
-	 *     result with a {@code ⇢} separator. (eg. {@code " ⇢ user.code.Class.method(Class.java:123)"})</li>
-	 *     <li>If no user code is found in the sanitized stack, then the API reference is outputed in the later format only.</li>
-	 *     <li>If the sanitized stack is empty, returns {@code "[no operator assembly information]"}</li>
-	 * </ol>
-	 *
+	 * The returned array will contain 0, 1 or 2 elements, extracted in a manner as described by
+	 * {@link #extractOperatorAssemblyInformation(String)}.
 	 *
 	 * @param source the sanitized assembly stacktrace in String format.
-	 * @return a {@link String} representing operator and operator assembly site extracted
-	 * from the assembly stack trace.
+	 * @return a 0-2 element string array containing the operator and operator assembly site extracted
+	 * from the assembly stack trace
 	 */
 	static String[] extractOperatorAssemblyInformationParts(String source) {
 		Iterator<String> traces = trimmedNonemptyLines(source);

--- a/reactor-core/src/main/java/reactor/core/publisher/Traces.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Traces.java
@@ -57,8 +57,8 @@ final class Traces {
 	static boolean shouldSanitize(String stackTraceRow) {
 		return stackTraceRow.startsWith("java.util.function")
 				|| stackTraceRow.startsWith("reactor.core.publisher.Mono.onAssembly")
-				|| stackTraceRow.equals("reactor.core.publisher.Flux.onAssembly")
-				|| stackTraceRow.equals("reactor.core.publisher.ParallelFlux.onAssembly")
+				|| stackTraceRow.startsWith("reactor.core.publisher.Flux.onAssembly")
+				|| stackTraceRow.startsWith("reactor.core.publisher.ParallelFlux.onAssembly")
 				|| stackTraceRow.startsWith("reactor.core.publisher.SignalLogger")
 				|| stackTraceRow.startsWith("reactor.core.publisher.FluxOnAssembly")
 				|| stackTraceRow.startsWith("reactor.core.publisher.MonoOnAssembly.")
@@ -197,10 +197,6 @@ final class Traces {
 
 			@Nullable
 			private String getNextLine() {
-				if (index >= source.length()) {
-					return null;
-				}
-
 				while (index < source.length()) {
 					int end = source.indexOf('\n', index);
 					if (end == -1) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Traces.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Traces.java
@@ -194,13 +194,24 @@ final class Traces {
 					if (end == -1) {
 						end = source.length();
 					}
-					String line = source.substring(index, end).trim();
+					String line = trimmedSubstring(source, index, end);
 					index = end + 1;
 					if (!line.isEmpty()) {
 						return line;
 					}
 				}
 				return null;
+			}
+
+			// Equivalent to source.substring(start, end).trim(), but avoids allocation of a new array.
+			private String trimmedSubstring(String source, int start, int end) {
+				while (start < end && source.charAt(start) <= ' ') {
+					start++;
+				}
+				while (end > start && source.charAt(end - 1) <= ' ') {
+					end--;
+				}
+				return source.substring(start, end);
 			}
 		};
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/Traces.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Traces.java
@@ -95,8 +95,12 @@ final class Traces {
 		switch (parts.length) {
 			case 0:
 				return "[no operator assembly information]";
+			case 1:
+				return parts[0];
+			case 2:
+				return parts[0] + CALL_SITE_GLUE + parts[1];
 			default:
-				return String.join(CALL_SITE_GLUE, parts);
+				throw new IllegalStateException("Unexpected number of assembly info parts: " + parts.length);
 		}
 	}
 


### PR DESCRIPTION
Performance is improved in two ways:
- By invoking `Scannable#stepName()` only when `Attr.NAME` is not
  explicitly set.
- By optimizing `Traces#extractOperatorAssemblyInformationParts`, to
  which several `Scannable#stepName()` implementations delegate.

The `Scannable#name()` logic may be executed many times, e.g. if a hot 
code path uses `{Mono,Flux}#log` or Micrometer instrumentation. The 
added benchmark shows that for large stack traces, the new `Traces`
implementation is several orders of magnitude more efficient in terms of
compute and memory resource utilization.

Deferral of invocation of `Scannable#stepName()` assumes that said 
method does not have side-effects. This is true for all built-in 
implementations.

While there:
- Improve two existing benchmarks by utilizing the black hole to which
  benchmark method return values are implicitly sent.
- Unify `reactor.core.publisher` package matching to prefix matching.