### PR TITLE
BlockHound and debug agent tests use toolchains

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -369,10 +369,10 @@ if (!JavaVersion.current().isJava9Compatible()) {
 	}
 }
 
-if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_13)) {
-  blockHoundTest {
-		jvmArgs = ["-XX:+AllowRedefinitionToAddDeleteMethods"]
-  }
+blockHoundTest {
+	if (javaLauncher.get().metadata.languageVersion.canCompileOrRun(13)) {
+	  jvmArgs = ["-XX:+AllowRedefinitionToAddDeleteMethods"]
+	}
 }
 
 jar {

--- a/reactor-tools/build.gradle
+++ b/reactor-tools/build.gradle
@@ -97,7 +97,7 @@ test {
     maxParallelForks = 1
     jvmArgs = [
             "-Xverify:all",
-            JavaVersion.current().isJava9Compatible()
+            javaLauncher.get().metadata.languageVersion.canCompileOrRun(9)
                     ? "-Xlog:redefine+class*=warning"
                     : "-XX:TraceRedefineClasses=2"
     ]
@@ -181,7 +181,7 @@ javaAgentTest {
     jvmArgs = [
             "-javaagent:${shadowJar.outputs.files.singleFile}",
             "-Xverify:all",
-            JavaVersion.current().isJava9Compatible()
+            javaLauncher.get().metadata.languageVersion.canCompileOrRun(9)
                     ? "-Xlog:redefine+class*=warning"
                     : "-XX:TraceRedefineClasses=2"
     ]


### PR DESCRIPTION
Running BlockHound and debug agent tests using JDK greater than 8 would fail due to improper version checks. `JavaVersion.current()` reports the JDK used to run gradle, while we are interested in the JDK currently in use by the current toolchain.