### PR TITLE
Remove redundant return in subscribe catch block

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Remove redundant return statement in CorePublisher subscribe method

The explicit return statement in the catch block is unnecessary since the method would naturally terminate after reporting the error through reportThrowInSubscribe.

### User Impact
Cleaner code with no behavioral changes for end users. This is purely a maintenance improvement that removes redundant code.

### Technical Details
The catch block in the subscribe method contained an unnecessary explicit return statement after `Operators.reportThrowInSubscribe()`. Since the method would naturally terminate after error reporting, this return statement was redundant and has been removed to improve code clarity.

### Related Issues
See #2072 

<!--
The PR description will be used to craft a final squash merge commit
and the title will be used in release notes, so please keep them up-to-date.
More detailed description of the commit message convention:
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#black_nib-commit-message-convention
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#message-convention
-->