### PR TITLE
Move java9 sources to java11 and drop JDK9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,12 @@ jobs:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # tag=v4
         with:
           fetch-depth: 0 #needed by spotless
-      - name: Download JDK 9
-        if: contains('main 3.6.x', github.base_ref)
-        run: ${GITHUB_WORKSPACE}/.github/setup.sh
-        shell: bash
-      - name: Setup JDK 9
-        if: contains('main 3.6.x', github.base_ref)
+      - name: Setup JDK 11
+        if: contains('main', github.base_ref)
         uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # tag=v3
         with:
-          distribution: 'jdkfile'
-          java-version: 9.0.4
-          jdkFile: /opt/openjdk/java9/OpenJDK9U-jdk_x64_linux_hotspot_9.0.4_11.tar.gz
+          distribution: 'temurin'
+          java-version: 11
       - name: Setup JDK 21
         if: contains('main 3.6.x', github.base_ref)
         uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # tag=v3
@@ -65,25 +60,20 @@ jobs:
             arguments: ":reactor-core:test --no-daemon"
           - type: core-java21
             arguments: ":reactor-core:java21Test --no-daemon"
-          - type: core-java9
-            arguments: ":reactor-core:java9Test --no-daemon"
+          - type: core-java11
+            arguments: ":reactor-core:java11Test --no-daemon"
           - type: other
-            arguments: "check -x :reactor-core:test -x :reactor-core:java21Test -x :reactor-core:java9Test -x spotlessCheck -Pjcstress.mode=sanity --no-daemon"
+            arguments: "check -x :reactor-core:test -x :reactor-core:java21Test -x :reactor-core:java11Test -x spotlessCheck -Pjcstress.mode=sanity --no-daemon"
     name: ${{ matrix.test-type.type }} tests
     needs: preliminary
     steps:
     - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # tag=v4
-    - name: Download Java 9
-      if: contains('main 3.6.x', github.base_ref)
-      run: ${GITHUB_WORKSPACE}/.github/setup.sh
-      shell: bash
-    - name: Setup Java 9
-      if: contains('main 3.6.x', github.base_ref)
+    - name: Setup JDK 11
+      if: contains('main', github.base_ref)
       uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # tag=v3
       with:
-        distribution: 'jdkfile'
-        java-version: 9.0.4
-        jdkFile: /opt/openjdk/java9/OpenJDK9U-jdk_x64_linux_hotspot_9.0.4_11.tar.gz
+        distribution: 'temurin'
+        java-version: 11
     - name: Setup Java 21
       if: contains('main 3.6.x', github.base_ref)
       uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # tag=v3

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -26,11 +26,11 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
       - name: Download Java 9
-        if: contains('main 3.6.x', matrix.branch)
+        if: contains('3.6.x', matrix.branch)
         run: ${GITHUB_WORKSPACE}/.github/setup.sh
         shell: bash
       - name: Setup Java 9
-        if: contains('main 3.6.x', matrix.branch)
+        if: contains('3.6.x', matrix.branch)
         uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # tag=v3
         with:
           distribution: 'jdkfile'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,24 +27,19 @@ jobs:
           - type: core-java21
             arguments: ":reactor-core:java21Test --no-daemon"
           - type: other
-            arguments: "check -x :reactor-core:test -x :reactor-core:java9Test -x :reactor-core:java21Test -x spotlessCheck -x :reactor-core:jcstress --no-daemon"
+            arguments: "check -x :reactor-core:test -x :reactor-core:java11Test -x :reactor-core:java21Test -x spotlessCheck -x :reactor-core:jcstress --no-daemon"
     name: prepare - ${{ matrix.test-type.type }} tests
     outputs:
       versionType: ${{ steps.version.outputs.versionType }}
       fullVersion: ${{ steps.version.outputs.fullVersion }}
     steps:
     - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # tag=v4
-    - name: Download JDK 9
-      if: contains('main 3.6.x', github.base_ref)
-      run: ${GITHUB_WORKSPACE}/.github/setup.sh
-      shell: bash
-    - name: Setup JDK 9
-      if: contains('main 3.6.x', github.base_ref)
+    - name: Setup JDK 11
+      if: contains('main', github.base_ref)
       uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # tag=v3
       with:
-        distribution: 'jdkfile'
-        java-version: 9.0.4
-        jdkFile: /opt/openjdk/java9/OpenJDK9U-jdk_x64_linux_hotspot_9.0.4_11.tar.gz
+        distribution: 'temurin'
+        java-version: 11
     - name: Setup JDK 21
       if: contains('main 3.6.x', github.base_ref)
       uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # tag=v3
@@ -106,17 +101,12 @@ jobs:
     environment: snapshots
     steps:
     - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # tag=v4
-    - name: Download JDK 9
-      if: contains('main 3.6.x', github.base_ref)
-      run: ${GITHUB_WORKSPACE}/.github/setup.sh
-      shell: bash
-    - name: Setup JDK 9
-      if: contains('main 3.6.x', github.base_ref)
+    - name: Setup JDK 11
+      if: contains('main', github.base_ref)
       uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # tag=v3
       with:
-        distribution: 'jdkfile'
-        java-version: 9.0.4
-        jdkFile: /opt/openjdk/java9/OpenJDK9U-jdk_x64_linux_hotspot_9.0.4_11.tar.gz
+        distribution: 'temurin'
+        java-version: 11
     - name: Setup JDK 21
       if: contains('main 3.6.x', github.base_ref)
       uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # tag=v3
@@ -149,17 +139,12 @@ jobs:
     environment: releases
     steps:
     - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # tag=v4
-    - name: Download JDK 9
-      if: contains('main 3.6.x', github.base_ref)
-      run: ${GITHUB_WORKSPACE}/.github/setup.sh
-      shell: bash
-    - name: Setup JDK 9
-      if: contains('main 3.6.x', github.base_ref)
+    - name: Setup JDK 11
+      if: contains('main', github.base_ref)
       uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # tag=v3
       with:
-        distribution: 'jdkfile'
-        java-version: 9.0.4
-        jdkFile: /opt/openjdk/java9/OpenJDK9U-jdk_x64_linux_hotspot_9.0.4_11.tar.gz
+        distribution: 'temurin'
+        java-version: 11
     - name: Setup JDK 21
       if: contains('main 3.6.x', github.base_ref)
       uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # tag=v3
@@ -194,17 +179,12 @@ jobs:
     environment: releases
     steps:
     - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # tag=v4
-    - name: Download JDK 9
-      if: contains('main 3.6.x', github.base_ref)
-      run: ${GITHUB_WORKSPACE}/.github/setup.sh
-      shell: bash
-    - name: Setup JDK 9
-      if: contains('main 3.6.x', github.base_ref)
+    - name: Setup JDK 11
+      if: contains('main', github.base_ref)
       uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # tag=v3
       with:
-        distribution: 'jdkfile'
-        java-version: 9.0.4
-        jdkFile: /opt/openjdk/java9/OpenJDK9U-jdk_x64_linux_hotspot_9.0.4_11.tar.gz
+        distribution: 'temurin'
+        java-version: 11
     - name: Setup JDK 21
       if: contains('main 3.6.x', github.base_ref)
       uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # tag=v3

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -24,11 +24,11 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
       - name: Download Java 9
-        if: contains('main 3.6.x', matrix.branch)
+        if: contains('3.6.x', matrix.branch)
         run: ${GITHUB_WORKSPACE}/.github/setup.sh
         shell: bash
       - name: Setup Java 9
-        if: contains('main 3.6.x', matrix.branch)
+        if: contains('3.6.x', matrix.branch)
         uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # tag=v3
         with:
           distribution: 'jdkfile'

--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ spotless {
 	}
 	java {
 		target '**/*.java'
-		targetExclude '**/java8stubs/**/*', '**/java9stubs/**/*', '**/scrabble/**/*',
+		targetExclude '**/java8stubs/**/*', '**/java11stubs/**/*', '**/scrabble/**/*',
 			'reactor-core/src/main/java/reactor/util/annotation/NonNull.java',
 			'reactor-core/src/main/java/reactor/util/annotation/NonNullApi.java',
 			'reactor-core/src/main/java/reactor/util/annotation/Nullable.java'

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -45,7 +45,7 @@ ext {
 }
 
 multiRelease {
-  targetVersions 8, 9, 21
+  targetVersions 8, 11, 21
 }
 
 testing {
@@ -302,7 +302,7 @@ test {
   }
 }
 
-java9Test {
+java11Test {
   maxParallelForks = Math.max(Runtime.runtime.availableProcessors() - 1, 1)
 }
 

--- a/reactor-core/src/main/java11/reactor/core/publisher/CallSiteSupplierFactory.java
+++ b/reactor-core/src/main/java11/reactor/core/publisher/CallSiteSupplierFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2023-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Since JDK9 is no longer in support by vendors, targeting 3.7.0 with JDK8 as the baseline and JDK11 and JDK21 sources sounds reasonable.