### PR TITLE
Fix javaagent parameter syntax

### DIFF
--- a/docs/modules/ROOT/pages/debugging.adoc
+++ b/docs/modules/ROOT/pages/debugging.adoc
@@ -471,7 +471,7 @@ If your environment does not support ByteBuddy's self-attachment, you can run `r
 Java Agent:
 [source,shell]
 ----
-java -javaagent reactor-tools.jar -jar app.jar
+java -javaagent:reactor-tools.jar -jar app.jar
 ----
 
 [[running-reactordebugagent-at-build-time]]


### PR DESCRIPTION
Fix a typo in the usage example of the reactor-tools Java agent.