### PR TITLE
Add MonoFirstWithValue missing tests

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFirstWithValueTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFirstWithValueTest.java
@@ -176,28 +176,28 @@ class MonoFirstWithValueTest {
 	}
 	@Test
 	void cancelInflightMono() {
-		AtomicLong inflightMonos = new AtomicLong(0);
+		AtomicLong cancelledInflightMonos = new AtomicLong(0);
 		Mono<Integer> inflightMono1 = Mono.fromCallable(() -> {
 			Thread.sleep(300);
 			return 1;
-		}).doOnCancel(inflightMonos::getAndIncrement).subscribeOn(Schedulers.boundedElastic());
+		}).doOnCancel(cancelledInflightMonos::getAndIncrement).subscribeOn(Schedulers.boundedElastic());
 
 		Mono<Integer> inflightMono2 = Mono.fromCallable(() -> {
 			Thread.sleep(400);
 			return 2;
-		}).doOnCancel(inflightMonos::getAndIncrement).subscribeOn(Schedulers.boundedElastic());
+		}).doOnCancel(cancelledInflightMonos::getAndIncrement).subscribeOn(Schedulers.boundedElastic());
 
 		Mono<Integer> completedMono = Mono.fromCallable(() -> {
 			Thread.sleep(100);
 			return 3;
-		}).doOnCancel(inflightMonos::getAndIncrement).subscribeOn(Schedulers.boundedElastic());
+		}).doOnCancel(cancelledInflightMonos::getAndIncrement).subscribeOn(Schedulers.boundedElastic());
 
 		StepVerifier.withVirtualTime(() -> Mono.firstWithValue(inflightMono1, inflightMono2, completedMono))
 				.thenAwait(Duration.ofMillis(100))
 				.expectNext(3)
 				.verifyComplete();
 
-		assertThat(inflightMonos).hasValue(2);
+		assertThat(cancelledInflightMonos).hasValue(2);
 	}
 
 	@Test


### PR DESCRIPTION
<!-- 
Thanks for contributing to Project Reactor. Please review the following notes
about formatting your PR description.
-->

<!-- What changes from the user's perspective? -->
Adding missing tests for MonoFirstWithValue.

<!-- Next paragraph contains more technical details -->
MonoFirstWithValue tests which verifies cancellation of in flight publishers when first value is emitted is missing. 
If you comment https://github.com/reactor/reactor-core/blob/main/reactor-core/src/main/java/reactor/core/publisher/FluxFirstWithValue.java#L283 current tests will pass.
In this test case we start three monos with 3 different sleep. Once Mono with lowest delay completes we verify remaining
monos are cancelled.

