### PR TITLE
Fix `SwitchOnFirst` hanging subscription

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchOnFirst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -716,7 +716,7 @@ final class FluxSwitchOnFirst<T, R> extends InternalFluxOperator<T, R> {
 				return;
 			}
 
-			if (hasInboundClosedPrematurely(previousState)) {
+			if (hasInboundCancelled(previousState) ||hasInboundClosedPrematurely(previousState)) {
 				Operators.error(inboundSubscriber, new CancellationException("FluxSwitchOnFirst has already been cancelled"));
 				return;
 			}


### PR DESCRIPTION
In a situation where `SwitchOnFirstMain` is subscribed to after the operator itself has terminated, the expectation is that either an error is propagated due to cancellation of the source or the first actual subscription succeeds. Due to a regression introduced in #2794 the subscription would hang with no termination. This change addresses the issue and the subscrption properly terminates.

Related to #3936.