### PR TITLE
Support logging exception stack traces when the last argument is Throwable

### DIFF
--- a/reactor-core/src/main/java/reactor/util/Loggers.java
+++ b/reactor-core/src/main/java/reactor/util/Loggers.java
@@ -442,12 +442,12 @@ public abstract class Loggers {
 		}
 
 		@Nullable
-		String format(@Nullable String from, @Nullable Object... arguments) {
-			return format(from, false, arguments);
+		private String format(@Nullable String from, @Nullable Object[] arguments) {
+			return format(from, arguments, false);
 		}
 
 		@Nullable
-		private String format(@Nullable String from, boolean skipLast, @Nullable Object... arguments) {
+		private String format(@Nullable String from, @Nullable Object[] arguments, boolean skipLast) {
 			if (from != null) {
 				String computed = from;
 				if (arguments != null && arguments.length != 0) {
@@ -465,7 +465,7 @@ public abstract class Loggers {
 		private void logWithPotentialThrowable(Level level, String format, Object... arguments) {
 			Throwable t = getPotentialThrowable(arguments);
 			if (t != null) {
-				logger.log(level, format(format, true, arguments), t);
+				logger.log(level, format(format, arguments, true), t);
 				return;
 			}
 
@@ -521,12 +521,12 @@ public abstract class Loggers {
 		}
 
 		@Nullable
-		String format(@Nullable String from, @Nullable Object... arguments) {
-			return format(from, false, arguments);
+		private String format(@Nullable String from, @Nullable Object[] arguments) {
+			return format(from, arguments, false);
 		}
 
 		@Nullable
-		private String format(@Nullable String from, boolean skipLast, @Nullable Object... arguments) {
+		private String format(@Nullable String from, @Nullable Object[] arguments, boolean skipLast) {
 			if (from != null) {
 				String computed = from;
 				if (arguments != null && arguments.length != 0) {
@@ -548,7 +548,7 @@ public abstract class Loggers {
 						"[%s] (%s) %s\n",
 						level.toUpperCase(),
 						Thread.currentThread().getName(),
-						format(format, true, arguments)
+						format(format, arguments, true)
 				);
 				t.printStackTrace(logger);
 				return;

--- a/reactor-core/src/main/java/reactor/util/Loggers.java
+++ b/reactor-core/src/main/java/reactor/util/Loggers.java
@@ -625,17 +625,17 @@ public abstract class Loggers {
 
 		@Override
 		public synchronized void info(String msg) {
-			this.log.format("[INFO] (%s) %s\n", Thread.currentThread().getName(), msg);
+			this.log.format("[ INFO] (%s) %s\n", Thread.currentThread().getName(), msg);
 		}
 
 		@Override
 		public void info(String format, Object... arguments) {
-			logWithOptionalThrowable("INFO", format, arguments);
+			logWithOptionalThrowable(" INFO", format, arguments);
 		}
 
 		@Override
 		public synchronized void info(String msg, Throwable t) {
-			this.log.format("[INFO] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
+			this.log.format("[ INFO] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
 			t.printStackTrace(this.log);
 		}
 
@@ -646,17 +646,17 @@ public abstract class Loggers {
 
 		@Override
 		public synchronized void warn(String msg) {
-			this.err.format("[WARN] (%s) %s\n", Thread.currentThread().getName(), msg);
+			this.err.format("[ WARN] (%s) %s\n", Thread.currentThread().getName(), msg);
 		}
 
 		@Override
 		public void warn(String format, Object... arguments) {
-			logErrorWithOptionalThrowable("WARN", format, arguments);
+			logErrorWithOptionalThrowable(" WARN", format, arguments);
 		}
 
 		@Override
 		public synchronized void warn(String msg, Throwable t) {
-			this.err.format("[WARN] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
+			this.err.format("[ WARN] (%s) %s - %s\n", Thread.currentThread().getName(), msg, t);
 			t.printStackTrace(this.err);
 		}
 

--- a/reactor-core/src/main/java/reactor/util/Loggers.java
+++ b/reactor-core/src/main/java/reactor/util/Loggers.java
@@ -452,7 +452,10 @@ public abstract class Loggers {
 				String computed = from;
 				if (arguments != null && arguments.length != 0) {
 					int lastIndex = arguments.length;
-					if (skipLast) --lastIndex;
+					if (skipLast) {
+						--lastIndex;
+					}
+
 					for (int index = 0; index < lastIndex; ++index) {
 						computed = computed.replaceFirst("\\{\\}", Matcher.quoteReplacement(String.valueOf(arguments[index])));
 					}
@@ -531,7 +534,10 @@ public abstract class Loggers {
 				String computed = from;
 				if (arguments != null && arguments.length != 0) {
 					int lastIndex = arguments.length;
-					if (skipLast) --lastIndex;
+					if (skipLast) {
+						--lastIndex;
+					}
+
 					for (int index = 0; index < lastIndex; ++index) {
 						computed = computed.replaceFirst("\\{\\}", Matcher.quoteReplacement(String.valueOf(arguments[index])));
 					}

--- a/reactor-core/src/main/java/reactor/util/Loggers.java
+++ b/reactor-core/src/main/java/reactor/util/Loggers.java
@@ -476,7 +476,11 @@ public abstract class Loggers {
 		}
 
 		@Nullable
-		private static Throwable getPotentialThrowable(Object... arguments) {
+		private Throwable getPotentialThrowable(Object... arguments) {
+			if (arguments == null) {
+				return null;
+			}
+
 			int length = arguments.length;
 			if (length > 0 && arguments[length - 1] instanceof Throwable) {
 				return (Throwable) arguments[length - 1];
@@ -570,6 +574,10 @@ public abstract class Loggers {
 
 		@Nullable
 		private static Throwable getPotentialThrowable(Object... arguments) {
+			if (arguments == null) {
+				return null;
+			}
+
 			int length = arguments.length;
 			if (length > 0 && arguments[length - 1] instanceof Throwable) {
 				return (Throwable) arguments[length - 1];

--- a/reactor-core/src/test/java/reactor/util/ConsoleLoggerTest.java
+++ b/reactor-core/src/test/java/reactor/util/ConsoleLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,6 +81,17 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
+	public void traceWithThrowable() throws Exception {
+		logger.trace("{} with cause {}", "test", CAUSE);
+
+		assertThat(errContent.size()).isZero();
+		assertThat(outContent.toString())
+				.startsWith("[TRACE] (" + Thread.currentThread().getName() + ") test with cause {}" +
+						"\njava.lang.IllegalStateException: cause\n" +
+						"\tat reactor.util.ConsoleLoggerTest");
+	}
+
+	@Test
 	public void traceNulls() {
 		logger.trace("vararg {} is {}", (Object[]) null);
 		logger.trace("param {} is {}", null, null);
@@ -132,6 +143,17 @@ public class ConsoleLoggerTest {
 		assertThat(errContent.size()).isZero();
 		assertThat(outContent.toString())
 				.startsWith("[DEBUG] (" + Thread.currentThread().getName() + ") with cause - java.lang.IllegalStateException: cause" +
+						"\njava.lang.IllegalStateException: cause\n" +
+						"\tat reactor.util.ConsoleLoggerTest");
+	}
+
+	@Test
+	public void debugWithThrowable() throws Exception {
+		logger.debug("{} with cause {}", "test", CAUSE);
+
+		assertThat(errContent.size()).isZero();
+		assertThat(outContent.toString())
+				.startsWith("[DEBUG] (" + Thread.currentThread().getName() + ") test with cause {}" +
 						"\njava.lang.IllegalStateException: cause\n" +
 						"\tat reactor.util.ConsoleLoggerTest");
 	}
@@ -193,6 +215,17 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
+	public void infoWithThrowable() throws Exception {
+		logger.info("{} with cause {}", "test", CAUSE);
+
+		assertThat(errContent.size()).isZero();
+		assertThat(outContent.toString())
+				.startsWith("[ INFO] (" + Thread.currentThread().getName() + ") test with cause {}" +
+						"\njava.lang.IllegalStateException: cause\n" +
+						"\tat reactor.util.ConsoleLoggerTest");
+	}
+
+	@Test
 	public void infoNulls() {
 		logger.info("vararg {} is {}", (Object[]) null);
 		logger.info("param {} is {}", null, null);
@@ -237,6 +270,17 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
+	public void warnWithThrowable() throws Exception {
+		logger.warn("{} with cause {}", "test", CAUSE);
+
+		assertThat(outContent.size()).isZero();
+		assertThat(errContent.toString())
+				.startsWith("[ WARN] (" + Thread.currentThread().getName() + ") test with cause {}" +
+						"\njava.lang.IllegalStateException: cause\n" +
+						"\tat reactor.util.ConsoleLoggerTest");
+	}
+
+	@Test
 	public void warnNulls() {
 		logger.warn("vararg {} is {}", (Object[]) null);
 		logger.warn("param {} is {}", null, null);
@@ -275,6 +319,17 @@ public class ConsoleLoggerTest {
 		assertThat(outContent.size()).isZero();
 		assertThat(errContent.toString())
 				.startsWith("[ERROR] (" + Thread.currentThread().getName() + ") with cause - java.lang.IllegalStateException: cause" +
+						"\njava.lang.IllegalStateException: cause\n" +
+						"\tat reactor.util.ConsoleLoggerTest");
+	}
+
+	@Test
+	public void errorWithThrowable() throws Exception {
+		logger.error("{} with cause {}", "test", CAUSE);
+
+		assertThat(outContent.size()).isZero();
+		assertThat(errContent.toString())
+				.startsWith("[ERROR] (" + Thread.currentThread().getName() + ") test with cause {}" +
 						"\njava.lang.IllegalStateException: cause\n" +
 						"\tat reactor.util.ConsoleLoggerTest");
 	}

--- a/reactor-core/src/test/java/reactor/util/ConsoleLoggerTest.java
+++ b/reactor-core/src/test/java/reactor/util/ConsoleLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,13 +27,8 @@ import reactor.test.util.RaceTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
-class ConsoleLoggerTest {
+public class ConsoleLoggerTest {
 
 	private static final RuntimeException CAUSE = new IllegalStateException("cause");
 
@@ -54,12 +49,12 @@ class ConsoleLoggerTest {
 	}
 
 	@Test
-	void isTraceEnabled() throws Exception {
+	public void isTraceEnabled() throws Exception {
 		assertThat(logger.isTraceEnabled()).isTrue();
 	}
 
 	@Test
-	void trace() throws Exception {
+	public void trace() throws Exception {
 		logger.trace("message");
 
 		assertThat(errContent.size()).isZero();
@@ -67,28 +62,26 @@ class ConsoleLoggerTest {
 	}
 
 	@Test
-	void trace1() throws Exception {
+	public void trace1() throws Exception {
 		logger.trace("message {} {} format", "with", 1);
 
 		assertThat(errContent.size()).isZero();
-		assertThat(outContent.toString()).isEqualTo("[TRACE] (" + Thread.currentThread()
-				.getName() + ") message with 1 format\n");
+		assertThat(outContent.toString()).isEqualTo("[TRACE] (" + Thread.currentThread().getName() + ") message with 1 format\n");
 	}
 
 	@Test
-	void trace2() throws Exception {
+	public void trace2() throws Exception {
 		logger.trace("with cause", CAUSE);
 
 		assertThat(errContent.size()).isZero();
 		assertThat(outContent.toString())
-				.startsWith("[TRACE] (" + Thread.currentThread()
-						.getName() + ") with cause - java.lang.IllegalStateException: cause" +
-						"\njava.lang.IllegalStateException: cause\n" +
-						"\tat reactor.util.ConsoleLoggerTest");
+				.startsWith("[TRACE] (" + Thread.currentThread().getName() + ") with cause - java.lang.IllegalStateException: cause" +
+				"\njava.lang.IllegalStateException: cause\n" +
+				"\tat reactor.util.ConsoleLoggerTest");
 	}
 
 	@Test
-	void traceNulls() {
+	public void traceNulls() {
 		logger.trace("vararg {} is {}", (Object[]) null);
 		logger.trace("param {} is {}", null, null);
 
@@ -99,7 +92,7 @@ class ConsoleLoggerTest {
 	}
 
 	@Test
-	void traceDismissedInNonVerboseMode() {
+	public void traceDismissedInNonVerboseMode() {
 		Logger log = new Loggers.ConsoleLogger("test", new PrintStream(outContent), new PrintStream(errContent), false);
 		log.trace("foo");
 		log.trace("foo", new IllegalArgumentException("foo"));
@@ -112,12 +105,12 @@ class ConsoleLoggerTest {
 	}
 
 	@Test
-	void isDebugEnabled() throws Exception {
+	public void isDebugEnabled() throws Exception {
 		assertThat(logger.isDebugEnabled()).isTrue();
 	}
 
 	@Test
-	void debug() throws Exception {
+	public void debug() throws Exception {
 		logger.debug("message");
 
 		assertThat(errContent.size()).isZero();
@@ -125,28 +118,26 @@ class ConsoleLoggerTest {
 	}
 
 	@Test
-	void debug1() throws Exception {
+	public void debug1() throws Exception {
 		logger.debug("message {} {} format", "with", 1);
 
 		assertThat(errContent.size()).isZero();
-		assertThat(outContent.toString()).isEqualTo("[DEBUG] (" + Thread.currentThread()
-				.getName() + ") message with 1 format\n");
+		assertThat(outContent.toString()).isEqualTo("[DEBUG] (" + Thread.currentThread().getName() + ") message with 1 format\n");
 	}
 
 	@Test
-	void debug2() throws Exception {
+	public void debug2() throws Exception {
 		logger.debug("with cause", CAUSE);
 
 		assertThat(errContent.size()).isZero();
 		assertThat(outContent.toString())
-				.startsWith("[DEBUG] (" + Thread.currentThread()
-						.getName() + ") with cause - java.lang.IllegalStateException: cause" +
+				.startsWith("[DEBUG] (" + Thread.currentThread().getName() + ") with cause - java.lang.IllegalStateException: cause" +
 						"\njava.lang.IllegalStateException: cause\n" +
 						"\tat reactor.util.ConsoleLoggerTest");
 	}
 
 	@Test
-	void debugNulls() {
+	public void debugNulls() {
 		logger.debug("vararg {} is {}", (Object[]) null);
 		logger.debug("param {} is {}", null, null);
 
@@ -157,7 +148,7 @@ class ConsoleLoggerTest {
 	}
 
 	@Test
-	void debugDismissedInNonVerboseMode() {
+	public void debugDismissedInNonVerboseMode() {
 		Logger log = new Loggers.ConsoleLogger("test", new PrintStream(outContent), new PrintStream(errContent), false);
 		log.debug("foo");
 		log.debug("foo", new IllegalArgumentException("foo"));
@@ -170,12 +161,12 @@ class ConsoleLoggerTest {
 	}
 
 	@Test
-	void isInfoEnabled() throws Exception {
+	public void isInfoEnabled() throws Exception {
 		assertThat(logger.isInfoEnabled()).isTrue();
 	}
 
 	@Test
-	void info() throws Exception {
+	public void info() throws Exception {
 		logger.info("message");
 
 		assertThat(errContent.size()).isZero();
@@ -183,28 +174,26 @@ class ConsoleLoggerTest {
 	}
 
 	@Test
-	void info1() throws Exception {
+	public void info1() throws Exception {
 		logger.info("message {} {} format", "with", 1);
 
 		assertThat(errContent.size()).isZero();
-		assertThat(outContent.toString()).isEqualTo("[ INFO] (" + Thread.currentThread()
-				.getName() + ") message with 1 format\n");
+		assertThat(outContent.toString()).isEqualTo("[ INFO] (" + Thread.currentThread().getName() + ") message with 1 format\n");
 	}
 
 	@Test
-	void info2() throws Exception {
+	public void info2() throws Exception {
 		logger.info("with cause", CAUSE);
 
 		assertThat(errContent.size()).isZero();
 		assertThat(outContent.toString())
-				.startsWith("[ INFO] (" + Thread.currentThread()
-						.getName() + ") with cause - java.lang.IllegalStateException: cause" +
+				.startsWith("[ INFO] (" + Thread.currentThread().getName() + ") with cause - java.lang.IllegalStateException: cause" +
 						"\njava.lang.IllegalStateException: cause\n" +
 						"\tat reactor.util.ConsoleLoggerTest");
 	}
 
 	@Test
-	void infoNulls() {
+	public void infoNulls() {
 		logger.info("vararg {} is {}", (Object[]) null);
 		logger.info("param {} is {}", null, null);
 
@@ -220,7 +209,7 @@ class ConsoleLoggerTest {
 	}
 
 	@Test
-	void warn() throws Exception {
+	public void warn() throws Exception {
 		logger.warn("message");
 
 		assertThat(outContent.size()).isZero();
@@ -228,29 +217,27 @@ class ConsoleLoggerTest {
 	}
 
 	@Test
-	void warn1() throws Exception {
+	public void warn1() throws Exception {
 		logger.warn("message {} {} format", "with", 1);
 
 		assertThat(outContent.size()).isZero();
-		assertThat(errContent.toString()).isEqualTo("[ WARN] (" + Thread.currentThread()
-				.getName() + ") message with 1 format\n");
+		assertThat(errContent.toString()).isEqualTo("[ WARN] (" + Thread.currentThread().getName() + ") message with 1 format\n");
 	}
 
 	@Test
-	void warn2() throws Exception {
+	public void warn2() throws Exception {
 		logger.warn("with cause", CAUSE);
 
 
 		assertThat(outContent.size()).isZero();
 		assertThat(errContent.toString())
-				.startsWith("[ WARN] (" + Thread.currentThread()
-						.getName() + ") with cause - java.lang.IllegalStateException: cause" +
+				.startsWith("[ WARN] (" + Thread.currentThread().getName() + ") with cause - java.lang.IllegalStateException: cause" +
 						"\njava.lang.IllegalStateException: cause\n" +
 						"\tat reactor.util.ConsoleLoggerTest");
 	}
 
 	@Test
-	void warnNulls() {
+	public void warnNulls() {
 		logger.warn("vararg {} is {}", (Object[]) null);
 		logger.warn("param {} is {}", null, null);
 
@@ -261,12 +248,12 @@ class ConsoleLoggerTest {
 	}
 
 	@Test
-	void isErrorEnabled() throws Exception {
+	public void isErrorEnabled() throws Exception {
 		assertThat(logger.isErrorEnabled()).isTrue();
 	}
 
 	@Test
-	void error() throws Exception {
+	public void error() throws Exception {
 		logger.error("message");
 
 		assertThat(outContent.size()).isZero();
@@ -274,28 +261,26 @@ class ConsoleLoggerTest {
 	}
 
 	@Test
-	void error1() throws Exception {
+	public void error1() throws Exception {
 		logger.error("message {} {} format", "with", 1);
 
 		assertThat(outContent.size()).isZero();
-		assertThat(errContent.toString()).isEqualTo("[ERROR] (" + Thread.currentThread()
-				.getName() + ") message with 1 format\n");
+		assertThat(errContent.toString()).isEqualTo("[ERROR] (" + Thread.currentThread().getName() + ") message with 1 format\n");
 	}
 
 	@Test
-	void error2() throws Exception {
+	public void error2() throws Exception {
 		logger.error("with cause", CAUSE);
 
 		assertThat(outContent.size()).isZero();
 		assertThat(errContent.toString())
-				.startsWith("[ERROR] (" + Thread.currentThread()
-						.getName() + ") with cause - java.lang.IllegalStateException: cause" +
+				.startsWith("[ERROR] (" + Thread.currentThread().getName() + ") with cause - java.lang.IllegalStateException: cause" +
 						"\njava.lang.IllegalStateException: cause\n" +
 						"\tat reactor.util.ConsoleLoggerTest");
 	}
 
 	@Test
-	void errorNulls() {
+	public void errorNulls() {
 		logger.error("vararg {} is {}", (Object[]) null);
 		logger.error("param {} is {}", null, null);
 
@@ -306,7 +291,7 @@ class ConsoleLoggerTest {
 	}
 
 	@Test
-	void formatNull() {
+	public void formatNull() {
 		logger.info(null, null, null);
 
 		assertThat(errContent.size()).isZero();
@@ -318,7 +303,7 @@ class ConsoleLoggerTest {
 	 * Ensure console logger factory synchronizes logger acquisition properly.
 	 */
 	@Test
-	void getConsoleLoggerShouldBeThreadSafe() {
+	public void getConsoleLoggerShouldBeThreadSafe() {
 		final Loggers.ConsoleLoggerFactory factory =
 				new Loggers.ConsoleLoggerFactory(false);
 		final String loggerName = "logger.thread-safety.test";
@@ -329,137 +314,24 @@ class ConsoleLoggerTest {
 		try {
 			Runnable[] loggerAcquisitionFunctions =
 					IntStream.range(0, 5)
-							.mapToObj(i -> acquireLogger)
-							.toArray(Runnable[]::new);
+					         .mapToObj(i -> acquireLogger)
+					         .toArray(Runnable[]::new);
 			RaceTestUtils.race(loggerAcquisitionFunctions);
-		}
-		catch (Exception e) {
+		} catch (Exception e) {
 			fail("Cannot acquire a console logger", e);
 		}
 	}
 
 	@Test
-	void consoleLoggerCacheDoesNotCorruptVerbosity() {
+	public void consoleLoggerCacheDoesNotCorruptVerbosity() {
 		final String loggerName = "console.cache.test";
 		final Logger verboseLogger = new Loggers.ConsoleLoggerFactory(true)
 				.apply(loggerName);
 		final Logger notVerboseLogger = new Loggers.ConsoleLoggerFactory(false)
-				.apply(loggerName);
+						.apply(loggerName);
 
 		assertThat(verboseLogger)
 				.as("Logger verbosity should not match")
 				.isNotEqualTo(notVerboseLogger);
-	}
-
-	@Test
-	void logWarn() {
-		PrintStream logConsoleLogger = mock(PrintStream.class);
-		PrintStream errorConsoleLogger = mock(PrintStream.class);
-		Loggers.ConsoleLogger log = new Loggers.ConsoleLogger(
-				"test",
-				logConsoleLogger,
-				errorConsoleLogger,
-				true
-		);
-
-		log.warn("message: {}, {}", "foo", "bar");
-
-		verify(errorConsoleLogger, times(1))
-				.format(
-						"[%s] (%s) %s\n",
-						" WARN",
-						Thread.currentThread().getName(),
-						"message: foo, bar"
-				);
-	}
-
-	@Test
-	void logWarnWithThrowable() {
-		PrintStream logConsoleLogger = mock(PrintStream.class);
-		PrintStream errorConsoleLogger = mock(PrintStream.class);
-		Loggers.ConsoleLogger log = new Loggers.ConsoleLogger(
-				"test",
-				logConsoleLogger,
-				errorConsoleLogger,
-				true
-		);
-
-		Throwable t = mock(IllegalAccessError.class);
-		log.warn("message: {}, {}", "foo", "bar", t);
-
-		verify(logConsoleLogger, never())
-				.format(
-						anyString(),
-						anyString(),
-						anyString(),
-						anyString()
-				);
-
-		verify(errorConsoleLogger, times(1))
-				.format(
-						"[%s] (%s) %s\n",
-						" WARN",
-						Thread.currentThread().getName(),
-						"message: foo, bar"
-				);
-
-		verify(t, times(1))
-				.printStackTrace(errorConsoleLogger);
-	}
-
-	@Test
-	void logInfo() {
-		PrintStream logConsoleLogger = mock(PrintStream.class);
-		PrintStream errorConsoleLogger = mock(PrintStream.class);
-		Loggers.ConsoleLogger log = new Loggers.ConsoleLogger(
-				"test",
-				logConsoleLogger,
-				errorConsoleLogger,
-				true
-		);
-
-		log.info("message: {}, {}", "foo", "bar");
-
-		verify(logConsoleLogger, times(1))
-				.format(
-						"[%s] (%s) %s\n",
-						" INFO",
-						Thread.currentThread().getName(),
-						"message: foo, bar"
-				);
-	}
-
-	@Test
-	void logInfoWithThrowable() {
-		PrintStream logConsoleLogger = mock(PrintStream.class);
-		PrintStream errorConsoleLogger = mock(PrintStream.class);
-		Loggers.ConsoleLogger log = new Loggers.ConsoleLogger(
-				"test",
-				logConsoleLogger,
-				errorConsoleLogger,
-				true
-		);
-
-		Throwable t = mock(IllegalAccessError.class);
-		log.info("message: {}, {}", "foo", "bar", t);
-
-		verify(errorConsoleLogger, never())
-				.format(
-						anyString(),
-						anyString(),
-						anyString(),
-						anyString()
-				);
-
-		verify(logConsoleLogger, times(1))
-				.format(
-						"[%s] (%s) %s\n",
-						" INFO",
-						Thread.currentThread().getName(),
-						"message: foo, bar"
-				);
-
-		verify(t, times(1))
-				.printStackTrace(logConsoleLogger);
 	}
 }

--- a/reactor-core/src/test/java/reactor/util/ConsoleLoggerTest.java
+++ b/reactor-core/src/test/java/reactor/util/ConsoleLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,13 @@ import reactor.test.util.RaceTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-public class ConsoleLoggerTest {
+class ConsoleLoggerTest {
 
 	private static final RuntimeException CAUSE = new IllegalStateException("cause");
 
@@ -49,12 +54,12 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
-	public void isTraceEnabled() throws Exception {
+	void isTraceEnabled() throws Exception {
 		assertThat(logger.isTraceEnabled()).isTrue();
 	}
 
 	@Test
-	public void trace() throws Exception {
+	void trace() throws Exception {
 		logger.trace("message");
 
 		assertThat(errContent.size()).isZero();
@@ -62,26 +67,28 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
-	public void trace1() throws Exception {
+	void trace1() throws Exception {
 		logger.trace("message {} {} format", "with", 1);
 
 		assertThat(errContent.size()).isZero();
-		assertThat(outContent.toString()).isEqualTo("[TRACE] (" + Thread.currentThread().getName() + ") message with 1 format\n");
+		assertThat(outContent.toString()).isEqualTo("[TRACE] (" + Thread.currentThread()
+				.getName() + ") message with 1 format\n");
 	}
 
 	@Test
-	public void trace2() throws Exception {
+	void trace2() throws Exception {
 		logger.trace("with cause", CAUSE);
 
 		assertThat(errContent.size()).isZero();
 		assertThat(outContent.toString())
-				.startsWith("[TRACE] (" + Thread.currentThread().getName() + ") with cause - java.lang.IllegalStateException: cause" +
-				"\njava.lang.IllegalStateException: cause\n" +
-				"\tat reactor.util.ConsoleLoggerTest");
+				.startsWith("[TRACE] (" + Thread.currentThread()
+						.getName() + ") with cause - java.lang.IllegalStateException: cause" +
+						"\njava.lang.IllegalStateException: cause\n" +
+						"\tat reactor.util.ConsoleLoggerTest");
 	}
 
 	@Test
-	public void traceNulls() {
+	void traceNulls() {
 		logger.trace("vararg {} is {}", (Object[]) null);
 		logger.trace("param {} is {}", null, null);
 
@@ -92,7 +99,7 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
-	public void traceDismissedInNonVerboseMode() {
+	void traceDismissedInNonVerboseMode() {
 		Logger log = new Loggers.ConsoleLogger("test", new PrintStream(outContent), new PrintStream(errContent), false);
 		log.trace("foo");
 		log.trace("foo", new IllegalArgumentException("foo"));
@@ -105,12 +112,12 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
-	public void isDebugEnabled() throws Exception {
+	void isDebugEnabled() throws Exception {
 		assertThat(logger.isDebugEnabled()).isTrue();
 	}
 
 	@Test
-	public void debug() throws Exception {
+	void debug() throws Exception {
 		logger.debug("message");
 
 		assertThat(errContent.size()).isZero();
@@ -118,26 +125,28 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
-	public void debug1() throws Exception {
+	void debug1() throws Exception {
 		logger.debug("message {} {} format", "with", 1);
 
 		assertThat(errContent.size()).isZero();
-		assertThat(outContent.toString()).isEqualTo("[DEBUG] (" + Thread.currentThread().getName() + ") message with 1 format\n");
+		assertThat(outContent.toString()).isEqualTo("[DEBUG] (" + Thread.currentThread()
+				.getName() + ") message with 1 format\n");
 	}
 
 	@Test
-	public void debug2() throws Exception {
+	void debug2() throws Exception {
 		logger.debug("with cause", CAUSE);
 
 		assertThat(errContent.size()).isZero();
 		assertThat(outContent.toString())
-				.startsWith("[DEBUG] (" + Thread.currentThread().getName() + ") with cause - java.lang.IllegalStateException: cause" +
+				.startsWith("[DEBUG] (" + Thread.currentThread()
+						.getName() + ") with cause - java.lang.IllegalStateException: cause" +
 						"\njava.lang.IllegalStateException: cause\n" +
 						"\tat reactor.util.ConsoleLoggerTest");
 	}
 
 	@Test
-	public void debugNulls() {
+	void debugNulls() {
 		logger.debug("vararg {} is {}", (Object[]) null);
 		logger.debug("param {} is {}", null, null);
 
@@ -148,7 +157,7 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
-	public void debugDismissedInNonVerboseMode() {
+	void debugDismissedInNonVerboseMode() {
 		Logger log = new Loggers.ConsoleLogger("test", new PrintStream(outContent), new PrintStream(errContent), false);
 		log.debug("foo");
 		log.debug("foo", new IllegalArgumentException("foo"));
@@ -161,12 +170,12 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
-	public void isInfoEnabled() throws Exception {
+	void isInfoEnabled() throws Exception {
 		assertThat(logger.isInfoEnabled()).isTrue();
 	}
 
 	@Test
-	public void info() throws Exception {
+	void info() throws Exception {
 		logger.info("message");
 
 		assertThat(errContent.size()).isZero();
@@ -174,26 +183,28 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
-	public void info1() throws Exception {
+	void info1() throws Exception {
 		logger.info("message {} {} format", "with", 1);
 
 		assertThat(errContent.size()).isZero();
-		assertThat(outContent.toString()).isEqualTo("[ INFO] (" + Thread.currentThread().getName() + ") message with 1 format\n");
+		assertThat(outContent.toString()).isEqualTo("[ INFO] (" + Thread.currentThread()
+				.getName() + ") message with 1 format\n");
 	}
 
 	@Test
-	public void info2() throws Exception {
+	void info2() throws Exception {
 		logger.info("with cause", CAUSE);
 
 		assertThat(errContent.size()).isZero();
 		assertThat(outContent.toString())
-				.startsWith("[ INFO] (" + Thread.currentThread().getName() + ") with cause - java.lang.IllegalStateException: cause" +
+				.startsWith("[ INFO] (" + Thread.currentThread()
+						.getName() + ") with cause - java.lang.IllegalStateException: cause" +
 						"\njava.lang.IllegalStateException: cause\n" +
 						"\tat reactor.util.ConsoleLoggerTest");
 	}
 
 	@Test
-	public void infoNulls() {
+	void infoNulls() {
 		logger.info("vararg {} is {}", (Object[]) null);
 		logger.info("param {} is {}", null, null);
 
@@ -209,7 +220,7 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
-	public void warn() throws Exception {
+	void warn() throws Exception {
 		logger.warn("message");
 
 		assertThat(outContent.size()).isZero();
@@ -217,27 +228,29 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
-	public void warn1() throws Exception {
+	void warn1() throws Exception {
 		logger.warn("message {} {} format", "with", 1);
 
 		assertThat(outContent.size()).isZero();
-		assertThat(errContent.toString()).isEqualTo("[ WARN] (" + Thread.currentThread().getName() + ") message with 1 format\n");
+		assertThat(errContent.toString()).isEqualTo("[ WARN] (" + Thread.currentThread()
+				.getName() + ") message with 1 format\n");
 	}
 
 	@Test
-	public void warn2() throws Exception {
+	void warn2() throws Exception {
 		logger.warn("with cause", CAUSE);
 
 
 		assertThat(outContent.size()).isZero();
 		assertThat(errContent.toString())
-				.startsWith("[ WARN] (" + Thread.currentThread().getName() + ") with cause - java.lang.IllegalStateException: cause" +
+				.startsWith("[ WARN] (" + Thread.currentThread()
+						.getName() + ") with cause - java.lang.IllegalStateException: cause" +
 						"\njava.lang.IllegalStateException: cause\n" +
 						"\tat reactor.util.ConsoleLoggerTest");
 	}
 
 	@Test
-	public void warnNulls() {
+	void warnNulls() {
 		logger.warn("vararg {} is {}", (Object[]) null);
 		logger.warn("param {} is {}", null, null);
 
@@ -248,12 +261,12 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
-	public void isErrorEnabled() throws Exception {
+	void isErrorEnabled() throws Exception {
 		assertThat(logger.isErrorEnabled()).isTrue();
 	}
 
 	@Test
-	public void error() throws Exception {
+	void error() throws Exception {
 		logger.error("message");
 
 		assertThat(outContent.size()).isZero();
@@ -261,26 +274,28 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
-	public void error1() throws Exception {
+	void error1() throws Exception {
 		logger.error("message {} {} format", "with", 1);
 
 		assertThat(outContent.size()).isZero();
-		assertThat(errContent.toString()).isEqualTo("[ERROR] (" + Thread.currentThread().getName() + ") message with 1 format\n");
+		assertThat(errContent.toString()).isEqualTo("[ERROR] (" + Thread.currentThread()
+				.getName() + ") message with 1 format\n");
 	}
 
 	@Test
-	public void error2() throws Exception {
+	void error2() throws Exception {
 		logger.error("with cause", CAUSE);
 
 		assertThat(outContent.size()).isZero();
 		assertThat(errContent.toString())
-				.startsWith("[ERROR] (" + Thread.currentThread().getName() + ") with cause - java.lang.IllegalStateException: cause" +
+				.startsWith("[ERROR] (" + Thread.currentThread()
+						.getName() + ") with cause - java.lang.IllegalStateException: cause" +
 						"\njava.lang.IllegalStateException: cause\n" +
 						"\tat reactor.util.ConsoleLoggerTest");
 	}
 
 	@Test
-	public void errorNulls() {
+	void errorNulls() {
 		logger.error("vararg {} is {}", (Object[]) null);
 		logger.error("param {} is {}", null, null);
 
@@ -291,7 +306,7 @@ public class ConsoleLoggerTest {
 	}
 
 	@Test
-	public void formatNull() {
+	void formatNull() {
 		logger.info(null, null, null);
 
 		assertThat(errContent.size()).isZero();
@@ -303,7 +318,7 @@ public class ConsoleLoggerTest {
 	 * Ensure console logger factory synchronizes logger acquisition properly.
 	 */
 	@Test
-	public void getConsoleLoggerShouldBeThreadSafe() {
+	void getConsoleLoggerShouldBeThreadSafe() {
 		final Loggers.ConsoleLoggerFactory factory =
 				new Loggers.ConsoleLoggerFactory(false);
 		final String loggerName = "logger.thread-safety.test";
@@ -314,24 +329,137 @@ public class ConsoleLoggerTest {
 		try {
 			Runnable[] loggerAcquisitionFunctions =
 					IntStream.range(0, 5)
-					         .mapToObj(i -> acquireLogger)
-					         .toArray(Runnable[]::new);
+							.mapToObj(i -> acquireLogger)
+							.toArray(Runnable[]::new);
 			RaceTestUtils.race(loggerAcquisitionFunctions);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Cannot acquire a console logger", e);
 		}
 	}
 
 	@Test
-	public void consoleLoggerCacheDoesNotCorruptVerbosity() {
+	void consoleLoggerCacheDoesNotCorruptVerbosity() {
 		final String loggerName = "console.cache.test";
 		final Logger verboseLogger = new Loggers.ConsoleLoggerFactory(true)
 				.apply(loggerName);
 		final Logger notVerboseLogger = new Loggers.ConsoleLoggerFactory(false)
-						.apply(loggerName);
+				.apply(loggerName);
 
 		assertThat(verboseLogger)
 				.as("Logger verbosity should not match")
 				.isNotEqualTo(notVerboseLogger);
+	}
+
+	@Test
+	void logWarn() {
+		PrintStream logConsoleLogger = mock(PrintStream.class);
+		PrintStream errorConsoleLogger = mock(PrintStream.class);
+		Loggers.ConsoleLogger log = new Loggers.ConsoleLogger(
+				"test",
+				logConsoleLogger,
+				errorConsoleLogger,
+				true
+		);
+
+		log.warn("message: {}, {}", "foo", "bar");
+
+		verify(errorConsoleLogger, times(1))
+				.format(
+						"[%s] (%s) %s\n",
+						" WARN",
+						Thread.currentThread().getName(),
+						"message: foo, bar"
+				);
+	}
+
+	@Test
+	void logWarnWithThrowable() {
+		PrintStream logConsoleLogger = mock(PrintStream.class);
+		PrintStream errorConsoleLogger = mock(PrintStream.class);
+		Loggers.ConsoleLogger log = new Loggers.ConsoleLogger(
+				"test",
+				logConsoleLogger,
+				errorConsoleLogger,
+				true
+		);
+
+		Throwable t = mock(IllegalAccessError.class);
+		log.warn("message: {}, {}", "foo", "bar", t);
+
+		verify(logConsoleLogger, never())
+				.format(
+						anyString(),
+						anyString(),
+						anyString(),
+						anyString()
+				);
+
+		verify(errorConsoleLogger, times(1))
+				.format(
+						"[%s] (%s) %s\n",
+						" WARN",
+						Thread.currentThread().getName(),
+						"message: foo, bar"
+				);
+
+		verify(t, times(1))
+				.printStackTrace(errorConsoleLogger);
+	}
+
+	@Test
+	void logInfo() {
+		PrintStream logConsoleLogger = mock(PrintStream.class);
+		PrintStream errorConsoleLogger = mock(PrintStream.class);
+		Loggers.ConsoleLogger log = new Loggers.ConsoleLogger(
+				"test",
+				logConsoleLogger,
+				errorConsoleLogger,
+				true
+		);
+
+		log.info("message: {}, {}", "foo", "bar");
+
+		verify(logConsoleLogger, times(1))
+				.format(
+						"[%s] (%s) %s\n",
+						" INFO",
+						Thread.currentThread().getName(),
+						"message: foo, bar"
+				);
+	}
+
+	@Test
+	void logInfoWithThrowable() {
+		PrintStream logConsoleLogger = mock(PrintStream.class);
+		PrintStream errorConsoleLogger = mock(PrintStream.class);
+		Loggers.ConsoleLogger log = new Loggers.ConsoleLogger(
+				"test",
+				logConsoleLogger,
+				errorConsoleLogger,
+				true
+		);
+
+		Throwable t = mock(IllegalAccessError.class);
+		log.info("message: {}, {}", "foo", "bar", t);
+
+		verify(errorConsoleLogger, never())
+				.format(
+						anyString(),
+						anyString(),
+						anyString(),
+						anyString()
+				);
+
+		verify(logConsoleLogger, times(1))
+				.format(
+						"[%s] (%s) %s\n",
+						" INFO",
+						Thread.currentThread().getName(),
+						"message: foo, bar"
+				);
+
+		verify(t, times(1))
+				.printStackTrace(logConsoleLogger);
 	}
 }

--- a/reactor-core/src/test/java/reactor/util/JdkLoggerTest.java
+++ b/reactor-core/src/test/java/reactor/util/JdkLoggerTest.java
@@ -22,28 +22,39 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
-class JdkLoggerTest {
+public class JdkLoggerTest {
 
 	@Test
-	void formatNullFormat() {
-		Logger logger = Mockito.mock(Logger.class);
-		Loggers.JdkLogger jdkLogger = new Loggers.JdkLogger(logger);
+	public void formatNullFormat() {
+		StringBuilder log = new StringBuilder();
+		Logger underlyingLogger = Logger.getAnonymousLogger();
+		underlyingLogger.setLevel(Level.FINE);
+		underlyingLogger.addHandler(
+				new Handler() {
+					@Override
+					public void publish(LogRecord record) {
+						log.append(record.getMessage());
+					}
+
+					@Override
+					public void flush() { }
+
+					@Override
+					public void close() throws SecurityException { }
+				});
+
+		Loggers.JdkLogger jdkLogger = new Loggers.JdkLogger(underlyingLogger);
 
 		jdkLogger.debug(null, (Object[]) null);
 
-		verify(logger, times(1))
-				.log(Level.FINE, (String) null);
+		assertThat(log.toString()).isEqualTo("null");
 	}
 
 	@Test
-	void nullFormatIsAcceptedByUnderlyingLogger() {
+	public void nullFormatIsAcceptedByUnderlyingLogger() {
 		StringBuilder log = new StringBuilder();
 		Logger underlyingLogger = Logger.getAnonymousLogger();
 		underlyingLogger.setLevel(Level.FINEST);
@@ -55,12 +66,10 @@ class JdkLoggerTest {
 					}
 
 					@Override
-					public void flush() {
-					}
+					public void flush() { }
 
 					@Override
-					public void close() throws SecurityException {
-					}
+					public void close() throws SecurityException { }
 				});
 
 		Loggers.JdkLogger jdkLogger = new Loggers.JdkLogger(underlyingLogger);
@@ -71,54 +80,107 @@ class JdkLoggerTest {
 	}
 
 	@Test
-	void formatNullVararg() {
-		Logger logger = Mockito.mock(Logger.class);
-		Loggers.JdkLogger jdkLogger = new Loggers.JdkLogger(logger);
+	public void formatNullVararg() {
+		StringBuilder log = new StringBuilder();
+		Logger underlyingLogger = Logger.getAnonymousLogger();
+		underlyingLogger.setLevel(Level.INFO);
+		underlyingLogger.addHandler(
+				new Handler() {
+					@Override
+					public void publish(LogRecord record) {
+						log.append(record.getMessage());
+					}
+
+					@Override
+					public void flush() { }
+
+					@Override
+					public void close() throws SecurityException { }
+				});
+
+		Loggers.JdkLogger jdkLogger = new Loggers.JdkLogger(underlyingLogger);
 
 		jdkLogger.info("test {} is {}", (Object[]) null);
 
-		verify(logger, times(1))
-				.log(Level.INFO, "test {} is {}");
+		assertThat(log.toString()).isEqualTo("test {} is {}");
 	}
 
 	@Test
-	void formatNullParamInVararg() {
-		Logger logger = Mockito.mock(Logger.class);
-		Loggers.JdkLogger jdkLogger = new Loggers.JdkLogger(logger);
+	public void formatNullParamInVararg() {
+		StringBuilder log = new StringBuilder();
+		Logger underlyingLogger = Logger.getAnonymousLogger();
+		underlyingLogger.setLevel(Level.FINEST);
+		underlyingLogger.addHandler(
+				new Handler() {
+					@Override
+					public void publish(LogRecord record) {
+						log.append(record.getMessage());
+					}
+
+					@Override
+					public void flush() { }
+
+					@Override
+					public void close() throws SecurityException { }
+				});
+
+		Loggers.JdkLogger jdkLogger = new Loggers.JdkLogger(underlyingLogger);
 
 		jdkLogger.trace("test {} is {}", null, null);
 
-		verify(logger, times(1))
-				.log(Level.FINEST, "test null is null");
+		assertThat(log.toString()).isEqualTo("test null is null");
 	}
 
 	@Test
-	void logWarnLevel() {
-		java.util.logging.Logger jdkLogger = mock(java.util.logging.Logger.class);
-		Loggers.JdkLogger log = new Loggers.JdkLogger(jdkLogger);
+	public void logWarnLevel() {
+		StringBuilder log = new StringBuilder();
+		Logger underlyingLogger = Logger.getAnonymousLogger();
+		underlyingLogger.setLevel(Level.WARNING);
+		underlyingLogger.addHandler(
+				new Handler() {
+					@Override
+					public void publish(LogRecord record) {
+						log.append(record.getMessage());
+					}
 
-		log.warn("message: {}, {}", "foo", "bar");
+					@Override
+					public void flush() { }
 
-		verify(jdkLogger, times(1))
-				.log(
-						Level.WARNING,
-						"message: foo, bar"
-				);
+					@Override
+					public void close() throws SecurityException { }
+				});
+
+		Loggers.JdkLogger jdkLogger = new Loggers.JdkLogger(underlyingLogger);
+
+		jdkLogger.warn("message: {}, {}", "foo", "bar");
+
+		assertThat(log.toString()).isEqualTo("message: foo, bar");
 	}
 
 	@Test
-	void logWithThrowable() {
-		java.util.logging.Logger jdkLogger = mock(java.util.logging.Logger.class);
-		Loggers.JdkLogger log = new Loggers.JdkLogger(jdkLogger);
+	public void logWithThrowable() {
+		StringBuilder log = new StringBuilder();
+		Logger underlyingLogger = Logger.getAnonymousLogger();
+		underlyingLogger.setLevel(Level.WARNING);
+		underlyingLogger.addHandler(
+				new Handler() {
+					@Override
+					public void publish(LogRecord record) {
+						log.append(record.getMessage());
+					}
+
+					@Override
+					public void flush() { }
+
+					@Override
+					public void close() throws SecurityException { }
+				});
+
+		Loggers.JdkLogger jdkLogger = new Loggers.JdkLogger(underlyingLogger);
 
 		Throwable t = new IllegalAccessError();
-		log.warn("message: {}, {}", "foo", "bar", t);
+		jdkLogger.warn("message: {}, {}", "foo", "bar", t);
 
-		verify(jdkLogger, times(1))
-				.log(
-						Level.WARNING,
-						"message: foo, bar",
-						t
-				);
+		assertThat(log.toString()).isEqualTo("message: foo, bar");
 	}
 }

--- a/reactor-core/src/test/java/reactor/util/JdkLoggerTest.java
+++ b/reactor-core/src/test/java/reactor/util/JdkLoggerTest.java
@@ -30,23 +30,7 @@ public class JdkLoggerTest {
 	@Test
 	public void formatNullFormat() {
 		StringBuilder log = new StringBuilder();
-		Logger underlyingLogger = Logger.getAnonymousLogger();
-		underlyingLogger.setLevel(Level.FINE);
-		underlyingLogger.addHandler(
-				new Handler() {
-					@Override
-					public void publish(LogRecord record) {
-						log.append(record.getMessage());
-					}
-
-					@Override
-					public void flush() { }
-
-					@Override
-					public void close() throws SecurityException { }
-				});
-
-		Loggers.JdkLogger jdkLogger = new Loggers.JdkLogger(underlyingLogger);
+		Loggers.JdkLogger jdkLogger = getJdkLogger(log, Level.FINE);
 
 		jdkLogger.debug(null, (Object[]) null);
 
@@ -56,23 +40,7 @@ public class JdkLoggerTest {
 	@Test
 	public void nullFormatIsAcceptedByUnderlyingLogger() {
 		StringBuilder log = new StringBuilder();
-		Logger underlyingLogger = Logger.getAnonymousLogger();
-		underlyingLogger.setLevel(Level.FINEST);
-		underlyingLogger.addHandler(
-				new Handler() {
-					@Override
-					public void publish(LogRecord record) {
-						log.append(record.getMessage());
-					}
-
-					@Override
-					public void flush() { }
-
-					@Override
-					public void close() throws SecurityException { }
-				});
-
-		Loggers.JdkLogger jdkLogger = new Loggers.JdkLogger(underlyingLogger);
+		Loggers.JdkLogger jdkLogger = getJdkLogger(log, Level.FINEST);
 
 		jdkLogger.trace(null, null, null);
 
@@ -82,23 +50,7 @@ public class JdkLoggerTest {
 	@Test
 	public void formatNullVararg() {
 		StringBuilder log = new StringBuilder();
-		Logger underlyingLogger = Logger.getAnonymousLogger();
-		underlyingLogger.setLevel(Level.INFO);
-		underlyingLogger.addHandler(
-				new Handler() {
-					@Override
-					public void publish(LogRecord record) {
-						log.append(record.getMessage());
-					}
-
-					@Override
-					public void flush() { }
-
-					@Override
-					public void close() throws SecurityException { }
-				});
-
-		Loggers.JdkLogger jdkLogger = new Loggers.JdkLogger(underlyingLogger);
+		Loggers.JdkLogger jdkLogger = getJdkLogger(log, Level.INFO);
 
 		jdkLogger.info("test {} is {}", (Object[]) null);
 
@@ -108,23 +60,7 @@ public class JdkLoggerTest {
 	@Test
 	public void formatNullParamInVararg() {
 		StringBuilder log = new StringBuilder();
-		Logger underlyingLogger = Logger.getAnonymousLogger();
-		underlyingLogger.setLevel(Level.FINEST);
-		underlyingLogger.addHandler(
-				new Handler() {
-					@Override
-					public void publish(LogRecord record) {
-						log.append(record.getMessage());
-					}
-
-					@Override
-					public void flush() { }
-
-					@Override
-					public void close() throws SecurityException { }
-				});
-
-		Loggers.JdkLogger jdkLogger = new Loggers.JdkLogger(underlyingLogger);
+		Loggers.JdkLogger jdkLogger = getJdkLogger(log, Level.FINEST);
 
 		jdkLogger.trace("test {} is {}", null, null);
 
@@ -132,41 +68,135 @@ public class JdkLoggerTest {
 	}
 
 	@Test
-	public void logWarnLevel() {
+	public void trace() {
 		StringBuilder log = new StringBuilder();
-		Logger underlyingLogger = Logger.getAnonymousLogger();
-		underlyingLogger.setLevel(Level.WARNING);
-		underlyingLogger.addHandler(
-				new Handler() {
-					@Override
-					public void publish(LogRecord record) {
-						log.append(record.getMessage());
-					}
+		Loggers.JdkLogger jdkLogger = getJdkLogger(log, Level.FINEST);
 
-					@Override
-					public void flush() { }
+		jdkLogger.trace("test {} is {}", "foo", "bar");
 
-					@Override
-					public void close() throws SecurityException { }
-				});
-
-		Loggers.JdkLogger jdkLogger = new Loggers.JdkLogger(underlyingLogger);
-
-		jdkLogger.warn("message: {}, {}", "foo", "bar");
-
-		assertThat(log.toString()).isEqualTo("message: foo, bar");
+		assertThat(log.toString()).isEqualTo("test foo is bar");
 	}
 
 	@Test
-	public void logWithThrowable() {
+	public void traceWithThrowable() {
 		StringBuilder log = new StringBuilder();
+		Loggers.JdkLogger jdkLogger = getJdkLogger(log, Level.FINEST);
+
+		Throwable t = new IllegalAccessError();
+		jdkLogger.trace("test {} is {}", "foo", "bar", t);
+
+		assertThat(log.toString()).startsWith("test foo is bar"
+				+ "\njava.lang.IllegalAccessError\n"
+				+ "\tat reactor.util.JdkLoggerTest.traceWithThrowable");
+	}
+
+	@Test
+	public void debug() {
+		StringBuilder log = new StringBuilder();
+		Loggers.JdkLogger jdkLogger = getJdkLogger(log, Level.FINE);
+
+		jdkLogger.debug("test {} is {}", "foo", "bar");
+
+		assertThat(log.toString()).isEqualTo("test foo is bar");
+	}
+
+	@Test
+	public void debugWithThrowable() {
+		StringBuilder log = new StringBuilder();
+		Loggers.JdkLogger jdkLogger = getJdkLogger(log, Level.FINE);
+
+		Throwable t = new IllegalAccessError();
+		jdkLogger.debug("test {} is {}", "foo", "bar", t);
+
+		assertThat(log.toString()).startsWith("test foo is bar"
+				+ "\njava.lang.IllegalAccessError\n"
+				+ "\tat reactor.util.JdkLoggerTest.debugWithThrowable");
+	}
+
+	@Test
+	public void info() {
+		StringBuilder log = new StringBuilder();
+		Loggers.JdkLogger jdkLogger = getJdkLogger(log, Level.FINE);
+
+		jdkLogger.info("test {} is {}", "foo", "bar");
+
+		assertThat(log.toString()).isEqualTo("test foo is bar");
+	}
+
+	@Test
+	public void infoWithThrowable() {
+		StringBuilder log = new StringBuilder();
+		Loggers.JdkLogger jdkLogger = getJdkLogger(log, Level.FINE);
+
+		Throwable t = new IllegalAccessError();
+		jdkLogger.info("test {} is {}", "foo", "bar", t);
+
+		assertThat(log.toString()).startsWith("test foo is bar"
+				+ "\njava.lang.IllegalAccessError\n"
+				+ "\tat reactor.util.JdkLoggerTest.infoWithThrowable");
+	}
+
+	@Test
+	public void warn() {
+		StringBuilder log = new StringBuilder();
+		Loggers.JdkLogger jdkLogger = getJdkLogger(log, Level.WARNING);
+
+		jdkLogger.warn("test {} is {}", "foo", "bar");
+
+		assertThat(log.toString()).isEqualTo("test foo is bar");
+	}
+
+	@Test
+	public void warnWithThrowable() {
+		StringBuilder log = new StringBuilder();
+		Loggers.JdkLogger jdkLogger = getJdkLogger(log, Level.WARNING);
+
+		Throwable t = new IllegalAccessError();
+		jdkLogger.warn("test {} is {}", "foo", "bar", t);
+
+		assertThat(log.toString()).startsWith("test foo is bar"
+				+ "\njava.lang.IllegalAccessError\n"
+				+ "\tat reactor.util.JdkLoggerTest.warnWithThrowable");
+	}
+
+	@Test
+	public void error() {
+		StringBuilder log = new StringBuilder();
+		Loggers.JdkLogger jdkLogger = getJdkLogger(log, Level.SEVERE);
+
+		jdkLogger.error("test {} is {}", "foo", "bar");
+
+		assertThat(log.toString()).isEqualTo("test foo is bar");
+	}
+
+	@Test
+	public void errorWithThrowable() {
+		StringBuilder log = new StringBuilder();
+		Loggers.JdkLogger jdkLogger = getJdkLogger(log, Level.SEVERE);
+
+		Throwable t = new IllegalAccessError();
+		jdkLogger.error("test {} is {}", "foo", "bar", t);
+
+		assertThat(log.toString()).startsWith("test foo is bar"
+				+ "\njava.lang.IllegalAccessError\n"
+				+ "\tat reactor.util.JdkLoggerTest.errorWithThrowable");
+	}
+
+	private Loggers.JdkLogger getJdkLogger(StringBuilder log, Level level) {
 		Logger underlyingLogger = Logger.getAnonymousLogger();
-		underlyingLogger.setLevel(Level.WARNING);
+		underlyingLogger.setLevel(level);
 		underlyingLogger.addHandler(
 				new Handler() {
 					@Override
 					public void publish(LogRecord record) {
 						log.append(record.getMessage());
+
+						if (record.getThrown() != null) {
+							log.append("\n").append(record.getThrown().toString());
+							for (StackTraceElement element : record.getThrown().getStackTrace()) {
+								log.append("\n\tat ").append(element.toString());
+							}
+						}
 					}
 
 					@Override
@@ -176,11 +206,6 @@ public class JdkLoggerTest {
 					public void close() throws SecurityException { }
 				});
 
-		Loggers.JdkLogger jdkLogger = new Loggers.JdkLogger(underlyingLogger);
-
-		Throwable t = new IllegalAccessError();
-		jdkLogger.warn("message: {}, {}", "foo", "bar", t);
-
-		assertThat(log.toString()).isEqualTo("message: foo, bar");
+		return new Loggers.JdkLogger(underlyingLogger);
 	}
 }

--- a/reactor-core/src/test/java/reactor/util/LoggersTest.java
+++ b/reactor-core/src/test/java/reactor/util/LoggersTest.java
@@ -18,6 +18,7 @@ package reactor.util;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+
 import reactor.ReactorLauncherSessionListener;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -109,4 +110,5 @@ class LoggersTest {
 			Loggers.resetLoggerFactory();
 		}
 	}
+
 }

--- a/reactor-core/src/test/java/reactor/util/LoggersTest.java
+++ b/reactor-core/src/test/java/reactor/util/LoggersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,11 @@
 
 package reactor.util;
 
-import java.io.PrintStream;
-import java.util.logging.Level;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import reactor.ReactorLauncherSessionListener;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 class LoggersTest {
 
@@ -116,147 +108,5 @@ class LoggersTest {
 		finally {
 			Loggers.resetLoggerFactory();
 		}
-	}
-
-	@Test
-	void logWhenUsingJdkLoggers() {
-		java.util.logging.Logger jdkLogger = mock(java.util.logging.Logger.class);
-		Loggers.JdkLogger log = new Loggers.JdkLogger(jdkLogger);
-
-		log.warn("message: {}, {}", "foo", "bar");
-
-		verify(jdkLogger, times(1))
-				.log(
-						Level.WARNING,
-						"message: foo, bar"
-				);
-	}
-
-	@Test
-	void logWithThrowableWhenUsingJdkLoggers() {
-		java.util.logging.Logger jdkLogger = mock(java.util.logging.Logger.class);
-		Loggers.JdkLogger log = new Loggers.JdkLogger(jdkLogger);
-
-		Throwable t = new IllegalAccessError();
-		log.warn("message: {}, {}", "foo", "bar", t);
-
-		verify(jdkLogger, times(1))
-				.log(
-						Level.WARNING,
-						"message: foo, bar",
-						t
-				);
-	}
-
-	@Test
-	void logWarnWhenUsingConsoleLoggers() {
-		PrintStream logConsoleLogger = mock(PrintStream.class);
-		PrintStream errorConsoleLogger = mock(PrintStream.class);
-		Loggers.ConsoleLogger log = new Loggers.ConsoleLogger(
-				"test",
-				logConsoleLogger,
-				errorConsoleLogger,
-				true
-		);
-
-		log.warn("message: {}, {}", "foo", "bar");
-
-		verify(errorConsoleLogger, times(1))
-				.format(
-						"[%s] (%s) %s\n",
-						" WARN",
-						Thread.currentThread().getName(),
-						"message: foo, bar"
-				);
-	}
-
-	@Test
-	void logWarnWithThrowableWhenUsingConsoleLoggers() {
-		PrintStream logConsoleLogger = mock(PrintStream.class);
-		PrintStream errorConsoleLogger = mock(PrintStream.class);
-		Loggers.ConsoleLogger log = new Loggers.ConsoleLogger(
-				"test",
-				logConsoleLogger,
-				errorConsoleLogger,
-				true
-		);
-
-		Throwable t = mock(IllegalAccessError.class);
-		log.warn("message: {}, {}", "foo", "bar", t);
-
-		verify(logConsoleLogger, never())
-				.format(
-						anyString(),
-						anyString(),
-						anyString(),
-						anyString()
-				);
-
-		verify(errorConsoleLogger, times(1))
-				.format(
-						"[%s] (%s) %s\n",
-						" WARN",
-						Thread.currentThread().getName(),
-						"message: foo, bar"
-				);
-
-		verify(t, times(1))
-				.printStackTrace(errorConsoleLogger);
-	}
-
-	@Test
-	void logInfoWhenUsingConsoleLoggers() {
-		PrintStream logConsoleLogger = mock(PrintStream.class);
-		PrintStream errorConsoleLogger = mock(PrintStream.class);
-		Loggers.ConsoleLogger log = new Loggers.ConsoleLogger(
-				"test",
-				logConsoleLogger,
-				errorConsoleLogger,
-				true
-		);
-
-		log.info("message: {}, {}", "foo", "bar");
-
-		verify(logConsoleLogger, times(1))
-				.format(
-						"[%s] (%s) %s\n",
-						" INFO",
-						Thread.currentThread().getName(),
-						"message: foo, bar"
-				);
-	}
-
-	@Test
-	void logInfoWithThrowableWhenUsingConsoleLoggers() {
-		PrintStream logConsoleLogger = mock(PrintStream.class);
-		PrintStream errorConsoleLogger = mock(PrintStream.class);
-		Loggers.ConsoleLogger log = new Loggers.ConsoleLogger(
-				"test",
-				logConsoleLogger,
-				errorConsoleLogger,
-				true
-		);
-
-		Throwable t = mock(IllegalAccessError.class);
-		log.info("message: {}, {}", "foo", "bar", t);
-
-		verify(errorConsoleLogger, never())
-				.format(
-						anyString(),
-						anyString(),
-						anyString(),
-						anyString()
-				);
-
-		verify(logConsoleLogger, times(1))
-				.format(
-						"[%s] (%s) %s\n",
-						" INFO",
-						Thread.currentThread().getName(),
-						"message: foo, bar"
-				);
-
-		verify(t, times(1))
-				.printStackTrace(logConsoleLogger);
 	}
 }


### PR DESCRIPTION
## Motivation
Hello,

Reactor Core supports SLF4J, Console Logger, and JDK Logger.
In SLF4J implementations (e.g., Logback), when the last argument is of type Throwable, the exception stack trace is automatically logged, as shown below.
(ref. [SLF4J FAQ](https://www.slf4j.org/faq.html#paramException))
(ref: [Logback implementation](https://github.com/qos-ch/logback/blob/1da2f171dc108a2576eb33918198db7f755b1224/logback-classic/src/main/java/ch/qos/logback/classic/spi/LoggingEvent.java#L140-L142))

```java
log.info("An error occurred: {}", "details", new Exception("Sample exception"));
```

However, the Console Logger and JDK Logger supported by Reactor Core do not provide this functionality, and users must manually check for `Throwable` and handle it accordingly in their code.

```java
	@Test
	void useVerboseConsoleLoggers() throws Exception {
		try {
			Loggers.useVerboseConsoleLoggers();
			Logger l = Loggers.getLogger("test");

			l.debug("Processing data for user: {}", "user123", new Exception("Sample exception"));
		}
		finally {
			Loggers.resetLoggerFactory();
		        ReactorLauncherSessionListener.resetLoggersFactory();
		}
	}
```

```
[DEBUG] (Test worker) Processing data for user: user123
```

This results in unnecessary branching in user code and decreases consistency across logging mechanisms.

Therefore, in this change, we have modified the `ConsoleLogger` and `JdkLogger` to detect if the last argument is of type `Throwable` and automatically log the exception stack trace.

## Description

This PR enhances the logging functionality in Reactor Core to check if the last argument in logger methods is of type `Throwable`. If a `Throwable` is detected, the exception stack trace is included in the log output.

## Key Changes
1. Added logic to inspect the last argument in logger method calls.
2. Automatically handles `Throwable` instances for improved debugging.
3. Ensures compatibility with existing SLF4J-style message formatting for consistency across logging frameworks.

## Example Usage
```java
log.info("Processing data for user: {}", "user123", new Exception("Sample exception"));
```

### Before
```java
INFO: Processing data for user: user123
```
### After
```java
INFO: Processing data for user: user123
java.lang.Exception: Sample exception
    at ...

```

## Benefits
- Aligns Reactor's logging capabilities with familiar SLF4J-style formatting.
- Simplifies exception handling for developers using JDK or Console Loggers.
- Improves traceability and debugging in complex systems.

## Testing
```java

	@Test
	void useVerboseConsoleLoggers() throws Exception {
		try {
			Loggers.useVerboseConsoleLoggers();
			Logger l = Loggers.getLogger("test");

			l.debug("Processing data for user: {}", "user123", new Exception("Sample exception"));
		}
		finally {
			Loggers.resetLoggerFactory();
		        ReactorLauncherSessionListener.resetLoggersFactory();
		}
	}

	@Test
	void useJdkLoggers() throws Exception {
		try {
			Loggers.useJdkLoggers();
			Logger l = Loggers.getLogger("test");

			l.debug("Processing data for user: {}", "user123", new Exception("Sample exception"));
		}
		finally {
			Loggers.resetLoggerFactory();
		        ReactorLauncherSessionListener.resetLoggersFactory();
		}
	}
```